### PR TITLE
refactor(python): replace deprecated unittest methods

### DIFF
--- a/Code/Demos/boost/smartPtrsAndIters/test.py
+++ b/Code/Demos/boost/smartPtrsAndIters/test.py
@@ -14,37 +14,37 @@ class TestCase(unittest.TestCase):
 
   def test1(self):
     obj = TestModule.DemoKlass(3)
-    self.failUnless(obj.GetVal() == 3)
+    self.assertTrue(obj.GetVal() == 3)
 
   def test2(self):
     obj = TestModule.buildPtr(3)
-    self.failUnless(obj.GetVal() == 3)
+    self.assertTrue(obj.GetVal() == 3)
 
   def test3(self):
     obj = TestModule.buildSPtr(3)
-    self.failUnless(obj.GetVal() == 3)
+    self.assertTrue(obj.GetVal() == 3)
 
   def test4(self):
     sz = 5
     vect = TestModule.buildPtrVector(sz)
-    self.failUnless(len(vect) == sz)
+    self.assertTrue(len(vect) == sz)
     for i in range(sz):
-      self.failUnless(vect[i].GetVal() == i)
+      self.assertTrue(vect[i].GetVal() == i)
 
   def test5(self):
     sz = 5
     vect = TestModule.buildSPtrVector(sz)
-    self.failUnless(len(vect) == sz)
+    self.assertTrue(len(vect) == sz)
     for i in range(sz):
-      self.failUnless(vect[i].GetVal() == i)
+      self.assertTrue(vect[i].GetVal() == i)
 
   def test5b(self):
     sz = 5
     vect = TestModule.buildSPtrVector(sz)
-    self.failUnless(len(vect) == sz)
+    self.assertTrue(len(vect) == sz)
     p = 0
     for itm in vect:
-      self.failUnless(itm.GetVal() == p)
+      self.assertTrue(itm.GetVal() == p)
       p += 1
 
   def test6(self):
@@ -52,9 +52,9 @@ class TestCase(unittest.TestCase):
     cont = TestModule.DemoContainer(sz)
     p = 0
     for itm in cont:
-      self.failUnless(itm.GetVal() == p)
+      self.assertTrue(itm.GetVal() == p)
       p += 1
-    self.failUnless(p == sz)
+    self.assertTrue(p == sz)
 
 
 if __name__ == '__main__':

--- a/Code/GraphMol/ChemReactions/Wrap/testEnumerations.py
+++ b/Code/GraphMol/ChemReactions/Wrap/testEnumerations.py
@@ -60,7 +60,7 @@ class TestCase(unittest.TestCase):
 
     cartProd = rdChemReactions.CartesianProductStrategy()
     cartProd.Initialize(rxn, rgroups)
-    self.assertEquals(cartProd.GetNumPermutations(), 10 * 5 * 6)
+    self.assertEqual(cartProd.GetNumPermutations(), 10 * 5 * 6)
     groups = []
     count = 0
     print(cartProd.__bool__())
@@ -70,10 +70,10 @@ class TestCase(unittest.TestCase):
 
 #      count += 1
 #      assert count <= cartProd.GetNumPermutations()
-    self.assertEquals(len(groups), 10 * 5 * 6)
+    self.assertEqual(len(groups), 10 * 5 * 6)
     # see if we are equal to the Python implementation
     g = list(itertools.product(list(range(10)), list(range(5)), list(range(6))))
-    self.assertEquals(set(g), set(groups))
+    self.assertEqual(set(g), set(groups))
     copy.copy(cartProd)
 
   def testRandomSample(self):
@@ -84,7 +84,7 @@ class TestCase(unittest.TestCase):
 
     randProd = rdChemReactions.RandomSampleStrategy()
     randProd.Initialize(rxn, rgroups)
-    self.assertEquals(randProd.GetNumPermutations(), 10 * 5 * 6)
+    self.assertEqual(randProd.GetNumPermutations(), 10 * 5 * 6)
     groups = []
     for i in range(10 * 5 * 6):
       groups.append(tuple(randProd.next()))
@@ -92,7 +92,7 @@ class TestCase(unittest.TestCase):
 
     randProd = rdChemReactions.RandomSampleStrategy()
     randProd.Initialize(rxn, rgroups)
-    self.assertEquals(randProd.GetNumPermutations(), 10 * 5 * 6)
+    self.assertEqual(randProd.GetNumPermutations(), 10 * 5 * 6)
     groups = []
     for i in range(10):
       groups.append(tuple(randProd.next()))
@@ -109,7 +109,7 @@ class TestCase(unittest.TestCase):
 
     randProd = rdChemReactions.RandomSampleAllBBsStrategy()
     randProd.Initialize(rxn, rgroups)
-    self.assertEquals(randProd.GetNumPermutations(), 10 * 5 * 6)
+    self.assertEqual(randProd.GetNumPermutations(), 10 * 5 * 6)
     groups = []
     for i in range(10 * 5 * 6):
       groups.append(tuple(randProd.next()))
@@ -118,14 +118,14 @@ class TestCase(unittest.TestCase):
 
     randProd = rdChemReactions.RandomSampleAllBBsStrategy()
     randProd.Initialize(rxn, rgroups)
-    self.assertEquals(randProd.GetNumPermutations(), 10 * 5 * 6)
+    self.assertEqual(randProd.GetNumPermutations(), 10 * 5 * 6)
     groups = []
     for i in range(10):
       groups.append(tuple(randProd.next()))
 
     for i in range(3):
       print(i, len(set([g[i] for g in groups])), "out of", [10, 5, 6][i])
-      self.assertEquals(len(set([g[i] for g in groups])), [10, 5, 6][i])
+      self.assertEqual(len(set([g[i] for g in groups])), [10, 5, 6][i])
     copy.copy(randProd)
 
   def testTimings(self):
@@ -171,9 +171,9 @@ class TestCase(unittest.TestCase):
       count += 1
 
     # each pair should be used roughly once
-    self.assertEquals(np.median(list(pairs01.values())), 1.0)
-    self.assertEquals(np.median(list(pairs02.values())), 1.0)
-    self.assertEquals(np.median(list(pairs12.values())), 1.0)
+    self.assertEqual(np.median(list(pairs01.values())), 1.0)
+    self.assertEqual(np.median(list(pairs02.values())), 1.0)
+    self.assertEqual(np.median(list(pairs12.values())), 1.0)
 
     # now try 1000
     pairs01 = {}
@@ -238,7 +238,7 @@ class TestCase(unittest.TestCase):
 
     # need to initialize the reaction before getting the binary serialization
     rxn.Initialize()
-    self.assertEquals(rxn.ToBinary(), enumerator.GetReaction().ToBinary())
+    self.assertEqual(rxn.ToBinary(), enumerator.GetReaction().ToBinary())
 
     bbs = enumerator.GetReagents()
     for i in range(len(bbs)):
@@ -266,7 +266,7 @@ class TestCase(unittest.TestCase):
         open(os.path.join(self.dataDir, "enumeration.pickle"), 'rb').read())
 
       print("==", enumerator.GetEnumerator().Type(), enumerator2.GetEnumerator().Type())
-      self.assertEquals(enumerator.GetEnumerator().Type(), enumerator2.GetEnumerator().Type())
+      self.assertEqual(enumerator.GetEnumerator().Type(), enumerator2.GetEnumerator().Type())
       enumerators.append(enumerator2)
       enumerators.append(enumerator3)
 
@@ -280,17 +280,17 @@ class TestCase(unittest.TestCase):
       for i, prods in enumerate(en):
         positions.append(list(en.GetPosition()))
         for mols in prods:
-          self.assertEquals(len(mols), 1)
+          self.assertEqual(len(mols), 1)
           smi = Chem.MolToSmiles(mols[0])
           if en is enumerator:
             out.append(smi)
-          self.assertEquals(smi, results[i])
+          self.assertEqual(smi, results[i])
 
         if en is enumerator and i == 1 and rdChemReactions.EnumerateLibraryCanSerialize():
           # save the state not at the start
           pickle_at_2 = enumerator.Serialize()
-      self.assertEquals(i, 5)
-      self.assertEquals(positions, expected_positions)
+      self.assertEqual(i, 5)
+      self.assertEqual(positions, expected_positions)
 
     if rdChemReactions.EnumerateLibraryCanSerialize():
       # see if we can restore the enumeration from the middle
@@ -299,20 +299,20 @@ class TestCase(unittest.TestCase):
       enumerator3.InitFromString(pickle_at_2)
       for prods in enumerator3:
         for mols in prods:
-          self.assertEquals(len(mols), 1)
+          self.assertEqual(len(mols), 1)
           smi = Chem.MolToSmiles(mols[0])
           out3.append(smi)
 
-      self.assertEquals(out[2:], out3)
+      self.assertEqual(out[2:], out3)
     # test smiles interface
     enumerator = rdChemReactions.EnumerateLibrary(rxn, reagents)
     i = 0
     while enumerator:
       for mols in enumerator.nextSmiles():
-        self.assertEquals(len(mols), 1)
-        self.assertEquals(mols[0], results[i])
+        self.assertEqual(len(mols), 1)
+        self.assertEqual(mols[0], results[i])
       i += 1
-    self.assertEquals(i, 6)
+    self.assertEqual(i, 6)
 
   def testRandomEnumerateLibrary(self):
     log("testRandomEnumerateLibrary")
@@ -345,7 +345,7 @@ class TestCase(unittest.TestCase):
       count += 1
       if count > 100000:
         print("Unable to find enumerate set with 100,000 random samples!", file=sys.stderr)
-        self.assertEquals(res, set(results))
+        self.assertEqual(res, set(results))
 
       prod = iteren.next()
       for mols in prod:
@@ -359,7 +359,7 @@ class TestCase(unittest.TestCase):
       enumerator2 = rdChemReactions.EnumerateLibrary()
       enumerator2.InitFromString(pickle)
 
-      self.assertEquals(enumerator.GetEnumerator().Type(), enumerator2.GetEnumerator().Type())
+      self.assertEqual(enumerator.GetEnumerator().Type(), enumerator2.GetEnumerator().Type())
 
       iteren = iter(enumerator)
       iteren2 = iter(enumerator2)
@@ -368,11 +368,11 @@ class TestCase(unittest.TestCase):
       for i in range(10):
         prods1 = iteren.next()
         prods2 = iteren2.next()
-        self.assertEquals(len(prods1), len(prods2))
+        self.assertEqual(len(prods1), len(prods2))
         for mols1, mols2 in zip(prods1, prods2):
-          self.assertEquals(len(mols1), 1)
+          self.assertEqual(len(mols1), 1)
           smi1 = Chem.MolToSmiles(mols1[0])
-          self.assertEquals(smi1, Chem.MolToSmiles(mols2[0]))
+          self.assertEqual(smi1, Chem.MolToSmiles(mols2[0]))
           outsmiles.append(smi1)
 
         if i == 1:
@@ -386,12 +386,12 @@ class TestCase(unittest.TestCase):
       for i in range(8):
         prods3 = iteren3.next()
         for mols3 in prods3:
-          self.assertEquals(len(mols3), 1)
+          self.assertEqual(len(mols3), 1)
           smi1 = Chem.MolToSmiles(mols3[0])
-          self.assertEquals(smi1, Chem.MolToSmiles(mols3[0]))
+          self.assertEqual(smi1, Chem.MolToSmiles(mols3[0]))
           outsmiles2.append(smi1)
 
-      self.assertEquals(outsmiles2, outsmiles[2:])
+      self.assertEqual(outsmiles2, outsmiles[2:])
 
   def testRandomEnumerateAllBBsLibrary(self):
     log("testRandomEnumerateAllBBsLibrary")
@@ -422,14 +422,14 @@ class TestCase(unittest.TestCase):
     print("**", list(groups), file=sys.stderr)
     r1.add(groups[0])
     r2.add(groups[1])
-    self.assertEquals(r1, set([0, 1]))  # two bbs at reagent one all sampled at one iteration
+    self.assertEqual(r1, set([0, 1]))  # two bbs at reagent one all sampled at one iteration
     strategy.next()
     groups = strategy.GetPosition()
     print("**", list(groups), file=sys.stderr)
     r1.add(groups[0])
     r2.add(groups[1])
-    self.assertEquals(r2, set([0, 1,
-                               2]))  # three bbs at reagent one all sampled in three iterations
+    self.assertEqual(r2, set([0, 1,
+                              2]))  # three bbs at reagent one all sampled in three iterations
 
     smiresults = [
       'C=CCNC(=S)NCc1ncc(Cl)cc1Br', 'CC=CCNC(=S)NCc1ncc(Cl)cc1Br', 'C=CCNC(=S)NCCc1ncc(Cl)cc1Br',
@@ -447,7 +447,7 @@ class TestCase(unittest.TestCase):
       enumerator2 = rdChemReactions.EnumerateLibrary()
       enumerator2.InitFromString(pickle)
 
-      self.assertEquals(enumerator.GetEnumerator().Type(), enumerator2.GetEnumerator().Type())
+      self.assertEqual(enumerator.GetEnumerator().Type(), enumerator2.GetEnumerator().Type())
       iteren = iter(enumerator)
       iteren2 = iter(enumerator2)
 
@@ -455,11 +455,11 @@ class TestCase(unittest.TestCase):
       for i in range(10):
         prods1 = iteren.next()
         prods2 = iteren2.next()
-        self.assertEquals(len(prods1), len(prods2))
+        self.assertEqual(len(prods1), len(prods2))
         for mols1, mols2 in zip(prods1, prods2):
-          self.assertEquals(len(mols1), 1)
+          self.assertEqual(len(mols1), 1)
           smi1 = Chem.MolToSmiles(mols1[0])
-          self.assertEquals(smi1, Chem.MolToSmiles(mols2[0]))
+          self.assertEqual(smi1, Chem.MolToSmiles(mols2[0]))
           outsmiles.append(smi1)
 
         if i == 1:
@@ -468,19 +468,19 @@ class TestCase(unittest.TestCase):
       # make sure we can pickle the state as well
       enumerator3 = rdChemReactions.EnumerateLibrary()
       enumerator3.InitFromString(pickle_at_2)
-      self.assertEquals(enumerator.GetEnumerator().Type(), enumerator3.GetEnumerator().Type())
+      self.assertEqual(enumerator.GetEnumerator().Type(), enumerator3.GetEnumerator().Type())
 
       iteren3 = iter(enumerator3)
       outsmiles2 = []
       for i in range(8):
         prods3 = iteren3.next()
         for mols3 in prods3:
-          self.assertEquals(len(mols3), 1)
+          self.assertEqual(len(mols3), 1)
           smi1 = Chem.MolToSmiles(mols3[0])
-          self.assertEquals(smi1, Chem.MolToSmiles(mols3[0]))
+          self.assertEqual(smi1, Chem.MolToSmiles(mols3[0]))
           outsmiles2.append(smi1)
 
-      self.assertEquals(outsmiles2, outsmiles[2:])
+      self.assertEqual(outsmiles2, outsmiles[2:])
 
   def testRGroupState(self):
     if not rdChemReactions.EnumerateLibraryCanSerialize():
@@ -507,8 +507,8 @@ class TestCase(unittest.TestCase):
     p = enumerator.nextSmiles()
     p2 = enumerator.nextSmiles()
     enumerator.SetState(state)
-    self.assertEquals(tostr(enumerator.nextSmiles()), tostr(p))
-    self.assertEquals(tostr(enumerator.nextSmiles()), tostr(p2))
+    self.assertEqual(tostr(enumerator.nextSmiles()), tostr(p))
+    self.assertEqual(tostr(enumerator.nextSmiles()), tostr(p2))
 
     enumerator = rdChemReactions.EnumerateLibrary(rxn, reagents,
                                                   rdChemReactions.RandomSampleStrategy())
@@ -517,8 +517,8 @@ class TestCase(unittest.TestCase):
     p = enumerator.nextSmiles()
     p2 = enumerator.nextSmiles()
     enumerator.SetState(state)
-    self.assertEquals(tostr(enumerator.nextSmiles()), tostr(p))
-    self.assertEquals(tostr(enumerator.nextSmiles()), tostr(p2))
+    self.assertEqual(tostr(enumerator.nextSmiles()), tostr(p))
+    self.assertEqual(tostr(enumerator.nextSmiles()), tostr(p2))
 
     enumerator = rdChemReactions.EnumerateLibrary(rxn, reagents,
                                                   rdChemReactions.RandomSampleAllBBsStrategy())
@@ -526,8 +526,8 @@ class TestCase(unittest.TestCase):
     p = enumerator.nextSmiles()
     p2 = enumerator.nextSmiles()
     enumerator.SetState(state)
-    self.assertEquals(tostr(enumerator.nextSmiles()), tostr(p))
-    self.assertEquals(tostr(enumerator.nextSmiles()), tostr(p2))
+    self.assertEqual(tostr(enumerator.nextSmiles()), tostr(p))
+    self.assertEqual(tostr(enumerator.nextSmiles()), tostr(p2))
 
     enumerator = rdChemReactions.EnumerateLibrary(rxn, reagents)
     smiresults = [
@@ -545,7 +545,7 @@ class TestCase(unittest.TestCase):
         for mol in prodSet:
           results.append(Chem.MolToSmiles(mol))
 
-    self.assertEquals(results, smiresults)
+    self.assertEqual(results, smiresults)
 
   def testRemovingBadMatches(self):
     log("testRemoveBadMatches")
@@ -568,7 +568,7 @@ class TestCase(unittest.TestCase):
     ]
 
     enumerator = rdChemReactions.EnumerateLibrary(rxn, reagents)
-    self.assertEquals([], list(enumerator))
+    self.assertEqual([], list(enumerator))
 
   def testRemoveInsaneReagents(self):
     rxndata = "$RXN\nUntitled Document-1\n  ChemDraw10291618492D\n\n  3  1\n$MOL\n\n\n\n  2  1  0  0  0  0  0  0  0  0999 V2000\n    0.4125    0.0000    0.0000 N   0  0  0  0  0  0  0  0  0  3  0  0\n   -0.4125    0.0000    0.0000 R2  0  0  0  0  0  0  0  0  0  2  0  0\n  1  2  1  0        0\nM  END\n$MOL\n\n\n\n  2  1  0  0  0  0  0  0  0  0999 V2000\n   -0.4125    0.0000    0.0000 R1  0  0  0  0  0  0  0  0  0  1  0  0\n    0.4125    0.0000    0.0000 Cl  0  0  0  0  0  0  0  0  0  0  0  0\n  1  2  1  0        0\nM  END\n$MOL\n\n\n\n  2  1  0  0  0  0  0  0  0  0999 V2000\n    0.4125    0.0000    0.0000 N   0  0  0  0  0  0  0  0  0  5  0  0\n   -0.4125    0.0000    0.0000 R4  0  0  0  0  0  0  0  0  0  4  0  0\n  1  2  1  0        0\nM  END\n$MOL\n\n\n\n 14 15  0  0  0  0  0  0  0  0999 V2000\n    0.5072   -0.5166    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n    0.5072    0.3084    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n    1.2949   -0.7616    0.0000 N   0  0  0  0  0  0  0  0  0  0  0  0\n    1.7817   -0.0880    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n    1.2967    0.5794    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n    1.5558   -1.5443    0.0000 R1  0  0  0  0  0  0  0  0  0  1  0  0\n   -0.2073    0.7208    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n   -0.9218    0.3083    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n   -0.9217   -0.5167    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n   -0.2073   -0.9292    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n   -1.6362    0.7208    0.0000 N   0  0  0  0  0  0  0  0  0  3  0  0\n    1.5452    1.3661    0.0000 N   0  0  0  0  0  0  0  0  0  5  0  0\n    2.3507    1.5443    0.0000 R4  0  0  0  0  0  0  0  0  0  4  0  0\n   -2.3507    0.3083    0.0000 R2  0  0  0  0  0  0  0  0  0  2  0  0\n  1  2  2  0        0\n  1  3  1  0        0\n  3  4  1  0        0\n  4  5  1  0        0\n  5  2  1  0        0\n  3  6  1  0        0\n  2  7  1  0        0\n  7  8  2  0        0\n  8  9  1  0        0\n  9 10  2  0        0\n 10  1  1  0        0\n  8 11  1  0        0\n 12 13  1  0        0\n 11 14  1  0        0\n 12  5  1  0        0\nM  END\n"

--- a/Code/GraphMol/ChemReactions/Wrap/testReactionWrapper.py
+++ b/Code/GraphMol/ChemReactions/Wrap/testReactionWrapper.py
@@ -509,34 +509,34 @@ M  END
   def test19RemoveUnmappedMoleculesToAgents(self):
     rxn = rdChemReactions.ReactionFromSmarts(
       "[C:1]=[O:2].[N:3].C(=O)O>[OH2].[Na].[Cl]>[N:3]~[C:1]=[O:2]")
-    self.failUnless(rxn)
+    self.assertTrue(rxn)
     rxn.Initialize()
-    self.failUnless(rxn.GetNumReactantTemplates() == 3)
-    self.failUnless(rxn.GetNumProductTemplates() == 1)
-    self.failUnless(rxn.GetNumAgentTemplates() == 3)
+    self.assertTrue(rxn.GetNumReactantTemplates() == 3)
+    self.assertTrue(rxn.GetNumProductTemplates() == 1)
+    self.assertTrue(rxn.GetNumAgentTemplates() == 3)
 
     rxn.RemoveUnmappedReactantTemplates()
     rxn.RemoveUnmappedProductTemplates()
 
-    self.failUnless(rxn.GetNumReactantTemplates() == 2)
-    self.failUnless(rxn.GetNumProductTemplates() == 1)
-    self.failUnless(rxn.GetNumAgentTemplates() == 4)
+    self.assertTrue(rxn.GetNumReactantTemplates() == 2)
+    self.assertTrue(rxn.GetNumProductTemplates() == 1)
+    self.assertTrue(rxn.GetNumAgentTemplates() == 4)
 
     rxn = rdChemReactions.ReactionFromSmarts("[C:1]=[O:2].[N:3].C(=O)O>>[N:3]~[C:1]=[O:2].[OH2]")
-    self.failUnless(rxn)
+    self.assertTrue(rxn)
     rxn.Initialize()
-    self.failUnless(rxn.GetNumReactantTemplates() == 3)
-    self.failUnless(rxn.GetNumProductTemplates() == 2)
-    self.failUnless(rxn.GetNumAgentTemplates() == 0)
+    self.assertTrue(rxn.GetNumReactantTemplates() == 3)
+    self.assertTrue(rxn.GetNumProductTemplates() == 2)
+    self.assertTrue(rxn.GetNumAgentTemplates() == 0)
 
     agentList = []
     rxn.RemoveUnmappedReactantTemplates(moveToAgentTemplates=False, targetList=agentList)
     rxn.RemoveUnmappedProductTemplates(targetList=agentList)
 
-    self.failUnless(rxn.GetNumReactantTemplates() == 2)
-    self.failUnless(rxn.GetNumProductTemplates() == 1)
-    self.failUnless(rxn.GetNumAgentTemplates() == 1)
-    self.failUnless(len(agentList) == 2)
+    self.assertTrue(rxn.GetNumReactantTemplates() == 2)
+    self.assertTrue(rxn.GetNumProductTemplates() == 1)
+    self.assertTrue(rxn.GetNumAgentTemplates() == 1)
+    self.assertTrue(len(agentList) == 2)
 
   def test20CheckCopyConstructedReactionAtomProps(self):
     RLABEL = "_MolFileRLabel"
@@ -552,7 +552,7 @@ M  END
     for atom in rxn2.GetReactantTemplate(0).GetAtoms():
       if atom.HasProp(RLABEL):
         res2.append((atom.GetIdx(), atom.GetProp(RLABEL)))
-    self.assertEquals(res, res2)
+    self.assertEqual(res, res2)
 
     # currently ToBinary does not save atom props
     # rxn2 = rdChemReactions.ChemicalReaction(rxn.ToBinary())
@@ -562,17 +562,17 @@ M  END
     amine_rxn = '$RXN\n\n      ISIS     090220091541\n\n  2  1\n$MOL\n\n  -ISIS-  09020915412D\n\n  3  2  0  0  0  0  0  0  0  0999 V2000\n   -2.9083   -0.4708    0.0000 R#  0  0  0  0  0  0  0  0  0  1  0  0\n   -2.3995   -0.1771    0.0000 C   0  0  0  0  0  0  0  0  0  2  0  0\n   -2.4042    0.4125    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0\n  1  2  1  0  0  0  0\n  2  3  2  0  0  0  0\nV    2 aldehyde\nM  RGP  1   1   1\nM  END\n$MOL\n\n  -ISIS-  09020915412D\n\n  2  1  0  0  0  0  0  0  0  0999 V2000\n    2.8375   -0.2500    0.0000 R#  0  0  0  0  0  0  0  0  0  3  0  0\n    3.3463    0.0438    0.0000 N   0  0  0  0  0  0  0  0  0  4  0  0\n  1  2  1  0  0  0  0\nV    2 amine\nM  RGP  1   1   2\nM  END\n$MOL\n\n  -ISIS-  09020915412D\n\n  4  3  0  0  0  0  0  0  0  0999 V2000\n   13.3088    0.9436    0.0000 C   0  0  0  0  0  0  0  0  0  2  0  0\n   13.8206    1.2321    0.0000 R#  0  0  0  0  0  0  0  0  0  1  0  0\n   13.3028    0.3561    0.0000 N   0  0  0  0  0  0  0  0  0  4  0  0\n   12.7911    0.0676    0.0000 R#  0  0  0  0  0  0  0  0  0  3  0  0\n  1  3  1  0  0  0  0\n  1  2  1  0  0  0  0\n  3  4  1  0  0  0  0\nM  RGP  2   2   1   4   2\nM  END\n'
     rxn = rdChemReactions.ReactionFromRxnBlock(amine_rxn)
     reactants = rxn.GetReactants()
-    self.assertEquals(len(reactants), rxn.GetNumReactantTemplates())
+    self.assertEqual(len(reactants), rxn.GetNumReactantTemplates())
     products = rxn.GetProducts()
-    self.assertEquals(len(products), rxn.GetNumProductTemplates())
+    self.assertEqual(len(products), rxn.GetNumProductTemplates())
     agents = rxn.GetAgents()
-    self.assertEquals(len(agents), rxn.GetNumAgentTemplates())
+    self.assertEqual(len(agents), rxn.GetNumAgentTemplates())
 
     for i in range(rxn.GetNumReactantTemplates()):
       p = rxn.GetReactantTemplate(i)
       mb1 = Chem.MolToMolBlock(p)
       mb2 = Chem.MolToMolBlock(reactants[i])
-      self.assertEquals(mb1, mb2)
+      self.assertEqual(mb1, mb2)
 
   def test22RunSingleReactant(self):
     # from
@@ -627,10 +627,10 @@ M  END
           sidechains.sort()
 
       if addDummy:
-        self.assertEquals(result, expected_result)
-        self.assertEquals(sidechains, sidechains_expected_result)
+        self.assertEqual(result, expected_result)
+        self.assertEqual(sidechains, sidechains_expected_result)
       else:
-        self.assertEquals(sidechains_nodummy, sidechains_nodummy_expected_result)
+        self.assertEqual(sidechains_nodummy, sidechains_nodummy_expected_result)
 
     expected_result = [Chem.MolToSmiles(Chem.MolFromSmiles("NCNCc1ncc(Cl)cc1Br"))]
     expected_result.sort()
@@ -649,8 +649,8 @@ M  END
           Chem.MolToSmiles(rdChemReactions.ReduceProductToSideChains(mol), isomericSmiles=True))
 
     result.sort()
-    self.assertEquals(result, expected_result)
-    self.assertEquals(sidechains, sidechains_expected_result)
+    self.assertEqual(result, expected_result)
+    self.assertEqual(sidechains, sidechains_expected_result)
 
     self.assertFalse(rxn.RunReactant(reagents[0], 1))
     self.assertFalse(rxn.RunReactant(reagents[1], 0))
@@ -668,7 +668,7 @@ M  END
           Chem.MolToSmiles(rdChemReactions.ReduceProductToSideChains(mol), isomericSmiles=True))
         sidechain = rdChemReactions.ReduceProductToSideChains(mol, addDummyAtoms=False)
 
-    self.assertEquals(sidechains, sidechains_expected_result)
+    self.assertEqual(sidechains, sidechains_expected_result)
 
   def test23CheckNonProduct(self):
     smirks_thiourea = "[N;$(N-[#6]):3]=[C;$(C=S):1].[N;$(N[#6]);!$(N=*);!$([N-]);!$(N#*);!$([ND3]);!$([ND4]);!$(N[O,N]);!$(N[C,S]=[S,O,N]):2]>>[N:3]-[C:1]-[N+0:2]"
@@ -685,7 +685,7 @@ M  END
     rxn = rdChemReactions.ReactionFromRxnFile(testFile)
     rxn.Initialize()
     res = rdChemReactions.PreprocessReaction(rxn)
-    self.assertEquals(res,
+    self.assertEqual(res,
                       (0, 0, 2, 1, (((0, 'halogen.bromine.aromatic'), ), ((1, 'boronicacid'), ))))
 
   def testProperties(self):
@@ -696,7 +696,7 @@ M  END
     rxn.SetIntProp("intprop", 3)
     self.assertTrue(rxn.HasProp("fooprop"))
     self.assertTrue(rxn.HasProp("intprop"))
-    self.assertEquals(rxn.GetIntProp("intprop"), 3)
+    self.assertEqual(rxn.GetIntProp("intprop"), 3)
     nrxn = rdChemReactions.ChemicalReaction(rxn.ToBinary())
     self.assertFalse(nrxn.HasProp("fooprop"))
     nrxn = rdChemReactions.ChemicalReaction(rxn.ToBinary(Chem.PropertyPickleOptions.AllProps))
@@ -704,7 +704,7 @@ M  END
     nrxn.ClearComputedProps()
     self.assertFalse(nrxn.HasProp("fooprop"))
     self.assertTrue(nrxn.HasProp("intprop"))
-    self.assertEquals(nrxn.GetIntProp("intprop"), 3)
+    self.assertEqual(nrxn.GetIntProp("intprop"), 3)
 
   def testRoundTripException(self):
     smarts = '[C:1]([C@:3]1([OH:24])[CH2:8][CH2:7][C@H:6]2[C@H:9]3[C@H:19]([C@@H:20]([F:22])[CH2:21][C@:4]12[CH3:5])[C@:17]1([CH3:18])[C:12](=[CH:13][C:14](=[O:23])[CH2:15][CH2:16]1)[CH:11]=[CH:10]3)#[CH:2].C(Cl)CCl.ClC1C=CC=C(C(OO)=[O:37])C=1.C(O)(C)(C)C>C(OCC)(=O)C>[C:1]([C@:3]1([OH:24])[CH2:8][CH2:7][C@H:6]2[C@H:9]3[C@H:19]([C@@H:20]([F:22])[CH2:21][C@:4]12[CH3:5])[C@:17]1([CH3:18])[C:12](=[CH:13][C:14](=[O:23])[CH2:15][CH2:16]1)[C@H:11]1[O:37][C@@H:10]31)#[CH:2]'
@@ -733,7 +733,7 @@ M  END
   def test_PNGMetadata(self):
     fname = os.path.join(self.dataDir, 'reaction1.smarts.png')
     rxn = rdChemReactions.ReactionFromPNGFile(fname)
-    self.failIf(rxn is None)
+    self.assertFalse(rxn is None)
     self.assertEqual(rxn.GetNumReactantTemplates(), 2)
     self.assertEqual(rxn.GetNumProductTemplates(), 1)
 
@@ -743,7 +743,7 @@ M  END
     npng2 = rdChemReactions.ReactionMetadataToPNGString(rxn, png)
     self.assertEqual(npng1, npng2)
     nrxn = rdChemReactions.ReactionFromPNGString(npng2)
-    self.failIf(nrxn is None)
+    self.assertFalse(nrxn is None)
     self.assertEqual(nrxn.GetNumReactantTemplates(), 2)
     self.assertEqual(nrxn.GetNumProductTemplates(), 1)
     opts = [
@@ -775,7 +775,7 @@ M  END
     for opt in opts:
       npng = rdChemReactions.ReactionMetadataToPNGString(rxn, png, **opt)
       nrxn = rdChemReactions.ReactionFromPNGString(npng)
-      self.failIf(nrxn is None)
+      self.assertFalse(nrxn is None)
       self.assertEqual(nrxn.GetNumReactantTemplates(), 2)
       self.assertEqual(nrxn.GetNumProductTemplates(), 1)
 

--- a/Code/GraphMol/ChemReactions/Wrap/testSanitize.py
+++ b/Code/GraphMol/ChemReactions/Wrap/testSanitize.py
@@ -284,16 +284,16 @@ class TestCase(unittest.TestCase):
       res = rdChemReactions.PreprocessReaction(rxna)
       print(AllChem.ReactionToRxnBlock(rxna))
       if status == "good":
-        self.assertEquals(res, good_res)
+        self.assertEqual(res, good_res)
       elif status == "bad":
-        self.assertEquals(res, bad_res)
+        self.assertEqual(res, bad_res)
       print(">" * 44)
       rxnb.Initialize()
       try:
         rdChemReactions.SanitizeRxn(rxnb)
         res = rdChemReactions.PreprocessReaction(rxnb)
         print(AllChem.ReactionToRxnBlock(rxnb))
-        self.assertEquals(res, good_res)
+        self.assertEqual(res, good_res)
         assert not status == "fail"
       except Exception:
         print("$RXN Failed")

--- a/Code/GraphMol/FilterCatalog/Wrap/rough_test.py
+++ b/Code/GraphMol/FilterCatalog/Wrap/rough_test.py
@@ -142,7 +142,7 @@ class TestCase(unittest.TestCase):
         catalogs = [catalog1, catalog2, catalog3]
       else:
         catalogs = [catalog1]
-        self.failUnlessRaises(RuntimeError, lambda: pickle.dumps(catalog1))
+        self.assertRaises(RuntimeError, lambda: pickle.dumps(catalog1))
 
       catalogs.append(FilterCatalog.FilterCatalog(catalog_idx))
       for index, catalog in enumerate(catalogs):
@@ -160,39 +160,39 @@ class TestCase(unittest.TestCase):
           self.assertTrue("FilterSet" in prop_list)
           for key in entry.GetPropList():
             if key == "Reference":
-              self.assertEquals(
+              self.assertEqual(
                 entry.GetProp(key), "Baell JB, Holloway GA. New Substructure Filters for "
                 "Removal of Pan Assay Interference Compounds (PAINS) "
                 "from Screening Libraries and for Their Exclusion in "
                 "Bioassays. J Med Chem 53 (2010) 2719D40. "
                 "doi:10.1021/jm901137j.")
             elif key == "Scope":
-              self.assertEquals(entry.GetProp(key), "PAINS filters (family A)")
+              self.assertEqual(entry.GetProp(key), "PAINS filters (family A)")
             elif key == "FilterSet":
-              self.assertEquals(entry.GetProp(key), "PAINS_A")
+              self.assertEqual(entry.GetProp(key), "PAINS_A")
 
           self.assertEqual(entry.GetDescription(), "hzone_phenol_A(479)")
           result = catalog.GetMatches(mol)
-          self.assertEquals(len(result), 1)
+          self.assertEqual(len(result), 1)
 
           for entry in result:
             for filtermatch in entry.GetFilterMatches(mol):
-              self.assertEquals(str(filtermatch.filterMatch), "hzone_phenol_A(479)")
+              self.assertEqual(str(filtermatch.filterMatch), "hzone_phenol_A(479)")
               atomPairs = [tuple(x) for x in filtermatch.atomPairs]
-              self.assertEquals(atomPairs, [(0, 23), (1, 22), (2, 20), (3, 19), (4, 25), (5, 24),
+              self.assertEqual(atomPairs, [(0, 23), (1, 22), (2, 20), (3, 19), (4, 25), (5, 24),
                                             (6, 18), (7, 17), (8, 16), (9, 21)])
 
         elif catalog_idx == FilterCatalogParams.FilterCatalogs.PAINS_B:
           mol = Chem.MolFromSmiles("FC(F)(F)Oc1ccc(NN=C(C#N)C#N)cc1")  # CHEMBL457504
           entry = catalog.GetFirstMatch(mol)
           self.assertTrue(entry)
-          self.assertEquals(entry.GetDescription(), "cyano_imine_B(17)")
+          self.assertEqual(entry.GetDescription(), "cyano_imine_B(17)")
 
         elif catalog_idx == FilterCatalogParams.FilterCatalogs.PAINS_C:
           mol = Chem.MolFromSmiles("O=C1C2OC2C(=O)c3cc4CCCCc4cc13")  # CHEMBL476649
           entry = catalog.GetFirstMatch(mol)
           self.assertTrue(entry)
-          self.assertEquals(entry.GetDescription(), "keto_keto_gamma(5)")
+          self.assertEqual(entry.GetDescription(), "keto_keto_gamma(5)")
 
   def test3ExclusionFilter(self):
     mol = Chem.MolFromSmiles("c1ccccc1")
@@ -238,7 +238,7 @@ class TestCase(unittest.TestCase):
 
     m = Chem.MolFromSmiles("CN" * 20)
     entry = catalog.GetFirstMatch(m)
-    self.assertEquals(catalog.GetFirstMatch(m), None)
+    self.assertEqual(catalog.GetFirstMatch(m), None)
 
   def testSmartsMatcherAPI(self):
     sm = FilterCatalog.SmartsMatcher("Too many carbons", "[#6]", 40 + 1)
@@ -289,7 +289,7 @@ class TestCase(unittest.TestCase):
     for i in range(catalog.GetNumEntries()):
       if catalog.GetEntryWithIdx(i).GetDescription() == desc:
         newcount += 1
-    self.assertEquals(count, newcount + 1)
+    self.assertEqual(count, newcount + 1)
 
   def testPyFilter(self):
 
@@ -309,22 +309,22 @@ class TestCase(unittest.TestCase):
         return True
 
     func = MyFilterMatcher("FilterMatcher")
-    self.assertEquals(func.GetName(), "FilterMatcher")
+    self.assertEqual(func.GetName(), "FilterMatcher")
     mol = Chem.MolFromSmiles("c1ccccc1")
-    self.assertEquals(func.HasMatch(mol), True)
+    self.assertEqual(func.HasMatch(mol), True)
 
     or_match = FilterMatchOps.Or(func, func)
-    self.assertEquals([[tuple(x) for x in filtermatch.atomPairs]
+    self.assertEqual([[tuple(x) for x in filtermatch.atomPairs]
                        for filtermatch in or_match.GetMatches(mol)], [[(1, 1)], [(1, 1)]])
 
     not_match = FilterMatchOps.Not(func)
     print(not_match)
-    self.assertEquals(not_match.HasMatch(mol), False)
+    self.assertEqual(not_match.HasMatch(mol), False)
     # test memory
     del func
 
-    self.assertEquals(not_match.HasMatch(mol), False)
-    self.assertEquals([[tuple(x) for x in filtermatch.atomPairs]
+    self.assertEqual(not_match.HasMatch(mol), False)
+    self.assertEqual([[tuple(x) for x in filtermatch.atomPairs]
                        for filtermatch in not_match.GetMatches(mol)], [])
 
     entry = FilterCatalog.FilterCatalogEntry("Bar", MyFilterMatcher("FilterMatcher"))
@@ -369,7 +369,7 @@ class TestCase(unittest.TestCase):
 
     def hierarchy(matcher):
       node = FilterCatalog.FilterHierarchyMatcher(matcher)
-      self.assertEquals(matcher.GetName(), node.GetName())
+      self.assertEqual(matcher.GetName(), node.GetName())
       return node
 
     sm = FilterCatalog.SmartsMatcher("Halogen.Aromatic", "[F,Cl,Br,I;$(*-!@c)]")
@@ -413,36 +413,36 @@ class TestCase(unittest.TestCase):
     m = Chem.MolFromSmiles("CCl")
     assert h.HasMatch(m)
     res = root.GetMatches(m)
-    self.assertEquals(len(res), 1)
-    self.assertEquals([match.filterMatch.GetName() for match in res],
+    self.assertEqual(len(res), 1)
+    self.assertEqual([match.filterMatch.GetName() for match in res],
                       ['Halogen.NotFluorine.Aliphatic'])
 
     m = Chem.MolFromSmiles("c1ccccc1Cl")
     assert h.HasMatch(m)
     res = root.GetMatches(m)
-    self.assertEquals(len(res), 2)
+    self.assertEqual(len(res), 2)
 
     m = Chem.MolFromSmiles("c1ccccc1Br")
     assert h.HasMatch(m)
     res = root.GetMatches(m)
-    self.assertEquals(len(res), 3)
+    self.assertEqual(len(res), 3)
 
-    self.assertEquals(
+    self.assertEqual(
       [match.filterMatch.GetName() for match in res],
       ['Halogen.Aromatic', 'Halogen.NotFluorine.Aromatic', 'Halogen.Bromine.Aromatic'])
 
     m = Chem.MolFromSmiles("c1ccccc1F")
     assert h.HasMatch(m)
     res = root.GetMatches(m)
-    self.assertEquals(len(res), 1)
+    self.assertEqual(len(res), 1)
 
-    self.assertEquals([match.filterMatch.GetName() for match in res], ['Halogen.Aromatic'])
+    self.assertEqual([match.filterMatch.GetName() for match in res], ['Halogen.Aromatic'])
 
     m = Chem.MolFromSmiles("CBr")
     assert h.HasMatch(m)
     res = root.GetMatches(m)
 
-    self.assertEquals([match.filterMatch.GetName() for match in res],
+    self.assertEqual([match.filterMatch.GetName() for match in res],
                       ['Halogen.NotFluorine.Aliphatic', 'Halogen.Bromine.Aliphatic'])
 
   def testFunctionalGroupHierarchy(self):
@@ -468,11 +468,11 @@ class TestCase(unittest.TestCase):
         entries = list(fc.GetMatches(mol))
         for entry in entries:
           hits = [match.filterMatch.GetName() for match in entry.GetFilterMatches(mol)]
-          self.assertEquals(res, hits)
+          self.assertEqual(res, hits)
 
       # test GetFilterMatches API
       for mol, res in matches:
-        self.assertEquals(res, [match.filterMatch.GetName() for match in fc.GetFilterMatches(mol)])
+        self.assertEqual(res, [match.filterMatch.GetName() for match in fc.GetFilterMatches(mol)])
 
   def testFlattenedFunctionalGroupHierarchy(self):
     queryDefs = FilterCatalog.GetFlattenedFunctionalGroupHierarchy()
@@ -497,7 +497,7 @@ class TestCase(unittest.TestCase):
     # test the normalized groups
     for mol, res in matches:
       hits = [name for name, pat in items if mol.HasSubstructMatch(pat)]
-      self.assertEquals(hits, res)
+      self.assertEqual(hits, res)
     queryDefs = FilterCatalog.GetFlattenedFunctionalGroupHierarchy(normalized=True)
 
     items = sorted(queryDefs.items())
@@ -520,14 +520,14 @@ class TestCase(unittest.TestCase):
 
     for mol, res in matches:
       hits = [name for name, pat in items if mol.HasSubstructMatch(pat)]
-      self.assertEquals(hits, res)
+      self.assertEqual(hits, res)
 
   def testThreadedRunner(self):
     path = os.path.join(os.environ['RDBASE'], 'Code', 'GraphMol', 'test_data', 'pains.smi')
     with open(path) as f:
       smiles = [f.strip() for f in f.readlines()][1:]
 
-    self.assertEquals(len(smiles), 3)
+    self.assertEqual(len(smiles), 3)
     params = FilterCatalog.FilterCatalogParams()
     params.AddCatalog(FilterCatalogParams.FilterCatalogs.PAINS_A)
     params.AddCatalog(FilterCatalogParams.FilterCatalogs.PAINS_B)
@@ -535,19 +535,19 @@ class TestCase(unittest.TestCase):
     fc = FilterCatalog.FilterCatalog(params)
 
     results = FilterCatalog.RunFilterCatalog(fc, smiles)
-    self.assertEquals(len(results), 3)
+    self.assertEqual(len(results), 3)
 
     descriptions = ["hzone_phenol_A(479)", "cyano_imine_B(17)", "keto_keto_gamma(5)"]
 
     for i, res in enumerate(results):
       self.assertTrue(len(res) > 0)
-      self.assertEquals(res[0].GetDescription(), descriptions[i])
+      self.assertEqual(res[0].GetDescription(), descriptions[i])
 
     # Test with some bad input
     smiles = ['mydoghasfleas']
     results = FilterCatalog.RunFilterCatalog(fc, smiles, numThreads=3)
-    self.assertEquals(len(results[0]), 1)
-    self.assertEquals(results[0][0].GetDescription(), "no valid RDKit molecule")
+    self.assertEqual(len(results[0]), 1)
+    self.assertEqual(results[0][0].GetDescription(), "no valid RDKit molecule")
 
   def testThreadedPythonFilter(self):
 

--- a/Code/GraphMol/MolChemicalFeatures/Wrap/testChemicalFeatures.py
+++ b/Code/GraphMol/MolChemicalFeatures/Wrap/testChemicalFeatures.py
@@ -27,27 +27,27 @@ class TestCase(unittest.TestCase):
     cfac = ChemicalFeatures.BuildFeatureFactory(
       os.path.join(RDConfig.RDBaseDir, 'Code', 'GraphMol', 'MolChemicalFeatures', 'test_data',
                    'featDef.txt'))
-    self.failUnless(cfac.GetNumFeatureDefs() == 2)
+    self.assertTrue(cfac.GetNumFeatureDefs() == 2)
 
     fNames = cfac.GetFeatureFamilies()
-    self.failUnless(len(fNames) == 2)
-    self.failUnless(fNames[0] == 'HBondDonor')
-    self.failUnless(fNames[1] == 'HBondAcceptor')
+    self.assertTrue(len(fNames) == 2)
+    self.assertTrue(fNames[0] == 'HBondDonor')
+    self.assertTrue(fNames[1] == 'HBondAcceptor')
 
     mol = Chem.MolFromSmiles("COCN")
     rdDistGeom.EmbedMolecule(mol, 30, 100, useExpTorsionAnglePrefs=False, useBasicKnowledge=False)
 
-    self.failUnless(cfac.GetNumMolFeatures(mol) == 3)
+    self.assertTrue(cfac.GetNumMolFeatures(mol) == 3)
     for i in range(cfac.GetNumMolFeatures(mol)):
-      self.failUnless(cfac.GetMolFeature(mol, i))
+      self.assertTrue(cfac.GetMolFeature(mol, i))
     # check that the recompute argument works:
-    self.failUnless(cfac.GetMolFeature(mol, 0))
+    self.assertTrue(cfac.GetMolFeature(mol, 0))
     for i in range(cfac.GetNumMolFeatures(mol)):
-      self.failUnless(cfac.GetMolFeature(mol, i, "", False))
-    self.failUnlessRaises(IndexError, lambda: cfac.GetMolFeature(mol, 3))
+      self.assertTrue(cfac.GetMolFeature(mol, i, "", False))
+    self.assertRaises(IndexError, lambda: cfac.GetMolFeature(mol, 3))
 
     feats = cfac.GetFeaturesForMol(mol)
-    self.failUnless(len(feats) == 3)
+    self.assertTrue(len(feats) == 3)
     fTypes = ['HBondDonor', 'HBondAcceptor', 'HBondAcceptor']
 
     positions = [[1.3041, -0.6079, 0.0924], [-0.7066, 0.5994, 0.1824], [1.3041, -0.6079, 0.0924]]
@@ -68,27 +68,27 @@ class TestCase(unittest.TestCase):
     cfac = ChemicalFeatures.BuildFeatureFactory(
       os.path.join(RDConfig.RDBaseDir, 'Code', 'GraphMol', 'MolChemicalFeatures', 'test_data',
                    'featDef.txt'))
-    self.failUnless(cfac.GetNumFeatureDefs() == 2)
+    self.assertTrue(cfac.GetNumFeatureDefs() == 2)
 
     mol = Chem.MolFromSmiles("COCN")
     rdDistGeom.EmbedMolecule(mol)
 
-    self.failUnless(cfac.GetNumMolFeatures(mol, includeOnly="HBondAcceptor") == 2)
-    self.failUnless(cfac.GetNumMolFeatures(mol, includeOnly="HBondDonor") == 1)
-    self.failUnless(cfac.GetNumMolFeatures(mol, includeOnly="Bogus") == 0)
+    self.assertTrue(cfac.GetNumMolFeatures(mol, includeOnly="HBondAcceptor") == 2)
+    self.assertTrue(cfac.GetNumMolFeatures(mol, includeOnly="HBondDonor") == 1)
+    self.assertTrue(cfac.GetNumMolFeatures(mol, includeOnly="Bogus") == 0)
 
-    self.failUnlessRaises(IndexError, lambda: cfac.GetMolFeature(mol, 1, includeOnly="HBondDonor"))
-    self.failUnlessRaises(IndexError,
-                          lambda: cfac.GetMolFeature(mol, 2, includeOnly="HBondAcceptor"))
+    self.assertRaises(IndexError, lambda: cfac.GetMolFeature(mol, 1, includeOnly="HBondDonor"))
+    self.assertRaises(IndexError,
+                      lambda: cfac.GetMolFeature(mol, 2, includeOnly="HBondAcceptor"))
     f = cfac.GetMolFeature(mol, 0, includeOnly="HBondDonor")
-    self.failUnless(f.GetFamily() == 'HBondDonor')
+    self.assertTrue(f.GetFamily() == 'HBondDonor')
 
     feats = cfac.GetFeaturesForMol(mol, includeOnly="HBondAcceptor")
-    self.failUnless(len(feats) == 2)
+    self.assertTrue(len(feats) == 2)
     feats = cfac.GetFeaturesForMol(mol, includeOnly="HBondDonor")
-    self.failUnless(len(feats) == 1)
+    self.assertTrue(len(feats) == 1)
     feats = cfac.GetFeaturesForMol(mol, includeOnly="Bogus")
-    self.failUnless(len(feats) == 0)
+    self.assertTrue(len(feats) == 0)
 
   def testStringParse(self):
     fdefBlock = \
@@ -102,7 +102,7 @@ DefineFeature HAcceptor1 [N,O;H0]
 EndFeature
 """
     cfac = ChemicalFeatures.BuildFeatureFactoryFromString(fdefBlock)
-    self.failUnless(cfac.GetNumFeatureDefs() == 2)
+    self.assertTrue(cfac.GetNumFeatureDefs() == 2)
 
   def testStringParse2(self):
     fdefBlock = \
@@ -116,7 +116,7 @@ DefineFeature HAcceptor1 [N,O;H0]\r
 EndFeature\r
 """
     cfac = ChemicalFeatures.BuildFeatureFactoryFromString(fdefBlock)
-    self.failUnless(cfac.GetNumFeatureDefs() == 2)
+    self.assertTrue(cfac.GetNumFeatureDefs() == 2)
 
   def testParseErrorHandling(self):
     fdefBlock = \
@@ -125,17 +125,17 @@ EndFeature\r
     Weights 1.0
 EndFeature
 """
-    self.failUnlessRaises(ValueError,
-                          lambda: ChemicalFeatures.BuildFeatureFactoryFromString(fdefBlock))
+    self.assertRaises(ValueError,
+                      lambda: ChemicalFeatures.BuildFeatureFactoryFromString(fdefBlock))
     fdefBlock = \
 """DefineFeature HDonor1 [N,O;!H0]
     Family HBondDonor
     Weights 1.0
 """
-    self.failUnlessRaises(ValueError,
-                          lambda: ChemicalFeatures.BuildFeatureFactoryFromString(fdefBlock))
+    self.assertRaises(ValueError,
+                      lambda: ChemicalFeatures.BuildFeatureFactoryFromString(fdefBlock))
 
-    self.failUnlessRaises(IOError, lambda: ChemicalFeatures.BuildFeatureFactory('noSuchFile.txt'))
+    self.assertRaises(IOError, lambda: ChemicalFeatures.BuildFeatureFactory('noSuchFile.txt'))
 
   def testAtomMatch(self):
     fdefBlock = \
@@ -150,18 +150,18 @@ DefineFeature Arom1 a1aaaaa1
 EndFeature
 """
     cfac = ChemicalFeatures.BuildFeatureFactoryFromString(fdefBlock)
-    self.failUnless(cfac.GetNumFeatureDefs() == 2)
+    self.assertTrue(cfac.GetNumFeatureDefs() == 2)
     mol = Chem.MolFromSmiles('n1ccccc1')
     feats = cfac.GetFeaturesForMol(mol)
-    self.failUnless(len(feats) == 2)
+    self.assertTrue(len(feats) == 2)
     m = ChemicalFeatures.GetAtomMatch(feats)
-    self.failIf(m)
+    self.assertFalse(m)
 
     mol = Chem.MolFromSmiles('c1ccccc1N')
     feats = cfac.GetFeaturesForMol(mol)
-    self.failUnless(len(feats) == 2)
+    self.assertTrue(len(feats) == 2)
     m = ChemicalFeatures.GetAtomMatch(feats)
-    self.failUnless(len(m) == 2)
+    self.assertTrue(len(m) == 2)
 
   def testIssue231(self):
     fdefs = """

--- a/Code/GraphMol/SLNParse/Wrap/testSLN.py
+++ b/Code/GraphMol/SLNParse/Wrap/testSLN.py
@@ -47,22 +47,22 @@ class TestCase(unittest.TestCase):
 
   def test1Basics(self):
     m1 = rdSLNParse.MolFromSLN('CH3CH3')
-    self.failUnless(m1)
-    self.failUnless(m1.GetNumAtoms() == 2)
+    self.assertTrue(m1)
+    self.assertTrue(m1.GetNumAtoms() == 2)
 
     m1 = rdSLNParse.MolFromSLN('C[1]H:CH:CH:CH:CH:CH:@1')
-    self.failUnless(m1)
-    self.failUnless(m1.GetNumAtoms() == 6)
+    self.assertTrue(m1)
+    self.assertTrue(m1.GetNumAtoms() == 6)
 
   def test2Queries(self):
     patt = rdSLNParse.MolFromQuerySLN('C[HC=2]~O')
-    self.failUnless(patt)
-    self.failUnless(patt.GetNumAtoms() == 2)
+    self.assertTrue(patt)
+    self.assertTrue(patt.GetNumAtoms() == 2)
 
     m = Chem.MolFromSmiles('COCC=O')
-    self.failUnless(m.HasSubstructMatch(patt))
+    self.assertTrue(m.HasSubstructMatch(patt))
     ms = m.GetSubstructMatches(patt)
-    self.failUnless(len(ms) == 1)
+    self.assertTrue(len(ms) == 1)
 
 
 if __name__ == '__main__':

--- a/Code/GraphMol/StructChecker/Wrap/rough_test.py
+++ b/Code/GraphMol/StructChecker/Wrap/rough_test.py
@@ -171,7 +171,7 @@ class TestCase(unittest.TestCase):
     self.assertTrue(m)
 
     res = checker.CheckMolStructure(m)
-    self.assertEquals(res, rdStructChecker.StructureFlags.ATOM_CHECK_FAILED)
+    self.assertEqual(res, rdStructChecker.StructureFlags.ATOM_CHECK_FAILED)
 
 
 if __name__ == '__main__':

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -2152,15 +2152,15 @@ CAS<~>
     self.assertFalse(ri.IsBondInRingOfSize(1, 3))
     self.assertFalse(ri.IsBondInRingOfSize(2, 3))
     if hasattr(Chem, 'FindRingFamilies'):
-      self.assertEquals(ri.AtomRingFamilies(), ())
+      self.assertEqual(ri.AtomRingFamilies(), ())
     if hasattr(Chem, 'FindRingFamilies'):
-      self.assertEquals(ri.BondRingFamilies(), ())
+      self.assertEqual(ri.BondRingFamilies(), ())
 
     smi = 'C1CC2C1C2'
     m = Chem.MolFromSmiles(smi)
     ri = m.GetRingInfo()
     self.assertTrue(ri)
-    self.assertEquals(ri.NumRings(), 2)
+    self.assertEqual(ri.NumRings(), 2)
     self.assertFalse(ri.IsAtomInRingOfSize(0, 3))
     self.assertTrue(ri.IsAtomInRingOfSize(0, 4))
     self.assertFalse(ri.IsBondInRingOfSize(0, 3))
@@ -2198,9 +2198,9 @@ CAS<~>
       Chem.FindRingFamilies(m)
       ri = m.GetRingInfo()
       self.assertTrue(ri.AreRingFamiliesInitialized())
-      self.assertEquals(ri.NumRingFamilies(), 2)
-      self.assertEquals(sorted(ri.AtomRingFamilies()), [(0, 1, 2, 3), (2, 3, 4)])
-      self.assertEquals(sorted(ri.BondRingFamilies()), [(0, 1, 2, 4), (2, 3, 5)])
+      self.assertEqual(ri.NumRingFamilies(), 2)
+      self.assertEqual(sorted(ri.AtomRingFamilies()), [(0, 1, 2, 3), (2, 3, 4)])
+      self.assertEqual(sorted(ri.BondRingFamilies()), [(0, 1, 2, 4), (2, 3, 5)])
 
   def test46ReplaceCore(self):
     """ test the ReplaceCore functionality

--- a/Code/ML/InfoTheory/Wrap/testRanker.py
+++ b/Code/ML/InfoTheory/Wrap/testRanker.py
@@ -120,7 +120,7 @@ class TestCase(unittest.TestCase):
     ids = [int(x[0]) for x in res]
     ids.sort()
     self.assertTrue(ids == [10, 15, 25, 63, 70])
-    with self.assertRaisesRegexp(Exception, ""):
+    with self.assertRaisesRegex(Exception, ""):
       res = rn.GetTopN(10)
 
   def test3Issue140(self):

--- a/Contrib/ConformerParser/Wrap/testConformerParser.py
+++ b/Contrib/ConformerParser/Wrap/testConformerParser.py
@@ -18,18 +18,18 @@ class TestCase(unittest.TestCase):
     mol = Chem.MolFromSmiles('O')
     mol = Chem.AddHs(mol)
     ids = rdConformerParser.AddConformersFromAmberTrajectory(mol, fileN)
-    self.failUnless(mol.GetNumConformers() == 1)
-    self.failUnless(len(ids) == 1)
-    self.failUnless(ids[0] == 0)
+    self.assertTrue(mol.GetNumConformers() == 1)
+    self.assertTrue(len(ids) == 1)
+    self.assertTrue(ids[0] == 0)
 
     fileN = os.path.join(RDConfig.RDBaseDir, 'Code', 'GraphMol', 'test_data', 'water_coords2.trx')
     ids = rdConformerParser.AddConformersFromAmberTrajectory(mol, fileN, clearConfs=True)
-    self.failUnless(mol.GetNumConformers() == 2)
+    self.assertTrue(mol.GetNumConformers() == 2)
     ids = rdConformerParser.AddConformersFromAmberTrajectory(mol, fileN, clearConfs=False)
-    self.failUnless(mol.GetNumConformers() == 4)
+    self.assertTrue(mol.GetNumConformers() == 4)
     ids = rdConformerParser.AddConformersFromAmberTrajectory(mol, fileN, numConfs=1,
                                                              clearConfs=True)
-    self.failUnless(mol.GetNumConformers() == 1)
+    self.assertTrue(mol.GetNumConformers() == 1)
 
 
 if __name__ == '__main__':

--- a/rdkit/Chem/MolStandardize/UnitTestMolStandardize.py
+++ b/rdkit/Chem/MolStandardize/UnitTestMolStandardize.py
@@ -20,11 +20,11 @@ class TestCase(unittest.TestCase):
     reord = MolStandardize.ReorderTautomers(m)[0]
     canonSmile = Chem.MolToSmiles(canon)
     reordSmile = Chem.MolToSmiles(reord)
-    self.assertEquals(canonSmile, reordSmile)
+    self.assertEqual(canonSmile, reordSmile)
 
   def testLength(self):
     m = Chem.MolFromSmiles('Oc1c(cccc3)c3nc2ccncc12')
     enumerator = rdMolStandardize.TautomerEnumerator()
     tauts = enumerator.Enumerate(m)
     reordtauts = MolStandardize.ReorderTautomers(m)
-    self.assertEquals(len(reordtauts), len(tauts))
+    self.assertEqual(len(reordtauts), len(tauts))

--- a/rdkit/DataStructs/UnitTestcBitVect.py
+++ b/rdkit/DataStructs/UnitTestcBitVect.py
@@ -38,7 +38,7 @@ class VectTests(object):
     v[2] = 1
     v[9] = 1
 
-    with self.assertRaisesRegexp(IndexError, ""):
+    with self.assertRaisesRegex(IndexError, ""):
       v[10] = 1
 
     assert v[0] == 1, 'bad bit'
@@ -48,7 +48,7 @@ class VectTests(object):
     assert v[-1] == 1, 'bad bit'
     assert v[-2] == 0, 'bad bit'
 
-    with self.assertRaisesRegexp(IndexError, ""):
+    with self.assertRaisesRegex(IndexError, ""):
       _ = v[10]
 
   def testSparseBitGet(self):

--- a/rdkit/Dbase/UnitTestDbUtils.py
+++ b/rdkit/Dbase/UnitTestDbUtils.py
@@ -93,7 +93,7 @@ class TestCase(unittest.TestCase):
     assert len(d) == 10
     assert tuple(d[0]) == (0, 11)
     assert tuple(d[2]) == (4, 31)
-    with self.assertRaisesRegexp(IndexError, ""):
+    with self.assertRaisesRegex(IndexError, ""):
       d[11]
 
   def testGetData2(self):
@@ -103,14 +103,14 @@ class TestCase(unittest.TestCase):
     assert tuple(d[0]) == (0, 11)
     assert tuple(d[2]) == (4, 31)
     assert len(d) == 10
-    with self.assertRaisesRegexp(IndexError, ""):
+    with self.assertRaisesRegex(IndexError, ""):
       d[11]
 
   def testGetData3(self):
     """ using a DbResultSet
     """
     d = DbUtils.GetData(self.dbName, 'ten_elements', forceList=0, randomAccess=0)
-    with self.assertRaisesRegexp(TypeError, ""):
+    with self.assertRaisesRegex(TypeError, ""):
       len(d)
     rs = []
     for thing in d:
@@ -130,7 +130,7 @@ class TestCase(unittest.TestCase):
     assert tuple(d[0]) == (0, 22)
     assert tuple(d[2]) == (4, 62)
     assert len(d) == 10
-    with self.assertRaisesRegexp(IndexError, ""):
+    with self.assertRaisesRegex(IndexError, ""):
       d[11]
 
   def testGetData5(self):
@@ -141,7 +141,7 @@ class TestCase(unittest.TestCase):
       return (x[0], x[1] * 2)
 
     d = DbUtils.GetData(self.dbName, 'ten_elements', forceList=0, randomAccess=0, transform=fn)
-    with self.assertRaisesRegexp(TypeError, ""):
+    with self.assertRaisesRegex(TypeError, ""):
       len(d)
 
     rs = []


### PR DESCRIPTION


<!--
Thanks for contributing a pull request! 
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.

https://docs.python.org/3/library/unittest.html#deprecated-aliases

#### Any other comments?

