### PR TITLE
Add a workflow to update molecular templates from rdkit/molecular_templates

### DIFF
--- a/.github/workflows/templates_updater.yml
+++ b/.github/workflows/templates_updater.yml
@@ -26,31 +26,42 @@ jobs:
             repository: ${{ env.tpl_repo }}
             ref: main
             path: molecular_templates
-      - name: Check for header changes
-        id: header-check
+      - name: Commit and push changes
+        id: push_changes
         run: |
             cp -f molecular_templates/${{ env.tpl_hdr }} ${{ env.rdk_hdr }}
-            header_changed=$(git diff --name-only ${{ env.rdk_hdr }} | wc -l)
-            echo "header_changed=${header_changed}" >> ${GITHUB_OUTPUT}
-            templates_sha=$(cd molecular_templates && git rev-parse --short HEAD)
-            echo "templates_sha=${templates_sha}" >> ${GITHUB_OUTPUT}
-      - name: Commit the new header file to RDKit branch
-        if: ${{ steps.header-check.outputs.header_changed == '1' && success() }}
-        uses: stefanzweifel/git-auto-commit-action@v4
-        with:
-            repository: rdkit
-            branch: ${{ format('templates_update_{0}', steps.header-check.outputs.pr_branch) }}
-            create_branch: true
-            commit_message: "[bot] Update molecular templates header"
-            file_pattern: ${{ env.rdk_hdr }}
+            if ! git diff --quiet --exit-code ${{ env.rdk_hdr }}; then
+                git config user.name "github-actions[bot]"
+                git config user.email "github-actions[bot]@users.noreply.github.com"
+
+                templates_sha=$(cd molecular_templates && git rev-parse --short HEAD)
+                pr_branch=templates_update_${templates_sha}
+                git checkout -b ${pr_branch}
+
+                git add ${{ env.rdk_hdr }}
+
+                coauthor=$(cd molecular_templates && git log -1 --pretty=format:'%an <%ae>')
+
+                > commitmsg
+                echo -e "[bot] Update molecular templates header\n\n" >> commitmsg
+                echo -e "> Co-authored-by: ${coauthor}\n" >> commitmsg
+
+                git commit -F commitmsg
+
+                git push origin ${pr_branch}
+
+                echo "header_changed=1" >> ${GITHUB_OUTPUT}
+            fi
+            echo "pr_branch=${pr_branch}" >> ${GITHUB_OUTPUT}
       - name: pull-request-action
+        if: ${{ steps.push_changes.outputs.header_changed == '1' }}
         uses: vsoch/pull-request-action@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PULL_REQUEST_FROM_BRANCH: ${{ format('templates_update_{0}', steps.header-check.outputs.pr_branch) }}
+          PULL_REQUEST_FROM_BRANCH: ${{ steps.push_changes.outputs.pr_branch }}
           PULL_REQUEST_BRANCH: "master"
           PULL_REQUEST_BODY: ${{ format('Automated Pull Request to update molecular templates for
-             coordinate generation to header in commit {0} \#{1}', env.tpl_repo,
-            steps.header-check.outputs.pr_branch) }}
+             coordinate generation to header in commit {0} in https://github.com/{1}',
+            steps.push_changes.outputs.templates_sha, env.tpl_repo) }}
           PULL_REQUEST_TITLE: "[bot] Update molecular templates header file"
           MAINTAINER_CANT_MODIFY: "true"

--- a/.github/workflows/templates_updater.yml
+++ b/.github/workflows/templates_updater.yml
@@ -62,7 +62,6 @@ jobs:
           PULL_REQUEST_FROM_BRANCH: ${{ steps.push_changes.outputs.pr_branch }}
           PULL_REQUEST_BRANCH: "master"
           PULL_REQUEST_BODY: ${{ format('Automated Pull Request to update molecular templates for
-             coordinate generation to header in https://github.com/{0}/commit/{1}', env.tpl_repo,
+             coordinate generation to header in https://github.com/{0}/commit/{1})', env.tpl_repo,
             steps.push_changes.outputs.templates_sha) }}
           PULL_REQUEST_TITLE: "[bot] Update molecular templates header file"
-          MAINTAINER_CANT_MODIFY: "true"

--- a/.github/workflows/templates_updater.yml
+++ b/.github/workflows/templates_updater.yml
@@ -10,7 +10,7 @@ permissions:
   pull-requests: write
 
 env:
-  tpl_repo: 'ricrogz/molecular_templates'
+  tpl_repo: 'rdkit/molecular_templates'
   tpl_hdr: 'template_smiles.h'
   rdk_hdr: 'Code/GraphMol/Depictor/TemplateSmiles.h'
 
@@ -32,7 +32,7 @@ jobs:
             cp -f molecular_templates/${{ env.tpl_hdr }} ${{ env.rdk_hdr }}
             if ! git diff --quiet --exit-code ${{ env.rdk_hdr }}; then
                 git config user.name "github-actions[bot]"
-                git config user.email "github-actions[bot]@users.noreply.github.com"
+                git config user.email "github-actions[bot]@noreply.github.com"
 
                 templates_sha=$(cd molecular_templates && git rev-parse --short HEAD)
                 pr_branch=templates_update_${templates_sha}
@@ -44,7 +44,7 @@ jobs:
 
                 > commitmsg
                 echo -e "[bot] Update molecular templates header\n\n" >> commitmsg
-                echo -e "> Co-authored-by: ${coauthor}\n" >> commitmsg
+                echo -e "Co-authored-by: ${coauthor}\n" >> commitmsg
 
                 git commit -F commitmsg
 

--- a/.github/workflows/templates_updater.yml
+++ b/.github/workflows/templates_updater.yml
@@ -1,0 +1,56 @@
+name: Pull molecular templates header updates
+on:
+  workflow_dispatch: ~
+  schedule:
+    # Run every Sunday at 00:00 UTC
+    - cron: '0 0 * * 6'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+env:
+  tpl_repo: 'ricrogz/molecular_templates'
+  tpl_hdr: 'template_smiles.h'
+  rdk_hdr: 'Code/GraphMol/Depictor/TemplateSmiles.h'
+
+jobs:
+  check_header_changes_and_create_pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout RDKit
+        uses: actions/checkout@v3
+      - name: Checkout molecular_templates
+        uses: actions/checkout@v3
+        with:
+            repository: ${{ env.tpl_repo }}
+            ref: main
+            path: molecular_templates
+      - name: Check for header changes
+        id: header-check
+        run: |
+            cp -f molecular_templates/${{ env.tpl_hdr }} ${{ env.rdk_hdr }}
+            header_changed=$(git diff --name-only ${{ env.rdk_hdr }} | wc -l)
+            echo "header_changed=${header_changed}" >> ${GITHUB_OUTPUT}
+            templates_sha=$(cd molecular_templates && git rev-parse --short HEAD)
+            echo "templates_sha=${templates_sha}" >> ${GITHUB_OUTPUT}
+      - name: Commit the new header file to RDKit branch
+        if: ${{ steps.header-check.outputs.header_changed == '1' && success() }}
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+            repository: rdkit
+            branch: ${{ format('templates_update_{0}', steps.header-check.outputs.pr_branch) }}
+            create_branch: true
+            commit_message: "[bot] Update molecular templates header"
+            file_pattern: ${{ env.rdk_hdr }}
+      - name: pull-request-action
+        uses: vsoch/pull-request-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PULL_REQUEST_FROM_BRANCH: ${{ format('templates_update_{0}', steps.header-check.outputs.pr_branch) }}
+          PULL_REQUEST_BRANCH: "master"
+          PULL_REQUEST_BODY: ${{ format('Automated Pull Request to update molecular templates for
+             coordinate generation to header in commit {0} \#{1}', env.tpl_repo,
+            steps.header-check.outputs.pr_branch) }}
+          PULL_REQUEST_TITLE: "[bot] Update molecular templates header file"
+          MAINTAINER_CANT_MODIFY: "true"

--- a/.github/workflows/templates_updater.yml
+++ b/.github/workflows/templates_updater.yml
@@ -52,6 +52,7 @@ jobs:
 
                 echo "header_changed=1" >> ${GITHUB_OUTPUT}
             fi
+            echo "templates_sha=${templates_sha}" >> ${GITHUB_OUTPUT}
             echo "pr_branch=${pr_branch}" >> ${GITHUB_OUTPUT}
       - name: pull-request-action
         if: ${{ steps.push_changes.outputs.header_changed == '1' }}
@@ -61,7 +62,7 @@ jobs:
           PULL_REQUEST_FROM_BRANCH: ${{ steps.push_changes.outputs.pr_branch }}
           PULL_REQUEST_BRANCH: "master"
           PULL_REQUEST_BODY: ${{ format('Automated Pull Request to update molecular templates for
-             coordinate generation to header in commit {0} in https://github.com/{1}',
-            steps.push_changes.outputs.templates_sha, env.tpl_repo) }}
+             coordinate generation to header in https://github.com/{0}/commit/{1}', env.tpl_repo,
+            steps.push_changes.outputs.templates_sha) }}
           PULL_REQUEST_TITLE: "[bot] Update molecular templates header file"
           MAINTAINER_CANT_MODIFY: "true"


### PR DESCRIPTION
This workflow creates an automated workflow to update the molecular templates used for 2d coordinate generation from `template_smiles.h` at the current head of https://github.com/rdkit/molecular_templates/tree/main.

The workflow is scheduled to run once a week, on Sunday midnight, but this can be adjusted. The workflow can also be manually triggered from the `Actions` tab.

When the workflow runs, if the templates in rdkit/molecular_templates and the ones in this repository are different, the workflow will push the changes to a new branch in this repository, and create a new Pull Request to merge the new header (we should make sure to delete the branches after merging the PRs!). If no differences between the headers are detected, nothing will happen.

Note that the first time this workflow runs it will create a PR, since the header files with the templates are currently different.

