### PR TITLE
add option to use sequential random seeds in the conformer generator

### DIFF
--- a/Code/GraphMol/DistGeomHelpers/Embedder.h
+++ b/Code/GraphMol/DistGeomHelpers/Embedder.h
@@ -112,6 +112,8 @@ enum EmbedFailureCauses {
   trackFailures    keep track of which checks during the embedding process fail
   failures         if trackFailures is true, this is used to track the number
                    of times each embedding check fails
+  enableSequentialRandomSeeds    handle the random number seeds so that
+                                 conformer generation can be restarted
 */
 struct RDKIT_DISTGEOMHELPERS_EXPORT EmbedParameters {
   unsigned int maxIterations{0};
@@ -145,6 +147,7 @@ struct RDKIT_DISTGEOMHELPERS_EXPORT EmbedParameters {
   double boundsMatForceScaling{1.0};
   bool trackFailures{false};
   std::vector<unsigned int> failures;
+  bool enableSequentialRandomSeeds{false};
 
   EmbedParameters() : boundsMat(nullptr), CPCI(nullptr), callback(nullptr) {}
   EmbedParameters(

--- a/Code/GraphMol/DistGeomHelpers/EmbedderUtils.cpp
+++ b/Code/GraphMol/DistGeomHelpers/EmbedderUtils.cpp
@@ -48,6 +48,8 @@ void updateEmbedParametersFromJSON(EmbedParameters &params,
   PT_OPT_GET(boundsMatForceScaling);
   PT_OPT_GET(forceTransAmides);
   PT_OPT_GET(useSymmetryForPruning);
+  PT_OPT_GET(enableSequentialRandomSeeds);
+
   std::map<int, RDGeom::Point3D> *cmap = nullptr;
   const auto coordMap = pt.get_child_optional("coordMap");
   if (coordMap) {

--- a/Code/GraphMol/DistGeomHelpers/Wrap/rdDistGeom.cpp
+++ b/Code/GraphMol/DistGeomHelpers/Wrap/rdDistGeom.cpp
@@ -526,7 +526,12 @@ BOOST_PYTHON_MODULE(rdDistGeom) {
           "trackFailures", &RDKit::DGeomHelpers::EmbedParameters::trackFailures,
           "keep track of which checks during the embedding process fail")
       .def("GetFailureCounts", &RDKit::getFailureCounts,
-           "returns the counts of eacu");
+           "returns the counts of each failure type")
+      .def_readwrite(
+          "enableSequentialRandomSeeds",
+          &RDKit::DGeomHelpers::EmbedParameters::enableSequentialRandomSeeds,
+          "handle random number seeds so that conformer generation can be restarted");
+
   docString =
       "Use distance geometry to obtain multiple sets of \n\
  coordinates for a molecule\n\

--- a/Code/GraphMol/DistGeomHelpers/catch_tests.cpp
+++ b/Code/GraphMol/DistGeomHelpers/catch_tests.cpp
@@ -725,3 +725,25 @@ TEST_CASE("Github #6365: cannot generate conformers for PF6- or SF6") {
     }
   }
 }
+
+TEST_CASE("Sequential random seeds") {
+  SECTION("basics") {
+    auto mol = "CCCCCCCCCCCC"_smiles;
+    REQUIRE(mol);
+    MolOps::addHs(*mol);
+
+    RWMol mol2(*mol);
+
+    DGeomHelpers::EmbedParameters ps = DGeomHelpers::ETKDGv3;
+    ps.enableSequentialRandomSeeds = true;
+    ps.useRandomCoords = true;
+    ps.randomSeed = 0xf00d;
+    auto cids = DGeomHelpers::EmbedMultipleConfs(*mol, 10, ps);
+    CHECK(cids.size() == 10);
+    ps.randomSeed = 0xf00d + 5;
+    auto cids2 = DGeomHelpers::EmbedMultipleConfs(mol2, 5, ps);
+    CHECK(cids2.size() == 5);
+
+    compareConfs(mol.get(), &mol2, 5, 0);
+  }
+}


### PR DESCRIPTION
This option allows conformer generation to be restarted with reproducible results.

As an example, the 5th conformer generated using the seed `0xf00d` and the first conformer generated using the seed `0xf00d+5` will be the same:
```
    DGeomHelpers::EmbedParameters ps = DGeomHelpers::ETKDGv3;
    ps.enableSequentialRandomSeeds = true;
    ps.randomSeed = 0xf00d;
    auto cids = DGeomHelpers::EmbedMultipleConfs(*mol, 10, ps);
    ps.randomSeed = 0xf00d + 5;
    auto cids2 = DGeomHelpers::EmbedMultipleConfs(mol2, 5, ps);
    compareConfs(mol.get(), &mol2, 5, 0);
```

