### PR TITLE
Placement of bond or atom labels gets confused when atoms overlap

### DIFF
--- a/Code/GraphMol/MolDraw2D/DrawMol.cpp
+++ b/Code/GraphMol/MolDraw2D/DrawMol.cpp
@@ -1622,6 +1622,14 @@ void DrawMol::extractLegend() {
 void DrawMol::makeStandardBond(Bond *bond, double doubleBondOffset) {
   int begAt = bond->getBeginAtomIdx();
   int endAt = bond->getEndAtomIdx();
+  // If the 2 atoms are on top of each other, don't do anything.  We can
+  // end up with NaN for points in the shapes for things like chiral atoms
+  // (issue 6569).
+  const Point2D &at1_cds = atCds_[begAt];
+  const Point2D &at2_cds = atCds_[endAt];
+  if ((at1_cds - at2_cds).lengthSq() < 0.0001) {
+    return;
+  }
   std::pair<DrawColour, DrawColour> cols = getBondColours(bond);
 
   auto bt = bond->getBondType();
@@ -1658,6 +1666,15 @@ void DrawMol::makeQueryBond(Bond *bond, double doubleBondOffset) {
 
   auto begAt = bond->getBeginAtom();
   auto endAt = bond->getEndAtom();
+  const Point2D &at1_cds = atCds_[begAt->getIdx()];
+  const Point2D &at2_cds = atCds_[endAt->getIdx()];
+  // If the 2 atoms are on top of each other, don't do anything.  We can
+  // end up with NaN for points in the shapes for things like chiral atoms
+  // (issue 6569).
+  if ((at1_cds - at2_cds).lengthSq() < 0.0001) {
+    return;
+  }
+
   Point2D end1, end2;
   adjustBondEndsForLabels(begAt->getIdx(), endAt->getIdx(), end1, end2);
   Point2D sat1 = atCds_[begAt->getIdx()];
@@ -1665,8 +1682,6 @@ void DrawMol::makeQueryBond(Bond *bond, double doubleBondOffset) {
   atCds_[begAt->getIdx()] = end1;
   atCds_[endAt->getIdx()] = end2;
 
-  const Point2D &at1_cds = atCds_[begAt->getIdx()];
-  const Point2D &at2_cds = atCds_[endAt->getIdx()];
   auto midp = (at2_cds + at1_cds) / 2.;
   auto tdash = shortDashes;
   const DrawColour &queryColour = drawOptions_.queryColour;
@@ -2303,7 +2318,14 @@ void DrawMol::calcAnnotationPosition(const Bond *bond,
                                      DrawAnnotation &annot) const {
   PRECONDITION(bond, "no bond");
   Point2D const &at1_cds = atCds_[bond->getBeginAtomIdx()];
-  Point2D const &at2_cds = atCds_[bond->getEndAtomIdx()];
+  Point2D at2_cds = atCds_[bond->getEndAtomIdx()];
+  // If the atoms are on top of each other, perp comes out as NaN which
+  // has very deleterious effects.  Issue 6569.  Move at2 by a small
+  // amount in an arbitrary direction.
+  if ((at1_cds - at2_cds).lengthSq() < 0.0001) {
+    at2_cds.x += 0.1;
+    at2_cds.y += 0.1;
+  }
   Point2D perp = calcPerpendicular(at1_cds, at2_cds);
   Point2D bond_vec = at1_cds.directionVector(at2_cds);
   double bond_len = (at1_cds - at2_cds).length();
@@ -2346,10 +2368,18 @@ double DrawMol::getNoteStartAngle(const Atom *atom) const {
   if (atom->getDegree() == 0) {
     return M_PI / 2.0;
   }
-  Point2D at_cds = atCds_[atom->getIdx()];
+  const Point2D &at_cds = atCds_[atom->getIdx()];
   std::vector<Point2D> bond_vecs;
   for (auto nbr : make_iterator_range(drawMol_->getAtomNeighbors(atom))) {
-    Point2D bond_vec = at_cds.directionVector(atCds_[nbr]);
+    // If the nbr has the same coords as atom, bond_vec comes out as NaN, NaN
+    // (issue 6559), so use a short arbitrary vector instead.
+    Point2D bond_vec;
+    if ((at_cds - atCds_[nbr]).lengthSq() < 0.0001) {
+      bond_vec.x = 0.1;
+      bond_vec.y = 0.1;
+    } else {
+      bond_vec = at_cds.directionVector(atCds_[nbr]);
+    }
     bond_vec.normalize();
     bond_vecs.push_back(bond_vec);
   }

--- a/Code/GraphMol/MolDraw2D/catch_tests.cpp
+++ b/Code/GraphMol/MolDraw2D/catch_tests.cpp
@@ -302,7 +302,9 @@ static const std::map<std::string, std::hash_result_t> SVG_HASHES = {
     {"test_github6397_4.svg", 187792316U},
     {"test_github6397_5.svg", 2795990448U},
     {"github6504_1.svg", 1429448598U},
-    {"github6504_2.svg", 2871662880U}};
+    {"github6504_2.svg", 2871662880U},
+    {"github6569_1.svg", 116573839U},
+    {"github6569_2.svg", 2367779037U}};
 
 // These PNG hashes aren't completely reliable due to floating point cruft,
 // but they can still reduce the number of drawings that need visual
@@ -8030,6 +8032,74 @@ M  END
     outs.flush();
     outs.close();
     checkEndSep(text);
+    check_file_hash(baseName + "_2.svg");
+  }
+}
+
+TEST_CASE("Github #6569: placement of bond labels bad when atoms overlap") {
+  std::string baseName = "github6569";
+  auto m = R"CTAB(CHEMBL3612237
+     RDKit          2D
+
+ 14 15  0  0  0  0  0  0  0  0999 V2000
+   -0.6828   -1.6239    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -0.6828    0.0000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    0.6090    0.5905    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    1.9007    0.0000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    1.9007   -1.6239    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    0.6090   -2.3805    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    1.9007    1.3471    0.0000 N   0  0  0  0  0  0  0  0  0  0  0  0
+   -0.6828    1.3471    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    0.6090    2.0668    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -0.6319    1.4849    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -0.5072    2.6784    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0
+   -1.7280    0.9964    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0
+   -0.6828    0.0000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    1.9007    0.0000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+  1  2  1  0
+  1  6  1  0
+  2  3  1  0
+  3  4  1  0
+  4  5  1  0
+  5  6  1  0
+  4  7  1  0
+  2  8  1  0
+  8  9  1  0
+  7  9  1  0
+  3 10  1  1
+ 10 11  1  0
+ 10 12  2  0
+  2 13  1  1
+  4 14  1  1
+M  END
+)CTAB"_ctab;
+  REQUIRE(m);
+  {
+    MolDraw2DSVG drawer(300, 300, -1, -1);
+    drawer.drawOptions().addAtomIndices = true;
+    drawer.drawMolecule(*m);
+    drawer.finishDrawing();
+    std::ofstream outs(baseName + "_1.svg");
+    std::string text = drawer.getDrawingText();
+    outs << text;
+    outs.flush();
+    outs.close();
+    // All the coords came out as nan in the buggy version
+    REQUIRE(text.find("nan") == std::string::npos);
+    check_file_hash(baseName + "_1.svg");
+  }
+  {
+    MolDraw2DSVG drawer(300, 300, -1, -1);
+    drawer.drawOptions().addBondIndices = true;
+    drawer.drawMolecule(*m);
+    drawer.finishDrawing();
+    std::ofstream outs(baseName + "_2.svg");
+    std::string text = drawer.getDrawingText();
+    outs << text;
+    outs.flush();
+    outs.close();
+    // All the coords came out as nan in the buggy version
+    REQUIRE(text.find("nan") == std::string::npos);
     check_file_hash(baseName + "_2.svg");
   }
 }


### PR DESCRIPTION
#### Reference Issue
Fixes #6569

#### What does this implement/fix? Explain your changes.
When 2 atoms had the same coordinates, some things like the placement of atom or bond notes or drawing wedges gave NaN due to division by the zero length.  This fix temporarily moves one of the atoms by 0.1, 0.1 in these circumstances so it doesn't occur.

#### Any other comments?
It was lucky that Greg's example had the offending atoms on a chiral centre, or the extra problem with drawing the wedges would have been missed.  Sometimes the sun shines on the righteous :-).

