### PR TITLE
Fixes #6108

### DIFF
--- a/Code/GraphMol/WedgeBonds.cpp
+++ b/Code/GraphMol/WedgeBonds.cpp
@@ -453,8 +453,7 @@ void wedgeMolBonds(ROMol &mol, const Conformer *conf,
   auto wedgeBonds = pickBondsToWedge(mol, params);
 
   // loop over the bonds we need to wedge:
-  for (auto wbIter = wedgeBonds.begin(); wbIter != wedgeBonds.end(); ++wbIter) {
-    auto [wbi, waid] = *wbIter;
+  for (const auto &[wbi, waid] : wedgeBonds) {
     auto bond = mol.getBondWithIdx(wbi);
     auto dir = detail::determineBondWedgeState(bond, waid, conf);
     if (dir == Bond::BEGINWEDGE || dir == Bond::BEGINDASH) {
@@ -469,8 +468,27 @@ void wedgeMolBonds(ROMol &mol, const Conformer *conf,
         bond->setBeginAtomIdx(bond->getEndAtomIdx());
         bond->setEndAtomIdx(tmp);
       }
-      if (params->wedgeTwoBondsIfPossible) {
-        addSecondWedgeAroundAtom(mol, bond, conf);
+    }
+  }
+  if (params->wedgeTwoBondsIfPossible) {
+    for (const auto atom : mol.atoms()) {
+      if (atom->getChiralTag() != Atom::CHI_TETRAHEDRAL_CW &&
+          atom->getChiralTag() != Atom::CHI_TETRAHEDRAL_CCW) {
+        continue;
+      }
+      unsigned numWedged = 0;
+      Bond *wedgedBond = nullptr;
+      for (const auto bond : mol.atomBonds(atom)) {
+        if (bond->getBeginAtom() == atom &&
+            bond->getBondType() == Bond::SINGLE &&
+            (bond->getBondDir() == Bond::BEGINWEDGE ||
+             bond->getBondDir() == Bond::BEGINDASH)) {
+          ++numWedged;
+          wedgedBond = bond;
+        }
+      }
+      if (numWedged == 1) {
+        addSecondWedgeAroundAtom(mol, wedgedBond, conf);
       }
     }
   }

--- a/Code/GraphMol/WedgeBonds.cpp
+++ b/Code/GraphMol/WedgeBonds.cpp
@@ -201,7 +201,7 @@ Bond::BondDir determineBondWedgeState(const Bond *bond,
   if (neighborBondAngles.size() == 3) {
     // three coordinated
     auto angleIt = neighborBondAngles.begin();
-    ++angleIt;  // the first is the 0 (or reference bond - we will ignoire
+    ++angleIt;  // the first is the 0 (or reference bond - we will ignore
                 // that
     double angle1 = (*angleIt);
     ++angleIt;
@@ -471,6 +471,9 @@ void wedgeMolBonds(ROMol &mol, const Conformer *conf,
     }
   }
   if (params->wedgeTwoBondsIfPossible) {
+    // This should probably check whether the existing wedge
+    // is in agreement with the chiral tag on the atom.
+
     for (const auto atom : mol.atoms()) {
       if (atom->getChiralTag() != Atom::CHI_TETRAHEDRAL_CW &&
           atom->getChiralTag() != Atom::CHI_TETRAHEDRAL_CCW) {

--- a/Code/GraphMol/catch_chirality.cpp
+++ b/Code/GraphMol/catch_chirality.cpp
@@ -3475,12 +3475,15 @@ M  END
 
         auto bond = cp.getBondBetweenAtoms(1, wedgedAtomIdx);
         if (bond->getEndAtomIdx() == 1) {
-          // One of the bonds is reversed, make sure the chiral atom is always
-          // at the start so that the wedge is valid!
+          // One of the bonds in the input is reversed, make sure the chiral
+          // atom is always at the start so that the wedge is valid!
           auto tmp = bond->getBeginAtomIdx();
           bond->setBeginAtomIdx(bond->getEndAtomIdx());
           bond->setEndAtomIdx(tmp);
         }
+
+        // This probably disagrees with the chirality in some of the test cases,
+        // but that's not relevant for this test
         bond->setBondDir(Bond::BondDir::BEGINWEDGE);
 
         Chirality::wedgeMolBonds(cp, nullptr, &ps);


### PR DESCRIPTION
This fixes #6108.

After a couple of tries, I found that the easiest way to fix the behavior was with something like this.

As mentioned in the comment, we don't check if any bonds present before adding the second one are in agreement with the chiral tag or not, so the user is responsible for that.