### PR TITLE
Fixes #6172

### DIFF
--- a/External/INCHI-API/inchi.cpp
+++ b/External/INCHI-API/inchi.cpp
@@ -1351,14 +1351,21 @@ RWMol* InchiToMol(const std::string& inchi, ExtraInchiReturnValues& rv,
           bondRegister.insert(std::make_pair(i, nbr));
           Bond* bond = nullptr;
           // bond type
-          if (inchiAtom->bond_type[b] <= INCHI_BOND_TYPE_TRIPLE) {
+          if ((unsigned int)inchiAtom->bond_type[b] <= INCHI_BOND_TYPE_TRIPLE) {
             bond = new Bond((Bond::BondType)inchiAtom->bond_type[b]);
-          } else {
+          } else if ((unsigned int)inchiAtom->bond_type[b] ==
+                     INCHI_BOND_TYPE_ALTERN) {
             BOOST_LOG(rdWarningLog)
                 << "receive ALTERN bond type which should be avoided. "
                 << "This is treated as aromatic." << std::endl;
             bond = new Bond(Bond::AROMATIC);
             bond->setIsAromatic(true);
+          } else {
+            BOOST_LOG(rdErrorLog) << "illegal bond type ("
+                                  << (unsigned int)inchiAtom->bond_type[b]
+                                  << ") in InChI" << std::endl;
+            delete m;
+            return nullptr;
           }
           // bond ends
           bond->setBeginAtomIdx(indexToAtomIndexMapping[i]);

--- a/External/INCHI-API/test.cpp
+++ b/External/INCHI-API/test.cpp
@@ -883,6 +883,20 @@ void test_clean_up_on_kekulization_error() {
   BOOST_LOG(rdInfoLog) << "done" << std::endl;
 }
 
+void testGithub6172() {
+  BOOST_LOG(rdErrorLog) << "-------------------------------------" << std::endl;
+  BOOST_LOG(rdInfoLog)
+      << "testing github #6172: bogus bond type when parsing InChI"
+      << std::endl;
+
+  {
+    std::string inchi =
+        "InChI=1S/2C18H36N3OP.2CH3.2ClH.Sn/c2*22-23(19-16-10-4-1-5-11-16,20-17-12-6-2-7-13-17)21-18-14-8-3-9-15-18;;;;;/h2*16-18H,1-15H2,(H3,19,20,21,22);2*1H3;2*1H;/q;;2*-1;;;+4/p-2";
+    ExtraInchiReturnValues tmp;
+    std::unique_ptr<ROMol> m{InchiToMol(inchi, tmp)};
+    TEST_ASSERT(!m);
+  }
+}
 //-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
 //
 //-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
@@ -905,4 +919,5 @@ int main() {
   testGithub3365();
   testGithub3645();
   test_clean_up_on_kekulization_error();
+  testGithub6172();
 }


### PR DESCRIPTION
The InChI in this case is clearly broken, but we shouldn't toss an exception in these cases... just return a null molecule instead.

