### PR TITLE
Bonds to R groups should be generic

### DIFF
--- a/Code/GraphMol/Depictor/RDDepictor.cpp
+++ b/Code/GraphMol/Depictor/RDDepictor.cpp
@@ -815,12 +815,16 @@ RDKit::MatchVectType generateDepictionMatching2DStructure(
   if (allowOptionalAttachments) {
     std::unique_ptr<RDKit::ROMol> molHs(RDKit::MolOps::addHs(mol));
     CHECK_INVARIANT(molHs, "addHs returned a nullptr");
-    auto matches = SubstructMatch(*molHs, query);
+    auto queryParams = RDKit::MolOps::AdjustQueryParameters::noAdjustments();
+    queryParams.adjustSingleBondsToDegreeOneNeighbors = true;
+    queryParams.adjustSingleBondsBetweenAromaticAtoms = true;
+    std::unique_ptr<RDKit::ROMol> queryAdj(RDKit::MolOps::adjustQueryProperties(query, &queryParams));
+    auto matches = SubstructMatch(*molHs, *queryAdj);
     if (matches.empty()) {
       allowOptionalAttachments = false;
     } else {
       for (const auto &pair :
-           getMostSubstitutedCoreMatch(*molHs, query, matches)) {
+           getMostSubstitutedCoreMatch(*molHs, *queryAdj, matches)) {
         if (molHs->getAtomWithIdx(pair.second)->getAtomicNum() != 1 &&
             refMatch.at(pair.first) >= 0) {
           matchVect.push_back(pair);

--- a/Code/GraphMol/Depictor/catch_tests.cpp
+++ b/Code/GraphMol/Depictor/catch_tests.cpp
@@ -236,3 +236,86 @@ TEST_CASE("dative bonds and rings") {
   auto v2 = conf.getAtomPos(1) - conf.getAtomPos(8);
   CHECK_THAT(v1.length(), Catch::Matchers::WithinAbs(v2.length(), 0.01));
 }
+
+TEST_CASE("vicinal R groups can match an aromatic ring") {
+  auto benzene = R"CTAB(
+  MJ201100                      
+
+  8  8  0  0  0  0  0  0  0  0999 V2000
+   -1.0263   -0.3133    0.0000 R#  0  0  0  0  0  0  0  0  0  0  0  0
+   -2.4553    0.5116    0.0000 R#  0  0  0  0  0  0  0  0  0  0  0  0
+   -1.7408   -0.7258    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -1.7408   -1.5509    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -2.4553   -1.9633    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -3.1698   -1.5509    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -3.1698   -0.7258    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -2.4553   -0.3133    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+  3  1  1  0  0  0  0
+  8  2  1  0  0  0  0
+  4  3  2  0  0  0  0
+  5  4  1  0  0  0  0
+  6  5  2  0  0  0  0
+  7  6  1  0  0  0  0
+  8  3  1  0  0  0  0
+  8  7  2  0  0  0  0
+M  RGP  2   1   2   2   1
+M  END)CTAB"_ctab;
+  REQUIRE(benzene);
+  auto biphenyl = R"CTAB(
+  MJ201100                      
+
+ 14 15  0  0  0  0  0  0  0  0999 V2000
+   -0.6027    2.4098    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -1.3171    1.9973    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -1.3171    1.1722    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -0.6027    0.7597    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    0.1117    1.1722    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    0.1117    1.9973    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -0.6027   -0.0652    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -1.3171   -0.4777    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -1.3171   -1.3028    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -0.6028   -1.7153    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    0.1117   -1.3028    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    0.1117   -0.4777    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -2.0316    0.7597    0.0000 R#  0  0  0  0  0  0  0  0  0  0  0  0
+   -2.0316   -0.0652    0.0000 R#  0  0  0  0  0  0  0  0  0  0  0  0
+  1  2  2  0  0  0  0
+  2  3  1  0  0  0  0
+  3  4  2  0  0  0  0
+  4  5  1  0  0  0  0
+  5  6  2  0  0  0  0
+  6  1  1  0  0  0  0
+  4  7  1  0  0  0  0
+  8  9  1  0  0  0  0
+  9 10  2  0  0  0  0
+ 10 11  1  0  0  0  0
+ 11 12  2  0  0  0  0
+  7  8  2  0  0  0  0
+ 12  7  1  0  0  0  0
+  3 13  1  0  0  0  0
+  8 14  1  0  0  0  0
+M  RGP  2  13   1  14   2
+M  END)CTAB"_ctab;
+  REQUIRE(biphenyl);
+  SECTION("R groups on benzene match quinoxaline") {
+    auto quinoxaline = "c1ccc2nccnc2c1"_smiles;
+    REQUIRE(quinoxaline);
+    auto match = RDDepict::generateDepictionMatching2DStructure(
+      *quinoxaline, *benzene, -1, nullptr, false, false, true);
+    CHECK(match.size() == 8);
+  }
+  SECTION("R groups on benzene match tetralin") {
+    auto tetralin = "c1cccc2CCCCc12"_smiles;
+    REQUIRE(tetralin);
+    auto match = RDDepict::generateDepictionMatching2DStructure(
+      *tetralin, *benzene, -1, nullptr, false, false, true);
+    CHECK(match.size() == 8);
+  }
+  SECTION("R groups on biphenyl match phenantridine") {
+    auto phenantridine = "c1cccc2ncc3ccccc3c12"_smiles;
+    REQUIRE(phenantridine);
+    auto match = RDDepict::generateDepictionMatching2DStructure(
+      *phenantridine, *biphenyl, -1, nullptr, false, false, true);
+    CHECK(match.size() == 14);
+  }
+}

--- a/Code/GraphMol/Substruct/SubstructUtils.cpp
+++ b/Code/GraphMol/Substruct/SubstructUtils.cpp
@@ -42,13 +42,12 @@ class ScoreMatchesByDegreeOfCoreSubstitution {
         d_minIdx(-1),
         d_isSorted(false) {
     PRECONDITION(!matches.empty(), "matches must not be empty");
-    for (unsigned int i = 0; i < d_mol.getNumAtoms(); ++i) {
-      d_sumIndices += static_cast<double>(i);
-    }
+    auto na = d_mol.getNumAtoms();
+    d_sumIndices = static_cast<double>(na * (na + 1) / 2);
     unsigned int i = 0;
     d_matchIdxVsScore.reserve(d_matches.size());
     for (const auto &match : d_matches) {
-      d_matchIdxVsScore.emplace_back(std::make_pair(i++, computeScore(match)));
+      d_matchIdxVsScore.emplace_back(i++, computeScore(match));
     }
   }
   const RDKit::MatchVectType &getMostSubstitutedCoreMatch() {

--- a/Code/MinimalLib/cffi_test.c
+++ b/Code/MinimalLib/cffi_test.c
@@ -2037,6 +2037,93 @@ void test_query_colour() {
   free(pkl);
 }
 
+void test_alignment_r_groups_aromatic_ring() {
+  printf("--------------------------\n");
+  printf("  test_alignment_r_groups_aromatic_ring\n");
+  char *mpkl;
+  size_t mpkl_size;
+  char *tpkl;
+  size_t tpkl_size;
+  char *match_json = NULL;
+  mpkl = get_mol("c1ccc2nccnc2c1", &mpkl_size, "");
+  assert(mpkl);
+  assert(mpkl_size > 0);
+  tpkl = get_mol(
+      "\n\
+  MJ201100                      \n\
+\n\
+  8  8  0  0  0  0  0  0  0  0999 V2000\n\
+   -1.0263   -0.3133    0.0000 R#  0  0  0  0  0  0  0  0  0  0  0  0\n\
+   -2.4553    0.5116    0.0000 R#  0  0  0  0  0  0  0  0  0  0  0  0\n\
+   -1.7408   -0.7258    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n\
+   -1.7408   -1.5509    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n\
+   -2.4553   -1.9633    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n\
+   -3.1698   -1.5509    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n\
+   -3.1698   -0.7258    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n\
+   -2.4553   -0.3133    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n\
+  3  1  1  0  0  0  0\n\
+  8  2  1  0  0  0  0\n\
+  4  3  2  0  0  0  0\n\
+  5  4  1  0  0  0  0\n\
+  6  5  2  0  0  0  0\n\
+  7  6  1  0  0  0  0\n\
+  8  3  1  0  0  0  0\n\
+  8  7  2  0  0  0  0\n\
+M  RGP  2   1   2   2   1\n\
+M  END\n",
+      &tpkl_size, "");
+  assert(tpkl);
+  assert(tpkl_size > 0);
+  assert(set_2d_coords_aligned(
+      &mpkl, &mpkl_size, tpkl, tpkl_size,
+      "{\"acceptFailure\":false,\"allowRGroups\":true}", &match_json));
+  assert(match_json);
+  assert(!strcmp(match_json,
+                 "{\"atoms\":[4,7,3,2,1,0,9,8],\"bonds\":[3,7,2,1,0,9,10,8]}"));
+  free(match_json);
+  free(mpkl);
+  mpkl = get_mol(
+      "\n\
+  MJ201100                      \n\
+\n\
+ 10 11  0  0  0  0  0  0  0  0999 V2000\n\
+    3.6937    2.5671    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n\
+    2.8687    2.5671    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n\
+    2.4561    1.8526    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n\
+    2.8687    1.1382    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n\
+    3.6937    1.1381    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n\
+    4.1062    1.8526    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n\
+    4.9313    1.8527    0.0000 N   0  0  0  0  0  0  0  0  0  0  0  0\n\
+    5.3438    2.5671    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n\
+    4.9313    3.2816    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n\
+    4.1062    3.2816    0.0000 N   0  0  0  0  0  0  0  0  0  0  0  0\n\
+  5  6  1  0  0  0  0\n\
+  4  5  2  0  0  0  0\n\
+  3  4  1  0  0  0  0\n\
+  2  3  2  0  0  0  0\n\
+  1  6  2  0  0  0  0\n\
+  1  2  1  0  0  0  0\n\
+  8  9  1  0  0  0  0\n\
+  9 10  2  0  0  0  0\n\
+ 10  1  1  0  0  0  0\n\
+  7  8  2  0  0  0  0\n\
+  6  7  1  0  0  0  0\n\
+M  END\n",
+      &mpkl_size, "");
+  assert(mpkl);
+  assert(mpkl_size > 0);
+  assert(set_2d_coords_aligned(
+      &mpkl, &mpkl_size, tpkl, tpkl_size,
+      "{\"acceptFailure\":false,\"allowRGroups\":true,\"alignOnly\":true}",
+      &match_json));
+  assert(match_json);
+  assert(!strcmp(match_json,
+                 "{\"atoms\":[6,9,5,4,3,2,1,0],\"bonds\":[10,8,0,1,2,3,4,5]}"));
+  free(match_json);
+  free(mpkl);
+  free(tpkl);
+}
+
 int main() {
   enable_logging();
   char *vers = version();
@@ -2061,5 +2148,6 @@ int main() {
   test_use_legacy_stereo();
   test_allow_non_tetrahedral_chirality();
   test_query_colour();
+  test_alignment_r_groups_aromatic_ring();
   return 0;
 }

--- a/Code/MinimalLib/tests/tests.js
+++ b/Code/MinimalLib/tests/tests.js
@@ -823,7 +823,6 @@ M  END
 
 function test_has_coords() {
     var mol = RDKitModule.get_mol('CC');
-    console.log(`1) test_has_coords`);
     assert(!mol.has_coords());
     var mol2 = RDKitModule.get_mol(mol.get_new_coords());
     assert(mol2.has_coords() === 2);
@@ -854,7 +853,7 @@ function test_has_coords() {
   3  9  1  0
 M  END
 `);
-assert(mol3.has_coords() === 3);
+    assert(mol3.has_coords() === 3);
 }
 
 function test_kekulize() {
@@ -1794,8 +1793,9 @@ M  END
 }
 
 function test_query_colour() {
-    var mol = RDKitModule.get_qmol('c1ccc2nc([*:1])nc([*:2])c2c1');
+    var mol;
     try {
+        mol = RDKitModule.get_qmol('c1ccc2nc([*:1])nc([*:2])c2c1');
         var svg1 = mol.get_svg_with_highlights(JSON.stringify({width: 350, height: 300}));
         assert(svg1.includes("width='350px'"));
         assert(svg1.includes("height='300px'"));
@@ -1807,7 +1807,88 @@ function test_query_colour() {
         assert(svg2.includes("</svg>"));
         assert(!svg2.includes("#7F7F7F"));
     } finally {
-        mol.delete();
+        if (mol) {
+            mol.delete();
+        }
+    }
+}
+
+function test_alignment_r_groups_aromatic_ring() {
+    var mol;
+    var scaffold;
+    try {
+        mol = RDKitModule.get_mol('c1ccc2nccnc2c1');
+        assert(mol && mol.is_valid());
+        scaffold = RDKitModule.get_mol(`
+  MJ201100                      
+
+  8  8  0  0  0  0  0  0  0  0999 V2000
+   -1.0263   -0.3133    0.0000 R#  0  0  0  0  0  0  0  0  0  0  0  0
+   -2.4553    0.5116    0.0000 R#  0  0  0  0  0  0  0  0  0  0  0  0
+   -1.7408   -0.7258    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -1.7408   -1.5509    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -2.4553   -1.9633    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -3.1698   -1.5509    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -3.1698   -0.7258    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -2.4553   -0.3133    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+  3  1  1  0  0  0  0
+  8  2  1  0  0  0  0
+  4  3  2  0  0  0  0
+  5  4  1  0  0  0  0
+  6  5  2  0  0  0  0
+  7  6  1  0  0  0  0
+  8  3  1  0  0  0  0
+  8  7  2  0  0  0  0
+M  RGP  2   1   2   2   1
+M  END`);
+        assert(scaffold && scaffold.is_valid());
+        var res = mol.generate_aligned_coords(scaffold, JSON.stringify({useCoordGen: true, allowRGroups: true}));
+        assert(res);
+        assert.equal(JSON.parse(res).atoms.length, 8);
+        assert.equal(JSON.parse(res).bonds.length, 8);
+    } finally {
+        if (mol) {
+            mol.delete();
+        }
+    }
+    try {
+        mol = RDKitModule.get_mol(`
+  MJ201100                      
+
+ 10 11  0  0  0  0  0  0  0  0999 V2000
+    3.6937    2.5671    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    2.8687    2.5671    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    2.4561    1.8526    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    2.8687    1.1382    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    3.6937    1.1381    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    4.1062    1.8526    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    4.9313    1.8527    0.0000 N   0  0  0  0  0  0  0  0  0  0  0  0
+    5.3438    2.5671    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    4.9313    3.2816    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    4.1062    3.2816    0.0000 N   0  0  0  0  0  0  0  0  0  0  0  0
+  5  6  1  0  0  0  0
+  4  5  2  0  0  0  0
+  3  4  1  0  0  0  0
+  2  3  2  0  0  0  0
+  1  6  2  0  0  0  0
+  1  2  1  0  0  0  0
+  8  9  1  0  0  0  0
+  9 10  2  0  0  0  0
+ 10  1  1  0  0  0  0
+  7  8  2  0  0  0  0
+  6  7  1  0  0  0  0
+M  END`);
+        var res = mol.generate_aligned_coords(scaffold, JSON.stringify({allowRGroups: true, alignOnly: true}));
+        assert(res);
+        assert.equal(JSON.parse(res).atoms.length, 8);
+        assert.equal(JSON.parse(res).bonds.length, 8);
+    } finally {
+        if (mol) {
+            mol.delete();
+        }
+        if (scaffold) {
+            scaffold.delete();
+        }
     }
 }
 
@@ -1864,6 +1945,7 @@ initRDKitModule().then(function(instance) {
     test_get_frags();
     test_hs_in_place();
     test_query_colour();
+    test_alignment_r_groups_aromatic_ring();
     waitAllTestsFinished().then(() =>
         console.log("Tests finished successfully")
     );


### PR DESCRIPTION
`generateDepictionMatching2DStructure` has an `allowOptionalAttachments` parameter which allows using scaffold bearing R groups. However, in most cases the bonds connecting R groups to the scaffold are single bonds, which won't match aromatic bonds. This is undesirable as the goal is to make depictions as consistent as possible in a SAR table to facilitate reading.
This PR corrects this by allowing single bonds from aromatic rings to R groups to match single or aromatic bonds using the existing `AdjustQueryParameters`.