### PR TITLE
Add a "rootedAtAtom" to MolToSmarts

### DIFF
--- a/Code/GraphMol/Canon.h
+++ b/Code/GraphMol/Canon.h
@@ -116,7 +116,8 @@ RDKIT_GRAPHMOL_EXPORT void canonicalizeFragment(
     const std::vector<unsigned int> &ranks, MolStack &molStack,
     const boost::dynamic_bitset<> *bondsInPlay = nullptr,
     const std::vector<std::string> *bondSymbols = nullptr,
-    bool doIsomericSmiles = false, bool doRandom = false);
+    bool doIsomericSmiles = false, bool doRandom = false,
+    bool doChiralInversions = true);
 
 //! Check if a chiral atom needs to have its tag flipped after reading or before
 //! writing SMILES

--- a/Code/GraphMol/SmilesParse/SmartsWrite.cpp
+++ b/Code/GraphMol/SmilesParse/SmartsWrite.cpp
@@ -1002,7 +1002,7 @@ std::string MolFragmentToSmarts(const ROMol &mol,
     colors[idx] = Canon::WHITE_NODE;
   }
 
-  unsigned rootedAtAtom = -1;
+  int rootedAtAtom = -1;
   return molToSmarts(mol, doIsomericSmarts, std::move(colors),
                      bondsInPlay.get(), rootedAtAtom);
 }

--- a/Code/GraphMol/SmilesParse/SmartsWrite.cpp
+++ b/Code/GraphMol/SmilesParse/SmartsWrite.cpp
@@ -647,25 +647,12 @@ std::string FragmentSmartsConstruct(
     atom->updatePropertyCache(false);
   }
 
-  // Another dirty trick to avoid reordering of lead chiral atoms in
-  // canonicalizeFragment: since we are writing SMARTS, there won't be a
-  // reordering on parsing.
-  // The trick is as easy as choosing the first non-chiral atom we can find as
-  // root of the string. This should not be a problem, since SMARTS do not get
-  // canonicalized.
-  if (molStack.empty()) {
-    for (const auto atom : mol.atoms()) {
-      if (colors[atom->getIdx()] == Canon::WHITE_NODE &&
-          atom->getChiralTag() != Atom::CHI_TETRAHEDRAL_CCW &&
-          atom->getChiralTag() != Atom::CHI_TETRAHEDRAL_CW) {
-        atomIdx = atom->getIdx();
-        break;
-      }
-    }
-  }
-
+  // For Smarts, we avoid reordering of chiral atoms in canonicalizeFragment.
+  bool doRandom = false;
+  bool doChiralInversions = false;
   Canon::canonicalizeFragment(mol, atomIdx, colors, ranks, molStack,
-                              bondsInPlay, nullptr, doIsomericSmiles);
+                              bondsInPlay, nullptr, doIsomericSmiles, doRandom,
+                              doChiralInversions);
 
   // now clear the "SSSR" property
   mol.getRingInfo()->reset();
@@ -800,7 +787,10 @@ std::string getNonQueryBondSmarts(const Bond *qbond, int atomToLeftIdx) {
 
 std::string molToSmarts(const ROMol &inmol, bool doIsomericSmiles,
                         std::vector<AtomColors> &&colors,
-                        const boost::dynamic_bitset<> *bondsInPlay) {
+                        const boost::dynamic_bitset<> *bondsInPlay,
+                        int rootedAtAtom) {
+  PRECONDITION(rootedAtAtom < static_cast<int>(inmol.getNumAtoms()),
+               "bad atom index");
   ROMol mol(inmol);
   const unsigned int nAtoms = mol.getNumAtoms();
   UINT_VECT ranks;
@@ -821,13 +811,18 @@ std::string molToSmarts(const ROMol &inmol, bool doIsomericSmiles,
   auto colorIt = std::find(colors.begin(), colors.end(), Canon::WHITE_NODE);
   while (colorIt != colors.end()) {
     unsigned int nextAtomIdx = 0;
-    unsigned int nextRank;
     std::string subSmi;
-    nextRank = nAtoms + 1;
-    for (unsigned int i = 0; i < nAtoms; ++i) {
-      if (colors[i] == Canon::WHITE_NODE && ranks[i] < nextRank) {
-        nextRank = ranks[i];
-        nextAtomIdx = i;
+
+    if (rootedAtAtom > -1 && colors[rootedAtAtom] == Canon::WHITE_NODE) {
+      nextAtomIdx = rootedAtAtom;
+    } else {
+      for (const auto atom : mol.atoms()) {
+        if (colors[atom->getIdx()] == Canon::WHITE_NODE &&
+            atom->getChiralTag() != Atom::CHI_TETRAHEDRAL_CCW &&
+            atom->getChiralTag() != Atom::CHI_TETRAHEDRAL_CW) {
+          nextAtomIdx = atom->getIdx();
+          break;
+        }
       }
     }
     subSmi = FragmentSmartsConstruct(mol, nextAtomIdx, colors, ranks,
@@ -956,14 +951,16 @@ std::string GetBondSmarts(const Bond *bond, int atomToLeftIdx) {
 
 }  // end of namespace SmartsWrite
 
-std::string MolToSmarts(const ROMol &mol, bool doIsomericSmarts) {
+std::string MolToSmarts(const ROMol &mol, bool doIsomericSmarts,
+                        int rootedAtAtom) {
   const unsigned int nAtoms = mol.getNumAtoms();
   if (!nAtoms) {
     return "";
   }
 
   std::vector<AtomColors> colors(nAtoms, Canon::WHITE_NODE);
-  return molToSmarts(mol, doIsomericSmarts, std::move(colors), nullptr);
+  return molToSmarts(mol, doIsomericSmarts, std::move(colors), nullptr,
+                     rootedAtAtom);
 }
 
 std::string MolFragmentToSmarts(const ROMol &mol,
@@ -995,8 +992,9 @@ std::string MolFragmentToSmarts(const ROMol &mol,
     colors[idx] = Canon::WHITE_NODE;
   }
 
+  unsigned rootedAtAtom = -1;
   return molToSmarts(mol, doIsomericSmarts, std::move(colors),
-                     bondsInPlay.get());
+                     bondsInPlay.get(), rootedAtAtom);
 }
 
 std::string MolToCXSmarts(const ROMol &mol, bool doIsomericSmarts) {

--- a/Code/GraphMol/SmilesParse/SmartsWrite.h
+++ b/Code/GraphMol/SmilesParse/SmartsWrite.h
@@ -28,7 +28,8 @@ RDKIT_SMILESPARSE_EXPORT std::string GetBondSmarts(const Bond *qbond,
 class ROMol;
 //! returns the SMARTS for a molecule
 RDKIT_SMILESPARSE_EXPORT std::string MolToSmarts(const ROMol &mol,
-                                                 bool doIsomericSmarts = true);
+                                                 bool doIsomericSmarts = true,
+                                                 int rootedAtAtom = -1);
 
 RDKIT_SMILESPARSE_EXPORT std::string MolFragmentToSmarts(
     const ROMol &mol, const std::vector<int> &atomsToUse,

--- a/Code/GraphMol/SmilesParse/catch_tests.cpp
+++ b/Code/GraphMol/SmilesParse/catch_tests.cpp
@@ -2520,3 +2520,99 @@ TEST_CASE("ensure unused features are not used") {
     CHECK(smiles == "C[C@H]1C[CH]CC(C[C@@H](C)[C@@H](C)O)C1");
   }
 }
+
+std::unique_ptr<ROMol> getSmartsRootedAtAtom(const ROMol &mol, int root_idx) {
+  bool doIsomericSmarts = true;
+  auto smarts = MolToSmarts(mol, doIsomericSmarts, root_idx);
+  return std::unique_ptr<ROMol>{SmartsToMol(smarts)};
+}
+
+TEST_CASE("Test rootedAtAtom argument", "[smarts]") {
+  SubstructMatchParameters sssparams;
+  sssparams.useChirality = GENERATE(false, true);
+  CAPTURE(sssparams.useChirality);
+
+  SECTION("fully substituted chiral center in linear mol") {
+    auto mol1 = "C[C@](O)(F)CCCl"_smiles;
+    auto mol2 = "C[C@](F)(O)CCCl"_smiles;
+    REQUIRE(mol1);
+    REQUIRE(mol2);
+    REQUIRE(mol1->getNumAtoms() == 7);
+    REQUIRE(mol2->getNumAtoms() == 7);
+
+    auto root_idx = GENERATE(range(-1, 6));
+    CAPTURE(root_idx);
+    auto qmol1 = getSmartsRootedAtAtom(*mol1, root_idx);
+    auto qmol2 = getSmartsRootedAtAtom(*mol2, root_idx);
+
+    CHECK(SubstructMatch(*qmol1, *mol1, sssparams).size() == 1);
+    CHECK(SubstructMatch(*qmol2, *mol2, sssparams).size() == 1);
+    CHECK(SubstructMatch(*qmol1, *mol2, sssparams).size() ==
+          !sssparams.useChirality);
+    CHECK(SubstructMatch(*qmol2, *mol1, sssparams).size() ==
+          !sssparams.useChirality);
+  }
+
+  SECTION("chiral center w/ implicit H in linear mol") {
+    auto mol1 = "C[C@H](F)CCCl"_smiles;
+    auto mol2 = "C[C@@H](F)CCCl"_smiles;
+    REQUIRE(mol1);
+    REQUIRE(mol2);
+    REQUIRE(mol1->getNumAtoms() == 6);
+    REQUIRE(mol2->getNumAtoms() == 6);
+
+    auto root_idx = GENERATE(range(-1, 5));
+    CAPTURE(root_idx);
+    auto qmol1 = getSmartsRootedAtAtom(*mol1, root_idx);
+    auto qmol2 = getSmartsRootedAtAtom(*mol2, root_idx);
+
+    CHECK(SubstructMatch(*qmol1, *mol1, sssparams).size() == 1);
+    CHECK(SubstructMatch(*qmol2, *mol2, sssparams).size() == 1);
+    CHECK(SubstructMatch(*qmol1, *mol2, sssparams).size() ==
+          !sssparams.useChirality);
+    CHECK(SubstructMatch(*qmol2, *mol1, sssparams).size() ==
+          !sssparams.useChirality);
+  }
+
+  SECTION("fully substituted, asymmetric chiral atoms (2) in ring") {
+    auto mol1 = "C[C@](F)1CC[C@](N)(F)CC1"_smiles;
+    auto mol2 = "F[C@](C)1CC[C@](N)(F)CC1"_smiles;
+    REQUIRE(mol1);
+    REQUIRE(mol2);
+    REQUIRE(mol1->getNumAtoms() == 10);
+    REQUIRE(mol2->getNumAtoms() == 10);
+
+    auto root_idx = GENERATE(range(-1, 9));
+    CAPTURE(root_idx);
+    auto qmol1 = getSmartsRootedAtAtom(*mol1, root_idx);
+    auto qmol2 = getSmartsRootedAtAtom(*mol2, root_idx);
+
+    CHECK(SubstructMatch(*qmol1, *mol1, sssparams).size() == 1);
+    CHECK(SubstructMatch(*qmol2, *mol2, sssparams).size() == 1);
+    CHECK(SubstructMatch(*qmol1, *mol2, sssparams).size() ==
+          !sssparams.useChirality);
+    CHECK(SubstructMatch(*qmol2, *mol1, sssparams).size() ==
+          !sssparams.useChirality);
+  }
+
+  SECTION("partially substituted, asymmetric chiral atoms (2) in ring") {
+    auto mol1 = "C[C@H]1CC[C@@H](N)CC1"_smiles;
+    auto mol2 = "C[C@H]1CC[C@H](N)CC1"_smiles;
+    REQUIRE(mol1);
+    REQUIRE(mol2);
+    REQUIRE(mol1->getNumAtoms() == 8);
+    REQUIRE(mol2->getNumAtoms() == 8);
+
+    auto root_idx = GENERATE(range(-1, 7));
+    CAPTURE(root_idx);
+    auto qmol1 = getSmartsRootedAtAtom(*mol1, root_idx);
+    auto qmol2 = getSmartsRootedAtAtom(*mol2, root_idx);
+
+    CHECK(SubstructMatch(*qmol1, *mol1, sssparams).size() == 1);
+    CHECK(SubstructMatch(*qmol2, *mol2, sssparams).size() == 1);
+    CHECK(SubstructMatch(*qmol1, *mol2, sssparams).size() ==
+          !sssparams.useChirality);
+    CHECK(SubstructMatch(*qmol2, *mol1, sssparams).size() ==
+          !sssparams.useChirality);
+  }
+}

--- a/Code/GraphMol/SmilesParse/catch_tests.cpp
+++ b/Code/GraphMol/SmilesParse/catch_tests.cpp
@@ -2545,11 +2545,11 @@ TEST_CASE("Test rootedAtAtom argument", "[smarts]") {
     auto qmol1 = getSmartsRootedAtAtom(*mol1, root_idx);
     auto qmol2 = getSmartsRootedAtAtom(*mol2, root_idx);
 
-    CHECK(SubstructMatch(*qmol1, *mol1, sssparams).size() == 1);
-    CHECK(SubstructMatch(*qmol2, *mol2, sssparams).size() == 1);
-    CHECK(SubstructMatch(*qmol1, *mol2, sssparams).size() ==
+    CHECK(SubstructMatch(*mol1, *qmol1, sssparams).size() == 1);
+    CHECK(SubstructMatch(*mol2, *qmol2, sssparams).size() == 1);
+    CHECK(SubstructMatch(*mol2, *qmol1, sssparams).size() ==
           !sssparams.useChirality);
-    CHECK(SubstructMatch(*qmol2, *mol1, sssparams).size() ==
+    CHECK(SubstructMatch(*mol1, *qmol2, sssparams).size() ==
           !sssparams.useChirality);
   }
 
@@ -2566,11 +2566,11 @@ TEST_CASE("Test rootedAtAtom argument", "[smarts]") {
     auto qmol1 = getSmartsRootedAtAtom(*mol1, root_idx);
     auto qmol2 = getSmartsRootedAtAtom(*mol2, root_idx);
 
-    CHECK(SubstructMatch(*qmol1, *mol1, sssparams).size() == 1);
-    CHECK(SubstructMatch(*qmol2, *mol2, sssparams).size() == 1);
-    CHECK(SubstructMatch(*qmol1, *mol2, sssparams).size() ==
+    CHECK(SubstructMatch(*mol1, *qmol1, sssparams).size() == 1);
+    CHECK(SubstructMatch(*mol2, *qmol2, sssparams).size() == 1);
+    CHECK(SubstructMatch(*mol2, *qmol1, sssparams).size() ==
           !sssparams.useChirality);
-    CHECK(SubstructMatch(*qmol2, *mol1, sssparams).size() ==
+    CHECK(SubstructMatch(*mol1, *qmol2, sssparams).size() ==
           !sssparams.useChirality);
   }
 
@@ -2587,11 +2587,11 @@ TEST_CASE("Test rootedAtAtom argument", "[smarts]") {
     auto qmol1 = getSmartsRootedAtAtom(*mol1, root_idx);
     auto qmol2 = getSmartsRootedAtAtom(*mol2, root_idx);
 
-    CHECK(SubstructMatch(*qmol1, *mol1, sssparams).size() == 1);
-    CHECK(SubstructMatch(*qmol2, *mol2, sssparams).size() == 1);
-    CHECK(SubstructMatch(*qmol1, *mol2, sssparams).size() ==
+    CHECK(SubstructMatch(*mol1, *qmol1, sssparams).size() == 1);
+    CHECK(SubstructMatch(*mol2, *qmol2, sssparams).size() == 1);
+    CHECK(SubstructMatch(*mol2, *qmol1, sssparams).size() ==
           !sssparams.useChirality);
-    CHECK(SubstructMatch(*qmol2, *mol1, sssparams).size() ==
+    CHECK(SubstructMatch(*mol1, *qmol2, sssparams).size() ==
           !sssparams.useChirality);
   }
 
@@ -2608,11 +2608,11 @@ TEST_CASE("Test rootedAtAtom argument", "[smarts]") {
     auto qmol1 = getSmartsRootedAtAtom(*mol1, root_idx);
     auto qmol2 = getSmartsRootedAtAtom(*mol2, root_idx);
 
-    CHECK(SubstructMatch(*qmol1, *mol1, sssparams).size() == 1);
-    CHECK(SubstructMatch(*qmol2, *mol2, sssparams).size() == 1);
-    CHECK(SubstructMatch(*qmol1, *mol2, sssparams).size() ==
+    CHECK(SubstructMatch(*mol1, *qmol1, sssparams).size() == 1);
+    CHECK(SubstructMatch(*mol2, *qmol2, sssparams).size() == 1);
+    CHECK(SubstructMatch(*mol2, *qmol1, sssparams).size() ==
           !sssparams.useChirality);
-    CHECK(SubstructMatch(*qmol2, *mol1, sssparams).size() ==
+    CHECK(SubstructMatch(*mol1, *qmol2, sssparams).size() ==
           !sssparams.useChirality);
   }
 }

--- a/Code/GraphMol/Wrap/rdmolfiles.cpp
+++ b/Code/GraphMol/Wrap/rdmolfiles.cpp
@@ -1533,7 +1533,8 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
     a string\n\
 \n";
   python::def("MolToSmarts", RDKit::MolToSmarts,
-              (python::arg("mol"), python::arg("isomericSmiles") = true),
+              (python::arg("mol"), python::arg("isomericSmiles") = true,
+               python::arg("rootedAtAtom") = -1),
               docString.c_str());
 
   docString =

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -840,7 +840,9 @@ class TestCase(unittest.TestCase):
     smi = Chem.MolToSmiles(query)
     self.assertEqual(smi, 'c1ccccc1')
     smi = Chem.MolToSmarts(query)
-    self.assertEqual(smi, '[#6]1:[#6]:[#6]:[#6]:[#6]:[#6,#7,#15]:1', smi)
+    self.assertEqual(smi, '[#6]1:[#6]:[#6]:[#6]:[#6]:[#6,#7,#15]:1')
+    smi = Chem.MolToSmarts(query, rootedAtAtom=5)
+    self.assertEqual(smi, '[#6,#7,#15]1:[#6]:[#6]:[#6]:[#6]:[#6]:1')
 
     query = Chem.MolFromMolFile(fileN, sanitize=False)
     smi = Chem.MolToSmiles(query)
@@ -848,6 +850,8 @@ class TestCase(unittest.TestCase):
     query.UpdatePropertyCache()
     smi = Chem.MolToSmarts(query)
     self.assertEqual(smi, '[#6]1=[#6]-[#6]=[#6]-[#6]=[#6,#7,#15]-1')
+    smi = Chem.MolToSmarts(query, rootedAtAtom=3)
+    self.assertEqual(smi, '[#6]1=[#6]-[#6]=[#6]-[#6,#7,#15]=[#6]-1')
     smi = "C1=CC=CC=C1"
     mol = Chem.MolFromSmiles(smi, 0)
     self.assertTrue(mol.HasSubstructMatch(query))


### PR DESCRIPTION
This adds a `rootedAtAtom` to `MolToSmarts()`. This argument may come in handy in the case of generating SMARTS expressions for inclusion in recursive SMARTS, where the atom for which the context is being specified must be the first atom in the SMARTS expression.

I'm not 100% sure about the handling of lead chiral atoms -- is it really that simple, just not reordering at all? Am I missing something here, @greglandrum ?
