### PR TITLE
Fail CI builds on compiler warnings + some fixes

### DIFF
--- a/.azure-pipelines/linux_build.yml
+++ b/.azure-pipelines/linux_build.yml
@@ -17,6 +17,7 @@ steps:
 - bash: |
     source ${CONDA}/etc/profile.d/conda.sh
     conda activate rdkit_build
+    export CXXFLAGS="${CXXFLAGS} -Wall -Werror"
     mkdir build && cd build && \
     cmake .. \
     -DCMAKE_BUILD_TYPE=Release \

--- a/.azure-pipelines/mac_build.yml
+++ b/.azure-pipelines/mac_build.yml
@@ -32,6 +32,7 @@ steps:
     conda activate rdkit_build
     export SDKROOT="$(pwd)/MacOSX$(target_platform).sdk/"
     export CONDA_BUILD_SYSROOT=${SDKROOT}
+    export CXXFLAGS="${CXXFLAGS} -Wall -Werror"
     mkdir build && cd build && \
     cmake .. \
     -DCMAKE_BUILD_TYPE=Release \

--- a/Code/GraphMol/ChemReactions/Enumerate/Enumerate.cpp
+++ b/Code/GraphMol/ChemReactions/Enumerate/Enumerate.cpp
@@ -30,12 +30,6 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
 
-#include <boost/version.hpp>
-#if (BOOST_VERSION / 100000) > 1 || ((BOOST_VERSION / 100) % 1000) >= 53
-#define RDK_HAVE_MULTIPREC
-#include <boost/multiprecision/cpp_int.hpp>
-#endif
-
 #include "Enumerate.h"
 #include "CartesianProduct.h"
 #include "RandomSample.h"
@@ -45,16 +39,19 @@
 #include <GraphMol/MolPickler.h>
 #include <GraphMol/SmilesParse/SmilesWrite.h>
 
-// Since we are exporting the classes for serialization,
-//  we should declare the archives types used here
-#ifdef RDK_USE_BOOST_SERIALIZATION
 #include <RDGeneral/BoostStartInclude.h>
+#include <boost/multiprecision/cpp_int.hpp>
+#ifdef RDK_USE_BOOST_SERIALIZATION
 #include <boost/archive/text_oarchive.hpp>
 #include <boost/archive/text_iarchive.hpp>
 #include <boost/serialization/shared_ptr.hpp>
 #include <boost/serialization/export.hpp>
+#endif
 #include <RDGeneral/BoostEndInclude.h>
 
+#ifdef RDK_USE_BOOST_SERIALIZATION
+// Since we are exporting the classes for serialization,
+//  we should declare the archives types used here
 BOOST_CLASS_EXPORT(RDKit::EnumerationStrategyBase);
 BOOST_CLASS_EXPORT(RDKit::CartesianProductStrategy);
 BOOST_CLASS_EXPORT(RDKit::RandomSampleStrategy);

--- a/Code/GraphMol/ChemTransforms/MolFragmenter.cpp
+++ b/Code/GraphMol/ChemTransforms/MolFragmenter.cpp
@@ -9,34 +9,36 @@
 //
 
 #include "MolFragmenter.h"
-#include "ChemTransforms.h"
-#include <RDGeneral/utils.h>
-#include <RDGeneral/Invariant.h>
-#include <RDGeneral/RDLog.h>
-#include <RDGeneral/Exceptions.h>
+
 #include <GraphMol/Depictor/RDDepictor.h>
 #include <GraphMol/RDKitBase.h>
-#include <boost/dynamic_bitset.hpp>
-#include <boost/tokenizer.hpp>
-#include <boost/algorithm/string/trim.hpp>
-#include <boost/algorithm/string.hpp>
-#include <boost/range/adaptor/reversed.hpp>
-#include <cstdint>
-#include <vector>
-#include <algorithm>
 #include <GraphMol/SmilesParse/SmilesParse.h>
 #include <GraphMol/SmilesParse/SmilesWrite.h>
 #include <GraphMol/Substruct/SubstructMatch.h>
+#include <RDGeneral/Exceptions.h>
+#include <RDGeneral/Invariant.h>
+#include <RDGeneral/RDLog.h>
 #include <RDGeneral/StreamOps.h>
+#include <RDGeneral/utils.h>
+#include "ChemTransforms.h"
 
 #include <RDGeneral/BoostStartInclude.h>
+#include <boost/algorithm/string.hpp>
+#include <boost/algorithm/string/trim.hpp>
+#include <boost/dynamic_bitset.hpp>
 #include <boost/flyweight.hpp>
 #include <boost/flyweight/no_tracking.hpp>
 #include <boost/functional/hash.hpp>
+#include <boost/range/adaptor/reversed.hpp>
+#include <boost/tokenizer.hpp>
 #include <RDGeneral/BoostEndInclude.h>
 
-#include <sstream>
+#include <algorithm>
+#include <cstdint>
 #include <map>
+#include <optional>
+#include <sstream>
+#include <vector>
 
 namespace RDKit {
 namespace MolFragmenter {

--- a/Code/GraphMol/Chirality.cpp
+++ b/Code/GraphMol/Chirality.cpp
@@ -7,23 +7,25 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
-#include <GraphMol/RDKitBase.h>
-#include <RDGeneral/Ranking.h>
-#include <GraphMol/new_canon.h>
-#include <GraphMol/QueryOps.h>
-#include <RDGeneral/types.h>
-#include <sstream>
-#include <set>
-#include <algorithm>
-#include <RDGeneral/utils.h>
-#include <RDGeneral/Invariant.h>
-#include <RDGeneral/RDLog.h>
-
-#include <boost/dynamic_bitset.hpp>
-#include <Geometry/point.h>
 #include "Chirality.h"
 
+#include <Geometry/point.h>
+#include <GraphMol/QueryOps.h>
+#include <GraphMol/RDKitBase.h>
+#include <GraphMol/new_canon.h>
+#include <RDGeneral/Invariant.h>
+#include <RDGeneral/RDLog.h>
+#include <RDGeneral/Ranking.h>
+#include <RDGeneral/types.h>
+#include <RDGeneral/utils.h>
+
+#include <boost/dynamic_bitset.hpp>
+
+#include <algorithm>
 #include <cstdlib>
+#include <optional>
+#include <set>
+#include <sstream>
 #include <utility>
 
 // #define VERBOSE_CANON 1

--- a/Code/GraphMol/Chirality.cpp
+++ b/Code/GraphMol/Chirality.cpp
@@ -478,7 +478,7 @@ std::optional<Atom::ChiralType> atomChiralTypeFromBondDirPseudo3D(
   //
   //  collect indices and bond vectors of neighbors and track whether or
   //  not there's an H neighbor and if all bonds are single
-  // 
+  //
   //  at the end of this process bond 0 is the input wedged bond
   //
   //----------------------------------------------------------
@@ -512,13 +512,14 @@ std::optional<Atom::ChiralType> atomChiralTypeFromBondDirPseudo3D(
       } else {
         tmpPt.z = 0;
       }
-      // check for overly short bonds. Note that we're doing this check *after* adjusting the z coordinate.
-      //    We want to allow atoms to overlap in x-y space if they are connected via a wedged bond.
+      // check for overly short bonds. Note that we're doing this check *after*
+      // adjusting the z coordinate.
+      //    We want to allow atoms to overlap in x-y space if they are connected
+      //    via a wedged bond.
       if ((centerLoc - tmpPt).lengthSq() < zeroTol) {
         BOOST_LOG(rdWarningLog)
             << "Warning: ambiguous stereochemistry - zero-length (or near zero-length) bond - at atom "
-            << atom->getIdx() << " ignored."
-            << std::endl;
+            << atom->getIdx() << " ignored." << std::endl;
         return std::nullopt;
       }
     }
@@ -555,9 +556,8 @@ std::optional<Atom::ChiralType> atomChiralTypeFromBondDirPseudo3D(
     for (auto j = 0u; j < i; ++j) {
       if ((bondVects[i] - bondVects[j]).lengthSq() < zeroTol) {
         BOOST_LOG(rdWarningLog)
-            << "Warning: ambiguous stereochemistry - overlapping neighbors  - at atom " << atom->getIdx()
-            << " ignored"
-            << std::endl;
+            << "Warning: ambiguous stereochemistry - overlapping neighbors  - at atom "
+            << atom->getIdx() << " ignored" << std::endl;
         return std::nullopt;
       }
     }
@@ -595,18 +595,24 @@ std::optional<Atom::ChiralType> atomChiralTypeFromBondDirPseudo3D(
     //
     // order the bonds so that the rotation order is:
     //   0 - 1 - 2        for three coordinate
-    // or 
+    // or
     //   0 - 1 - 2 - 3    for four coordinate
     //
     // this makes the rest of the code a lot simpler
     //
     //----------------------------------------------------------
-    
-    
-    // checks to see if the vectors 1 and 2 need to have their order 
+
+    // checks to see if the vectors 1 and 2 need to have their order
     //    relative to vector 0 swapped.
     // we don't actually pass the vectors in, but use their cross products
     // and dot products to vector 0 to figure out if they need to be swapped
+#if defined(__clang__)
+// Clang apparently doesn't need to capture the constexpr zeroTol, and complains
+// about it being specified, but MSVC does need it, and removing it will break
+// the build
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-lambda-capture"
+#endif
     auto needsSwap = [&zeroTol](const RDGeom::Point3D &cp01,
                                 const RDGeom::Point3D &cp02, double dp01,
                                 double dp02) -> bool {
@@ -636,9 +642,13 @@ std::optional<Atom::ChiralType> atomChiralTypeFromBondDirPseudo3D(
       }
       return fabs(dp01) > fabs(dp02);
     };
+#if defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
 
     if (nNbrs == 3) {
-      // this case is simple, we either need to swap vectors 1 and 2 or we don't:
+      // this case is simple, we either need to swap vectors 1 and 2 or we
+      // don't:
       auto cp01 = bondVects[order[0]].crossProduct(bondVects[order[1]]);
       auto cp02 = bondVects[order[0]].crossProduct(bondVects[order[2]]);
       auto dp01 = bondVects[order[0]].dotProduct(bondVects[order[1]]);
@@ -649,15 +659,14 @@ std::optional<Atom::ChiralType> atomChiralTypeFromBondDirPseudo3D(
       }
     } else if (nNbrs > 3) {
       // here there are more permutations. Rather than hand-coding all of them
-      // we'll just sort bonds 1, 2, and 3 based on their cross- and dot- products
-      // to bond 0
+      // we'll just sort bonds 1, 2, and 3 based on their cross- and dot-
+      // products to bond 0
       std::vector<std::tuple<double, double, unsigned>> orderedBonds(3);
       for (auto i = 1u; i < 4; ++i) {
         auto cp0i = bondVects[order[0]].crossProduct(bondVects[order[i]]);
         auto sgn = cp0i.z < -zeroTol ? -1 : 1;
         auto dp0i = bondVects[order[0]].dotProduct(bondVects[order[i]]);
-        orderedBonds[i - 1] =
-            std::move(std::make_tuple(sgn, sgn * dp0i, order[i]));
+        orderedBonds[i - 1] = std::make_tuple(sgn, sgn * dp0i, order[i]);
       }
       std::sort(orderedBonds.rbegin(), orderedBonds.rend());
 
@@ -677,7 +686,9 @@ std::optional<Atom::ChiralType> atomChiralTypeFromBondDirPseudo3D(
       }
     }
 
-    // std::cerr<<"ORDER "<<neighborBondIndices[order[0]]<<" "<<neighborBondIndices[order[1]]<<" "<<neighborBondIndices[order[2]]<<" "<<neighborBondIndices[order[3]]<<std::endl;
+    // std::cerr<<"ORDER "<<neighborBondIndices[order[0]]<<"
+    // "<<neighborBondIndices[order[1]]<<" "<<neighborBondIndices[order[2]]<<"
+    // "<<neighborBondIndices[order[3]]<<std::endl;
 
     // check for opposing bonds with opposite wedging
     for (auto i = 0u; i < nNbrs; ++i) {
@@ -701,7 +712,8 @@ std::optional<Atom::ChiralType> atomChiralTypeFromBondDirPseudo3D(
               }
             }
             BOOST_LOG(rdWarningLog)
-                << "Warning: ambiguous stereochemistry - opposing bonds have opposite wedging - at atom "<< atom->getIdx() <<" ignored." << std::endl;
+                << "Warning: ambiguous stereochemistry - opposing bonds have opposite wedging - at atom "
+                << atom->getIdx() << " ignored." << std::endl;
             return std::nullopt;
           }
         }
@@ -738,8 +750,7 @@ std::optional<Atom::ChiralType> atomChiralTypeFromBondDirPseudo3D(
       if (conflict) {
         BOOST_LOG(rdWarningLog)
             << "Warning: conflicting stereochemistry - bond wedging contradiction - at atom "
-            << atom->getIdx() << " ignored"
-            << std::endl;
+            << atom->getIdx() << " ignored" << std::endl;
         return std::nullopt;
       }
     }
@@ -752,8 +763,9 @@ std::optional<Atom::ChiralType> atomChiralTypeFromBondDirPseudo3D(
     const auto crossp1 = bv1.crossProduct(bv2);
     // catch linear arrangements
     if (nNbrs == 3) {
-      if (crossp1.lengthSq() <5*zeroTol) {
-        // nothing we can do in a linear arrangement if there are only three neighbors
+      if (crossp1.lengthSq() < 5 * zeroTol) {
+        // nothing we can do in a linear arrangement if there are only three
+        // neighbors
         BOOST_LOG(rdWarningLog)
             << "Warning: ambiguous stereochemistry - linear bond arrangement - at atom "
             << atom->getIdx() << " ignored" << std::endl;
@@ -798,7 +810,8 @@ std::optional<Atom::ChiralType> atomChiralTypeFromBondDirPseudo3D(
       std::cerr << " !!! " << vol << " " << vol2 << std::endl;
 #endif
 
-      // detect the case where there's no chiral volume for the default evaluation
+      // detect the case where there's no chiral volume for the default
+      // evaluation
       if (fabs(vol) < zeroTol) {
         // and check the other evaluation:
         if (fabs(vol2) < zeroTol) {
@@ -827,7 +840,8 @@ std::optional<Atom::ChiralType> atomChiralTypeFromBondDirPseudo3D(
     vol *= prefactor;
     // std::cerr << " final " << vol << std::endl;
 
-    // at this point we can assign our atomic stereo based on the sign of the chiral volume
+    // at this point we can assign our atomic stereo based on the sign of the
+    // chiral volume
     if (vol > volumeTolerance) {
       res = Atom::ChiralType::CHI_TETRAHEDRAL_CCW;
     } else if (vol < -volumeTolerance) {

--- a/Code/GraphMol/Descriptors/AUTOCORR3D.cpp
+++ b/Code/GraphMol/Descriptors/AUTOCORR3D.cpp
@@ -37,11 +37,12 @@
 #include "MolData3Ddescriptors.h"
 
 #include <cmath>
-#include <Eigen/Dense>
-#include <Eigen/SVD>
 #include <iostream>
+
 #include <Eigen/Core>
+#include <Eigen/Dense>
 #include <Eigen/QR>
+#include <Eigen/SVD>
 
 using namespace Eigen;
 namespace RDKit {
@@ -105,8 +106,6 @@ void get3DautocorrelationDesc(double* dist3D, double* topologicaldistance,
   std::vector<double> wr = moldata3D.GetRelativeRcov(mol);
   VectorXd Wr = getEigenVect(wr);
 
-  MatrixXd Bi;
-  MatrixXd tmp;
   double TDBmat[8][10];
   double dtmp;
 
@@ -114,9 +113,8 @@ void get3DautocorrelationDesc(double* dist3D, double* topologicaldistance,
     double* Bimat = GetGeodesicMatrix(topologicaldistance, i + 1, numAtoms);
     Map<MatrixXd> Bi(Bimat, numAtoms, numAtoms);
     MatrixXd RBi = Bi.cwiseProduct(dm);
-    // double Bicount = (double)Bi.sum();
 
-    tmp = Wu.transpose() * RBi * Wu;
+    MatrixXd tmp = Wu.transpose() * RBi * Wu;
     dtmp = (double)tmp(0);
     if (std::isnan(dtmp)) {
       dtmp = 0.0;
@@ -194,8 +192,6 @@ void get3DautocorrelationDescCustom(double* dist3D, double* topologicaldistance,
       moldata3D.GetCustomAtomProp(mol, customAtomPropName);
   VectorXd Wc = getEigenVect(customAtomArray);
 
-  MatrixXd Bi;
-  MatrixXd tmp;
   double TDBmat[10];
   double dtmp;
 
@@ -204,7 +200,7 @@ void get3DautocorrelationDescCustom(double* dist3D, double* topologicaldistance,
     Map<MatrixXd> Bi(Bimat, numAtoms, numAtoms);
     MatrixXd RBi = Bi.cwiseProduct(dm);
 
-    tmp = Wc.transpose() * RBi * Wc;
+    MatrixXd tmp = Wc.transpose() * RBi * Wc;
     dtmp = (double)tmp(0);
     if (std::isnan(dtmp)) {
       dtmp = 0.0;

--- a/Code/GraphMol/DetermineBonds/DetermineBonds.cpp
+++ b/Code/GraphMol/DetermineBonds/DetermineBonds.cpp
@@ -16,9 +16,12 @@
 #include <numeric>
 #include <cmath>
 #include <unordered_map>
+
+#include <RDGeneral/BoostStartInclude.h>
 #include <boost/graph/adjacency_list.hpp>
 #include <boost/graph/max_cardinality_matching.hpp>
 #include <boost/multiprecision/cpp_int.hpp>
+#include <RDGeneral/BoostEndInclude.h>
 
 typedef boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS>
     Graph;

--- a/Code/GraphMol/DetermineBonds/README.md
+++ b/Code/GraphMol/DetermineBonds/README.md
@@ -20,7 +20,7 @@ As of the end of the GSOC coding period, the first 3 steps have been completed. 
 
 ## The XYZ File Parser
 
-As with other RDKit file parsers (such as the Mol file parser), the XYZ parser contructs an RDKit molecule from the file data. Since the only information an XYZ file contains is the element and location of each atom, the molecule built from the parser contains only atoms and not bonds, as well as a conformer containing the atomic coordinates. The function ```XYZFileToMol()``` calls the file parser.
+As with other RDKit file parsers (such as the Mol file parser), the XYZ parser constructs an RDKit molecule from the file data. Since the only information an XYZ file contains is the element and location of each atom, the molecule built from the parser contains only atoms and not bonds, as well as a conformer containing the atomic coordinates. The function ```XYZFileToMol()``` calls the file parser.
 
 ## Atomic Connectivity Determination
 

--- a/Code/GraphMol/FMCS/MaximumCommonSubgraph.cpp
+++ b/Code/GraphMol/FMCS/MaximumCommonSubgraph.cpp
@@ -752,8 +752,7 @@ MaximumCommonSubgraph::generateResultSMARTSAndQueryMol(
       const auto& targets = mcsIdx.Targets;
       const auto numAtomRings = ri->numAtomRings(atom->getIdx());
       const auto isAtomFusedAcrossAllTargets =
-          [ai, numAtomRings, &targets, &atomIdxMap,
-           &atomMatchResult](unsigned int itarget) {
+          [ai, numAtomRings, &targets, &atomMatchResult](unsigned int itarget) {
             const auto& tag = targets.at(itarget);
             const auto tagRingInfo = tag.Molecule->getRingInfo();
             const auto ti = atomMatchResult.at(itarget).at(ai).TargetAtomIdx;
@@ -910,13 +909,12 @@ MCSResult MaximumCommonSubgraph::find(const std::vector<ROMOL_SPTR>& src_mols) {
   // molecule as a query
   std::stable_sort(Molecules.begin(), Molecules.end(), molPtr_NumBondLess);
   size_t startIdx = 0;
-  size_t endIdx = Molecules.size() - ThresholdCount;  
+  size_t endIdx = Molecules.size() - ThresholdCount;
   while (startIdx < endIdx && !Molecules.at(startIdx)->getNumAtoms()) {
     ++startIdx;
   }
   bool areSeedsEmpty = false;
-  for (size_t i = startIdx;
-       i < endIdx && !areSeedsEmpty && !res.Canceled;
+  for (size_t i = startIdx; i < endIdx && !areSeedsEmpty && !res.Canceled;
        ++i) {
     init(startIdx);
     if (Targets.empty()) {

--- a/Code/GraphMol/FMCS/testFMCS_Unit.cpp
+++ b/Code/GraphMol/FMCS/testFMCS_Unit.cpp
@@ -2599,7 +2599,11 @@ void testSlowCompleteRingsOnly() {
   p.BondCompareParameters.CompleteRingsOnly = true;
   p.AtomTyper = MCSAtomCompareAny;
   p.BondTyper = MCSBondCompareAny;
+#ifdef NDEBUG
   p.Timeout = 10;
+#else  // allow more time when building in debug mode
+  p.Timeout = 60;
+#endif
   auto mcs = findMCS(mols, &p);
 
   TEST_ASSERT(!mcs.Canceled);
@@ -2926,7 +2930,11 @@ void testGitHub3965() {
       "Nc1cc2cc(c1)C(=O)N[C@H](c1ccccc1)c1cccc(COCCNC2=O)c1"_smiles,
       "Nc1nc2cc(c1)C(=O)N[C@H](c1ccccc1)c1cccc(COCCNC2=O)c1"_smiles};
   MCSParameters p;
+#ifdef NDEBUG
   p.Timeout = 30;
+#else  // allow more time when building in debug mode
+  p.Timeout = 120;
+#endif
   p.BondCompareParameters.CompleteRingsOnly = true;
   auto mcs = findMCS(mols, &p);
 

--- a/Code/GraphMol/GeneralizedSubstruct/TextIO.cpp
+++ b/Code/GraphMol/GeneralizedSubstruct/TextIO.cpp
@@ -9,25 +9,25 @@
 //
 //
 
-#include <cstdint>
-#include <variant>
-#include <sstream>
-#include <RDGeneral/StreamOps.h>
-#include <GraphMol/RDKitBase.h>
-#include <GraphMol/MolPickler.h>
+#include <DataStructs/base64.h>
 #include <GraphMol/MolBundle.h>
+#include <GraphMol/MolPickler.h>
+#include <GraphMol/RDKitBase.h>
+#include <GraphMol/SmilesParse/SmartsWrite.h>
 #include <GraphMol/SmilesParse/SmilesParse.h>
 #include <GraphMol/SmilesParse/SmilesWrite.h>
-#include <GraphMol/SmilesParse/SmartsWrite.h>
-
 #include <GraphMol/TautomerQuery/TautomerQuery.h>
-#include <DataStructs/base64.h>
+#include <RDGeneral/StreamOps.h>
+#include "XQMol.h"
 
 #include <RDGeneral/BoostStartInclude.h>
-#include <boost/property_tree/ptree.hpp>
 #include <boost/property_tree/json_parser.hpp>
+#include <boost/property_tree/ptree.hpp>
 #include <RDGeneral/BoostEndInclude.h>
-#include "XQMol.h"
+
+#include <cstdint>
+#include <sstream>
+#include <variant>
 
 namespace bpt = boost::property_tree;
 
@@ -72,10 +72,6 @@ std::string ExtendedQueryMol::toBinary() const {
 }
 
 namespace {
-
-struct charArrayDeleter {
-  void operator()(char *p) const { delete[] p; }
-};
 
 ExtendedQueryMol::TautomerBundle_T readTautomerQueries(std::stringstream &ss) {
   ExtendedQueryMol::TautomerBundle_T res{
@@ -152,8 +148,7 @@ bool has_query_feature(const ROMol &mol) {
 void add_mol_to_elem(bpt::ptree &elem, const ROMol &mol) {
   std::string pkl;
   MolPickler::pickleMol(mol, pkl);
-  std::unique_ptr<char, charArrayDeleter> b64(
-      Base64Encode(pkl.c_str(), pkl.length()));
+  std::unique_ptr<char[]> b64(Base64Encode(pkl.c_str(), pkl.length()));
   elem.put("pkl", b64.get());
   if (has_query_feature(mol)) {
     elem.put("smarts", MolToCXSmarts(mol));
@@ -233,8 +228,7 @@ RWMol *pt_to_mol(bpt::ptree &pt) {
   auto b64pkl = pt.get<std::string>("pkl", "");
   if (!b64pkl.empty()) {
     unsigned int len;
-    std::unique_ptr<char, charArrayDeleter> cpkl(
-        Base64Decode(b64pkl.c_str(), &len));
+    std::unique_ptr<char[]> cpkl(Base64Decode(b64pkl.c_str(), &len));
     std::string pkl(cpkl.get(), len);
     return new RWMol(pkl);
   }

--- a/Code/GraphMol/GeneralizedSubstruct/Wrap/rdGeneralizedSubstruct.cpp
+++ b/Code/GraphMol/GeneralizedSubstruct/Wrap/rdGeneralizedSubstruct.cpp
@@ -89,8 +89,8 @@ ExtendedQueryMol *createExtendedQueryMolHelper(
   if (!ps) {
     ps = &defaults;
   }
-  return new ExtendedQueryMol(std::move(createExtendedQueryMol(
-      mol, doEnumeration, doTautomers, adjustQueryProperties, *ps)));
+  return new ExtendedQueryMol(createExtendedQueryMol(
+      mol, doEnumeration, doTautomers, adjustQueryProperties, *ps));
 }
 
 }  // namespace

--- a/Code/GraphMol/MarvinParse/MarvinDefs.cpp
+++ b/Code/GraphMol/MarvinParse/MarvinDefs.cpp
@@ -977,7 +977,7 @@ const std::string MarvinBond::getBondType() const {
       throw FileParseException(err.str());
     }
   } else if (tempOrder !=
-             "")  // if no query type not conventtion,  so check for order
+             "")  // if no query type not convention,  so check for order
   {
     if (tempOrder == "1" || tempOrder == "2" || tempOrder == "3" ||
         tempOrder == "A") {
@@ -1312,7 +1312,7 @@ MarvinSruCoModSgroup::MarvinSruCoModSgroup(MarvinMolBase *parentInit,
 
     if (atomPtr == nullptr) {
       throw FileParseException(
-          "AtomRef specification for an SRU, Coplomer, or Modification group definition was not found in any parent");
+          "AtomRef specification for an SRU, Copolymer, or Modification group definition was not found in any parent");
     }
     this->atoms.push_back(atomPtr);
   }
@@ -1353,7 +1353,7 @@ MarvinSruCoModSgroup::MarvinSruCoModSgroup(MarvinMolBase *parentInit,
 
       if (bondPtr == nullptr) {
         throw FileParseException(
-            "BondList specification for an SRU, Coplomer, or Modification group definition was not found in any parent");
+            "BondList specification for an SRU, Copolymer, or Modification group definition was not found in any parent");
       }
       this->bonds.push_back(bondPtr);
     }
@@ -1400,10 +1400,10 @@ MarvinMolBase *getActualParent(const MarvinMolBase *child) {
   TEST_ASSERT(false);  // should not be reachable
 }
 
-MarvinMolBase *MarvinSruCoModSgroup::copyMol(std::string idAppendage) const {
+MarvinMolBase *MarvinSruCoModSgroup::copyMol(
+    const std::string &idAppendage) const {
   auto outSgroup = new MarvinSruCoModSgroup(this->roleName, this->parent);
-  this->parent->sgroups.push_back(
-      std::move(std::unique_ptr<MarvinMolBase>(outSgroup)));
+  this->parent->sgroups.emplace_back(outSgroup);
 
   outSgroup->molID = this->molID + idAppendage;
   outSgroup->title = this->title;
@@ -1412,7 +1412,7 @@ MarvinMolBase *MarvinSruCoModSgroup::copyMol(std::string idAppendage) const {
 
   auto actualParent = getActualParent(this);
 
-  // the only time this is to be called is when a mutliple group above it is
+  // the only time this is to be called is when a multiple group above it is
   // being expanded and the new atoms and bonds have already been made
   //  here we just need to find them and add refs to the new multiple sgroup
 
@@ -1525,10 +1525,9 @@ MarvinDataSgroup::MarvinDataSgroup(MarvinMolBase *parentInit, ptree &molTree) {
   }
 }
 
-MarvinMolBase *MarvinDataSgroup::copyMol(std::string idAppendage) const {
+MarvinMolBase *MarvinDataSgroup::copyMol(const std::string &idAppendage) const {
   auto outSgroup = new MarvinDataSgroup(this->parent);
-  this->parent->sgroups.push_back(
-      std::move(std::unique_ptr<MarvinMolBase>(outSgroup)));
+  this->parent->sgroups.emplace_back(outSgroup);
 
   outSgroup->molID = this->molID + idAppendage;
   outSgroup->id = this->id + idAppendage;
@@ -1543,7 +1542,7 @@ MarvinMolBase *MarvinDataSgroup::copyMol(std::string idAppendage) const {
   outSgroup->x = this->x;
   outSgroup->y = this->y;
 
-  // the only time this is to be called is when a mutliple group above it is
+  // the only time this is to be called is when a multiple group above it is
   // being expanded and the new atoms and bonds have already been made
   //  here we just need to find them and add refs to the new multiple sgroup
 
@@ -1669,16 +1668,16 @@ std::string MarvinMultipleSgroup::role() const { return "MultipleSgroup"; }
 
 bool MarvinMultipleSgroup::hasAtomBondBlocks() const { return false; }
 
-MarvinMolBase *MarvinMultipleSgroup::copyMol(std::string idAppendage) const {
+MarvinMolBase *MarvinMultipleSgroup::copyMol(
+    const std::string &idAppendage) const {
   auto outSgroup = new MarvinMultipleSgroup(this->parent);
-  this->parent->sgroups.push_back(
-      std::move(std::unique_ptr<MarvinMolBase>(outSgroup)));
+  this->parent->sgroups.emplace_back(outSgroup);
 
   outSgroup->molID = this->molID + idAppendage;
   outSgroup->id = this->id + idAppendage;
   outSgroup->title = this->title;
 
-  // the only time this is to be called is when a mutliple group above it is
+  // the only time this is to be called is when a multiple group above it is
   // being expanded and the new atoms and bonds have already been made
   //  here we just need to find them and add refs to the new multiple sgroup
 
@@ -1800,15 +1799,15 @@ std::string MarvinMulticenterSgroup::role() const {
 
 bool MarvinMulticenterSgroup::hasAtomBondBlocks() const { return false; }
 
-MarvinMolBase *MarvinMulticenterSgroup::copyMol(std::string idAppendage) const {
+MarvinMolBase *MarvinMulticenterSgroup::copyMol(
+    const std::string &idAppendage) const {
   auto outSgroup = new MarvinMulticenterSgroup(this->parent);
-  this->parent->sgroups.push_back(
-      std::move(std::unique_ptr<MarvinMolBase>(outSgroup)));
+  this->parent->sgroups.emplace_back(outSgroup);
 
   outSgroup->molID = this->molID + idAppendage;
   outSgroup->id = this->id;
 
-  // the only time this is to be called is when a mutliple group above it is
+  // the only time this is to be called is when a multiple group above it is
   // being expanded and the new atoms and bonds have already been made
   //  here we just need to find them and add refs to the new multiple sgroup
 
@@ -1901,15 +1900,15 @@ std::string MarvinGenericSgroup::role() const { return "GenericSgroup"; }
 
 bool MarvinGenericSgroup::hasAtomBondBlocks() const { return false; }
 
-MarvinMolBase *MarvinGenericSgroup::copyMol(std::string idAppendage) const {
+MarvinMolBase *MarvinGenericSgroup::copyMol(
+    const std::string &idAppendage) const {
   auto outSgroup = new MarvinGenericSgroup(this->parent);
-  this->parent->sgroups.push_back(
-      std::move(std::unique_ptr<MarvinMolBase>(outSgroup)));
+  this->parent->sgroups.emplace_back(outSgroup);
 
   outSgroup->molID = this->molID + idAppendage;
   outSgroup->id = this->id + idAppendage;
 
-  // the only time this is to be called is when a mutliple group above it is
+  // the only time this is to be called is when a multiple group above it is
   // being expanded and the new atoms and bonds have already been made
   //  here we just need to find them and add refs to the new multiple sgroup
 
@@ -1999,17 +1998,17 @@ std::string MarvinMonomerSgroup::role() const { return "MonomerSgroup"; }
 
 bool MarvinMonomerSgroup::hasAtomBondBlocks() const { return false; }
 
-MarvinMolBase *MarvinMonomerSgroup::copyMol(std::string idAppendage) const {
+MarvinMolBase *MarvinMonomerSgroup::copyMol(
+    const std::string &idAppendage) const {
   auto outSgroup = new MarvinMonomerSgroup(this->parent);
-  this->parent->sgroups.push_back(
-      std::move(std::unique_ptr<MarvinMolBase>(outSgroup)));
+  this->parent->sgroups.emplace_back(outSgroup);
 
   outSgroup->molID = this->molID + idAppendage;
   outSgroup->id = this->id + idAppendage;
   outSgroup->title = this->title;
   outSgroup->charge = this->charge;
 
-  // the only time this is to be called is when a mutliple group above it is
+  // the only time this is to be called is when a multiple group above it is
   // being expanded and the new atoms and bonds have already been made
   //  here we just need to find them and add refs to the new multiple sgroup
 
@@ -2084,8 +2083,8 @@ MarvinSuperatomSgroupExpanded::MarvinSuperatomSgroupExpanded(
       }
       this->atoms.push_back(atomPtr);
     }
-  } else  // must have no atomRefs nor AtomAray - get the atoms from
-          // the parent block - the ones that referene this
+  } else  // must have no atomRefs nor AtomArray - get the atoms from
+          // the parent block - the ones that reference this
           // superSgroup
   {
     for (MarvinAtom *atom : parent->atoms) {
@@ -2105,10 +2104,9 @@ MarvinSuperatomSgroupExpanded::MarvinSuperatomSgroupExpanded(
 MarvinSuperatomSgroupExpanded::~MarvinSuperatomSgroupExpanded() {}
 
 MarvinMolBase *MarvinSuperatomSgroupExpanded::copyMol(
-    std::string idAppendage) const {
+    const std::string &idAppendage) const {
   auto outSgroup = new MarvinSuperatomSgroupExpanded(this->parent);
-  this->parent->sgroups.push_back(
-      std::move(std::unique_ptr<MarvinMolBase>(outSgroup)));
+  this->parent->sgroups.emplace_back(outSgroup);
 
   outSgroup->molID = this->molID + idAppendage;
   outSgroup->id = this->id + idAppendage;
@@ -2116,7 +2114,7 @@ MarvinMolBase *MarvinSuperatomSgroupExpanded::copyMol(
 
   auto actualParent = getActualParent(this);
 
-  // the only time this is to be called is when a mutliple group above it is
+  // the only time this is to be called is when a multiple group above it is
   // being expanded and the new atoms and bonds have already been made
   //  here we just need to find them and add refs to the new multiple sgroup
 
@@ -2262,7 +2260,7 @@ std::string MarvinSuperatomSgroup::role() const { return "SuperatomSgroup"; }
 
 bool MarvinSuperatomSgroup::hasAtomBondBlocks() const { return true; }
 
-MarvinMolBase *MarvinSuperatomSgroup::copyMol(std::string) const {
+MarvinMolBase *MarvinSuperatomSgroup::copyMol(const std::string &) const {
   PRECONDITION(0, "Internal error:  copying a SuperatomSgroup");
 }
 
@@ -2382,7 +2380,7 @@ void MarvinMolBase::cleanUpSgNumbering(
 void MarvinSuperatomSgroup::cleanUpNumberingMolsAtomsBonds(
     int &molCount,   // this is the starting mol count, and receives the ending
                      // mol count - THis is used when
-                     // MarvinMol->convertToSuperAtaoms is called multiple
+                     // MarvinMol->convertToSuperAtoms is called multiple
                      // times from a RXN
     int &atomCount,  // starting and ending atom count
     int &bondCount,  // starting and ending bond count
@@ -2405,7 +2403,7 @@ void MarvinSuperatomSgroup::cleanUpNumberingMolsAtomsBonds(
 void MarvinMolBase::cleanUpNumberingMolsAtomsBonds(
     int &molCount,   // this is the starting mol count, and receives the ending
                      // mol count - THis is used when
-                     // MarvinMol->convertToSuperAtaoms is called multiple
+                     // MarvinMol->convertToSuperAtoms is called multiple
                      // times from a RXN
     int &atomCount,  // starting and ending atom count
     int &bondCount,  // starting and ending bond count)
@@ -2452,7 +2450,7 @@ void MarvinMolBase::cleanUpNumberingMolsAtomsBonds(
 void MarvinMolBase::cleanUpNumbering(
     int &molCount  // this is the starting mol count, and receives the ending
                    // mol count - THis is used when
-                   // MarvinMol->convertToSuperAtaoms is called multiple times
+                   // MarvinMol->convertToSuperAtoms is called multiple times
                    // from a RXN
     ,
     int &atomCount  // starting and ending atom count
@@ -2534,8 +2532,7 @@ void MarvinSuperatomSgroupExpanded::parseMoleculeSpecific(
   PRECONDITION(mol != nullptr, "mol cannot be null");
 
   std::string typ = "SUP";
-  sgroup =
-      std::move(std::unique_ptr<SubstanceGroup>{new SubstanceGroup(mol, typ)});
+  sgroup.reset(new SubstanceGroup(mol, typ));
   sgroup->setProp<unsigned int>("index", sequenceId);
 
   for (auto atomPtr : this->atoms) {
@@ -2557,8 +2554,7 @@ void MarvinMultipleSgroup::parseMoleculeSpecific(
   // note: sequence continues counting from the loop above
 
   std::string typ = "MUL";
-  sgroup =
-      std::move(std::unique_ptr<SubstanceGroup>{new SubstanceGroup(mol, typ)});
+  sgroup.reset(new SubstanceGroup(mol, typ));
   sgroup->setProp<unsigned int>("index", sequenceId);
 
   for (auto atomPtr : this->atoms) {
@@ -2594,8 +2590,7 @@ void MarvinSruCoModSgroup::parseMoleculeSpecific(
         "Internal error: unrecognized role in a MarvinSruCoPolSgroup");
   }
 
-  sgroup =
-      std::move(std::unique_ptr<SubstanceGroup>{new SubstanceGroup(mol, typ)});
+  sgroup.reset(new SubstanceGroup(mol, typ));
   sgroup->setProp<unsigned int>("index", sequenceId);
 
   sgroup->setProp("CONNECT", this->connect);
@@ -2618,8 +2613,7 @@ void MarvinDataSgroup::parseMoleculeSpecific(
   // Now the data groups
 
   std::string typ = "DAT";
-  sgroup =
-      std::move(std::unique_ptr<SubstanceGroup>{new SubstanceGroup(mol, typ)});
+  sgroup.reset(new SubstanceGroup(mol, typ));
   sgroup->setProp<unsigned int>("index", sequenceId);
 
   for (auto atomPtr : this->atoms) {
@@ -2675,8 +2669,7 @@ void MarvinGenericSgroup::parseMoleculeSpecific(
   PRECONDITION(mol != nullptr, "mol cannot be null");
 
   std::string typ = "GEN";
-  sgroup =
-      std::move(std::unique_ptr<SubstanceGroup>{new SubstanceGroup(mol, typ)});
+  sgroup.reset(new SubstanceGroup(mol, typ));
   sgroup->setProp<unsigned int>("index", sequenceId);
 
   for (auto atomPtr : this->atoms) {
@@ -2695,8 +2688,7 @@ void MarvinMonomerSgroup::parseMoleculeSpecific(
   PRECONDITION(mol != nullptr, "mol cannot be null");
 
   std::string typ = "MON";
-  sgroup =
-      std::move(std::unique_ptr<SubstanceGroup>{new SubstanceGroup(mol, typ)});
+  sgroup.reset(new SubstanceGroup(mol, typ));
   sgroup->setProp<unsigned int>("index", sequenceId);
 
   std::vector<MarvinAtom *>::const_iterator atomIter;
@@ -2746,7 +2738,7 @@ void MarvinMultipleSgroup::expandOneMultipleSgroup() {
   //
   // In Marvin, the atoms of the group are indicated, and the "title" contains
   // the number of replicates In mol files, the atoms of the group are
-  // actually replicated in the atomBlock, and the MUL contructs indicates the
+  // actually replicated in the atomBlock, and the MUL constructs indicates the
   // list of ALL such atoms and the list of the original parent atoms from
   // which the others were replicated.  It also indicate the two bonds from
   // the group atoms to atoms NOT in the group (although these could be
@@ -2769,8 +2761,8 @@ void MarvinMultipleSgroup::expandOneMultipleSgroup() {
   // find the two bonds (or zero bonds) to atoms NOT in the group
 
   std::vector<std::string>
-      originalConnectorAtoms;     // the bonds inthe parent that were to outside
-                                  // atoms BEFORE replication
+      originalConnectorAtoms;  // the bonds in the parent that were to outside
+                               // atoms BEFORE replication
   std::string connectorAtoms[2];  // working atoms to connect the replicates
   std::string outsideConnectorAtom;
   std::vector<MarvinBond *> bondsInGroup;
@@ -2847,7 +2839,7 @@ void MarvinMultipleSgroup::expandOneMultipleSgroup() {
         copyAtom->sgroupRef = parentAtomPtr->sgroupRef + idAppendage;
       }
 
-      // copy atoms to all parents up to the actual parent (multipleSgrups in
+      // copy atoms to all parents up to the actual parent (multipleSgroups in
       // multipleSgroups)
 
       for (auto thisParent = this->parent;; thisParent = thisParent->parent) {
@@ -2946,16 +2938,16 @@ void MarvinSuperatomSgroup::convertFromOneSuperAtom() {
   // In the contracted form, the MRV block can have one or more dummy atoms
   // with the super atom name in the main molecule, and a separate sub-mol
   // with the atoms and bonds of the superatom. It also can have one or more
-  // separate records called attachmentPoints that specifiy which atom(s) in
+  // separate records called attachmentPoints that specify which atom(s) in
   // the super atom sub-mol that replaces the dummy atom(s), and also a bond
   // pointer (in the parent mol).
   //
   // In the expanded form, all of the atoms are in the parent molecule, and
-  // the sub-mol only refers to them.  The attachement points refer to the
+  // the sub-mol only refers to them.  The attachment points refer to the
   // atoms in the parent mol. The MultipleSgroup and SruGroup seem very much
   // alike.   In both, all atoms are in the parent mol, and the sub-mol refers
   // to a group of atoms in that parent. The SruGroup specifies the name and
-  // also the connection informat (head-to-tail, head-head, and unspecified).
+  // also the connection information (head-to-tail, head-head, and unspecified).
   // The Multiple S-group specifies the report count for the group
   //
   // This routine deals with only the contracted form of the SuperatomSgroups,
@@ -2997,7 +2989,7 @@ void MarvinSuperatomSgroup::convertFromOneSuperAtom() {
     // before we move or delete any atoms from the superatomSgroup,  Make sure
     // that the  sibling sgroups are handled if a sibling contains the dummy R
     // atom, then the atoms to be promoted from this sgroup should be member
-    // of the sibing too
+    // of the sibling too
 
     for (auto &sibling : parent->sgroups) {
       if (sibling.get() == this) {
@@ -3189,7 +3181,7 @@ void MarvinSuperatomSgroup::convertFromOneSuperAtom() {
     this->atoms.clear();
     this->bonds.clear();
 
-    // promate any children sgroups
+    // promote any children sgroups
 
     for (auto &childSgroup : this->sgroups) {
       moveSgroup(childSgroup.get(), actualParent, false);
@@ -3281,7 +3273,7 @@ void MarvinMulticenterSgroup::processOneMulticenterSgroup() {
 
 void MarvinMolBase::prepSgroupsForRDKit() {
   // this routine recursively fixes the hierarchy of sgroups - some may NOT
-  // actaully belong underneath their parent and can be promnoted to the
+  // actually belong underneath their parent and can be promoted to the
   // grandparent
 
   // first fix all the children
@@ -3291,7 +3283,7 @@ void MarvinMolBase::prepSgroupsForRDKit() {
        !allDone;)  // until all at this level are done - but fixing one child
                    // can add sgroups to this level
   {
-    allDone = true;  // unitl it is not true in the loop below
+    allDone = true;  // until it is not true in the loop below
     for (auto &childSgroup : this->sgroups) {
       if (!boost::algorithm::contains(
               sgroupsMolIdsDone, std::vector<std::string>{childSgroup->molID},
@@ -3347,7 +3339,7 @@ void MarvinMolBase::prepSgroupsForRDKit() {
             "Child sGroup has atoms both in the parent and NOT in the parent");
       default:
         throw FileParseException(
-            "Unexpected error: unrecogized result from isSgroupInSetOfAtoms");
+            "Unexpected error: unrecognized result from isSgroupInSetOfAtoms");
     }
   }
 
@@ -3374,7 +3366,7 @@ void MarvinMultipleSgroup::processSpecialSgroups() {
 }
 
 MarvinMolBase *MarvinSuperatomSgroupExpanded::convertToOneSuperAtom() {
-  // the mol-style super atoms are significatnly different than the Marvin
+  // the mol-style super atoms are significantly different than the Marvin
   // super atoms.  The mol style has all atoms and bonds in the main mol, and
   // parameter lines that indicate the name of the super atom and the atom
   // indices affected.
@@ -3459,7 +3451,7 @@ MarvinMolBase *MarvinSuperatomSgroupExpanded::convertToOneSuperAtom() {
     }
 
     if (coordsExist)  // get the center of all atoms in the group - we might
-                      // use this if there are no attachement points
+                      // use this if there are no attachment points
     {
       centerOfGroup.x += atom->x2;
       centerOfGroup.y += atom->y2;
@@ -3502,7 +3494,7 @@ MarvinMolBase *MarvinSuperatomSgroupExpanded::convertToOneSuperAtom() {
 
       atomPtr->sgroupAttachmentPoint = std::to_string(++attachmentPointsAdded);
 
-      // add an attachentPoint structure
+      // add an attachmentPoint structure
 
       auto marvinAttachmentPoint = new MarvinAttachmentPoint();
       marvinSuperatomSgroup->attachmentPoints.push_back(std::move(
@@ -3581,7 +3573,7 @@ MarvinMolBase *MarvinSuperatomSgroupExpanded::convertToOneSuperAtom() {
 
     switch (isSgroupInSetOfAtomsResult) {
       case SgroupInAtomSet:
-        // remove the group atoms from the sibling and add the dumm atom
+        // remove the group atoms from the sibling and add the dummy atom
 
         sibling->atoms.push_back(dummyParentAtom);
         for (auto atomToRemove : marvinSuperatomSgroup->atoms) {
@@ -3760,7 +3752,7 @@ void MarvinMultipleSgroup::contractOneMultipleSgroup() {
 
     orphanedBondToFix->atomRefs2[1] =
         orphanedBonds[matchedOrphanBondIndex]
-            ->atomRefs2[0];  // [0] is the orpahened atom (still in the mol)
+            ->atomRefs2[0];  // [0] is the orphaned atom (still in the mol)
 
     // undelete the bond which has been fixed (really remove it from the list
     // of bonds to be delete)
@@ -3860,7 +3852,7 @@ void MarvinMultipleSgroup::contractOneMultipleSgroup() {
 
 IsSgroupInAtomSetResult MarvinMolBase::isSgroupInSetOfAtoms(
     const std::vector<MarvinAtom *> &setOfAtoms) const {
-  // superatom sgrups are different - it has an override for this call
+  // superatom sgroups are different - it has an override for this call
   // if not overridden,  types are in the group based on their atoms
 
   bool isInGroup = false;
@@ -3888,7 +3880,7 @@ IsSgroupInAtomSetResult MarvinMolBase::isSgroupInSetOfAtoms(
 
 IsSgroupInAtomSetResult MarvinSuperatomSgroup::isSgroupInSetOfAtoms(
     const std::vector<MarvinAtom *> &setOfAtoms) const {
-  // superatom sgrups are different - they are in the set if one of the
+  // superatom sgroups are different - they are in the set if one of the
   // condensed atom in the parent is in group
 
   auto dummyAtomIter = find_if(
@@ -3914,7 +3906,7 @@ void MarvinMolBase::processSgroupsFromRDKit() {
     return;  // passive mols are only leaves of the tree - nothing to do
   }
 
-  // see if any siblings should be chilren of this one
+  // see if any siblings should be children of this one
 
   MarvinMolBase *molToProcess =
       this;  // the processing MIGHT change the mol from one kind to another
@@ -3926,7 +3918,7 @@ void MarvinMolBase::processSgroupsFromRDKit() {
     for (bool allDone = false; !allDone;) {
       // until all at this level are done - but fixing one
       // child can add sgroups to this level
-      allDone = true;  // unitl it is not true in the loop below
+      allDone = true;  // until it is not true in the loop below
       for (auto &sibling : this->parent->sgroups) {
         if (boost::algorithm::contains(sgroupsMolIdsDone,
                                        std::vector<std::string>{sibling->molID},
@@ -3966,7 +3958,7 @@ void MarvinMolBase::processSgroupsFromRDKit() {
       } catch (FileParseException &e) {
         BOOST_LOG(rdErrorLog)
             << e.what() << std::endl
-            << "The Mutliple sgroup will be ignored" << std::endl;
+            << "The multiple sgroup will be ignored" << std::endl;
 
         auto sgroupIter = std::find_if(
             this->parent->sgroups.begin(), this->parent->sgroups.end(),
@@ -3982,20 +3974,20 @@ void MarvinMolBase::processSgroupsFromRDKit() {
 
   // now fix all this groups children
 
-  std::vector<std::string> chilrenSgroupsMolIdsDone;
+  std::vector<std::string> childrenSgroupsMolIdsDone;
   for (bool allDone = false;
        !allDone;)  // until all at this level are done - but fixing one child
                    // can add sgroups to this level
   {
-    allDone = true;  // unitl it is not true in the loop below
+    allDone = true;  // until it is not true in the loop below
     for (auto &childSgroup : molToProcess->sgroups) {
       if (boost::algorithm::contains(
-              chilrenSgroupsMolIdsDone,
+              childrenSgroupsMolIdsDone,
               std::vector<std::string>{childSgroup->molID}, molIDInSgroups)) {
         continue;  // this one is done, look at the next one
       }
 
-      chilrenSgroupsMolIdsDone.push_back(childSgroup->molID);
+      childrenSgroupsMolIdsDone.push_back(childSgroup->molID);
       childSgroup->processSgroupsFromRDKit();
       allDone = false;
       break;  // have to start the loop over - we might have changed the
@@ -4006,7 +3998,7 @@ void MarvinMolBase::processSgroupsFromRDKit() {
   return;
 }
 
-MarvinMolBase *MarvinMol::copyMol(std::string) const {
+MarvinMolBase *MarvinMol::copyMol(const std::string &) const {
   PRECONDITION(0, "Internal error:  copying a MarvinMol");
 }
 

--- a/Code/GraphMol/MarvinParse/MarvinDefs.cpp
+++ b/Code/GraphMol/MarvinParse/MarvinDefs.cpp
@@ -1089,22 +1089,13 @@ int MarvinMolBase::getAtomIndex(std::string id) const {
 }
 
 void MarvinMolBase::pushOwnedAtom(MarvinAtom *atom) {
-  PRECONDITION(atom, "bad atom");
-  pushOwnedAtomUniqPtr(std::unique_ptr<MarvinAtom>(atom));
+  PRECONDITION(this->parent, "only sgroups should call the base class version");
+  this->parent->pushOwnedAtom(atom);
 }
 
 void MarvinMolBase::pushOwnedBond(MarvinBond *bond) {
-  PRECONDITION(bond, "bad bond");
-  pushOwnedBondUniqPtr(std::unique_ptr<MarvinBond>(bond));
-}
-
-void MarvinMolBase::pushOwnedAtomUniqPtr(std::unique_ptr<MarvinAtom> atom) {
   PRECONDITION(this->parent, "only sgroups should call the base class version");
-  this->parent->pushOwnedAtomUniqPtr(std::move(atom));
-}
-void MarvinMolBase::pushOwnedBondUniqPtr(std::unique_ptr<MarvinBond> bond) {
-  PRECONDITION(this->parent, "only sgroups should call the base class version");
-  this->parent->pushOwnedBondUniqPtr(std::move(bond));
+  this->parent->pushOwnedBond(std::move(bond));
 }
 
 void MarvinMolBase::removeOwnedAtom(MarvinAtom *atom) {
@@ -2222,9 +2213,8 @@ MarvinSuperatomSgroup::MarvinSuperatomSgroup(MarvinMolBase *parentInit,
         continue;
       }
 
-      auto *marvinAttachmentPoint = new MarvinAttachmentPoint();
-      this->attachmentPoints.push_back(std::move(
-          std::unique_ptr<MarvinAttachmentPoint>(marvinAttachmentPoint)));
+      auto &marvinAttachmentPoint =
+          this->attachmentPoints.emplace_back(new MarvinAttachmentPoint);
 
       marvinAttachmentPoint->atom =
           v.second.get<std::string>("<xmlattr>.atom", "");
@@ -2346,19 +2336,12 @@ bool MarvinMol::hasAtomBondBlocks() const { return true; }
 
 void MarvinMol::pushOwnedAtom(MarvinAtom *atom) {
   PRECONDITION(atom, "bad atom");
-  pushOwnedAtomUniqPtr(std::unique_ptr<MarvinAtom>(atom));
+  ownedAtoms.emplace_back(atom);
 }
 
 void MarvinMol::pushOwnedBond(MarvinBond *bond) {
   PRECONDITION(bond, "bad bond");
-  pushOwnedBondUniqPtr(std::unique_ptr<MarvinBond>(bond));
-}
-
-void MarvinMol::pushOwnedAtomUniqPtr(std::unique_ptr<MarvinAtom> atomUniqPtr) {
-  ownedAtoms.push_back(std::move(atomUniqPtr));
-}
-void MarvinMol::pushOwnedBondUniqPtr(std::unique_ptr<MarvinBond> bondUniqPtr) {
-  ownedBonds.push_back(std::move(bondUniqPtr));
+  ownedBonds.emplace_back(bond);
 }
 
 void MarvinMol::removeOwnedAtom(MarvinAtom *atom) {

--- a/Code/GraphMol/MarvinParse/MarvinDefs.cpp
+++ b/Code/GraphMol/MarvinParse/MarvinDefs.cpp
@@ -2691,7 +2691,6 @@ void MarvinMonomerSgroup::parseMoleculeSpecific(
   sgroup.reset(new SubstanceGroup(mol, typ));
   sgroup->setProp<unsigned int>("index", sequenceId);
 
-  std::vector<MarvinAtom *>::const_iterator atomIter;
   for (auto atomPtr : this->parent->atoms) {
     int atomIndex = this->getAtomIndex(atomPtr->id);
     sgroup->addAtomWithIdx(atomIndex);
@@ -3496,9 +3495,9 @@ MarvinMolBase *MarvinSuperatomSgroupExpanded::convertToOneSuperAtom() {
 
       // add an attachmentPoint structure
 
-      auto marvinAttachmentPoint = new MarvinAttachmentPoint();
-      marvinSuperatomSgroup->attachmentPoints.push_back(std::move(
-          std::unique_ptr<MarvinAttachmentPoint>(marvinAttachmentPoint)));
+      auto &marvinAttachmentPoint =
+          marvinSuperatomSgroup->attachmentPoints.emplace_back(
+              new MarvinAttachmentPoint);
       marvinAttachmentPoint->atom = atomPtr->id;
       marvinAttachmentPoint->bond = bond->id;
 

--- a/Code/GraphMol/MarvinParse/MarvinDefs.h
+++ b/Code/GraphMol/MarvinParse/MarvinDefs.h
@@ -263,7 +263,7 @@ class MarvinMolBase {
   virtual ptree toPtree() const;
   void addSgroupsToPtree(ptree &pt) const;
 
-  virtual MarvinMolBase *copyMol(std::string idAppend) const = 0;
+  virtual MarvinMolBase *copyMol(const std::string &idAppend) const = 0;
   virtual void pushOwnedAtom(MarvinAtom *atom);
   virtual void pushOwnedBond(MarvinBond *bond);
 
@@ -286,7 +286,7 @@ class MarvinMolBase {
   void cleanUpNumbering(
       int &molCount  // this is the starting mol count, and receives the ending
                      // mol count - THis is used when
-                     // MarvinMol->convertToSuperAtaoms is called multiple times
+                     // MarvinMol->convertToSuperAtoms is called multiple times
                      // from a RXN
       ,
       int &atomCount  // starting and ending atom count
@@ -305,13 +305,13 @@ class MarvinMolBase {
           &bondMap  // map from old bond number to new bond number
   );
 
-  // the following is vitual because some dirived classes need to do more than
+  // the following is virtual because some derived classes need to do more than
   // just call the base class.  Currently, only MarvinSuperatomSgroup does this
  public:
   virtual void cleanUpNumberingMolsAtomsBonds(
       int &molCount,  // this is the starting mol count, and receives the ending
                       // mol count - THis is used when
-                      // MarvinMol->convertToSuperAtaoms is called multiple
+                      // MarvinMol->convertToSuperAtoms is called multiple
                       // times from a RXN
       int &atomCount,  // starting and ending atom count
       int &bondCount,  // starting and ending bond count
@@ -322,7 +322,7 @@ class MarvinMolBase {
   void cleanUpSgNumbering(int &sgCount,
                           std::map<std::string, std::string> &sgMap);
 
-  // the following is vitual because some dirived classes need to do more than
+  // the following is virtual because some derived classes need to do more than
   // just call the base class.  Currently, only MarvinSuperatomSgroup does this
 
   virtual IsSgroupInAtomSetResult isSgroupInSetOfAtoms(
@@ -365,7 +365,7 @@ class MarvinSruCoModSgroup : public MarvinMolBase {
   MarvinSruCoModSgroup(std::string type, MarvinMolBase *parent);
   MarvinSruCoModSgroup(MarvinMolBase *parent, std::string role, ptree &molTree);
 
-  MarvinMolBase *copyMol(std::string idAppendage) const override;
+  MarvinMolBase *copyMol(const std::string &idAppend) const override;
 
   std::string title;
   std::string connect;
@@ -386,7 +386,7 @@ class MarvinDataSgroup : public MarvinMolBase {
   MarvinDataSgroup(MarvinMolBase *parent);
   MarvinDataSgroup(MarvinMolBase *parent, ptree &molTree);
 
-  MarvinMolBase *copyMol(std::string idAppendage) const override;
+  MarvinMolBase *copyMol(const std::string &idAppend) const override;
 
   std::string context;
   std::string fieldName;
@@ -416,7 +416,7 @@ class MarvinSuperatomSgroupExpanded : public MarvinMolBase {
   MarvinSuperatomSgroupExpanded(MarvinMolBase *parent);
   MarvinSuperatomSgroupExpanded(MarvinMolBase *parent, ptree &molTree);
 
-  MarvinMolBase *copyMol(std::string idAppendage) const override;
+  MarvinMolBase *copyMol(const std::string &idAppend) const override;
 
   ~MarvinSuperatomSgroupExpanded() override;
 
@@ -439,7 +439,7 @@ class MarvinMultipleSgroup : public MarvinMolBase {
   MarvinMultipleSgroup(MarvinMolBase *parent);
   MarvinMultipleSgroup(MarvinMolBase *parent, ptree &molTree);
 
-  MarvinMolBase *copyMol(std::string idAppendage) const override;
+  MarvinMolBase *copyMol(const std::string &idAppend) const override;
 
   std::string title;
   bool isExpanded = false;
@@ -474,7 +474,7 @@ class MarvinMulticenterSgroup : public MarvinMolBase {
   MarvinMulticenterSgroup(MarvinMolBase *parent);
   MarvinMulticenterSgroup(MarvinMolBase *parent, ptree &molTree);
 
-  MarvinMolBase *copyMol(std::string idAppendage) const override;
+  MarvinMolBase *copyMol(const std::string &idAppend) const override;
 
   void processOneMulticenterSgroup();
 
@@ -497,7 +497,7 @@ class MarvinGenericSgroup : public MarvinMolBase {
   MarvinGenericSgroup(MarvinMolBase *parent);
   MarvinGenericSgroup(MarvinMolBase *parent, ptree &molTree);
 
-  MarvinMolBase *copyMol(std::string idAppendage) const override;
+  MarvinMolBase *copyMol(const std::string &idAppend) const override;
 
   std::string charge;  // onAtoms or onBrackets
   std::string toString() const override;
@@ -518,7 +518,7 @@ class MarvinMonomerSgroup : public MarvinMolBase {
   MarvinMonomerSgroup(MarvinMolBase *parent);
   MarvinMonomerSgroup(MarvinMolBase *parent, ptree &molTree);
 
-  MarvinMolBase *copyMol(std::string idAppendage) const override;
+  MarvinMolBase *copyMol(const std::string &idAppend) const override;
 
   std::string title;
   std::string charge;  // onAtoms or onBrackets
@@ -540,7 +540,7 @@ class MarvinSuperatomSgroup : public MarvinMolBase {
   MarvinSuperatomSgroup(MarvinMolBase *parent);
   MarvinSuperatomSgroup(MarvinMolBase *parent, ptree &molTree);
 
-  MarvinMolBase *copyMol(std::string idAppendage) const override;
+  MarvinMolBase *copyMol(const std::string &idAppend) const override;
 
   ~MarvinSuperatomSgroup() override;
 
@@ -556,7 +556,7 @@ class MarvinSuperatomSgroup : public MarvinMolBase {
   void cleanUpNumberingMolsAtomsBonds(
       int &molCount,  // this is the starting mol count, and receives the ending
                       // mol count - THis is used when
-                      // MarvinMol->convertToSuperAtaoms is called multiple
+                      // MarvinMol->convertToSuperAtoms is called multiple
                       // times from a RXN
       int &atomCount,  // starting and ending atom count
       int &bondCount,  // starting and ending bond count
@@ -575,7 +575,7 @@ class MarvinMol : public MarvinMolBase {
   MarvinMol();
   MarvinMol(ptree &molTree);
 
-  MarvinMolBase *copyMol(std::string idAppendage) const override;
+  MarvinMolBase *copyMol(const std::string &idAppend) const override;
 
   ~MarvinMol() override;
 

--- a/Code/GraphMol/MarvinParse/MarvinDefs.h
+++ b/Code/GraphMol/MarvinParse/MarvinDefs.h
@@ -267,9 +267,6 @@ class MarvinMolBase {
   virtual void pushOwnedAtom(MarvinAtom *atom);
   virtual void pushOwnedBond(MarvinBond *bond);
 
-  virtual void pushOwnedAtomUniqPtr(std::unique_ptr<MarvinAtom> atom);
-  virtual void pushOwnedBondUniqPtr(std::unique_ptr<MarvinBond> bond);
-
   virtual void removeOwnedAtom(MarvinAtom *atom);
   virtual void removeOwnedBond(MarvinBond *bond);
 
@@ -587,9 +584,6 @@ class MarvinMol : public MarvinMolBase {
 
   void pushOwnedAtom(MarvinAtom *atom) override;
   void pushOwnedBond(MarvinBond *bond) override;
-
-  void pushOwnedAtomUniqPtr(std::unique_ptr<MarvinAtom> atom) override;
-  void pushOwnedBondUniqPtr(std::unique_ptr<MarvinBond> bond) override;
 
   void removeOwnedAtom(MarvinAtom *atom) override;
   void removeOwnedBond(MarvinBond *bond) override;

--- a/Code/GraphMol/MarvinParse/MarvinWriter.cpp
+++ b/Code/GraphMol/MarvinParse/MarvinWriter.cpp
@@ -1039,9 +1039,7 @@ class MarvinCMLWriter {
               PLUS_SPACE / 2.0;
         }
 
-        auto newMarvinPlus = new MarvinPlus();
-        rxn.pluses.push_back(
-            std::move(std::unique_ptr<MarvinPlus>(newMarvinPlus)));
+        auto &newMarvinPlus = rxn.pluses.emplace_back(new MarvinPlus);
 
         newMarvinPlus->id = "o" + std::to_string(++plusCount);
         newMarvinPlus->x1 = x;
@@ -1062,11 +1060,8 @@ class MarvinCMLWriter {
         auto rectCurr =
             MarvinRectangle(*rowPtr);  // composite rectangle for the row
 
+        auto &newMarvinPlus = rxn.pluses.emplace_back(new MarvinPlus);
         if (rectPrev.lowerRight.y - rectCurr.upperLeft.y > PLUS_SPACE) {
-          auto newMarvinPlus = new MarvinPlus();
-          rxn.pluses.push_back(
-              std::move(std::unique_ptr<MarvinPlus>(newMarvinPlus)));
-
           double x = (rectPrev.getCenter().x + rectCurr.getCenter().x) / 2;
           double y = (rectPrev.lowerRight.y + rectCurr.upperLeft.y) / 2;
           newMarvinPlus->id = "o" + std::to_string(++plusCount);
@@ -1076,10 +1071,6 @@ class MarvinCMLWriter {
           newMarvinPlus->y2 = y + (PLUS_SPACE);
         } else  // just put it in front of the current row
         {
-          auto newMarvinPlus = new MarvinPlus();
-          rxn.pluses.push_back(
-              std::move(std::unique_ptr<MarvinPlus>(newMarvinPlus)));
-
           double x = rowPtr->front().upperLeft.x;
           double y = rowPtr->front().getCenter().y;
           newMarvinPlus->id = "o" + std::to_string(++plusCount);
@@ -1209,23 +1200,20 @@ class MarvinCMLWriter {
     try {
       auto marvinReaction = new MarvinReaction();
       int molCount = 0, atomCount = 0, bondCount = 0, sgCount = 0;
-      for (auto mol : rxn->getReactants()) {
+      for (const auto &mol : rxn->getReactants()) {
         RWMol rwMol(*mol);
-        marvinReaction->reactants.push_back(
-            std::move(std::unique_ptr<MarvinMol>(MolToMarvinMol(
-                &rwMol, molCount, atomCount, bondCount, sgCount, confId))));
+        marvinReaction->reactants.emplace_back(MolToMarvinMol(
+            &rwMol, molCount, atomCount, bondCount, sgCount, confId));
       }
-      for (auto mol : rxn->getAgents()) {
+      for (const auto &mol : rxn->getAgents()) {
         RWMol rwMol(*mol);
-        marvinReaction->agents.push_back(
-            std::move(std::unique_ptr<MarvinMol>(MolToMarvinMol(
-                &rwMol, molCount, atomCount, bondCount, sgCount, confId))));
+        marvinReaction->agents.emplace_back(MolToMarvinMol(
+            &rwMol, molCount, atomCount, bondCount, sgCount, confId));
       }
-      for (auto mol : rxn->getProducts()) {
+      for (const auto &mol : rxn->getProducts()) {
         RWMol rwMol(*mol);
-        marvinReaction->products.push_back(
-            std::move(std::unique_ptr<MarvinMol>(MolToMarvinMol(
-                &rwMol, molCount, atomCount, bondCount, sgCount, confId))));
+        marvinReaction->products.emplace_back(MolToMarvinMol(
+            &rwMol, molCount, atomCount, bondCount, sgCount, confId));
       }
 
       // make up some pluses

--- a/Code/GraphMol/MolDraw2D/DrawMolMCHLasso.cpp
+++ b/Code/GraphMol/MolDraw2D/DrawMolMCHLasso.cpp
@@ -36,7 +36,9 @@ DrawMolMCHLasso::DrawMolMCHLasso(
                  highlight_linewidth_multipliers, confId) {}
 
 // ****************************************************************************
-void DrawMolMCHLasso::extractHighlights(double scale) { extractMCHighlights(); }
+void DrawMolMCHLasso::extractHighlights(double /* scale  */) {
+  extractMCHighlights();
+}
 
 // ****************************************************************************
 void DrawMolMCHLasso::extractMCHighlights() {
@@ -151,7 +153,7 @@ void DrawMolMCHLasso::extractAtomArcs(
     std::vector<std::unique_ptr<DrawShapeArc>> &arcs) const {
   double xradius, yradius;
   for (auto ca : colAtoms) {
-    if (ca < 0 || ca >= drawMol_->getNumAtoms()) {
+    if (ca < 0 || static_cast<unsigned int>(ca) >= drawMol_->getNumAtoms()) {
       // there's an error in the colour map
       continue;
     }
@@ -172,7 +174,8 @@ void DrawMolMCHLasso::extractBondLines(
     std::vector<std::unique_ptr<DrawShapeSimpleLine>> &lines) const {
   if (colAtoms.size() > 1) {
     for (size_t i = 0U; i < colAtoms.size() - 1; ++i) {
-      if (colAtoms[i] < 0 || colAtoms[i] >= drawMol_->getNumAtoms()) {
+      if (colAtoms[i] < 0 ||
+          static_cast<unsigned int>(colAtoms[i]) >= drawMol_->getNumAtoms()) {
         // there's an error in the colour map.
         continue;
       }
@@ -181,7 +184,8 @@ void DrawMolMCHLasso::extractBondLines(
       xradiusI += xradiusI * lassoNum * 0.5;
       auto dispI = xradiusI * 0.75;
       for (size_t j = i + 1; j < colAtoms.size(); ++j) {
-        if (colAtoms[j] < 0 || colAtoms[j] >= drawMol_->getNumAtoms()) {
+        if (colAtoms[j] < 0 ||
+            static_cast<unsigned int>(colAtoms[j]) >= drawMol_->getNumAtoms()) {
           // there's an error in the colour map.
           continue;
         }
@@ -191,7 +195,6 @@ void DrawMolMCHLasso::extractBondLines(
         auto dispJ = xradiusJ * 0.75;
         auto bond = drawMol_->getBondBetweenAtoms(colAtoms[i], colAtoms[j]);
         if (bond) {
-          const DrawColour *colToUse = &col;
           if (!mcHighlightBondMap_.empty()) {
             auto bndIt = mcHighlightBondMap_.find(bond->getIdx());
             if (bndIt == mcHighlightBondMap_.end()) {

--- a/Code/GraphMol/MolDraw2D/MolDraw2DUtils.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DUtils.cpp
@@ -164,7 +164,6 @@ void get_highlight_style_option(boost::property_tree::ptree *pt,
     return;
   }
   const auto &node = pt->get_child(pnm);
-  boost::property_tree::ptree::const_iterator itm = node.begin();
   auto styleStr = node.get_value<std::string>();
   if (styleStr == "Lasso") {
     mchs = MultiColourHighlightStyle::LASSO;

--- a/Code/GraphMol/MolDraw2D/catch_tests.cpp
+++ b/Code/GraphMol/MolDraw2D/catch_tests.cpp
@@ -8188,21 +8188,6 @@ TEST_CASE("Lasso highlights") {
     delete query;
     return hit_atoms;
   };
-  auto get_all_hit_bonds =
-      [](ROMol &mol, const std::vector<int> &hit_atoms) -> std::vector<int> {
-    std::vector<int> hit_bonds;
-    for (int i : hit_atoms) {
-      for (int j : hit_atoms) {
-        if (i > j) {
-          Bond *bnd = mol.getBondBetweenAtoms(i, j);
-          if (bnd) {
-            hit_bonds.push_back(bnd->getIdx());
-          }
-        }
-      }
-    }
-    return hit_bonds;
-  };
   auto update_colour_map = [](const std::vector<int> &ats, DrawColour col,
                               std::map<int, std::vector<DrawColour>> &ha_map) {
     for (auto h : ats) {

--- a/Code/GraphMol/MolOps.cpp
+++ b/Code/GraphMol/MolOps.cpp
@@ -1058,7 +1058,9 @@ void addHapticBond(RWMol &mol, unsigned int metalIdx,
   auto dummyAt = new QueryAtom(0);
   dummyAt->setQuery(makeAtomNullQuery());
 
-  unsigned int dummyIdx = mol.addAtom(dummyAt);
+  bool updateLabel = true;
+  bool takeOwnwership = true;
+  unsigned int dummyIdx = mol.addAtom(dummyAt, updateLabel, takeOwnwership);
   for (auto i = 0u; i < mol.getNumConformers(); ++i) {
     auto &conf = mol.getConformer(i);
     RDGeom::Point3D dummyPos;

--- a/Code/GraphMol/RascalMCES/RascalDetails.h
+++ b/Code/GraphMol/RascalMCES/RascalDetails.h
@@ -21,7 +21,7 @@ class ROMol;
 
 namespace RascalMCES {
 
-class RascalClusterOptions;
+struct RascalClusterOptions;
 
 namespace details {
 

--- a/Code/GraphMol/RascalMCES/RascalMCES.cpp
+++ b/Code/GraphMol/RascalMCES/RascalMCES.cpp
@@ -64,8 +64,8 @@ class TimedOutException : public std::exception {
 };
 
 // This is in lap_a_la_scipy.cpp and solves the linear assignment problem.
-int lap_maximize(const std::vector<std::vector<int>> &costsMat,
-                 std::vector<size_t> &a, std::vector<size_t> &b);
+int lapMaximize(const std::vector<std::vector<int>> &costsMat,
+                std::vector<size_t> &a, std::vector<size_t> &b);
 
 // Contains the information used to start off a Rascal job.
 struct RascalStartPoint {
@@ -102,14 +102,14 @@ struct RascalStartPoint {
 // Get the sorted degree sequences for the molecule, one sequence for each
 // atomic number in the molecule.  Each element in the degree sequence is
 // the degree of the atom and its index.
-void sorted_degree_seqs(
+void sortedDegreeSeqs(
     const ROMol &mol,
-    std::map<int, std::vector<std::pair<int, int>>> &deg_seqs) {
+    std::map<int, std::vector<std::pair<int, int>>> &degSeqs) {
   for (const auto &a : mol.atoms()) {
-    deg_seqs[a->getAtomicNum()].push_back(
+    degSeqs[a->getAtomicNum()].push_back(
         std::make_pair(a->getDegree(), a->getIdx()));
   }
-  for (auto &it : deg_seqs) {
+  for (auto &it : degSeqs) {
     std::sort(it.second.begin(), it.second.end(),
               [](const std::pair<int, int> &p1, const std::pair<int, int> &p2)
                   -> bool { return p1.first > p2.first; });
@@ -117,8 +117,8 @@ void sorted_degree_seqs(
 }
 
 // Make labels for the atoms - by default the atomic symbol.
-void get_atom_labels(const ROMol &mol, const RascalOptions & /* opts */,
-                     std::vector<std::string> &atomLabels) {
+void getAtomLabels(const ROMol &mol, const RascalOptions & /* opts */,
+                   std::vector<std::string> &atomLabels) {
   atomLabels.resize(mol.getNumAtoms());
   for (const auto &a : mol.atoms()) {
     std::string label = a->getSymbol();
@@ -126,8 +126,8 @@ void get_atom_labels(const ROMol &mol, const RascalOptions & /* opts */,
   }
 }
 
-int calc_cost(const std::vector<unsigned int> &atomiBLs,
-              const std::vector<unsigned int> &atomjBLs) {
+int calcCost(const std::vector<unsigned int> &atomiBLs,
+             const std::vector<unsigned int> &atomjBLs) {
   std::unordered_set<unsigned int> uniqAtomiBLs;
   for (const auto bl : atomiBLs) {
     uniqAtomiBLs.insert(bl);
@@ -163,7 +163,7 @@ void assignCosts(const std::vector<std::pair<int, int>> &atomDegrees1,
       for (const auto b : mol2.atomBonds(atomj)) {
         atomjBLs.push_back(bondLabels2[b->getIdx()]);
       }
-      costsMat[i][j] = calc_cost(atomiBLs, atomjBLs);
+      costsMat[i][j] = calcCost(atomiBLs, atomjBLs);
     }
   }
 }
@@ -185,7 +185,7 @@ int getAssignmentScore(const std::vector<std::pair<int, int>> &atomDegrees1,
                         unassignedValue);
   std::vector<size_t> b(std::min(atomDegrees1.size(), atomDegrees2.size()),
                         unassignedValue);
-  int retVal = lap_maximize(costsMat, a, b);
+  int retVal = lapMaximize(costsMat, a, b);
   if (retVal < 0) {
     // no solution for the LAP was possible.
     return 0;
@@ -202,8 +202,8 @@ namespace details {
 double tier1Sim(const ROMol &mol1, const ROMol &mol2,
                 std::map<int, std::vector<std::pair<int, int>>> &degSeqs1,
                 std::map<int, std::vector<std::pair<int, int>>> &degSeqs2) {
-  sorted_degree_seqs(mol1, degSeqs1);
-  sorted_degree_seqs(mol2, degSeqs2);
+  sortedDegreeSeqs(mol1, degSeqs1);
+  sortedDegreeSeqs(mol2, degSeqs2);
   int vg1g2 = 0;
   int eg1g2 = 0;
   for (const auto &it1 : degSeqs1) {
@@ -250,7 +250,7 @@ double tier2Sim(const ROMol &mol1, const ROMol &mol2,
 void getBondLabels(const ROMol &mol, const RascalOptions &opts,
                    std::vector<std::string> &bondLabels) {
   std::vector<std::string> atomLabels;
-  get_atom_labels(mol, opts, atomLabels);
+  getAtomLabels(mol, opts, atomLabels);
   bondLabels = std::vector<std::string>(mol.getNumBonds());
   for (const auto &b : mol.bonds()) {
     if (b->getBeginAtom()->getAtomicNum() < b->getEndAtom()->getAtomicNum()) {
@@ -365,8 +365,8 @@ void extractRings(const ROMol &mol,
     for (auto a : molAtomRings[i]) {
       atomsInRing.set(a);
     }
-    for (auto ring_bond_idx : molBondRings[i]) {
-      auto ringBond = ringMol->getBondWithIdx(ring_bond_idx);
+    for (auto ringBondIdx : molBondRings[i]) {
+      auto ringBond = ringMol->getBondWithIdx(ringBondIdx);
       ringBond->setProp<int>("ORIG_INDEX", ringBond->getIdx());
     }
     ringMol->beginBatchEdit();
@@ -515,8 +515,8 @@ unsigned int calcLowerBound(const ROMol &mol1, const ROMol &mol2,
     }
   }
   int deltaVg1 = 0;
-  for (auto mol1_atno : mol1AtNos) {
-    if (!mol2AtNos[mol1_atno]) {
+  for (auto mol1AtNo : mol1AtNos) {
+    if (!mol2AtNos[mol1AtNo]) {
       ++deltaVg1;
     }
   }
@@ -609,15 +609,15 @@ RWMol *makeCliqueFrags(const ROMol &mol,
                        const std::vector<unsigned int> &clique,
                        const std::vector<std::pair<int, int>> &vtxPairs,
                        int pairNum) {
-  auto *mol_frags = new RWMol(mol);
+  auto *molFrags = new RWMol(mol);
   boost::dynamic_bitset<> aInClique(mol.getNumAtoms());
   boost::dynamic_bitset<> bInClique(mol.getNumBonds());
   for (auto mem : clique) {
     const Bond *bond = nullptr;
     if (pairNum == 1) {
-      bond = mol_frags->getBondWithIdx(vtxPairs[mem].first);
+      bond = molFrags->getBondWithIdx(vtxPairs[mem].first);
     } else {
-      bond = mol_frags->getBondWithIdx(vtxPairs[mem].second);
+      bond = molFrags->getBondWithIdx(vtxPairs[mem].second);
     }
     bInClique[bond->getIdx()] = 1;
     aInClique.set(bond->getBeginAtomIdx());
@@ -625,29 +625,29 @@ RWMol *makeCliqueFrags(const ROMol &mol,
     aInClique.set(bond->getEndAtomIdx());
     bond->getEndAtom()->setProp<int>("ORIG_INDEX", bond->getEndAtomIdx());
   }
-  mol_frags->beginBatchEdit();
-  for (auto &a : mol_frags->atoms()) {
+  molFrags->beginBatchEdit();
+  for (auto &a : molFrags->atoms()) {
     if (!aInClique[a->getIdx()]) {
-      mol_frags->removeAtom(a);
+      molFrags->removeAtom(a);
     }
   }
-  for (auto &b : mol_frags->bonds()) {
+  for (auto &b : molFrags->bonds()) {
     if (!bInClique[b->getIdx()]) {
-      mol_frags->removeBond(b->getBeginAtomIdx(), b->getEndAtomIdx());
+      molFrags->removeBond(b->getBeginAtomIdx(), b->getEndAtomIdx());
     }
   }
-  mol_frags->commitBatchEdit();
-  return mol_frags;
+  molFrags->commitBatchEdit();
+  return molFrags;
 }
 
 // Calculate the shortest bond distance between the 2 fragments in the molecule.
 int minFragSeparation(const ROMol &mol, const ROMol &molFrags,
                       std::vector<int> &fragMapping, int frag1, int frag2) {
-  auto extractFragAtoms = [&](int frag_num, std::vector<int> &frag_atoms) {
+  auto extractFragAtoms = [&](int fragNum, std::vector<int> &fragAtoms) {
     for (size_t i = 0u; i < fragMapping.size(); ++i) {
-      if (fragMapping[i] == frag_num) {
-        int orig_idx = molFrags.getAtomWithIdx(i)->getProp<int>("ORIG_INDEX");
-        frag_atoms.push_back(orig_idx);
+      if (fragMapping[i] == fragNum) {
+        int origIdx = molFrags.getAtomWithIdx(i)->getProp<int>("ORIG_INDEX");
+        fragAtoms.push_back(origIdx);
       }
     }
   };
@@ -819,7 +819,7 @@ bool checkEquivalentsAllowed(const ROMol &mol) {
   return true;
 }
 
-void explore_partitions(
+void explorePartitions(
     RascalStartPoint &starter,
     const std::chrono::time_point<std::chrono::high_resolution_clock>
         &startTime,
@@ -1050,7 +1050,7 @@ std::vector<RascalResult> findMCES(RascalStartPoint &starter,
     tmpOpts.allBestMCESs = true;
   }
   try {
-    explore_partitions(starter, startTime, tmpOpts, maxCliques);
+    explorePartitions(starter, startTime, tmpOpts, maxCliques);
   } catch (TimedOutException &e) {
     std::cout << e.what() << std::endl;
     maxCliques = e.d_cliques;

--- a/Code/GraphMol/RascalMCES/RascalMCES.cpp
+++ b/Code/GraphMol/RascalMCES/RascalMCES.cpp
@@ -803,7 +803,7 @@ bool checkEquivalentsAllowed(const ROMol &mol) {
       "*~*", "*~*1~*~*~1", "*12~*~*~2~*~1", "*14~*(~*~2~3~4)~*~2~*~3~1"};
   static std::vector<std::unique_ptr<ROMol>> notStructs;
   if (notStructs.empty()) {
-    for (const auto smt : notSmarts) {
+    for (const auto &smt : notSmarts) {
       notStructs.emplace_back(SmartsToMol(smt));
     }
   }

--- a/Code/GraphMol/RascalMCES/RascalMCES.cpp
+++ b/Code/GraphMol/RascalMCES/RascalMCES.cpp
@@ -117,7 +117,7 @@ void sorted_degree_seqs(
 }
 
 // Make labels for the atoms - by default the atomic symbol.
-void get_atom_labels(const ROMol &mol, const RascalOptions &opts,
+void get_atom_labels(const ROMol &mol, const RascalOptions & /* opts */,
                      std::vector<std::string> &atomLabels) {
   atomLabels.resize(mol.getNumAtoms());
   for (const auto &a : mol.atoms()) {

--- a/Code/GraphMol/RascalMCES/RascalOptions.h
+++ b/Code/GraphMol/RascalMCES/RascalOptions.h
@@ -40,9 +40,9 @@ struct RDKIT_RASCALMCES_EXPORT RascalOptions {
   bool returnEmptyMCES = false; /* if true, if the similarity thresholds aren't
                                    matched still return a RascalResult with the
                                    tier1 and tier2 sims filled in. */
-  unsigned maxBondMatchPairs = 1000; /* Too many matching bond (vertex) pairs
-                                   can cause it to run out of memory.  This is a
-                                   reasonable default for my Mac. */
+  unsigned int maxBondMatchPairs = 1000; /* Too many matching bond (vertex)
+                                   pairs can cause it to run out of memory. This
+                                   is a reasonable default for my Mac. */
 };
 }  // namespace RascalMCES
 }  // namespace RDKit

--- a/Code/GraphMol/RascalMCES/RascalOptions.h
+++ b/Code/GraphMol/RascalMCES/RascalOptions.h
@@ -40,8 +40,8 @@ struct RDKIT_RASCALMCES_EXPORT RascalOptions {
   bool returnEmptyMCES = false; /* if true, if the similarity thresholds aren't
                                    matched still return a RascalResult with the
                                    tier1 and tier2 sims filled in. */
-  int maxBondMatchPairs = 1000; /* Too many matching bond (vertex) pairs can
-                                   cause it to run out of memory.  This is a
+  unsigned maxBondMatchPairs = 1000; /* Too many matching bond (vertex) pairs
+                                   can cause it to run out of memory.  This is a
                                    reasonable default for my Mac. */
 };
 }  // namespace RascalMCES

--- a/Code/GraphMol/RascalMCES/RascalResult.cpp
+++ b/Code/GraphMol/RascalMCES/RascalResult.cpp
@@ -632,14 +632,14 @@ int RascalResult::getMaxDeltaAtomAtomDist() const {
   return d_maxDeltaAtomAtomDist;
 }
 
-int RascalResult::getLargestFragSize() const {
+unsigned int RascalResult::getLargestFragSize() const {
   if (!d_mol1 || !d_mol2) {
     return 0;
   }
   if (d_largestFragSize == -1) {
     d_largestFragSize = calcLargestFragSize();
   }
-  return d_largestFragSize;
+  return static_cast<unsigned int>(d_largestFragSize);
 }
 
 std::string RascalResult::getSmarts() const {

--- a/Code/GraphMol/RascalMCES/RascalResult.h
+++ b/Code/GraphMol/RascalMCES/RascalResult.h
@@ -88,7 +88,7 @@ class RDKIT_RASCALMCES_EXPORT RascalResult {
 
   // returns the number of atoms in the largest contiguous fragment
   // in the MCES.
-  int getLargestFragSize() const;
+  unsigned int getLargestFragSize() const;
 
   std::string getSmarts() const;
   const std::shared_ptr<ROMol> getMcesMol() const;

--- a/Code/GraphMol/RascalMCES/lap_a_la_scipy.cpp
+++ b/Code/GraphMol/RascalMCES/lap_a_la_scipy.cpp
@@ -57,7 +57,7 @@ Author: PM Larsen
 namespace RDKit {
 namespace RascalMCES {
 template <typename T>
-std::vector<size_t> argsort_iter(const std::vector<T> &v) {
+std::vector<size_t> argsortIter(const std::vector<T> &v) {
   std::vector<size_t> index(v.size());
   std::iota(index.begin(), index.end(), 0);
   std::sort(index.begin(), index.end(),
@@ -65,18 +65,18 @@ std::vector<size_t> argsort_iter(const std::vector<T> &v) {
   return index;
 }
 
-static int augmenting_path(size_t nc, std::vector<int> &cost,
-                           std::vector<double> &u, std::vector<double> &v,
-                           std::vector<size_t> &path,
-                           std::vector<size_t> &row4col,
-                           std::vector<double> &shortestPathCosts, size_t i,
-                           std::vector<bool> &SR, std::vector<bool> &SC,
-                           std::vector<size_t> &remaining, double *p_minVal) {
+static int augmentingPath(size_t nc, std::vector<int> &cost,
+                          std::vector<double> &u, std::vector<double> &v,
+                          std::vector<size_t> &path,
+                          std::vector<size_t> &row4col,
+                          std::vector<double> &shortestPathCosts, size_t i,
+                          std::vector<bool> &SR, std::vector<bool> &SC,
+                          std::vector<size_t> &remaining, double *p_minVal) {
   double minVal = 0;
 
   // Crouse's pseudocode uses set complements to keep track of remaining
   // nodes.  Here we use a vector, as it is more efficient in C++.
-  size_t num_remaining = nc;
+  size_t numRemaining = nc;
   for (size_t it = 0; it < nc; it++) {
     // Filling this up in reverse order ensures that the solution of a
     // constant cost matrix is the identity matrix (c.f. #11602).
@@ -98,7 +98,7 @@ static int augmenting_path(size_t nc, std::vector<int> &cost,
     double lowest = std::numeric_limits<double>::max();
     SR[i] = true;
 
-    for (size_t it = 0; it < num_remaining; it++) {
+    for (size_t it = 0; it < numRemaining; it++) {
       size_t j = remaining[it];
 
       double r = minVal + cost[i * nc + j] - u[i] - v[j];
@@ -132,15 +132,15 @@ static int augmenting_path(size_t nc, std::vector<int> &cost,
     }
 
     SC[j] = true;
-    remaining[index] = remaining[--num_remaining];
+    remaining[index] = remaining[--numRemaining];
   }
 
   *p_minVal = minVal;
   return sink;
 }
 
-int lap_maximize(const std::vector<std::vector<int>> &costsMat,
-                 std::vector<size_t> &a, std::vector<size_t> &b) {
+int lapMaximize(const std::vector<std::vector<int>> &costsMat,
+                std::vector<size_t> &a, std::vector<size_t> &b) {
   if (costsMat.empty() || costsMat.front().empty()) {
     return 0;
   }
@@ -175,8 +175,8 @@ int lap_maximize(const std::vector<std::vector<int>> &costsMat,
   // iteratively build the solution
   for (size_t curRow = 0; curRow < nr; curRow++) {
     double minVal;
-    int sink = augmenting_path(nc, cost, u, v, path, row4col, shortestPathCosts,
-                               curRow, SR, SC, remaining, &minVal);
+    int sink = augmentingPath(nc, cost, u, v, path, row4col, shortestPathCosts,
+                              curRow, SR, SC, remaining, &minVal);
     if (sink < 0) {
       return -1;
     }
@@ -209,7 +209,7 @@ int lap_maximize(const std::vector<std::vector<int>> &costsMat,
 
   if (transpose) {
     size_t i = 0;
-    for (auto v : argsort_iter(col4row)) {
+    for (auto v : argsortIter(col4row)) {
       a[i] = col4row[v];
       b[i] = v;
       i++;

--- a/Code/GraphMol/RascalMCES/mces_catch.cpp
+++ b/Code/GraphMol/RascalMCES/mces_catch.cpp
@@ -542,7 +542,7 @@ TEST_CASE("single fragment") {
     res = rascalMCES(*m1, *m2, opts);
     REQUIRE(res.front().getNumFrags() == 1);
     REQUIRE(res.front().getBondMatches().size() == std::get<3>(test));
-    REQUIRE(static_cast<unsigned>(res.front().getLargestFragSize()) ==
+    REQUIRE(res.front().getLargestFragSize() ==
             res.front().getAtomMatches().size());
     check_smarts_ok(*m1, *m2, res.front());
   }

--- a/Code/GraphMol/RascalMCES/mces_catch.cpp
+++ b/Code/GraphMol/RascalMCES/mces_catch.cpp
@@ -542,7 +542,7 @@ TEST_CASE("single fragment") {
     res = rascalMCES(*m1, *m2, opts);
     REQUIRE(res.front().getNumFrags() == 1);
     REQUIRE(res.front().getBondMatches().size() == std::get<3>(test));
-    REQUIRE(res.front().getLargestFragSize() ==
+    REQUIRE(static_cast<unsigned>(res.front().getLargestFragSize()) ==
             res.front().getAtomMatches().size());
     check_smarts_ok(*m1, *m2, res.front());
   }

--- a/Code/GraphMol/RascalMCES/mces_catch.cpp
+++ b/Code/GraphMol/RascalMCES/mces_catch.cpp
@@ -796,7 +796,11 @@ TEST_CASE("benchmarks") {
   //              << " runs\n";
   //  }
   for (size_t i = 0; i < tests.size(); ++i) {
-    REQUIRE(timings[i] < std::get<6>(tests[i]));
+    auto ref_time = std::get<6>(tests[i]);
+#ifndef NDEBUG  // allow more time for debug builds
+    ref_time *= 5;
+#endif
+    REQUIRE(timings[i] < ref_time);
   }
 }
 

--- a/Code/GraphMol/RascalMCES/mces_cluster_catch.cpp
+++ b/Code/GraphMol/RascalMCES/mces_cluster_catch.cpp
@@ -102,7 +102,7 @@ TEST_CASE("Small Butina test", "[basics]") {
   }
   RDKit::RascalMCES::RascalClusterOptions clusOpts;
   auto clusters = RDKit::RascalMCES::rascalButinaCluster(mols, clusOpts);
-  unsigned numMols = 0;
+  unsigned int numMols = 0;
   for (const auto &cl : clusters) {
     numMols += cl.size();
   }

--- a/Code/GraphMol/RascalMCES/mces_cluster_catch.cpp
+++ b/Code/GraphMol/RascalMCES/mces_cluster_catch.cpp
@@ -102,7 +102,7 @@ TEST_CASE("Small Butina test", "[basics]") {
   }
   RDKit::RascalMCES::RascalClusterOptions clusOpts;
   auto clusters = RDKit::RascalMCES::rascalButinaCluster(mols, clusOpts);
-  int numMols = 0;
+  unsigned numMols = 0;
   for (const auto &cl : clusters) {
     numMols += cl.size();
   }

--- a/Code/GraphMol/catch_chirality.cpp
+++ b/Code/GraphMol/catch_chirality.cpp
@@ -3496,7 +3496,7 @@ M  END
         "[H][C@@]12CC(=O)N1[C@@H](C(=O)O)C(C)(C)S2(=O)=O |(-2.78382,0.183015,;-1.38222,-0.351313,;-2.12923,-1.65207,;-0.828466,-2.39908,;-0.436905,-3.84707,;-0.0814577,-1.09832,;1.03095,-0.0920638,;2.49888,-0.400554,;2.96569,-1.82607,;3.50001,0.71647,;0.41769,1.27685,;1.8432,1.74365,;0.102447,2.74335,;-1.07373,1.11662,;-1.07718,2.61662,;-2.56587,1.26998,)|";
     SmilesParserParams spps;
     spps.removeHs = false;
-    auto m = SmilesToMol(smi, spps);
+    std::unique_ptr<RWMol> m{SmilesToMol(smi, spps)};
     REQUIRE(m);
     Chirality::BondWedgingParameters bwps;
     bwps.wedgeTwoBondsIfPossible = true;
@@ -3514,7 +3514,7 @@ M  END
         "[H][C@@]12CCCN1C(=O)CN1C(=O)[C@](C)(N)O[C@]12O |(-0.888297,0.626611,;-1.19852,-0.840959,;-1.94707,-2.14084,;-3.41464,-1.83061,;-3.5731,-0.339006,;-2.20347,0.272634,;-1.74154,1.69974,;-2.74648,2.81333,;-0.274666,2.01325,;0.730277,0.899655,;2.23028,0.901335,;3.11059,2.11585,;2.6954,-0.52473,;3.44685,-1.82293,;4.06503,0.0869091,;1.48286,-1.40777,;0.26835,-0.527448,;-0.0418744,-1.99502,)|";
     SmilesParserParams spps;
     spps.removeHs = false;
-    auto m = SmilesToMol(smi, spps);
+    std::unique_ptr<RWMol> m{SmilesToMol(smi, spps)};
     REQUIRE(m);
     Chirality::BondWedgingParameters bwps;
     bwps.wedgeTwoBondsIfPossible = true;

--- a/Code/GraphMol/catch_graphmol.cpp
+++ b/Code/GraphMol/catch_graphmol.cpp
@@ -3182,7 +3182,7 @@ M  END
     REQUIRE(mol);
     bool explicitOnly = false;
     bool addCoords = true;
-    RDKit::ROMol *m = MolOps::addHs(*mol, explicitOnly, addCoords);
+    std::unique_ptr<ROMol> m{MolOps::addHs(*mol, explicitOnly, addCoords)};
     REQUIRE(m->getNumAtoms() == 5);
     const auto &conf = m->getConformer();
     // Hydrogen will always be in the last position
@@ -3215,7 +3215,7 @@ M  END
     REQUIRE(mol);
     bool explicitOnly = false;
     bool addCoords = true;
-    RDKit::ROMol *m = MolOps::addHs(*mol, explicitOnly, addCoords);
+    std::unique_ptr<ROMol> m{MolOps::addHs(*mol, explicitOnly, addCoords)};
     REQUIRE(m->getNumAtoms() == 5);
     const auto &conf = m->getConformer();
     // Hydrogen will always be in the last position

--- a/Code/GraphMol/catch_organometallics.cpp
+++ b/Code/GraphMol/catch_organometallics.cpp
@@ -99,8 +99,8 @@ TEST_CASE("convert explicit dative bonds to haptic bond") {
       std::unique_ptr<ROMol> mol(MolFileToMol(pathName + td));
       REQUIRE(mol);
       auto initSmi = MolToSmiles(*mol);
-      auto mol1 = MolOps::hapticBondsToDative(*mol);
-      auto mol2 = MolOps::dativeBondsToHaptic(*mol1);
+      std::unique_ptr<ROMol> mol1{MolOps::hapticBondsToDative(*mol)};
+      std::unique_ptr<ROMol> mol2{MolOps::dativeBondsToHaptic(*mol1)};
       CHECK(initSmi == MolToSmiles(*mol2));
     }
   }

--- a/Code/RDGeneral/BoostStartInclude.h
+++ b/Code/RDGeneral/BoostStartInclude.h
@@ -69,6 +69,7 @@
 #endif
 #if (__GNUC__ > 8)
 #pragma GCC diagnostic ignored "-Wdeprecated-copy"
+#pragma GCC diagnostic ignored "-Wpessimizing-move"
 #endif
 #elif defined(__HP_cc) || defined(__HP_aCC)
 /* Hewlett-Packard C/aC++. ---------------------------------- */

--- a/Contrib/ChiralPairs/ChiralDescriptors.py
+++ b/Contrib/ChiralPairs/ChiralDescriptors.py
@@ -121,7 +121,7 @@ def determineAtomSubstituents(atomID, mol, distanceMatrix, verbose=False):
       for n in atom.GetNeighbors():
         nidx = n.GetIdx()
         for k, v in subs.items():
-          # is the neighbor in the substituent and is not inthe same shell as the current atom
+          # is the neighbor in the substituent and is not in the same shell as the current atom
           # and we haven't added the current atom already then put it in the correct substituent list
           if nidx in v and nidx not in newShell and aidx not in v:
             subs[k].append(aidx)


### PR DESCRIPTION
This causes the Linux and Mac builds to fail if any compiler warnings are raised during the build. We do this by setting the env var `CXXFLAGS="-Wall -Werror"`. This spares C code, as we don't want to fail due to warnings in thirdparty code like Inchi, Avalon or Yaehmop, and there's too many of them...

Note that different compilers/versions raise different warnings, but any supported gcc or clang version should be able to catch the major issues (plus a bunch of annoying stuff like comparing signed vs unsigned). I'm not enabling `-Werror` on windows because the MSVC compiler is way too zealous...

Besides enabling the flags, this fixes the warnings that are currently showing up in the builds, so that they don't start failing right after we merge this. And then some mem errors too.


