### PR TITLE
Fixes #6633

### DIFF
--- a/Code/GraphMol/catch_canon.cpp
+++ b/Code/GraphMol/catch_canon.cpp
@@ -467,3 +467,75 @@ TEST_CASE("ensure unused features are not used") {
     CHECK(ranks[1] == ranks[4]);
   }
 }
+
+TEST_CASE(
+    "GitHub Issue #6633: Pre-condition violation in canonicalization of dative bond adjacent to double bond",
+    "[bug][canonicalization]") {
+  auto mb = R"CTAB(
+                    3D
+
+  0  0  0     0  0            999 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 16 16 0 0 0
+M  V30 BEGIN ATOM
+M  V30 1 C  -2.0033 -1.4133 -0.0473 0
+M  V30 2 C  -2.9101 -0.3985 -0.2677 0
+M  V30 3 O  -2.7092 0.8645 -0.2504 0
+M  V30 4 Ir -0.9429 1.8106 0.2184 0
+M  V30 5 N  0.0151 -0.0816 0.3618 0
+M  V30 6 C  1.4929 -0.0477 0.5631 0
+M  V30 7 C  -0.6236 -1.2309 0.2291 0
+M  V30 8 C  -4.3730 -0.7437 -0.5877 0
+M  V30 9 H  -2.3752 -2.4232 -0.1048 0
+M  V30 10 H  1.8628 -0.9806 0.9803 0
+M  V30 11 H  1.6928 0.7152 1.3165 0
+M  V30 12 H  2.0044 0.1878 -0.3701 0
+M  V30 13 H  -4.9409 0.1756 -0.7308 0
+M  V30 14 H  -4.4149 -1.3416 -1.4982 0
+M  V30 15 H  -4.8022 -1.3104 0.2386 0
+M  V30 16 H  0.0202 -2.0891 0.3538 0
+M  V30 END ATOM
+M  V30 BEGIN BOND
+M  V30 1 1 1 7
+M  V30 2 2 1 2
+M  V30 3 1 1 9
+M  V30 4 1 2 3
+M  V30 5 1 2 8
+M  V30 6 1 3 4
+M  V30 7 9 5 4
+M  V30 8 1 5 6
+M  V30 9 2 5 7
+M  V30 10 1 6 10
+M  V30 11 1 6 11
+M  V30 12 1 6 12
+M  V30 13 1 7 16
+M  V30 14 1 8 13
+M  V30 15 1 8 14
+M  V30 16 1 8 15
+M  V30 END BOND
+M  V30 END CTAB
+M  END)CTAB";
+
+  auto countStereoBonds = [](const auto& mol) {
+    unsigned num_stereo_bonds = 0;
+    for (const auto bond : mol.bonds()) {
+      if (bond->getBondType() == Bond::BondType::DOUBLE &&
+          bond->getStereo() != Bond::BondStereo::STEREONONE) {
+        ++num_stereo_bonds;
+      }
+    }
+    return num_stereo_bonds;
+  };
+
+  auto sanitize = true;
+  auto removeHs = false;
+  std::unique_ptr<ROMol> mol(MolBlockToMol(mb, sanitize, removeHs));
+
+  REQUIRE(mol);
+  REQUIRE(mol->getNumAtoms() == 16);
+  REQUIRE(countStereoBonds(*mol) == 2);
+
+  CHECK_NOTHROW(MolToSmiles(*mol));
+
+  CHECK(countStereoBonds(*mol) == 2);
+}


### PR DESCRIPTION
This fixes #6633.

The cause of the issue is that when running `canonicalizeDoubleBond()`, we allow any neighboring bonds to be used as a reference. These bonds will be given a direction (`ENDDOWNRIGHT` / `ENDUPRIGHT`), and will potentially be written to the smiles as `/` or `\`. The problem with this is that according to the documentation, https://www.daylight.com/dayhtml/doc/theory/theory.smiles.html#RTFToC23, the slashes represent single or aromatic bonds. `switchBondDir()` has a precondition that checks for these types of bonds, and it is being triggered in the case of the mol I attached to the issue, since, due to the mol's construction, it is the dative bond that is being chosen as a reference for the stereochemistry of the double bond.

This addresses the issue by restricting the types of bonds we can use as a reference to only single and aromatic bonds. I also took the chance to do some refactoring to reduce code duplication.

This change was enough to fix the issue, but when I ran the tests I found that this broke an Inchi test. Specifically, it was mol #1165 in `UnitTestInchi.py TestCase.test1InchiReadPubChem`. Initially, the mol looks like this:
<img src="https://github.com/rdkit/rdkit/assets/7498185/6da60309-f32e-47db-842e-9c36201aa3fe" width=200px />
But after being rountripped to inchi it is transformed into this (this is one of the mols we consider as "reasonably changed"):
<img src="https://github.com/rdkit/rdkit/assets/7498185/b21e665b-6b12-4929-9041-d01359082c80" width=200px />

The issue in this case is that the inchi-roundtripped mol was triggering the `CHECK_INVARIANT(firstFromAtom2, "could not find atom2");` in `canonicalizeDoubleBond()` when trying to canonicalize the double bond between the 
`C` and `N+` atoms, which shouldn't be stereo at all.

It seems this roundtrip through Inchi is setting a stereo flag on this bond, despite it doesn't have any viable neighboring bonds. To fix this I added another check (plus some more refactoring) to the inchi parser, which will disregard double bonds if no neighboring single or aromatic bonds are available.