### PR TITLE
Fixes #6312: reduces the size of molecule pickles which include atom and bond properties

### DIFF
--- a/Code/GraphMol/CMakeLists.txt
+++ b/Code/GraphMol/CMakeLists.txt
@@ -189,3 +189,6 @@ rdkit_catch_test(moliteratorTestsCatch catch_moliterators.cpp
 
 rdkit_catch_test(queryTestsCatch catch_queries.cpp
         LINK_LIBRARIES SmilesParse GraphMol)
+
+rdkit_catch_test(pickleTestsCatch catch_pickles.cpp
+        LINK_LIBRARIES FileParsers SmilesParse GraphMol)

--- a/Code/GraphMol/MolPickler.cpp
+++ b/Code/GraphMol/MolPickler.cpp
@@ -162,10 +162,13 @@ std::vector<std::pair<std::string, std::uint16_t>> explicitAtomProps = {
     {common_properties::molStereoCare, 0x1},
     {common_properties::molParity, 0x2},
     {common_properties::molInversionFlag, 0x4},
+    {common_properties::_ChiralityPossible, 0x8},
+
 };
-std::vector<std::string> ignoreAtomProps =
-    {  // common_properties::molAtomMapNumber,
-        common_properties::dummyLabel};
+std::vector<std::string> ignoreAtomProps = {
+    common_properties::molAtomMapNumber,
+    common_properties::dummyLabel,
+};
 
 bool pickleAtomProperties(std::ostream &ss, const RDProps &props,
                           unsigned int pickleFlags) {
@@ -173,6 +176,9 @@ bool pickleAtomProperties(std::ostream &ss, const RDProps &props,
   if (ignoreProps.empty()) {
     for (const auto &pr : explicitAtomProps) {
       ignoreProps.insert(pr.first);
+    }
+    for (const auto &pn : ignoreAtomProps) {
+      ignoreProps.insert(pn);
     }
   }
 
@@ -191,10 +197,10 @@ bool pickleAtomProperties(std::ostream &ss, const RDProps &props,
 void unpickleAtomProperties(std::istream &ss, RDProps &props, int version) {
   if (version >= 14000) {
     streamReadProps<std::uint16_t>(ss, props,
-                                   MolPickler::getCustomPropHandlers());
+                                   MolPickler::getCustomPropHandlers(), false);
   } else {
     streamReadProps<unsigned int>(ss, props,
-                                  MolPickler::getCustomPropHandlers());
+                                  MolPickler::getCustomPropHandlers(), false);
   }
   unpickleExplicitProperties<std::int16_t, int>(ss, props, version,
                                                 explicitAtomProps);
@@ -232,10 +238,10 @@ bool pickleBondProperties(std::ostream &ss, const RDProps &props,
 void unpickleBondProperties(std::istream &ss, RDProps &props, int version) {
   if (version >= 14000) {
     streamReadProps<std::uint16_t>(ss, props,
-                                   MolPickler::getCustomPropHandlers());
+                                   MolPickler::getCustomPropHandlers(), false);
   } else {
     streamReadProps<unsigned int>(ss, props,
-                                  MolPickler::getCustomPropHandlers());
+                                  MolPickler::getCustomPropHandlers(), false);
   }
   unpickleExplicitProperties<std::int8_t, int>(ss, props, version,
                                                explicitBondProps);

--- a/Code/GraphMol/MolPickler.h
+++ b/Code/GraphMol/MolPickler.h
@@ -286,7 +286,8 @@ class RDKIT_GRAPHMOL_EXPORT MolPickler {
   static void _pickleProperties(std::ostream &ss, const RDProps &props,
                                 unsigned int pickleFlags);
   //! unpickle standard properties
-  static void _unpickleProperties(std::istream &ss, RDProps &props);
+  static void _unpickleProperties(std::istream &ss, RDProps &props,
+                                  int version);
 
   //! backwards compatibility
   static void _pickleV1(const ROMol *mol, std::ostream &ss);

--- a/Code/GraphMol/catch_pickles.cpp
+++ b/Code/GraphMol/catch_pickles.cpp
@@ -97,6 +97,9 @@ M  END)CTAB"_ctab;
                               PicklerOps::PropertyPickleOptions::PrivateProps);
 
     CHECK(pkl.size() > basepkl.size());
+    // make sure the property names aren't in the pickle
+    CHECK(pkl.find(common_properties::_MolFileBondType) == std::string::npos);
+    CHECK(pkl.find(common_properties::_MolFileBondCfg) == std::string::npos);
     // std::cerr << "!!!! " << pkl.size() << " " << basepkl.size() << std::endl;
 
     RWMol mol2(pkl);
@@ -151,7 +154,6 @@ M  END
                               PicklerOps::PropertyPickleOptions::PrivateProps);
 
     CHECK(pkl.size() > basepkl.size());
-    std::cerr << "!!!! " << pkl.size() << " " << basepkl.size() << std::endl;
 
     RWMol mol2(pkl);
     CHECK(mol2.getAtomWithIdx(0)->getProp<int>(common_properties::molParity) ==

--- a/Code/GraphMol/catch_pickles.cpp
+++ b/Code/GraphMol/catch_pickles.cpp
@@ -1,0 +1,116 @@
+//
+//  Copyright (C) 2023 Greg Landrum and other RDKit contributors
+//
+//   @@ All Rights Reserved @@
+//  This file is part of the RDKit.
+//  The contents are covered by the terms of the BSD license
+//  which is included in the file license.txt, found at the root
+//  of the RDKit source tree.
+//
+
+#include "catch.hpp"
+
+#include <algorithm>
+#include <limits>
+#include <fstream>
+
+#include <GraphMol/RDKitBase.h>
+#include <GraphMol/MolPickler.h>
+#include <GraphMol/FileParsers/FileParsers.h>
+#include <GraphMol/SmilesParse/SmilesParse.h>
+#include <GraphMol/SmilesParse/SmilesWrite.h>
+
+using namespace RDKit;
+TEST_CASE("Github #6312: space overhead of serializing properties") {
+  SECTION("Bonds v2000") {
+    auto mol = R"CTAB(
+  Mrv1810 02111915042D          
+
+  4  3  0  0  0  0            999 V2000
+   -1.5625    1.6071    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -0.8480    2.0196    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -2.2770    2.0196    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -1.5625    0.7821    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+  1  3  1  0  0  0  0
+  1  2  6  0  0  0  0
+  1  4  1  1  0  0  0
+M  END)CTAB"_ctab;
+    REQUIRE(mol);
+    CHECK(mol->getBondWithIdx(1)->getProp<unsigned int>(
+              common_properties::_MolFileBondType) == 6);
+    CHECK(mol->getBondWithIdx(2)->getProp<unsigned int>(
+              common_properties::_MolFileBondType) == 1);
+    CHECK(mol->getBondWithIdx(2)->getProp<unsigned int>(
+              common_properties::_MolFileBondStereo) == 1);
+    // mol->getBondWithIdx(2)->setProp<std::string>("foo", "bar");
+
+    std::string basepkl;
+    MolPickler::pickleMol(*mol, basepkl);
+
+    std::string pkl;
+    MolPickler::pickleMol(*mol, pkl,
+                          PicklerOps::PropertyPickleOptions::BondProps |
+                              PicklerOps::PropertyPickleOptions::PrivateProps);
+
+    CHECK(pkl.size() > basepkl.size());
+    std::cerr << "!!!! " << pkl.size() << " " << basepkl.size() << std::endl;
+
+    RWMol mol2(pkl);
+    CHECK(mol2.getBondWithIdx(1)->getProp<unsigned int>(
+              common_properties::_MolFileBondType) == 6);
+    CHECK(mol2.getBondWithIdx(2)->getProp<unsigned int>(
+              common_properties::_MolFileBondType) == 1);
+    CHECK(mol2.getBondWithIdx(2)->getProp<unsigned int>(
+              common_properties::_MolFileBondStereo) == 1);
+    // CHECK(mol2.getBondWithIdx(2)->getProp<std::string>("foo") == "bar");
+  }
+  SECTION("basics-v3k") {
+    auto mol = R"CTAB(
+  Mrv1810 02111915102D          
+
+  0  0  0     0  0            999 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 4 3 0 0 0
+M  V30 BEGIN ATOM
+M  V30 1 C -2.9167 3 0 0
+M  V30 2 C -1.583 3.77 0 0
+M  V30 3 C -4.2503 3.77 0 0
+M  V30 4 C -2.9167 1.46 0 0
+M  V30 END ATOM
+M  V30 BEGIN BOND
+M  V30 1 1 1 3
+M  V30 2 6 1 2
+M  V30 3 1 1 4 CFG=1
+M  V30 END BOND
+M  V30 END CTAB
+M  END)CTAB"_ctab;
+    REQUIRE(mol);
+    CHECK(mol->getBondWithIdx(1)->getProp<unsigned int>(
+              common_properties::_MolFileBondType) == 6);
+    CHECK(mol->getBondWithIdx(2)->getProp<unsigned int>(
+              common_properties::_MolFileBondType) == 1);
+    CHECK(mol->getBondWithIdx(2)->getProp<unsigned int>(
+              common_properties::_MolFileBondCfg) == 1);
+    mol->getBondWithIdx(2)->setProp<std::string>("foo", "bar");
+
+    std::string basepkl;
+    MolPickler::pickleMol(*mol, basepkl);
+
+    std::string pkl;
+    MolPickler::pickleMol(*mol, pkl,
+                          PicklerOps::PropertyPickleOptions::BondProps |
+                              PicklerOps::PropertyPickleOptions::PrivateProps);
+
+    CHECK(pkl.size() > basepkl.size());
+    std::cerr << "!!!! " << pkl.size() << " " << basepkl.size() << std::endl;
+
+    RWMol mol2(pkl);
+    CHECK(mol2.getBondWithIdx(1)->getProp<unsigned int>(
+              common_properties::_MolFileBondType) == 6);
+    CHECK(mol2.getBondWithIdx(2)->getProp<unsigned int>(
+              common_properties::_MolFileBondType) == 1);
+    CHECK(mol2.getBondWithIdx(2)->getProp<unsigned int>(
+              common_properties::_MolFileBondCfg) == 1);
+    CHECK(mol2.getBondWithIdx(2)->getProp<std::string>("foo") == "bar");
+  }
+}

--- a/Code/GraphMol/catch_pickles.cpp
+++ b/Code/GraphMol/catch_pickles.cpp
@@ -42,7 +42,6 @@ M  END)CTAB"_ctab;
               common_properties::_MolFileBondType) == 1);
     CHECK(mol->getBondWithIdx(2)->getProp<unsigned int>(
               common_properties::_MolFileBondStereo) == 1);
-    // mol->getBondWithIdx(2)->setProp<std::string>("foo", "bar");
 
     std::string basepkl;
     MolPickler::pickleMol(*mol, basepkl);
@@ -51,9 +50,7 @@ M  END)CTAB"_ctab;
     MolPickler::pickleMol(*mol, pkl,
                           PicklerOps::PropertyPickleOptions::BondProps |
                               PicklerOps::PropertyPickleOptions::PrivateProps);
-
-    CHECK(pkl.size() > basepkl.size());
-    std::cerr << "!!!! " << pkl.size() << " " << basepkl.size() << std::endl;
+    // std::cerr << "!!!! " << pkl.size() << " " << basepkl.size() << std::endl;
 
     RWMol mol2(pkl);
     CHECK(mol2.getBondWithIdx(1)->getProp<unsigned int>(
@@ -62,9 +59,8 @@ M  END)CTAB"_ctab;
               common_properties::_MolFileBondType) == 1);
     CHECK(mol2.getBondWithIdx(2)->getProp<unsigned int>(
               common_properties::_MolFileBondStereo) == 1);
-    // CHECK(mol2.getBondWithIdx(2)->getProp<std::string>("foo") == "bar");
   }
-  SECTION("basics-v3k") {
+  SECTION("bonds-v3k") {
     auto mol = R"CTAB(
   Mrv1810 02111915102D          
 
@@ -91,7 +87,6 @@ M  END)CTAB"_ctab;
               common_properties::_MolFileBondType) == 1);
     CHECK(mol->getBondWithIdx(2)->getProp<unsigned int>(
               common_properties::_MolFileBondCfg) == 1);
-    mol->getBondWithIdx(2)->setProp<std::string>("foo", "bar");
 
     std::string basepkl;
     MolPickler::pickleMol(*mol, basepkl);
@@ -102,7 +97,7 @@ M  END)CTAB"_ctab;
                               PicklerOps::PropertyPickleOptions::PrivateProps);
 
     CHECK(pkl.size() > basepkl.size());
-    std::cerr << "!!!! " << pkl.size() << " " << basepkl.size() << std::endl;
+    // std::cerr << "!!!! " << pkl.size() << " " << basepkl.size() << std::endl;
 
     RWMol mol2(pkl);
     CHECK(mol2.getBondWithIdx(1)->getProp<unsigned int>(
@@ -111,6 +106,5 @@ M  END)CTAB"_ctab;
               common_properties::_MolFileBondType) == 1);
     CHECK(mol2.getBondWithIdx(2)->getProp<unsigned int>(
               common_properties::_MolFileBondCfg) == 1);
-    CHECK(mol2.getBondWithIdx(2)->getProp<std::string>("foo") == "bar");
   }
 }

--- a/Code/RDGeneral/StreamOps.h
+++ b/Code/RDGeneral/StreamOps.h
@@ -624,15 +624,19 @@ inline bool streamReadProp(std::istream &ss, Dict::Pair &pair,
 
 template <typename COUNT_TYPE = unsigned int>
 inline unsigned int streamReadProps(std::istream &ss, RDProps &props,
-                                    const CustomPropHandlerVec &handlers = {}) {
+                                    const CustomPropHandlerVec &handlers = {},
+                                    bool reset = true) {
   COUNT_TYPE count;
   streamRead(ss, count);
 
   Dict &dict = props.getDict();
-  dict.reset();  // Clear data before repopulating
-  dict.getData().resize(count);
+  if (reset) {
+    dict.reset();  // Clear data before repopulating
+  }
+  auto startSz = dict.getData().size();
+  dict.getData().resize(startSz + count);
   for (unsigned index = 0; index < count; ++index) {
-    CHECK_INVARIANT(streamReadProp(ss, dict.getData()[index],
+    CHECK_INVARIANT(streamReadProp(ss, dict.getData()[startSz + index],
                                    dict.getNonPODStatus(), handlers),
                     "Corrupted property serialization detected");
   }

--- a/Code/RDGeneral/StreamOps.h
+++ b/Code/RDGeneral/StreamOps.h
@@ -481,6 +481,7 @@ inline bool streamWriteProp(std::ostream &ss, const Dict::Pair &pair,
   return true;
 }
 
+template <typename COUNT_TYPE = unsigned int>
 inline bool streamWriteProps(
     std::ostream &ss, const RDProps &props, bool savePrivate = false,
     bool saveComputed = false, const CustomPropHandlerVec &handlers = {},
@@ -494,7 +495,7 @@ inline bool streamWriteProps(
   }
 
   const Dict &dict = props.getDict();
-  unsigned int count = 0;
+  COUNT_TYPE count = 0;
   for (const auto &elem : dict.getData()) {
     if (propnames.find(elem.key) != propnames.end()) {
       if (isSerializable(elem, handlers)) {
@@ -502,10 +503,12 @@ inline bool streamWriteProps(
       }
     }
   }
-
   streamWrite(ss, count);  // packed int?
+  if (!count) {
+    return false;
+  }
 
-  unsigned int writtenCount = 0;
+  COUNT_TYPE writtenCount = 0;
   for (const auto &elem : dict.getData()) {
     if (propnames.find(elem.key) != propnames.end()) {
       if (isSerializable(elem, handlers)) {
@@ -619,9 +622,10 @@ inline bool streamReadProp(std::istream &ss, Dict::Pair &pair,
   return true;
 }
 
+template <typename COUNT_TYPE = unsigned int>
 inline unsigned int streamReadProps(std::istream &ss, RDProps &props,
                                     const CustomPropHandlerVec &handlers = {}) {
-  unsigned int count;
+  COUNT_TYPE count;
   streamRead(ss, count);
 
   Dict &dict = props.getDict();
@@ -633,7 +637,7 @@ inline unsigned int streamReadProps(std::istream &ss, RDProps &props,
                     "Corrupted property serialization detected");
   }
 
-  return count;
+  return static_cast<unsigned int>(count);
 }
 
 }  // namespace RDKit


### PR DESCRIPTION
The code changes aren't all that complex: storing key-value pairs is expensive, so we recognize particular keys when present and store then differently.

Using this scheme storing the private properties for atoms and bonds on the 1000 ChEMBL molecules I looked at in the discussion of #6312 looks like this:
```
In [6]: len(b''.join([x.ToBinary() for x in ms]))
Out[6]: 1578735

In [7]: len(b''.join([x.ToBinary(Chem.PropertyPickleOptions.AtomProps|Chem.PropertyPickleOptions.BondProps|Chem.PropertyPickleOption
   ...: s.PrivateProps) for x in ms]))
Out[7]: 2184606
```
Previously just storing either the atom or bond properties was larger than that.

Adding computed properties still takes a lot of space:
```
In [8]: len(b''.join([x.ToBinary(Chem.PropertyPickleOptions.AtomProps|Chem.PropertyPickleOptions.BondProps|Chem.PropertyPickleOption
   ...: s.PrivateProps|Chem.PropertyPickleOptions.ComputedProps) for x in ms]))
Out[8]: 5731323
```
But that's more or less inevitable due to the vector of computed property names which is currently being stored.

We could work around that, but I wonder if it's worth it.