### PR TITLE
Fixes Issue 6437

### DIFF
--- a/Code/GraphMol/AddHs.cpp
+++ b/Code/GraphMol/AddHs.cpp
@@ -136,7 +136,7 @@ std::map<unsigned int, std::vector<unsigned int>> getIsoMap(const ROMol &mol) {
   return isoMap;
 }
 
-bool is_atom_n_pyrrol_like(const ROMol &mol, const Atom *atom) {
+bool may_need_extra_H(const ROMol &mol, const Atom *atom) {
   unsigned single_bonds = 0;
   unsigned aromatic_bonds = 0;
   for (auto bond : mol.atomBonds(atom)) {
@@ -674,7 +674,7 @@ void molRemoveH(RWMol &mol, unsigned int idx, bool updateExplicitCount) {
       const INT_VECT &defaultVs =
           PeriodicTable::getTable()->getValenceList(heavyAtomNum);
       if (((heavyAtomNum == 7 || heavyAtomNum == 15 ||
-            is_atom_n_pyrrol_like(mol, heavyAtom)) &&
+            may_need_extra_H(mol, heavyAtom)) &&
            heavyAtom->getIsAromatic()) ||
           (std::find(defaultVs.begin() + 1, defaultVs.end(),
                      heavyAtom->getTotalValence()) != defaultVs.end())) {

--- a/Code/GraphMol/AddHs.cpp
+++ b/Code/GraphMol/AddHs.cpp
@@ -136,6 +136,22 @@ std::map<unsigned int, std::vector<unsigned int>> getIsoMap(const ROMol &mol) {
   return isoMap;
 }
 
+bool is_atom_n_pyrrol_like(const ROMol &mol, const Atom *atom) {
+  unsigned single_bonds = 0;
+  unsigned aromatic_bonds = 0;
+  for (auto bond : mol.atomBonds(atom)) {
+    if (bond->getBondType() == Bond::SINGLE) {
+      ++single_bonds;
+    } else if (bond->getBondType() == Bond::AROMATIC) {
+      ++aromatic_bonds;
+    } else {
+      return false;
+    }
+  }
+  return single_bonds == 1 && aromatic_bonds == 2 &&
+         atom->getTotalValence() == 3;
+}
+
 }  // end of unnamed namespace
 
 namespace MolOps {
@@ -657,7 +673,8 @@ void molRemoveH(RWMol &mol, unsigned int idx, bool updateExplicitCount) {
       // explicit count, even if the H itself isn't marked as explicit
       const INT_VECT &defaultVs =
           PeriodicTable::getTable()->getValenceList(heavyAtomNum);
-      if (((heavyAtomNum == 7 || heavyAtomNum == 15) &&
+      if (((heavyAtomNum == 7 || heavyAtomNum == 15 ||
+            is_atom_n_pyrrol_like(mol, heavyAtom)) &&
            heavyAtom->getIsAromatic()) ||
           (std::find(defaultVs.begin() + 1, defaultVs.end(),
                      heavyAtom->getTotalValence()) != defaultVs.end())) {

--- a/Code/GraphMol/catch_graphmol.cpp
+++ b/Code/GraphMol/catch_graphmol.cpp
@@ -3227,3 +3227,166 @@ M  END
     CHECK(distToTarget.lengthSq() < 0.1);
   }
 }
+
+TEST_CASE(
+    "GitHub Issue #6437 Removing Hs on a pyrrol-like structure throws kekulization error",
+    "[bug][molops][removeHs]") {
+  auto run_test = [](const std::string &mb,
+                     const std::string &reference_smiles) {
+    bool sanitize = true;  // aromatization is key in triggering the issue
+    bool removeHs = false;
+    std::unique_ptr<RWMol> mol(MolBlockToMol(mb, sanitize, removeHs));
+
+    REQUIRE(mol);
+
+    MolOps::removeHs(*mol);
+
+    REQUIRE_NOTHROW(MolOps::Kekulize(*mol));
+
+    MolOps::sanitizeMol(*mol);
+    auto smiles = MolToSmiles(*mol);
+    CHECK(smiles == reference_smiles);
+
+    REQUIRE_NOTHROW(mol.reset(SmilesToMol(smiles)));
+  };
+
+  SECTION("original issue") {
+    const std::string mb = R"CTAB(
+     RDKit          3D
+
+  0  0  0  0  0  0  0  0  0  0999 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 21 23 0 0 1
+M  V30 BEGIN ATOM
+M  V30 1 C -2.860897 0.790642 -0.873026 0 CHG=-1
+M  V30 2 C -2.892815 1.449062 0.345481 0
+M  V30 3 N -1.696600 1.269967 0.996982 0 CHG=1
+M  V30 4 C -0.879551 0.492797 0.203823 0
+M  V30 5 C -1.573299 0.166246 -0.987870 0
+M  V30 6 C 0.442583 0.044533 0.450671 0
+M  V30 7 C 1.074625 -0.756491 -0.540699 0
+M  V30 8 C 0.374093 -1.078083 -1.728707 0
+M  V30 9 C -0.929617 -0.625959 -1.953003 0
+M  V30 10 C 2.393185 -1.188970 -0.266871 0
+M  V30 11 N 3.077189 -0.890802 0.863186 0
+M  V30 12 C 2.450112 -0.125881 1.790360 0
+M  V30 13 C 1.151414 0.363643 1.640805 0
+M  V30 14 H -3.670927 0.767620 -1.587024 0
+M  V30 15 H -3.671872 2.035677 0.809804 0
+M  V30 16 H 0.862037 -1.686990 -2.476160 0
+M  V30 17 H -1.436100 -0.889168 -2.869956 0
+M  V30 18 H 2.914471 -1.799551 -0.989817 0
+M  V30 19 H 3.016681 0.097751 2.682259 0
+M  V30 20 H 0.694206 0.970092 2.408942 0
+M  V30 21 H -1.498216 1.663637 1.905533 0
+M  V30 END ATOM
+M  V30 BEGIN BOND
+M  V30 1 1 2 1
+M  V30 2 2 3 2
+M  V30 3 1 4 3
+M  V30 4 1 5 1
+M  V30 5 2 5 4
+M  V30 6 1 6 4
+M  V30 7 2 7 6
+M  V30 8 1 8 7
+M  V30 9 1 9 5
+M  V30 10 2 9 8
+M  V30 11 1 10 7
+M  V30 12 2 11 10
+M  V30 13 1 12 11
+M  V30 14 1 13 6
+M  V30 15 2 13 12
+M  V30 16 1 14 1
+M  V30 17 1 15 2
+M  V30 18 1 16 8
+M  V30 19 1 17 9
+M  V30 20 1 18 10
+M  V30 21 1 19 12
+M  V30 22 1 20 13
+M  V30 23 1 21 3
+M  V30 END BOND
+M  V30 END CTAB
+M  END
+)CTAB";
+
+    const std::string reference_smiles = "c1cc2c(ccc3[cH-]c[nH+]c32)cn1";
+    run_test(mb, reference_smiles);
+  }
+
+  SECTION("pyrrole") {
+    const std::string mb = R"CTAB(
+     RDKit          3D
+
+  0  0  0  0  0  0  0  0  0  0999 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 10 10 0 0 1
+M  V30 BEGIN ATOM
+M  V30 1 C 3.080550 -0.830350 2.955935 0
+M  V30 2 C 1.665136 -0.838141 2.947220 0
+M  V30 3 C 1.247504 0.474081 2.948961 0
+M  V30 4 N 2.361202 1.272855 2.958419 0
+M  V30 5 C 3.483658 0.486391 2.962730 0
+M  V30 6 H 2.355611 2.284759 2.961704 0
+M  V30 7 H 1.020283 -1.707337 2.940409 0
+M  V30 8 H 0.256169 0.906820 2.944294 0
+M  V30 9 H 3.734967 -1.692394 2.957125 0
+M  V30 10 H 4.470152 0.930015 2.970242 0
+M  V30 END ATOM
+M  V30 BEGIN BOND
+M  V30 1 1 2 1
+M  V30 2 2 3 2
+M  V30 3 1 4 3
+M  V30 4 2 5 1
+M  V30 5 1 5 4
+M  V30 6 1 6 4
+M  V30 7 1 7 2
+M  V30 8 1 8 3
+M  V30 9 1 9 1
+M  V30 10 1 10 5
+M  V30 END BOND
+M  V30 END CTAB
+M  END
+)CTAB";
+    const std::string reference_smiles = "c1cc[nH]c1";
+    run_test(mb, reference_smiles);
+  }
+
+  SECTION("pseudo-pyrrole") {
+    const std::string mb = R"CTAB(
+     RDKit          3D
+
+  0  0  0  0  0  0  0  0  0  0999 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 10 10 0 0 1
+M  V30 BEGIN ATOM
+M  V30 1 C 3.080550 -0.830350 2.955935 0
+M  V30 2 C 1.665136 -0.838141 2.947220 0
+M  V30 3 C 1.247504 0.474081 2.948961 0
+M  V30 4 C 2.361202 1.272855 2.958419 0 CHG=-1
+M  V30 5 C 3.483658 0.486391 2.962730 0
+M  V30 6 H 2.355611 2.284759 2.961704 0
+M  V30 7 H 1.020283 -1.707337 2.940409 0
+M  V30 8 H 0.256169 0.906820 2.944294 0
+M  V30 9 H 3.734967 -1.692394 2.957125 0
+M  V30 10 H 4.470152 0.930015 2.970242 0
+M  V30 END ATOM
+M  V30 BEGIN BOND
+M  V30 1 1 2 1
+M  V30 2 2 3 2
+M  V30 3 1 4 3
+M  V30 4 2 5 1
+M  V30 5 1 5 4
+M  V30 6 1 6 4
+M  V30 7 1 7 2
+M  V30 8 1 8 3
+M  V30 9 1 9 1
+M  V30 10 1 10 5
+M  V30 END BOND
+M  V30 END CTAB
+M  END
+)CTAB";
+
+    const std::string reference_smiles = "c1cc[cH-]c1";
+    run_test(mb, reference_smiles);
+  }
+}


### PR DESCRIPTION
Fixes #6437

The issue with pyrrole and pseudo-pyrroles like the one described in the issue is that the problematic atom has to satisfy a valence of 3 during kekulization (note that to trigger the issue, the mol has to start in the aromatic form!), and this can happen in two ways:
- With a single and a double bond to neighboring atoms in the aromatic cycle.
- With three single bonds, 2 to neighbors in the aromatic cycle, and one to a H.

If the input mol has the H atom attached, and we remove it without turning it into explicit H, then the kekulization routine will not have any way to disambiguate between both possibilities, and will therefore fail.

As mentioned in the issue, we have code in place to add the explicit H to the pyrrole case, so I'm just adding an extra case to the check. This case checks for the conditions above: we only hit it for heavy atoms attached to H atoms being removed, and the only way to satisfy a valence of 3 with 1 single + 2 aromatic bonds is that these kekulize into single bonds.