### PR TITLE
Fixes #6208

### DIFF
--- a/Code/GraphMol/Wrap/Mol.cpp
+++ b/Code/GraphMol/Wrap/Mol.cpp
@@ -11,22 +11,22 @@
 #include <RDBoost/python.h>
 #include <string>
 
+#include "props.hpp"
 #include "rdchem.h"
 #include "seqs.hpp"
-#include "props.hpp"
 #include "substructmethods.h"
 
 // ours
-#include <RDBoost/pyint_api.h>
-#include <RDBoost/Wrap.h>
-#include <GraphMol/RDKitBase.h>
-#include <GraphMol/QueryOps.h>
-#include <GraphMol/MolPickler.h>
 #include <GraphMol/MolBundle.h>
-#include <GraphMol/Substruct/SubstructMatch.h>
-#include <boost/python/iterator.hpp>
-#include <boost/python/copy_non_const_reference.hpp>
+#include <GraphMol/MolPickler.h>
+#include <GraphMol/QueryOps.h>
+#include <GraphMol/RDKitBase.h>
 #include <GraphMol/SmilesParse/SmilesParse.h>
+#include <GraphMol/Substruct/SubstructMatch.h>
+#include <RDBoost/Wrap.h>
+#include <RDBoost/pyint_api.h>
+#include <boost/python/copy_non_const_reference.hpp>
+#include <boost/python/iterator.hpp>
 
 namespace python = boost::python;
 
@@ -117,11 +117,6 @@ void MolDebug(const ROMol &mol, bool useStdout) {
 }
 
 // FIX: we should eventually figure out how to do iterators properly
-AtomIterSeq *MolGetAtoms(const ROMOL_SPTR &mol) {
-  AtomIterSeq *res = new AtomIterSeq(mol, mol->beginAtoms(), mol->endAtoms(),
-                                     AtomCountFunctor(mol));
-  return res;
-}
 QueryAtomIterSeq *MolGetAromaticAtoms(const ROMOL_SPTR &mol) {
   auto *qa = new QueryAtom();
   qa->setQuery(makeAtomAromaticQuery());
@@ -137,16 +132,6 @@ QueryAtomIterSeq *MolGetQueryAtoms(const ROMOL_SPTR &mol, QueryAtom *qa) {
   return res;
 }
 
-// AtomIterSeq *MolGetHeteros(ROMol *mol){
-//  AtomIterSeq *res = new AtomIterSeq(mol->beginHeteros(),
-//                                     mol->endHeteros());
-//  return res;
-//}
-BondIterSeq *MolGetBonds(const ROMOL_SPTR &mol) {
-  BondIterSeq *res = new BondIterSeq(mol, mol->beginBonds(), mol->endBonds(),
-                                     BondCountFunctor(mol));
-  return res;
-}
 ConformerIterSeq *GetMolConformers(const ROMOL_SPTR &mol) {
   ConformerIterSeq *res =
       new ConformerIterSeq(mol, mol->beginConformers(), mol->endConformers(),
@@ -678,16 +663,18 @@ struct mol_wrapper {
              "assigned.\n\n"
              "  ARGUMENTS:\n"
              "    - key: the name of the property to check for (a string).\n")
-        .def("GetProp", GetPyProp<ROMol>,
-	     (python::arg("self"), python::arg("key"), python::arg("autoConvert")=false),
-             "Returns the value of the property.\n\n"
-             "  ARGUMENTS:\n"
-             "    - key: the name of the property to return (a string).\n\n"
-             "    - autoConvert: if True attempt to convert the property into a python object\n\n"
-             "  RETURNS: a string\n\n"
-             "  NOTE:\n"
-             "    - If the property has not been set, a KeyError exception "
-             "will be raised.\n")
+        .def(
+            "GetProp", GetPyProp<ROMol>,
+            (python::arg("self"), python::arg("key"),
+             python::arg("autoConvert") = false),
+            "Returns the value of the property.\n\n"
+            "  ARGUMENTS:\n"
+            "    - key: the name of the property to return (a string).\n\n"
+            "    - autoConvert: if True attempt to convert the property into a python object\n\n"
+            "  RETURNS: a string\n\n"
+            "  NOTE:\n"
+            "    - If the property has not been set, a KeyError exception "
+            "will be raised.\n")
         .def("GetDoubleProp", GetProp<ROMol, double>,
              "Returns the double value of the property if possible.\n\n"
              "  ARGUMENTS:\n"
@@ -763,7 +750,7 @@ struct mol_wrapper {
         .def("GetPropsAsDict", GetPropsAsDict<ROMol>,
              (python::arg("self"), python::arg("includePrivate") = false,
               python::arg("includeComputed") = false,
-	      python::arg("autoConvertStrings") = true),
+              python::arg("autoConvertStrings") = true),
              "Returns a dictionary populated with the molecules properties.\n"
              " n.b. Some properties are not able to be converted to python "
              "types.\n\n"
@@ -776,12 +763,6 @@ struct mol_wrapper {
              "                      Defaults to False.\n\n"
              "  RETURNS: a dictionary\n")
 
-        .def("GetAtoms", MolGetAtoms,
-             python::return_value_policy<
-                 python::manage_new_object,
-                 python::with_custodian_and_ward_postcall<0, 1>>(),
-             "Returns a read-only sequence containing all of the molecule's "
-             "Atoms.\n")
         .def("GetAromaticAtoms", MolGetAromaticAtoms,
              python::return_value_policy<
                  python::manage_new_object,
@@ -794,13 +775,6 @@ struct mol_wrapper {
                  python::with_custodian_and_ward_postcall<0, 1>>(),
              "Returns a read-only sequence containing all of the atoms in a "
              "molecule that match the query atom.\n")
-
-        .def("GetBonds", MolGetBonds,
-             python::return_value_policy<
-                 python::manage_new_object,
-                 python::with_custodian_and_ward_postcall<0, 1>>(),
-             "Returns a read-only sequence containing all of the molecule's "
-             "Bonds.\n")
 
         // enable pickle support
         .def_pickle(mol_pickle_suite())
@@ -903,7 +877,6 @@ struct mol_wrapper {
         // enable pickle support
         .def_pickle(mol_pickle_suite());
   };
-
 };
 
 }  // namespace RDKit

--- a/Code/GraphMol/Wrap/rdchem.cpp
+++ b/Code/GraphMol/Wrap/rdchem.cpp
@@ -9,10 +9,10 @@
 //  of the RDKit source tree.
 //
 #define PY_ARRAY_UNIQUE_SYMBOL rdchem_array_API
-#include <RDBoost/Wrap.h>
 #include "rdchem.h"
 #include <GraphMol/RDKitBase.h>
 #include <GraphMol/SanitException.h>
+#include <RDBoost/Wrap.h>
 #include <RDBoost/import_array.h>
 
 #include <sstream>
@@ -168,21 +168,6 @@ BOOST_PYTHON_MODULE(rdchem) {
   //  Utility Classes
   //
   //*********************************************
-  python::class_<AtomIterSeq>(
-      "_ROAtomSeq",
-      "Read-only sequence of atoms, not constructible from Python.",
-      python::no_init)
-      .def("__iter__", &AtomIterSeq::__iter__,
-           python::return_internal_reference<
-               1, python::with_custodian_and_ward_postcall<0, 1>>())
-      .def("__next__", &AtomIterSeq::next,
-           python::return_internal_reference<
-               1, python::with_custodian_and_ward_postcall<0, 1>>())
-
-      .def("__len__", &AtomIterSeq::len)
-      .def("__getitem__", &AtomIterSeq::get_item,
-           python::return_internal_reference<
-               1, python::with_custodian_and_ward_postcall<0, 1>>());
   python::class_<QueryAtomIterSeq>("_ROQAtomSeq",
                                    "Read-only sequence of atoms matching a "
                                    "query, not constructible from Python.",
@@ -195,20 +180,6 @@ BOOST_PYTHON_MODULE(rdchem) {
                1, python::with_custodian_and_ward_postcall<0, 1>>())
       .def("__len__", &QueryAtomIterSeq::len)
       .def("__getitem__", &QueryAtomIterSeq::get_item,
-           python::return_internal_reference<
-               1, python::with_custodian_and_ward_postcall<0, 1>>());
-  python::class_<BondIterSeq>(
-      "_ROBondSeq",
-      "Read-only sequence of bonds, not constructible from Python.",
-      python::no_init)
-      .def("__iter__", &BondIterSeq::__iter__,
-           python::return_internal_reference<
-               1, python::with_custodian_and_ward_postcall<0, 1>>())
-      .def("__next__", &BondIterSeq::next,
-           python::return_internal_reference<
-               1, python::with_custodian_and_ward_postcall<0, 1>>())
-      .def("__len__", &BondIterSeq::len)
-      .def("__getitem__", &BondIterSeq::get_item,
            python::return_internal_reference<
                1, python::with_custodian_and_ward_postcall<0, 1>>());
   python::class_<ConformerIterSeq>(

--- a/Code/GraphMol/Wrap/seqs.hpp
+++ b/Code/GraphMol/Wrap/seqs.hpp
@@ -7,9 +7,9 @@
 #define _SEQS_HPP_
 
 #include <GraphMol/RDKitBase.h>
+#include <RDBoost/python.h>
 #include <iostream>
 #include <utility>
-#include <RDBoost/python.h>
 namespace python = boost::python;
 
 namespace RDKit {
@@ -122,10 +122,9 @@ class ReadOnlySeq {
   }
 };
 
-typedef ReadOnlySeq<ROMol::AtomIterator, Atom *, AtomCountFunctor> AtomIterSeq;
 typedef ReadOnlySeq<ROMol::QueryAtomIterator, Atom *, AtomCountFunctor>
     QueryAtomIterSeq;
-typedef ReadOnlySeq<ROMol::BondIterator, Bond *, BondCountFunctor> BondIterSeq;
+
 typedef ReadOnlySeq<ROMol::ConformerIterator, CONFORMER_SPTR &,
                     ConformerCountFunctor>
     ConformerIterSeq;

--- a/rdkit/Chem/__init__.py
+++ b/rdkit/Chem/__init__.py
@@ -42,6 +42,24 @@ else:
   rdCoordGen.SetDefaultTemplateFileDir(templDir)
 
 
+# Github Issue #6208: boost::python iterators are slower than they should
+# (cause is that boost::python throws exceptions as actual C++ exceptions)
+def _GetAtoms(mol):
+  """Returns a read-only sequence containing all of the molecule's Atoms."""
+  return (mol.GetAtomWithIdx(i) for i in range(mol.GetNumAtoms()))
+
+
+def _GetBonds(mol):
+  """Returns a read-only sequence containing all of the molecule's Bonds."""
+  return (mol.GetBondWithIdx(i) for i in range(mol.GetNumBonds()))
+
+
+rdchem.Mol.GetAtoms = _GetAtoms
+rdchem.Mol.GetBonds = _GetBonds
+del _GetAtoms
+del _GetBonds
+
+
 def QuickSmartsMatch(smi, sma, unique=True, display=False):
   m = MolFromSmiles(smi)
   p = MolFromSmarts(sma)


### PR DESCRIPTION
This fixes #6208:

The 'slowness' in the iterators is due to seqs.hpp actually throwing a C++ exception to tell boost::python that a Python exception should be thrown, even for the `StopIteration` at the end of an iterator.

As suggested in the issue, we can get around that by implementing the iterator directly in Python.

With this patch, the benchmarks on my Mac go from
```python
In [1]: from rdkit import Chem
   ...: mol = Chem.MolFromSmiles('CC(C)(C)NCC(C1=CC(=C(C=C1)O)CO)O')
   ...: 
   ...: %time for a in mol.GetAtoms(): pass
CPU times: user 1.57 ms, sys: 44 µs, total: 1.61 ms
Wall time: 1.64 ms
```
to (note the change in the units, from `ms` to `µs`)
```python
In [1]: from rdkit import Chem
   ...: mol = Chem.MolFromSmiles('CC(C)(C)NCC(C1=CC(=C(C=C1)O)CO)O')
   ...: 
   ...: %time for a in mol.GetAtoms(): pass
CPU times: user 64 µs, sys: 1 µs, total: 65 µs
Wall time: 67.9 µs
```

Which is about ~1.5-2x slower than directly accessing by index, though we do some checking, so it makes sense to me.
```python
In [2]: %time for i in range(0, mol.GetNumAtoms()): mol.GetAtomWithIdx(i)
CPU times: user 36 µs, sys: 1 µs, total: 37 µs
Wall time: 40.1 µs
```

I did `GetAtoms()` and `GetBonds()`, but left `GetConformers()`, `GetAromaticAtoms()` and `GetAtomsMatchingQuery()` untouched, since these are a bit more complicated to implement on the Python side.

No new tests, since the existing ones seem to capture the expected behavior quite well.