### PR TITLE
Fix cleanupOrganometallics and reinstate to sanitisation

### DIFF
--- a/Code/GraphMol/MolOps.cpp
+++ b/Code/GraphMol/MolOps.cpp
@@ -185,11 +185,8 @@ void halogenCleanup(RWMol &mol, Atom *atom) {
 }
 
 bool isMetal(const Atom *atom) {
-  // This is the list of not metal atoms from QueryOps.cpp
-  static const std::set<int> notMetals{0,  1,  2,  5,  6,  7,  8,  9,
-                                       10, 14, 15, 16, 17, 18, 33, 34,
-                                       35, 36, 52, 53, 54, 85, 86};
-  return (notMetals.find(atom->getAtomicNum()) == notMetals.end());
+  static const std::unique_ptr<ATOM_OR_QUERY> q(makeMAtomQuery());
+  return q->Match(atom);
 }
 
 bool isHypervalentNonMetal(Atom *atom) {
@@ -254,7 +251,7 @@ void metalBondCleanup(RWMol &mol, Atom *atom) {
   };
 
   std::vector<unsigned int> ranks(mol.getNumAtoms());
-  RDKit::Canon::rankMolAtoms(mol, ranks, true, true, true);
+  RDKit::Canon::rankMolAtoms(mol, ranks);
 
   if (isHypervalentNonMetal(atom) && !noDative(atom)) {
     std::vector<Atom *> metals;

--- a/Code/GraphMol/MolOps.h
+++ b/Code/GraphMol/MolOps.h
@@ -336,8 +336,8 @@ struct RDKIT_GRAPHMOL_EXPORT AdjustQueryParameters {
   std::uint32_t adjustRingCountFlags =
       ADJUST_IGNOREDUMMIES | ADJUST_IGNORECHAINS;
 
-  bool makeDummiesQueries = true; /**< convert dummy atoms without isotope
-                                labels to any-atom queries */
+  bool makeDummiesQueries = true;  /**< convert dummy atoms without isotope
+                                 labels to any-atom queries */
 
   bool aromatizeIfPossible = true; /**< perceive and set aromaticity */
 
@@ -441,6 +441,7 @@ typedef enum {
   SANITIZE_SETHYBRIDIZATION = 0x80,
   SANITIZE_CLEANUPCHIRALITY = 0x100,
   SANITIZE_ADJUSTHS = 0x200,
+  SANITIZE_CLEANUP_ORGANOMETALLICS = 0x400,
   SANITIZE_ALL = 0xFFFFFFF
 } SanitizeFlags;
 

--- a/Code/GraphMol/Wrap/MolOps.cpp
+++ b/Code/GraphMol/Wrap/MolOps.cpp
@@ -970,6 +970,8 @@ struct molops_wrapper {
         .value("SANITIZE_SETHYBRIDIZATION", MolOps::SANITIZE_SETHYBRIDIZATION)
         .value("SANITIZE_CLEANUPCHIRALITY", MolOps::SANITIZE_CLEANUPCHIRALITY)
         .value("SANITIZE_ADJUSTHS", MolOps::SANITIZE_ADJUSTHS)
+        .value("SANITIZE_CLEANUP_ORGANOMETALLICS",
+               MolOps::SANITIZE_CLEANUP_ORGANOMETALLICS)
         .value("SANITIZE_ALL", MolOps::SANITIZE_ALL)
         .export_values();
     ;

--- a/Code/GraphMol/catch_graphmol.cpp
+++ b/Code/GraphMol/catch_graphmol.cpp
@@ -13,6 +13,7 @@
 #include <algorithm>
 #include <limits>
 #include <fstream>
+#include <random>
 #include <boost/format.hpp>
 
 #include <GraphMol/RDKitBase.h>
@@ -2946,7 +2947,7 @@ TEST_CASE("molecules with single bond to metal atom use dative instead") {
   // Change heme coordination from single bond to dative.
   // Test mols are CHEBI:26355, CHEBI:60344, CHEBI:17627.  26355 should be
   // changed (Github 6019) the other two should not be.
-  // 4th mol is one that gave other problems during testing.
+  // Counting from 1, 4th mol is one that gave other problems during testing.
   std::vector<std::pair<std::string, std::string>> test_vals{
       {"CC1=C(CCC(O)=O)C2=[N]3C1=Cc1c(C)c(C=C)c4C=C5C(C)=C(C=C)C6=[N]5[Fe]3(n14)n1c(=C6)c(C)c(CCC(O)=O)c1=C2",
        "C=CC1=C(C)C2=Cc3c(C=C)c(C)c4n3[Fe]35<-N2=C1C=c1c(C)c(CCC(=O)O)c(n13)=CC1=N->5C(=C4)C(C)=C1CCC(=O)O"},
@@ -2964,6 +2965,34 @@ TEST_CASE("molecules with single bond to metal atom use dative instead") {
     MolOps::cleanUpOrganometallics(*m);
     MolOps::sanitizeMol(*m);
     TEST_ASSERT(MolToSmiles(*m) == test_vals[i].second);
+  }
+}
+
+TEST_CASE(
+    "cleanUpOrganometallics should produce canonical output.  cf PR6292") {
+  std::string smi = "F[Pd](Cl)(Cl1)Cl[Pd]1(Cl)Cl";
+  std::string canon_smi = "F[Pd]1(Cl)<-Cl[Pd](Cl)(Cl)<-Cl1";
+
+  SmilesParserParams ps;
+  ps.sanitize = false;
+  RWMOL_SPTR m(RDKit::SmilesToMol(smi, ps));
+  MolOps::cleanUpOrganometallics(*m);
+  MolOps::sanitizeMol(*m);
+  TEST_ASSERT(MolToSmiles(*m) == canon_smi);
+
+  // scramble the order and check
+  std::vector<unsigned int> atomInds(m->getNumAtoms(), 0);
+  std::iota(atomInds.begin(), atomInds.end(), 0);
+  std::random_device rd;
+  std::mt19937 g(rd());
+  for (int i = 0; i < 100; ++i) {
+    std::unique_ptr<ROMol> mol(RDKit::SmilesToMol(smi, ps));
+    std::shuffle(atomInds.begin(), atomInds.end(), g);
+    std::unique_ptr<ROMol> randmol(MolOps::renumberAtoms(*mol, atomInds));
+    std::unique_ptr<RWMol> rwrandmol(new RWMol(*randmol));
+    MolOps::cleanUpOrganometallics(*rwrandmol);
+    MolOps::sanitizeMol(*rwrandmol);
+    TEST_ASSERT(MolToSmiles(*rwrandmol) == canon_smi);
   }
 }
 

--- a/Docs/Book/RDKit_Book.rst
+++ b/Docs/Book/RDKit_Book.rst
@@ -1603,38 +1603,44 @@ Here are the steps involved, in order.
         Example: ``O=Cl(=O)O -> [O-][Cl+2][O-]O``
 
      This step should not generate exceptions.
+  3. ``cleanUpOrganometallics``: standardizes a small number of non-standard
+     situations encountered in organometallics. The cleanup operations are:
 
-  3. ``updatePropertyCache``: calculates the explicit and implicit valences on
+       - replaces single bonds from hypervalent atoms to metals with dative bonds.
+
+     This step should not generate exceptions.
+
+  4. ``updatePropertyCache``: calculates the explicit and implicit valences on
      all atoms. This generates exceptions for atoms in higher-than-allowed
      valence states. This step is always performed, but if it is "skipped"
      the test for non-standard valences will not be carried out.
 
-  4. ``symmetrizeSSSR``: calls the symmetrized smallest set of smallest rings
+  5. ``symmetrizeSSSR``: calls the symmetrized smallest set of smallest rings
      algorithm (discussed in the Getting Started document).
 
-  5. ``Kekulize``: converts aromatic rings to their Kekule form. Will raise an
+  6. ``Kekulize``: converts aromatic rings to their Kekule form. Will raise an
      exception if a ring cannot be kekulized or if aromatic bonds are found
      outside of rings.
 
-  6. ``assignRadicals``: determines the number of radical electrons (if any) on
+  7. ``assignRadicals``: determines the number of radical electrons (if any) on
      each atom.
 
-  7. ``setAromaticity``: identifies the aromatic rings and ring systems
+  8. ``setAromaticity``: identifies the aromatic rings and ring systems
      (see above), sets the aromatic flag on atoms and bonds, sets bond orders
      to aromatic.
 
-  8. ``setConjugation``: identifies which bonds are conjugated
+  9. ``setConjugation``: identifies which bonds are conjugated
 
-  9. ``setHybridization``: calculates the hybridization state of each atom
+  10. ``setHybridization``: calculates the hybridization state of each atom
 
-  10. ``cleanupChirality``: removes chiral tags from atoms that are not sp3
+  11. ``cleanupChirality``: removes chiral tags from atoms that are not sp3
       hybridized.
 
-  11. ``adjustHs``: adds explicit Hs where necessary to preserve the chemistry.
+  12. ``adjustHs``: adds explicit Hs where necessary to preserve the chemistry.
       This is typically needed for heteroatoms in aromatic rings. The classic
       example is the nitrogen atom in pyrrole.
 
-  12. ``updatePropertyCache``: re-calculates the explicit and implicit valences on
+  13. ``updatePropertyCache``: re-calculates the explicit and implicit valences on
      all atoms. This generates exceptions for atoms in higher-than-allowed
      valence states. This step is required to catch some edge cases where input 
      atoms with non-physical valences are accepted if they are flagged as aromatic.


### PR DESCRIPTION
#### Reference Issue
Fixed the problem identified in PR #6292.


#### What does this implement/fix? Explain your changes.
As mentioned in the PR, when an atom could have a dative bond to 2 metals, the one selected wasn't canonical, such that different atom input orders gave different results, and sometimes 2 dative bonds went to the same metal.  It now picks the metal with fewer dative bonds with the canonical rank order as a tie breaker.  The examples in #6292 are now dealt with correctly.

![image](https://github.com/rdkit/rdkit/assets/9198870/13615caa-76fd-40ad-9ed5-c4fa4d81281c)

#### Any other comments?
I have put it back in the default sanitisation pipeline.
