### PR TITLE
CMAKE_INSTALL_PREFIX not honored during installation of the Python Files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -325,7 +325,7 @@ if(RDK_BUILD_PYTHON_WRAPPERS)
         COMMAND
         ${PYTHON_EXECUTABLE} -c "import sys; import sysconfig; \
           schema = 'nt' if sys.platform == 'win32' else 'posix_prefix'; \
-          print(sysconfig.get_path('platlib', vars={'platbase': '${CMAKE_INSTALL_PREFIX}'}))"
+          print(sysconfig.get_path('platlib', schema, vars={'platbase': '${CMAKE_INSTALL_PREFIX}'}))"
         OUTPUT_VARIABLE PYTHON_INSTDIR
         OUTPUT_STRIP_TRAILING_WHITESPACE
       )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -323,7 +323,9 @@ if(RDK_BUILD_PYTHON_WRAPPERS)
       # Determine correct installation directory for Python bindings
       execute_process(
         COMMAND
-        ${PYTHON_EXECUTABLE} -c "import sysconfig; print(sysconfig.get_path('platlib'))"
+        ${PYTHON_EXECUTABLE} -c "import sys; import sysconfig; \
+          schema = 'nt' if sys.platform == 'win32' else 'posix_prefix'; \
+          print(sysconfig.get_path('platlib', vars={'platbase': '${CMAKE_INSTALL_PREFIX}'}))"
         OUTPUT_VARIABLE PYTHON_INSTDIR
         OUTPUT_STRIP_TRAILING_WHITESPACE
       )


### PR DESCRIPTION
In PR #6339 we dropped `CMAKE_INSTALL_PATH` from the code that detects the `PYTHON_INSTDIR` variable in the CMake script. As a consequence of this, when running `make install`, the Python package would not be installed to the `CMAKE_INSTALL_PATH`, but to a location that is dependent on the environment being used in the build. E.g., under `/usr/local/lib` (which requires root privileges), on my personal Ubuntu system.

This patch restores `CMAKE_INSTALL_PATH` in the `PYTHON_INSTDIR` determination in a way that makes sure that the results always match a POSIX or a WIN32 style schema.

