### PR TITLE
fix order of cleanupOrganometallics() in sanitizeMol()

### DIFF
--- a/Code/GraphMol/MolOps.cpp
+++ b/Code/GraphMol/MolOps.cpp
@@ -326,6 +326,7 @@ void cleanUpOrganometallics(RWMol &mol) {
     return;
   }
 
+  mol.updatePropertyCache(false);
   // First see if anything needs doing
   std::vector<unsigned int> ranks(mol.getNumAtoms());
   RDKit::Canon::rankMolAtoms(mol, ranks);

--- a/Code/GraphMol/MolOps.cpp
+++ b/Code/GraphMol/MolOps.cpp
@@ -465,6 +465,12 @@ void sanitizeMol(RWMol &mol, unsigned int &operationThatFailed,
     cleanUp(mol);
   }
 
+  // fix things like non-metal to metal bonds that should be dative.
+  operationThatFailed = SANITIZE_CLEANUP_ORGANOMETALLICS;
+  if (sanitizeOps & operationThatFailed) {
+    cleanUpOrganometallics(mol);
+  }
+
   // update computed properties on atoms and bonds:
   operationThatFailed = SANITIZE_PROPERTIES;
   if (sanitizeOps & operationThatFailed) {
@@ -526,12 +532,6 @@ void sanitizeMol(RWMol &mol, unsigned int &operationThatFailed,
   operationThatFailed = SANITIZE_ADJUSTHS;
   if (sanitizeOps & operationThatFailed) {
     adjustHs(mol);
-  }
-
-  // fix things like non-metal to metal bonds that should be dative.
-  operationThatFailed = SANITIZE_CLEANUP_ORGANOMETALLICS;
-  if (sanitizeOps & operationThatFailed) {
-    cleanUpOrganometallics(mol);
   }
 
   // now that everything has been cleaned up, go through and check/update the

--- a/Code/GraphMol/catch_graphmol.cpp
+++ b/Code/GraphMol/catch_graphmol.cpp
@@ -2962,6 +2962,14 @@ TEST_CASE("molecules with single bond to metal atom use dative instead") {
     RWMOL_SPTR m(RDKit::SmilesToMol(test_vals[i].first));
     TEST_ASSERT(MolToSmiles(*m) == test_vals[i].second);
   }
+  // make sure we can call cleanupOrganometallics() on non-sanitized molecules
+  for (size_t i = 0; i < test_vals.size(); ++i) {
+    INFO(test_vals[i].first);
+    bool sanitize=false;
+    RWMOL_SPTR m(RDKit::SmilesToMol(test_vals[i].first,0,sanitize));
+    MolOps::cleanUpOrganometallics(*m);
+    TEST_ASSERT(MolToSmiles(*m) == test_vals[i].second);
+  }
 }
 
 TEST_CASE(

--- a/Code/GraphMol/catch_graphmol.cpp
+++ b/Code/GraphMol/catch_graphmol.cpp
@@ -2958,12 +2958,8 @@ TEST_CASE("molecules with single bond to metal atom use dative instead") {
       {"CCC1=[O+][Cu]2([O+]=C(CC)C1)[O+]=C(CC)CC(CC)=[O+]2",
        "CCC1=[O+][Cu]2([O+]=C(CC)C1)[O+]=C(CC)CC(CC)=[O+]2"}};
   for (size_t i = 0; i < test_vals.size(); ++i) {
-    SmilesParserParams ps;
-    ps.sanitize = false;
-    RWMOL_SPTR m(RDKit::SmilesToMol(test_vals[i].first, ps));
-    // MolOps::cleanUp(*m);
-    MolOps::cleanUpOrganometallics(*m);
-    MolOps::sanitizeMol(*m);
+    INFO(test_vals[i].first);
+    RWMOL_SPTR m(RDKit::SmilesToMol(test_vals[i].first));
     TEST_ASSERT(MolToSmiles(*m) == test_vals[i].second);
   }
 }
@@ -2975,14 +2971,10 @@ TEST_CASE(
       {"F[Pt]1(F)[35Cl][Pt]([Cl]1)(F)Br", "F[Pt]1(Br)<-Cl[Pt](F)(F)<-[35Cl]1"},
   };
 
-  SmilesParserParams ps;
-  ps.sanitize = false;
   for (size_t j = 0; j < test_vals.size(); ++j) {
     std::string &smi = test_vals[j].first;
     std::string &canon_smi = test_vals[j].second;
-    RWMOL_SPTR m(RDKit::SmilesToMol(smi, ps));
-    MolOps::cleanUpOrganometallics(*m);
-    MolOps::sanitizeMol(*m);
+    RWMOL_SPTR m(RDKit::SmilesToMol(smi));
     TEST_ASSERT(MolToSmiles(*m) == canon_smi);
 
     // scramble the order and check
@@ -2991,11 +2983,12 @@ TEST_CASE(
     std::random_device rd;
     std::mt19937 g(rd());
     for (int i = 0; i < 100; ++i) {
+      SmilesParserParams ps;
+      ps.sanitize = false;
       std::unique_ptr<ROMol> mol(RDKit::SmilesToMol(smi, ps));
       std::shuffle(atomInds.begin(), atomInds.end(), g);
       std::unique_ptr<ROMol> randmol(MolOps::renumberAtoms(*mol, atomInds));
       std::unique_ptr<RWMol> rwrandmol(new RWMol(*randmol));
-      MolOps::cleanUpOrganometallics(*rwrandmol);
       MolOps::sanitizeMol(*rwrandmol);
       TEST_ASSERT(MolToSmiles(*rwrandmol) == canon_smi);
     }


### PR DESCRIPTION
We were calling `cleanupOrganometallics()` far too late in the sanitization process. This moves it up to where it belongs.