### PR TITLE
Do not trust the 2D/3D tag in ctab mol files

### DIFF
--- a/Code/GraphMol/FileParsers/MolFileParser.cpp
+++ b/Code/GraphMol/FileParsers/MolFileParser.cpp
@@ -1369,7 +1369,6 @@ void ParseAtomValue(RWMol *mol, std::string text, unsigned int line) {
               text.substr(7, text.length() - 7));
 }
 
-namespace {
 void setRGPProps(const std::string_view symb, Atom *res) {
   PRECONDITION(res, "bad atom pointer");
   // set the dummy label so that this is shown correctly
@@ -1391,8 +1390,6 @@ void lookupAtomicNumber(Atom *res, const std::string &symb,
     }
   }
 }
-
-}  // namespace
 
 Atom *ParseMolFileAtomLine(const std::string_view text, RDGeom::Point3D &pos,
                            unsigned int line, bool strictParsing) {
@@ -2442,6 +2439,37 @@ void tokenizeV3000Line(std::string_view line,
 #endif
 }
 
+bool calculate3dFlag(const RWMol &mol, const Conformer &conf,
+                     bool chiralityPossible) {
+  int marked3d = 0;
+  if (mol.getPropIfPresent(common_properties::_3DConf, marked3d)) {
+    mol.clearProp(common_properties::_3DConf);
+  }
+
+  bool nonzeroZ = hasNonZeroZCoords(conf);
+
+  if (!nonzeroZ && marked3d == 1) {
+    // If we have no Z coordinates, mark the structure 2D if we see any
+    // 2D stereo markers, or stay as 3D if
+    if (chiralityPossible) {
+      BOOST_LOG(rdWarningLog)
+          << "Warning: molecule is tagged as 3D, but all Z coords are zero and 2D stereo "
+             "markers have been found, marking the mol as 2D."
+          << std::endl;
+      return false;
+    }
+    return true;
+  } else if (marked3d == 0 && nonzeroZ) {
+    BOOST_LOG(rdWarningLog)
+        << "Warning: molecule is tagged as 2D, but at least one Z coordinate is not zero. "
+           "Marking the mol as 3D."
+        << std::endl;
+    return true;
+  }
+
+  return nonzeroZ;
+}
+
 void ParseV3000AtomBlock(std::istream *inStream, unsigned int &line,
                          unsigned int nAtoms, RWMol *mol, Conformer *conf,
                          bool strictParsing) {
@@ -2543,20 +2571,8 @@ void ParseV3000AtomBlock(std::istream *inStream, unsigned int &line,
     errout << "END ATOM line not found on line " << line;
     throw FileParseException(errout.str());
   }
-
-  bool nonzeroZ = hasNonZeroZCoords(*conf);
-  if (mol->hasProp(common_properties::_3DConf)) {
-    conf->set3D(true);
-    mol->clearProp(common_properties::_3DConf);
-    if (!nonzeroZ) {
-      BOOST_LOG(rdWarningLog)
-          << "Warning: molecule is tagged as 3D, but all Z coords are zero"
-          << std::endl;
-    }
-  } else {
-    conf->set3D(nonzeroZ);
-  }
 }
+
 void ParseV3000BondBlock(std::istream *inStream, unsigned int &line,
                          unsigned int nBonds, RWMol *mol,
                          bool &chiralityPossible) {
@@ -3168,6 +3184,8 @@ bool ParseV3000CTAB(std::istream *inStream, unsigned int &line, RWMol *mol,
     fileComplete = true;
   }
 
+  auto is3d = calculate3dFlag(*mol, *conf, chiralityPossible);
+  conf->set3D(is3d);
   mol->addConformer(conf, true);
   conf = nullptr;
 
@@ -3183,24 +3201,13 @@ bool ParseV2000CTAB(std::istream *inStream, unsigned int &line, RWMol *mol,
     conf->set3D(false);
   } else {
     ParseMolBlockAtoms(inStream, line, nAtoms, mol, conf, strictParsing);
-
-    bool nonzeroZ = hasNonZeroZCoords(*conf);
-    if (mol->hasProp(common_properties::_3DConf)) {
-      conf->set3D(true);
-      mol->clearProp(common_properties::_3DConf);
-      if (!nonzeroZ) {
-        BOOST_LOG(rdWarningLog)
-            << "Warning: molecule is tagged as 3D, but all Z coords are zero"
-            << std::endl;
-      }
-    } else {
-      conf->set3D(nonzeroZ);
-    }
   }
+  ParseMolBlockBonds(inStream, line, nBonds, mol, chiralityPossible);
+
+  auto is3d = calculate3dFlag(*mol, *conf, chiralityPossible);
+  conf->set3D(is3d);
   mol->addConformer(conf, true);
   conf = nullptr;
-
-  ParseMolBlockBonds(inStream, line, nBonds, mol, chiralityPossible);
 
   bool fileComplete =
       ParseMolBlockProperties(inStream, line, mol, strictParsing);

--- a/Code/GraphMol/FileParsers/file_parsers_catch.cpp
+++ b/Code/GraphMol/FileParsers/file_parsers_catch.cpp
@@ -6528,3 +6528,170 @@ M  END
   CHECK(mol->getAtomWithIdx(1)->getChiralTag() ==
         Atom::ChiralType::CHI_TETRAHEDRAL_CCW);
 }
+
+TEST_CASE("Calculate 2D/3D from coordinates", "[molblock]") {
+  SECTION("v2000, 2D structure marked as 3D without 2D stereo marks") {
+    const auto mol = R"CTAB(
+     RDKit          3D
+
+  4  3  0  0  0  0  0  0  0  0999 V2000
+    0.0000    0.0000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    1.2990    0.7500    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    2.5981   -0.0000    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0
+    1.2990    2.2500    0.0000 S   0  0  0  0  0  0  0  0  0  0  0  0
+  2  1  1
+  2  3  1
+  2  4  1
+M  END
+)CTAB"_ctab;
+    REQUIRE(mol);
+    REQUIRE(mol->getNumConformers() == 1);
+
+    auto conf = mol->getConformer();
+    CHECK(conf.is3D());
+
+    CHECK(mol->getAtomWithIdx(1)->getChiralTag() ==
+          Atom::ChiralType::CHI_UNSPECIFIED);
+  }
+
+  SECTION("v2000, 2D structure marked as 3D with 2D stereo marks") {
+    const auto mol = R"CTAB(
+     RDKit          3D
+
+  4  3  0  0  0  0  0  0  0  0999 V2000
+    0.0000    0.0000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    1.2990    0.7500    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    2.5981   -0.0000    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0
+    1.2990    2.2500    0.0000 S   0  0  0  0  0  0  0  0  0  0  0  0
+  2  1  1  1
+  2  3  1  0
+  2  4  1  0
+M  END
+)CTAB"_ctab;
+    REQUIRE(mol);
+    REQUIRE(mol->getNumConformers() == 1);
+
+    auto conf = mol->getConformer();
+    CHECK(!conf.is3D());
+
+    CHECK(mol->getAtomWithIdx(1)->getChiralTag() ==
+          Atom::ChiralType::CHI_TETRAHEDRAL_CCW);
+  }
+
+  SECTION("v2000, 3D structure marked as 2D") {
+    const auto mol = R"CTAB(
+     RDKit          2D
+
+  4  3  0  0  0  0  0  0  0  0999 V2000
+   -0.0017    0.0135    0.0027 C   0  0  0  0  0  0  0  0  0  0  0  0
+    0.8238    0.0150    0.0040 C   0  0  0  0  0  0  0  0  0  0  0  0
+    1.0881   -0.3228    0.6346 O   0  0  0  0  0  0  0  0  0  0  0  0
+    1.1772    0.9156   -0.0296 S   0  0  0  0  0  0  0  0  0  0  0  0
+  2  1  1
+  2  3  1
+  2  4  1
+M  END
+)CTAB"_ctab;
+    REQUIRE(mol);
+    REQUIRE(mol->getNumConformers() == 1);
+
+    auto conf = mol->getConformer();
+    CHECK(conf.is3D());
+
+    CHECK(mol->getAtomWithIdx(1)->getChiralTag() ==
+          Atom::ChiralType::CHI_TETRAHEDRAL_CCW);
+  }
+
+  SECTION("v3000, 2D structure marked as 3D without 2D stereo marks") {
+    const auto mol = R"CTAB(
+     RDKit          3D
+
+  0  0  0     0  0            999 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 4 3 0 0 0
+M  V30 BEGIN ATOM
+M  V30 1 C 1.0912 0.945 0 0
+M  V30 2 C 2.4248 1.715 0 0
+M  V30 3 O 3.7586 0.945 0 0
+M  V30 4 S 2.4248 3.255 0 0
+M  V30 END ATOM
+M  V30 BEGIN BOND
+M  V30 1 1 2 1
+M  V30 2 1 2 3
+M  V30 3 1 2 4
+M  V30 END BOND
+M  V30 END CTAB
+M  END
+)CTAB"_ctab;
+    REQUIRE(mol);
+    REQUIRE(mol->getNumConformers() == 1);
+
+    auto conf = mol->getConformer();
+    CHECK(conf.is3D());
+
+    CHECK(mol->getAtomWithIdx(1)->getChiralTag() ==
+          Atom::ChiralType::CHI_UNSPECIFIED);
+  }
+
+  SECTION("v3000, 2D structure marked as 3D with 2D stereo marks") {
+    const auto mol = R"CTAB(
+     RDKit          3D
+
+  0  0  0     0  0            999 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 4 3 0 0 0
+M  V30 BEGIN ATOM
+M  V30 1 C 1.0912 0.945 0 0
+M  V30 2 C 2.4248 1.715 0 0 CFG=2
+M  V30 3 O 3.7586 0.945 0 0
+M  V30 4 S 2.4248 3.255 0 0
+M  V30 END ATOM
+M  V30 BEGIN BOND
+M  V30 1 1 2 1 CFG=1
+M  V30 2 1 2 3
+M  V30 3 1 2 4
+M  V30 END BOND
+M  V30 END CTAB
+M  END
+)CTAB"_ctab;
+    REQUIRE(mol);
+    REQUIRE(mol->getNumConformers() == 1);
+
+    auto conf = mol->getConformer();
+    CHECK(!conf.is3D());
+
+    CHECK(mol->getAtomWithIdx(1)->getChiralTag() ==
+          Atom::ChiralType::CHI_TETRAHEDRAL_CCW);
+  }
+
+  SECTION("v3000, 3D structure marked as 2D") {
+    const auto mol = R"CTAB(
+     RDKit          2D
+
+  0  0  0     0  0            999 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 4 3 0 0 0
+M  V30 BEGIN ATOM
+M  V30 1 C -0.0033 0.0252 0.0052 0
+M  V30 2 C 1.5379 0.028 0.0075 0 CFG=2
+M  V30 3 O 2.0313 -0.6027 1.1846 0
+M  V30 4 S 2.1975 1.7092 -0.0554 0
+M  V30 END ATOM
+M  V30 BEGIN BOND
+M  V30 1 1 2 1
+M  V30 2 1 2 3
+M  V30 3 1 2 4
+M  V30 END BOND
+M  V30 END CTAB
+M  END
+)CTAB"_ctab;
+    REQUIRE(mol);
+    REQUIRE(mol->getNumConformers() == 1);
+
+    auto conf = mol->getConformer();
+    CHECK(conf.is3D());
+
+    CHECK(mol->getAtomWithIdx(1)->getChiralTag() ==
+          Atom::ChiralType::CHI_TETRAHEDRAL_CCW);
+  }
+}


### PR DESCRIPTION
Sometimes, mol files may have an incorrect 2D/3D tag. RDKit's current behavior is to always honor a "3D" tag, but check the Z coordinate and eventually override the tag if it is "2D".

This PR changes this behavior to distrust the tag, and always assign the conformer dimensionality flag depending on the Z coordinates and the chirality marks on the input.

Basically, the new behavior would be to honor what we see in the Z coordinates, with the exception of all-zero coordinate mols, where we also check the existence of 2D stereo marks (i.e., bond directions) to decide whether the structure should be marked 2D (so that we honor the stereo marks) or 3D (so that `assignStereochemistryFrom3D()` can be used if changes are made to the mol).