### PR TITLE
Fixes rdkit-js/issues/347

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -222,8 +222,11 @@ if(RDK_BUILD_XYZ2MOL_SUPPORT)
     include_directories(${RDKit_ExternalDir})
 endif()
 
-
-
+# Detect clang, which masquerades as gcc.  CMake 2.6 doesn't know how to
+# detect it.
+string(REGEX MATCH "clang" CMAKE_COMPILER_IS_CLANG "${CMAKE_C_COMPILER}")
+# Detect emcc
+string(REGEX MATCH "Emscripten" CMAKE_COMPILER_IS_EMCC "${CMAKE_SYSTEM_NAME}")
 
 if(CMAKE_SIZEOF_VOID_P EQUAL 4)
   target_compile_definitions(rdkit_base INTERFACE "-DRDK_32BIT_BUILD")
@@ -234,6 +237,12 @@ endif()
 if(MINGW)
   target_compile_definitions(rdkit_base INTERFACE "-DBOOST_SYSTEM_NO_DEPRECATED")
 endif(MINGW)
+if (CMAKE_COMPILER_IS_CLANG OR CMAKE_COMPILER_IS_EMCC)
+  if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 15)
+    target_compile_definitions(rdkit_base INTERFACE -DBOOST_SYSTEM_NO_DEPRECATED -DBOOST_NO_CXX98_FUNCTION_BASE -D_HAS_AUTO_PTR_ETC=0)
+    target_compile_options(rdkit_base INTERFACE -Wno-deprecated-builtins -Wno-deprecated-non-prototype -Wno-unused-parameter)
+  endif()
+endif()
 
 # defines macros: rdkit_python_extension, rdkit_test
 include(RDKitUtils)
@@ -394,10 +403,6 @@ if(RDK_BUILD_PYTHON_WRAPPERS)
 else(RDK_BUILD_PYTHON_WRAPPERS)
   find_package(Boost ${RDK_BOOST_VERSION} REQUIRED)
 endif(RDK_BUILD_PYTHON_WRAPPERS)
-
-# Detect clang, which masquerades as gcc.  CMake 2.6 doesn't know how to
-# detect it.
-string(REGEX MATCH "clang" CMAKE_COMPILER_IS_CLANG "${CMAKE_C_COMPILER}")
 
 find_package(Eigen3)
 if(RDK_BUILD_DESCRIPTORS3D)

--- a/Code/MinimalLib/docker/Dockerfile
+++ b/Code/MinimalLib/docker/Dockerfile
@@ -93,7 +93,7 @@ RUN make -j2 RDKit_minimal && \
 
 # run the tests
 WORKDIR /src/rdkit/Code/MinimalLib/tests
-RUN node tests.js
+RUN /opt/emsdk/node/*/bin/node tests.js
 
 # Copy js and wasm rdkit files to use in browser
 # This feature requires the BuildKit backend

--- a/Code/MinimalLib/docker/Dockerfile_legacy_browsers
+++ b/Code/MinimalLib/docker/Dockerfile_legacy_browsers
@@ -44,7 +44,7 @@ Array.prototype.includes||Object.defineProperty(Array.prototype,"includes",{valu
 
 # run the tests
 WORKDIR /src/rdkit/Code/MinimalLib/tests
-RUN RDKIT_MINIMAL_JS="../demo/RDKit_minimal_legacy.js" node tests.js
+RUN RDKIT_MINIMAL_JS="../demo/RDKit_minimal_legacy.js" /opt/emsdk/node/*/bin/node tests.js
 
 # Copy pure js RDKit MinimalLib file to use in legacy browsers
 # This feature requires the BuildKit backend


### PR DESCRIPTION
This PR allows building MinimalLib using the latest `emsdk` (see https://github.com/rdkit/rdkit-js/issues/347).
The issue described in https://github.com/rdkit/rdkit-js/issues/347 is not actually caused by anything changed in RDKit, but rather by an `emsdk` update.

- Add appropriate compiler flags such that MinimalLib builds also when using `clang` version >=15
- Use the `nodejs` version bundled with `emscripten` to run tests since the one in Ubuntu is ancient and does not support recent `wasm` features
