### PR TITLE
Fixes #6640

### DIFF
--- a/Code/GraphMol/FindStereo.cpp
+++ b/Code/GraphMol/FindStereo.cpp
@@ -770,6 +770,20 @@ bool updateBonds(ROMol &mol, const std::vector<unsigned int> &aranks,
       auto sinfo = detail::getStereoInfo(bond);
       ASSERT_INVARIANT(sinfo.controllingAtoms.size() == 4,
                        "bad controlling atoms size");
+
+      if ((sinfo.controllingAtoms[0] == Chirality::StereoInfo::NOATOM &&
+           sinfo.controllingAtoms[1] == Chirality::StereoInfo::NOATOM) ||
+          (sinfo.controllingAtoms[2] == Chirality::StereoInfo::NOATOM &&
+           sinfo.controllingAtoms[3] == Chirality::StereoInfo::NOATOM)) {
+        // we have a bond with no neighbors on one side, which means it must
+        // have a single implicit H on that side. Since the H is implicit,
+        // there is no way to know whether it is cis or trans.
+        ASSERT_INVARIANT(
+            sinfo.specified == StereoSpecified::Unknown,
+            "stereo bond without neighbors can only be unspecified");
+        fixedBonds.set(bidx);
+      }
+
       if (fixedBonds[bidx]) {
         sinfos.push_back(std::move(sinfo));
       } else {

--- a/Code/GraphMol/catch_chirality.cpp
+++ b/Code/GraphMol/catch_chirality.cpp
@@ -3655,3 +3655,23 @@ M  END)CTAB";
   std::unique_ptr<ROMol> mol(MolBlockToMol(mb));
   REQUIRE(mol);
 }
+
+TEST_CASE("GitHub Issue #6640", "[bug][stereo]") {
+  UseLegacyStereoPerceptionFixture reset_stereo_perception;
+  Chirality::setUseLegacyStereoPerception(false);
+
+  auto p = SmilesParserParams();
+  p.sanitize = false;
+  p.removeHs = false;
+  std::string smiles{"NC1=NC(=N)N=C(N)C1C"};
+  std::unique_ptr<RWMol> mol(SmilesToMol(smiles, p));
+  REQUIRE(mol);
+
+  MolOps::removeHs(*mol);
+
+  auto cleanIt = true;
+  auto force = true;
+  auto flagPossibleStereoCenters = true;
+  MolOps::assignStereochemistry(*mol, cleanIt, force,
+                                flagPossibleStereoCenters);
+}


### PR DESCRIPTION
This Fixes #6640.

This is the structure that is causing the infinite loop:
<img alt="NC1=NC(=N)N=C(N)C1C" src="https://github.com/rdkit/rdkit/assets/7498185/d3623faa-c705-4792-be9c-58ca9a8a0c03" width=200px />

The cause of the loop is the dependency between the potential stereochemistries of atom 8 and  the imide double bond at the opposite side of the ring. Given that the imide bond does not have any "real" neighbors (just an implicit H), it can never be resolved to cis or trans, and would stay undersolved after https://github.com/rdkit/rdkit/pull/6473 and https://github.com/rdkit/rdkit/pull/6527. The reason we didn't see this after any of these patches is that none of the structures we looked at there did have a dependency on the newly added (and fixed) imine bonds.

This fix solves the infinite loop problem by catching the neighborless imine bonds in `updateBonds()` and definitively marking them as "Unknown", since the lack of neighbors on one side prevents us from ever resolving the bond into cis or trans. Once the imine bond is no longer indetermined, the dependency does no longer trigger an infinite loop.