### PR TITLE
Fix some build warnings

### DIFF
--- a/Code/ForceField/ForceField.cpp
+++ b/Code/ForceField/ForceField.cpp
@@ -278,7 +278,7 @@ int ForceField::minimize(unsigned int snapshotFreq,
 
   unsigned int numIters = 0;
   unsigned int dim = this->d_numPoints * d_dimension;
-  double finalForce;
+  double finalForce = 0.0;
   auto *points = new double[dim];
 
   this->scatter(points);

--- a/Code/GraphMol/ChemReactions/Wrap/rdChemReactions.cpp
+++ b/Code/GraphMol/ChemReactions/Wrap/rdChemReactions.cpp
@@ -123,10 +123,9 @@ PyObject *RunReactants(ChemicalReaction *self, T reactants,
   return res;
 }
 
-template <typename T>
-PyObject *RunReactant(ChemicalReaction *self, T reactant,
+PyObject *RunReactant(ChemicalReaction *self, python::object reactant,
                       unsigned int reactionIdx) {
-  ROMOL_SPTR react = python::extract<ROMOL_SPTR>(reactant);
+  auto react = python::extract<ROMOL_SPTR>(reactant);
 
   std::vector<MOL_SPTR_VECT> mols;
 
@@ -562,9 +561,7 @@ Sample Usage:
            "the products as a tuple of tuples.  If maxProducts is not zero,"
            " stop the reaction when maxProducts have been generated "
            "[default=1000]")
-      .def("RunReactant",
-           (PyObject * (*)(RDKit::ChemicalReaction *, python::object, unsigned))
-               RDKit::RunReactant,
+      .def("RunReactant", RDKit::RunReactant,
            "apply the reaction to a single reactant")
       .def("RunReactantInPlace", RDKit::RunReactantInPlace,
            (python::arg("self"), python::arg("reactant"),

--- a/Code/GraphMol/ChemTransforms/testChemTransforms.cpp
+++ b/Code/GraphMol/ChemTransforms/testChemTransforms.cpp
@@ -970,9 +970,7 @@ void testReplaceCoreMatchVectMultipleMappingToCore() {
   // 3 dummies in core map to single N in molecule
   core = "C1([*:1])C([*:2])C([*:3])C1"_smiles;
   mol = "C1C2C3N2C13"_smiles;
-  mapping.clear();
-  mapping.insert(mapping.end(),
-                 {{0, 4}, {1, 3}, {2, 2}, {3, 3}, {4, 1}, {5, 3}, {6, 0}});
+  mapping.assign({{0, 4}, {1, 3}, {2, 2}, {3, 3}, {4, 1}, {5, 3}, {6, 0}});
   result.reset(replaceCore(*mol.get(), *core.get(), mapping, false));
   smi = MolToSmiles(*result.get(), true);
   TEST_ASSERT("[1*]N([2*])[3*]" == smi);
@@ -1072,13 +1070,13 @@ void testMurckoDecomp() {
       {"OC2C(C)C21C(N)C1C", "C2CC12CC1"},  // Spiro
       {"C1CC1C(=O)OC", "C1CC1"},           // Carbonyl outside scaffold
       {"C1CC1C=C", "C1CC1"},               // Double bond outside scaffold
-      {"C1CC1C=CC1CC1C=CNNCO", "C1CC1C=CC1CC1"},  // Double bond in scaffold
+      {"C1CC1C=CC1CC1C=CNNCO", "C1CC1C=CC1CC1"},      // Double bond in scaffold
       {"CC1CC1C(N)C1C(N)C1", "C1CC1CC1CC1"},
       {"C1CC1S(=O)C1CC1C=CNNCO", "C1CC1S(=O)C1CC1"},  // S=O group in scaffold
       {"O=SCNC1CC1S(=O)C1CC1C=CNNCO",
-       "C1CC1S(=O)C1CC1"},  // S=O group outside scaffold
+       "C1CC1S(=O)C1CC1"},                        // S=O group outside scaffold
       {"C1CC1S(=O)(=O)C1CC1C=CNNCO",
-       "C1CC1S(=O)(=O)C1CC1"},  // SO2 group in scaffold
+       "C1CC1S(=O)(=O)C1CC1"},                    // SO2 group in scaffold
       {"O=S(CNCNC)(=O)CNC1CC1S(=O)(=O)C1CC1C=CNNCO",
        "C1CC1S(=O)(=O)C1CC1"},                    // SO2 group outside scaffold
       {"C1CC1C=NO", "C1CC1"},                     // Hydroxamide

--- a/Code/GraphMol/Descriptors/PMI.h
+++ b/Code/GraphMol/Descriptors/PMI.h
@@ -37,9 +37,9 @@ RDKIT_DESCRIPTORS_EXPORT double PMI1(const ROMol&, int confId = -1,
                                      bool force = false);
 const std::string PMI1Version = "1.0.0";
 //! second principal moment of inertia
-RDKIT_DESCRIPTORS_EXPORT RDKIT_DESCRIPTORS_EXPORT double PMI2(
-    const ROMol&, int confId = -1, bool useAtomicMasses = true,
-    bool force = false);
+RDKIT_DESCRIPTORS_EXPORT double PMI2(const ROMol&, int confId = -1,
+                                     bool useAtomicMasses = true,
+                                     bool force = false);
 const std::string PMI2Version = "1.0.0";
 //! Third (largest) principal moment of inertia
 RDKIT_DESCRIPTORS_EXPORT double PMI3(const ROMol&, int confId = -1,

--- a/Code/GraphMol/FileParsers/MolWriters.h
+++ b/Code/GraphMol/FileParsers/MolWriters.h
@@ -395,7 +395,7 @@ class RDKIT_FILEPARSERS_EXPORT MaeWriter : public MolWriter {
                              const STR_VECT &propNames = STR_VECT());
 
   //! \brief write a new molecule to the file.
-  void write(const ROMol &mol, int confId = defaultConfId);
+  void write(const ROMol &mol, int confId = defaultConfId) override;
 
   //! \brief flush the ostream
   void flush() override;

--- a/Code/GraphMol/GeneralizedSubstruct/catch_tests.cpp
+++ b/Code/GraphMol/GeneralizedSubstruct/catch_tests.cpp
@@ -84,8 +84,6 @@ TEST_CASE("tautomer basics") {
   REQUIRE(mol);
   ExtendedQueryMol xqm =
       std::unique_ptr<TautomerQuery>(TautomerQuery::fromMol(*mol));
-  const TautomerQuery &otq =
-      *std::get<ExtendedQueryMol::TautomerQuery_T>(xqm.xqmol);
 
   SECTION("substructure matching and serialization") {
     ExtendedQueryMol xqm2(xqm.toBinary());

--- a/Code/GraphMol/MolBundle.h
+++ b/Code/GraphMol/MolBundle.h
@@ -65,6 +65,8 @@ class MolBundle : public RDProps {
   MolBundle(const std::string &pkl) { initFromString(pkl); }
   virtual ~MolBundle() {}
 
+  MolBundle &operator=(const MolBundle &other) = default;
+
   //! returns our molecules
   virtual const std::vector<boost::shared_ptr<ROMol>> &getMols() const {
     return d_mols;

--- a/Code/GraphMol/MolStandardize/Tautomer.cpp
+++ b/Code/GraphMol/MolStandardize/Tautomer.cpp
@@ -443,7 +443,7 @@ TautomerEnumeratorResult TautomerEnumerator::enumerate(const ROMol &mol) const {
                                     MolOps::SANITIZE_SETCONJUGATION |
                                     MolOps::SANITIZE_SETHYBRIDIZATION |
                                     MolOps::SANITIZE_ADJUSTHS);
-          } catch (const KekulizeException &ke) {
+          } catch (const KekulizeException &) {
             continue;
           }
 #ifdef VERBOSE_ENUMERATION

--- a/Code/GraphMol/Wrap/MolOps.cpp
+++ b/Code/GraphMol/Wrap/MolOps.cpp
@@ -1009,7 +1009,7 @@ void testSetProps(ROMol &mol) {
   for (auto &bond : mol.bonds()) {
     _testSetProps(*bond, std::string("bond_") + std::to_string(bond->getIdx()));
   }
-  for (int conf_idx = 0; conf_idx < mol.getNumConformers(); ++conf_idx) {
+  for (unsigned conf_idx = 0; conf_idx < mol.getNumConformers(); ++conf_idx) {
     _testSetProps(mol.getConformer(conf_idx),
                   "conf_" + std::to_string(conf_idx));
   }

--- a/Code/RDBoost/python_streambuf.h
+++ b/Code/RDBoost/python_streambuf.h
@@ -24,7 +24,6 @@
 #include <boost/utility/typed_in_place_factory.hpp>
 #include <RDGeneral/BoostEndInclude.h>
 
-//#include <tbxx/error_utils.hpp>
 #include <RDGeneral/Invariant.h>
 #include <RDGeneral/Exceptions.h>
 
@@ -459,7 +458,7 @@ class streambuf : public std::basic_streambuf<char> {
 
   boost::optional<off_type> seekoff_without_calling_python(
       off_type off, std::ios_base::seekdir way, std::ios_base::openmode which) {
-    boost::optional<off_type> const failure;
+    boost::optional<off_type> const failure = off_type(-1);
 
     // Buffer range and current position
     off_type buf_begin, buf_end, buf_cur, upper_bound;

--- a/Contrib/ConformerParser/test.cpp
+++ b/Contrib/ConformerParser/test.cpp
@@ -65,7 +65,7 @@ void test1() {
   bool ok = false;
   try {
     readAmberTrajectory(fName, coords, mol->getNumAtoms());
-  } catch (ValueErrorException &e) {
+  } catch (ValueErrorException &) {
     ok = true;
   }
   TEST_ASSERT(ok);
@@ -74,7 +74,7 @@ void test1() {
   ok = false;
   try {
     readAmberTrajectory(fName, coords, mol->getNumAtoms());
-  } catch (ValueErrorException &e) {
+  } catch (ValueErrorException &) {
     // std::cout << e.what() << std::endl;
     ok = true;
   }


### PR DESCRIPTION
This fixes some build warnings I have been noticing over the past weeks.

The most annoying one is the missing `override` in `Code/GraphMol/FileParsers/MolWriters.h`, since this is propagated to code that uses this header.