### PR TITLE
Enable using JSSubstructLibrary without pattern fps

### DIFF
--- a/Code/MinimalLib/minilib.cpp
+++ b/Code/MinimalLib/minilib.cpp
@@ -46,6 +46,8 @@ namespace rj = rapidjson;
 using namespace RDKit;
 
 namespace {
+static const char *NO_SUPPORT_FOR_PATTERN_FPS = "This SubstructLibrary was built without support for pattern fps";
+
 std::string mappingToJsonArray(const ROMol &mol) {
   std::vector<unsigned int> atomMapping;
   std::vector<unsigned int> bondMapping;
@@ -682,7 +684,9 @@ int JSSubstructLibrary::add_trusted_smiles(const std::string &smi) {
 
 int JSSubstructLibrary::add_trusted_smiles_and_pattern_fp(
     const std::string &smi, const std::string &patternFp) {
-  PRECONDITION(d_fpHolder, "d_fpHolder != nullptr");
+  if (!d_fpHolder) {
+    throw ValueErrorException(NO_SUPPORT_FOR_PATTERN_FPS);
+  }
   auto bitVect = new ExplicitBitVect(patternFp);
   if (!bitVect) {
     return -1;
@@ -698,7 +702,9 @@ std::string JSSubstructLibrary::get_trusted_smiles(unsigned int i) const {
 }
 
 std::string JSSubstructLibrary::get_pattern_fp(unsigned int i) const {
-  PRECONDITION(d_fpHolder, "d_fpHolder != nullptr");
+  if (!d_fpHolder) {
+    throw ValueErrorException(NO_SUPPORT_FOR_PATTERN_FPS);
+  }
   return d_fpHolder->getFingerprints().at(i)->toString();
 }
 

--- a/Code/MinimalLib/minilib.cpp
+++ b/Code/MinimalLib/minilib.cpp
@@ -644,14 +644,18 @@ std::string JSReaction::get_svg_with_highlights(
   return MinimalLib::rxn_to_svg(*d_rxn, w, h, details);
 }
 
-JSSubstructLibrary::JSSubstructLibrary(unsigned int num_bits)
-    : d_sslib(new SubstructLibrary(
-          boost::shared_ptr<CachedTrustedSmilesMolHolder>(
-              new CachedTrustedSmilesMolHolder()),
-          boost::shared_ptr<PatternHolder>(new PatternHolder(num_bits)))) {
-  d_molHolder = dynamic_cast<CachedTrustedSmilesMolHolder *>(
-      d_sslib->getMolHolder().get());
-  d_fpHolder = dynamic_cast<PatternHolder *>(d_sslib->getFpHolder().get());
+JSSubstructLibrary::JSSubstructLibrary(unsigned int num_bits) :
+  d_fpHolder(nullptr) {
+  boost::shared_ptr<CachedTrustedSmilesMolHolder> molHolderSptr(new CachedTrustedSmilesMolHolder());
+  boost::shared_ptr<PatternHolder> fpHolderSptr;
+  d_molHolder = molHolderSptr.get();
+  if (num_bits) {
+    fpHolderSptr.reset(new PatternHolder(num_bits));
+    d_fpHolder = fpHolderSptr.get();
+    d_sslib.reset(new SubstructLibrary(molHolderSptr, fpHolderSptr));
+  } else {
+    d_sslib.reset(new SubstructLibrary(molHolderSptr));
+  }
 }
 
 int JSSubstructLibrary::add_trusted_smiles(const std::string &smi) {
@@ -661,24 +665,32 @@ int JSSubstructLibrary::add_trusted_smiles(const std::string &smi) {
   }
   mol->updatePropertyCache();
   MolOps::fastFindRings(*mol);
-  auto fp = d_fpHolder->makeFingerprint(*mol);
-  if (!fp) {
-    return -1;
+  int smiIdx;
+  if (d_fpHolder) {
+    auto fp = d_fpHolder->makeFingerprint(*mol);
+    if (!fp) {
+      return -1;
+    }
+    int fpIdx = d_fpHolder->addFingerprint(fp);
+    smiIdx = d_molHolder->addSmiles(smi);
+    CHECK_INVARIANT(fpIdx == smiIdx, "");
+  } else {
+    smiIdx = d_molHolder->addSmiles(smi);
   }
-  auto fpIdx = d_fpHolder->addFingerprint(fp);
-  auto smiIdx = d_molHolder->addSmiles(smi);
-  return (fpIdx == smiIdx ? fpIdx : -1);
+  return smiIdx;
 }
 
 int JSSubstructLibrary::add_trusted_smiles_and_pattern_fp(
     const std::string &smi, const std::string &patternFp) {
+  PRECONDITION(d_fpHolder, "d_fpHolder != nullptr");
   auto bitVect = new ExplicitBitVect(patternFp);
   if (!bitVect) {
     return -1;
   }
-  auto fpIdx = d_fpHolder->addFingerprint(bitVect);
-  auto smiIdx = d_molHolder->addSmiles(smi);
-  return (fpIdx == smiIdx ? fpIdx : -1);
+  int fpIdx = d_fpHolder->addFingerprint(bitVect);
+  int smiIdx = d_molHolder->addSmiles(smi);
+  CHECK_INVARIANT(fpIdx == smiIdx, "");
+  return smiIdx;
 }
 
 std::string JSSubstructLibrary::get_trusted_smiles(unsigned int i) const {
@@ -686,6 +698,7 @@ std::string JSSubstructLibrary::get_trusted_smiles(unsigned int i) const {
 }
 
 std::string JSSubstructLibrary::get_pattern_fp(unsigned int i) const {
+  PRECONDITION(d_fpHolder, "d_fpHolder != nullptr");
   return d_fpHolder->getFingerprints().at(i)->toString();
 }
 

--- a/Code/MinimalLib/tests/tests.js
+++ b/Code/MinimalLib/tests/tests.js
@@ -329,87 +329,101 @@ function test_abbreviations() {
 
 function test_substruct_library(done) {
     done.test_substruct_library = false;
-    var smiReader = readline.createInterface({
-        input: fs.createReadStream(__dirname + '/../../GraphMol/test_data/compounds.smi')
-    });
     var query = RDKitModule.get_qmol('C1CCCCN1');
     var nonExistingQuery = RDKitModule.get_mol('O=C(O)C(c1ccc(cc1)CCN4CCC(c2nc3ccccc3n2CCOCC)CC4)(C)C');
-    var sslib = new RDKitModule.SubstructLibrary();
-    assert.equal(sslib.count_matches(query), 0);
-    assert.equal(sslib.get_matches(query), JSON.stringify([]));
-    assert.equal(sslib.get_matches_as_uint32array(query).length, 0);
-    // var t0 = performance.now()
-    // console.log('Started adding trusted SMILES');
-    var matches = [];
-    var expectedMatches = [39, 64, 80, 127, 128, 234, 240];
-    var i = 0;
+    const numBitOptions = [-1, 0];
     var patternFpArray = [];
-    var trustedSmiArray = []
-    smiReader.on('line', (smi) => {
-        sslib.add_trusted_smiles(smi);
-        var mol = RDKitModule.get_mol(smi);
-        var res = JSON.parse(mol.get_substruct_match(query));
-        if (res.atoms) {
-            matches.push(i);
-        }
-        ++i;
-        mol.delete();
-    });
-    smiReader.on('close', () => {
-        // var t1 = performance.now();
-        // console.log('Finished adding trusted SMILES took ' + (t1 - t0) / 1000 + ' seconds');
-        for (var i = 0; i < sslib.size(); ++i) {
-            trustedSmiArray.push(sslib.get_trusted_smiles(i));
-            var fp = sslib.get_pattern_fp_as_uint8array(i);
-            patternFpArray.push(fp);
-        }
-        assert.equal(trustedSmiArray.length, sslib.size());
-        assert.equal(patternFpArray.length, sslib.size());
-        assert.equal(trustedSmiArray.length, patternFpArray.length);
-        var sslib2 = new RDKitModule.SubstructLibrary();
-        for (var i = 0; i < sslib.size(); ++i) {
-            sslib2.add_trusted_smiles_and_pattern_fp(trustedSmiArray[i], patternFpArray[i]);
-        }
-        assert.equal(sslib.size(), sslib2.size());
+    numBitOptions.forEach((numBits, optIdx) => {
+        var smiReader = readline.createInterface({
+            input: fs.createReadStream(__dirname + '/../../GraphMol/test_data/compounds.smi')
+        });
+        var sslib = numBits < 0 ? new RDKitModule.SubstructLibrary() : new RDKitModule.SubstructLibrary(numBits);
+        assert.equal(sslib.count_matches(query), 0);
+        assert.equal(sslib.get_matches(query), JSON.stringify([]));
+        assert.equal(sslib.get_matches_as_uint32array(query).length, 0);
+        // var t0 = performance.now()
+        // console.log('Started adding trusted SMILES');
+        var matches = [];
+        var expectedMatches = [39, 64, 80, 127, 128, 234, 240];
+        var i = 0;
+        var trustedSmiArray = []
+        smiReader.on('line', (smi) => {
+            sslib.add_trusted_smiles(smi);
+            var mol = RDKitModule.get_mol(smi);
+            var res = JSON.parse(mol.get_substruct_match(query));
+            if (res.atoms) {
+                matches.push(i);
+            }
+            ++i;
+            mol.delete();
+        });
+        smiReader.on('close', () => {
+            // var t1 = performance.now();
+            // console.log('Finished adding trusted SMILES took ' + (t1 - t0) / 1000 + ' seconds');
+            for (var i = 0; i < sslib.size(); ++i) {
+                trustedSmiArray.push(sslib.get_trusted_smiles(i));
+                let excRaised = false;
+                try {
+                    var fp = sslib.get_pattern_fp_as_uint8array(i);
+                    patternFpArray.push(fp);
+                } catch (e) {
+                    // this is expected to fails when numBits === 0
+                    excRaised = true;
+                }
+                assert((excRaised && numBits === 0) || (!excRaised && numBits !== 0));
+            }
+            assert.equal(trustedSmiArray.length, sslib.size());
+            assert.equal(patternFpArray.length, sslib.size());
+            assert.equal(trustedSmiArray.length, patternFpArray.length);
+            var sslib2 = new RDKitModule.SubstructLibrary();
+            for (var i = 0; i < sslib.size(); ++i) {
+                sslib2.add_trusted_smiles_and_pattern_fp(trustedSmiArray[i], patternFpArray[i]);
+            }
+            assert.equal(sslib.size(), sslib2.size());
             {
-            assert.equal(sslib.count_matches(query, false), 7);
-            var sslibMatches = sslib.get_matches(query);
-            assert.equal(sslibMatches, JSON.stringify(expectedMatches));
-            var sslibMatchesUInt32Array = sslib.get_matches_as_uint32array(query);
-            assert.equal(sslibMatchesUInt32Array.length, expectedMatches.length);
-            for (var i = 0; i < expectedMatches.length; ++i) {
-                assert.equal(sslibMatchesUInt32Array[i], expectedMatches[i]);
+                assert.equal(sslib.count_matches(query, false), 7);
+                var sslibMatches = sslib.get_matches(query);
+                assert.equal(sslibMatches, JSON.stringify(expectedMatches));
+                assert.equal(sslibMatches, JSON.stringify(matches));
+                var sslibMatchesUInt32Array = sslib.get_matches_as_uint32array(query);
+                assert.equal(sslibMatchesUInt32Array.length, expectedMatches.length);
+                for (var i = 0; i < expectedMatches.length; ++i) {
+                    assert.equal(sslibMatchesUInt32Array[i], expectedMatches[i]);
+                }
             }
-        }
-        {
-            assert.equal(sslib.count_matches(nonExistingQuery, false), 0);
-            var sslibMatches = sslib.get_matches(nonExistingQuery);
-            assert.equal(sslibMatches, JSON.stringify([]));
-            var sslibMatchesUInt32Array = sslib.get_matches_as_uint32array(nonExistingQuery);
-            assert.equal(sslibMatchesUInt32Array.length, 0);
-        }
-        {
-            assert.equal(sslib2.count_matches(query, false), 7);
-            var sslib2Matches = sslib2.get_matches(query);
-            assert.equal(sslib2Matches, JSON.stringify(expectedMatches));
-            var sslib2MatchesUInt32Array = sslib2.get_matches_as_uint32array(query);
-            assert.equal(sslib2MatchesUInt32Array.length, expectedMatches.length);
-            for (var i = 0; i < expectedMatches.length; ++i) {
-                assert.equal(sslib2MatchesUInt32Array[i], expectedMatches[i]);
+            {
+                assert.equal(sslib.count_matches(nonExistingQuery, false), 0);
+                var sslibMatches = sslib.get_matches(nonExistingQuery);
+                assert.equal(sslibMatches, JSON.stringify([]));
+                var sslibMatchesUInt32Array = sslib.get_matches_as_uint32array(nonExistingQuery);
+                assert.equal(sslibMatchesUInt32Array.length, 0);
             }
-        }
-        {
-            assert.equal(sslib2.count_matches(nonExistingQuery, false), 0);
-            var sslib2Matches = sslib2.get_matches(nonExistingQuery);
-            assert.equal(sslib2Matches, JSON.stringify([]));
-            var sslib2MatchesUInt32Array = sslib2.get_matches_as_uint32array(nonExistingQuery);
-            assert.equal(sslib2MatchesUInt32Array.length, 0);
-        }
-        done.test_substruct_library = true;
-        query.delete();
-        nonExistingQuery.delete();
-        sslib.delete();
-        sslib2.delete();
+            {
+                assert.equal(sslib2.count_matches(query, false), 7);
+                var sslib2Matches = sslib2.get_matches(query);
+                assert.equal(sslib2Matches, JSON.stringify(expectedMatches));
+                assert.equal(sslib2Matches, JSON.stringify(matches));
+                var sslib2MatchesUInt32Array = sslib2.get_matches_as_uint32array(query);
+                assert.equal(sslib2MatchesUInt32Array.length, expectedMatches.length);
+                for (var i = 0; i < expectedMatches.length; ++i) {
+                    assert.equal(sslib2MatchesUInt32Array[i], expectedMatches[i]);
+                }
+            }
+            {
+                assert.equal(sslib2.count_matches(nonExistingQuery, false), 0);
+                var sslib2Matches = sslib2.get_matches(nonExistingQuery);
+                assert.equal(sslib2Matches, JSON.stringify([]));
+                var sslib2MatchesUInt32Array = sslib2.get_matches_as_uint32array(nonExistingQuery);
+                assert.equal(sslib2MatchesUInt32Array.length, 0);
+            }
+            sslib.delete();
+            sslib2.delete();
+            if (optIdx === numBitOptions.length - 1) {
+                done.test_substruct_library = true;
+                query.delete();
+                nonExistingQuery.delete();
+            }
+        });
     });
 }
 

--- a/Code/MinimalLib/tests/tests.js
+++ b/Code/MinimalLib/tests/tests.js
@@ -367,7 +367,7 @@ function test_substruct_library(done) {
                     var fp = sslib.get_pattern_fp_as_uint8array(i);
                     patternFpArray.push(fp);
                 } catch (e) {
-                    // this is expected to fails when numBits === 0
+                    // this is expected to fail when numBits === 0
                     excRaised = true;
                 }
                 assert((excRaised && numBits === 0) || (!excRaised && numBits !== 0));


### PR DESCRIPTION
Small PR to enable using JSSubstructLibrary without pattern fps.

- enable using `JSSubstructLibrary` with no fps by passing `num_bits 0`
- get rid of `dynamic_cast` which never looks great
- add unit tests for no-fingerprint `JSSubstructLibrary`
