### PR TITLE
Github 6504 - incorrect drawing of double bonds in sulfoximines

### DIFF
--- a/Code/GraphMol/MolDraw2D/DrawMol.cpp
+++ b/Code/GraphMol/MolDraw2D/DrawMol.cpp
@@ -2803,8 +2803,9 @@ void DrawMol::calcDoubleBondLines(double offset, const Bond &bond, Point2D &l1s,
       if (atomLabels_[at1->getIdx()] && atomLabels_[at2->getIdx()]) {
         doubleBondTerminal(at1, at2, offset, l1s, l1f, l2s, l2f);
         offset /= 2.0;
+      } else {
+        bondNonRing(bond, offset, l2s, l2f);
       }
-      bondNonRing(bond, offset, l2s, l2f);
     }
 
     // Occasionally, as seen in Github6170, a bad geometry about a bond can
@@ -2921,7 +2922,8 @@ void DrawMol::bondNonRing(const Bond &bond, double offset, Point2D &l2s,
     const Atom *thirdAtom = nullptr;
     for (auto i = 1u; i < at1->getDegree(); ++i) {
       thirdAtom = otherNeighbor(at1, at2, i, *drawMol_);
-      if (thirdAtom && !areBondsParallel(atCds_[at1->getIdx()], atCds_[at2->getIdx()],
+      if (thirdAtom &&
+          !areBondsParallel(atCds_[at1->getIdx()], atCds_[at2->getIdx()],
                             atCds_[at1->getIdx()],
                             atCds_[thirdAtom->getIdx()])) {
         return thirdAtom;
@@ -2964,7 +2966,6 @@ void DrawMol::bondNonRing(const Bond &bond, double offset, Point2D &l2s,
     }
     l2f = doubleBondEnd(fourthAtom->getIdx(), endAt->getIdx(), begAt->getIdx(),
                         offset, endTrunc);
-
   } else if (begAt->getDegree() > 2 && endAt->getDegree() == 2) {
     thirdAtom = otherNeighbor(begAt, endAt, 0, *drawMol_);
     fourthAtom = otherNeighbor(endAt, begAt, 0, *drawMol_);

--- a/Code/GraphMol/MolDraw2D/catch_tests.cpp
+++ b/Code/GraphMol/MolDraw2D/catch_tests.cpp
@@ -300,7 +300,9 @@ static const std::map<std::string, std::hash_result_t> SVG_HASHES = {
     {"test_github6397_2.svg", 3407468353U},
     {"test_github6397_3.svg", 3170656352U},
     {"test_github6397_4.svg", 187792316U},
-    {"test_github6397_5.svg", 2795990448U}};
+    {"test_github6397_5.svg", 2795990448U},
+    {"github6504_1.svg", 1429448598U},
+    {"github6504_2.svg", 2871662880U}};
 
 // These PNG hashes aren't completely reliable due to floating point cruft,
 // but they can still reduce the number of drawings that need visual
@@ -7643,8 +7645,7 @@ TEST_CASE(
   }
 }
 
-TEST_CASE(
-    "Github #6416: crash with colinear atoms") {
+TEST_CASE("Github #6416: crash with colinear atoms") {
   std::string name = "github6416.svg";
   auto m = R"CTAB(168010013
      RDKit          2D
@@ -7947,5 +7948,88 @@ M  END)CTAB"_ctab;
     outs.flush();
     outs.close();
     check_file_hash(svgName);
+  }
+}
+
+TEST_CASE("Github #6504: double bonds not drawn correctly for sulfoximines") {
+  std::string baseName = "github6504";
+  auto m1 = R"CTAB(
+     RDKit          2D
+
+  7  6  0  0  0  0  0  0  0  0999 V2000
+   -3.3489   -2.7067    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -2.0093   -3.4808    0.0000 N   0  0  0  0  0  0  0  0  0  0  0  0
+   -0.6698   -2.7067    0.0000 S   0  0  0  0  0  0  0  0  0  0  0  0
+    0.6696   -3.4792    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0
+   -0.6698   -1.1601    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    0.6696   -0.3864    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -0.6698   -4.2536    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+  1  2  1  0
+  2  3  2  0
+  3  4  2  0
+  3  5  1  0
+  5  6  1  0
+  3  7  1  1
+M  END
+)CTAB"_ctab;
+  // The bug report showed different manifestations of the problem
+  // using the given coords and those generated from scratch.
+  REQUIRE(m1);
+  std::unique_ptr<RDKit::ROMol> m2(new RDKit::ROMol(*m1));
+  RDDepict::compute2DCoords(*m2);
+
+  // The test, in both cases, is that the 2 ends of the lines
+  // making bond 1 are separated by a small distance.  It's a two
+  // colour line, so the relevant points are 0,4 and 3,7.
+  auto checkEndSep = [](const std::string &text) {
+    std::regex bond5(
+        "'bond-1 atom-1 atom-2' d='M\\s+(\\d+\\.\\d+),(\\d+\\.\\d+)"
+        " L\\s+(\\d+\\.\\d+),(\\d+\\.\\d+)");
+    std::ptrdiff_t const match_count(
+        std::distance(std::sregex_iterator(text.begin(), text.end(), bond5),
+                      std::sregex_iterator()));
+    REQUIRE(match_count == 4);
+    auto match_begin = std::sregex_iterator(text.begin(), text.end(), bond5);
+    auto match_end = std::sregex_iterator();
+    std::vector<Point2D> points;
+    for (std::sregex_iterator i = match_begin; i != match_end; ++i) {
+      std::smatch match = *i;
+      points.push_back(Point2D(stod(match[1]), stod(match[2])));
+      points.push_back(Point2D(stod(match[3]), stod(match[4])));
+    }
+    auto d1 = (points[0] - points[4]).length();
+    auto d2 = (points[3] - points[7]).length();
+    // the distances should be > 10 and roughly equal.  They are
+    // 12 and 14 pixels apart in the two molecules.
+    REQUIRE(d1 > 10.0);
+    REQUIRE(d2 > 10.0);
+    REQUIRE_THAT(fabs(d1 - d2), Catch::Matchers::WithinAbs(0.0, 0.1));
+  };
+
+  {
+    MolDraw2DSVG drawer(300, 300, -1, -1);
+    drawer.drawOptions().addAtomIndices = true;
+    drawer.drawMolecule(*m1);
+    drawer.finishDrawing();
+    std::ofstream outs(baseName + "_1.svg");
+    std::string text = drawer.getDrawingText();
+    outs << text;
+    outs.flush();
+    outs.close();
+    checkEndSep(text);
+    check_file_hash(baseName + "_1.svg");
+  }
+  {
+    MolDraw2DSVG drawer(300, 300, -1, -1);
+    drawer.drawOptions().addAtomIndices = true;
+    drawer.drawMolecule(*m2);
+    drawer.finishDrawing();
+    std::ofstream outs(baseName + "_2.svg");
+    std::string text = drawer.getDrawingText();
+    outs << text;
+    outs.flush();
+    outs.close();
+    checkEndSep(text);
+    check_file_hash(baseName + "_2.svg");
   }
 }


### PR DESCRIPTION
#### Reference Issue
<!-- Example: Fixes #1234 -->
Fixes #6504

#### What does this implement/fix? Explain your changes.
Fixes the bug.  The code for stepping the inner bond of a double bond shouldn't be called when there's an atomic symbol at each end of the bond.

#### Any other comments?
The action is on line 2807.  There's some re-formatting as well, for some reason.

