### PR TITLE
Optionally forward Enhanced Stereo Group ids

### DIFF
--- a/Code/GraphMol/Canon.cpp
+++ b/Code/GraphMol/Canon.cpp
@@ -1339,7 +1339,7 @@ void canonicalizeEnhancedStereo(ROMol &mol,
 
     // note that we do not forward the Group Ids: this is intentional, so that
     // the Ids are reassigned based on the canonicalized order.
-    newSgs.emplace_back(sg.getGroupType(), std::move(sgAtoms));
+    newSgs.emplace_back(sg.getGroupType(), std::move(sgAtoms), 0u);
     refAtom->setProp("_stereoGroup", newSgs.size() - 1, true);
   }
   mol.setStereoGroups(newSgs);

--- a/Code/GraphMol/Canon.cpp
+++ b/Code/GraphMol/Canon.cpp
@@ -1336,7 +1336,10 @@ void canonicalizeEnhancedStereo(ROMol &mol,
       std::for_each(sgAtoms.begin(), sgAtoms.end(),
                     [](auto atom) { atom->invertChirality(); });
     }
-    newSgs.emplace_back(StereoGroup(sg.getGroupType(), std::move(sgAtoms)));
+
+    // note that we do not forward the Group Ids: this is intentional, so that
+    // the Ids are reassigned based on the canonicalized order.
+    newSgs.emplace_back(sg.getGroupType(), std::move(sgAtoms));
     refAtom->setProp("_stereoGroup", newSgs.size() - 1, true);
   }
   mol.setStereoGroups(newSgs);

--- a/Code/GraphMol/ChemReactions/ReactionRunner.cpp
+++ b/Code/GraphMol/ChemReactions/ReactionRunner.cpp
@@ -1279,7 +1279,8 @@ void copyEnhancedStereoGroups(const ROMol &reactant, RWMOL_SPTR product,
       }
     }
     if (!atoms.empty()) {
-      new_stereo_groups.emplace_back(sg.getGroupType(), std::move(atoms));
+      new_stereo_groups.emplace_back(sg.getGroupType(), std::move(atoms),
+                                     sg.getReadId());
     }
   }
 

--- a/Code/GraphMol/ChemTransforms/ChemTransforms.cpp
+++ b/Code/GraphMol/ChemTransforms/ChemTransforms.cpp
@@ -67,8 +67,8 @@ void copyStereoGroups(const std::map<const Atom *, Atom *> &molAtomMap,
         }
       }
       if (!newStereoAtoms.empty()) {
-        newStereoGroups.emplace_back(stereoGroup.getGroupType(),
-                                     newStereoAtoms);
+        newStereoGroups.emplace_back(stereoGroup.getGroupType(), newStereoAtoms,
+                                     stereoGroup.getReadId());
       }
     }
     newMol.setStereoGroups(std::move(newStereoGroups));

--- a/Code/GraphMol/Chirality.cpp
+++ b/Code/GraphMol/Chirality.cpp
@@ -1845,7 +1845,8 @@ void cleanupStereoGroups(ROMol &mol) {
     if (keep) {
       newsgs.push_back(sg);
     } else if (!okatoms.empty()) {
-      newsgs.emplace_back(sg.getGroupType(), std::move(okatoms));
+      newsgs.emplace_back(sg.getGroupType(), std::move(okatoms),
+                          sg.getReadId());
     }
   }
   mol.setStereoGroups(std::move(newsgs));
@@ -2633,19 +2634,19 @@ static bool assignNontetrahedralChiralTypeFrom3D(ROMol &mol,
           atom->setChiralTag(Atom::ChiralType::CHI_TRIGONALBIPYRAMIDAL);
           res = true;
           if (pair[0] == 2) {
-            perm = VOLTEST(0, 2, 3) ? 7 : 8;  // a b
+            perm = VOLTEST(0, 2, 3) ? 7 : 8;    // a b
           } else if (pair[0] == 3) {
-            perm = VOLTEST(0, 1, 3) ? 5 : 6;  // a c
+            perm = VOLTEST(0, 1, 3) ? 5 : 6;    // a c
           } else if (pair[0] == 4) {
-            perm = VOLTEST(0, 1, 2) ? 3 : 4;  // a d
+            perm = VOLTEST(0, 1, 2) ? 3 : 4;    // a d
           } else if (pair[0] == 5) {
-            perm = VOLTEST(0, 1, 2) ? 1 : 2;  // a e
+            perm = VOLTEST(0, 1, 2) ? 1 : 2;    // a e
           } else if (pair[1] == 3) {
             perm = VOLTEST(1, 0, 3) ? 13 : 14;  // b c
           } else if (pair[1] == 4) {
             perm = VOLTEST(1, 0, 2) ? 10 : 12;  // b d
           } else if (pair[1] == 5) {
-            perm = VOLTEST(1, 0, 2) ? 9 : 11;  // b e
+            perm = VOLTEST(1, 0, 2) ? 9 : 11;   // b e
           } else if (pair[2] == 4) {
             perm = VOLTEST(2, 0, 1) ? 16 : 19;  // c d
           } else if (pair[2] == 5) {

--- a/Code/GraphMol/FileParsers/CDXMLParser.cpp
+++ b/Code/GraphMol/FileParsers/CDXMLParser.cpp
@@ -478,8 +478,13 @@ bool parse_fragment(RWMol &mol, ptree &frag,
   if (!sgroups.empty()) {
     std::vector<StereoGroup> stereo_groups;
     for (auto &sgroup : sgroups) {
-      stereo_groups.emplace_back(
-          StereoGroup(sgroup.second.grouptype, sgroup.second.atoms));
+      unsigned gId = 0;
+      if (sgroup.second.grouptype != StereoGroupType::STEREO_ABSOLUTE &&
+          sgroup.second.sgroup > 0) {
+        gId = sgroup.second.sgroup;
+      }
+      stereo_groups.emplace_back(sgroup.second.grouptype, sgroup.second.atoms,
+                                 gId);
     }
     mol.setStereoGroups(std::move(stereo_groups));
   }

--- a/Code/GraphMol/FileParsers/MolFileParser.cpp
+++ b/Code/GraphMol/FileParsers/MolFileParser.cpp
@@ -201,7 +201,7 @@ std::string parseEnhancedStereo(std::istream *inStream, unsigned int &line,
   // M  V30 MDLV30/STEREL1 ATOMS=(1 12)
   // M  V30 MDLV30/STERAC1 ATOMS=(1 12)
   const regex stereo_label(
-      R"regex(MDLV30/STE(...)[0-9]* +ATOMS=\(([0-9]+) +(.*)\) *)regex");
+      R"regex(MDLV30/STE(...)([0-9]*) +ATOMS=\(([0-9]+) +(.*)\) *)regex");
 
   smatch match;
   std::vector<StereoGroup> groups;
@@ -213,13 +213,16 @@ std::string parseEnhancedStereo(std::istream *inStream, unsigned int &line,
     // If this line in the collection is part of a stereo group
     if (regex_match(tempStr, match, stereo_label)) {
       StereoGroupType grouptype = RDKit::StereoGroupType::STEREO_ABSOLUTE;
+      unsigned groupid = 0;
 
       if (match[1] == "ABS") {
         grouptype = RDKit::StereoGroupType::STEREO_ABSOLUTE;
       } else if (match[1] == "REL") {
         grouptype = RDKit::StereoGroupType::STEREO_OR;
+        groupid = FileParserUtils::toUnsigned(match[2], true);
       } else if (match[1] == "RAC") {
         grouptype = RDKit::StereoGroupType::STEREO_AND;
+        groupid = FileParserUtils::toUnsigned(match[2], true);
       } else {
         std::ostringstream errout;
         errout << "Unrecognized stereogroup type : '" << tempStr << "' on line"
@@ -227,16 +230,16 @@ std::string parseEnhancedStereo(std::istream *inStream, unsigned int &line,
         throw FileParseException(errout.str());
       }
 
-      const unsigned int count = FileParserUtils::toUnsigned(match[2], true);
+      const unsigned int count = FileParserUtils::toUnsigned(match[3], true);
       std::vector<Atom *> atoms;
-      std::stringstream ss(match[3]);
+      std::stringstream ss(match[4]);
       unsigned int index;
       for (size_t i = 0; i < count; ++i) {
         ss >> index;
         // atoms are 1 indexed in molfiles
         atoms.push_back(mol->getAtomWithIdx(index - 1));
       }
-      groups.emplace_back(grouptype, std::move(atoms));
+      groups.emplace_back(grouptype, std::move(atoms), groupid);
     } else {
       // skip collection types we don't know how to read. Only one documented
       // is MDLV30/HILITE
@@ -539,15 +542,15 @@ void ParseSubstitutionCountLine(RWMol *mol, const std::string &text,
           break;
         case 6:
           BOOST_LOG(rdWarningLog) << " atom degree query with value 6 found. "
-                                      "This will not match degree >6. The MDL "
-                                      "spec says it should.  line: "
+                                     "This will not match degree >6. The MDL "
+                                     "spec says it should.  line: "
                                   << line;
           q->setVal(6);
           break;
         default:
           std::ostringstream errout;
           errout << "Value " << count
-                  << " is not supported as a degree query. line: " << line;
+                 << " is not supported as a degree query. line: " << line;
           throw FileParseException(errout.str());
       }
       if (!atom->hasQuery()) {
@@ -601,10 +604,10 @@ void ParseUnsaturationLine(RWMol *mol, const std::string &text,
       } else {
         std::ostringstream errout;
         errout << "Value " << count
-                << " is not supported as an unsaturation "
+               << " is not supported as an unsaturation "
                   "query (only 0 and 1 are allowed). "
                   "line: "
-                << line;
+               << line;
         throw FileParseException(errout.str());
       }
     } catch (boost::bad_lexical_cast &) {
@@ -670,8 +673,8 @@ void ParseRingBondCountLine(RWMol *mol, const std::string &text,
         default:
           std::ostringstream errout;
           errout << "Value " << count
-                  << " is not supported as a ring-bond count query. line: "
-                  << line;
+                 << " is not supported as a ring-bond count query. line: "
+                 << line;
           throw FileParseException(errout.str());
       }
       if (!atom->hasQuery()) {

--- a/Code/GraphMol/FileParsers/MolFileWriter.cpp
+++ b/Code/GraphMol/FileParsers/MolFileWriter.cpp
@@ -1143,9 +1143,9 @@ const std::string GetV3000MolFileBondLine(const Bond *bond,
 }
 
 void appendEnhancedStereoGroups(std::string &res, const RWMol &tmol) {
-  unsigned or_count = 1u, and_count = 1u;
-  auto &stereo_groups = tmol.getStereoGroups();
-  if (!stereo_groups.empty()) {
+  if (!tmol.getStereoGroups().empty()) {
+    auto stereo_groups = tmol.getStereoGroups();
+    assignStereoGroupIds(stereo_groups);
     res += "M  V30 BEGIN COLLECTION\n";
     for (auto &&group : stereo_groups) {
       res += "M  V30 MDLV30/";
@@ -1155,13 +1155,11 @@ void appendEnhancedStereoGroups(std::string &res, const RWMol &tmol) {
           break;
         case RDKit::StereoGroupType::STEREO_OR:
           res += "STEREL";
-          res += std::to_string(or_count);
-          ++or_count;
+          res += std::to_string(group.getWriteId());
           break;
         case RDKit::StereoGroupType::STEREO_AND:
           res += "STERAC";
-          res += std::to_string(and_count);
-          ++and_count;
+          res += std::to_string(group.getWriteId());
           break;
       }
       res += " ATOMS=(";

--- a/Code/GraphMol/FileParsers/file_parsers_catch.cpp
+++ b/Code/GraphMol/FileParsers/file_parsers_catch.cpp
@@ -6379,8 +6379,8 @@ f_m_ct {
   }
 }
 TEST_CASE("Chained bond stereo and wiggly bonds") {
-    SECTION("github6434") {
-        std::string molblock = R"CTAB(
+  SECTION("github6434") {
+    std::string molblock = R"CTAB(
   Mrv2004 07102311132D
 
  10  9  0  0  0  0            999 V2000
@@ -6405,11 +6405,34 @@ TEST_CASE("Chained bond stereo and wiggly bonds") {
   8 10  1  0  0  0  0
 M  END
   )CTAB";
-        std::unique_ptr<RWMol> m;
-        m.reset(MolBlockToMol(molblock));
-        REQUIRE(m);
-        CHECK(m->getNumAtoms() == 8);
+    std::unique_ptr<RWMol> m;
+    m.reset(MolBlockToMol(molblock));
+    REQUIRE(m);
+    CHECK(m->getNumAtoms() == 8);
+  }
 }
+
+TEST_CASE("StereoGroup id forwarding", "[StereoGroup][ctab]") {
+  auto m = "C[C@@H](O)[C@H](C)[C@@H](C)[C@@H](C)O |&7:3,o1:7,&8:1,&9:5|"_smiles;
+  REQUIRE(m);
+  CHECK(m->getStereoGroups().size() == 4);
+
+  SECTION("ids reassigned by default") {
+    const auto mb_out = MolToMolBlock(*m);
+    CHECK(mb_out.find("M  V30 MDLV30/STERAC1") != std::string::npos);
+    CHECK(mb_out.find("M  V30 MDLV30/STERAC2") != std::string::npos);
+    CHECK(mb_out.find("M  V30 MDLV30/STERAC3") != std::string::npos);
+    CHECK(mb_out.find("M  V30 MDLV30/STEREL1") != std::string::npos);
+  }
+
+  SECTION("forward input ids") {
+    forwardStereoGroupIds(*m);
+    const auto mb_out = MolToMolBlock(*m);
+    CHECK(mb_out.find("M  V30 MDLV30/STERAC7") != std::string::npos);
+    CHECK(mb_out.find("M  V30 MDLV30/STERAC8") != std::string::npos);
+    CHECK(mb_out.find("M  V30 MDLV30/STERAC9") != std::string::npos);
+    CHECK(mb_out.find("M  V30 MDLV30/STEREL1") != std::string::npos);
+  }
 }
 
 #endif

--- a/Code/GraphMol/FileParsers/testExtendedStereoParsing.cpp
+++ b/Code/GraphMol/FileParsers/testExtendedStereoParsing.cpp
@@ -51,6 +51,11 @@ void testOr() {
   TEST_ASSERT(stereo_groups[1].getWriteId() == 0u);
   TEST_ASSERT(stereo_groups[1].getAtoms().size() == 2u);
 
+  forwardStereoGroupIds(*m);
+  stereo_groups = m->getStereoGroups();
+  TEST_ASSERT(stereo_groups[0].getWriteId() == 0u);
+  TEST_ASSERT(stereo_groups[1].getWriteId() == 1u);
+
   BOOST_LOG(rdInfoLog) << "done" << std::endl;
 }
 
@@ -70,6 +75,11 @@ void testAnd() {
   TEST_ASSERT(stereo_groups[1].getGroupType() ==
               RDKit::StereoGroupType::STEREO_AND);
   TEST_ASSERT(stereo_groups[1].getReadId() == 1u);
+
+  forwardStereoGroupIds(*m);
+  stereo_groups = m->getStereoGroups();
+  TEST_ASSERT(stereo_groups[0].getWriteId() == 0u);
+  TEST_ASSERT(stereo_groups[1].getWriteId() == 1u);
 
   BOOST_LOG(rdInfoLog) << "done" << std::endl;
 }

--- a/Code/GraphMol/FileParsers/testExtendedStereoParsing.cpp
+++ b/Code/GraphMol/FileParsers/testExtendedStereoParsing.cpp
@@ -42,9 +42,13 @@ void testOr() {
   TEST_ASSERT(stereo_groups.size() == 2);
   TEST_ASSERT(stereo_groups[0].getGroupType() ==
               RDKit::StereoGroupType::STEREO_ABSOLUTE);
+  TEST_ASSERT(stereo_groups[0].getReadId() == 0u);
+  TEST_ASSERT(stereo_groups[0].getWriteId() == 0u);
   TEST_ASSERT(stereo_groups[0].getAtoms().size() == 1u);
   TEST_ASSERT(stereo_groups[1].getGroupType() ==
               RDKit::StereoGroupType::STEREO_OR);
+  TEST_ASSERT(stereo_groups[1].getReadId() == 1u);
+  TEST_ASSERT(stereo_groups[1].getWriteId() == 0u);
   TEST_ASSERT(stereo_groups[1].getAtoms().size() == 2u);
 
   BOOST_LOG(rdInfoLog) << "done" << std::endl;
@@ -62,8 +66,10 @@ void testAnd() {
   TEST_ASSERT(stereo_groups.size() == 2);
   TEST_ASSERT(stereo_groups[0].getGroupType() ==
               RDKit::StereoGroupType::STEREO_ABSOLUTE);
+  TEST_ASSERT(stereo_groups[0].getReadId() == 0u);
   TEST_ASSERT(stereo_groups[1].getGroupType() ==
               RDKit::StereoGroupType::STEREO_AND);
+  TEST_ASSERT(stereo_groups[1].getReadId() == 1u);
 
   BOOST_LOG(rdInfoLog) << "done" << std::endl;
 }

--- a/Code/GraphMol/MolDraw2D/MolDraw2DDetails.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DDetails.cpp
@@ -49,9 +49,9 @@ void arcPoints(const Point2D &cds1, const Point2D &cds2,
 }
 
 void addStereoAnnotation(const ROMol &mol, bool includeRelativeCIP) {
-  const auto &sgs = mol.getStereoGroups();
+  auto sgs = mol.getStereoGroups();
+  assignStereoGroupIds(sgs);
   std::vector<unsigned int> doneAts(mol.getNumAtoms(), 0);
-  unsigned int grpid = 1;
   for (const auto &sg : sgs) {
     for (const auto atom : sg.getAtoms()) {
       if (doneAts[atom->getIdx()]) {
@@ -72,10 +72,10 @@ void addStereoAnnotation(const ROMol &mol, bool includeRelativeCIP) {
           lab = "abs";
           break;
         case StereoGroupType::STEREO_OR:
-          lab = (boost::format("or%d") % grpid).str();
+          lab = (boost::format("or%d") % sg.getWriteId()).str();
           break;
         case StereoGroupType::STEREO_AND:
-          lab = (boost::format("and%d") % grpid).str();
+          lab = (boost::format("and%d") % sg.getWriteId()).str();
           break;
         default:
           break;
@@ -87,9 +87,6 @@ void addStereoAnnotation(const ROMol &mol, bool includeRelativeCIP) {
         }
         atom->setProp(common_properties::atomNote, lab);
       }
-    }
-    if (sg.getGroupType() != StereoGroupType::STEREO_ABSOLUTE) {
-      ++grpid;
     }
   }
   for (auto atom : mol.atoms()) {

--- a/Code/GraphMol/MolDraw2D/catch_tests.cpp
+++ b/Code/GraphMol/MolDraw2D/catch_tests.cpp
@@ -1249,7 +1249,7 @@ TEST_CASE(
     CHECK(txt == "abs (S)");
     CHECK(m2.getAtomWithIdx(3)->getPropIfPresent(common_properties::atomNote,
                                                  txt));
-    CHECK(txt == "and4");
+    CHECK(txt == "and2");
   }
   SECTION("including CIP with relative stereo") {
     ROMol m2(*m1);
@@ -1262,7 +1262,7 @@ TEST_CASE(
     CHECK(txt == "abs (S)");
     CHECK(m2.getAtomWithIdx(3)->getPropIfPresent(common_properties::atomNote,
                                                  txt));
-    CHECK(txt == "and4 (R)");
+    CHECK(txt == "and2 (R)");
   }
   SECTION("new CIP labels") {
     ROMol m2(*m1);
@@ -7643,8 +7643,7 @@ TEST_CASE(
   }
 }
 
-TEST_CASE(
-    "Github #6416: crash with colinear atoms") {
+TEST_CASE("Github #6416: crash with colinear atoms") {
   std::string name = "github6416.svg";
   auto m = R"CTAB(168010013
      RDKit          2D

--- a/Code/GraphMol/MolInterchange/Parser.cpp
+++ b/Code/GraphMol/MolInterchange/Parser.cpp
@@ -237,6 +237,12 @@ void readStereoGroups(RWMol *mol, const rj::Value &sgVals) {
     }
     const auto typ =
         MolInterchange::stereoGrouplookup.at(sgVal["type"].GetString());
+
+    unsigned gId = 0;
+    if (typ != StereoGroupType::STEREO_ABSOLUTE && sgVal.HasMember("id")) {
+      gId = sgVal["id"].GetUint();
+    }
+
     const auto &aids = sgVal["atoms"].GetArray();
     std::vector<Atom *> atoms;
     for (const auto &aid : aids) {
@@ -244,7 +250,7 @@ void readStereoGroups(RWMol *mol, const rj::Value &sgVals) {
     }
 
     if (!atoms.empty()) {
-      molSGs.emplace_back(typ, std::move(atoms));
+      molSGs.emplace_back(typ, std::move(atoms), gId);
     }
   }
   mol->setStereoGroups(std::move(molSGs));

--- a/Code/GraphMol/MolInterchange/Writer.cpp
+++ b/Code/GraphMol/MolInterchange/Writer.cpp
@@ -296,6 +296,11 @@ void addStereoGroup(const StereoGroup &sg, rj::Value &rjSG, rj::Document &doc) {
     throw ValueErrorException("unrecognized StereoGroup type");
   }
   addStringVal(rjSG, "type", inv_stereoGrouplookup.at(sg.getGroupType()), doc);
+
+  if (sg.getGroupType() != StereoGroupType::STEREO_ABSOLUTE) {
+    addIntVal(rjSG, "id", sg.getWriteId(), doc);
+  }
+
   rj::Value rjAtoms(rj::kArrayType);
   for (const auto atm : sg.getAtoms()) {
     rj::Value v1(static_cast<int>(atm->getIdx()));

--- a/Code/GraphMol/MolOps.cpp
+++ b/Code/GraphMol/MolOps.cpp
@@ -756,7 +756,7 @@ std::vector<ROMOL_SPTR> getMolFrags(const ROMol &mol, bool sanitizeFrags,
             }
           }
           if (!sgats.empty()) {
-            fragsgs.push_back(StereoGroup(sg.getGroupType(), sgats));
+            fragsgs.emplace_back(sg.getGroupType(), sgats, sg.getReadId());
           }
         }
         if (!fragsgs.empty()) {

--- a/Code/GraphMol/MolPickler.h
+++ b/Code/GraphMol/MolPickler.h
@@ -239,8 +239,7 @@ class RDKIT_GRAPHMOL_EXPORT MolPickler {
 
   //! do the actual work of pickling Stereo Group data
   template <typename T>
-  static void _pickleStereo(std::ostream &ss,
-                            const std::vector<StereoGroup> &groups,
+  static void _pickleStereo(std::ostream &ss, std::vector<StereoGroup> groups,
                             std::map<int, int> &atomIdxMap);
 
   //! do the actual work of pickling a Conformer

--- a/Code/GraphMol/ROMol.cpp
+++ b/Code/GraphMol/ROMol.cpp
@@ -114,7 +114,9 @@ void ROMol::initFromOther(const ROMol &other, bool quickCopy, int confId) {
     for (auto &&otherAtom : otherGroup.getAtoms()) {
       atoms.push_back(getAtomWithIdx(otherAtom->getIdx()));
     }
-    d_stereo_groups.emplace_back(otherGroup.getGroupType(), std::move(atoms));
+    d_stereo_groups.emplace_back(otherGroup.getGroupType(), std::move(atoms),
+                                 otherGroup.getReadId());
+    d_stereo_groups.back().setWriteId(otherGroup.getWriteId());
   }
 
   if (other.dp_delAtoms) {

--- a/Code/GraphMol/Renumber.cpp
+++ b/Code/GraphMol/Renumber.cpp
@@ -107,8 +107,7 @@ ROMol *renumberAtoms(const ROMol &mol,
       for (const auto aptr : osg.getAtoms()) {
         ats.push_back(res->getAtomWithIdx(revOrder[aptr->getIdx()]));
       }
-      StereoGroup nsg(osg.getGroupType(), ats);
-      nsgs.push_back(nsg);
+      nsgs.emplace_back(osg.getGroupType(), ats, osg.getReadId());
     }
     res->setStereoGroups(std::move(nsgs));
   }

--- a/Code/GraphMol/SmilesParse/CXSmilesOps.cpp
+++ b/Code/GraphMol/SmilesParse/CXSmilesOps.cpp
@@ -1540,7 +1540,7 @@ std::vector<unsigned> getSortedMappedIndexes(
 
 std::pair<std::vector<StereoGroup>, std::vector<std::vector<unsigned>>>
 getSortedStereoGroupsAndIndices(const std::vector<StereoGroup> &groups,
-                      const std::vector<unsigned int> &revOrder) {
+                                const std::vector<unsigned int> &revOrder) {
   using StGrpIdxPair = std::pair<StereoGroup, std::vector<unsigned>>;
 
   std::vector<StGrpIdxPair> sortingGroups;
@@ -1610,7 +1610,7 @@ std::string get_enhanced_stereo_block(
   }
 
   auto [groups, groupsAtoms] =
-      getIndexeSortedGroups(mol.getStereoGroups(), revOrder);
+      getSortedStereoGroupsAndIndices(mol.getStereoGroups(), revOrder);
 
   assignStereoGroupIds(groups);
 
@@ -1626,6 +1626,7 @@ std::string get_enhanced_stereo_block(
         break;
       case StereoGroupType::STEREO_AND:
         res << "&" << sgItr->getWriteId() << ":";
+        break;
     }
 
     for (const auto &aid : *grpAtomsItr) {

--- a/Code/GraphMol/SmilesParse/CXSmilesOps.cpp
+++ b/Code/GraphMol/SmilesParse/CXSmilesOps.cpp
@@ -1355,24 +1355,24 @@ bool parse_enhanced_stereo(Iterator &first, Iterator last, RDKit::RWMol &mol,
   if (!atoms.empty()) {
     // we need to do a bit of work to check whether or not we've already seen
     // this particular StereoGroup (was Github #6050)
-    group_id = 10 * group_id + static_cast<unsigned int>(group_type);
+    const auto group_hash =
+        10 * group_id + static_cast<unsigned int>(group_type);
     std::vector<unsigned int> sgTracker;
     mol.getPropIfPresent(cxsgTracker, sgTracker);
     std::vector<StereoGroup> mol_stereo_groups(mol.getStereoGroups());
     TEST_ASSERT(mol_stereo_groups.size() == sgTracker.size());
 
-    auto iter = std::find(sgTracker.begin(), sgTracker.end(), group_id);
+    auto iter = std::find(sgTracker.begin(), sgTracker.end(), group_hash);
     if (iter != sgTracker.end()) {
       auto index = iter - sgTracker.begin();
       auto gAtoms = mol_stereo_groups[index].getAtoms();
       gAtoms.insert(gAtoms.end(), atoms.begin(), atoms.end());
       mol_stereo_groups[index] = StereoGroup(
-          mol_stereo_groups[index].getGroupType(), std::move(gAtoms));
+          mol_stereo_groups[index].getGroupType(), std::move(gAtoms), group_id);
     } else {
       // not seen this before, create a new stereogroup
-      mol_stereo_groups.emplace_back(group_type, std::move(atoms));
-      sgTracker.resize(mol_stereo_groups.size());
-      sgTracker.back() = group_id;
+      mol_stereo_groups.emplace_back(group_type, std::move(atoms), group_id);
+      sgTracker.push_back(group_hash);
       mol.setProp(cxsgTracker, sgTracker);
     }
 
@@ -1525,6 +1525,60 @@ void parseCXExtensions(RDKit::RWMol &mol, const std::string &extText,
 namespace RDKit {
 namespace SmilesWrite {
 namespace {
+
+std::vector<unsigned> getSortedMappedIndexes(
+    const std::vector<Atom *> &atoms, const std::vector<unsigned> &revOrder) {
+  std::vector<unsigned> res;
+  res.reserve(atoms.size());
+  for (auto atom : atoms) {
+    auto idx = atom->getIdx();
+    res.push_back(revOrder[idx]);
+  }
+  std::sort(res.begin(), res.end());
+  return res;
+}
+
+std::pair<std::vector<StereoGroup>, std::vector<std::vector<unsigned>>>
+getIndexeSortedGroups(const std::vector<StereoGroup> &groups,
+                      const std::vector<unsigned int> &revOrder) {
+  using StGrpIdxPair = std::pair<StereoGroup, std::vector<unsigned>>;
+
+  std::vector<StGrpIdxPair> sortingGroups;
+  sortingGroups.reserve(groups.size());
+
+  for (const auto &sg : groups) {
+    const auto atomIndexes = getSortedMappedIndexes(sg.getAtoms(), revOrder);
+    if (!atomIndexes.empty()) {
+      sortingGroups.emplace_back(sg, atomIndexes);
+    }
+  }
+
+  // sort by 1) StereoGroup type; 2) StereoGroup id; 3) atom indexes
+  std::sort(sortingGroups.begin(), sortingGroups.end(),
+            [](const StGrpIdxPair &a, const StGrpIdxPair &b) {
+              const auto &[sgA, idxsA] = a;
+              const auto &[sgB, idxsB] = b;
+              if (sgA.getGroupType() == sgB.getGroupType()) {
+                if (sgA.getWriteId() == sgB.getWriteId()) {
+                  return idxsA < idxsB;
+                }
+                return sgA.getWriteId() < sgB.getWriteId();
+              }
+              return sgA.getGroupType() < sgB.getGroupType();
+            });
+
+  std::vector<StereoGroup> sgs;
+  std::vector<std::vector<unsigned>> sgAtomIdxs;
+  sgs.reserve(sortingGroups.size());
+  sgAtomIdxs.reserve(sortingGroups.size());
+
+  for (auto &&p : sortingGroups) {
+    sgs.push_back(std::move(p.first));
+    sgAtomIdxs.push_back(std::move(p.second));
+  }
+  return {std::move(sgs), std::move(sgAtomIdxs)};
+}
+
 std::string quote_string(const std::string &txt) {
   // FIX
   return txt;
@@ -1554,58 +1608,31 @@ std::string get_enhanced_stereo_block(
   for (unsigned i = 0; i < atomOrder.size(); ++i) {
     revOrder[atomOrder[i]] = i;
   }
-  std::vector<unsigned int> absAts;
-  std::vector<std::vector<unsigned int>> orGps;
-  std::vector<std::vector<unsigned int>> andGps;
 
-  // we want this to be canonical (future proofing)
-  for (const auto &sg : mol.getStereoGroups()) {
-    std::vector<unsigned int> aids;
-    aids.reserve(sg.getAtoms().size());
-    for (const auto at : sg.getAtoms()) {
-      aids.push_back(revOrder[at->getIdx()]);
-    }
-    switch (sg.getGroupType()) {
+  auto [groups, groupsAtoms] =
+      getIndexeSortedGroups(mol.getStereoGroups(), revOrder);
+
+  assignStereoGroupIds(groups);
+
+  auto grpAtomsItr = groupsAtoms.begin();
+  for (auto sgItr = groups.begin(); sgItr != groups.end();
+       ++sgItr, ++grpAtomsItr) {
+    switch (sgItr->getGroupType()) {
       case StereoGroupType::STEREO_ABSOLUTE:
-        absAts.insert(absAts.end(), aids.begin(), aids.end());
+        res << "a:";
         break;
       case StereoGroupType::STEREO_OR:
-        std::sort(aids.begin(), aids.end());
-        orGps.push_back(aids);
+        res << "o" << sgItr->getWriteId() << ":";
         break;
       case StereoGroupType::STEREO_AND:
-        std::sort(aids.begin(), aids.end());
-        andGps.push_back(aids);
-        break;
+        res << "&" << sgItr->getWriteId() << ":";
     }
-  }
-  if (!absAts.empty()) {
-    res << "a:";
-    std::sort(absAts.begin(), absAts.end());
-    for (auto aid : absAts) {
+
+    for (const auto &aid : *grpAtomsItr) {
       res << aid << ",";
     }
   }
-  if (!orGps.empty()) {
-    std::sort(orGps.begin(), orGps.end());
-    unsigned int gIdx = 1;
-    for (const auto &gp : orGps) {
-      res << "o" << gIdx++ << ":";
-      for (auto aid : gp) {
-        res << aid << ",";
-      }
-    }
-  }
-  if (!andGps.empty()) {
-    std::sort(andGps.begin(), andGps.end());
-    unsigned int gIdx = 1;
-    for (const auto &gp : andGps) {
-      res << "&" << gIdx++ << ":";
-      for (auto aid : gp) {
-        res << aid << ",";
-      }
-    }
-  }
+
   std::string resStr = res.str();
   if (!resStr.empty() && resStr.back() == ',') {
     resStr.pop_back();

--- a/Code/GraphMol/SmilesParse/CXSmilesOps.cpp
+++ b/Code/GraphMol/SmilesParse/CXSmilesOps.cpp
@@ -1539,7 +1539,7 @@ std::vector<unsigned> getSortedMappedIndexes(
 }
 
 std::pair<std::vector<StereoGroup>, std::vector<std::vector<unsigned>>>
-getIndexeSortedGroups(const std::vector<StereoGroup> &groups,
+getSortedStereoGroupsAndIndices(const std::vector<StereoGroup> &groups,
                       const std::vector<unsigned int> &revOrder) {
   using StGrpIdxPair = std::pair<StereoGroup, std::vector<unsigned>>;
 

--- a/Code/GraphMol/SmilesParse/cxsmiles_test.cpp
+++ b/Code/GraphMol/SmilesParse/cxsmiles_test.cpp
@@ -707,3 +707,26 @@ TEST_CASE(
     CHECK(order == std::vector<unsigned int>{2, 0, 1, 3});
   }
 }
+
+TEST_CASE("StereoGroup id forwarding", "[StereoGroup][cxsmiles]") {
+  auto m = "C[C@@H](O)[C@H](C)[C@@H](C)[C@@H](C)O |&7:3,o1:7,&8:1,&9:5|"_smiles;
+  REQUIRE(m);
+  CHECK(m->getStereoGroups().size() == 4);
+
+  SECTION("ids reassigned by default") {
+    const auto smi_out = MolToCXSmiles(*m);
+    CHECK(smi_out.find("&1") != std::string::npos);
+    CHECK(smi_out.find("&2") != std::string::npos);
+    CHECK(smi_out.find("&3") != std::string::npos);
+    CHECK(smi_out.find("o1") != std::string::npos);
+  }
+
+  SECTION("forward input ids") {
+    forwardStereoGroupIds(*m);
+    const auto smi_out = MolToCXSmiles(*m);
+    CHECK(smi_out.find("&7") != std::string::npos);
+    CHECK(smi_out.find("&8") != std::string::npos);
+    CHECK(smi_out.find("&9") != std::string::npos);
+    CHECK(smi_out.find("o1") != std::string::npos);
+  }
+}

--- a/Code/GraphMol/StereoGroup.cpp
+++ b/Code/GraphMol/StereoGroup.cpp
@@ -6,11 +6,12 @@
 
 namespace RDKit {
 
-StereoGroup::StereoGroup(StereoGroupType grouptype, std::vector<Atom *> &&atoms)
-    : d_grouptype(grouptype), d_atoms(atoms) {}
+StereoGroup::StereoGroup(StereoGroupType grouptype, std::vector<Atom *> &&atoms,
+                         unsigned readId)
+    : d_grouptype(grouptype), d_atoms(atoms), d_readId{readId} {}
 StereoGroup::StereoGroup(StereoGroupType grouptype,
-                         const std::vector<Atom *> &atoms)
-    : d_grouptype(grouptype), d_atoms(std::move(atoms)) {}
+                         const std::vector<Atom *> &atoms, unsigned readId)
+    : d_grouptype(grouptype), d_atoms(std::move(atoms)), d_readId{readId} {}
 
 StereoGroupType StereoGroup::getGroupType() const { return d_grouptype; }
 

--- a/Code/GraphMol/StereoGroup.cpp
+++ b/Code/GraphMol/StereoGroup.cpp
@@ -1,5 +1,6 @@
 #include <algorithm>
 #include <utility>
+
 #include "StereoGroup.h"
 #include "Atom.h"
 
@@ -47,13 +48,15 @@ std::ostream &operator<<(std::ostream &target, const RDKit::StereoGroup &stg) {
       target << "ABS";
       break;
     case RDKit::StereoGroupType::STEREO_OR:
-      target << "OR";
+      target << "OR ";
       break;
     case RDKit::StereoGroupType::STEREO_AND:
       target << "AND";
       break;
   }
-  target << " Atoms: { ";
+  target << " rId: " << stg.getReadId();
+  target << " wRd: " << stg.getWriteId();
+  target << " atoms: { ";
   for (auto atom : stg.getAtoms()) {
     target << atom->getIdx() << ' ';
   }

--- a/Code/GraphMol/StereoGroup.h
+++ b/Code/GraphMol/StereoGroup.h
@@ -89,6 +89,8 @@ RDKIT_GRAPHMOL_EXPORT void removeGroupsWithAtoms(
 RDKIT_GRAPHMOL_EXPORT void assignStereoGroupIds(
     std::vector<StereoGroup>& groups);
 
+//! Copy StereoGroup "read" IDs to "write" IDs so that they will be preserved
+//! when the mol is exported.
 RDKIT_GRAPHMOL_EXPORT void forwardStereoGroupIds(ROMol& mol);
 
 }  // namespace RDKit

--- a/Code/GraphMol/StereoGroup.h
+++ b/Code/GraphMol/StereoGroup.h
@@ -44,8 +44,13 @@ class RDKIT_GRAPHMOL_EXPORT StereoGroup {
   StereoGroupType d_grouptype{StereoGroupType::STEREO_ABSOLUTE};
   std::vector<Atom*> d_atoms;
 
+  // The group ID for AND/OR groups (it has no meaning in ABS groups).
+  // 0 means no group ID is defined.
+  unsigned d_readId = 0u;
+  unsigned d_writeId = 0u;
+
  public:
-  StereoGroup() : d_atoms(0u) {}
+  StereoGroup() {}
   // Takes control of atoms if possible.
   StereoGroup(StereoGroupType grouptype, std::vector<Atom*>&& atoms);
   StereoGroup(StereoGroupType grouptype, const std::vector<Atom*>& atoms);
@@ -56,6 +61,11 @@ class RDKIT_GRAPHMOL_EXPORT StereoGroup {
 
   StereoGroupType getGroupType() const;
   const std::vector<Atom*>& getAtoms() const;
+
+  unsigned getReadId() const { return d_readId; }
+  unsigned getWriteId() const { return d_writeId; }
+  void setWriteId(unsigned id) { d_writeId = id; }
+
   // Seems odd to have to define these, but otherwise the SWIG wrappers
   // won't build
   bool operator==(const StereoGroup& other) const {

--- a/Code/GraphMol/StereoGroup.h
+++ b/Code/GraphMol/StereoGroup.h
@@ -52,8 +52,10 @@ class RDKIT_GRAPHMOL_EXPORT StereoGroup {
  public:
   StereoGroup() {}
   // Takes control of atoms if possible.
-  StereoGroup(StereoGroupType grouptype, std::vector<Atom*>&& atoms);
-  StereoGroup(StereoGroupType grouptype, const std::vector<Atom*>& atoms);
+  StereoGroup(StereoGroupType grouptype, std::vector<Atom*>&& atoms,
+              unsigned readId = 0);
+  StereoGroup(StereoGroupType grouptype, const std::vector<Atom*>& atoms,
+              unsigned readId = 0);
   StereoGroup(const StereoGroup& other) = default;
   StereoGroup& operator=(const StereoGroup& other) = default;
   StereoGroup(StereoGroup&& other) = default;

--- a/Code/GraphMol/StereoGroup.h
+++ b/Code/GraphMol/StereoGroup.h
@@ -23,6 +23,7 @@
 
 namespace RDKit {
 class Atom;
+class ROMol;
 
 // OR means that it is known to be one or the other, but not both
 // AND means that it is known to be a mix.
@@ -81,6 +82,14 @@ RDKIT_GRAPHMOL_EXPORT void removeGroupsWithAtom(
     const Atom* atom, std::vector<StereoGroup>& groups);
 RDKIT_GRAPHMOL_EXPORT void removeGroupsWithAtoms(
     const std::vector<Atom*>& atoms, std::vector<StereoGroup>& groups);
+
+//! Assign Group output IDs to all AND and OR StereoGroups in the vector
+//! that don't already have one. The IDs are assigned based on the order
+//! of the groups.
+RDKIT_GRAPHMOL_EXPORT void assignStereoGroupIds(
+    std::vector<StereoGroup>& groups);
+
+RDKIT_GRAPHMOL_EXPORT void forwardStereoGroupIds(ROMol& mol);
 
 }  // namespace RDKit
 

--- a/Code/GraphMol/Wrap/StereoGroup.cpp
+++ b/Code/GraphMol/Wrap/StereoGroup.cpp
@@ -84,6 +84,10 @@ struct stereogroup_wrap {
                 python::return_value_policy<
                     python::manage_new_object,
                     python::with_custodian_and_ward_postcall<0, 2>>());
+
+    python::def(
+        "ForwardStereoGroupIds", &RDKit::forwardStereoGroupIds,
+        "Forward the original Stereo Group IDs when exporting the Mol.");
   }
 };
 }  // namespace RDKit

--- a/Code/GraphMol/Wrap/StereoGroup.cpp
+++ b/Code/GraphMol/Wrap/StereoGroup.cpp
@@ -28,7 +28,7 @@ std::string stereoGroupClassDoc =
     "is a mix\nof diastereomers.\n";
 
 StereoGroup *createStereoGroup(StereoGroupType typ, ROMol &mol,
-                               python::object atomIds) {
+                               python::object atomIds, unsigned readId) {
   std::vector<Atom *> cppAtoms;
   python::stl_input_iterator<unsigned int> beg(atomIds), end;
   while (beg != end) {
@@ -39,7 +39,7 @@ StereoGroup *createStereoGroup(StereoGroupType typ, ROMol &mol,
     cppAtoms.push_back(mol.getAtomWithIdx(v));
     ++beg;
   }
-  auto *sg = new StereoGroup(typ, cppAtoms);
+  auto *sg = new StereoGroup(typ, cppAtoms, readId);
   return sg;
 }
 
@@ -80,7 +80,7 @@ struct stereogroup_wrap {
                 "creates a StereoGroup associated with a molecule from a list "
                 "of atom Ids",
                 (python::arg("stereoGroupType"), python::arg("mol"),
-                 python::arg("atomIds")),
+                 python::arg("atomIds"), python::arg("readId") = 0),
                 python::return_value_policy<
                     python::manage_new_object,
                     python::with_custodian_and_ward_postcall<0, 2>>());

--- a/Code/GraphMol/Wrap/StereoGroup.cpp
+++ b/Code/GraphMol/Wrap/StereoGroup.cpp
@@ -65,7 +65,16 @@ struct stereogroup_wrap {
         .def("GetGroupType", &StereoGroup::getGroupType,
              "Returns the StereoGroupType.\n")
         .def("GetAtoms", getAtomsHelper,
-             "access the atoms in the StereoGroup.\n");
+             "access the atoms in the StereoGroup.\n")
+        .def("GetReadId", &StereoGroup::getReadId,
+             "return the StereoGroup's original ID.\n"
+             "Note that the ID only makes sense for AND/OR groups.\n")
+        .def("GetWriteId", &StereoGroup::getReadId,
+             "return the StereoGroup's ID that will be exported.\n"
+             "Note that the ID only makes sense for AND/OR groups.\n")
+        .def("SetWriteId", &StereoGroup::setWriteId,
+             "return the StereoGroup's ID that will be exported.\n"
+             "Note that the ID only makes sense for AND/OR groups.\n");
 
     python::def("CreateStereoGroup", &createStereoGroup,
                 "creates a StereoGroup associated with a molecule from a list "

--- a/Code/GraphMol/Wrap/rdmolfiles.cpp
+++ b/Code/GraphMol/Wrap/rdmolfiles.cpp
@@ -1312,6 +1312,8 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
       in the output SMILES. Defaults to false.\n\
     - allHsExplicit: (optional) if true, all H counts will be explicitly indicated\n\
       in the output SMILES. Defaults to false.\n\
+    - doRandom: (optional) if true, randomized the DFS transversal graph,\n\
+      so we can generate random smiles. Defaults to false.\n\
 \n\
   RETURNS:\n\
 \n\
@@ -1377,8 +1379,6 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
       in the output SMILES. Defaults to false.\n\
     - allHsExplicit: (optional) if true, all H counts will be explicitly indicated\n\
       in the output SMILES. Defaults to false.\n\
-    - doRandom: (optional) if true, randomized the DFS transversal graph,\n\
-      so we can generate random smiles. Defaults to false.\n\
 \n\
   RETURNS:\n\
 \n\
@@ -1438,6 +1438,8 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
       in the output SMILES. Defaults to false.\n\
     - allHsExplicit: (optional) if true, all H counts will be explicitly indicated\n\
       in the output SMILES. Defaults to false.\n\
+    - doRandom: (optional) if true, randomized the DFS transversal graph,\n\
+      so we can generate random smiles. Defaults to false.\n\
 \n\
   RETURNS:\n\
 \n\
@@ -1503,8 +1505,6 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
       in the output SMILES. Defaults to false.\n\
     - allHsExplicit: (optional) if true, all H counts will be explicitly indicated\n\
       in the output SMILES. Defaults to false.\n\
-    - doRandom: (optional) if true, randomized the DFS transversal graph,\n\
-      so we can generate random smiles. Defaults to false.\n\
 \n\
   RETURNS:\n\
 \n\

--- a/Code/GraphMol/Wrap/rdmolfiles.cpp
+++ b/Code/GraphMol/Wrap/rdmolfiles.cpp
@@ -1312,7 +1312,7 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
       in the output SMILES. Defaults to false.\n\
     - allHsExplicit: (optional) if true, all H counts will be explicitly indicated\n\
       in the output SMILES. Defaults to false.\n\
-    - doRandom: (optional) if true, randomized the DFS transversal graph,\n\
+    - doRandom: (optional) if true, randomize the traversal of the molecule graph,\n\
       so we can generate random smiles. Defaults to false.\n\
 \n\
   RETURNS:\n\

--- a/Code/GraphMol/Wrap/rdmolfiles.cpp
+++ b/Code/GraphMol/Wrap/rdmolfiles.cpp
@@ -1438,7 +1438,7 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
       in the output SMILES. Defaults to false.\n\
     - allHsExplicit: (optional) if true, all H counts will be explicitly indicated\n\
       in the output SMILES. Defaults to false.\n\
-    - doRandom: (optional) if true, randomized the DFS transversal graph,\n\
+    - doRandom: (optional) if true, randomized the trasversal of the molecule graph,\n\
       so we can generate random smiles. Defaults to false.\n\
 \n\
   RETURNS:\n\

--- a/Code/GraphMol/catch_canon.cpp
+++ b/Code/GraphMol/catch_canon.cpp
@@ -347,6 +347,74 @@ TEST_CASE("more enhanced stereo canonicalization") {
 
     CHECK(MolToCXSmiles(*m1) == MolToCXSmiles(*m2));
   }
+  SECTION("case 3") {
+    auto m1 =
+        "C[C@@H](O)[C@H](C)[C@@H](C)[C@@H](C)O |&8:3,5,o1:7,&7:1,r|"_smiles;
+    REQUIRE(m1);
+    auto m2 =
+        "C[C@@H](O)[C@H](C)[C@@H](C)[C@@H](C)O |&3:3,5,&2:7,o1:1,r|"_smiles;
+    REQUIRE(m2);
+    Canon::canonicalizeEnhancedStereo(*m1);
+    Canon::canonicalizeEnhancedStereo(*m2);
+
+    CHECK(MolToCXSmiles(*m1) == MolToCXSmiles(*m2));
+  }
+  SECTION("case 4") {
+    auto m1 =
+        "C[C@@H](O)[C@H](C)[C@@H](C)[C@@H](C)O |&8:3,5,o1:7,&7:1,r|"_smiles;
+    REQUIRE(m1);
+    auto m2 =
+        "C[C@@H](O)[C@H](C)[C@@H](C)[C@@H](C)O |&3:3,5,&2:7,o1:1,r|"_smiles;
+    REQUIRE(m2);
+
+    CHECK(MolToCXSmiles(*m1) == MolToCXSmiles(*m2));
+  }
+  SECTION("case 5") {
+    auto m1 =
+        "C[C@@H](O)[C@H](C)[C@@H](C)[C@@H](C)O |&8:3,5,o1:7,&7:1,r|"_smiles;
+    REQUIRE(m1);
+    auto m2 =
+        "C[C@@H](O)[C@H](C)[C@@H](C)[C@@H](C)O |&3:3,5,&2:7,o1:1,r|"_smiles;
+    REQUIRE(m2);
+
+    forwardStereoGroupIds(*m1);
+    forwardStereoGroupIds(*m2);
+
+    auto cx1 = MolToCXSmiles(*m1);
+    auto cx2 = MolToCXSmiles(*m2);
+    CHECK(cx1 != cx2);
+    CHECK(cx1.find("&7:") != std::string::npos);
+    CHECK(cx1.find("&8:") != std::string::npos);
+    CHECK(cx2.find("&2:") != std::string::npos);
+    CHECK(cx2.find("&3:") != std::string::npos);
+  }
+  SECTION("case 6") {
+    auto m1 =
+        "C[C@@H](O)[C@H](C)[C@@H](C)[C@@H](C)O |&8:3,5,o1:7,&7:1,r|"_smiles;
+    REQUIRE(m1);
+    auto m2 =
+        "C[C@@H](O)[C@H](C)[C@@H](C)[C@@H](C)O |&3:3,5,&2:7,o1:1,r|"_smiles;
+    REQUIRE(m2);
+
+    forwardStereoGroupIds(*m1);
+    forwardStereoGroupIds(*m2);
+
+    // Canonicalization resets the Stereo Group IDs
+    Canon::canonicalizeEnhancedStereo(*m1);
+    Canon::canonicalizeEnhancedStereo(*m2);
+
+    auto cx1 = MolToCXSmiles(*m1);
+    auto cx2 = MolToCXSmiles(*m2);
+    CHECK(MolToCXSmiles(*m1) == MolToCXSmiles(*m2));
+
+    // "read" ids are also reset!
+    forwardStereoGroupIds(*m1);
+    forwardStereoGroupIds(*m2);
+
+    cx1 = MolToCXSmiles(*m1);
+    cx2 = MolToCXSmiles(*m2);
+    CHECK(MolToCXSmiles(*m1) == MolToCXSmiles(*m2));
+  }
 }
 
 TEST_CASE("ensure unused features are not used") {


### PR DESCRIPTION
This implements parsing, storing and optionally forwarding the Enhanced Stereo Group ids on output for multiple formats: CXSMILES, mdl V3000, pickle, mol interchange and cdxml (parsing only).

By default, we reassign the Stereo Group IDs, but we can use the `forwardStereoGroupIds()` function to preserve the Stereo Group IDs on output. Still, it must be noted that some operations (stereo group canonicalization, reactions) can either reset the ids or potentially alter the Stereo Groups, so that the IDs won't be preserved even if `forwardStereoGroupIds()` is used.

Also note that Stereo Group id "0" means that the id is not set, so that one will be assigned on the fly on export.
