### PR TITLE
Fixes 6398 - unspecified stereo when directionality at only 1 end of bond

### DIFF
--- a/Code/GraphMol/FileParsers/MolFileWriter.cpp
+++ b/Code/GraphMol/FileParsers/MolFileWriter.cpp
@@ -830,7 +830,7 @@ void GetMolFileBondStereoInfo(const Bond *bond, const INT_MAP_INT &wedgeBonds,
             // FIX: this is the fix for github #2649, but we will need to change
             // it once we start handling allenes properly
 
-            if (checkNeighbors(bond, bond->getBeginAtom()) &&
+            if (checkNeighbors(bond, bond->getBeginAtom()) ||
                 checkNeighbors(bond, bond->getEndAtom())) {
               dirCode = 3;
             }

--- a/Code/GraphMol/FileParsers/testMolWriter.cpp
+++ b/Code/GraphMol/FileParsers/testMolWriter.cpp
@@ -1543,8 +1543,8 @@ void testMarkUnspecifiedStereoAsUnknown() {
   mols.emplace_back("C\\C=C/C=C\\C(F)Cl"_smiles);
   mols.emplace_back("CC=CC=CC(F)Cl"_smiles);
   std::vector<Bond::BondStereo> expTypes = {
-      Bond::BondStereo::STEREONONE, Bond::BondStereo::STEREOE,
-      Bond::BondStereo::STEREONONE, Bond::BondStereo::STEREOZ,
+      Bond::BondStereo::STEREOANY, Bond::BondStereo::STEREOE,
+      Bond::BondStereo::STEREOANY, Bond::BondStereo::STEREOZ,
       Bond::BondStereo::STEREOANY};
   for (size_t i = 0; i < mols.size(); ++i) {
     const bool canonOrient = true;

--- a/Code/GraphMol/MolDraw2D/DrawMol.cpp
+++ b/Code/GraphMol/MolDraw2D/DrawMol.cpp
@@ -2808,7 +2808,7 @@ void DrawMol::calcDoubleBondLines(double offset, const Bond &bond, Point2D &l1s,
       std::swap(l1s, l2s);
     }
     if ((Bond::EITHERDOUBLE == bond.getBondDir()) ||
-        (Bond::STEREOANY == bond.getStereo())) {
+        (Bond::BondStereo::STEREOANY == bond.getStereo())) {
       // crossed bond
       std::swap(l1s, l2s);
     }


### PR DESCRIPTION
#### Reference Issue
Fixes #6398 

#### What does this implement/fix? Explain your changes.
A worryingly simple change that doesn't seem to break any other tests, and fixes the issue at hand.

C/C=C/C=CC(F)Cl now gives
![image](https://github.com/rdkit/rdkit/assets/9198870/3e4bfdf5-c7ee-409d-bcd3-9ff90dcca174)

#### Any other comments?
I'm not confident that this won't have broken other things, but I don't know where to look.
