### PR TITLE
Make sure that molecules are shown as images by PandasTools also when DataFrames are truncated horizontally

### DIFF
--- a/rdkit/Chem/UnitTestPandasTools.py
+++ b/rdkit/Chem/UnitTestPandasTools.py
@@ -214,6 +214,23 @@ class TestPandasTools(unittest.TestCase):
     self.assertEqual([Chem.MolToSmiles(x) for x in df.R2],
                      ['F[*:2]', 'Cl[*:2]', 'O[*:2]', 'F[*:2]', 'F[*:2]'])
 
+  def testPandasShouldShowMoleculesWhenTruncating(self):
+    csv_data = '''"Molecule ChEMBL ID";"Molecule Name";"Molecule Max Phase";"Molecular Weight";"#RO5 Violations";"AlogP";"Compound Key";"Smiles";"Standard Type";"Standard Relation";"Standard Value";"Standard Units";"pChEMBL Value";"Data Validity Comment";"Comment";"Uo Units";"Ligand Efficiency BEI";"Ligand Efficiency LE";"Ligand Efficiency LLE";"Ligand Efficiency SEI";"Potential Duplicate";"Assay ChEMBL ID";"Assay Description";"Assay Type";"BAO Format ID";"BAO Label";"Assay Organism";"Assay Tissue ChEMBL ID";"Assay Tissue Name";"Assay Cell Type";"Assay Subcellular Fraction";"Target ChEMBL ID";"Target Name";"Target Organism";"Target Type";"Document ChEMBL ID";"Source ID";"Source Description";"Document Journal";"Document Year";"Cell ChEMBL ID"
+  "CHEMBL543779";"";"0";"341.86";"0";"2.60";"1w";"CCN(CC)CCS/C(=N\O)C(=O)c1ccc(C#N)cc1.Cl";"IC50";"'='";"180000.0";"nM";"";"Outside typical range";"";"UO_0000065";"";"";"";"";"False";"CHEMBL644102";"Reversible inhibition of Human AchE";"B";"BAO_0000357";"single protein format";"None";"None";"None";"None";"None";"CHEMBL220";"Acetylcholinesterase";"Homo sapiens";"SINGLE PROTEIN";"CHEMBL1123431";"1";"Scientific Literature";"J. Med. Chem.";"1986";"None"
+  '''
+    try:
+      with StringIO(csv_data) as hnd:
+        df = PandasTools.pd.read_csv(hnd, sep=";")
+        PandasTools.InstallPandasTools()
+        PandasTools.RenderImagesInAllDataFrames()
+        PandasTools.AddMoleculeColumnToFrame(df, 'Smiles')
+        html_output = df.to_html(notebook=True, max_cols=10)
+        self.assertIn('...', html_output)
+        self.assertIn('data-content="rdkit/molecule"', html_output)
+        self.assertIn('data:image/png;base64', html_output)
+    finally:
+      PandasTools.UninstallPandasTools()
+
 
 @unittest.skipIf((not hasattr(PandasTools, 'pd')) or PandasTools.pd is None,
                  'Pandas not installed, skipping')


### PR DESCRIPTION
This issue was originally reported by Rainer Wilcken.
In the current version of `PandasTools`, molecules will not show up as images in a Jupyter Notebook whenever the number of columns in the DataFrame exceeds `max_cols` and therefore some columns are truncated and replaced with `...`.
See a simple reproducible below:

```
from rdkit import Chem
from rdkit.Chem import PandasTools
from io import StringIO

import pandas as pd
pd.__version__
1.5.2

PandasTools.RenderImagesInAllDataFrames()
buf = '''"Molecule ChEMBL ID";"Molecule Name";"Molecule Max Phase";"Molecular Weight";"#RO5 Violations";"AlogP";"Compound Key";"Smiles";"Standard Type";"Standard Relation";"Standard Value";"Standard Units";"pChEMBL Value";"Data Validity Comment";"Comment";"Uo Units";"Ligand Efficiency BEI";"Ligand Efficiency LE";"Ligand Efficiency LLE";"Ligand Efficiency SEI";"Potential Duplicate";"Assay ChEMBL ID";"Assay Description";"Assay Type";"BAO Format ID";"BAO Label";"Assay Organism";"Assay Tissue ChEMBL ID";"Assay Tissue Name";"Assay Cell Type";"Assay Subcellular Fraction";"Target ChEMBL ID";"Target Name";"Target Organism";"Target Type";"Document ChEMBL ID";"Source ID";"Source Description";"Document Journal";"Document Year";"Cell ChEMBL ID"
"CHEMBL543779";"";"0";"341.86";"0";"2.60";"1w";"CCN(CC)CCS/C(=N\O)C(=O)c1ccc(C#N)cc1.Cl";"IC50";"'='";"180000.0";"nM";"";"Outside typical range";"";"UO_0000065";"";"";"";"";"False";"CHEMBL644102";"Reversible inhibition of Human AchE";"B";"BAO_0000357";"single protein format";"None";"None";"None";"None";"None";"CHEMBL220";"Acetylcholinesterase";"Homo sapiens";"SINGLE PROTEIN";"CHEMBL1123431";"1";"Scientific Literature";"J. Med. Chem.";"1986";"None"
'''
with StringIO(buf) as hnd:
    df = pd.read_csv(hnd, sep=";")
PandasTools.AddMoleculeColumnToFrame(df, "Smiles")
df
```
![image](https://github.com/rdkit/rdkit/assets/5244385/325d5d82-aefe-4236-bd5f-c1a640e50c23)

The problem can be reproduced across the following `pandas` version range:
* `1.0.5`
* `1.1.5`
* `1.2.5`
* `1.3.5`
* `1.4.3`
* `1.5.0`
* `2.0.2`

The problem is caused by what I believe is a bug in `pandas`, which will not take into account truncated columns when looking up custom formatters.
In fact, [while `pandas` has code to truncate the custom formatter list when this is passed as a `list` or `tuple`](https://github.com/pandas-dev/pandas/blob/49851bbb723f758bbdbd983fe0cb36c2bc5d1b83/pandas/io/formats/format.py#L813), it does not take into account the case where formatters are passed as a `dict`.
In this case, [`_get_formatters` will retrieve the wrong formatter](https://github.com/pandas-dev/pandas/blob/49851bbb723f758bbdbd983fe0cb36c2bc5d1b83/pandas/io/formats/format.py#L902), because, `self.columns` contains _all_ columns in the DataFrame, while only a subset is visualized in the notebook while all the central columns exceeding `max_cols` are replaced with an elision marker `...`.
Therefore, when retrieving the column name associated to the `i`-th to pick the relevant column formatter, `i` should take into account the elided range and be increased accordingly.

I will file a bug with `pandas`, but we still need to fix this in RDKit as
1. `pandas` might take a while to acknowledge and fix the problem
2. RDKit should be able to cope with older versions of `pandas` affected by the bug.

With this PR in place, the expected output is obtained:
```
from rdkit import Chem
from rdkit.Chem import PandasTools
from io import StringIO

import pandas as pd
pd.__version__
1.5.2

PandasTools.RenderImagesInAllDataFrames()
buf = '''"Molecule ChEMBL ID";"Molecule Name";"Molecule Max Phase";"Molecular Weight";"#RO5 Violations";"AlogP";"Compound Key";"Smiles";"Standard Type";"Standard Relation";"Standard Value";"Standard Units";"pChEMBL Value";"Data Validity Comment";"Comment";"Uo Units";"Ligand Efficiency BEI";"Ligand Efficiency LE";"Ligand Efficiency LLE";"Ligand Efficiency SEI";"Potential Duplicate";"Assay ChEMBL ID";"Assay Description";"Assay Type";"BAO Format ID";"BAO Label";"Assay Organism";"Assay Tissue ChEMBL ID";"Assay Tissue Name";"Assay Cell Type";"Assay Subcellular Fraction";"Target ChEMBL ID";"Target Name";"Target Organism";"Target Type";"Document ChEMBL ID";"Source ID";"Source Description";"Document Journal";"Document Year";"Cell ChEMBL ID"
"CHEMBL543779";"";"0";"341.86";"0";"2.60";"1w";"CCN(CC)CCS/C(=N\O)C(=O)c1ccc(C#N)cc1.Cl";"IC50";"'='";"180000.0";"nM";"";"Outside typical range";"";"UO_0000065";"";"";"";"";"False";"CHEMBL644102";"Reversible inhibition of Human AchE";"B";"BAO_0000357";"single protein format";"None";"None";"None";"None";"None";"CHEMBL220";"Acetylcholinesterase";"Homo sapiens";"SINGLE PROTEIN";"CHEMBL1123431";"1";"Scientific Literature";"J. Med. Chem.";"1986";"None"
'''
with StringIO(buf) as hnd:
    df = pd.read_csv(hnd, sep=";")
PandasTools.AddMoleculeColumnToFrame(df, "Smiles")
df
```
![image](https://github.com/rdkit/rdkit/assets/5244385/27ff94fc-d9da-415f-897f-2534c72eb7dc)

The fix described in this PR is very conservative and should still work also when eventually the root cause of the problem will be fixed in `pandas`.
I have tested the fix across the following `pandas` version range:
* `1.0.5`
* `1.1.5`
* `1.2.5`
* `1.3.5`
* `1.4.3`
* `1.5.0`
* `2.0.2`
