### PR TITLE
Fixes #6502

### DIFF
--- a/Code/GraphMol/FileParsers/MolFileWriter.cpp
+++ b/Code/GraphMol/FileParsers/MolFileWriter.cpp
@@ -810,11 +810,7 @@ void GetMolFileBondStereoInfo(const Bond *bond, const INT_MAP_INT &wedgeBonds,
     if (bond->getStereo() <= Bond::STEREOANY) {
       if (bond->getStereo() == Bond::STEREOANY) {
         dirCode = 3;
-      } else if (bond->getBeginAtom()->getDegree() > 1 &&
-                 bond->getEndAtom()->getDegree() > 1 &&
-                 (!queryIsBondInRing(bond) ||
-                  static_cast<unsigned int>(queryBondMinRingSize(bond)) >=
-                      Chirality::minRingSizeForDoubleBondStereo)) {
+      } else if (Chirality::detail::isBondPotentialStereoBond(bond)) {
         // we don't know that it's explicitly unspecified (covered above with
         // the ==STEREOANY check)
 

--- a/Code/GraphMol/FileParsers/molfile_stereo_catch.cpp
+++ b/Code/GraphMol/FileParsers/molfile_stereo_catch.cpp
@@ -554,3 +554,14 @@ M  END
     }
   }
 }
+
+TEST_CASE(
+    "GitHub Issue #6502: MolToMolBlock writes \"either\" stereo for double bonds "
+    "which shouldn't be stereo.",
+    "[bug][molblock][stereo]") {
+  auto m = "CP1(O)=NP(C)(O)=NP(C)(O)=NP(C)(O)=N1"_smiles;
+  REQUIRE(m);
+
+  auto mb = MolToV3KMolBlock(*m);
+  CHECK(mb.find("CFG=2") == std::string::npos);
+}


### PR DESCRIPTION
Fixes #6502

The issue was happening because in #6387 we check that the ends of the stereo bonds have at least one neighbor, but we should also check that there are no more than 2 neighbors (or degree 3, including the double bond).

This patch fixes the issue by replacing the check in the code with `Chirality::detail::isBondPotentialStereoBond()`, which includes the check for the maximum allowed neighbors. This means checking the order of the bond twice, but I think it is a good idea to centralize the check in a single function instead of reimplementing multiple times.
