### PR TITLE
straightenDepiction should not consider 0-degree rotations as multiples of 60

### DIFF
--- a/Code/GraphMol/Depictor/RDDepictor.cpp
+++ b/Code/GraphMol/Depictor/RDDepictor.cpp
@@ -966,8 +966,12 @@ void straightenDepiction(RDKit::ROMol &mol, int confId, bool minimizeRotation) {
   if (!minimizeRotation) {
     unsigned int count60vs30[2] = {0, 0};
     for (auto theta : minRotationBin.thetaValues) {
-      theta += d_thetaMin;
-      auto idx = static_cast<unsigned int>((fabs(theta) + 0.5) / INCR_DEG) % 2;
+      auto absTheta = fabs(theta + d_thetaMin);
+      // Do not count 0 as multiple of 60 degrees
+      if (absTheta < ALMOST_ZERO) {
+        continue;
+      }
+      auto idx = static_cast<unsigned int>((absTheta + 0.5) / INCR_DEG) % 2;
       CHECK_INVARIANT(idx < 2, "");
       ++count60vs30[idx];
     }

--- a/Code/GraphMol/Depictor/testDepictor.cpp
+++ b/Code/GraphMol/Depictor/testDepictor.cpp
@@ -1518,7 +1518,7 @@ M  END)RES"_ctab;
     TEST_ASSERT(RDKit::feq(bond4_11Conf2.y, bond4_11Conf3.y, 1.e-3));
   }
   {
-    std::string zeroCoordCTab = R"RES(
+    auto zeroCoordCTab = R"RES(
      RDKit          2D
 
   6  6  0  0  0  0  0  0  0  0999 V2000
@@ -1545,7 +1545,7 @@ M  END
     // cyclopentadiene which is already straight should not be biased
     // towards a 30-degree angle rotate since it has no bonds
     // whose angle with the X axis is multiple of 60 degrees
-    std::string cpSittingOnHorizontalBondCTab = R"RES(
+    auto cpSittingOnHorizontalBondCTab = R"RES(
   MJ201100                      
 
   5  5  0  0  0  0  0  0  0  0999 V2000

--- a/Code/MinimalLib/tests/tests.js
+++ b/Code/MinimalLib/tests/tests.js
@@ -791,34 +791,56 @@ M  END
 }
 
 function test_straighten_depiction() {
-    var mol1 = RDKitModule.get_mol(`
-  MJ201900
+    var benzeneHoriz = RDKitModule.get_mol(`
+  MJ201100                      
 
-  2  1  0  0  0  0  0  0  0  0999 V2000
-   -0.3904    2.1535    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
-   -1.1049    1.7410    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
-  2  1  1  0  0  0  0
+  6  6  0  0  0  0  0  0  0  0999 V2000
+   -0.0785    1.6073    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -0.9035    1.6073    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -1.3160    0.8928    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -0.9036    0.1783    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -0.0786    0.1783    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    0.3339    0.8929    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+  1  2  2  0  0  0  0
+  2  3  1  0  0  0  0
+  3  4  2  0  0  0  0
+  4  5  1  0  0  0  0
+  5  6  2  0  0  0  0
+  6  1  1  0  0  0  0
 M  END
 `);
-    var mol2 = RDKitModule.get_mol(`
-  MJ201900
+    var benzeneVert = RDKitModule.get_mol(`
+  MJ201100                      
 
-  2  1  0  0  0  0  0  0  0  0999 V2000
-    0.1899    1.9526    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
-   -0.5245    1.5401    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
-  2  1  1  0  0  0  0
+  6  6  0  0  0  0  0  0  0  0999 V2000
+    0.2234    1.3054    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -0.4910    1.7178    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -1.2055    1.3053    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -1.2056    0.4803    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -0.4911    0.0678    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    0.2234    0.4804    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+  1  2  2  0  0  0  0
+  2  3  1  0  0  0  0
+  3  4  2  0  0  0  0
+  4  5  1  0  0  0  0
+  5  6  2  0  0  0  0
+  6  1  1  0  0  0  0
 M  END
 `);
-    mol1.normalize_depiction();
-    mol1Copy1 = RDKitModule.get_mol_copy(mol1)
-    mol1Copy2 = RDKitModule.get_mol_copy(mol1)
-    mol1.straighten_depiction();
-    mol2.normalize_depiction();
-    mol2.straighten_depiction();
-    assert(mol1.get_molblock() === mol2.get_molblock());
-    mol1Copy1.straighten_depiction(true);
-    assert(mol1Copy1.get_molblock() !== mol2.get_molblock());
-    assert(mol1Copy1.get_molblock() === mol1Copy2.get_molblock());
+    var benzeneHorizCopy = RDKitModule.get_mol_copy(benzeneHoriz);
+    var benzeneVertCopy = RDKitModule.get_mol_copy(benzeneVert);
+    benzeneHoriz.straighten_depiction();
+    benzeneVert.straighten_depiction();
+    assert(benzeneHoriz.get_molblock() !== benzeneHorizCopy.get_molblock());
+    assert(benzeneVert.get_molblock() === benzeneVertCopy.get_molblock());
+    benzeneHoriz = benzeneHorizCopy;
+    benzeneVert = benzeneVertCopy;
+    benzeneHorizCopy = RDKitModule.get_mol_copy(benzeneHoriz);
+    benzeneVertCopy = RDKitModule.get_mol_copy(benzeneVert);
+    benzeneHoriz.straighten_depiction(true);
+    benzeneVert.straighten_depiction(true);
+    assert(benzeneHoriz.get_molblock() === benzeneHorizCopy.get_molblock());
+    assert(benzeneVert.get_molblock() === benzeneVertCopy.get_molblock());
 }
 
 function test_has_coords() {


### PR DESCRIPTION
When deciding whether to bias the straightening towards a multiple of 30-degrees, we should not be counting 0-degree rotations as multiples of 60 degrees, as otherwise layouts which have no angles which are multiple of 60 degrees such as
![image](https://github.com/rdkit/rdkit/assets/5244385/1bc10e1a-f02f-40bb-bfbb-8e5cb78dec87)
would still be rotated by 30 degrees, even though it is not necessary nor desirable:
![image](https://github.com/rdkit/rdkit/assets/5244385/15052320-e532-4467-82db-7eb0a0d45d0e)
This small PR avoids that the above happens, and adds a couple of tests.