### PR TITLE
Drop the s_m_color_rgb property from MaeWriter

### DIFF
--- a/Code/GraphMol/FileParsers/MolWriters.h
+++ b/Code/GraphMol/FileParsers/MolWriters.h
@@ -33,7 +33,6 @@ class Writer;
 namespace RDKit {
 
 static int defaultConfId = -1;
-static const std::string defaultMaeHeavyAtomColor = "A0A0A0";
 
 class RDKIT_FILEPARSERS_EXPORT MolWriter : private boost::noncopyable {
  public:
@@ -392,18 +391,11 @@ class RDKIT_FILEPARSERS_EXPORT MaeWriter : public MolWriter {
   void setProps(const STR_VECT &propNames) override;
 
   //! \brief return the text that would be written to the file
-  static std::string getText(
-      const ROMol &mol,
-      const std::string &heavyAtomColor = defaultMaeHeavyAtomColor,
-      int confId = defaultConfId, const STR_VECT &propNames = STR_VECT());
+  static std::string getText(const ROMol &mol, int confId = defaultConfId,
+                             const STR_VECT &propNames = STR_VECT());
 
-  //! \brief write a new molecule to the file
-  void write(const ROMol &mol, int confId = defaultConfId) override;
-
-  //! \brief write a new molecule to the file, specifying the HTML color string
-  //! which should be used for heavy atoms when the file is opened in Maestro.
-  void write(const ROMol &mol, const std::string &heavyAtomColor,
-             int confId = defaultConfId);
+  //! \brief write a new molecule to the file.
+  void write(const ROMol &mol, int confId = defaultConfId);
 
   //! \brief flush the ostream
   void flush() override;

--- a/Code/GraphMol/FileParsers/file_parsers_catch.cpp
+++ b/Code/GraphMol/FileParsers/file_parsers_catch.cpp
@@ -10,6 +10,7 @@
 #include <algorithm>
 #include <fstream>
 #include <string>
+#include <sstream>
 #include <string_view>
 #include <streambuf>
 
@@ -5934,6 +5935,68 @@ TEST_CASE("MaeWriter basic testing", "[mae][MaeWriter][writer]") {
     CHECK(bondBlock.find("s_rdk_bond_string_prop") != std::string::npos);
   }
 
+  SECTION("Check bond ends indices order") {
+    // in the bonds block, 'from' index must be lower than 'to' index
+
+    // As usual, the writer takes ownership of the stream
+    auto oss = new std::stringstream;
+    MaeWriter w(oss);
+    w.write(*mol);
+    w.flush();
+
+    std::string line;
+    while (std::getline(*oss, line) &&
+           line.find("m_bond[6]") == std::string::npos) {
+      // Discard data until we reach the bond block
+    }
+
+    unsigned from_pos = -1;  // offset comment
+    unsigned to_pos = -1;    // offset comment
+    bool from_seen = false;
+    bool to_seen = false;
+
+    while (std::getline(*oss, line) && line.find(":::") == std::string::npos) {
+      // Skip lines (comment, property names, separator)
+      // until we reach the actual data.
+      // Also, find position of 'to' and 'from' indices in the property list
+      if (!from_seen) {
+        ++from_pos;
+        if (line.find("i_m_from") != std::string::npos) {
+          from_seen = true;
+        }
+      }
+      if (!to_seen) {
+        ++to_pos;
+        if (line.find("i_m_to") != std::string::npos) {
+          to_seen = true;
+        }
+      }
+    }
+    REQUIRE(from_pos > 0);
+    REQUIRE(to_pos > 0);
+
+    int from = -1;
+    int to = -1;
+    std::string prop;
+    unsigned tokens = 1 + std::max(from_pos, to_pos);
+    for (unsigned i = 0; i < mol->getNumAtoms(); ++i) {
+      std::getline(*oss, line);
+      std::stringstream ss(line);
+      for (unsigned j = 0; j < tokens; ++j) {
+        if (j == from_pos) {
+          ss >> from;
+        } else if (j == to_pos) {
+          ss >> to;
+        } else {
+          ss >> prop;
+        }
+      }
+      REQUIRE(from != -1);
+      REQUIRE(to != -1);
+      CHECK(from < to);
+    }
+  }
+
   SECTION("Check Property filtering") {
     std::vector<std::string> keptProps{
         "mol_bool_prop",
@@ -6051,6 +6114,75 @@ TEST_CASE("MaeWriter basic testing", "[mae][MaeWriter][writer]") {
       }
     }
     // Maeparser does not parse bond properties, so don't check them.
+  }
+  SECTION("Check reverse roundtrip") {
+    constexpr std::string_view maeBlock = R"MAE(f_m_ct {
+  s_m_title
+  :::
+  ""
+  m_atom[1] {
+    # First column is Index #
+    r_m_x_coord
+    r_m_y_coord
+    r_m_z_coord
+    i_m_atomic_number
+    i_m_formal_charge
+    :::
+    1 -2.542857 2.171429 0.000000 6 0
+    :::
+  }
+})MAE";
+
+    auto iss = new std::istringstream(maeBlock.data());
+    MaeMolSupplier r(iss);
+
+    std::unique_ptr<ROMol> mol(r.next());
+    REQUIRE(mol);
+
+    // The writer always takes ownership of the stream!
+    auto oss = new std::stringstream;
+    MaeWriter w(oss);
+    w.write(*mol);
+    w.flush();
+
+    std::string line;
+    while (std::getline(*oss, line) && line != "f_m_ct {") {
+      // Skip ahead to the ct block
+    }
+
+    // The only ct level should be the title
+    std::getline(*oss, line);
+    CHECK(line.find("s_m_title") != std::string::npos);
+
+    // End block marker
+    std::getline(*oss, line);
+    CHECK(line.find(":::") != std::string::npos);
+
+    while (std::getline(*oss, line) &&
+           line.find("m_atom[1]") == std::string::npos) {
+      // Skip ahead to the atom block
+    }
+
+    // Only the atom properties in the initial mae block should be present
+    std::getline(*oss, line);  // Chomp the comment line
+    CAPTURE(line);
+    REQUIRE(line.find("# First column is Index #") != std::string::npos);
+    std::getline(*oss, line);
+
+    CAPTURE(line);
+    CHECK(line.find("r_m_x_coord") != std::string::npos);
+    std::getline(*oss, line);
+    CHECK(line.find("r_m_y_coord") != std::string::npos);
+    std::getline(*oss, line);
+    CHECK(line.find("r_m_z_coord") != std::string::npos);
+    std::getline(*oss, line);
+    CHECK(line.find("i_m_atomic_number") != std::string::npos);
+    std::getline(*oss, line);
+    CHECK(line.find("i_m_formal_charge") != std::string::npos);
+
+    // End block marker
+    std::getline(*oss, line);
+    CHECK(line.find(":::") != std::string::npos);
   }
 
   SECTION("getText()") {

--- a/Code/GraphMol/FileParsers/file_parsers_catch.cpp
+++ b/Code/GraphMol/FileParsers/file_parsers_catch.cpp
@@ -5447,8 +5447,7 @@ M  END
   }
 }
 
-TEST_CASE(
-    "Github #6395: Mol Unsaturated Query Not Parsed Correctly") {
+TEST_CASE("Github #6395: Mol Unsaturated Query Not Parsed Correctly") {
   SECTION("as reported") {
     auto m = R"CTAB(
 MOESketch           2D                              
@@ -5918,7 +5917,6 @@ TEST_CASE("MaeWriter basic testing", "[mae][MaeWriter][writer]") {
     CHECK(atomBlock.find("r_m_z_coord") != std::string::npos);
     CHECK(atomBlock.find("i_m_atomic_number") != std::string::npos);
     CHECK(atomBlock.find("i_m_formal_charge") != std::string::npos);
-    CHECK(atomBlock.find("s_m_color_rgb") != std::string::npos);
 
     CHECK(atomBlock.find("b_rdk_atom_bool_prop") != std::string::npos);
     CHECK(atomBlock.find("i_rdk_atom_int_prop") != std::string::npos);
@@ -5952,8 +5950,7 @@ TEST_CASE("MaeWriter basic testing", "[mae][MaeWriter][writer]") {
 
     w.setProps(keptProps);
 
-    std::string heavyAtomColor = "131313";
-    w.write(*mol, heavyAtomColor);
+    w.write(*mol);
     w.flush();
 
     auto mae = oss->str();
@@ -5991,7 +5988,6 @@ TEST_CASE("MaeWriter basic testing", "[mae][MaeWriter][writer]") {
     CHECK(atomBlock.find("r_m_z_coord") != std::string::npos);
     CHECK(atomBlock.find("i_m_atomic_number") != std::string::npos);
     CHECK(atomBlock.find("i_m_formal_charge") != std::string::npos);
-    CHECK(atomBlock.find("s_m_color_rgb") != std::string::npos);
 
     CHECK(atomBlock.find("i_rdk_atom_int_prop") != std::string::npos);
 
@@ -6010,14 +6006,20 @@ TEST_CASE("MaeWriter basic testing", "[mae][MaeWriter][writer]") {
     CHECK(bondBlock.find("i_rdk_bond_int_prop") == std::string::npos);
     CHECK(bondBlock.find("s_rdk_bond_string_prop") == std::string::npos);
 
-    size_t pos = 0;
-    unsigned atom_color_count = 0;
-    while (pos < std::string::npos) {
-      pos = atomBlock.find(heavyAtomColor, pos + 1);
-      atom_color_count += (pos != std::string::npos);
-    }
+    // The "i_rdk_atom_int_prop" prop should only be set on the first atom,
+    // and unset on the other five
+    auto count_occurrences = [&atomBlock](const char *needle) {
+      size_t pos = 0;
+      unsigned counter = 0;
+      while (pos < std::string::npos) {
+        pos = atomBlock.find(needle, pos + 1);
+        counter += (pos != std::string::npos);
+      }
+      return counter;
+    };
 
-    CHECK(atom_color_count == mol->getNumAtoms());
+    CHECK(count_occurrences(" 42") == 1);
+    CHECK(count_occurrences(" <>") == 5);
   }
 
   SECTION("Check roundtrip") {
@@ -6147,9 +6149,8 @@ TEST_CASE("GitHub issue #6153: MaeMolSupplier requires bond block",
     r_m_z_coord
     i_m_atomic_number
     i_m_formal_charge
-    s_m_color_rgb
     :::
-    1 -2.542857 2.171429 0.000000 6 0 A0A0A0
+    1 -2.542857 2.171429 0.000000 6 0
     :::
   }
 })MAE";
@@ -6190,7 +6191,6 @@ TEST_CASE("GitHub issue #6153: MaeMolSupplier requires bond block",
     r_m_z_coord
     i_m_atomic_number
     i_m_formal_charge
-    s_m_color_rgb
     :::
     :::
   }
@@ -6213,9 +6213,8 @@ TEST_CASE("GitHub issue #6153: MaeMolSupplier requires bond block",
     r_m_z_coord
     i_m_atomic_number
     i_m_formal_charge
-    s_m_color_rgb
     :::
-    1 -2.542857 2.171429 0.000000 6 0 A0A0A0
+    1 -2.542857 2.171429 0.000000 6 0
     :::
   }
 }
@@ -6231,7 +6230,6 @@ f_m_ct {
     r_m_z_coord
     i_m_atomic_number
     i_m_formal_charge
-    s_m_color_rgb
     :::
     :::
   }

--- a/Code/GraphMol/Wrap/MaeWriter.cpp
+++ b/Code/GraphMol/Wrap/MaeWriter.cpp
@@ -92,18 +92,15 @@ struct wrap_maewriter {
             "Sets the atom and mol properties to be written to the output file\n\n"
             "  ARGUMENTS:\n\n"
             "    - props: a list or tuple of atom and mol property names\n\n")
-        .def(
-            "write",
-            (void(LocalMaeWriter::*)(const ROMol &, const std::string &, int)) &
-                LocalMaeWriter::write,
-            (python::arg("self"), python::arg("mol"),
-             python::arg("heavyAtomColor") = defaultMaeHeavyAtomColor,
-             python::arg("confId") = defaultConfId),
-            "Writes a molecule to the output file.\n\n"
-            "  ARGUMENTS:\n\n"
-            "    - mol: the Mol to be written\n"
-            "    - heavyAtomColor: (optional) color which heavy atoms will have in Maestro\n"
-            "    - confId: (optional) ID of the conformation to write\n\n")
+        .def("write",
+             (void(LocalMaeWriter::*)(const ROMol &, int)) &
+                 LocalMaeWriter::write,
+             (python::arg("self"), python::arg("mol"),
+              python::arg("confId") = defaultConfId),
+             "Writes a molecule to the output file.\n\n"
+             "  ARGUMENTS:\n\n"
+             "    - mol: the Mol to be written\n"
+             "    - confId: (optional) ID of the conformation to write\n\n")
 
         .def("flush", &LocalMaeWriter::flush,
              "Flushes the output file (forces the disk file to be "
@@ -114,9 +111,7 @@ struct wrap_maewriter {
         .def("NumMols", &LocalMaeWriter::numMols,
              "Returns the number of molecules written so far.\n\n")
         .def("GetText", &LocalMaeWriter::getText,
-             (python::arg("mol"),
-              python::arg("heavyAtomColor") = defaultMaeHeavyAtomColor,
-              python::arg("confId") = -1,
+             (python::arg("mol"), python::arg("confId") = -1,
               python::arg("props_list") = std::vector<std::string>()),
              "returns the Maestro ct block text for a molecule")
         .staticmethod("GetText");

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -7119,8 +7119,6 @@ CAS<~>
 
     self.assertIn(f' m_atom[{mol.GetNumAtoms()}] {{', maefile)
 
-    self.assertEqual(maefile.count("A0A0A0"), 6)  # 6 grey-colored heavy atoms
-
     self.assertTrue(f' m_bond[{mol.GetNumBonds()}] {{', maefile)
 
   @unittest.skipIf(not hasattr(Chem, 'MaeWriter'), "not built with MAEParser support")
@@ -7159,12 +7157,10 @@ CAS<~>
     b.SetProp(str_dummy_prop, strProp)
     b.SetProp(ignored_prop, ignored_prop)
 
-    heavyAtomColor = "767676"
-
     osio = StringIO()
     with Chem.MaeWriter(osio) as w:
       w.SetProps(exported_props)
-      w.write(mol, heavyAtomColor=heavyAtomColor)
+      w.write(mol)
 
     maestr = osio.getvalue()
 
@@ -7199,7 +7195,6 @@ CAS<~>
         break
     self.assertIn(str(realProp), line)
     self.assertIn(strProp, line)
-    self.assertIn(heavyAtomColor, line)
 
     # bond properties
     self.assertIn(bond_prop, maestr[bondBlockStart:])
@@ -7241,12 +7236,10 @@ CAS<~>
     mol.SetProp(dummy_prop, dummy_prop)
     mol.SetProp(another_dummy_prop, another_dummy_prop)
 
-    heavyAtomColor = "767676"
-
     osio = StringIO()
     with Chem.MaeWriter(osio) as w:
       w.SetProps([dummy_prop])
-      w.write(mol, heavyAtomColor=heavyAtomColor)
+      w.write(mol)
 
     iomae = osio.getvalue()
 
@@ -7256,7 +7249,7 @@ CAS<~>
     self.assertIn(dummy_prop, iomae)
     self.assertNotIn(another_dummy_prop, iomae)
 
-    mae = Chem.MaeWriter.GetText(mol, heavyAtomColor, -1, [dummy_prop])
+    mae = Chem.MaeWriter.GetText(mol, -1, [dummy_prop])
 
     self.assertEqual(mae, iomae[ctBlockStart:])
 


### PR DESCRIPTION
The `s_m_color_rgb` property is not one of the required atom properties by the Maestro format, but it was added to MaeWriter in #6069. This PR removes this property. It also fixes a couple of bugs that I found during testing.
