### PR TITLE
allow building the cartridge against PostgreSQL 16

### DIFF
--- a/Code/PgSQL/rdkit/rdkit.h
+++ b/Code/PgSQL/rdkit/rdkit.h
@@ -39,6 +39,14 @@ extern "C" {
 #endif
 
 #include <postgres.h>
+#ifdef PG_VERSION_NUM
+#if PG_VERSION_NUM >= 160000
+#include <varatt.h>
+#ifndef Abs
+#define Abs(x)  ((x) >= 0 ? (x) : -(x))
+#endif
+#endif
+#endif
 
 #define RDKIT_FREE_IF_COPY_P(ptrsrc, ptrori)                   \
   do {                                                         \


### PR DESCRIPTION
Small PR to add the `varatt.h` header and define the `Abs` macro as it was defined on PostgreSQL <16.