### PR TITLE
Fix swig memory leak

### DIFF
--- a/Code/GraphMol/FilterCatalog/CMakeLists.txt
+++ b/Code/GraphMol/FilterCatalog/CMakeLists.txt
@@ -7,7 +7,7 @@ endif()
 
 find_package(PythonInterp)
 if (PYTHONINTERP_FOUND)
-  if(${PYTHON_VERSION_STRING} VERSION_GREATER "2.6" )
+  if(DEFINED ${PYTHON_VERSION_STRING} AND ${PYTHON_VERSION_STRING} VERSION_GREATER "2.6" )
         message("== Updating Filters.cpp from pains file")
         execute_process(
           COMMAND

--- a/Code/JavaWrappers/RWMol.i
+++ b/Code/JavaWrappers/RWMol.i
@@ -48,6 +48,20 @@
 %ignore RDKit::RWMol::addAtom(Atom *atom,bool updateLabel,bool takeOwnership);
 %ignore RDKit::RWMol::addBond(Bond *bond,bool takeOwnership);
 
+%newobject RDKit::SmilesToMol;
+%newobject RDKit::SmartsToMol;
+%newobject RDKit::MolBlockToMol;
+%newobject RDKit::MolFileToMol;
+%newobject RDKit::MolFromMolFile;
+%newobject RDKit::MolFromTPLFIle;
+%newobject RDKit::MolFromMol2File;
+%newobject RDKit::MolFromMol2Block;
+%newobject RDKit::MolFromPDBBlock;
+%newobject RDKit::MolFromPDBFile;
+%newobject RDKit::MolFromSequence;
+%newobject RDKit::MolFromFasta;
+
+
 %shared_ptr(RDKit::RWMol)
 %include "enums.swg"
 #if swifjava

--- a/Code/JavaWrappers/csharp_wrapper/RDKitCSharpTest/ToMolMemoryTest.cs
+++ b/Code/JavaWrappers/csharp_wrapper/RDKitCSharpTest/ToMolMemoryTest.cs
@@ -1,0 +1,85 @@
+﻿using System;
+using System.Diagnostics;
+using GraphMolWrap;
+using Xunit;
+
+namespace RdkitTests
+{
+    public class ToMolMemoryTest
+    {
+        private static readonly long hundredMB = 1024 * 1024 * 100;
+
+        private static void gc()
+        {
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
+        }
+
+
+        [Fact]
+        public void TestSmilesToMolMemoryUsage()
+        {
+            string smi =
+                "CC(C)C[C@H](NC(=O)[C@H](CC(=O)O)NC(=O)[C@H](Cc1ccccc1)NC(=O)[C@H](CO)NC(=O)[C@@H]1CCCN1C(=O)[C@H](CCC(N)=O)NC(=O)[C@@H](N)CS)C(=O)N[C@@H](CCC(N)=O)C(=O)N[C@@H](CS)C(=O)O";
+
+            var before = Process.GetCurrentProcess().VirtualMemorySize64;
+            long after;
+            for (int i = 0; i < 10000; ++i)
+            {
+                using RWMol mol = RDKFuncs.SmilesToMol(smi);
+                mol?.Dispose();
+                if (i % 1000 == 0)
+                {
+                    gc();
+                    after = Process.GetCurrentProcess().VirtualMemorySize64;
+                    Assert.True(after - before < hundredMB);
+                }
+            }
+
+            gc();
+            after = Process.GetCurrentProcess().VirtualMemorySize64;
+            Assert.True(after - before < hundredMB);
+        }
+
+        [Fact]
+        public void TestMolBlockToMolMemoryUsage()
+        {
+            var block = @"
+     RDKit          2D
+
+  6  6  0  0  0  0  0  0  0  0999 V2000
+    1.5000    0.0000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    0.7500   -1.2990    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -0.7500   -1.2990    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -1.5000    0.0000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -0.7500    1.2990    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    0.7500    1.2990    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+  1  2  2  0
+  2  3  1  0
+  3  4  2  0
+  4  5  1  0
+  5  6  2  0
+  6  1  1  0
+M  END
+";
+            var before = Process.GetCurrentProcess().VirtualMemorySize64;
+            long after;
+            for (int i = 0; i < 10000; ++i)
+            {
+                using RWMol mol = RDKFuncs.MolBlockToMol(block);
+                mol?.Dispose();
+                if (i % 1000 == 0)
+                {
+                    gc();
+                    after = Process.GetCurrentProcess().VirtualMemorySize64;
+                    Assert.True(after - before < hundredMB);
+                }
+            }
+
+            gc();
+            after = System.Diagnostics.Process.GetCurrentProcess().PeakVirtualMemorySize64;
+            Assert.True(after - before < hundredMB);
+        }
+    }
+}


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

All the different `*ToMol` methods defined in `RWMol.i` contain memory leaks.

Looking at the generated `GraphMolCSharpCSHARP_wrap.cxx` they all return `boost::shared_ptr` with an empty deleter:

```c++
struct SWIG_null_deleter {
  void operator() (void const *) const {
  }
};
#define SWIG_NO_NULL_DELETER_0 , SWIG_null_deleter()

.....

 jresult = result ? new boost::shared_ptr<  RDKit::RWMol >(result SWIG_NO_NULL_DELETER_0) : 0;
}
```

This is fixed by including `%newobject` statements for the C++ parser functions.

#### Any other comments?

I've included a `C#` test file.

I ran into an error with one of the CMakelists.txt files where `PythonInterp` found a Python executable with no version.  The docs at https://cmake.org/cmake/help/latest/module/FindPythonInterp.html indicate that this is a possibility.

