### PR TITLE
Add newline to ConstrainedEmbed docstring.

### DIFF
--- a/Docs/Book/Cookbook.rst
+++ b/Docs/Book/Cookbook.rst
@@ -1729,7 +1729,7 @@ Molecule Hash Strings
 
 .. image:: images/RDKitCB_21_im5.png
 
-Contiguous Rotable Bonds
+Contiguous Rotatable Bonds
 =========================
 
 | **Author:** Paulo Tosco

--- a/rdkit/Chem/AllChem.py
+++ b/rdkit/Chem/AllChem.py
@@ -283,6 +283,7 @@ def ConstrainedEmbed(mol, core, useTethers=True, coreConfId=-1, randomseed=2342,
     >>> mol = AllChem.MolFromSmiles("c1nn(Cc2ccccc2)cc1-c3ccccc3")
 
     Now do the constrained embedding
+  
     >>> mol = AllChem.ConstrainedEmbed(mol, template)
 
     Demonstrate that the positions are nearly the same with template:


### PR DESCRIPTION
#### Reference Issue
No issue


#### What does this implement/fix? Explain your changes.
The docs for ConstrainedEmbed at http://rdkit.org/docs/source/rdkit.Chem.AllChem.html have a poorly formatted line such that the crucial exemplification of use of the function is buried in the text rather than highlighted with a green background:
![image](https://github.com/rdkit/rdkit/assets/9198870/3e11738e-4321-46c1-85db-dc76b76d19fd)
Working from analogy with the rest of the docstring I think this newline is important.

#### Any other comments?
I don't know how to test to see if this has fixed it.
