### PR TITLE
Add inlines to ForceFieldHelpers header functions

### DIFF
--- a/Code/GraphMol/ForceFieldHelpers/FFConvenience.h
+++ b/Code/GraphMol/ForceFieldHelpers/FFConvenience.h
@@ -18,7 +18,7 @@ class ROMol;
 namespace ForceFieldsHelper {
 namespace detail {
 #ifdef RDK_BUILD_THREADSAFE_SSS
-void OptimizeMoleculeConfsHelper_(ForceFields::ForceField ff, ROMol *mol,
+inline void OptimizeMoleculeConfsHelper_(ForceFields::ForceField ff, ROMol *mol,
                                   std::vector<std::pair<int, double>> *res,
                                   unsigned int threadIdx,
                                   unsigned int numThreads, int maxIters) {
@@ -43,7 +43,7 @@ void OptimizeMoleculeConfsHelper_(ForceFields::ForceField ff, ROMol *mol,
   }
 }
 
-void OptimizeMoleculeConfsMT(ROMol &mol, const ForceFields::ForceField &ff,
+inline void OptimizeMoleculeConfsMT(ROMol &mol, const ForceFields::ForceField &ff,
                              std::vector<std::pair<int, double>> &res,
                              int numThreads, int maxIters) {
   std::vector<std::thread> tg;
@@ -59,7 +59,7 @@ void OptimizeMoleculeConfsMT(ROMol &mol, const ForceFields::ForceField &ff,
 }
 #endif
 
-void OptimizeMoleculeConfsST(ROMol &mol, ForceFields::ForceField &ff,
+inline void OptimizeMoleculeConfsST(ROMol &mol, ForceFields::ForceField &ff,
                              std::vector<std::pair<int, double>> &res,
                              int maxIters) {
   PRECONDITION(res.size() >= mol.getNumConformers(),
@@ -90,7 +90,7 @@ void OptimizeMoleculeConfsST(ROMol &mol, ForceFields::ForceField &ff,
   more iterations are required.
      second: the energy
 */
-std::pair<int, double> OptimizeMolecule(ForceFields::ForceField &ff,
+inline std::pair<int, double> OptimizeMolecule(ForceFields::ForceField &ff,
                                         int maxIters = 1000) {
   ff.initialize();
   int res = ff.minimize(maxIters);
@@ -111,7 +111,7 @@ std::pair<int, double> OptimizeMolecule(ForceFields::ForceField &ff,
   \param maxIters   the maximum number of force-field iterations
 
 */
-void OptimizeMoleculeConfs(ROMol &mol, ForceFields::ForceField &ff,
+inline void OptimizeMoleculeConfs(ROMol &mol, ForceFields::ForceField &ff,
                            std::vector<std::pair<int, double>> &res,
                            int numThreads = 1, int maxIters = 1000) {
   res.resize(mol.getNumConformers());

--- a/Code/GraphMol/ForceFieldHelpers/MMFF/MMFF.h
+++ b/Code/GraphMol/ForceFieldHelpers/MMFF/MMFF.h
@@ -42,7 +42,7 @@ namespace MMFF {
   more iterations are required.
      second: the energy
 */
-std::pair<int, double> MMFFOptimizeMolecule(
+inline std::pair<int, double> MMFFOptimizeMolecule(
     ROMol &mol, int maxIters = 1000, std::string mmffVariant = "MMFF94",
     double nonBondedThresh = 10.0, int confId = -1,
     bool ignoreInterfragInteractions = true) {
@@ -79,7 +79,7 @@ std::pair<int, double> MMFFOptimizeMolecule(
                                      fragments
 
 */
-void MMFFOptimizeMoleculeConfs(ROMol &mol,
+inline void MMFFOptimizeMoleculeConfs(ROMol &mol,
                                std::vector<std::pair<int, double>> &res,
                                int numThreads = 1, int maxIters = 1000,
                                std::string mmffVariant = "MMFF94",

--- a/Code/GraphMol/ForceFieldHelpers/UFF/UFF.h
+++ b/Code/GraphMol/ForceFieldHelpers/UFF/UFF.h
@@ -37,7 +37,7 @@ namespace UFF {
      first: 0 if the optimization converged, 1 if more iterations are required.
      second: the energy
 */
-std::pair<int, double> UFFOptimizeMolecule(
+inline std::pair<int, double> UFFOptimizeMolecule(
     ROMol &mol, int maxIters = 1000, double vdwThresh = 10.0, int confId = -1,
     bool ignoreInterfragInteractions = true) {
   ForceFields::ForceField *ff = UFF::constructForceField(
@@ -67,7 +67,7 @@ std::pair<int, double> UFFOptimizeMolecule(
                                      fragments
 
 */
-void UFFOptimizeMoleculeConfs(ROMol &mol,
+inline void UFFOptimizeMoleculeConfs(ROMol &mol,
                               std::vector<std::pair<int, double>> &res,
                               int numThreads = 1, int maxIters = 1000,
                               double vdwThresh = 10.0,


### PR DESCRIPTION
Added some inlines to header functions at ForceFieldHelpers. Without these including 
`<GraphMol/ForceFieldHelpers/MMFF/MMFF.h>` to an external C++ project caused "already defined" linker issue at least in MSVC.
