### PR TITLE
Fix RWMol::addAtom docstring

### DIFF
--- a/Code/GraphMol/ROMol.h
+++ b/Code/GraphMol/ROMol.h
@@ -835,7 +835,7 @@ class RDKIT_GRAPHMOL_EXPORT ROMol : public RDProps {
     atom
                          instead of copying it.
 
-    \return the new number of atoms
+    \return the index of the new atom
   */
   unsigned int addAtom(Atom *atom, bool updateLabel = true,
                        bool takeOwnership = false);


### PR DESCRIPTION
The docstring claimed that it returned the new number of atoms. It actually returns the index of the new atom.

I think it makes more sense to change the documentation than the behavior, because callers are definitely out there using the current behavior.
