### PR TITLE
expose some missing CXSmiles flags to python

### DIFF
--- a/Code/GraphMol/Wrap/rdmolfiles.cpp
+++ b/Code/GraphMol/Wrap/rdmolfiles.cpp
@@ -1408,7 +1408,10 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
              RDKit::SmilesWrite::CXSmilesFields::CX_ENHANCEDSTEREO)
       .value("CX_SGROUPS", RDKit::SmilesWrite::CXSmilesFields::CX_SGROUPS)
       .value("CX_POLYMER", RDKit::SmilesWrite::CXSmilesFields::CX_POLYMER)
-      .value("CX_ALL", RDKit::SmilesWrite::CXSmilesFields::CX_ALL);
+      .value("CX_BOND_CFG", RDKit::SmilesWrite::CXSmilesFields::CX_BOND_CFG)
+      .value("CX_ALL", RDKit::SmilesWrite::CXSmilesFields::CX_ALL)
+      .value("CX_ALL_BUT_COORDS",
+             RDKit::SmilesWrite::CXSmilesFields::CX_ALL_BUT_COORDS);
 
   python::def(
       "MolToCXSmiles",

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -6872,6 +6872,8 @@ CAS<~>
     self.assertEqual(
       Chem.MolToCXSmiles(m, ps, (Chem.CXSmilesFields.CX_ALL ^ Chem.CXSmilesFields.CX_LINKNODES)),
       "C1(O)CCC(F)C1")
+    self.assertTrue(hasattr(Chem.CXSmilesFields, 'CX_BOND_CFG'))
+    self.assertTrue(hasattr(Chem.CXSmilesFields, 'CX_ALL_BUT_COORDS'))
 
   def testKekulizeIfPossible(self):
     m = Chem.MolFromSmiles('c1cccn1', sanitize=False)


### PR DESCRIPTION
Two members of the enum had not been exposed.
@adalke pointed this out in #6315 
