### PR TITLE
CMAKE_INSTALL_PREFIX not honored for Python files installation on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -330,8 +330,9 @@ if(RDK_BUILD_PYTHON_WRAPPERS)
       execute_process(
         COMMAND
         ${PYTHON_EXECUTABLE} -c "import sys; import sysconfig; \
+          base_key = 'base' if sys.platform == 'win32' else 'platbase'; \
           schema = 'nt' if sys.platform == 'win32' else 'posix_prefix'; \
-          print(sysconfig.get_path('platlib', schema, vars={'platbase': '${CMAKE_INSTALL_PREFIX}'}))"
+          print(sysconfig.get_path('platlib', schema, vars={base_key: '${CMAKE_INSTALL_PREFIX}'}))"
         OUTPUT_VARIABLE PYTHON_INSTDIR
         OUTPUT_STRIP_TRAILING_WHITESPACE
       )


### PR DESCRIPTION
This is a second fix after #6339. Even after #6371, `CMAKE_INSTALL_PREFIX` is not honored when building under windows. I just built 2023.03.2, and noticed that the Python wrappers were not installed under the path I had specified.

The cause of the issue is that the "nt" scheme in `sysconfig.get_path()` uses the `base` key for the "platlib" path instead of  `platbase`, as does the "posix_prefix" schema:

```
In [9]: sysconfig._INSTALL_SCHEMES
Out[9]:
{'posix_prefix': {'stdlib': '{installed_base}/lib/python{py_version_short}',
  'platstdlib': '{platbase}/lib/python{py_version_short}',
  'purelib': '{base}/lib/python{py_version_short}/site-packages',
  'platlib': '{platbase}/lib/python{py_version_short}/site-packages',
  'include': '{installed_base}/include/python{py_version_short}{abiflags}',
  'platinclude': '{installed_platbase}/include/python{py_version_short}{abiflags}',
  'scripts': '{base}/bin',
  'data': '{base}'},
[...]
 'nt': {'stdlib': '{installed_base}/Lib',
  'platstdlib': '{base}/Lib',
  'purelib': '{base}/Lib/site-packages',
  'platlib': '{base}/Lib/site-packages',
  'include': '{installed_base}/Include',
  'platinclude': '{installed_base}/Include',
  'scripts': '{base}/Scripts',
  'data': '{base}'},
[...]
}

```

Nice inconsisteny, Python...