### PR TITLE
update windows DLL CI build config

### DIFF
--- a/.azure-pipelines/vs_build_dll.yml
+++ b/.azure-pipelines/vs_build_dll.yml
@@ -4,10 +4,12 @@ steps:
 - script: |
     conda config --set always_yes yes --set changeps1 no
     conda info -a
+    conda install -n base conda-libmamba-solver
+    conda config --set solver libmamba
     conda create --name rdkit_build ^
         boost-cpp=$(boost_version) boost=$(boost_version) ^
         py-boost=$(boost_version) libboost=$(boost_version) ^
-        numpy matplotlib cairo pillow eigen pandas
+        numpy matplotlib cairo pillow eigen pandas jupyter
     call activate rdkit_build
     conda install -c conda-forge cmake nbval
   displayName: Install dependencies

--- a/.azure-pipelines/vs_build_dll.yml
+++ b/.azure-pipelines/vs_build_dll.yml
@@ -40,7 +40,7 @@ steps:
     -DRDK_SWIG_STATIC=OFF ^
     -DRDK_TEST_MULTITHREADED=ON ^
     -DRDK_BOOST_PYTHON3_NAME=$(python_name) ^
-    -DBoost_NO_BOOST_CMAKE=TRUE ^   
+    -DBoost_NO_BOOST_CMAKE=TRUE ^
     -DCMAKE_INCLUDE_PATH=%CONDA_PREFIX%/Library/include ^
     -DCMAKE_LIBRARY_PATH="%CONDA_PREFIX%/Library/lib
   displayName: Configure build (Run CMake)

--- a/.azure-pipelines/vs_build_dll.yml
+++ b/.azure-pipelines/vs_build_dll.yml
@@ -40,6 +40,7 @@ steps:
     -DRDK_SWIG_STATIC=OFF ^
     -DRDK_TEST_MULTITHREADED=ON ^
     -DRDK_BOOST_PYTHON3_NAME=$(python_name) ^
+    -DBoost_NO_BOOST_CMAKE=TRUE ^   
     -DCMAKE_INCLUDE_PATH=%CONDA_PREFIX%/Library/include ^
     -DCMAKE_LIBRARY_PATH="%CONDA_PREFIX%/Library/lib
   displayName: Configure build (Run CMake)

--- a/.azure-pipelines/vs_build_dll.yml
+++ b/.azure-pipelines/vs_build_dll.yml
@@ -8,10 +8,10 @@ steps:
     conda config --set solver libmamba
     conda create --name rdkit_build ^
         boost-cpp=$(boost_version) boost=$(boost_version) ^
-        py-boost=$(boost_version) libboost=$(boost_version) ^
-        numpy matplotlib cairo pillow eigen pandas jupyter
+        libboost=$(boost_version) ^
+        eigen
     call activate rdkit_build
-    conda install -c conda-forge cmake nbval
+    conda install -c conda-forge cmake
   displayName: Install dependencies
 - script: |
     set Boost_ROOT=
@@ -24,6 +24,7 @@ steps:
     -DRDK_INSTALL_STATIC_LIBS=OFF ^
     -DRDK_INSTALL_DLLS_MSVC=ON ^
     -DRDK_BUILD_CPP_TESTS=ON ^
+    -DRDK_BUILD_PYTHON_WRAPPERS=OFF ^
     -DRDK_USE_BOOST_REGEX=ON ^
     -DRDK_BUILD_COORDGEN_SUPPORT=ON ^
     -DRDK_BUILD_MAEPARSER_SUPPORT=ON ^
@@ -39,7 +40,6 @@ steps:
     -DRDK_BUILD_SWIG_WRAPPERS=OFF ^
     -DRDK_SWIG_STATIC=OFF ^
     -DRDK_TEST_MULTITHREADED=ON ^
-    -DRDK_BOOST_PYTHON3_NAME=$(python_name) ^
     -DBoost_NO_BOOST_CMAKE=TRUE ^
     -DCMAKE_INCLUDE_PATH=%CONDA_PREFIX%/Library/include ^
     -DCMAKE_LIBRARY_PATH="%CONDA_PREFIX%/Library/lib
@@ -52,7 +52,6 @@ steps:
 - script: |
     call activate rdkit_build
     set RDBASE=%cd%
-    set PYTHONPATH=%RDBASE%;%PYTHONPATH%
     set PATH=%RDBASE%\lib;%PATH%
     cd build
     ctest -C Release -j $(number_of_cores) --output-on-failure -T Test

--- a/.azure-pipelines/vs_build_dll.yml
+++ b/.azure-pipelines/vs_build_dll.yml
@@ -9,7 +9,7 @@ steps:
     conda create --name rdkit_build ^
         boost-cpp=$(boost_version) boost=$(boost_version) ^
         libboost=$(boost_version) ^
-        eigen
+        cairo eigen
     call activate rdkit_build
     conda install -c conda-forge cmake
   displayName: Install dependencies

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -56,9 +56,9 @@ jobs:
   pool:
     vmImage: windows-2019
   variables:
-    boost_version: 1.67.0
+    boost_version: 1.71.0
     number_of_cores: '%NUMBER_OF_PROCESSORS%'
-    python_name: python37
+    python_name: python38
   steps:
   - template: .azure-pipelines/vs_build_dll.yml
 - job: Ubuntu_x64_java


### PR DESCRIPTION
The windows DLL CI builds were failing due to an error deep in some python dependency. Rather than tracking that down and pinning things, this just disables the python wrappers for the windows DLL build. 
The primary purpose of the DLL builds is to make sure that it's actually possible to build the RDKit in DLL mode on winows (it's easy to forget to add some boilerplate and break this), and we test that python builds work on Windows in another CI configuration, so this change shouldn't affect test coverage.