### PR TITLE
Fixes #6664

### DIFF
--- a/Code/GraphMol/FileParsers/CDXMLParser.cpp
+++ b/Code/GraphMol/FileParsers/CDXMLParser.cpp
@@ -605,12 +605,30 @@ std::vector<std::unique_ptr<RWMol>> CDXMLDataStreamToMols(
                 DetectAtomStereoChemistry(*res, &res->getConformer(confidx));
               }
 
+              // now that atom stereochem has been perceived, the wedging
+              // information is no longer needed, so we clear
+              // single bond dir flags:
+              MolOps::clearSingleBondDirFlags(*res);
+
               if (sanitize) {
                 try {
                   if (removeHs) {
+                    // Bond stereo detection must happen before H removal, or
+                    // else we might be removing stereogenic H atoms in double
+                    // bonds (e.g. imines). But before we run stereo detection,
+                    // we need to run mol cleanup so don't have trouble with
+                    // e.g. nitro groups. Sadly, this a;; means we will find
+                    // run both cleanup and ring finding twice (a fast find
+                    // rings in bond stereo detection, and another in
+                    // sanitization's SSSR symmetrization).
+                    unsigned int failedOp = 0;
+                    MolOps::sanitizeMol(*res, failedOp,
+                                        MolOps::SANITIZE_CLEANUP);
+                    MolOps::detectBondStereochemistry(*res);
                     MolOps::removeHs(*res, false, false);
                   } else {
                     MolOps::sanitizeMol(*res);
+                    MolOps::detectBondStereochemistry(*res);
                   }
                 } catch (...) {
                   BOOST_LOG(rdWarningLog)
@@ -619,15 +637,8 @@ std::vector<std::unique_ptr<RWMol>> CDXMLDataStreamToMols(
                   mols.pop_back();
                   continue;
                 }
-                // now that atom stereochem has been perceived, the wedging
-                // information is no longer needed, so we clear
-                // single bond dir flags:
-
-                ClearSingleBondDirFlags(*res);
-                MolOps::detectBondStereochemistry(*res);
                 MolOps::assignStereochemistry(*res, true, true, true);
               } else {
-                ClearSingleBondDirFlags(*res);
                 MolOps::detectBondStereochemistry(*res);
               }
             } else if (frag.first == "scheme") {  // get the reaction info

--- a/Code/GraphMol/FileParsers/Mol2FileParser.cpp
+++ b/Code/GraphMol/FileParsers/Mol2FileParser.cpp
@@ -930,8 +930,7 @@ RWMol *Mol2DataStreamToMol(std::istream *inStream, bool sanitize, bool removeHs,
     }
 
     // mol2 format does not support formal charge information, hence we need to
-    // guess it
-    // based on default and explicit valences
+    // guess it based on default and explicit valences
     guessFormalCharges(res);
   } else {
     inStream->seekg(chargeStart, std::ios::beg);
@@ -943,11 +942,10 @@ RWMol *Mol2DataStreamToMol(std::istream *inStream, bool sanitize, bool removeHs,
     }
   }
 
-  // set chirality prior to sanitisation since it happens from 3D and it's not
+  // set chirality prior to sanitization since it happens from 3D and it's not
   // possible anymore once the hydrogens are removed
   // FIX: for now this is only for the first conformer - need to be changed once
-  // we
-  // use multiconformer files
+  // we use multiconformer files
   MolOps::assignChiralTypesFrom3D(*res);
 
   if (res && sanitize) {
@@ -955,18 +953,25 @@ RWMol *Mol2DataStreamToMol(std::istream *inStream, bool sanitize, bool removeHs,
 
     try {
       if (removeHs) {
+        // Bond stereo detection must happen before H removal, or
+        // else we might be removing stereogenic H atoms in double
+        // bonds (e.g. imines). But before we run stereo detection,
+        // we need to run mol cleanup so don't have trouble with
+        // e.g. nitro groups. Sadly, this a;; means we will find
+        // run both cleanup and ring finding twice (a fast find
+        // rings in bond stereo detection, and another in
+        // sanitization's SSSR symmetrization).
+        unsigned int failedOp = 0;
+        MolOps::sanitizeMol(*res, failedOp, MolOps::SANITIZE_CLEANUP);
+        MolOps::detectBondStereochemistry(*res);
         MolOps::removeHs(*res, false, false);
       } else {
         MolOps::sanitizeMol(*res);
+        MolOps::detectBondStereochemistry(*res);
       }
 
-      // call detectBondStereochemistry after sanitization "because we need
-      // the ring information".  Also this will set the E/Z labels on the bond.
-      // Similar in spirit to what happens in MolFileParser
-      MolOps::detectBondStereochemistry(*res);
-
     } catch (MolSanitizeException &se) {
-      BOOST_LOG(rdWarningLog) << "sanitise ";
+      BOOST_LOG(rdWarningLog) << "sanitize ";
       std::string molName;
       res->getProp(common_properties::_Name, molName);
       BOOST_LOG(rdWarningLog) << molName << ": ";

--- a/Docs/Book/GettingStartedInPython.rst
+++ b/Docs/Book/GettingStartedInPython.rst
@@ -962,7 +962,7 @@ sequence numbers.
 
 .. doctest::
    
-   >>> mol = Chem.MolFromSmiles('Cl[C@H](F)NC\C=C\C')
+   >>> mol = Chem.MolFromSmiles(r'Cl[C@H](F)NC\C=C\C')
    >>> d = rdMolDraw2D.MolDraw2DCairo(250, 200) # or MolDraw2DSVG to get SVGs
    >>> mol.GetAtomWithIdx(2).SetProp('atomNote', 'foo')
    >>> mol.GetBondWithIdx(0).SetProp('bondNote', 'bar')
@@ -2727,10 +2727,12 @@ The molecules have not been sanitized, so it's a good idea to at least update th
   ...     prod.UpdatePropertyCache(strict=False)
   ...  
   >>> Chem.MolToSmiles(prods[0],True)
-  'CC(C)C(=O)N/C=C1\\C(=O)Nc2ccc3ncsc3c21'
+  '[H]/N=C(\\N)NC(=O)C(C)C'
   >>> Chem.MolToSmiles(prods[1],True)
-  'CC(C)C(=O)N/C=C1\\C(=O)Nc2ccccc21'
+  'CC(C)C(=O)N/C=C1\\C(=O)Nc2ccc3ncsc3c21'
   >>> Chem.MolToSmiles(prods[2],True)
+  'CC(C)C(=O)N/C=C1\\C(=O)Nc2ccccc21'
+  >>> Chem.MolToSmiles(prods[3],True)
   'CNC(=O)C(C)C'
 
 


### PR DESCRIPTION
The issue in #6664 is happening, basically, because we run H removal before stereo bond detection.

In H removal, the option to not remove stereogenic H is enabled by default, but since the removal is run before stereo bond detection, the imine H does not have anything that marks it as stereogenic, and is removed. So, when bond stereo is finally run, the H atom are no longer there, so that the imine double bond cannot be resolved.

The fix is to run stereo bond detection prior to H removal, but as this also causes some problems, we also need to call "cleanup" sanitization before the detection so that we charge separate some double bonds as the ones in nitro groups.