### PR TITLE
Avoid leaking memory in case exceptions are thrown while generating FPs

### DIFF
--- a/Code/GraphMol/Fingerprints/MACCS.cpp
+++ b/Code/GraphMol/Fingerprints/MACCS.cpp
@@ -940,9 +940,9 @@ void GenerateFP(const RDKit::ROMol &mol, ExplicitBitVect &fp) {
 namespace RDKit {
 namespace MACCSFingerprints {
 ExplicitBitVect *getFingerprintAsBitVect(const ROMol &mol) {
-  auto *fp = new ExplicitBitVect(167);
+  std::unique_ptr<ExplicitBitVect> fp(new ExplicitBitVect(167));
   GenerateFP(mol, *fp);
-  return fp;
+  return fp.release();
 }
 }  // namespace MACCSFingerprints
 }  // namespace RDKit

--- a/Code/GraphMol/Fingerprints/MorganGenerator.cpp
+++ b/Code/GraphMol/Fingerprints/MorganGenerator.cpp
@@ -33,10 +33,9 @@ MorganAtomInvGenerator::MorganAtomInvGenerator(const bool includeRingMembership)
 std::vector<std::uint32_t> *MorganAtomInvGenerator::getAtomInvariants(
     const ROMol &mol) const {
   unsigned int nAtoms = mol.getNumAtoms();
-  std::vector<std::uint32_t> *atomInvariants =
-      new std::vector<std::uint32_t>(nAtoms);
+  std::unique_ptr<std::vector<std::uint32_t>> atomInvariants(new std::vector<std::uint32_t>(nAtoms));
   getConnectivityInvariants(mol, *atomInvariants, df_includeRingMembership);
-  return atomInvariants;
+  return atomInvariants.release();
 }
 
 std::string MorganAtomInvGenerator::infoString() const {

--- a/Code/GraphMol/Substruct/vf2.hpp
+++ b/Code/GraphMol/Substruct/vf2.hpp
@@ -663,16 +663,13 @@ bool vf2_all(const Graph &g1, const Graph &g2, VertexLabeling &vertex_labeling,
              DoubleBackInsertionSequence &F, unsigned int max_results = 1000) {
   detail::VF2SubState<const Graph, VertexLabeling, EdgeLabeling, MatchChecking>
       s0(&g1, &g2, vertex_labeling, edge_labeling, match_checking, false);
-  detail::node_id *ni1 = new detail::node_id[num_vertices(g1)];
-  detail::node_id *ni2 = new detail::node_id[num_vertices(g2)];
+  std::unique_ptr<detail::node_id[]> ni1(new detail::node_id[num_vertices(g1)]);
+  std::unique_ptr<detail::node_id[]> ni2(new detail::node_id[num_vertices(g2)]);
 
   F.clear();
   F.resize(0);
 
-  match(ni1, ni2, s0, F, max_results);
-
-  delete[] ni1;
-  delete[] ni2;
+  match(ni1.get(), ni2.get(), s0, F, max_results);
 
   return !F.empty();
 };


### PR DESCRIPTION
While running CFFI tests under `valgrind` I noticed that memory is leaked when an exception is thrown during generation of certain FPs; see the `valgrind` trace below:
```
$ valgrind --leak-check=full ./Code/MinimalLib/cffi_test
[...]
==255551==
==255551== HEAP SUMMARY:
==255551==     in use at exit: 192 bytes in 7 blocks
==255551==   total heap usage: 524,741 allocs, 524,734 frees, 39,361,697 bytes allocated
==255551==
==255551== 16 bytes in 1 blocks are definitely lost in loss record 1 of 7
==255551==    at 0x4C2C866: operator new[](unsigned long) (vg_replace_malloc.c:579)
==255551==    by 0x5162D5A: bool boost::vf2_all<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*, boost::no_property, boost::listS>, RDKit::detail::AtomLabelFunctor, RDKit::detail::BondL
abelFunctor, RDKit::MolMatchFinalCheckFunctor, std::__cxx11::list<std::__cxx11::list<std::pair<unsigned long, unsigned long>, std::allocator<std::pair<unsigned long, unsigned long> > >, std::allocator<std::__cxx11::list<std::pair<un
signed long, unsigned long>, std::allocator<std::pair<unsigned long, unsigned long> > > > > >(boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*, boost::no_property, boost::listS> const&,
boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*, boost::no_property, boost::listS> const&, RDKit::detail::AtomLabelFunctor&, RDKit::detail::BondLabelFunctor&, RDKit::MolMatchFinalCheckF
unctor&, std::__cxx11::list<std::__cxx11::list<std::pair<unsigned long, unsigned long>, std::allocator<std::pair<unsigned long, unsigned long> > >, std::allocator<std::__cxx11::list<std::pair<unsigned long, unsigned long>, std::allo
cator<std::pair<unsigned long, unsigned long> > > > >&, unsigned int) (vf2.hpp:666)
==255551==    by 0x516413A: RDKit::SubstructMatch(RDKit::ROMol const&, RDKit::ROMol const&, RDKit::SubstructMatchParameters const&) (SubstructMatch.cpp:512)
==255551==    by 0x5011D5E: bool RDKit::SubstructMatch<RDKit::ROMol const, RDKit::ROMol>(RDKit::ROMol const&, RDKit::ROMol const&, std::vector<std::pair<int, int>, std::allocator<std::pair<int, int> > >&, bool, bool, bool) (Substruc
tMatch.h:136)
==255551==    by 0x5381346: (anonymous namespace)::GenerateFP(RDKit::ROMol const&, ExplicitBitVect&) [clone .constprop.0] (MACCS.cpp:600)
==255551==    by 0x5382EBD: RDKit::MACCSFingerprints::getFingerprintAsBitVect(RDKit::ROMol const&) (MACCS.cpp:944)
==255551==    by 0x4FDB3DC: RDKit::MinimalLib::maccs_fp_as_bitvect(RDKit::RWMol const&) (common.h:829)
==255551==    by 0x4FE9A12: get_maccs_fp (cffiwrapper.cpp:636)
==255551==    by 0x111ABA: test_partial_sanitization (cffi_test.c:2157)
==255551==    by 0x10A11E: main (cffi_test.c:2192)
==255551==
==255551== 36 bytes in 1 blocks are definitely lost in loss record 5 of 7
==255551==    at 0x4C2C866: operator new[](unsigned long) (vg_replace_malloc.c:579)
==255551==    by 0x5162D8A: bool boost::vf2_all<boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*, boost::no_property, boost::listS>, RDKit::detail::AtomLabelFunctor, RDKit::detail::BondL
abelFunctor, RDKit::MolMatchFinalCheckFunctor, std::__cxx11::list<std::__cxx11::list<std::pair<unsigned long, unsigned long>, std::allocator<std::pair<unsigned long, unsigned long> > >, std::allocator<std::__cxx11::list<std::pair<un
signed long, unsigned long>, std::allocator<std::pair<unsigned long, unsigned long> > > > > >(boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*, boost::no_property, boost::listS> const&,
boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, RDKit::Atom*, RDKit::Bond*, boost::no_property, boost::listS> const&, RDKit::detail::AtomLabelFunctor&, RDKit::detail::BondLabelFunctor&, RDKit::MolMatchFinalCheckF
unctor&, std::__cxx11::list<std::__cxx11::list<std::pair<unsigned long, unsigned long>, std::allocator<std::pair<unsigned long, unsigned long> > >, std::allocator<std::__cxx11::list<std::pair<unsigned long, unsigned long>, std::allo
cator<std::pair<unsigned long, unsigned long> > > > >&, unsigned int) (vf2.hpp:667)
==255551==    by 0x516413A: RDKit::SubstructMatch(RDKit::ROMol const&, RDKit::ROMol const&, RDKit::SubstructMatchParameters const&) (SubstructMatch.cpp:512)
==255551==    by 0x5011D5E: bool RDKit::SubstructMatch<RDKit::ROMol const, RDKit::ROMol>(RDKit::ROMol const&, RDKit::ROMol const&, std::vector<std::pair<int, int>, std::allocator<std::pair<int, int> > >&, bool, bool, bool) (Substruc
tMatch.h:136)
==255551==    by 0x5381346: (anonymous namespace)::GenerateFP(RDKit::ROMol const&, ExplicitBitVect&) [clone .constprop.0] (MACCS.cpp:600)
==255551==    by 0x5382EBD: RDKit::MACCSFingerprints::getFingerprintAsBitVect(RDKit::ROMol const&) (MACCS.cpp:944)
==255551==    by 0x4FDB3DC: RDKit::MinimalLib::maccs_fp_as_bitvect(RDKit::RWMol const&) (common.h:829)
==255551==    by 0x4FE9A12: get_maccs_fp (cffiwrapper.cpp:636)
==255551==    by 0x111ABA: test_partial_sanitization (cffi_test.c:2157)
==255551==    by 0x10A11E: main (cffi_test.c:2192)
==255551==
==255551== 60 (24 direct, 36 indirect) bytes in 1 blocks are definitely lost in loss record 6 of 7
==255551==    at 0x4C2B788: operator new(unsigned long) (vg_replace_malloc.c:417)
==255551==    by 0x5391C66: RDKit::MorganFingerprint::MorganAtomInvGenerator::getAtomInvariants(RDKit::ROMol const&) const (MorganGenerator.cpp:37)
==255551==    by 0x538CA61: RDKit::FingerprintGenerator<unsigned int>::getFingerprintHelper(RDKit::ROMol const&, RDKit::FingerprintFuncArguments&, unsigned long) const (FingerprintGenerator.cpp:161)
==255551==    by 0x538D212: RDKit::FingerprintGenerator<unsigned int>::getFingerprint(RDKit::ROMol const&, RDKit::FingerprintFuncArguments&) const (FingerprintGenerator.cpp:409)
==255551==    by 0x5376671: RDKit::MorganFingerprints::getFingerprintAsBitVect(RDKit::ROMol const&, unsigned int, unsigned int, std::vector<unsigned int, std::allocator<unsigned int> >*, std::vector<unsigned int, std::allocator<unsi
gned int> > const*, bool, bool, bool, std::map<unsigned int, std::vector<std::pair<unsigned int, unsigned int>, std::allocator<std::pair<unsigned int, unsigned int> > >, std::less<unsigned int>, std::allocator<std::pair<unsigned int
 const, std::vector<std::pair<unsigned int, unsigned int>, std::allocator<std::pair<unsigned int, unsigned int> > > > > >*, bool) (MorganFingerprints.cpp:145)
==255551==    by 0x4FF24B1: RDKit::MinimalLib::morgan_fp_as_bitvect(RDKit::RWMol const&, char const*) (common.h:740)
==255551==    by 0x4FF27FA: get_morgan_fp (cffiwrapper.cpp:481)
==255551==    by 0x111A37: test_partial_sanitization (cffi_test.c:2146)
==255551==    by 0x10A11E: main (cffi_test.c:2192)
==255551==
==255551== 80 (24 direct, 56 indirect) bytes in 1 blocks are definitely lost in loss record 7 of 7
==255551==    at 0x4C2B788: operator new(unsigned long) (vg_replace_malloc.c:417)
==255551==    by 0x5382E83: RDKit::MACCSFingerprints::getFingerprintAsBitVect(RDKit::ROMol const&) (MACCS.cpp:943)
==255551==    by 0x4FDB3DC: RDKit::MinimalLib::maccs_fp_as_bitvect(RDKit::RWMol const&) (common.h:829)
==255551==    by 0x4FE9A12: get_maccs_fp (cffiwrapper.cpp:636)
==255551==    by 0x111ABA: test_partial_sanitization (cffi_test.c:2157)
==255551==    by 0x10A11E: main (cffi_test.c:2192)
==255551==
==255551== LEAK SUMMARY:
==255551==    definitely lost: 100 bytes in 4 blocks
==255551==    indirectly lost: 92 bytes in 3 blocks
==255551==      possibly lost: 0 bytes in 0 blocks
==255551==    still reachable: 0 bytes in 0 blocks
==255551==         suppressed: 0 bytes in 0 blocks
==255551==
==255551== For lists of detected and suppressed errors, rerun with: -s
==255551== ERROR SUMMARY: 4 errors from 4 contexts (suppressed: 0 from 0)
```
This PR avoid all those leaks by wrapping pointer into `unique_ptr` objects which are only released before returning.