### PR TITLE
Allow systems like C/C=N/[H] to be stereogenic with the new chirality code

### DIFF
--- a/Code/GraphMol/FindStereo.cpp
+++ b/Code/GraphMol/FindStereo.cpp
@@ -334,20 +334,17 @@ bool isBondPotentialStereoBond(const Bond *bond) {
   }
 
   // at the moment the condition for being a potential stereo bond is that
-  // each of the beginning and end neighbors must have at least 2 heavy atom
-  // neighbors i.e. C/C=N/[H] is not a possible stereo bond but no more than 3
-  // total neighbors.
+  // each of the beginning and end neighbors must have at least 2 explicit
+  // neighbors but no more than 3 total neighbors.
   // if it's a ring bond, the smallest ring it's in must have at least 8
   // members
   //  (this is common with InChI)
   const auto beginAtom = bond->getBeginAtom();
-  auto begHeavyDegree =
-      beginAtom->getTotalDegree() - beginAtom->getTotalNumHs(true);
+  auto begDegree = beginAtom->getTotalDegree();
   const auto endAtom = bond->getEndAtom();
-  auto endHeavyDegree =
-      endAtom->getTotalDegree() - endAtom->getTotalNumHs(true);
-  if (begHeavyDegree > 1 && beginAtom->getDegree() < 4 && endHeavyDegree > 1 &&
-      endAtom->getDegree() < 4) {
+  auto endDegree = endAtom->getTotalDegree();
+  if (begDegree > 1 && begDegree < 4 && endDegree > 1 && endDegree < 4 &&
+      beginAtom->getTotalNumHs(true) < 2 && endAtom->getTotalNumHs(true) < 2) {
     // check rings
     const auto ri = bond->getOwningMol().getRingInfo();
     for (const auto &bring : ri->bondRings()) {


### PR DESCRIPTION
The old stereo perception code handled these cases, as does InChI, so we shouldn't reject them.

This was raised in discussion #6291 here:
https://github.com/rdkit/rdkit/discussions/6291#discussioncomment-6214078

