### PR TITLE
Preserve Enhanced Stereo Group ids

### DIFF
--- a/Code/GraphMol/Canon.cpp
+++ b/Code/GraphMol/Canon.cpp
@@ -1335,7 +1335,10 @@ void canonicalizeEnhancedStereo(ROMol &mol,
       std::for_each(sgAtoms.begin(), sgAtoms.end(),
                     [](auto atom) { atom->invertChirality(); });
     }
-    newSgs.emplace_back(StereoGroup(sg.getGroupType(), std::move(sgAtoms)));
+
+    // note that we do not forward the Group Ids: this is intentional, so that
+    // the Ids are reassigned based on the canonicalized order.
+    newSgs.emplace_back(sg.getGroupType(), std::move(sgAtoms));
     refAtom->setProp("_stereoGroup", newSgs.size() - 1, true);
   }
   mol.setStereoGroups(newSgs);

--- a/Code/GraphMol/Canon.h
+++ b/Code/GraphMol/Canon.h
@@ -127,6 +127,7 @@ RDKIT_GRAPHMOL_EXPORT bool chiralAtomNeedsTagInversion(const RDKit::ROMol &mol,
 
 //! Canonicalizes the atom stereo labels in enhanced stereo groups
 /*!
+  Note that this will also reset AND/OR StereoGroup labels.
 
   For example, after calling this function the chiral centers in the
   molecules `C[C@H](F)Cl |&1:1|` and `C[C@@H](F)Cl |&1:1|` will have the same

--- a/Code/GraphMol/ChemReactions/ReactionRunner.cpp
+++ b/Code/GraphMol/ChemReactions/ReactionRunner.cpp
@@ -1279,7 +1279,8 @@ void copyEnhancedStereoGroups(const ROMol &reactant, RWMOL_SPTR product,
       }
     }
     if (!atoms.empty()) {
-      new_stereo_groups.emplace_back(sg.getGroupType(), std::move(atoms));
+      new_stereo_groups.emplace_back(sg.getGroupType(), std::move(atoms),
+                                     sg.getId());
     }
   }
 

--- a/Code/GraphMol/ChemTransforms/ChemTransforms.cpp
+++ b/Code/GraphMol/ChemTransforms/ChemTransforms.cpp
@@ -67,8 +67,8 @@ void copyStereoGroups(const std::map<const Atom *, Atom *> &molAtomMap,
         }
       }
       if (!newStereoAtoms.empty()) {
-        newStereoGroups.emplace_back(stereoGroup.getGroupType(),
-                                     newStereoAtoms);
+        newStereoGroups.emplace_back(stereoGroup.getGroupType(), newStereoAtoms,
+                                     stereoGroup.getId());
       }
     }
     newMol.setStereoGroups(std::move(newStereoGroups));

--- a/Code/GraphMol/Chirality.cpp
+++ b/Code/GraphMol/Chirality.cpp
@@ -1846,7 +1846,7 @@ void cleanupStereoGroups(ROMol &mol) {
     if (keep) {
       newsgs.push_back(sg);
     } else if (!okatoms.empty()) {
-      newsgs.emplace_back(sg.getGroupType(), std::move(okatoms));
+      newsgs.emplace_back(sg.getGroupType(), std::move(okatoms), sg.getId());
     }
   }
   mol.setStereoGroups(std::move(newsgs));

--- a/Code/GraphMol/FileParsers/CDXMLParser.cpp
+++ b/Code/GraphMol/FileParsers/CDXMLParser.cpp
@@ -334,6 +334,7 @@ bool parse_fragment(RWMol &mol, ptree &frag,
         }
         stereo.grouptype = grouptype;
         stereo.atoms.push_back(rd_atom);
+        stereo.sgroup = sgroup;
       }
       ids[atom_id] = rd_atom;  // The mol has ownership so this can't leak
       if (nodetype == "Nickname" || nodetype == "Fragment") {
@@ -478,8 +479,13 @@ bool parse_fragment(RWMol &mol, ptree &frag,
   if (!sgroups.empty()) {
     std::vector<StereoGroup> stereo_groups;
     for (auto &sgroup : sgroups) {
-      stereo_groups.emplace_back(
-          StereoGroup(sgroup.second.grouptype, sgroup.second.atoms));
+      unsigned gId = 0;
+      if (sgroup.second.grouptype != StereoGroupType::STEREO_ABSOLUTE &&
+          sgroup.second.sgroup > 0) {
+        gId = sgroup.second.sgroup;
+      }
+      stereo_groups.emplace_back(sgroup.second.grouptype, sgroup.second.atoms,
+                                 gId);
     }
     mol.setStereoGroups(std::move(stereo_groups));
   }

--- a/Code/GraphMol/FileParsers/MolFileParser.cpp
+++ b/Code/GraphMol/FileParsers/MolFileParser.cpp
@@ -201,7 +201,7 @@ std::string parseEnhancedStereo(std::istream *inStream, unsigned int &line,
   // M  V30 MDLV30/STEREL1 ATOMS=(1 12)
   // M  V30 MDLV30/STERAC1 ATOMS=(1 12)
   const regex stereo_label(
-      R"regex(MDLV30/STE(...)[0-9]* +ATOMS=\(([0-9]+) +(.*)\) *)regex");
+      R"regex(MDLV30/STE(...)([0-9]*) +ATOMS=\(([0-9]+) +(.*)\) *)regex");
 
   smatch match;
   std::vector<StereoGroup> groups;
@@ -213,13 +213,16 @@ std::string parseEnhancedStereo(std::istream *inStream, unsigned int &line,
     // If this line in the collection is part of a stereo group
     if (regex_match(tempStr, match, stereo_label)) {
       StereoGroupType grouptype = RDKit::StereoGroupType::STEREO_ABSOLUTE;
+      unsigned groupid = 0;
 
       if (match[1] == "ABS") {
         grouptype = RDKit::StereoGroupType::STEREO_ABSOLUTE;
       } else if (match[1] == "REL") {
         grouptype = RDKit::StereoGroupType::STEREO_OR;
+        groupid = FileParserUtils::toUnsigned(match[2], true);
       } else if (match[1] == "RAC") {
         grouptype = RDKit::StereoGroupType::STEREO_AND;
+        groupid = FileParserUtils::toUnsigned(match[2], true);
       } else {
         std::ostringstream errout;
         errout << "Unrecognized stereogroup type : '" << tempStr << "' on line"
@@ -227,16 +230,16 @@ std::string parseEnhancedStereo(std::istream *inStream, unsigned int &line,
         throw FileParseException(errout.str());
       }
 
-      const unsigned int count = FileParserUtils::toUnsigned(match[2], true);
+      const unsigned int count = FileParserUtils::toUnsigned(match[3], true);
       std::vector<Atom *> atoms;
-      std::stringstream ss(match[3]);
+      std::stringstream ss(match[4]);
       unsigned int index;
       for (size_t i = 0; i < count; ++i) {
         ss >> index;
         // atoms are 1 indexed in molfiles
         atoms.push_back(mol->getAtomWithIdx(index - 1));
       }
-      groups.emplace_back(grouptype, std::move(atoms));
+      groups.emplace_back(grouptype, std::move(atoms), groupid);
     } else {
       // skip collection types we don't know how to read. Only one documented
       // is MDLV30/HILITE
@@ -539,15 +542,15 @@ void ParseSubstitutionCountLine(RWMol *mol, const std::string &text,
           break;
         case 6:
           BOOST_LOG(rdWarningLog) << " atom degree query with value 6 found. "
-                                      "This will not match degree >6. The MDL "
-                                      "spec says it should.  line: "
+                                     "This will not match degree >6. The MDL "
+                                     "spec says it should.  line: "
                                   << line;
           q->setVal(6);
           break;
         default:
           std::ostringstream errout;
           errout << "Value " << count
-                  << " is not supported as a degree query. line: " << line;
+                 << " is not supported as a degree query. line: " << line;
           throw FileParseException(errout.str());
       }
       if (!atom->hasQuery()) {
@@ -601,10 +604,10 @@ void ParseUnsaturationLine(RWMol *mol, const std::string &text,
       } else {
         std::ostringstream errout;
         errout << "Value " << count
-                << " is not supported as an unsaturation "
+               << " is not supported as an unsaturation "
                   "query (only 0 and 1 are allowed). "
                   "line: "
-                << line;
+               << line;
         throw FileParseException(errout.str());
       }
     } catch (boost::bad_lexical_cast &) {
@@ -670,8 +673,8 @@ void ParseRingBondCountLine(RWMol *mol, const std::string &text,
         default:
           std::ostringstream errout;
           errout << "Value " << count
-                  << " is not supported as a ring-bond count query. line: "
-                  << line;
+                 << " is not supported as a ring-bond count query. line: "
+                 << line;
           throw FileParseException(errout.str());
       }
       if (!atom->hasQuery()) {

--- a/Code/GraphMol/FileParsers/MolFileWriter.cpp
+++ b/Code/GraphMol/FileParsers/MolFileWriter.cpp
@@ -1147,9 +1147,9 @@ const std::string GetV3000MolFileBondLine(const Bond *bond,
 }
 
 void appendEnhancedStereoGroups(std::string &res, const RWMol &tmol) {
-  unsigned or_count = 1u, and_count = 1u;
-  auto &stereo_groups = tmol.getStereoGroups();
-  if (!stereo_groups.empty()) {
+  if (!tmol.getStereoGroups().empty()) {
+    auto stereo_groups = tmol.getStereoGroups();
+    assignStereoGroupIds(stereo_groups);
     res += "M  V30 BEGIN COLLECTION\n";
     for (auto &&group : stereo_groups) {
       res += "M  V30 MDLV30/";
@@ -1159,13 +1159,11 @@ void appendEnhancedStereoGroups(std::string &res, const RWMol &tmol) {
           break;
         case RDKit::StereoGroupType::STEREO_OR:
           res += "STEREL";
-          res += std::to_string(or_count);
-          ++or_count;
+          res += std::to_string(group.getId());
           break;
         case RDKit::StereoGroupType::STEREO_AND:
           res += "STERAC";
-          res += std::to_string(and_count);
-          ++and_count;
+          res += std::to_string(group.getId());
           break;
       }
       res += " ATOMS=(";

--- a/Code/GraphMol/FileParsers/file_parsers_catch.cpp
+++ b/Code/GraphMol/FileParsers/file_parsers_catch.cpp
@@ -5447,8 +5447,7 @@ M  END
   }
 }
 
-TEST_CASE(
-    "Github #6395: Mol Unsaturated Query Not Parsed Correctly") {
+TEST_CASE("Github #6395: Mol Unsaturated Query Not Parsed Correctly") {
   SECTION("as reported") {
     auto m = R"CTAB(
 MOESketch           2D                              
@@ -6250,3 +6249,64 @@ f_m_ct {
 }
 
 #endif
+
+TEST_CASE("Stereo Group ID preservation: parsing and writing to/from ctab",
+          "[ctab][StereoGroup]") {
+  auto mol = R"CTAB(
+     RDKit          2D
+
+  0  0  0  0  0  0  0  0  0  0999 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 10 9 0 0 0
+M  V30 BEGIN ATOM
+M  V30 1 C 0.000000 0.000000 0.000000 0
+M  V30 2 C 1.299038 0.750000 0.000000 0
+M  V30 3 O 1.299038 2.250000 0.000000 0
+M  V30 4 C 2.598076 -0.000000 0.000000 0
+M  V30 5 C 3.897114 0.750000 0.000000 0
+M  V30 6 C 2.598076 -1.500000 0.000000 0
+M  V30 7 C 3.897114 -2.250000 0.000000 0
+M  V30 8 C 1.299038 -2.250000 0.000000 0
+M  V30 9 C 1.299038 -3.750000 0.000000 0
+M  V30 10 O 0.000000 -1.500000 0.000000 0
+M  V30 END ATOM
+M  V30 BEGIN BOND
+M  V30 1 1 2 1 CFG=1
+M  V30 2 1 2 3
+M  V30 3 1 2 4
+M  V30 4 1 4 5 CFG=3
+M  V30 5 1 4 6
+M  V30 6 1 6 7 CFG=1
+M  V30 7 1 6 8
+M  V30 8 1 8 9 CFG=1
+M  V30 9 1 8 10
+M  V30 END BOND
+M  V30 BEGIN COLLECTION
+M  V30 MDLV30/STERAC8 ATOMS=(2 4 6)
+M  V30 MDLV30/STEREL1 ATOMS=(1 8)
+M  V30 MDLV30/STERAC7 ATOMS=(1 2)
+M  V30 END COLLECTION
+M  V30 END CTAB
+M  END
+)CTAB"_ctab;
+  REQUIRE(mol);
+
+  // Parse
+  const auto &groups = mol->getStereoGroups();
+  REQUIRE(groups.size() == 3);
+
+  CHECK(groups[0].getGroupType() == RDKit::StereoGroupType::STEREO_AND);
+  CHECK(groups[0].getId() == 8);
+  CHECK(groups[1].getGroupType() == RDKit::StereoGroupType::STEREO_OR);
+  CHECK(groups[1].getId() == 1);
+  CHECK(groups[2].getGroupType() == RDKit::StereoGroupType::STEREO_AND);
+  CHECK(groups[2].getId() == 7);
+
+  // Write
+  auto mb = MolToV3KMolBlock(*mol);
+
+  CAPTURE(mb);
+  CHECK(mb.find("MDLV30/STERAC8 ATOMS=(2 4 6)") != std::string::npos);
+  CHECK(mb.find("MDLV30/STEREL1 ATOMS=(1 8)") != std::string::npos);
+  CHECK(mb.find("MDLV30/STERAC7 ATOMS=(1 2)") != std::string::npos);
+}

--- a/Code/GraphMol/FileParsers/testExtendedStereoParsing.cpp
+++ b/Code/GraphMol/FileParsers/testExtendedStereoParsing.cpp
@@ -42,9 +42,11 @@ void testOr() {
   TEST_ASSERT(stereo_groups.size() == 2);
   TEST_ASSERT(stereo_groups[0].getGroupType() ==
               RDKit::StereoGroupType::STEREO_ABSOLUTE);
+  TEST_ASSERT(stereo_groups[0].getId() == 0u);
   TEST_ASSERT(stereo_groups[0].getAtoms().size() == 1u);
   TEST_ASSERT(stereo_groups[1].getGroupType() ==
               RDKit::StereoGroupType::STEREO_OR);
+  TEST_ASSERT(stereo_groups[1].getId() == 1u);
   TEST_ASSERT(stereo_groups[1].getAtoms().size() == 2u);
 
   BOOST_LOG(rdInfoLog) << "done" << std::endl;
@@ -62,8 +64,10 @@ void testAnd() {
   TEST_ASSERT(stereo_groups.size() == 2);
   TEST_ASSERT(stereo_groups[0].getGroupType() ==
               RDKit::StereoGroupType::STEREO_ABSOLUTE);
+  TEST_ASSERT(stereo_groups[0].getId() == 0u);
   TEST_ASSERT(stereo_groups[1].getGroupType() ==
               RDKit::StereoGroupType::STEREO_AND);
+  TEST_ASSERT(stereo_groups[1].getId() == 1u);
 
   BOOST_LOG(rdInfoLog) << "done" << std::endl;
 }

--- a/Code/GraphMol/MolDraw2D/MolDraw2DDetails.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DDetails.cpp
@@ -49,9 +49,9 @@ void arcPoints(const Point2D &cds1, const Point2D &cds2,
 }
 
 void addStereoAnnotation(const ROMol &mol, bool includeRelativeCIP) {
-  const auto &sgs = mol.getStereoGroups();
+  auto sgs = mol.getStereoGroups();
+  assignStereoGroupIds(sgs);
   std::vector<unsigned int> doneAts(mol.getNumAtoms(), 0);
-  unsigned int grpid = 1;
   for (const auto &sg : sgs) {
     for (const auto atom : sg.getAtoms()) {
       if (doneAts[atom->getIdx()]) {
@@ -72,10 +72,10 @@ void addStereoAnnotation(const ROMol &mol, bool includeRelativeCIP) {
           lab = "abs";
           break;
         case StereoGroupType::STEREO_OR:
-          lab = (boost::format("or%d") % grpid).str();
+          lab = (boost::format("or%d") % sg.getId()).str();
           break;
         case StereoGroupType::STEREO_AND:
-          lab = (boost::format("and%d") % grpid).str();
+          lab = (boost::format("and%d") % sg.getId()).str();
           break;
         default:
           break;
@@ -87,9 +87,6 @@ void addStereoAnnotation(const ROMol &mol, bool includeRelativeCIP) {
         }
         atom->setProp(common_properties::atomNote, lab);
       }
-    }
-    if (sg.getGroupType() != StereoGroupType::STEREO_ABSOLUTE) {
-      ++grpid;
     }
   }
   for (auto atom : mol.atoms()) {

--- a/Code/GraphMol/MolDraw2D/catch_tests.cpp
+++ b/Code/GraphMol/MolDraw2D/catch_tests.cpp
@@ -1249,7 +1249,7 @@ TEST_CASE(
     CHECK(txt == "abs (S)");
     CHECK(m2.getAtomWithIdx(3)->getPropIfPresent(common_properties::atomNote,
                                                  txt));
-    CHECK(txt == "and4");
+    CHECK(txt == "and2");
   }
   SECTION("including CIP with relative stereo") {
     ROMol m2(*m1);
@@ -1262,7 +1262,7 @@ TEST_CASE(
     CHECK(txt == "abs (S)");
     CHECK(m2.getAtomWithIdx(3)->getPropIfPresent(common_properties::atomNote,
                                                  txt));
-    CHECK(txt == "and4 (R)");
+    CHECK(txt == "and2 (R)");
   }
   SECTION("new CIP labels") {
     ROMol m2(*m1);
@@ -7643,8 +7643,7 @@ TEST_CASE(
   }
 }
 
-TEST_CASE(
-    "Github #6416: crash with colinear atoms") {
+TEST_CASE("Github #6416: crash with colinear atoms") {
   std::string name = "github6416.svg";
   auto m = R"CTAB(168010013
      RDKit          2D

--- a/Code/GraphMol/MolInterchange/Parser.cpp
+++ b/Code/GraphMol/MolInterchange/Parser.cpp
@@ -237,6 +237,12 @@ void readStereoGroups(RWMol *mol, const rj::Value &sgVals) {
     }
     const auto typ =
         MolInterchange::stereoGrouplookup.at(sgVal["type"].GetString());
+
+    unsigned gId = 0;
+    if (typ != StereoGroupType::STEREO_ABSOLUTE && sgVal.HasMember("id")) {
+      gId = sgVal["id"].GetUint();
+    }
+
     const auto &aids = sgVal["atoms"].GetArray();
     std::vector<Atom *> atoms;
     for (const auto &aid : aids) {
@@ -244,7 +250,7 @@ void readStereoGroups(RWMol *mol, const rj::Value &sgVals) {
     }
 
     if (!atoms.empty()) {
-      molSGs.emplace_back(typ, std::move(atoms));
+      molSGs.emplace_back(typ, std::move(atoms), gId);
     }
   }
   mol->setStereoGroups(std::move(molSGs));

--- a/Code/GraphMol/MolInterchange/Writer.cpp
+++ b/Code/GraphMol/MolInterchange/Writer.cpp
@@ -296,6 +296,11 @@ void addStereoGroup(const StereoGroup &sg, rj::Value &rjSG, rj::Document &doc) {
     throw ValueErrorException("unrecognized StereoGroup type");
   }
   addStringVal(rjSG, "type", inv_stereoGrouplookup.at(sg.getGroupType()), doc);
+
+  if (sg.getGroupType() != StereoGroupType::STEREO_ABSOLUTE) {
+    addIntVal(rjSG, "id", sg.getId(), doc);
+  }
+
   rj::Value rjAtoms(rj::kArrayType);
   for (const auto atm : sg.getAtoms()) {
     rj::Value v1(static_cast<int>(atm->getIdx()));

--- a/Code/GraphMol/MolOps.cpp
+++ b/Code/GraphMol/MolOps.cpp
@@ -756,7 +756,7 @@ std::vector<ROMOL_SPTR> getMolFrags(const ROMol &mol, bool sanitizeFrags,
             }
           }
           if (!sgats.empty()) {
-            fragsgs.push_back(StereoGroup(sg.getGroupType(), sgats));
+            fragsgs.emplace_back(sg.getGroupType(), sgats, sg.getId());
           }
         }
         if (!fragsgs.empty()) {

--- a/Code/GraphMol/MolPickler.cpp
+++ b/Code/GraphMol/MolPickler.cpp
@@ -35,7 +35,7 @@ using std::uint32_t;
 namespace RDKit {
 
 const int32_t MolPickler::versionMajor = 14;
-const int32_t MolPickler::versionMinor = 0;
+const int32_t MolPickler::versionMinor = 1;
 const int32_t MolPickler::versionPatch = 0;
 const int32_t MolPickler::endianId = 0xDEADBEEF;
 
@@ -2305,12 +2305,16 @@ SubstanceGroup MolPickler::_getSubstanceGroupFromPickle(std::istream &ss,
 
 template <typename T>
 void MolPickler::_pickleStereo(std::ostream &ss,
-                               const std::vector<StereoGroup> &groups,
+                               std::vector<StereoGroup> groups,
                                std::map<int, int> &atomIdxMap) {
   T tmpT = static_cast<T>(groups.size());
   streamWrite(ss, tmpT);
+  assignStereoGroupIds(groups);
   for (auto &&group : groups) {
     streamWrite(ss, static_cast<T>(group.getGroupType()));
+    if (group.getGroupType() != StereoGroupType::STEREO_ABSOLUTE) {
+      streamWrite(ss, static_cast<T>(group.getId()));
+    }
     auto &atoms = group.getAtoms();
     streamWrite(ss, static_cast<T>(atoms.size()));
     for (auto &&atom : atoms) {
@@ -2333,6 +2337,12 @@ void MolPickler::_depickleStereo(std::istream &ss, ROMol *mol, int version) {
       streamRead(ss, tmpT, version);
       const auto groupType = static_cast<RDKit::StereoGroupType>(tmpT);
 
+      unsigned gId = 0;
+      if (version >= 14010 && groupType != StereoGroupType::STEREO_ABSOLUTE) {
+        streamRead(ss, tmpT, version);
+        gId = static_cast<unsigned>(tmpT);
+      }
+
       streamRead(ss, tmpT, version);
       const auto numAtoms = static_cast<unsigned>(tmpT);
 
@@ -2343,7 +2353,7 @@ void MolPickler::_depickleStereo(std::istream &ss, ROMol *mol, int version) {
         atoms.push_back(mol->getAtomWithIdx(tmpT));
       }
 
-      groups.emplace_back(groupType, std::move(atoms));
+      groups.emplace_back(groupType, std::move(atoms), gId);
     }
 
     mol->setStereoGroups(std::move(groups));

--- a/Code/GraphMol/MolPickler.h
+++ b/Code/GraphMol/MolPickler.h
@@ -239,8 +239,7 @@ class RDKIT_GRAPHMOL_EXPORT MolPickler {
 
   //! do the actual work of pickling Stereo Group data
   template <typename T>
-  static void _pickleStereo(std::ostream &ss,
-                            const std::vector<StereoGroup> &groups,
+  static void _pickleStereo(std::ostream &ss, std::vector<StereoGroup> groups,
                             std::map<int, int> &atomIdxMap);
 
   //! do the actual work of pickling a Conformer

--- a/Code/GraphMol/ROMol.cpp
+++ b/Code/GraphMol/ROMol.cpp
@@ -114,7 +114,8 @@ void ROMol::initFromOther(const ROMol &other, bool quickCopy, int confId) {
     for (auto &&otherAtom : otherGroup.getAtoms()) {
       atoms.push_back(getAtomWithIdx(otherAtom->getIdx()));
     }
-    d_stereo_groups.emplace_back(otherGroup.getGroupType(), std::move(atoms));
+    d_stereo_groups.emplace_back(otherGroup.getGroupType(), std::move(atoms),
+                                 otherGroup.getId());
   }
 
   if (other.dp_delAtoms) {

--- a/Code/GraphMol/Renumber.cpp
+++ b/Code/GraphMol/Renumber.cpp
@@ -107,8 +107,7 @@ ROMol *renumberAtoms(const ROMol &mol,
       for (const auto aptr : osg.getAtoms()) {
         ats.push_back(res->getAtomWithIdx(revOrder[aptr->getIdx()]));
       }
-      StereoGroup nsg(osg.getGroupType(), ats);
-      nsgs.push_back(nsg);
+      nsgs.emplace_back(osg.getGroupType(), ats, osg.getId());
     }
     res->setStereoGroups(std::move(nsgs));
   }

--- a/Code/GraphMol/SmilesParse/CXSmilesOps.cpp
+++ b/Code/GraphMol/SmilesParse/CXSmilesOps.cpp
@@ -1355,24 +1355,24 @@ bool parse_enhanced_stereo(Iterator &first, Iterator last, RDKit::RWMol &mol,
   if (!atoms.empty()) {
     // we need to do a bit of work to check whether or not we've already seen
     // this particular StereoGroup (was Github #6050)
-    group_id = 10 * group_id + static_cast<unsigned int>(group_type);
+    const auto group_hash =
+        10 * group_id + static_cast<unsigned int>(group_type);
     std::vector<unsigned int> sgTracker;
     mol.getPropIfPresent(cxsgTracker, sgTracker);
     std::vector<StereoGroup> mol_stereo_groups(mol.getStereoGroups());
     TEST_ASSERT(mol_stereo_groups.size() == sgTracker.size());
 
-    auto iter = std::find(sgTracker.begin(), sgTracker.end(), group_id);
+    auto iter = std::find(sgTracker.begin(), sgTracker.end(), group_hash);
     if (iter != sgTracker.end()) {
       auto index = iter - sgTracker.begin();
       auto gAtoms = mol_stereo_groups[index].getAtoms();
       gAtoms.insert(gAtoms.end(), atoms.begin(), atoms.end());
       mol_stereo_groups[index] = StereoGroup(
-          mol_stereo_groups[index].getGroupType(), std::move(gAtoms));
+          mol_stereo_groups[index].getGroupType(), std::move(gAtoms), group_id);
     } else {
       // not seen this before, create a new stereogroup
-      mol_stereo_groups.emplace_back(group_type, std::move(atoms));
-      sgTracker.resize(mol_stereo_groups.size());
-      sgTracker.back() = group_id;
+      mol_stereo_groups.emplace_back(group_type, std::move(atoms), group_id);
+      sgTracker.push_back(group_hash);
       mol.setProp(cxsgTracker, sgTracker);
     }
 
@@ -1525,6 +1525,60 @@ void parseCXExtensions(RDKit::RWMol &mol, const std::string &extText,
 namespace RDKit {
 namespace SmilesWrite {
 namespace {
+
+std::vector<unsigned> getSortedMappedIndexes(
+    const std::vector<Atom *> &atoms, const std::vector<unsigned> &revOrder) {
+  std::vector<unsigned> res;
+  res.reserve(atoms.size());
+  for (auto atom : atoms) {
+    auto idx = atom->getIdx();
+    res.push_back(revOrder[idx]);
+  }
+  std::sort(res.begin(), res.end());
+  return res;
+}
+
+std::pair<std::vector<StereoGroup>, std::vector<std::vector<unsigned>>>
+getIndexeSortedGroups(const std::vector<StereoGroup> &groups,
+                      const std::vector<unsigned int> &revOrder) {
+  using StGrpIdxPair = std::pair<StereoGroup, std::vector<unsigned>>;
+
+  std::vector<StGrpIdxPair> sortingGroups;
+  sortingGroups.reserve(groups.size());
+
+  for (const auto &sg : groups) {
+    const auto atomIndexes = getSortedMappedIndexes(sg.getAtoms(), revOrder);
+    if (!atomIndexes.empty()) {
+      sortingGroups.emplace_back(sg, atomIndexes);
+    }
+  }
+
+  // sort by 1) StereoGroup type; 2) StereoGroup id; 3) atom indexes
+  std::sort(sortingGroups.begin(), sortingGroups.end(),
+            [](const StGrpIdxPair &a, const StGrpIdxPair &b) {
+              const auto &[sgA, idxsA] = a;
+              const auto &[sgB, idxsB] = b;
+              if (sgA.getGroupType() == sgB.getGroupType()) {
+                if (sgA.getId() == sgB.getId()) {
+                  return idxsA < idxsB;
+                }
+                return sgA.getId() < sgB.getId();
+              }
+              return sgA.getGroupType() < sgB.getGroupType();
+            });
+
+  std::vector<StereoGroup> sgs;
+  std::vector<std::vector<unsigned>> sgAtomIdxs;
+  sgs.reserve(sortingGroups.size());
+  sgAtomIdxs.reserve(sortingGroups.size());
+
+  for (auto &&p : sortingGroups) {
+    sgs.push_back(std::move(p.first));
+    sgAtomIdxs.push_back(std::move(p.second));
+  }
+  return {std::move(sgs), std::move(sgAtomIdxs)};
+}
+
 std::string quote_string(const std::string &txt) {
   // FIX
   return txt;
@@ -1554,58 +1608,31 @@ std::string get_enhanced_stereo_block(
   for (unsigned i = 0; i < atomOrder.size(); ++i) {
     revOrder[atomOrder[i]] = i;
   }
-  std::vector<unsigned int> absAts;
-  std::vector<std::vector<unsigned int>> orGps;
-  std::vector<std::vector<unsigned int>> andGps;
 
-  // we want this to be canonical (future proofing)
-  for (const auto &sg : mol.getStereoGroups()) {
-    std::vector<unsigned int> aids;
-    aids.reserve(sg.getAtoms().size());
-    for (const auto at : sg.getAtoms()) {
-      aids.push_back(revOrder[at->getIdx()]);
-    }
-    switch (sg.getGroupType()) {
+  auto [groups, groupsAtoms] =
+      getIndexeSortedGroups(mol.getStereoGroups(), revOrder);
+
+  assignStereoGroupIds(groups);
+
+  auto grpAtomsItr = groupsAtoms.begin();
+  for (auto sgItr = groups.begin(); sgItr != groups.end();
+       ++sgItr, ++grpAtomsItr) {
+    switch (sgItr->getGroupType()) {
       case StereoGroupType::STEREO_ABSOLUTE:
-        absAts.insert(absAts.end(), aids.begin(), aids.end());
+        res << "a:";
         break;
       case StereoGroupType::STEREO_OR:
-        std::sort(aids.begin(), aids.end());
-        orGps.push_back(aids);
+        res << "o" << sgItr->getId() << ":";
         break;
       case StereoGroupType::STEREO_AND:
-        std::sort(aids.begin(), aids.end());
-        andGps.push_back(aids);
-        break;
+        res << "&" << sgItr->getId() << ":";
     }
-  }
-  if (!absAts.empty()) {
-    res << "a:";
-    std::sort(absAts.begin(), absAts.end());
-    for (auto aid : absAts) {
+
+    for (const auto &aid : *grpAtomsItr) {
       res << aid << ",";
     }
   }
-  if (!orGps.empty()) {
-    std::sort(orGps.begin(), orGps.end());
-    unsigned int gIdx = 1;
-    for (const auto &gp : orGps) {
-      res << "o" << gIdx++ << ":";
-      for (auto aid : gp) {
-        res << aid << ",";
-      }
-    }
-  }
-  if (!andGps.empty()) {
-    std::sort(andGps.begin(), andGps.end());
-    unsigned int gIdx = 1;
-    for (const auto &gp : andGps) {
-      res << "&" << gIdx++ << ":";
-      for (auto aid : gp) {
-        res << aid << ",";
-      }
-    }
-  }
+
   std::string resStr = res.str();
   if (!resStr.empty() && resStr.back() == ',') {
     resStr.pop_back();

--- a/Code/GraphMol/SmilesParse/SmilesWrite.cpp
+++ b/Code/GraphMol/SmilesParse/SmilesWrite.cpp
@@ -659,7 +659,10 @@ std::string MolToCXSmiles(const ROMol &mol, const SmilesWriteParams &params,
                  SmilesWrite::CXSmilesFields::CX_BOND_CFG);
     }
 
-    auto cxext = SmilesWrite::getCXExtensions(mol, flags);
+    // Only reassign stereo group IDs if we are generating canonical smiles
+    // and the reassignment was requested.
+    bool reassignStGrpIds = params.canonical && params.reassignStereoGroupIds;
+    auto cxext = SmilesWrite::getCXExtensions(mol, flags, reassignStGrpIds);
     if (!cxext.empty()) {
       res += " " + cxext;
     }
@@ -866,7 +869,9 @@ std::string MolFragmentToCXSmiles(const ROMol &mol,
                                   const std::vector<std::string> *bondSymbols) {
   auto res = MolFragmentToSmiles(mol, params, atomsToUse, bondsToUse,
                                  atomSymbols, bondSymbols);
-  auto cxext = SmilesWrite::getCXExtensions(mol);
+  auto flags = SmilesWrite::CXSmilesFields::CX_ALL;
+  auto cxext =
+      SmilesWrite::getCXExtensions(mol, flags, params.reassignStereoGroupIds);
   if (!cxext.empty()) {
     res += " " + cxext;
   }

--- a/Code/GraphMol/SmilesParse/SmilesWrite.h
+++ b/Code/GraphMol/SmilesParse/SmilesWrite.h
@@ -36,6 +36,9 @@ struct RDKIT_SMILESPARSE_EXPORT SmilesWriteParams {
                             is not canonical */
   int rootedAtAtom = -1; /**< make sure the SMILES starts at the specified
                              atom. The resulting SMILES is not canonical */
+  bool reassignStereoGroupIds =
+      true; /**< whether to reset and reassign AND/OR StereoGroups ids.
+                 This option is only used for CX Smiles. */
 };
 namespace SmilesWrite {
 
@@ -57,7 +60,8 @@ enum CXSmilesFields : uint32_t {
 
 //! \brief returns the cxsmiles data for a molecule
 RDKIT_SMILESPARSE_EXPORT std::string getCXExtensions(
-    const ROMol &mol, std::uint32_t flags = CXSmilesFields::CX_ALL);
+    const ROMol &mol, std::uint32_t flags = CXSmilesFields::CX_ALL,
+    bool reassignStereoGroupIds = true);
 
 //! \brief returns true if the atom number is in the SMILES organic subset
 RDKIT_SMILESPARSE_EXPORT bool inOrganicSubset(int atomicNumber);
@@ -218,13 +222,16 @@ RDKIT_SMILESPARSE_EXPORT std::string MolToCXSmiles(
   \param allBondsExplicit : if true, symbols will be included for all bonds.
   \param allHsExplicit : if true, hydrogen counts will be provided for every
   atom.
+  \param reassignStereoGroupIds : if true, AND/OR StereoGroup ids will be
+  reset and reassigned.
  */
 inline std::string MolToCXSmiles(const ROMol &mol, bool doIsomericSmiles = true,
                                  bool doKekule = false, int rootedAtAtom = -1,
                                  bool canonical = true,
                                  bool allBondsExplicit = false,
                                  bool allHsExplicit = false,
-                                 bool doRandom = false) {
+                                 bool doRandom = false,
+                                 bool reassignStereoGroupIds = true) {
   SmilesWriteParams ps;
   ps.doIsomericSmiles = doIsomericSmiles;
   ps.doKekule = doKekule;
@@ -233,6 +240,7 @@ inline std::string MolToCXSmiles(const ROMol &mol, bool doIsomericSmiles = true,
   ps.allBondsExplicit = allBondsExplicit;
   ps.allHsExplicit = allHsExplicit;
   ps.doRandom = doRandom;
+  ps.reassignStereoGroupIds = reassignStereoGroupIds;
   return MolToCXSmiles(mol, ps);
 };
 
@@ -263,6 +271,9 @@ RDKIT_SMILESPARSE_EXPORT std::string MolFragmentToCXSmiles(
   \param allBondsExplicit : if true, symbols will be included for all bonds.
   \param allHsExplicit : if true, hydrogen counts will be provided for every
   atom.
+  \param reassignStereoGroupIds : if true, AND/OR StereoGroup ids will be
+  reset and reassigned.
+
 
   \b NOTE: the bondSymbols are *not* currently used in the canonicalization.
 
@@ -274,7 +285,7 @@ inline std::string MolFragmentToCXSmiles(
     const std::vector<std::string> *bondSymbols = nullptr,
     bool doIsomericSmiles = true, bool doKekule = false, int rootedAtAtom = -1,
     bool canonical = true, bool allBondsExplicit = false,
-    bool allHsExplicit = false) {
+    bool allHsExplicit = false, bool reassignStereoGroupIds = true) {
   SmilesWriteParams ps;
   ps.doIsomericSmiles = doIsomericSmiles;
   ps.doKekule = doKekule;
@@ -282,6 +293,7 @@ inline std::string MolFragmentToCXSmiles(
   ps.canonical = canonical;
   ps.allBondsExplicit = allBondsExplicit;
   ps.allHsExplicit = allHsExplicit;
+  ps.reassignStereoGroupIds = reassignStereoGroupIds;
   return MolFragmentToCXSmiles(mol, ps, atomsToUse, bondsToUse, atomSymbols,
                                bondSymbols);
 }

--- a/Code/GraphMol/SmilesParse/catch_tests.cpp
+++ b/Code/GraphMol/SmilesParse/catch_tests.cpp
@@ -2421,3 +2421,34 @@ TEST_CASE("smilesSymbol in SMARTS", "[smarts][smilesSymbol]") {
     CHECK(MolToSmarts(*m) == "[Xa;C,N,O]C");
   }
 }
+
+TEST_CASE("Stereo Group ID canonicalization", "[cxsmiles][StereoGroup]") {
+  auto m1 = "C[C@@H](O)[C@H](C)[C@@H](C)[C@@H](C)O |&8:3,5,o1:7,&7:1,r|"_smiles;
+  auto m2 = "C[C@@H](O)[C@H](C)[C@@H](C)[C@@H](C)O |&3:3,5,&2:7,o1:1,r|"_smiles;
+  REQUIRE(m1);
+  REQUIRE(m2);
+
+  SECTION("default canonicalization") {
+    CHECK(MolToCXSmiles(*m1) == MolToCXSmiles(*m2));
+  }
+  SECTION("disable Stereo Group canonicalization") {
+    auto ps = SmilesWriteParams();
+    ps.reassignStereoGroupIds = false;
+
+    auto cx1 = MolToCXSmiles(*m1, ps);
+    auto cx2 = MolToCXSmiles(*m2, ps);
+    CHECK(cx1 != cx2);
+    CHECK(cx1.find("&7:") != std::string::npos);
+    CHECK(cx1.find("&8:") != std::string::npos);
+  }
+  SECTION("disable all canonicalization") {
+    auto ps = SmilesWriteParams();
+    ps.canonical = false;
+
+    auto cx1 = MolToCXSmiles(*m1, ps);
+    auto cx2 = MolToCXSmiles(*m2, ps);
+    CHECK(cx1 != cx2);
+    CHECK(cx1.find("&7:") != std::string::npos);
+    CHECK(cx1.find("&8:") != std::string::npos);
+  }
+}

--- a/Code/GraphMol/StereoGroup.cpp
+++ b/Code/GraphMol/StereoGroup.cpp
@@ -47,13 +47,14 @@ std::ostream &operator<<(std::ostream &target, const RDKit::StereoGroup &stg) {
       target << "ABS";
       break;
     case RDKit::StereoGroupType::STEREO_OR:
-      target << "OR";
+      target << "OR ";
       break;
     case RDKit::StereoGroupType::STEREO_AND:
       target << "AND";
       break;
   }
-  target << " Atoms: { ";
+  target << " id: " << stg.getId();
+  target << " atoms: { ";
   for (auto atom : stg.getAtoms()) {
     target << atom->getIdx() << ' ';
   }

--- a/Code/GraphMol/StereoGroup.cpp
+++ b/Code/GraphMol/StereoGroup.cpp
@@ -5,11 +5,12 @@
 
 namespace RDKit {
 
-StereoGroup::StereoGroup(StereoGroupType grouptype, std::vector<Atom *> &&atoms)
-    : d_grouptype(grouptype), d_atoms(atoms) {}
+StereoGroup::StereoGroup(StereoGroupType grouptype, std::vector<Atom *> &&atoms,
+                         unsigned id)
+    : d_grouptype(grouptype), d_atoms(atoms), d_id{id} {}
 StereoGroup::StereoGroup(StereoGroupType grouptype,
-                         const std::vector<Atom *> &atoms)
-    : d_grouptype(grouptype), d_atoms(std::move(atoms)) {}
+                         const std::vector<Atom *> &atoms, unsigned id)
+    : d_grouptype(grouptype), d_atoms(std::move(atoms)), d_id{id} {}
 
 StereoGroupType StereoGroup::getGroupType() const { return d_grouptype; }
 

--- a/Code/GraphMol/StereoGroup.h
+++ b/Code/GraphMol/StereoGroup.h
@@ -44,8 +44,13 @@ class RDKIT_GRAPHMOL_EXPORT StereoGroup {
   StereoGroupType d_grouptype{StereoGroupType::STEREO_ABSOLUTE};
   std::vector<Atom*> d_atoms;
 
+  // The group ID for AND/OR groups (it has no meaning in ABS groups).
+  // 0 means no group ID is defined, and one will be automatically
+  // assigned when required (e.g. on export)
+  unsigned d_id;
+
  public:
-  StereoGroup() : d_atoms(0u) {}
+  StereoGroup() : d_id(0u) {}
   // Takes control of atoms if possible.
   StereoGroup(StereoGroupType grouptype, std::vector<Atom*>&& atoms);
   StereoGroup(StereoGroupType grouptype, const std::vector<Atom*>& atoms);
@@ -56,6 +61,10 @@ class RDKIT_GRAPHMOL_EXPORT StereoGroup {
 
   StereoGroupType getGroupType() const;
   const std::vector<Atom*>& getAtoms() const;
+
+  unsigned getId() const { return d_id; }
+  void setId(unsigned id) { d_id = id; }
+
   // Seems odd to have to define these, but otherwise the SWIG wrappers
   // won't build
   bool operator==(const StereoGroup& other) const {

--- a/Code/GraphMol/StereoGroup.h
+++ b/Code/GraphMol/StereoGroup.h
@@ -52,8 +52,10 @@ class RDKIT_GRAPHMOL_EXPORT StereoGroup {
  public:
   StereoGroup() : d_id(0u) {}
   // Takes control of atoms if possible.
-  StereoGroup(StereoGroupType grouptype, std::vector<Atom*>&& atoms);
-  StereoGroup(StereoGroupType grouptype, const std::vector<Atom*>& atoms);
+  StereoGroup(StereoGroupType grouptype, std::vector<Atom*>&& atoms,
+              unsigned id = 0);
+  StereoGroup(StereoGroupType grouptype, const std::vector<Atom*>& atoms,
+              unsigned id = 0);
   StereoGroup(const StereoGroup& other) = default;
   StereoGroup& operator=(const StereoGroup& other) = default;
   StereoGroup(StereoGroup&& other) = default;

--- a/Code/GraphMol/StereoGroup.h
+++ b/Code/GraphMol/StereoGroup.h
@@ -81,6 +81,11 @@ RDKIT_GRAPHMOL_EXPORT void removeGroupsWithAtom(
 RDKIT_GRAPHMOL_EXPORT void removeGroupsWithAtoms(
     const std::vector<Atom*>& atoms, std::vector<StereoGroup>& groups);
 
+//! Assign Group IDs to all AND and OR StereoGroups in the vector that don't
+//! already have one. The IDs are assigned based on the order of the groups.
+RDKIT_GRAPHMOL_EXPORT void assignStereoGroupIds(
+    std::vector<StereoGroup>& groups);
+
 }  // namespace RDKit
 
 //! allows StereoGroup objects to be dumped to streams

--- a/Code/GraphMol/Wrap/StereoGroup.cpp
+++ b/Code/GraphMol/Wrap/StereoGroup.cpp
@@ -28,7 +28,7 @@ std::string stereoGroupClassDoc =
     "is a mix\nof diastereomers.\n";
 
 StereoGroup *createStereoGroup(StereoGroupType typ, ROMol &mol,
-                               python::object atomIds) {
+                               python::object atomIds, unsigned id) {
   std::vector<Atom *> cppAtoms;
   python::stl_input_iterator<unsigned int> beg(atomIds), end;
   while (beg != end) {
@@ -39,7 +39,7 @@ StereoGroup *createStereoGroup(StereoGroupType typ, ROMol &mol,
     cppAtoms.push_back(mol.getAtomWithIdx(v));
     ++beg;
   }
-  auto *sg = new StereoGroup(typ, cppAtoms);
+  auto *sg = new StereoGroup(typ, cppAtoms, id);
   return sg;
 }
 
@@ -77,7 +77,7 @@ struct stereogroup_wrap {
                 "creates a StereoGroup associated with a molecule from a list "
                 "of atom Ids",
                 (python::arg("stereoGroupType"), python::arg("mol"),
-                 python::arg("atomIds")),
+                 python::arg("atomIds"), python::arg("id") = 0),
                 python::return_value_policy<
                     python::manage_new_object,
                     python::with_custodian_and_ward_postcall<0, 2>>());

--- a/Code/GraphMol/Wrap/StereoGroup.cpp
+++ b/Code/GraphMol/Wrap/StereoGroup.cpp
@@ -65,7 +65,13 @@ struct stereogroup_wrap {
         .def("GetGroupType", &StereoGroup::getGroupType,
              "Returns the StereoGroupType.\n")
         .def("GetAtoms", getAtomsHelper,
-             "access the atoms in the StereoGroup.\n");
+             "access the atoms in the StereoGroup.\n")
+        .def("GetId", &StereoGroup::getId,
+             "return the StereoGroup's ID.\n"
+             "Note that the ID only makes sense for AND/OR groups.\n")
+        .def("SetId", &StereoGroup::setId,
+             "return the StereoGroup's ID.\n"
+             "Note that the ID only makes sense for AND/OR groups.\n");
 
     python::def("CreateStereoGroup", &createStereoGroup,
                 "creates a StereoGroup associated with a molecule from a list "

--- a/Code/GraphMol/catch_canon.cpp
+++ b/Code/GraphMol/catch_canon.cpp
@@ -347,4 +347,16 @@ TEST_CASE("more enhanced stereo canonicalization") {
 
     CHECK(MolToCXSmiles(*m1) == MolToCXSmiles(*m2));
   }
+  SECTION("case 3") {
+    auto m1 =
+        "C[C@@H](O)[C@H](C)[C@@H](C)[C@@H](C)O |&8:3,5,o1:7,&7:1,r|"_smiles;
+    REQUIRE(m1);
+    auto m2 =
+        "C[C@@H](O)[C@H](C)[C@@H](C)[C@@H](C)O |&3:3,5,&2:7,o1:1,r|"_smiles;
+    REQUIRE(m2);
+    Canon::canonicalizeEnhancedStereo(*m1);
+    Canon::canonicalizeEnhancedStereo(*m2);
+
+    CHECK(MolToCXSmiles(*m1) == MolToCXSmiles(*m2));
+  }
 }

--- a/Code/GraphMol/catch_pickles.cpp
+++ b/Code/GraphMol/catch_pickles.cpp
@@ -171,3 +171,85 @@ M  END
               common_properties::dummyLabel) == "foo");
   }
 }
+
+TEST_CASE("Stereo Group ID preservation: pickle and unpickle",
+          "[pickle][StereoGroup]") {
+  std::string pkl;
+
+  auto run_checks = [](ROMol &m) {
+    const auto &groups = m.getStereoGroups();
+    REQUIRE(groups.size() == 3);
+
+    auto g = groups[0];
+    CHECK(g.getGroupType() == RDKit::StereoGroupType::STEREO_AND);
+    CHECK(g.getId() == 8);
+    CHECK(g.getAtoms() ==
+          std::vector<Atom *>{m.getAtomWithIdx(3), m.getAtomWithIdx(5)});
+
+    g = groups[1];
+    CHECK(g.getGroupType() == RDKit::StereoGroupType::STEREO_OR);
+    CHECK(g.getId() == 1);
+    CHECK(g.getAtoms() == std::vector<Atom *>{m.getAtomWithIdx(7)});
+
+    g = groups[2];
+    CHECK(g.getGroupType() == RDKit::StereoGroupType::STEREO_AND);
+    CHECK(g.getId() == 7);
+    CHECK(g.getAtoms() == std::vector<Atom *>{m.getAtomWithIdx(1)});
+  };
+
+  {
+    auto mol = R"CTAB(
+     RDKit          2D
+
+  0  0  0  0  0  0  0  0  0  0999 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 10 9 0 0 0
+M  V30 BEGIN ATOM
+M  V30 1 C 0.000000 0.000000 0.000000 0
+M  V30 2 C 1.299038 0.750000 0.000000 0
+M  V30 3 O 1.299038 2.250000 0.000000 0
+M  V30 4 C 2.598076 -0.000000 0.000000 0
+M  V30 5 C 3.897114 0.750000 0.000000 0
+M  V30 6 C 2.598076 -1.500000 0.000000 0
+M  V30 7 C 3.897114 -2.250000 0.000000 0
+M  V30 8 C 1.299038 -2.250000 0.000000 0
+M  V30 9 C 1.299038 -3.750000 0.000000 0
+M  V30 10 O 0.000000 -1.500000 0.000000 0
+M  V30 END ATOM
+M  V30 BEGIN BOND
+M  V30 1 1 2 1 CFG=1
+M  V30 2 1 2 3
+M  V30 3 1 2 4
+M  V30 4 1 4 5 CFG=3
+M  V30 5 1 4 6
+M  V30 6 1 6 7 CFG=1
+M  V30 7 1 6 8
+M  V30 8 1 8 9 CFG=1
+M  V30 9 1 8 10
+M  V30 END BOND
+M  V30 BEGIN COLLECTION
+M  V30 MDLV30/STERAC8 ATOMS=(2 4 6)
+M  V30 MDLV30/STEREL1 ATOMS=(1 8)
+M  V30 MDLV30/STERAC7 ATOMS=(1 2)
+M  V30 END COLLECTION
+M  V30 END CTAB
+M  END
+)CTAB"_ctab;
+    REQUIRE(mol);
+
+    // Parse
+    const auto &groups = mol->getStereoGroups();
+    REQUIRE(groups.size() == 3);
+
+    INFO("Reference mol");
+    run_checks(*mol);
+
+    MolPickler::pickleMol(*mol, pkl);
+
+    REQUIRE(!pkl.empty());
+  }
+  RWMol mol2(pkl);
+
+  INFO("roundtripped mol");
+  run_checks(mol2);
+}


### PR DESCRIPTION
This implements parsing, storing and writing the Enhanced Stereo Group ids from multiple formats: CXSMILES, mdl V3000, pickle, mol interchange and cdxml (parsing only).

Most of these formats will roundtrip the Enhanced Stereo Group IDs. The exception is CXSMILES: since this writer canonicalizes the output by default, and some people use it to deduplicate structures, it resets and canonicalizes the Enhanced Stereo Group IDs. In order to allow CXSMILES writer to preserve the ids, the `reassignStereoGroupIds` argument has been added to `MolToCXSmiles()`. Setting it to `false` will cause the ids to be preserved (note that, in that case, the CXSMILES output will **not** be canonical).

Some more notes:
- Enhanced Stereo Group id "0" means that the id is not set, and that the group's will be automatically assigned one at export time.
- Enhanced Stereo Group ids are not used in canonicalization (this would break canonicalization).
- Calling `canonicalizeEnhancedStereo();` resets Enhanced Stereo Group ids, since it is required for canonicalization.
- Passing `canonical = False` to `MolToCXSmiles()` implies `reassignStereoGroupIds = False`.
- Draw2D code will use the stored ids too.
