### PR TITLE
Deprecate the pure python MolStandardize implementations.

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -33,8 +33,9 @@ been renamed to `molList`.
 ## Code removed in this release:
 
 ## Deprecated code (to be removed in a future release):
-JSMol::is_valid() and JSReaction::is_valid() are now deprecated and always
+- JSMol::is_valid() and JSReaction::is_valid() are now deprecated and always
 return true, as invalid `JSMol` and `JSReaction` cannot exist anymore.
+- The python implementations of MolStandardize will be removed in the next release. Please use the implementation in `rdkit.Chem.MolStandardize.rdMolStandardize` instead.
 
 # Release_2023.03.1
 (Changes relative to Release_2022.09.1)

--- a/rdkit/Chem/MolStandardize/charge.py
+++ b/rdkit/Chem/MolStandardize/charge.py
@@ -10,6 +10,10 @@ which attempts to neutralize ionized acids and bases on a molecule.
 :copyright: Copyright 2016 by Matt Swain.
 :license: MIT, see LICENSE file for more details.
 """
+from warnings import warn
+
+warn(f'The module {__name__} is deprecated and will be removed in the next release.',
+     DeprecationWarning, stacklevel=2)
 
 import copy
 import logging

--- a/rdkit/Chem/MolStandardize/fragment.py
+++ b/rdkit/Chem/MolStandardize/fragment.py
@@ -10,6 +10,10 @@ This module contains tools for dealing with molecules with more than one covalen
 :copyright: Copyright 2016 by Matt Swain.
 :license: MIT, see LICENSE file for more details.
 """
+from warnings import warn
+
+warn(f'The module {__name__} is deprecated and will be removed in the next release.',
+     DeprecationWarning, stacklevel=2)
 
 import logging
 

--- a/rdkit/Chem/MolStandardize/metal.py
+++ b/rdkit/Chem/MolStandardize/metal.py
@@ -8,6 +8,11 @@ This module contains tools for disconnecting metal atoms that are defined as cov
 :copyright: Copyright 2016 by Matt Swain.
 :license: MIT, see LICENSE file for more details.
 """
+from warnings import warn
+
+warn(f'The module {__name__} is deprecated and will be removed in the next release.',
+     DeprecationWarning, stacklevel=2)
+
 
 import logging
 

--- a/rdkit/Chem/MolStandardize/normalize.py
+++ b/rdkit/Chem/MolStandardize/normalize.py
@@ -8,6 +8,10 @@ This module contains tools for normalizing molecules using reaction SMARTS patte
 :copyright: Copyright 2016 by Matt Swain.
 :license: MIT, see LICENSE file for more details.
 """
+from warnings import warn
+
+warn(f'The module {__name__} is deprecated and will be removed in the next release.',
+     DeprecationWarning, stacklevel=2)
 
 import logging
 

--- a/rdkit/Chem/MolStandardize/resonance.py
+++ b/rdkit/Chem/MolStandardize/resonance.py
@@ -8,6 +8,10 @@ Resonance (mesomeric) transformations.
 :copyright: Copyright 2016 by Matt Swain.
 :license: MIT, see LICENSE file for more details.
 """
+from warnings import warn
+
+warn(f'The module {__name__} is deprecated and will be removed in the next release.',
+     DeprecationWarning, stacklevel=2)
 
 import logging
 

--- a/rdkit/Chem/MolStandardize/standardize.py
+++ b/rdkit/Chem/MolStandardize/standardize.py
@@ -10,6 +10,10 @@ standardization tasks.
 :copyright: Copyright 2016 by Matt Swain.
 :license: MIT, see LICENSE file for more details.
 """
+from warnings import warn
+
+warn(f'The module {__name__} is deprecated and will be removed in the next release.',
+     DeprecationWarning, stacklevel=2)
 
 import copy
 import logging
@@ -20,8 +24,8 @@ from .charge import ACID_BASE_PAIRS, CHARGE_CORRECTIONS, Reionizer, Uncharger
 from .fragment import PREFER_ORGANIC, FragmentRemover, LargestFragmentChooser
 from .metal import MetalDisconnector
 from .normalize import MAX_RESTARTS, NORMALIZATIONS, Normalizer
-from .tautomer import (MAX_TAUTOMERS, TAUTOMER_SCORES, TAUTOMER_TRANSFORMS,
-                       TautomerCanonicalizer, TautomerEnumerator)
+from .tautomer import (MAX_TAUTOMERS, TAUTOMER_SCORES, TAUTOMER_TRANSFORMS, TautomerCanonicalizer,
+                       TautomerEnumerator)
 from .utils import memoized_property
 
 log = logging.getLogger(__name__)
@@ -59,6 +63,9 @@ class Standardizer(object):
         :param max_tautomers: The maximum number of tautomers to enumerate (default 1000).
         :param prefer_organic: Whether to prioritize organic fragments when choosing fragment parent (default False).
         """
+    warn(
+      f'The class {self.__class__.__name__} is deprecated and will be removed in the next release.',
+      DeprecationWarning, stacklevel=2)
     log.debug('Initializing Standardizer')
     self.normalizations = normalizations
     self.acid_base_pairs = acid_base_pairs
@@ -297,6 +304,8 @@ def standardize_smiles(smiles):
     :returns: The SMILES for the standardized molecule.
     :rtype: string.
     """
+  warn(f'The function standardize_smiles is deprecated and will be removed in the next release.',
+       DeprecationWarning, stacklevel=2)
   # Skip sanitize as standardize does this anyway
   mol = Chem.MolFromSmiles(smiles, sanitize=False)
   mol = Standardizer().standardize(mol)
@@ -310,6 +319,9 @@ def enumerate_tautomers_smiles(smiles):
     :returns: A set containing SMILES strings for every possible tautomer.
     :rtype: set of strings.
     """
+  warn(
+    f'The function enumerate_tautomers_smiles is deprecated and will be removed in the next release.',
+    DeprecationWarning, stacklevel=2)
   # Skip sanitize as standardize does this anyway
   mol = Chem.MolFromSmiles(smiles, sanitize=False)
   mol = Standardizer().standardize(mol)
@@ -328,6 +340,10 @@ def canonicalize_tautomer_smiles(smiles):
     :returns: The SMILES for the standardize canonical tautomer.
     :rtype: string.
     """
+  warn(
+    f'The function canonicalize_tautomer_smiles is deprecated and will be removed in the next release.',
+    DeprecationWarning, stacklevel=2)
+
   # Skip sanitize as standardize does this anyway
   mol = Chem.MolFromSmiles(smiles, sanitize=False)
   mol = Standardizer().standardize(mol)

--- a/rdkit/Chem/MolStandardize/tautomer.py
+++ b/rdkit/Chem/MolStandardize/tautomer.py
@@ -8,6 +8,10 @@ This module contains tools for enumerating tautomers and determining a canonical
 :copyright: Copyright 2016 by Matt Swain.
 :license: MIT, see LICENSE file for more details.
 """
+from warnings import warn
+
+warn(f'The module {__name__} is deprecated and will be removed in the next release.',
+     DeprecationWarning, stacklevel=2)
 
 import copy
 import logging

--- a/rdkit/Chem/MolStandardize/validate.py
+++ b/rdkit/Chem/MolStandardize/validate.py
@@ -10,6 +10,10 @@ convenience function.
 :copyright: Copyright 2016 by Matt Swain.
 :license: MIT, see LICENSE file for more details.
 """
+from warnings import warn
+
+warn(f'The module {__name__} is deprecated and will be removed in the next release.',
+     DeprecationWarning, stacklevel=2)
 
 import logging
 import sys
@@ -68,6 +72,9 @@ class Validator(object):
         :param bool stdout: Whether to send log messages to standard output.
         :param bool raw: Whether to return raw :class:`~logging.LogRecord` objects instead of formatted log strings.
         """
+    warn(
+      f'The class {self.__class__.__name__} is deprecated and will be removed in the next release.',
+      DeprecationWarning, stacklevel=2)
     self.raw = raw
     # Set up logger and add default LogHandler
     self.log = logging.getLogger(type(self).__name__)
@@ -113,6 +120,9 @@ def validate_smiles(smiles):
     :rtype: list of strings.
     """
   # Skip sanitize as standardize does this anyway
+  warn(f'The function validate_smiles is deprecated and will be removed in the next release.',
+     DeprecationWarning, stacklevel=2)
+
   mol = Chem.MolFromSmiles(smiles)
   logs = Validator().validate(mol)
   return logs

--- a/rdkit/Chem/MolStandardize/validations.py
+++ b/rdkit/Chem/MolStandardize/validations.py
@@ -8,6 +8,10 @@ This module contains all the built-in :class:`Validations <molvs.validations.Val
 :copyright: Copyright 2016 by Matt Swain.
 :license: MIT, see LICENSE file for more details.
 """
+from warnings import warn
+
+warn(f'The module {__name__} is deprecated and will be removed in the next release.',
+     DeprecationWarning, stacklevel=2)
 
 import logging
 


### PR DESCRIPTION
We aren't supporting this any more and it's causing some confusion, so it should be removed for the 2024.03 release.