### PR TITLE
Fixes #6395: Move string index appropriately with molfiles

### DIFF
--- a/Code/GraphMol/FileParsers/MolFileParser.cpp
+++ b/Code/GraphMol/FileParsers/MolFileParser.cpp
@@ -480,9 +480,9 @@ void ParseIsotopeLine(RWMol *mol, const std::string &text, unsigned int line) {
               << " has a negative isotope value. line:  " << line << std::endl;
         } else {
           atom->setIsotope(isotope);
-          spos += 4;
         }
       }
+      spos += 4;
     } catch (boost::bad_lexical_cast &) {
       std::ostringstream errout;
       errout << "Cannot convert '" << text.substr(spos, 4)
@@ -509,7 +509,7 @@ void ParseSubstitutionCountLine(RWMol *mol, const std::string &text,
   unsigned int spos = 9;
   for (unsigned int ie = 0; ie < nent; ie++) {
     unsigned int aid;
-    int count;
+    int count = 0;
     try {
       aid = FileParserUtils::stripSpacesAndCast<unsigned int>(
           text.substr(spos, 4));
@@ -517,43 +517,43 @@ void ParseSubstitutionCountLine(RWMol *mol, const std::string &text,
       Atom *atom = mol->getAtomWithIdx(aid - 1);
       if (text.size() >= spos + 4 && text.substr(spos, 4) != "    ") {
         count = FileParserUtils::toInt(text.substr(spos, 4));
-        if (count == 0) {
-          continue;
-        }
-        ATOM_EQUALS_QUERY *q = makeAtomExplicitDegreeQuery(0);
-        switch (count) {
-          case -1:
-            q->setVal(0);
-            break;
-          case -2:
-            q->setVal(atom->getDegree());
-            break;
-          case 1:
-          case 2:
-          case 3:
-          case 4:
-          case 5:
-            q->setVal(count);
-            break;
-          case 6:
-            BOOST_LOG(rdWarningLog) << " atom degree query with value 6 found. "
-                                       "This will not match degree >6. The MDL "
-                                       "spec says it should.  line: "
-                                    << line;
-            q->setVal(6);
-            break;
-          default:
-            std::ostringstream errout;
-            errout << "Value " << count
-                   << " is not supported as a degree query. line: " << line;
-            throw FileParseException(errout.str());
-        }
-        if (!atom->hasQuery()) {
-          atom = QueryOps::replaceAtomWithQueryAtom(mol, atom);
-        }
-        atom->expandQuery(q, Queries::COMPOSITE_AND);
-        spos += 4;
       }
+      spos += 4;
+      if (count == 0) {
+        continue;
+      }
+      ATOM_EQUALS_QUERY *q = makeAtomExplicitDegreeQuery(0);
+      switch (count) {
+        case -1:
+          q->setVal(0);
+          break;
+        case -2:
+          q->setVal(atom->getDegree());
+          break;
+        case 1:
+        case 2:
+        case 3:
+        case 4:
+        case 5:
+          q->setVal(count);
+          break;
+        case 6:
+          BOOST_LOG(rdWarningLog) << " atom degree query with value 6 found. "
+                                      "This will not match degree >6. The MDL "
+                                      "spec says it should.  line: "
+                                  << line;
+          q->setVal(6);
+          break;
+        default:
+          std::ostringstream errout;
+          errout << "Value " << count
+                  << " is not supported as a degree query. line: " << line;
+          throw FileParseException(errout.str());
+      }
+      if (!atom->hasQuery()) {
+        atom = QueryOps::replaceAtomWithQueryAtom(mol, atom);
+      }
+      atom->expandQuery(q, Queries::COMPOSITE_AND);
     } catch (boost::bad_lexical_cast &) {
       std::ostringstream errout;
       errout << "Cannot convert '" << text.substr(spos, 4)
@@ -580,7 +580,7 @@ void ParseUnsaturationLine(RWMol *mol, const std::string &text,
   unsigned int spos = 9;
   for (unsigned int ie = 0; ie < nent; ie++) {
     unsigned int aid;
-    int count;
+    int count = 0;
     try {
       aid = FileParserUtils::stripSpacesAndCast<unsigned int>(
           text.substr(spos, 4));
@@ -588,23 +588,24 @@ void ParseUnsaturationLine(RWMol *mol, const std::string &text,
       Atom *atom = mol->getAtomWithIdx(aid - 1);
       if (text.size() >= spos + 4 && text.substr(spos, 4) != "    ") {
         count = FileParserUtils::toInt(text.substr(spos, 4));
-        if (count == 0) {
-          continue;
-        } else if (count == 1) {
-          ATOM_EQUALS_QUERY *q = makeAtomUnsaturatedQuery();
-          if (!atom->hasQuery()) {
-            atom = QueryOps::replaceAtomWithQueryAtom(mol, atom);
-          }
-          atom->expandQuery(q, Queries::COMPOSITE_AND);
-        } else {
-          std::ostringstream errout;
-          errout << "Value " << count
-                 << " is not supported as an unsaturation "
-                    "query (only 0 and 1 are allowed). "
-                    "line: "
-                 << line;
-          throw FileParseException(errout.str());
+      }
+      spos += 4;
+      if (count == 0) {
+        continue;
+      } else if (count == 1) {
+        ATOM_EQUALS_QUERY *q = makeAtomUnsaturatedQuery();
+        if (!atom->hasQuery()) {
+          atom = QueryOps::replaceAtomWithQueryAtom(mol, atom);
         }
+        atom->expandQuery(q, Queries::COMPOSITE_AND);
+      } else {
+        std::ostringstream errout;
+        errout << "Value " << count
+                << " is not supported as an unsaturation "
+                  "query (only 0 and 1 are allowed). "
+                  "line: "
+                << line;
+        throw FileParseException(errout.str());
       }
     } catch (boost::bad_lexical_cast &) {
       std::ostringstream errout;
@@ -632,7 +633,7 @@ void ParseRingBondCountLine(RWMol *mol, const std::string &text,
   unsigned int spos = 9;
   for (unsigned int ie = 0; ie < nent; ie++) {
     unsigned int aid;
-    int count;
+    int count = 0;
     try {
       aid = FileParserUtils::stripSpacesAndCast<unsigned int>(
           text.substr(spos, 4));
@@ -640,43 +641,43 @@ void ParseRingBondCountLine(RWMol *mol, const std::string &text,
       Atom *atom = mol->getAtomWithIdx(aid - 1);
       if (text.size() >= spos + 4 && text.substr(spos, 4) != "    ") {
         count = FileParserUtils::toInt(text.substr(spos, 4));
-        if (count == 0) {
-          continue;
-        }
-        ATOM_EQUALS_QUERY *q = makeAtomRingBondCountQuery(0);
-        switch (count) {
-          case -1:
-            q->setVal(0);
-            break;
-          case -2:
-            q->setVal(0xDEADBEEF);
-            mol->setProp(common_properties::_NeedsQueryScan, 1);
-            break;
-          case 1:
-          case 2:
-          case 3:
-            q->setVal(count);
-            break;
-          case 4:
-            delete q;
-            q = static_cast<ATOM_EQUALS_QUERY *>(new ATOM_LESSEQUAL_QUERY);
-            q->setVal(4);
-            q->setDescription("AtomRingBondCount");
-            q->setDataFunc(queryAtomRingBondCount);
-            break;
-          default:
-            std::ostringstream errout;
-            errout << "Value " << count
-                   << " is not supported as a ring-bond count query. line: "
-                   << line;
-            throw FileParseException(errout.str());
-        }
-        if (!atom->hasQuery()) {
-          atom = QueryOps::replaceAtomWithQueryAtom(mol, atom);
-        }
-        atom->expandQuery(q, Queries::COMPOSITE_AND);
-        spos += 4;
       }
+      spos += 4;
+      if (count == 0) {
+        continue;
+      }
+      ATOM_EQUALS_QUERY *q = makeAtomRingBondCountQuery(0);
+      switch (count) {
+        case -1:
+          q->setVal(0);
+          break;
+        case -2:
+          q->setVal(0xDEADBEEF);
+          mol->setProp(common_properties::_NeedsQueryScan, 1);
+          break;
+        case 1:
+        case 2:
+        case 3:
+          q->setVal(count);
+          break;
+        case 4:
+          delete q;
+          q = static_cast<ATOM_EQUALS_QUERY *>(new ATOM_LESSEQUAL_QUERY);
+          q->setVal(4);
+          q->setDescription("AtomRingBondCount");
+          q->setDataFunc(queryAtomRingBondCount);
+          break;
+        default:
+          std::ostringstream errout;
+          errout << "Value " << count
+                  << " is not supported as a ring-bond count query. line: "
+                  << line;
+          throw FileParseException(errout.str());
+      }
+      if (!atom->hasQuery()) {
+        atom = QueryOps::replaceAtomWithQueryAtom(mol, atom);
+      }
+      atom->expandQuery(q, Queries::COMPOSITE_AND);
     } catch (boost::bad_lexical_cast &) {
       std::ostringstream errout;
       errout << "Cannot convert '" << text.substr(spos, 4)

--- a/Code/GraphMol/FileParsers/file_parsers_catch.cpp
+++ b/Code/GraphMol/FileParsers/file_parsers_catch.cpp
@@ -5447,6 +5447,126 @@ M  END
   }
 }
 
+TEST_CASE(
+    "Github #6395: Mol Unsaturated Query Not Parsed Correctly") {
+  SECTION("as reported") {
+    auto m = R"CTAB(
+MOESketch           2D                              
+
+  5  5  0  0  1  0            999 V2000
+   13.5413    2.8394    0.0000 N   0  0  0  0  0  0  0  0  0  3  0  0
+   14.0120    1.4152    0.0000 N   0  0  0  0  0  0  0  0  0  0  0  0
+   15.5120    1.4227    0.0000 N   0  0  0  0  0  0  0  0  0  0  0  0
+   15.9683    2.8516    0.0000 N   0  0  0  0  0  0  0  0  0  2  0  0
+   14.7504    3.7272    0.0000 C   0  0  0  0  0  0  0  0  0  1  0  0
+  1  2  8  0  0  0  4
+  2  3  8  0  0  0  0
+  3  4  8  0  0  0  4
+  4  5  8  0  0  0  9
+  5  1  1  0  0  0  0
+M  SUB  4   1   2   2   2   3   2   4   2
+M  UNS  4   2   1   3   1   4   1   5   1
+M  END
+)CTAB"_ctab;
+    REQUIRE(m);
+  }
+  SECTION("test that queries exist for only nonzero unsaturated values") {
+    auto m = R"CTAB(
+MOESketch           2D                              
+
+  5  5  0  0  1  0            999 V2000
+   13.5413    2.8394    0.0000 N   0  0  0  0  0  0  0  0  0  3  0  0
+   14.0120    1.4152    0.0000 N   0  0  0  0  0  0  0  0  0  0  0  0
+   15.5120    1.4227    0.0000 N   0  0  0  0  0  0  0  0  0  0  0  0
+   15.9683    2.8516    0.0000 N   0  0  0  0  0  0  0  0  0  2  0  0
+   14.7504    3.7272    0.0000 C   0  0  0  0  0  0  0  0  0  1  0  0
+  1  2  8  0  0  0  4
+  2  3  8  0  0  0  0
+  3  4  8  0  0  0  4
+  4  5  8  0  0  0  9
+  5  1  1  0  0  0  0
+M  UNS  4   2   1   3   0   4   1   5   0
+M  END
+)CTAB"_ctab;
+    REQUIRE(m);
+    REQUIRE(m->getAtomWithIdx(1)->hasQuery());
+    REQUIRE(!m->getAtomWithIdx(2)->hasQuery());
+    REQUIRE(m->getAtomWithIdx(3)->hasQuery());
+    REQUIRE(!m->getAtomWithIdx(4)->hasQuery());
+  }
+  SECTION("test that isotope properties parse correctly") {
+    auto m = R"CTAB(
+MOESketch           2D                              
+
+  5  5  0  0  1  0            999 V2000
+   13.5413    2.8394    0.0000 N   0  0  0  0  0  0  0  0  0  3  0  0
+   14.0120    1.4152    0.0000 N   0  0  0  0  0  0  0  0  0  0  0  0
+   15.5120    1.4227    0.0000 N   0  0  0  0  0  0  0  0  0  0  0  0
+   15.9683    2.8516    0.0000 N   0  0  0  0  0  0  0  0  0  2  0  0
+   14.7504    3.7272    0.0000 C   0  0  0  0  0  0  0  0  0  1  0  0
+  1  2  8  0  0  0  4
+  2  3  8  0  0  0  0
+  3  4  8  0  0  0  4
+  4  5  8  0  0  0  9
+  5  1  1  0  0  0  0
+M  ISO  3   2  15   3  -1   5  14
+M  END
+)CTAB"_ctab;
+    REQUIRE(m);
+    REQUIRE(m->getAtomWithIdx(1)->getIsotope() == 15);
+    REQUIRE(m->getAtomWithIdx(2)->getIsotope() == 0);
+    REQUIRE(m->getAtomWithIdx(4)->getIsotope() == 14);
+  }
+  SECTION("test that substitution properties parse correctly") {
+    auto m = R"CTAB(
+MOESketch           2D                              
+
+  5  5  0  0  1  0            999 V2000
+   13.5413    2.8394    0.0000 N   0  0  0  0  0  0  0  0  0  3  0  0
+   14.0120    1.4152    0.0000 N   0  0  0  0  0  0  0  0  0  0  0  0
+   15.5120    1.4227    0.0000 N   0  0  0  0  0  0  0  0  0  0  0  0
+   15.9683    2.8516    0.0000 N   0  0  0  0  0  0  0  0  0  2  0  0
+   14.7504    3.7272    0.0000 C   0  0  0  0  0  0  0  0  0  1  0  0
+  1  2  8  0  0  0  4
+  2  3  8  0  0  0  0
+  3  4  8  0  0  0  4
+  4  5  8  0  0  0  9
+  5  1  1  0  0  0  0
+M  SUB  4   2   1   3   0   4  -1   5   0
+M  END
+)CTAB"_ctab;
+    REQUIRE(m);
+    REQUIRE(m->getAtomWithIdx(1)->hasQuery());
+    REQUIRE(!m->getAtomWithIdx(2)->hasQuery());
+    REQUIRE(m->getAtomWithIdx(3)->hasQuery());
+    REQUIRE(!m->getAtomWithIdx(4)->hasQuery());
+  }
+  SECTION("test that ring bond count properties parse correctly") {
+    auto m = R"CTAB(
+MOESketch           2D                              
+
+  5  5  0  0  1  0            999 V2000
+   13.5413    2.8394    0.0000 N   0  0  0  0  0  0  0  0  0  3  0  0
+   14.0120    1.4152    0.0000 N   0  0  0  0  0  0  0  0  0  0  0  0
+   15.5120    1.4227    0.0000 N   0  0  0  0  0  0  0  0  0  0  0  0
+   15.9683    2.8516    0.0000 N   0  0  0  0  0  0  0  0  0  2  0  0
+   14.7504    3.7272    0.0000 C   0  0  0  0  0  0  0  0  0  1  0  0
+  1  2  8  0  0  0  4
+  2  3  8  0  0  0  0
+  3  4  8  0  0  0  4
+  4  5  8  0  0  0  9
+  5  1  1  0  0  0  0
+M  RBC  4   2   1   3   0   4  -1   5   0
+M  END
+)CTAB"_ctab;
+    REQUIRE(m);
+    REQUIRE(m->getAtomWithIdx(1)->hasQuery());
+    REQUIRE(!m->getAtomWithIdx(2)->hasQuery());
+    REQUIRE(m->getAtomWithIdx(3)->hasQuery());
+    REQUIRE(!m->getAtomWithIdx(4)->hasQuery());
+  }
+}
+
 TEST_CASE("Github #3246: O.co2 types around P not correctly handled") {
   SECTION("as reported") {
     std::string mol2 = R"MOL2(#       Name: temp


### PR DESCRIPTION
Fixes #6395 

This code gives a fix to molfile parsing, where properties lines might not be processed correctly when they use pairs of values. The old code would fail to increase the string index when certain values were provided, so the code would fail to move completely to the next pair of values.

I've adjusted the code to be similar to the Attachment Points code https://github.com/rdkit/rdkit/blob/d4547e21165cf9cdc04ea6e0bfd1f25bbf2ed14e/Code/GraphMol/FileParsers/MolFileParser.cpp#L903-L973
and the ZCH code https://github.com/rdkit/rdkit/blob/d4547e21165cf9cdc04ea6e0bfd1f25bbf2ed14e/Code/GraphMol/FileParsers/MolFileParser.cpp#L689-L738

This code adjusts the string index close to where the values are being parsed, so that there aren't issues later on with continues skipping the string index incrementing step. Additionally, the code also sets default values in the case that the substring being parsed is too short or consists only of spaces.

