### PR TITLE
Fixes #6505

### DIFF
--- a/Code/GraphMol/MolHash/catch_tests.cpp
+++ b/Code/GraphMol/MolHash/catch_tests.cpp
@@ -704,3 +704,29 @@ M  END
     }
   }
 }
+
+TEST_CASE("GitHub Issue #6505") {
+  const auto m = "CCCCCC[NH3+] |SgD:6:lambda max:230:=:nm::|"_smiles;
+  REQUIRE(m);
+  REQUIRE(getSubstanceGroups(*m).size() == 1);
+
+  const auto use_cx_smiles = true;
+
+  SECTION("Do not skip any CX flags") {
+    const auto cx_to_skip = SmilesWrite::CXSmilesFields::CX_NONE;
+    const auto hsh1 =
+        MolHash::MolHash(m.get(), MolHash::HashFunction::HetAtomTautomerv2,
+                         use_cx_smiles, cx_to_skip);
+    CHECK(
+        hsh1 ==
+        "[CH3]-[CH2]-[CH2]-[CH2]-[CH2]-[CH2]-[NH3+]_0_0 |SgD:6:lambda max:230:=:nm::|");
+  }
+
+  SECTION("Strip all CX flags") {
+    const auto cx_to_skip = SmilesWrite::CXSmilesFields::CX_ALL;
+    const auto hsh2 =
+        MolHash::MolHash(m.get(), MolHash::HashFunction::HetAtomTautomerv2,
+                         use_cx_smiles, cx_to_skip);
+    CHECK(hsh2 == "[CH3]-[CH2]-[CH2]-[CH2]-[CH2]-[CH2]-[NH3+]_0_0");
+  }
+}

--- a/Code/GraphMol/MolHash/hashfunctions.cpp
+++ b/Code/GraphMol/MolHash/hashfunctions.cpp
@@ -1193,7 +1193,7 @@ std::string MolHash(RWMol *mol, HashFunction func, bool useCXSmiles,
       result = TautomerHash(mol, false, useCXSmiles, cxFlagsToSkip);
       break;
     case HashFunction::HetAtomTautomerv2:
-      result = TautomerHashv2(mol, false, useCXSmiles);
+      result = TautomerHashv2(mol, false, useCXSmiles, cxFlagsToSkip);
       break;
     case HashFunction::HetAtomProtomer:
       result = TautomerHash(mol, true, useCXSmiles, cxFlagsToSkip);

--- a/rdkit/Chem/UnitTestRegistrationHash.py
+++ b/rdkit/Chem/UnitTestRegistrationHash.py
@@ -12,7 +12,7 @@ from rdkit.Chem import RegistrationHash
 from rdkit.Chem.RegistrationHash import HashLayer
 
 
-def hash_sdf(molblock: str, escape=None, data_field_names=None):
+def hash_sdf(molblock: str, escape=None, data_field_names=None, enable_tautomer_hash_v2=False):
   """
     Gets the layers of the SDF, and generates the hash based on only the layers passed in
 
@@ -24,7 +24,8 @@ def hash_sdf(molblock: str, escape=None, data_field_names=None):
     :return: A dict with the hash & the layers
     """
   mol = Chem.MolFromMolBlock(molblock)
-  return RegistrationHash.GetMolLayers(mol, escape=escape, data_field_names=data_field_names)
+  return RegistrationHash.GetMolLayers(mol, escape=escape, data_field_names=data_field_names,
+                                       enable_tautomer_hash_v2=enable_tautomer_hash_v2)
 
 
 class CanonicalizerTest(unittest.TestCase):
@@ -218,8 +219,21 @@ M  END
       HashLayer.TAUTOMER_HASH: 'CCCCCCC_0_0'
     }
 
+    expected_layers_v2 = {
+      HashLayer.CANONICAL_SMILES: 'CCCCCCC',
+      HashLayer.ESCAPE: '',
+      HashLayer.FORMULA: 'C7H16',
+      HashLayer.NO_STEREO_SMILES: 'CCCCCCC',
+      HashLayer.NO_STEREO_TAUTOMER_HASH: '[CH3]-[CH2]-[CH2]-[CH2]-[CH2]-[CH2]-[CH3]_0_0',
+      HashLayer.SGROUP_DATA: '[]',
+      HashLayer.TAUTOMER_HASH: '[CH3]-[CH2]-[CH2]-[CH2]-[CH2]-[CH2]-[CH3]_0_0'
+    }
+
     layers = hash_sdf(structure)
     self.assertEqual(layers, expected_layers)
+
+    layers_v2 = hash_sdf(structure, enable_tautomer_hash_v2=True)
+    self.assertEqual(layers_v2, expected_layers_v2)
 
   def test_stereo_imine_hash(self):
     stereo_mol = Chem.MolFromSmiles(r'[H]\N=C\C', sanitize=False)
@@ -791,6 +805,7 @@ $$$$
         enol_layers, hash_scheme=RegistrationHash.HashScheme.TAUTOMER_INSENSITIVE_LAYERS),
       RegistrationHash.GetMolHash(
         keto_layers, hash_scheme=RegistrationHash.HashScheme.TAUTOMER_INSENSITIVE_LAYERS))
+
 
 if __name__ == '__main__':  # pragma: nocover
   unittest.main()


### PR DESCRIPTION
Fixes #6505.

The fix is trivial: the call to `TautomerHashv2()` in `MolHash::MolHash()` was not passing the `cxFlagsToSkip` argument, so that no CX extensions were being filtered from the output.