### PR TITLE
Add int64 bit conversions to getProp<std::string>

### DIFF
--- a/Code/GraphMol/FileParsers/testPropertyLists.cpp
+++ b/Code/GraphMol/FileParsers/testPropertyLists.cpp
@@ -42,6 +42,7 @@ TEST_CASE("Property list conversion", "[atom_list_properties]") {
     CHECK(m->getAtomWithIdx(1)->getProp<std::int64_t>("foo1") == 6);
     CHECK(m->getAtomWithIdx(2)->getProp<std::int64_t>("foo2") == 9);
     CHECK(m->getAtomWithIdx(1)->getProp<std::int64_t>("foo3") == 1);
+    CHECK(m->getAtomWithIdx(1)->getProp<std::string>("foo3") == "1");
   }
   SECTION("basics: dprops") {
     auto m = "COC"_smiles;

--- a/Code/RDGeneral/RDValue.h
+++ b/Code/RDGeneral/RDValue.h
@@ -234,11 +234,17 @@ inline bool rdvalue_tostring(RDValue_cast_t val, std::string &res) {
       try {
         res = boost::any_cast<std::string>(rdvalue_cast<boost::any &>(val));
       } catch (const boost::bad_any_cast &) {
-        if (rdvalue_cast<boost::any &>(val).type() == typeid(long)) {
+        auto &rdtype = rdvalue_cast<boost::any &>(val).type();
+        if (rdtype == typeid(long)) {
           res = boost::lexical_cast<std::string>(
               boost::any_cast<long>(rdvalue_cast<boost::any &>(val)));
-        } else if (rdvalue_cast<boost::any &>(val).type() ==
-                   typeid(unsigned long)) {
+        } else if (rdtype == typeid(int64_t)) {
+            res = boost::lexical_cast<std::string>(
+                boost::any_cast<int64_t>(rdvalue_cast<boost::any &>(val)));
+        } else if (rdtype == typeid(uint64_t)) {
+            res = boost::lexical_cast<std::string>(
+                boost::any_cast<uint64_t>(rdvalue_cast<boost::any &>(val)));
+        } else if (rdtype == typeid(unsigned long)) {
           res = boost::lexical_cast<std::string>(
               boost::any_cast<unsigned long>(rdvalue_cast<boost::any &>(val)));
         } else {


### PR DESCRIPTION
Fixes #6465 

Adds int64 bit conversions to getProp<std::string>, this allows the atom property lists in mol files to be used in the substructure property match code.