### PR TITLE
add DebugDraw() function

### DIFF
--- a/rdkit/Chem/Draw/__init__.py
+++ b/rdkit/Chem/Draw/__init__.py
@@ -704,6 +704,40 @@ def MolToQPixmap(mol, size=(300, 300), kekulize=True, wedgeBonds=True, fitImage=
   return canvas.pixmap
 
 
+def DebugDraw(mol, size=(350, 350), drawer=None, asSVG=True, useBW=True, includeHLabels=True,
+              addAtomIndices=True, addBondIndices=False):
+  if drawer is None:
+    if asSVG:
+      drawer = rdMolDraw2D.MolDraw2DSVG(size[0], size[1])
+    else:
+      drawer = rdMolDraw2D.MolDraw2DCairo(size[0], size[1])
+  if useBW:
+    drawer.drawOptions().useBWAtomPalette()
+
+  drawer.drawOptions().addAtomIndices = addAtomIndices
+  drawer.drawOptions().addBondIndices = addBondIndices
+
+  drawer.drawOptions().annotationFontScale = 0.75
+
+  if includeHLabels:
+    for atom in mol.GetAtoms():
+      if atom.GetTotalNumHs():
+        atom.SetProp('atomNote', f'H{atom.GetTotalNumHs()}')
+
+  aromAtoms = [x.GetIdx() for x in mol.GetAtoms() if x.GetIsAromatic()]
+  clrs = {x: (.9, .9, .2) for x in aromAtoms}
+  aromBonds = [x.GetIdx() for x in mol.GetBonds() if x.GetIsAromatic()]
+
+  rdMolDraw2D.PrepareMolForDrawing(mol, kekulize=False, addChiralHs=False)
+  drawer.drawOptions().prepareMolsBeforeDrawing = False
+
+  drawer.DrawMolecule(mol, highlightAtoms=aromAtoms, highlightAtomColors=clrs,
+                      highlightBonds=aromBonds)
+
+  drawer.FinishDrawing()
+  return drawer.GetDrawingText()
+
+
 def DrawMorganBit(mol, bitId, bitInfo, whichExample=0, **kwargs):
   atomId, radius = bitInfo[bitId][whichExample]
   return DrawMorganEnv(mol, atomId, radius, **kwargs)


### PR DESCRIPTION
Adds a graphical equivalent of the Debug() function. Here's what the output looks like:

![image](https://user-images.githubusercontent.com/540511/236237526-bc79d362-f1a9-46f1-8d09-a3e3c4ba4064.png)

I think that having this easily available in Draw will really help when the code isn't behaving as people expect it to.

Feedback on what should be added is very welcome!