### PR TITLE
take drawOptions into account when exporting structure to xlsx format

### DIFF
--- a/rdkit/Chem/PandasTools.py
+++ b/rdkit/Chem/PandasTools.py
@@ -543,7 +543,7 @@ def SaveXlsxFromFrame(frame, outFile, molCol='ROMol', size=(300, 300), formats=N
       if col_idx in molCol_indices:
         image_data = BytesIO()
         m = row[col]
-        img = Draw.MolToImage(m if isinstance(m, Chem.Mol) else Chem.Mol(), size=size)
+        img = Draw.MolToImage(m if isinstance(m, Chem.Mol) else Chem.Mol(), size=size, options=drawOptions)
         img.save(image_data, format='PNG')
         worksheet.insert_image(row_idx_actual, col_idx, "f", {'image_data': image_data})
         worksheet.set_column(col_idx, col_idx,


### PR DESCRIPTION
This is a really tiny one. Currently `IPythonConsole.drawOptions` are being ignored when exporting a `pandas` dataframe to `xlsx` format with `SaveXlsxFromFrame()`. This PR corrects that.