### PR TITLE
Expose RascalMCES singleLargestFrag option to Python.

### DIFF
--- a/Code/GraphMol/RascalMCES/Wrap/rdRascalMCES.cpp
+++ b/Code/GraphMol/RascalMCES/Wrap/rdRascalMCES.cpp
@@ -66,6 +66,10 @@ struct RascalResult_wrapper {
         .def_readonly("largestFragmentSize",
                       &RDKit::RascalMCES::RascalResult::getLargestFragSize,
                       "Number of atoms in largest fragment.")
+        .def_readonly("tier1Sim", &RDKit::RascalMCES::RascalResult::getTier1Sim,
+                      "The tier 1 similarity estimate.")
+        .def_readonly("tier2Sim", &RDKit::RascalMCES::RascalResult::getTier2Sim,
+                      "The tier 2 similarity estimate.")
         .def_readonly("timedOut", &RDKit::RascalMCES::RascalResult::getTimedOut,
                       "Whether it timed out.");
   }
@@ -159,9 +163,10 @@ BOOST_PYTHON_MODULE(rdRascalMCES) {
           "similarityThreshold",
           &RDKit::RascalMCES::RascalOptions::similarityThreshold,
           "Threshold below which MCES won't be run.  Between 0.0 and 1.0, default=0.7.")
-      .def_readwrite("singleLargestFrag",
-                     &RDKit::RascalMCES::RascalOptions::singleLargestFrag,
-                     "Return the just single largest fragment of the MCES.")
+      .def_readwrite(
+          "singleLargestFrag",
+          &RDKit::RascalMCES::RascalOptions::singleLargestFrag,
+          "Return the just single largest fragment of the MCES.  This is equivalent to running with allBestMCEs=True, finding the result with the largest largestFragmentSize, and calling its largestFragmentOnly method.")
       .def_readwrite(
           "completeAromaticRings",
           &RDKit::RascalMCES::RascalOptions::completeAromaticRings,
@@ -179,6 +184,10 @@ BOOST_PYTHON_MODULE(rdRascalMCES) {
       .def_readwrite(
           "allBestMCESs", &RDKit::RascalMCES::RascalOptions::allBestMCESs,
           "If True, reports all MCESs found of the same maximum size.  Default False means just report the first found.")
+      .def_readwrite(
+          "returnEmptyMCES", &RDKit::RascalMCES::RascalOptions::returnEmptyMCES,
+          "If the estimated similarity between the 2 molecules doesn't meet the similarityThreshold, no results are returned.  If you want to know what the"
+          " estimates were, set this to True, and examine the tier1Sim and tier2Sim properties of the result then returned.")
       .def_readwrite(
           "timeout", &RDKit::RascalMCES::RascalOptions::timeout,
           "Maximum time (in seconds) to spend on an individual MCESs determination.  Default 60, -1 means no limit.");

--- a/Code/GraphMol/RascalMCES/Wrap/rdRascalMCES.cpp
+++ b/Code/GraphMol/RascalMCES/Wrap/rdRascalMCES.cpp
@@ -203,6 +203,41 @@ BOOST_PYTHON_MODULE(rdRascalMCES) {
               (python::arg("mol1"), python::arg("mol2"),
                python::arg("opts") = python::object()),
               docString.c_str());
+
+  docString =
+      "RASCAL Cluster Options.  Most of these pertain to RascalCluster calculations.  Only similarityCutoff is used by RascalButinaCluster.";
+  python::class_<RDKit::RascalMCES::RascalClusterOptions, boost::noncopyable>(
+      "RascalClusterOptions", docString.c_str())
+      .def_readwrite(
+          "similarityCutoff",
+          &RDKit::RascalMCES::RascalClusterOptions::similarityCutoff,
+          "Similarity cutoff for molecules to be in the same cluster.  Between 0.0 and 1.0, default=0.7.")
+      .def_readwrite(
+          "minFragSize", &RDKit::RascalMCES::RascalClusterOptions::minFragSize,
+          "The minimum number of atoms in a fragment for it to be included in the MCES.  Default=3.")
+      .def_readwrite(
+          "maxNumFrags", &RDKit::RascalMCES::RascalClusterOptions::maxNumFrags,
+          "The maximum number of fragments allowed in the MCES for each pair of molecules. Default=2.  So that the MCES"
+          " isn't a lot of small fragments scattered around the molecules giving an inflated estimate of similarity.")
+      .def_readwrite(
+          "numThreads", &RDKit::RascalMCES::RascalClusterOptions::numThreads,
+          "Number of threads to use during clustering.  Default=-1 means all the hardware threads less one.")
+      .def_readwrite(
+          "a", &RDKit::RascalMCES::RascalClusterOptions::a,
+          "The penalty score for each unconnected component in the MCES. Default=0.05.")
+      .def_readwrite(
+          "b", &RDKit::RascalMCES::RascalClusterOptions::a,
+          "The weight of matched bonds over matched atoms. Default=2.")
+      .def_readwrite(
+          "minIntraClusterSim",
+          &RDKit::RascalMCES::RascalClusterOptions::minIntraClusterSim,
+          "Two pairs of molecules are included in the same cluster if the similarity between"
+          " their MCESs is greater than this.  Default=0.9.")
+      .def_readwrite(
+          "clusterMergeSim",
+          &RDKit::RascalMCES::RascalClusterOptions::clusterMergeSim,
+          "Two clusters are merged if the fraction of molecules they have in common is greater than this.  Default=0.6.");
+
   docString =
       "Use the RASCAL MCES similarity metric to do fuzzy clustering.  Returns a list of lists "
       "of molecules, each inner list being a cluster.  The last cluster is all the "

--- a/Code/GraphMol/RascalMCES/Wrap/rdRascalMCES.cpp
+++ b/Code/GraphMol/RascalMCES/Wrap/rdRascalMCES.cpp
@@ -159,6 +159,9 @@ BOOST_PYTHON_MODULE(rdRascalMCES) {
           "similarityThreshold",
           &RDKit::RascalMCES::RascalOptions::similarityThreshold,
           "Threshold below which MCES won't be run.  Between 0.0 and 1.0, default=0.7.")
+      .def_readwrite("singleLargestFrag",
+                     &RDKit::RascalMCES::RascalOptions::singleLargestFrag,
+                     "Return the just single largest fragment of the MCES.")
       .def_readwrite(
           "completeAromaticRings",
           &RDKit::RascalMCES::RascalOptions::completeAromaticRings,

--- a/Code/GraphMol/RascalMCES/Wrap/testRascalMCES.py
+++ b/Code/GraphMol/RascalMCES/Wrap/testRascalMCES.py
@@ -57,7 +57,7 @@ class TestCase(unittest.TestCase):
     self.assertEqual(len(results[0].atomMatches()), 6)
 
   def test2(self):
-    # Test single largest fragment extraction
+    # Test single largest fragment extraction from results
     ad1 = Chem.MolFromSmiles("CN(C)c1ccc(CC(=O)NCCCCCCCCCCNC23CC4CC(C2)CC(C3)C4)cc1 CHEMBL153934")
     ad2 = Chem.MolFromSmiles("N(C)c1ccc(CC(=O)NCCCCCCCCCCCCNC23CC4CC(C2)CC(C3)C4)cc1 CHEMBL157336")
 
@@ -91,6 +91,17 @@ class TestCase(unittest.TestCase):
     opts.similarityThreshold = 0.5
     results = rdRascalMCES.FindMCES(mol1, mol2, opts)
     self.assertEqual(len(results), 1)
+
+  def test5(self):
+    # Test setting non-default option singleLargestFrag
+    ad1 = Chem.MolFromSmiles("CN(C)c1ccc(CC(=O)NCCCCCCCCCCNC23CC4CC(C2)CC(C3)C4)cc1 CHEMBL153934")
+    ad2 = Chem.MolFromSmiles("N(C)c1ccc(CC(=O)NCCCCCCCCCCCCNC23CC4CC(C2)CC(C3)C4)cc1 CHEMBL157336")
+
+    opts = rdRascalMCES.RascalOptions()
+    opts.singleLargestFrag = True
+    results = rdRascalMCES.FindMCES(ad1, ad2, opts)
+    self.assertEqual(len(results), 1)
+    self.assertEqual(results[0].smartsString, 'CCCCCCCCCCNC12CC3CC(-C1)-CC(-C2)-C3')
 
   def testRascalCluster(self):
     cdk2_file = Path(os.environ['RDBASE']) / 'Contrib' / 'Fastcluster' / 'cdk2.smi'

--- a/Code/GraphMol/RascalMCES/Wrap/testRascalMCES.py
+++ b/Code/GraphMol/RascalMCES/Wrap/testRascalMCES.py
@@ -103,6 +103,20 @@ class TestCase(unittest.TestCase):
     self.assertEqual(len(results), 1)
     self.assertEqual(results[0].smartsString, 'CCCCCCCCCCNC12CC3CC(-C1)-CC(-C2)-C3')
 
+  def test6(self):
+    # Test the threshold and examine the tier1 and tier2 similarities.
+    ad1 = Chem.MolFromSmiles("CN(C)c1ccc(CC(=O)NCCCCCCCCCCNC23CC4CC(C2)CC(C3)C4)cc1 CHEMBL153934")
+    ad2 = Chem.MolFromSmiles("N(C)c1ccc(CC(=O)NCCCCCCCCCCCCNC23CC4CC(C2)CC(C3)C4)cc1 CHEMBL157336")
+
+    opts = rdRascalMCES.RascalOptions()
+    opts.similarityThreshold = 0.95
+    results = rdRascalMCES.FindMCES(ad1, ad2, opts)
+    self.assertEqual(len(results), 0)
+    opts.returnEmptyMCES = True
+    results = rdRascalMCES.FindMCES(ad1, ad2, opts)
+    self.assertEqual(len(results), 1)
+    print(results[0].tier1Sim, results[0].tier2Sim)
+
   def testRascalCluster(self):
     cdk2_file = Path(os.environ['RDBASE']) / 'Contrib' / 'Fastcluster' / 'cdk2.smi'
     suppl = Chem.SmilesMolSupplier(str(cdk2_file), '\t', 1, 0, False)

--- a/Code/GraphMol/RascalMCES/Wrap/testRascalMCES.py
+++ b/Code/GraphMol/RascalMCES/Wrap/testRascalMCES.py
@@ -115,7 +115,6 @@ class TestCase(unittest.TestCase):
     opts.returnEmptyMCES = True
     results = rdRascalMCES.FindMCES(ad1, ad2, opts)
     self.assertEqual(len(results), 1)
-    print(results[0].tier1Sim, results[0].tier2Sim)
 
   def testRascalCluster(self):
     cdk2_file = Path(os.environ['RDBASE']) / 'Contrib' / 'Fastcluster' / 'cdk2.smi'
@@ -124,6 +123,13 @@ class TestCase(unittest.TestCase):
     clusters = rdRascalMCES.RascalCluster(mols)
     self.assertEqual(len(clusters), 8)
     expClusters = [7, 7, 6, 2, 2, 2, 2, 20]
+    for clus, expClusSize in zip(clusters, expClusters):
+      self.assertEqual(expClusSize, len(clus))
+
+    clusOpts = rdRascalMCES.RascalClusterOptions()
+    clusOpts.similarityCutoff = 0.6
+    clusters = rdRascalMCES.RascalCluster(mols, clusOpts)
+    expClusters = [9, 8, 6, 2, 2, 2, 2, 2, 2, 2, 11]
     for clus, expClusSize in zip(clusters, expClusters):
       self.assertEqual(expClusSize, len(clus))
 


### PR DESCRIPTION
#### Reference Issue
No issue.

#### What does this implement/fix? Explain your changes.
Exposes the singleLargestFrag option of RascalMCES::RascalOptions to the Python wrapper.

#### Any other comments?
Writing documentation is always valuable!
