### PR TITLE
Add atom and bond property parameters to substruct matching

### DIFF
--- a/Code/GraphMol/Substruct/SubstructMatch.h
+++ b/Code/GraphMol/Substruct/SubstructMatch.h
@@ -57,10 +57,10 @@ struct RDKIT_SUBSTRUCTMATCH_EXPORT SubstructMatchParameters {
                        //!< concurrent threads supported by the hardware
                        //!< negative values are added to the number of
                        //!< concurrent threads supported by the hardware
-  std::vector<std::string> atomProperties = {};  //!< atom properties that must be
-                                                 //!< equivilent in order to match
-  std::vector<std::string> bondProperties = {};  //!< bond properties that must be
-                                                 //!< equivilent in order to match
+  std::vector<std::string> atomProperties;  //!< atom properties that must be
+                                                 //!< equivalent in order to match
+  std::vector<std::string> bondProperties;  //!< bond properties that must be
+                                                 //!< equivalent in order to match
   std::function<bool(const ROMol &mol,
                      const std::vector<unsigned int> &match)>
       extraFinalCheck;  //!< a function to be called at the end to validate a

--- a/Code/GraphMol/Substruct/SubstructMatch.h
+++ b/Code/GraphMol/Substruct/SubstructMatch.h
@@ -57,6 +57,10 @@ struct RDKIT_SUBSTRUCTMATCH_EXPORT SubstructMatchParameters {
                        //!< concurrent threads supported by the hardware
                        //!< negative values are added to the number of
                        //!< concurrent threads supported by the hardware
+  std::vector<std::string> atomProperties = {};  //!< atom properties that must be
+                                                 //!< equivilent in order to match
+  std::vector<std::string> bondProperties = {};  //!< bond properties that must be
+                                                 //!< equivilent in order to match
   std::function<bool(const ROMol &mol,
                      const std::vector<unsigned int> &match)>
       extraFinalCheck;  //!< a function to be called at the end to validate a

--- a/Code/GraphMol/Substruct/SubstructUtils.cpp
+++ b/Code/GraphMol/Substruct/SubstructUtils.cpp
@@ -105,14 +105,18 @@ class ScoreMatchesByDegreeOfCoreSubstitution {
 
 bool propertyCompat(const RDProps *r1, const RDProps *r2,
                     const std::vector<std::string>& properties) {
+  std::string prop1;
+  std::string prop2;
   for (const auto &prop : properties) {
-    if (r1->hasProp(prop) && r2->hasProp(prop)) {
-      if (r1->getProp<std::string>(prop) != r2->getProp<std::string>(prop)) {
+    bool hasprop1 = r1->getPropIfPresent<std::string>(prop, prop1);
+    bool hasprop2 = r2->getPropIfPresent<std::string>(prop, prop2);
+    if (hasprop1 && hasprop2) {
+        if (prop1 != prop2) {
+            return false;
+        }
+    } else if (hasprop1 || hasprop2) {
+        // only one has the property
         return false;
-      }
-    } else if (r1->hasProp(prop) || r2->hasProp(prop)) {
-      // only one has the property
-      return false;
     }
   }
   return true;

--- a/Code/GraphMol/Substruct/SubstructUtils.cpp
+++ b/Code/GraphMol/Substruct/SubstructUtils.cpp
@@ -105,10 +105,13 @@ class ScoreMatchesByDegreeOfCoreSubstitution {
 
 bool propertyCompat(const RDProps *r1, const RDProps *r2,
                     const std::vector<std::string>& properties) {
-  std::string prop1;
-  std::string prop2;
+  PRECONDITION(r1,"bad RDProps");
+  PRECONDITION(r2,"bad RDProps");
+  
   for (const auto &prop : properties) {
+    std::string prop1;
     bool hasprop1 = r1->getPropIfPresent<std::string>(prop, prop1);
+    std::string prop2;
     bool hasprop2 = r2->getPropIfPresent<std::string>(prop, prop2);
     if (hasprop1 && hasprop2) {
         if (prop1 != prop2) {

--- a/Code/GraphMol/Substruct/SubstructUtils.cpp
+++ b/Code/GraphMol/Substruct/SubstructUtils.cpp
@@ -103,6 +103,21 @@ class ScoreMatchesByDegreeOfCoreSubstitution {
 };
 }  // namespace detail
 
+bool propertyCompat(const RDProps *r1, const RDProps *r2,
+                    const std::vector<std::string>& properties) {
+  for (const auto &prop : properties) {
+    if (r1->hasProp(prop) && r2->hasProp(prop)) {
+      if (r1->getProp<std::string>(prop) != r2->getProp<std::string>(prop)) {
+        return false;
+      }
+    } else if (r1->hasProp(prop) || r2->hasProp(prop)) {
+      // only one has the property
+      return false;
+    }
+  }
+  return true;
+}
+
 bool atomCompat(const Atom *a1, const Atom *a2,
                 const SubstructMatchParameters &ps) {
   PRECONDITION(a1, "bad atom");
@@ -116,6 +131,10 @@ bool atomCompat(const Atom *a1, const Atom *a2,
   } else {
     res = a1->Match(a2);
   }
+  if (res) {
+    res = propertyCompat(a1, a2, ps.atomProperties);
+  }
+
   return res;
 }
 
@@ -162,6 +181,9 @@ bool bondCompat(const Bond *b1, const Bond *b2,
         !b1->getEndAtom()->Match(b2->getEndAtom())) {
       res = false;
     }
+  }
+  if (res) {
+    res = propertyCompat(b1, b2, ps.bondProperties);
   }
   // std::cerr << "\t\tbondCompat: " << b1->getIdx() << "-" << b2->getIdx() <<
   // ":"

--- a/Code/GraphMol/Substruct/SubstructUtils.cpp
+++ b/Code/GraphMol/Substruct/SubstructUtils.cpp
@@ -135,7 +135,7 @@ bool atomCompat(const Atom *a1, const Atom *a2,
   } else {
     res = a1->Match(a2);
   }
-  if (res) {
+  if (res && !ps.atomProperties.empty()) {
     res = propertyCompat(a1, a2, ps.atomProperties);
   }
 

--- a/Code/GraphMol/Substruct/SubstructUtils.cpp
+++ b/Code/GraphMol/Substruct/SubstructUtils.cpp
@@ -186,7 +186,7 @@ bool bondCompat(const Bond *b1, const Bond *b2,
       res = false;
     }
   }
-  if (res) {
+  if (res && !ps.bondProperties.empty()) {
     res = propertyCompat(b1, b2, ps.bondProperties);
   }
   // std::cerr << "\t\tbondCompat: " << b1->getIdx() << "-" << b2->getIdx() <<

--- a/Code/GraphMol/Substruct/SubstructUtils.h
+++ b/Code/GraphMol/Substruct/SubstructUtils.h
@@ -15,12 +15,15 @@
 
 namespace RDKit {
 class ROMol;
+class RDProps;
 class Atom;
 class Bond;
 
 RDKIT_SUBSTRUCTMATCH_EXPORT double toPrime(const MatchVectType& v);
 RDKIT_SUBSTRUCTMATCH_EXPORT void removeDuplicates(std::vector<MatchVectType>& v,
                                                   unsigned int nAtoms);
+RDKIT_SUBSTRUCTMATCH_EXPORT bool propertyCompat(const RDProps* r1, const RDProps* r2,
+                                                const std::vector<std::string>& properties);
 RDKIT_SUBSTRUCTMATCH_EXPORT bool atomCompat(const Atom* a1, const Atom* a2,
                                             const SubstructMatchParameters& ps);
 RDKIT_SUBSTRUCTMATCH_EXPORT bool chiralAtomCompat(const Atom* a1,

--- a/Code/GraphMol/Wrap/Mol.cpp
+++ b/Code/GraphMol/Wrap/Mol.cpp
@@ -346,6 +346,12 @@ struct mol_wrapper {
             "0 selects the number of concurrent threads supported by the"
             "hardware. negative values are added to the number of concurrent"
             "threads supported by the hardware.")
+        .def_readwrite(
+            "atomProperties", &RDKit::SubstructMatchParameters::atomProperties,
+            "atom properties that must be equivalent in order to match.")
+        .def_readwrite(
+            "bondProperties", &RDKit::SubstructMatchParameters::bondProperties,
+            "bond properties that must be equivalent in order to match.")
         .def("setExtraFinalCheck", setSubstructMatchFinalCheck,
              python::with_custodian_and_ward<1, 2>(),
              R"DOC(allows you to provide a function that will be called

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -5606,6 +5606,46 @@ M  END
     self.assertEqual(b.GetSubstructMatches(b2, ps), ())
     self.assertEqual(b2.GetSubstructMatches(b, ps), ())
 
+  def testSubstructMatchAtomProperties(self):
+    m = Chem.MolFromSmiles("CCCCCCCCC")
+    query = Chem.MolFromSmiles("CCC")
+    m.GetAtomWithIdx(0).SetProp("test_prop", "1")
+    query.GetAtomWithIdx(0).SetProp("test_prop", "1")
+    ps = Chem.SubstructMatchParameters()
+    ps.atomProperties = ["test_prop"]
+
+    self.assertEqual(len(m.GetSubstructMatches(query)), 7)
+    self.assertEqual(len(m.GetSubstructMatches(query, ps)), 1)
+
+    # more than one property works as well
+    m.GetAtomWithIdx(1).SetProp("test_prop2", "1")
+    query.GetAtomWithIdx(1).SetProp("test_prop2", "1")
+    ps.atomProperties = ["test_prop", "test_prop2"]
+    self.assertEqual(len(m.GetSubstructMatches(query, ps)), 1)
+
+  def testSubstructMatchBondProperties(self):
+    m = Chem.MolFromSmiles("CCCCCCCCC")
+    query = Chem.MolFromSmiles("CCC")
+    m.GetBondWithIdx(0).SetProp("test_prop", "1")
+    query.GetBondWithIdx(0).SetProp("test_prop", "1")
+    ps = Chem.SubstructMatchParameters()
+    ps.bondProperties = ["test_prop"]
+
+    self.assertEqual(len(m.GetSubstructMatches(query)), 7)
+    self.assertEqual(len(m.GetSubstructMatches(query, ps)), 1)
+
+    # more than one property works as well
+    m.GetBondWithIdx(1).SetProp("test_prop2", "1")
+    query.GetBondWithIdx(1).SetProp("test_prop2", "1")
+    ps.bondProperties = ["test_prop", "test_prop2"]
+    self.assertEqual(len(m.GetSubstructMatches(query, ps)), 1)
+
+    # atom and bond properties work together
+    m.GetAtomWithIdx(0).SetProp("test_prop", "1")
+    query.GetAtomWithIdx(0).SetProp("test_prop", "1")
+    ps.atomProperties = ["test_prop"]
+    self.assertEqual(len(m.GetSubstructMatches(query, ps)), 1)
+
   def testGithub2285(self):
     fileN = os.path.join(RDConfig.RDBaseDir, 'Code', 'GraphMol', 'FileParsers', 'test_data',
                          'github2285.sdf')


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

These changes add parameters to `SubstructMatchParams` that allows callers to require specific properties on atoms and bonds to match when performing a substructure search. A simple example:

```
m = Chem.MolFromSmiles("CCCCCCCCC")
query = Chem.MolFromSmiles("CCC")
m.GetAtomWithIdx(0).SetProp("test_prop", "1")
query.GetAtomWithIdx(0).SetProp("test_prop", "1")

print(f"Without setting atomProperties: {m.GetSubstructMatches(query)}")

ps = Chem.SubstructMatchParameters()
ps.atomProperties = ["test_prop"]

print(f"With setting atomProperties: {m.GetSubstructMatches(query, ps)}")
```
gives
```
Without setting atomProperties: ((0, 1, 2), (1, 2, 3), (2, 3, 4), (3, 4, 5), (4, 5, 6), (5, 6, 7), (6, 7, 8))
With setting atomProperties: ((0, 1, 2),)
```
and the same can be done with bond properties.

#### Any other comments?

I think this gives users a simple way to add matching requirements during the substructure search (instead of some sort of post-processing) without using query atoms. It might be helpful for common properties like `molAtomMapNumber` or `atomLabel`.

Currently, properties will always be cast to string when checking if they are equivalent, meaning types are not considered. I talked to Greg about this a little offline and we probably want to update this to consider types.

```
# continuing example from above
query.GetAtomWithIdx(0).ClearProp("test_prop")
query.GetAtomWithIdx(0).SetIntProp("test_prop", 1)
m.GetSubstructMatches(query, ps)

>> ((0, 1, 2),)
```