### PR TITLE
unused targetBondLength argument in the CDXML parser's scaleBonds

### DIFF
--- a/Code/GraphMol/FileParsers/CDXMLParser.cpp
+++ b/Code/GraphMol/FileParsers/CDXMLParser.cpp
@@ -38,6 +38,8 @@ const std::string CDX_ATOM_ID("_CDX_ATOM_ID");
 const std::string CDX_BOND_ID("_CDX_BOND_ID");
 const std::string CDX_BOND_ORDERING("CDXML_BOND_ORDERING");
 
+const double RDKIT_DEPICT_BONDLENGTH = 1.5;
+
 struct BondInfo {
   int bond_id = -1;
   int start = -1;
@@ -593,7 +595,7 @@ std::vector<std::unique_ptr<RWMol>> CDXMLDataStreamToMols(
               }
 
               if (hasConf) {
-                scaleBonds(*res, *conf, 1.5, bondLength);
+                scaleBonds(*res, *conf, RDKIT_DEPICT_BONDLENGTH, bondLength);
                 auto confidx = res->addConformer(conf.release());
                 DetectAtomStereoChemistry(*res, &res->getConformer(confidx));
               }

--- a/Code/GraphMol/FileParsers/CDXMLParser.cpp
+++ b/Code/GraphMol/FileParsers/CDXMLParser.cpp
@@ -133,7 +133,7 @@ void scaleBonds(const ROMol &mol, Conformer &conf, double targetBondLength,
   }
 
   if (avg_bond_length > 0) {
-    double scale = 1.5 / avg_bond_length;
+    double scale = targetBondLength / avg_bond_length;
     for (auto &pos : conf.getPositions()) {
       pos *= scale;
     }

--- a/Code/GraphMol/FileParsers/CDXMLParser.cpp
+++ b/Code/GraphMol/FileParsers/CDXMLParser.cpp
@@ -38,7 +38,7 @@ const std::string CDX_ATOM_ID("_CDX_ATOM_ID");
 const std::string CDX_BOND_ID("_CDX_BOND_ID");
 const std::string CDX_BOND_ORDERING("CDXML_BOND_ORDERING");
 
-const double RDKIT_DEPICT_BONDLENGTH = 1.5;
+constexpr double RDKIT_DEPICT_BONDLENGTH = 1.5;
 
 struct BondInfo {
   int bond_id = -1;


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
This PR should fix a warning about an unused `targetBondLength` argument in the CDXML parser implementation, that looked like an oversight. It then replaces the literal 1.5 value with a constant as suggested in a recent related PR.

