### PR TITLE
adjustQueryProperties cleanup

### DIFF
--- a/Code/GraphMol/AdjustQuery.cpp
+++ b/Code/GraphMol/AdjustQuery.cpp
@@ -348,7 +348,7 @@ void adjustQueryProperties(RWMol &mol, const AdjustQueryParameters *inParams) {
   if (inParams) {
     params = *inParams;
   }
-  const RingInfo *ringInfo = mol.getRingInfo();
+  const auto ringInfo = mol.getRingInfo();
 
   if (params.aromatizeIfPossible) {
     unsigned int failed;
@@ -358,6 +358,8 @@ void adjustQueryProperties(RWMol &mol, const AdjustQueryParameters *inParams) {
       MolOps::symmetrizeSSSR(mol);
     }
   }
+  QueryAtom qaTmpl;
+  QueryBond qbTmpl;
 
   if (params.makeAtomsGeneric) {
     for (unsigned int i = 0; i < mol.getNumAtoms(); ++i) {
@@ -367,12 +369,10 @@ void adjustQueryProperties(RWMol &mol, const AdjustQueryParameters *inParams) {
             ringInfo->numAtomRings(i)) &&
           !((params.makeAtomsGenericFlags & ADJUST_IGNOREMAPPED) &&
             isMapped(mol.getAtomWithIdx(i)))) {
-        auto *qa = new QueryAtom();
-        qa->setQuery(makeAtomNullQuery());
-        const bool updateLabel = false;
-        const bool preserveProps = true;
-        mol.replaceAtom(i, qa, updateLabel, preserveProps);
-        delete qa;
+        qaTmpl.setQuery(makeAtomNullQuery());
+        constexpr bool updateLabel = false;
+        constexpr bool preserveProps = true;
+        mol.replaceAtom(i, &qaTmpl, updateLabel, preserveProps);
       }
     }
   }  // end of makeAtomsGeneric
@@ -382,28 +382,24 @@ void adjustQueryProperties(RWMol &mol, const AdjustQueryParameters *inParams) {
             !ringInfo->numBondRings(i)) &&
           !((params.makeBondsGenericFlags & ADJUST_IGNORERINGS) &&
             ringInfo->numBondRings(i))) {
-        auto *qb = new QueryBond();
-        qb->setQuery(makeBondNullQuery());
-        const bool preserveProps = true;
-        mol.replaceBond(i, qb, preserveProps);
-        delete qb;
+        qbTmpl.setQuery(makeBondNullQuery());
+        constexpr bool preserveProps = true;
+        mol.replaceBond(i, &qbTmpl, preserveProps);
       }
     }
   }  // end of makeBondsGeneric
   for (unsigned int i = 0; i < mol.getNumAtoms(); ++i) {
-    Atom *at = mol.getAtomWithIdx(i);
+    auto *at = mol.getAtomWithIdx(i);
     // pull properties we need from the atom here, once we
     // create a query atom they may no longer be valid.
-    unsigned int nRings = ringInfo->numAtomRings(i);
-    int atomicNum = at->getAtomicNum();
+    auto nRings = ringInfo->numAtomRings(i);
+    auto atomicNum = at->getAtomicNum();
     if (params.makeDummiesQueries && atomicNum == 0 && !at->hasQuery() &&
         !at->getIsotope()) {
-      auto *qa = new QueryAtom();
-      qa->setQuery(makeAtomNullQuery());
-      const bool updateLabel = false;
-      const bool preserveProps = true;
-      mol.replaceAtom(i, qa, updateLabel, preserveProps);
-      delete qa;
+      qaTmpl.setQuery(makeAtomNullQuery());
+      constexpr bool updateLabel = false;
+      constexpr bool preserveProps = true;
+      mol.replaceAtom(i, &qaTmpl, updateLabel, preserveProps);
       at = mol.getAtomWithIdx(i);
     }  // end of makeDummiesQueries
     if (params.adjustDegree &&
@@ -414,11 +410,10 @@ void adjustQueryProperties(RWMol &mol, const AdjustQueryParameters *inParams) {
         !((params.adjustDegreeFlags & ADJUST_IGNOREMAPPED) && isMapped(at))) {
       QueryAtom *qa;
       if (!at->hasQuery()) {
-        qa = new QueryAtom(*at);
-        const bool updateLabel = false;
-        const bool preserveProps = true;
-        mol.replaceAtom(i, qa, updateLabel, preserveProps);
-        delete qa;
+        QueryAtom atQueryAtom(*at);
+        constexpr bool updateLabel = false;
+        constexpr bool preserveProps = true;
+        mol.replaceAtom(i, &atQueryAtom, updateLabel, preserveProps);
         qa = static_cast<QueryAtom *>(mol.getAtomWithIdx(i));
         at = static_cast<Atom *>(qa);
       } else {
@@ -437,11 +432,10 @@ void adjustQueryProperties(RWMol &mol, const AdjustQueryParameters *inParams) {
           isMapped(at))) {
       QueryAtom *qa;
       if (!at->hasQuery()) {
-        qa = new QueryAtom(*at);
-        const bool updateLabel = false;
-        const bool preserveProps = true;
-        mol.replaceAtom(i, qa, updateLabel, preserveProps);
-        delete qa;
+        QueryAtom atQueryAtom(*at);
+        constexpr bool updateLabel = false;
+        constexpr bool preserveProps = true;
+        mol.replaceAtom(i, &atQueryAtom, updateLabel, preserveProps);
         qa = static_cast<QueryAtom *>(mol.getAtomWithIdx(i));
         at = static_cast<Atom *>(qa);
       } else {
@@ -460,11 +454,10 @@ void adjustQueryProperties(RWMol &mol, const AdjustQueryParameters *inParams) {
           isMapped(at))) {
       QueryAtom *qa;
       if (!at->hasQuery()) {
-        qa = new QueryAtom(*at);
-        const bool updateLabel = false;
-        const bool preserveProps = true;
-        mol.replaceAtom(i, qa, updateLabel, preserveProps);
-        delete qa;
+        QueryAtom atQueryAtom(*at);
+        constexpr bool updateLabel = false;
+        constexpr bool preserveProps = true;
+        mol.replaceAtom(i, &atQueryAtom, updateLabel, preserveProps);
         qa = static_cast<QueryAtom *>(mol.getAtomWithIdx(i));
         at = static_cast<Atom *>(qa);
       } else {
@@ -482,11 +475,10 @@ void adjustQueryProperties(RWMol &mol, const AdjustQueryParameters *inParams) {
           isMapped(at))) {
       QueryAtom *qa;
       if (!at->hasQuery()) {
-        qa = new QueryAtom(*at);
-        const bool updateLabel = false;
-        const bool preserveProps = true;
-        mol.replaceAtom(i, qa, updateLabel, preserveProps);
-        delete qa;
+        QueryAtom atQueryAtom(*at);
+        constexpr bool updateLabel = false;
+        constexpr bool preserveProps = true;
+        mol.replaceAtom(i, &atQueryAtom, updateLabel, preserveProps);
         qa = static_cast<QueryAtom *>(mol.getAtomWithIdx(i));
         at = static_cast<Atom *>(qa);
       } else {

--- a/Code/GraphMol/Wrap/MolOps.cpp
+++ b/Code/GraphMol/Wrap/MolOps.cpp
@@ -2742,6 +2742,7 @@ must be the core",
   - ADJUST_IGNORERINGS: ring atoms/bonds will be ignored
   - ADJUST_IGNOREDUMMIES: dummy atoms will be ignored
   - ADJUST_IGNORENONDUMMIES: non-dummy atoms will be ignored
+  - ADJUST_IGNOREMAPPED: mapped atoms will be ignored
   - ADJUST_IGNOREALL: everything will be ignored
 )DOC";
     python::enum_<MolOps::AdjustQueryWhichFlags>("AdjustQueryWhichFlags")
@@ -2750,6 +2751,7 @@ must be the core",
         .value("ADJUST_IGNORERINGS", MolOps::ADJUST_IGNORERINGS)
         .value("ADJUST_IGNOREDUMMIES", MolOps::ADJUST_IGNOREDUMMIES)
         .value("ADJUST_IGNORENONDUMMIES", MolOps::ADJUST_IGNORENONDUMMIES)
+        .value("ADJUST_IGNOREMAPPED", MolOps::ADJUST_IGNOREMAPPED)
         .value("ADJUST_IGNOREALL", MolOps::ADJUST_IGNOREALL)
         .export_values();
 


### PR DESCRIPTION
A small cleanup PR.
* In `adjustQueryProperties`, it is not necessary to dynamically allocate `QueryAtom` and `QueryBond` instances to be used with `RWMol::replaceAtom()` and `RWMol::replaceBond()`, since both functions will make a copy of the query rather than taking ownership. Therefore, it is better to use static allocation to avoid potential memory leaks in case an exception is thrown between allocation and deletion. Note that elsewhere in the same file static allocation is already used for `QueryAtom` and `QueryBond`; this PR only makes usage of static allocation consistent across the whole file
* switched to `auto` and `constexpr` where possible
* `ADJUST_IGNOREMAPPED` was not exposed to Python - this PR exposes it
