### PR TITLE
Fix a few broken docstrings

### DIFF
--- a/Code/GraphMol/Fingerprints/Wrap/MHFPWrapper.cpp
+++ b/Code/GraphMol/Fingerprints/Wrap/MHFPWrapper.cpp
@@ -128,8 +128,6 @@ VectExplicitBitVect EncodeSECFPMolsBulk(
                               min_radius, length);
 }
 
-BOOST_PYTHON_FUNCTION_OVERLOADS(FromStringArrayOverloads, FromStringArray, 2, 2)
-BOOST_PYTHON_FUNCTION_OVERLOADS(FromArrayOverloads, FromArray, 2, 2)
 BOOST_PYTHON_FUNCTION_OVERLOADS(CreateShinglingFromSmilesOverloads,
                                 CreateShinglingFromSmiles, 2, 7)
 BOOST_PYTHON_FUNCTION_OVERLOADS(CreateShinglingFromMolOverloads,

--- a/Code/GraphMol/Fingerprints/Wrap/MHFPWrapper.cpp
+++ b/Code/GraphMol/Fingerprints/Wrap/MHFPWrapper.cpp
@@ -128,6 +128,8 @@ VectExplicitBitVect EncodeSECFPMolsBulk(
                               min_radius, length);
 }
 
+BOOST_PYTHON_FUNCTION_OVERLOADS(FromStringArrayOverloads, FromStringArray, 2, 2)
+BOOST_PYTHON_FUNCTION_OVERLOADS(FromArrayOverloads, FromArray, 2, 2)
 BOOST_PYTHON_FUNCTION_OVERLOADS(CreateShinglingFromSmilesOverloads,
                                 CreateShinglingFromSmiles, 2, 7)
 BOOST_PYTHON_FUNCTION_OVERLOADS(CreateShinglingFromMolOverloads,
@@ -151,12 +153,14 @@ BOOST_PYTHON_MODULE(rdMHFPFingerprint) {
   python::class_<MHFPEncoder>(
       "MHFPEncoder",
       python::init<python::optional<unsigned int, unsigned int>>())
-      .def("FromStringArray", &FromStringArray,
-           ((python::arg("vec")),
-            "Creates a MHFP vector from a list of arbitrary strings."))
-      .def("FromArray", &FromArray,
-           ((python::arg("vec")),
-            "Creates a MHFP vector from a list of unsigned integers."))
+      .def("FromStringArray", FromStringArray,
+           FromStringArrayOverloads(
+               (python::arg("vec")),
+               "Creates a MHFP vector from a list of arbitrary strings."))
+      .def("FromArray", FromArray,
+           FromArrayOverloads(
+               (python::arg("vec")),
+               "Creates a MHFP vector from a list of unsigned integers."))
       .def("CreateShinglingFromSmiles", CreateShinglingFromSmiles,
            CreateShinglingFromSmilesOverloads(
                (python::arg("smiles"), python::arg("radius") = 3,

--- a/Code/GraphMol/Fingerprints/Wrap/MHFPWrapper.cpp
+++ b/Code/GraphMol/Fingerprints/Wrap/MHFPWrapper.cpp
@@ -153,14 +153,10 @@ BOOST_PYTHON_MODULE(rdMHFPFingerprint) {
   python::class_<MHFPEncoder>(
       "MHFPEncoder",
       python::init<python::optional<unsigned int, unsigned int>>())
-      .def("FromStringArray", FromStringArray,
-           FromStringArrayOverloads(
-               (python::arg("vec")),
-               "Creates a MHFP vector from a list of arbitrary strings."))
-      .def("FromArray", FromArray,
-           FromArrayOverloads(
-               (python::arg("vec")),
-               "Creates a MHFP vector from a list of unsigned integers."))
+      .def("FromStringArray", FromStringArray, python::args("self", "vec"),
+           "Creates a MHFP vector from a list of arbitrary strings.")
+      .def("FromArray", FromArray, python::args("self", "vec"),
+           "Creates a MHFP vector from a list of unsigned integers.")
       .def("CreateShinglingFromSmiles", CreateShinglingFromSmiles,
            CreateShinglingFromSmilesOverloads(
                (python::arg("smiles"), python::arg("radius") = 3,

--- a/Code/GraphMol/Wrap/Trajectory.cpp
+++ b/Code/GraphMol/Wrap/Trajectory.cpp
@@ -108,12 +108,12 @@ struct Trajectory_wrapper {
         .def("Clear", &Trajectory::clear, (python::arg("self")),
              "removes all Snapshots from the Trajectory\n")
         .def("AddConformersToMol", &Trajectory::addConformersToMol,
-             (python::arg("self"), python::arg("mol"), python::arg("from") = -1,
-              python::arg("to") = -1),
+             (python::arg("self"), python::arg("mol"), python::arg("fromCid") = -1,
+              python::arg("toCid") = -1),
              "adds conformations from the Trajectory to mol\n"
-             "from is the first Snapshot that will be added as a Conformer; "
+             "fromCid is the first Snapshot that will be added as a Conformer; "
              "defaults to -1 (first available)\n"
-             "to is the last Snapshot that will be added as a Conformer; "
+             "toCid is the last Snapshot that will be added as a Conformer; "
              "defaults to -1 (all)\n");
 
     python::class_<Snapshot>(

--- a/rdkit/Chem/FilterCatalog.py
+++ b/rdkit/Chem/FilterCatalog.py
@@ -44,7 +44,7 @@ class FilterMatcher(PythonFilterMatcher):
                               self.__class__.__name__)
 
   def GetMatches(self, mol, matchVect):
-    """GetMatches(mol, matchVect) -> returns True if the filter matches
+    """Return True if the filter matches the molecule
         (By default, this calls HasMatch and does not modify matchVect)
         
         matchVect is a vector of FilterMatch's which hold the matching


### PR DESCRIPTION
- Fix a couple of docstrings that were confusing `boost::python` ([FromArray](http://rdkit.org/docs/source/rdkit.Chem.rdMHFPFingerprint.html?highlight=fromstringarray#rdkit.Chem.rdMHFPFingerprint.MHFPEncoder.FromArray), [FromStringArray](http://rdkit.org/docs/source/rdkit.Chem.rdMHFPFingerprint.html?highlight=fromstringarray#rdkit.Chem.rdMHFPFingerprint.MHFPEncoder.FromStringArray)); namely, the comment was being parsed as the parameter name, i.e.:
**FromArray**(_(MHFPEncoder)vec, (list)Creates a MHFP vector from a list of unsigned integers._) → `_vectj`
**FromStringArray**(_(MHFPEncoder)vec, (list)Creates a MHFP vector from a list of arbitrary strings.) → `_vectj`
- Python keywords should not be used as parameter names (namely, `from`)
- Function documentation should not include the function signature