### PR TITLE
Fix issue introduced in #6473

### DIFF
--- a/Code/GraphMol/catch_chirality.cpp
+++ b/Code/GraphMol/catch_chirality.cpp
@@ -3627,3 +3627,31 @@ TEST_CASE("double bonded N with H should be stereogenic", "[bug][stereo]") {
     CHECK(si.size() == 1);
   }
 }
+
+TEST_CASE("Issue in GitHub #6473", "[bug][stereo]") {
+  constexpr const char *mb = R"CTAB(
+     RDKit          2D
+
+  6  5  0  0  0  0  0  0  0  0999 V2000
+    2.0443    0.2759    0.0000 N   0  0  0  0  0  0  0  0  0  0  0  0
+    0.7038    2.5963    0.0000 N   0  0  0  0  0  0  0  0  0  0  0  0
+    3.3828    2.5961    0.0000 N   0  0  0  0  0  0  0  0  0  0  0  0
+    2.0444    1.8228    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -0.6359    1.8229    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    3.3827   -0.4985    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+  1  4  1  0
+  4  2  1  0
+  4  3  2  0
+  2  5  1  0
+  6  1  1  0
+M  END)CTAB";
+
+  UseLegacyStereoPerceptionFixture reset_stereo_perception;
+
+  auto use_legacy_stereo = GENERATE(true, false);
+  CAPTURE(use_legacy_stereo);
+  Chirality::setUseLegacyStereoPerception(use_legacy_stereo);
+
+  std::unique_ptr<ROMol> mol(MolBlockToMol(mb));
+  REQUIRE(mol);
+}


### PR DESCRIPTION
This fixes the issue @ptosco noticede in PR #6473: the problem is that, since we use `getTotalDegree()` to evaluate the minimum number of neighbors to each bond end atom, we allow stereo bonds with just one implicit Hydrogen neighbor on one side, as in Paolo's example.

If that is the case, when we try to call `getStereoInfo(bond)` we get the exception due to this check https://github.com/rdkit/rdkit/blob/88c5d80b3309d2b2ae15d766434650029923fa05/Code/GraphMol/FindStereo.cpp#L131. And further down we'd have even more trouble when trying to figure out the bond's stereo.

This PR fixes this problem by detecting the `getTotalDegree() == 1` and marking the stereo as "unspecified". Note that this also causes both controlling atoms associated to that bond end  to be `StereoInfo::NOATOM`. I think we don't use the controlling atoms of "unspecified" stereo bonds for anything, so this shouldn't cause issues downstream.

The other approach I could think of was using `getDegree() > 1` in https://github.com/rdkit/rdkit/blob/88c5d80b3309d2b2ae15d766434650029923fa05/Code/GraphMol/FindStereo.cpp#L346, so that bond ends with only implicit neighbors would not be marked as potential stereo bonds. But that would break this test, added in #6473: (this one: https://github.com/rdkit/rdkit/blob/88c5d80b3309d2b2ae15d766434650029923fa05/Code/GraphMol/catch_chirality.cpp#L219-L221
