### PR TITLE
Fix const char* comparator in parseMCSParametersJSON

### DIFF
--- a/Code/GraphMol/FMCS/FMCS.cpp
+++ b/Code/GraphMol/FMCS/FMCS.cpp
@@ -24,6 +24,14 @@
 
 namespace RDKit {
 
+namespace {
+struct cmpCStr {
+   bool operator()(const char *a, const char *b) const {
+    return std::strcmp(a, b) < 0;
+  }
+};
+} // namespace
+
 void MCSParameters::setMCSAtomTyperFromEnum(AtomComparator atomComp) {
   switch (atomComp) {
     case AtomCompareAny:
@@ -45,7 +53,7 @@ void MCSParameters::setMCSAtomTyperFromEnum(AtomComparator atomComp) {
 
 void MCSParameters::setMCSAtomTyperFromConstChar(const char* atomComp) {
   PRECONDITION(atomComp, "atomComp must not be NULL");
-  static const std::map<const char*, AtomComparator> atomCompStringToEnum = {
+  static const std::map<const char*, AtomComparator, cmpCStr> atomCompStringToEnum = {
       {"Any", AtomCompareAny},
       {"Elements", AtomCompareElements},
       {"Isotopes", AtomCompareIsotopes},
@@ -75,7 +83,7 @@ void MCSParameters::setMCSBondTyperFromEnum(BondComparator bondComp) {
 
 void MCSParameters::setMCSBondTyperFromConstChar(const char* bondComp) {
   PRECONDITION(bondComp, "bondComp must not be NULL");
-  static const std::map<const char*, BondComparator> bondCompStringToEnum = {
+  static const std::map<const char*, BondComparator, cmpCStr> bondCompStringToEnum = {
       {"Any", BondCompareAny},
       {"Order", BondCompareOrder},
       {"OrderExact", BondCompareOrderExact}};

--- a/Code/GraphMol/FMCS/testFMCS_Unit.cpp
+++ b/Code/GraphMol/FMCS/testFMCS_Unit.cpp
@@ -1043,6 +1043,8 @@ void testJSONParameters() {
         ", \"MatchFusedRings\": true"
         ", \"MatchFusedRingsStrict\": true"
         ", \"InitialSeed\": \"CNC\""
+        ", \"AtomCompare\": \"Isotopes\""
+        ", \"BondCompare\": \"OrderExact\""
         "}";
     parseMCSParametersJSON(json, &pj);
     TEST_ASSERT(!pj.MaximizeBonds && pj.Threshold == 0.7 && pj.Timeout == 3 &&
@@ -1055,6 +1057,8 @@ void testJSONParameters() {
                 pj.BondCompareParameters.CompleteRingsOnly &&
                 pj.BondCompareParameters.MatchFusedRings &&
                 pj.BondCompareParameters.MatchFusedRingsStrict &&
+                pj.AtomTyper == MCSAtomCompareIsotopes &&
+                pj.BondTyper == MCSBondCompareOrderExact &&
                 0 == strcmp(pj.InitialSeed.c_str(), "CNC"));
   }
   {


### PR DESCRIPTION
Small PR that fixes a long-standing issue that has gone unnoticed so far: a `std::map` keyed on `const char *` needs a custom comparator or it will always fail to retrieve the value associated to a key, since the pointer values will always be different.