### PR TITLE
Fix vulnerabilities found by fuzzer.

### DIFF
--- a/Code/GraphMol/FileParsers/MolFileParser.cpp
+++ b/Code/GraphMol/FileParsers/MolFileParser.cpp
@@ -299,6 +299,12 @@ void ParseOldAtomList(RWMol *mol, const std::string_view &text,
   int nQueries;
   try {
     nQueries = FileParserUtils::toInt(text.substr(9, 1));
+  } catch (const std::out_of_range &) {
+    delete q;
+    std::ostringstream errout;
+    errout << "Cannot convert position 9 of '" << text << "' to int on line "
+           << line;
+    throw FileParseException(errout.str());
   } catch (boost::bad_lexical_cast &) {
     delete q;
     std::ostringstream errout;
@@ -313,6 +319,12 @@ void ParseOldAtomList(RWMol *mol, const std::string_view &text,
     int atNum;
     try {
       atNum = FileParserUtils::toInt(text.substr(pos, 3));
+    } catch (const std::out_of_range &) {
+      delete q;
+      std::ostringstream errout;
+      errout << "Cannot convert position " << pos << " of '" << text
+             << "' to int on line " << line;
+      throw FileParseException(errout.str());
     } catch (boost::bad_lexical_cast &) {
       delete q;
       std::ostringstream errout;

--- a/Code/GraphMol/RWMol.cpp
+++ b/Code/GraphMol/RWMol.cpp
@@ -158,12 +158,11 @@ void RWMol::replaceAtom(unsigned int idx, Atom *atom_pin, bool,
   for (auto &group : d_stereo_groups) {
     auto atoms = group.getAtoms();
     auto aiter = std::find(atoms.begin(), atoms.end(), orig_p);
-    while (aiter != atoms.end()) {
+    if (aiter != atoms.end()) {
       *aiter = atom_p;
-      ++aiter;
-      aiter = std::find(aiter, atoms.end(), orig_p);
+      group = StereoGroup(group.getGroupType(), std::move(atoms));
     }
-    group = StereoGroup(group.getGroupType(), std::move(atoms));
+    
   }
 };
 

--- a/Code/GraphMol/RWMol.cpp
+++ b/Code/GraphMol/RWMol.cpp
@@ -161,7 +161,7 @@ void RWMol::replaceAtom(unsigned int idx, Atom *atom_pin, bool,
     while (aiter != atoms.end()) {
       *aiter = atom_p;
       ++aiter;
-      aiter = std::find(atier, atoms.end(), orig_p);
+      aiter = std::find(aiter, atoms.end(), orig_p);
     }
     group = StereoGroup(group.getGroupType(), std::move(atoms));
   }

--- a/Code/GraphMol/RWMol.cpp
+++ b/Code/GraphMol/RWMol.cpp
@@ -158,11 +158,12 @@ void RWMol::replaceAtom(unsigned int idx, Atom *atom_pin, bool,
   for (auto &group : d_stereo_groups) {
     auto atoms = group.getAtoms();
     auto aiter = std::find(atoms.begin(), atoms.end(), orig_p);
-    if (aiter != atoms.end()) {
+    while (aiter != atoms.end()) {
       *aiter = atom_p;
-      group = StereoGroup(group.getGroupType(), std::move(atoms));
+      ++aiter;
+      aiter = std::find(aiter, atoms.end(), orig_p);
     }
-    
+    group = StereoGroup(group.getGroupType(), std::move(atoms));
   }
 };
 

--- a/Code/GraphMol/RWMol.cpp
+++ b/Code/GraphMol/RWMol.cpp
@@ -158,10 +158,12 @@ void RWMol::replaceAtom(unsigned int idx, Atom *atom_pin, bool,
   for (auto &group : d_stereo_groups) {
     auto atoms = group.getAtoms();
     auto aiter = std::find(atoms.begin(), atoms.end(), orig_p);
-    if (aiter != atoms.end()) {
+    while (aiter != atoms.end()) {
       *aiter = atom_p;
-      group = StereoGroup(group.getGroupType(), std::move(atoms));
+      ++aiter;
+      aiter = std::find(atier, atoms.end(), orig_p);
     }
+    group = StereoGroup(group.getGroupType(), std::move(atoms));
   }
 };
 


### PR DESCRIPTION
#### Reference Issue

https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=49783
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=44520

#### What does this implement/fix? Explain your changes.

(1) During fuzzing, it's possible that one atom object is added to the same Stereo group multiple times. The replaceAtom function only replaces a single occurrence. The code later references the second copy of the atom in the stereo group (which wasn't replaced) which accesses deleted memory. This change replaces all copies of an atom during the replaceAtom process.

(2) Catches situations during fuzzing where index values for text substrings in ParseOldAtomList could go out of range. 

#### Any other comments?

