### PR TITLE
Exposed partial sanitization options to MinimalLib (both JS and CFFI)

### DIFF
--- a/Code/MinimalLib/cffi_test.c
+++ b/Code/MinimalLib/cffi_test.c
@@ -2124,6 +2124,46 @@ M  END\n",
   free(tpkl);
 }
 
+void test_partial_sanitization() {
+  printf("--------------------------\n");
+  printf("  test_partial_sanitization\n");
+  char *mpkl;
+  char *fp;
+  size_t mpkl_size;
+  const char *mfp_json = "{\"radius\":2,\"nBits\":32}";
+  const char *otherfp_json = "{\"nBits\":32}";
+  mpkl = get_mol("C1CCC2CCCC2C1", &mpkl_size, "{\"sanitize\":false,\"removeHs\":false,\"assignStereo\":false}");
+  assert(mpkl);
+  assert(mpkl_size > 0);
+  fp = get_morgan_fp(mpkl, mpkl_size, mfp_json);
+  assert(fp);
+  assert(strlen(fp) == 32);
+  free(fp);
+  free(mpkl);
+  mpkl = get_mol("C1CCC2CCCC2C1", &mpkl_size, "{\"sanitize\":false,\"removeHs\":false,\"assignStereo\":false,\"fastFindRings\":false}");
+  assert(mpkl);
+  assert(mpkl_size > 0);
+  fp = get_morgan_fp(mpkl, mpkl_size, mfp_json);
+  assert(!fp);
+  fp = get_rdkit_fp(mpkl, mpkl_size, otherfp_json);
+  assert(fp);
+  free(fp);
+  fp = get_pattern_fp(mpkl, mpkl_size, otherfp_json);
+  assert(fp);
+  free(fp);
+  fp = get_atom_pair_fp(mpkl, mpkl_size, otherfp_json);
+  assert(fp);
+  free(fp);
+  fp = get_maccs_fp(mpkl, mpkl_size);
+  assert(!fp);
+#ifdef RDK_BUILD_AVALON_SUPPORT
+  fp = get_avalon_fp(mpkl, mpkl_size, otherfp_json);
+  assert(fp);
+  free(fp);
+#endif
+  free(mpkl);
+}
+
 int main() {
   enable_logging();
   char *vers = version();
@@ -2149,5 +2189,6 @@ int main() {
   test_allow_non_tetrahedral_chirality();
   test_query_colour();
   test_alignment_r_groups_aromatic_ring();
+  test_partial_sanitization();
   return 0;
 }

--- a/Code/MinimalLib/cffiwrapper.cpp
+++ b/Code/MinimalLib/cffiwrapper.cpp
@@ -476,10 +476,14 @@ extern "C" char *get_morgan_fp(const char *mol_pkl, size_t mol_pkl_sz,
   if (!mol_pkl || !mol_pkl_sz) {
     return nullptr;
   }
-  auto fp = MinimalLib::morgan_fp_as_bitvect(mol_from_pkl(mol_pkl, mol_pkl_sz),
-                                             details_json);
-  auto res = BitVectToText(*fp);
-  return str_to_c(res);
+  try {
+    auto fp = MinimalLib::morgan_fp_as_bitvect(mol_from_pkl(mol_pkl, mol_pkl_sz),
+                                               details_json);
+    auto res = BitVectToText(*fp);
+    return str_to_c(res);
+  } catch(...) {
+    return nullptr;
+  }
 }
 
 extern "C" char *get_morgan_fp_as_bytes(const char *mol_pkl, size_t mol_pkl_sz,
@@ -488,10 +492,14 @@ extern "C" char *get_morgan_fp_as_bytes(const char *mol_pkl, size_t mol_pkl_sz,
   if (!mol_pkl || !mol_pkl_sz) {
     return nullptr;
   }
-  auto fp = MinimalLib::morgan_fp_as_bitvect(mol_from_pkl(mol_pkl, mol_pkl_sz),
-                                             details_json);
-  auto res = BitVectToBinaryText(*fp);
-  return str_to_c(res, nbytes);
+  try {
+    auto fp = MinimalLib::morgan_fp_as_bitvect(mol_from_pkl(mol_pkl, mol_pkl_sz),
+                                               details_json);
+    auto res = BitVectToBinaryText(*fp);
+    return str_to_c(res, nbytes);
+  } catch(...) {
+    return nullptr;
+  }
 }
 
 extern "C" char *get_rdkit_fp(const char *mol_pkl, size_t mol_pkl_sz,
@@ -499,10 +507,14 @@ extern "C" char *get_rdkit_fp(const char *mol_pkl, size_t mol_pkl_sz,
   if (!mol_pkl || !mol_pkl_sz) {
     return nullptr;
   }
-  auto fp = MinimalLib::rdkit_fp_as_bitvect(mol_from_pkl(mol_pkl, mol_pkl_sz),
-                                            details_json);
-  auto res = BitVectToText(*fp);
-  return str_to_c(res);
+  try {
+    auto fp = MinimalLib::rdkit_fp_as_bitvect(mol_from_pkl(mol_pkl, mol_pkl_sz),
+                                              details_json);
+    auto res = BitVectToText(*fp);
+    return str_to_c(res);
+  } catch(...) {
+    return nullptr;
+  }
 }
 
 extern "C" char *get_rdkit_fp_as_bytes(const char *mol_pkl, size_t mol_pkl_sz,
@@ -511,10 +523,14 @@ extern "C" char *get_rdkit_fp_as_bytes(const char *mol_pkl, size_t mol_pkl_sz,
   if (!mol_pkl || !mol_pkl_sz) {
     return nullptr;
   }
-  auto fp = MinimalLib::rdkit_fp_as_bitvect(mol_from_pkl(mol_pkl, mol_pkl_sz),
-                                            details_json);
-  auto res = BitVectToBinaryText(*fp);
-  return str_to_c(res, nbytes);
+  try {
+    auto fp = MinimalLib::rdkit_fp_as_bitvect(mol_from_pkl(mol_pkl, mol_pkl_sz),
+                                              details_json);
+    auto res = BitVectToBinaryText(*fp);
+    return str_to_c(res, nbytes);
+  } catch(...) {
+    return nullptr;
+  }
 }
 
 extern "C" char *get_pattern_fp(const char *mol_pkl, size_t mol_pkl_sz,
@@ -522,10 +538,14 @@ extern "C" char *get_pattern_fp(const char *mol_pkl, size_t mol_pkl_sz,
   if (!mol_pkl || !mol_pkl_sz) {
     return nullptr;
   }
-  auto fp = MinimalLib::pattern_fp_as_bitvect(mol_from_pkl(mol_pkl, mol_pkl_sz),
-                                              details_json);
-  auto res = BitVectToText(*fp);
-  return str_to_c(res);
+  try {
+    auto fp = MinimalLib::pattern_fp_as_bitvect(mol_from_pkl(mol_pkl, mol_pkl_sz),
+                                                details_json);
+    auto res = BitVectToText(*fp);
+    return str_to_c(res);
+  } catch(...) {
+    return nullptr;
+  }
 }
 
 extern "C" char *get_pattern_fp_as_bytes(const char *mol_pkl, size_t mol_pkl_sz,
@@ -534,10 +554,14 @@ extern "C" char *get_pattern_fp_as_bytes(const char *mol_pkl, size_t mol_pkl_sz,
   if (!mol_pkl || !mol_pkl_sz) {
     return nullptr;
   }
-  auto fp = MinimalLib::pattern_fp_as_bitvect(mol_from_pkl(mol_pkl, mol_pkl_sz),
-                                              details_json);
-  auto res = BitVectToBinaryText(*fp);
-  return str_to_c(res, nbytes);
+  try {
+    auto fp = MinimalLib::pattern_fp_as_bitvect(mol_from_pkl(mol_pkl, mol_pkl_sz),
+                                                details_json);
+    auto res = BitVectToBinaryText(*fp);
+    return str_to_c(res, nbytes);
+  } catch(...) {
+    return nullptr;
+  }
 }
 
 extern "C" char *get_topological_torsion_fp(const char *mol_pkl,
@@ -546,10 +570,14 @@ extern "C" char *get_topological_torsion_fp(const char *mol_pkl,
   if (!mol_pkl || !mol_pkl_sz) {
     return nullptr;
   }
-  auto fp = MinimalLib::topological_torsion_fp_as_bitvect(
-      mol_from_pkl(mol_pkl, mol_pkl_sz), details_json);
-  auto res = BitVectToText(*fp);
-  return str_to_c(res);
+  try {
+    auto fp = MinimalLib::topological_torsion_fp_as_bitvect(
+        mol_from_pkl(mol_pkl, mol_pkl_sz), details_json);
+    auto res = BitVectToText(*fp);
+    return str_to_c(res);
+  } catch(...) {
+    return nullptr;
+  }
 }
 
 extern "C" char *get_topological_torsion_fp_as_bytes(const char *mol_pkl,
@@ -559,10 +587,14 @@ extern "C" char *get_topological_torsion_fp_as_bytes(const char *mol_pkl,
   if (!mol_pkl || !mol_pkl_sz) {
     return nullptr;
   }
-  auto fp = MinimalLib::topological_torsion_fp_as_bitvect(
-      mol_from_pkl(mol_pkl, mol_pkl_sz), details_json);
-  auto res = BitVectToBinaryText(*fp);
-  return str_to_c(res, nbytes);
+  try {
+    auto fp = MinimalLib::topological_torsion_fp_as_bitvect(
+        mol_from_pkl(mol_pkl, mol_pkl_sz), details_json);
+    auto res = BitVectToBinaryText(*fp);
+    return str_to_c(res, nbytes);
+  } catch(...) {
+    return nullptr;
+  }
 }
 
 extern "C" char *get_atom_pair_fp(const char *mol_pkl, size_t mol_pkl_sz,
@@ -570,10 +602,14 @@ extern "C" char *get_atom_pair_fp(const char *mol_pkl, size_t mol_pkl_sz,
   if (!mol_pkl || !mol_pkl_sz) {
     return nullptr;
   }
-  auto fp = MinimalLib::atom_pair_fp_as_bitvect(
-      mol_from_pkl(mol_pkl, mol_pkl_sz), details_json);
-  auto res = BitVectToText(*fp);
-  return str_to_c(res);
+  try {
+    auto fp = MinimalLib::atom_pair_fp_as_bitvect(
+        mol_from_pkl(mol_pkl, mol_pkl_sz), details_json);
+    auto res = BitVectToText(*fp);
+    return str_to_c(res);
+  } catch(...) {
+    return nullptr;
+  }
 }
 
 extern "C" char *get_atom_pair_fp_as_bytes(const char *mol_pkl,
@@ -582,19 +618,27 @@ extern "C" char *get_atom_pair_fp_as_bytes(const char *mol_pkl,
   if (!mol_pkl || !mol_pkl_sz) {
     return nullptr;
   }
-  auto fp = MinimalLib::atom_pair_fp_as_bitvect(
-      mol_from_pkl(mol_pkl, mol_pkl_sz), details_json);
-  auto res = BitVectToBinaryText(*fp);
-  return str_to_c(res, nbytes);
+  try {
+    auto fp = MinimalLib::atom_pair_fp_as_bitvect(
+        mol_from_pkl(mol_pkl, mol_pkl_sz), details_json);
+    auto res = BitVectToBinaryText(*fp);
+    return str_to_c(res, nbytes);
+  } catch(...) {
+    return nullptr;
+  }
 }
 
 extern "C" char *get_maccs_fp(const char *mol_pkl, size_t mol_pkl_sz) {
   if (!mol_pkl || !mol_pkl_sz) {
     return nullptr;
   }
-  auto fp = MinimalLib::maccs_fp_as_bitvect(mol_from_pkl(mol_pkl, mol_pkl_sz));
-  auto res = BitVectToText(*fp);
-  return str_to_c(res);
+  try {
+    auto fp = MinimalLib::maccs_fp_as_bitvect(mol_from_pkl(mol_pkl, mol_pkl_sz));
+    auto res = BitVectToText(*fp);
+    return str_to_c(res);
+  } catch(...) {
+    return nullptr;
+  }
 }
 
 extern "C" char *get_maccs_fp_as_bytes(const char *mol_pkl, size_t mol_pkl_sz,
@@ -602,9 +646,13 @@ extern "C" char *get_maccs_fp_as_bytes(const char *mol_pkl, size_t mol_pkl_sz,
   if (!mol_pkl || !mol_pkl_sz) {
     return nullptr;
   }
-  auto fp = MinimalLib::maccs_fp_as_bitvect(mol_from_pkl(mol_pkl, mol_pkl_sz));
-  auto res = BitVectToBinaryText(*fp);
-  return str_to_c(res, nbytes);
+  try {
+    auto fp = MinimalLib::maccs_fp_as_bitvect(mol_from_pkl(mol_pkl, mol_pkl_sz));
+    auto res = BitVectToBinaryText(*fp);
+    return str_to_c(res, nbytes);
+  } catch(...) {
+    return nullptr;
+  }
 }
 
 #ifdef RDK_BUILD_AVALON_SUPPORT
@@ -613,10 +661,14 @@ extern "C" char *get_avalon_fp(const char *mol_pkl, size_t mol_pkl_sz,
   if (!mol_pkl || !mol_pkl_sz) {
     return nullptr;
   }
-  auto fp = MinimalLib::avalon_fp_as_bitvect(mol_from_pkl(mol_pkl, mol_pkl_sz),
-                                             details_json);
-  auto res = BitVectToText(*fp);
-  return str_to_c(res);
+  try {
+    auto fp = MinimalLib::avalon_fp_as_bitvect(mol_from_pkl(mol_pkl, mol_pkl_sz),
+                                              details_json);
+    auto res = BitVectToText(*fp);
+    return str_to_c(res);
+  } catch(...) {
+    return nullptr;
+  }
 }
 
 extern "C" char *get_avalon_fp_as_bytes(const char *mol_pkl, size_t mol_pkl_sz,
@@ -625,10 +677,14 @@ extern "C" char *get_avalon_fp_as_bytes(const char *mol_pkl, size_t mol_pkl_sz,
   if (!mol_pkl || !mol_pkl_sz) {
     return nullptr;
   }
-  auto fp = MinimalLib::avalon_fp_as_bitvect(mol_from_pkl(mol_pkl, mol_pkl_sz),
-                                             details_json);
-  auto res = BitVectToBinaryText(*fp);
-  return str_to_c(res, nbytes);
+  try {
+    auto fp = MinimalLib::avalon_fp_as_bitvect(mol_from_pkl(mol_pkl, mol_pkl_sz),
+                                              details_json);
+    auto res = BitVectToBinaryText(*fp);
+    return str_to_c(res, nbytes);
+  } catch(...) {
+    return nullptr;
+  }
 }
 #endif
 

--- a/Code/MinimalLib/common.h
+++ b/Code/MinimalLib/common.h
@@ -99,6 +99,9 @@ RWMol *mol_from_input(const std::string &input,
   bool kekulize = true;
   bool removeHs = true;
   bool mergeQueryHs = false;
+  bool setAromaticity = true;
+  bool fastFindRings = true;
+  bool assignStereo = true;
   RWMol *res = nullptr;
   boost::property_tree::ptree pt;
   if (!details_json.empty()) {
@@ -109,6 +112,9 @@ RWMol *mol_from_input(const std::string &input,
     LPT_OPT_GET(kekulize);
     LPT_OPT_GET(removeHs);
     LPT_OPT_GET(mergeQueryHs);
+    LPT_OPT_GET(setAromaticity);
+    LPT_OPT_GET(fastFindRings);
+    LPT_OPT_GET(assignStereo);
   }
   try {
     if (input.find("M  END") != std::string::npos) {
@@ -146,11 +152,19 @@ RWMol *mol_from_input(const std::string &input,
         if (!kekulize) {
           sanitizeOps ^= MolOps::SANITIZE_KEKULIZE;
         }
+        if (!setAromaticity) {
+          sanitizeOps ^= MolOps::SANITIZE_SETAROMATICITY;
+        }
         MolOps::sanitizeMol(*res, failedOp, sanitizeOps);
       } else {
         res->updatePropertyCache(false);
+        if (fastFindRings) {
+          MolOps::fastFindRings(*res);
+        }
       }
-      MolOps::assignStereochemistry(*res, true, true, true);
+      if (assignStereo) {
+        MolOps::assignStereochemistry(*res, true, true, true);
+      }
       if (mergeQueryHs) {
         MolOps::mergeQueryHs(*res);
       }

--- a/Code/MinimalLib/minilib.cpp
+++ b/Code/MinimalLib/minilib.cpp
@@ -663,7 +663,10 @@ JSSubstructLibrary::JSSubstructLibrary(unsigned int num_bits) :
 }
 
 int JSSubstructLibrary::add_trusted_smiles(const std::string &smi) {
-  std::unique_ptr<RWMol> mol(SmilesToMol(smi, 0, false));
+  SmilesParserParams ps;
+  ps.sanitize = false;
+  ps.removeHs = false;
+  std::unique_ptr<RWMol> mol(SmilesToMol(smi, ps));
   if (!mol) {
     return -1;
   }


### PR DESCRIPTION
This PR exposes partial sanitization options to MinimalLib (both JS and CFFI), namely:

- `setAromaticity` (defaults to true)
- `fastFindRings` (defaults to true; only used when sanitize=false)
- `assignStereo` (defaults to true)

These options avoid doing unnecessary work when the molecule is only used for specific purposes (e.g., computing FPs or doing substructure searches), as nicely described [in this blog post](https://rdkit.blogspot.com/2016/09/avoiding-unnecessary-work-and.html).

I also added `try..catch` blocks to the CFFI library FP functions to avoid that they throw exceptions that cannot be caught from C, but rather return `nullptr`, as other functions already do.