### PR TITLE
Fixes some issues in the SubstructLibrary JS implementation

### DIFF
--- a/Code/MinimalLib/jswrapper.cpp
+++ b/Code/MinimalLib/jswrapper.cpp
@@ -551,6 +551,9 @@ EMSCRIPTEN_BINDINGS(RDKit_minimal) {
                 select_overload<unsigned int(const JSMol &, bool, int) const>(
                     &JSSubstructLibrary::count_matches))
       .function("count_matches",
+                select_overload<unsigned int(const JSMol &, bool) const>(
+                    &JSSubstructLibrary::count_matches))
+      .function("count_matches",
                 select_overload<unsigned int(const JSMol &) const>(
                     &JSSubstructLibrary::count_matches));
 

--- a/Code/MinimalLib/jswrapper.cpp
+++ b/Code/MinimalLib/jswrapper.cpp
@@ -185,7 +185,8 @@ emscripten::val binary_string_to_uint8array(const std::string &pkl) {
   return res;
 }
 
-emscripten::val uint_vector_to_uint32array(const std::vector<unsigned int> &vec) {
+emscripten::val uint_vector_to_uint32array(
+    const std::vector<unsigned int> &vec) {
   auto res = emscripten::val::global("Uint32Array").new_(vec.size());
   if (!vec.empty()) {
     emscripten::val view(emscripten::typed_memory_view(
@@ -320,29 +321,39 @@ emscripten::val get_frags_helper(JSMol &self) {
   return get_frags_helper(self, "{}");
 }
 
-int add_trusted_smiles_and_pattern_fp_helper(JSSubstructLibrary &self, const std::string &smi,
-                                  const emscripten::val &patternFpAsUInt8Array) {
-  return self.add_trusted_smiles_and_pattern_fp(smi, patternFpAsUInt8Array.as<std::string>());
+int add_trusted_smiles_and_pattern_fp_helper(
+    JSSubstructLibrary &self, const std::string &smi,
+    const emscripten::val &patternFpAsUInt8Array) {
+  return self.add_trusted_smiles_and_pattern_fp(
+      smi, patternFpAsUInt8Array.as<std::string>());
 }
 
-emscripten::val get_pattern_fp_as_uint8array_from_sslib(const JSSubstructLibrary &self, unsigned int i) {
+emscripten::val get_pattern_fp_as_uint8array_from_sslib(
+    const JSSubstructLibrary &self, unsigned int i) {
   return binary_string_to_uint8array(self.get_pattern_fp(i));
 }
 
-emscripten::val get_matches_as_uint32array(const JSSubstructLibrary &self, const JSMol &q, bool useChirality,
-                                            int numThreads,
-                                            int maxResults) {
-  auto indices = self.d_sslib->size() ? self.d_sslib->getMatches(
-      *q.d_mol, true, useChirality, false, numThreads, maxResults) : std::vector<unsigned int>();
+emscripten::val get_matches_as_uint32array(const JSSubstructLibrary &self,
+                                           const JSMol &q, bool useChirality,
+                                           int numThreads, int maxResults) {
+  auto indices = self.d_sslib->size()
+                     ? self.d_sslib->getMatches(*q.d_mol, true, useChirality,
+                                                false, numThreads, maxResults)
+                     : std::vector<unsigned int>();
   return uint_vector_to_uint32array(indices);
 }
 
-emscripten::val get_matches_as_uint32array(const JSSubstructLibrary &self, const JSMol &q, int maxResults) {
-    return get_matches_as_uint32array(self, q, self.d_defaultUseChirality, self.d_defaultNumThreads, maxResults);
+emscripten::val get_matches_as_uint32array(const JSSubstructLibrary &self,
+                                           const JSMol &q, int maxResults) {
+  return get_matches_as_uint32array(self, q, self.d_defaultUseChirality,
+                                    self.d_defaultNumThreads, maxResults);
 }
 
-emscripten::val get_matches_as_uint32array(const JSSubstructLibrary &self, const JSMol &q) {
-    return get_matches_as_uint32array(self, q, self.d_defaultUseChirality, self.d_defaultNumThreads, self.d_defaultMaxResults);
+emscripten::val get_matches_as_uint32array(const JSSubstructLibrary &self,
+                                           const JSMol &q) {
+  return get_matches_as_uint32array(self, q, self.d_defaultUseChirality,
+                                    self.d_defaultNumThreads,
+                                    self.d_defaultMaxResults);
 }
 
 #ifdef RDK_BUILD_AVALON_SUPPORT
@@ -573,18 +584,25 @@ EMSCRIPTEN_BINDINGS(RDKit_minimal) {
       .function("add_trusted_smiles", &JSSubstructLibrary::add_trusted_smiles)
       .function("get_trusted_smiles", &JSSubstructLibrary::get_trusted_smiles)
 #ifdef __EMSCRIPTEN__
-      .function("add_trusted_smiles_and_pattern_fp", select_overload<int(JSSubstructLibrary &, const std::string &, const emscripten::val &)>(
-              add_trusted_smiles_and_pattern_fp_helper))
-      .function("get_pattern_fp_as_uint8array", select_overload<emscripten::val(const JSSubstructLibrary &, unsigned int)>(
-              get_pattern_fp_as_uint8array_from_sslib))
+      .function("add_trusted_smiles_and_pattern_fp",
+                select_overload<int(JSSubstructLibrary &, const std::string &,
+                                    const emscripten::val &)>(
+                    add_trusted_smiles_and_pattern_fp_helper))
+      .function("get_pattern_fp_as_uint8array",
+                select_overload<emscripten::val(const JSSubstructLibrary &,
+                                                unsigned int)>(
+                    get_pattern_fp_as_uint8array_from_sslib))
       .function("get_matches_as_uint32array",
-          select_overload<emscripten::val(const JSSubstructLibrary &, const JSMol &, bool, int, int)>(
-              get_matches_as_uint32array))
-      .function("get_matches_as_uint32array",
-                select_overload<emscripten::val(const JSSubstructLibrary &, const JSMol &, int)>(
+                select_overload<emscripten::val(const JSSubstructLibrary &,
+                                                const JSMol &, bool, int, int)>(
                     get_matches_as_uint32array))
       .function("get_matches_as_uint32array",
-                select_overload<emscripten::val(const JSSubstructLibrary &, const JSMol &)>(
+                select_overload<emscripten::val(const JSSubstructLibrary &,
+                                                const JSMol &, int)>(
+                    get_matches_as_uint32array))
+      .function("get_matches_as_uint32array",
+                select_overload<emscripten::val(const JSSubstructLibrary &,
+                                                const JSMol &)>(
                     get_matches_as_uint32array))
 #endif
       .function("get_mol", &JSSubstructLibrary::get_mol, allow_raw_pointers())

--- a/Code/MinimalLib/jswrapper.cpp
+++ b/Code/MinimalLib/jswrapper.cpp
@@ -185,6 +185,16 @@ emscripten::val binary_string_to_uint8array(const std::string &pkl) {
   return res;
 }
 
+emscripten::val uint_vector_to_uint32array(const std::vector<unsigned int> &vec) {
+  auto res = emscripten::val::global("Uint32Array").new_(vec.size());
+  if (!vec.empty()) {
+    emscripten::val view(emscripten::typed_memory_view(
+        vec.size(), reinterpret_cast<const unsigned int *>(vec.data())));
+    res.call<void>("set", view);
+  }
+  return res;
+}
+
 emscripten::val get_as_uint8array(const JSMol &self) {
   return binary_string_to_uint8array(self.get_pickle());
 }
@@ -308,6 +318,31 @@ emscripten::val get_frags_helper(JSMol &self, const std::string &details) {
 
 emscripten::val get_frags_helper(JSMol &self) {
   return get_frags_helper(self, "{}");
+}
+
+int add_trusted_smiles_and_pattern_fp_helper(JSSubstructLibrary &self, const std::string &smi,
+                                  const emscripten::val &patternFpAsUInt8Array) {
+  return self.add_trusted_smiles_and_pattern_fp(smi, patternFpAsUInt8Array.as<std::string>());
+}
+
+emscripten::val get_pattern_fp_as_uint8array_from_sslib(const JSSubstructLibrary &self, unsigned int i) {
+  return binary_string_to_uint8array(self.get_pattern_fp(i));
+}
+
+emscripten::val get_matches_as_uint32array(const JSSubstructLibrary &self, const JSMol &q, bool useChirality,
+                                            int numThreads,
+                                            int maxResults) {
+  auto indices = self.d_sslib->size() ? self.d_sslib->getMatches(
+      *q.d_mol, true, useChirality, false, numThreads, maxResults) : std::vector<unsigned int>();
+  return uint_vector_to_uint32array(indices);
+}
+
+emscripten::val get_matches_as_uint32array(const JSSubstructLibrary &self, const JSMol &q, int maxResults) {
+    return get_matches_as_uint32array(self, q, self.d_defaultUseChirality, self.d_defaultNumThreads, maxResults);
+}
+
+emscripten::val get_matches_as_uint32array(const JSSubstructLibrary &self, const JSMol &q) {
+    return get_matches_as_uint32array(self, q, self.d_defaultUseChirality, self.d_defaultNumThreads, self.d_defaultMaxResults);
 }
 
 #ifdef RDK_BUILD_AVALON_SUPPORT
@@ -536,6 +571,22 @@ EMSCRIPTEN_BINDINGS(RDKit_minimal) {
       .function("add_mol", &JSSubstructLibrary::add_mol)
       .function("add_smiles", &JSSubstructLibrary::add_smiles)
       .function("add_trusted_smiles", &JSSubstructLibrary::add_trusted_smiles)
+      .function("get_trusted_smiles", &JSSubstructLibrary::get_trusted_smiles)
+#ifdef __EMSCRIPTEN__
+      .function("add_trusted_smiles_and_pattern_fp", select_overload<int(JSSubstructLibrary &, const std::string &, const emscripten::val &)>(
+              add_trusted_smiles_and_pattern_fp_helper))
+      .function("get_pattern_fp_as_uint8array", select_overload<emscripten::val(const JSSubstructLibrary &, unsigned int)>(
+              get_pattern_fp_as_uint8array_from_sslib))
+      .function("get_matches_as_uint32array",
+          select_overload<emscripten::val(const JSSubstructLibrary &, const JSMol &, bool, int, int)>(
+              get_matches_as_uint32array))
+      .function("get_matches_as_uint32array",
+                select_overload<emscripten::val(const JSSubstructLibrary &, const JSMol &, int)>(
+                    get_matches_as_uint32array))
+      .function("get_matches_as_uint32array",
+                select_overload<emscripten::val(const JSSubstructLibrary &, const JSMol &)>(
+                    get_matches_as_uint32array))
+#endif
       .function("get_mol", &JSSubstructLibrary::get_mol, allow_raw_pointers())
       .function(
           "get_matches",
@@ -555,7 +606,8 @@ EMSCRIPTEN_BINDINGS(RDKit_minimal) {
                     &JSSubstructLibrary::count_matches))
       .function("count_matches",
                 select_overload<unsigned int(const JSMol &) const>(
-                    &JSSubstructLibrary::count_matches));
+                    &JSSubstructLibrary::count_matches))
+      .function("size", &JSSubstructLibrary::size);
 
   function("version", &version);
   function("prefer_coordgen", &prefer_coordgen);

--- a/Code/MinimalLib/minilib.cpp
+++ b/Code/MinimalLib/minilib.cpp
@@ -33,6 +33,7 @@
 #include <GraphMol/MolTransforms/MolTransforms.h>
 #include <Geometry/Transform3D.h>
 #include <DataStructs/BitOps.h>
+#include <DataStructs/ExplicitBitVect.h>
 
 #include <INCHI-API/inchi.h>
 
@@ -669,6 +670,24 @@ int JSSubstructLibrary::add_trusted_smiles(const std::string &smi) {
   return (fpIdx == smiIdx ? fpIdx : -1);
 }
 
+int JSSubstructLibrary::add_trusted_smiles_and_pattern_fp(const std::string &smi, const std::string &patternFp) {
+  auto bitVect = new ExplicitBitVect(patternFp);
+  if (!bitVect) {
+    return -1;
+  }
+  auto fpIdx = d_fpHolder->addFingerprint(bitVect);
+  auto smiIdx = d_molHolder->addSmiles(smi);
+  return (fpIdx == smiIdx ? fpIdx : -1);
+}
+
+std::string JSSubstructLibrary::get_trusted_smiles(unsigned int i) const {
+  return d_molHolder->getMols().at(i);
+}
+
+std::string JSSubstructLibrary::get_pattern_fp(unsigned int i) const {
+  return d_fpHolder->getFingerprints().at(i)->toString();
+}
+
 inline int JSSubstructLibrary::add_mol_helper(const ROMol &mol) {
   std::string smi = MolToSmiles(mol);
   return add_trusted_smiles(smi);
@@ -696,7 +715,7 @@ std::string JSSubstructLibrary::get_matches(const JSMol &q, bool useChirality,
   if (!d_sslib->size()) {
     return "[]";
   }
-  std::vector<unsigned int> indices = d_sslib->getMatches(
+  auto indices = d_sslib->getMatches(
       *q.d_mol, true, useChirality, false, numThreads, maxResults);
   rj::Document doc;
   doc.SetArray();
@@ -714,7 +733,7 @@ std::string JSSubstructLibrary::get_matches(const JSMol &q, bool useChirality,
 unsigned int JSSubstructLibrary::count_matches(const JSMol &q,
                                                bool useChirality,
                                                int numThreads) const {
-  return d_sslib->countMatches(*q.d_mol, true, useChirality, false, numThreads);
+  return d_sslib->size() ? d_sslib->countMatches(*q.d_mol, true, useChirality, false, numThreads) : 0;
 }
 
 std::string get_inchikey_for_inchi(const std::string &input) {

--- a/Code/MinimalLib/minilib.cpp
+++ b/Code/MinimalLib/minilib.cpp
@@ -670,7 +670,8 @@ int JSSubstructLibrary::add_trusted_smiles(const std::string &smi) {
   return (fpIdx == smiIdx ? fpIdx : -1);
 }
 
-int JSSubstructLibrary::add_trusted_smiles_and_pattern_fp(const std::string &smi, const std::string &patternFp) {
+int JSSubstructLibrary::add_trusted_smiles_and_pattern_fp(
+    const std::string &smi, const std::string &patternFp) {
   auto bitVect = new ExplicitBitVect(patternFp);
   if (!bitVect) {
     return -1;
@@ -715,8 +716,8 @@ std::string JSSubstructLibrary::get_matches(const JSMol &q, bool useChirality,
   if (!d_sslib->size()) {
     return "[]";
   }
-  auto indices = d_sslib->getMatches(
-      *q.d_mol, true, useChirality, false, numThreads, maxResults);
+  auto indices = d_sslib->getMatches(*q.d_mol, true, useChirality, false,
+                                     numThreads, maxResults);
   rj::Document doc;
   doc.SetArray();
   auto &alloc = doc.GetAllocator();
@@ -733,7 +734,9 @@ std::string JSSubstructLibrary::get_matches(const JSMol &q, bool useChirality,
 unsigned int JSSubstructLibrary::count_matches(const JSMol &q,
                                                bool useChirality,
                                                int numThreads) const {
-  return d_sslib->size() ? d_sslib->countMatches(*q.d_mol, true, useChirality, false, numThreads) : 0;
+  return d_sslib->size() ? d_sslib->countMatches(*q.d_mol, true, useChirality,
+                                                 false, numThreads)
+                         : 0;
 }
 
 std::string get_inchikey_for_inchi(const std::string &input) {

--- a/Code/MinimalLib/minilib.h
+++ b/Code/MinimalLib/minilib.h
@@ -183,6 +183,9 @@ class JSSubstructLibrary {
   int add_mol(const JSMol &m);
   int add_smiles(const std::string &smi);
   int add_trusted_smiles(const std::string &smi);
+  int add_trusted_smiles_and_pattern_fp(const std::string &smi, const std::string &patternFp);
+  std::string get_trusted_smiles(unsigned int i) const;
+  std::string get_pattern_fp(unsigned int i) const;
   JSMol *get_mol(unsigned int i);
   std::string get_matches(const JSMol &q, bool useChirality, int numThreads,
                           int maxResults) const;
@@ -201,6 +204,9 @@ class JSSubstructLibrary {
   }
   unsigned int count_matches(const JSMol &q) const {
     return count_matches(q, d_defaultUseChirality, d_defaultNumThreads);
+  }
+  unsigned int size() const {
+    return d_sslib->size();
   }
 
   std::unique_ptr<RDKit::SubstructLibrary> d_sslib;

--- a/Code/MinimalLib/minilib.h
+++ b/Code/MinimalLib/minilib.h
@@ -183,7 +183,8 @@ class JSSubstructLibrary {
   int add_mol(const JSMol &m);
   int add_smiles(const std::string &smi);
   int add_trusted_smiles(const std::string &smi);
-  int add_trusted_smiles_and_pattern_fp(const std::string &smi, const std::string &patternFp);
+  int add_trusted_smiles_and_pattern_fp(const std::string &smi,
+                                        const std::string &patternFp);
   std::string get_trusted_smiles(unsigned int i) const;
   std::string get_pattern_fp(unsigned int i) const;
   JSMol *get_mol(unsigned int i);
@@ -205,9 +206,7 @@ class JSSubstructLibrary {
   unsigned int count_matches(const JSMol &q) const {
     return count_matches(q, d_defaultUseChirality, d_defaultNumThreads);
   }
-  unsigned int size() const {
-    return d_sslib->size();
-  }
+  unsigned int size() const { return d_sslib->size(); }
 
   std::unique_ptr<RDKit::SubstructLibrary> d_sslib;
   RDKit::CachedTrustedSmilesMolHolder *d_molHolder;

--- a/Code/MinimalLib/minilib.h
+++ b/Code/MinimalLib/minilib.h
@@ -196,6 +196,9 @@ class JSSubstructLibrary {
   }
   unsigned int count_matches(const JSMol &q, bool useChirality,
                              int numThreads) const;
+  unsigned int count_matches(const JSMol &q, bool useChirality) const {
+    return count_matches(q, useChirality, d_defaultNumThreads);
+  }
   unsigned int count_matches(const JSMol &q) const {
     return count_matches(q, d_defaultUseChirality, d_defaultNumThreads);
   }

--- a/Code/MinimalLib/tests/tests.js
+++ b/Code/MinimalLib/tests/tests.js
@@ -335,20 +335,30 @@ function test_substruct_library(done) {
     var sslib = new RDKitModule.SubstructLibrary();
     // var t0 = performance.now()
     // console.log('Started adding trusted SMILES');
+    var matches = [];
+    var query = RDKitModule.get_qmol('C1CCCCN1');
+    var i = 0;
     smiReader.on('line', (smi) => {
         sslib.add_trusted_smiles(smi);
+        var mol = RDKitModule.get_mol(smi);
+        var res = JSON.parse(mol.get_substruct_match(query));
+        if (res.atoms) {
+            matches.push(i);
+        }
+        ++i;
+        mol.delete();
     });
     smiReader.on('close', () => {
-        var query = RDKitModule.get_qmol("N");
         // var t1 = performance.now();
         // console.log('Finished adding trusted SMILES took ' + (t1 - t0) / 1000 + ' seconds');
-        assert.equal(sslib.count_matches(query), 52);
-        assert.equal(sslib.get_matches(query), JSON.stringify([
-            12,13,19,22,24,30,31,32,35,36,39,41,43,44,55,56,58,64,72,80,
-            85,95,96,101,105,113,124,127,128,131,143,150,151,185,201,202,
-            203,214,215,223,232,234,238,240,241,246,258,261,263,265,266,284
+        assert.equal(sslib.count_matches(query, false), 7);
+        var sslibMatches = sslib.get_matches(query);
+        assert.equal(sslibMatches, JSON.stringify([
+            39, 64, 80, 127, 128, 234, 240
         ]));
+        assert.equal(sslibMatches, JSON.stringify(matches));
         done.test_substruct_library = true;
+        query.delete();
     });
 }
 


### PR DESCRIPTION
- `fastFindRings()` was not being called
- a `count_matches()` overload was missing
- `count_matches()` was ignoring the `numThreads` parameter
- adding a `PatternFingerprintMol` created with a certain number of bits to the `PatternHolder` will *not* work: one needs to create the `PatternHolder` with the desired number of bits, and then call `makeFingerprint`
- improved tests to make sure the library actually behaves as expected
- added a `get_matches_as_uint32array()` function
- added functionality to serialize/deserialize a `JSSubstructLibrary`