### PR TITLE
Add trans layout for double bonds in rings

### DIFF
--- a/Code/GraphMol/Depictor/DepictUtils.cpp
+++ b/Code/GraphMol/Depictor/DepictUtils.cpp
@@ -25,7 +25,7 @@ unsigned int MAX_COLL_ITERS = 15;
 double HETEROATOM_COLL_SCALE = 1.3;
 unsigned int NUM_BONDS_FLIPS = 3;
 
-RDGeom::INT_POINT2D_MAP embedRing(const RDKit::INT_VECT &ring, const RDKit::INT_VECT &transRingAtoms) {
+RDGeom::INT_POINT2D_MAP embedRing(const RDKit::INT_VECT &ring) {
   // The process here is very straight forward
   // we take the center of the ring to lies at the origin put the first
   // point at the origin and then sweep
@@ -56,23 +56,6 @@ RDGeom::INT_POINT2D_MAP embedRing(const RDKit::INT_VECT &ring, const RDKit::INT_
     res[ring[i]] = loc;
   }
 
-  // Mirror one atom in each trans bond across the line defined by its two
-  // neighbors. This bumps it into the ring
-  for (auto idx: transRingAtoms) {
-    size_t offset = std::find(ring.begin(), ring.end(), idx) - ring.begin();
-    int left = ring[(offset + ring.size() - 1) % ring.size()];
-    int right = ring[(offset + 1) % ring.size()];
-
-    const auto last = res[left];
-    const auto ref = res[right];
-    const auto interest = res[idx];
-    const auto d = last - ref;
-    double a = (d.x * d.x - d.y * d.y) / d.dotProduct(d);
-    double b = 2 * d.x * d.y / d.dotProduct(d);
-    double x = a * (interest.x - ref.x) + b * (interest.y - ref.y) + ref.x;
-    double y = b * (interest.x - ref.x) - a * (interest.y - ref.y) + ref.y;
-    res[idx] = RDGeom::Point2D(x, y);
-  }
 
   return res;
 }

--- a/Code/GraphMol/Depictor/DepictUtils.cpp
+++ b/Code/GraphMol/Depictor/DepictUtils.cpp
@@ -25,7 +25,7 @@ unsigned int MAX_COLL_ITERS = 15;
 double HETEROATOM_COLL_SCALE = 1.3;
 unsigned int NUM_BONDS_FLIPS = 3;
 
-RDGeom::INT_POINT2D_MAP embedRing(const RDKit::INT_VECT &ring) {
+RDGeom::INT_POINT2D_MAP embedRing(const RDKit::INT_VECT &ring, const RDKit::INT_VECT &transRingAtoms) {
   // The process here is very straight forward
   // we take the center of the ring to lies at the origin put the first
   // point at the origin and then sweep
@@ -55,6 +55,25 @@ RDGeom::INT_POINT2D_MAP embedRing(const RDKit::INT_VECT &ring) {
     RDGeom::Point2D loc(x, y);
     res[ring[i]] = loc;
   }
+
+  // Mirror one atom in each trans bond across the line defined by its two
+  // neighbors. This bumps it into the ring
+  for (auto idx: transRingAtoms) {
+    size_t offset = std::find(ring.begin(), ring.end(), idx) - ring.begin();
+    int left = ring[(offset + ring.size() - 1) % ring.size()];
+    int right = ring[(offset + 1) % ring.size()];
+
+    const auto last = res[left];
+    const auto ref = res[right];
+    const auto interest = res[idx];
+    const auto d = last - ref;
+    double a = (d.x * d.x - d.y * d.y) / d.dotProduct(d);
+    double b = 2 * d.x * d.y / d.dotProduct(d);
+    double x = a * (interest.x - ref.x) + b * (interest.y - ref.y) + ref.x;
+    double y = b * (interest.x - ref.x) - a * (interest.y - ref.y) + ref.y;
+    res[idx] = RDGeom::Point2D(x, y);
+  }
+
   return res;
 }
 

--- a/Code/GraphMol/Depictor/DepictUtils.h
+++ b/Code/GraphMol/Depictor/DepictUtils.h
@@ -68,8 +68,7 @@ typedef std::list<PAIR_D_I_I> LIST_PAIR_DII;
 
   where A is the angle between a and b
  */
-RDKIT_DEPICTOR_EXPORT RDGeom::INT_POINT2D_MAP embedRing(
-    const RDKit::INT_VECT &ring, const RDKit::INT_VECT &transRingAtoms);
+RDKIT_DEPICTOR_EXPORT RDGeom::INT_POINT2D_MAP embedRing(const RDKit::INT_VECT &ring);
 
 RDKIT_DEPICTOR_EXPORT void transformPoints(RDGeom::INT_POINT2D_MAP &nringCor,
                                            const RDGeom::Transform2D &trans);

--- a/Code/GraphMol/Depictor/DepictUtils.h
+++ b/Code/GraphMol/Depictor/DepictUtils.h
@@ -69,7 +69,7 @@ typedef std::list<PAIR_D_I_I> LIST_PAIR_DII;
   where A is the angle between a and b
  */
 RDKIT_DEPICTOR_EXPORT RDGeom::INT_POINT2D_MAP embedRing(
-    const RDKit::INT_VECT &ring);
+    const RDKit::INT_VECT &ring, const RDKit::INT_VECT &transRingAtoms);
 
 RDKIT_DEPICTOR_EXPORT void transformPoints(RDGeom::INT_POINT2D_MAP &nringCor,
                                            const RDGeom::Transform2D &trans);

--- a/Code/GraphMol/Depictor/EmbeddedFrag.cpp
+++ b/Code/GraphMol/Depictor/EmbeddedFrag.cpp
@@ -442,7 +442,7 @@ static RDKit::INT_VECT findTransRingAtoms(const RDKit::ROMol& mol, const RDKit::
     }
     const auto leftIsIn = std::find(ring.begin(), ring.end(), neighbors[0]) != ring.end();
     const auto rightIsIn = std::find(ring.begin(), ring.end(), neighbors[1]) != ring.end();
-    if (stype == RDKit::Bond::STEREOTRANS or stype == RDKit::Bond::STEREOE) {
+    if (stype == RDKit::Bond::STEREOTRANS || stype == RDKit::Bond::STEREOE) {
       if (leftIsIn == rightIsIn) {
         // trans, both neighbors in the ring (or both out)
         res.push_back(atom1);

--- a/Code/GraphMol/Depictor/EmbeddedFrag.cpp
+++ b/Code/GraphMol/Depictor/EmbeddedFrag.cpp
@@ -420,40 +420,60 @@ bool EmbeddedFrag::matchToTemplate(const RDKit::INT_VECT &ringSystemAtoms,
 }
 
 // find any atoms in the ring that are in trans double bonds
-static RDKit::INT_VECT findTransRingAtoms(const RDKit::ROMol& mol, const RDKit::INT_VECT& ring)
+// and mirror them into the ring
+static void mirrorTransRingAtoms(const RDKit::ROMol& mol, const RDKit::INT_VECT& ring, RDGeom::INT_POINT2D_MAP& coords)
 {
-  RDKit::INT_VECT res;
+  // a nice place for C++23 generator coroutines...
+  RDKit::INT_VECT transRingAtoms;
   for (size_t i=0; i<ring.size(); ++i) {
     const auto atom1 = ring[i];
     const auto atom2 = ring[(i + 1) % ring.size()];
-    const auto b = mol.getBondBetweenAtoms(atom1, atom2);
-    if (b->getBondType() != RDKit::Bond::DOUBLE) {
+    const auto bond = mol.getBondBetweenAtoms(atom1, atom2);
+    if (bond->getBondType() != RDKit::Bond::DOUBLE) {
       continue;
     }
-    const auto stype = b->getStereo();
+    const auto stype = bond->getStereo();
     if (stype <= RDKit::Bond::STEREOANY) {
       continue;
     }
 
     // We care about bonds that are trans with respect to this ring
-    const auto& neighbors = b->getStereoAtoms();
+    const auto& neighbors = bond->getStereoAtoms();
     if (neighbors.size() != 2) {
       continue;
     }
     const auto leftIsIn = std::find(ring.begin(), ring.end(), neighbors[0]) != ring.end();
     const auto rightIsIn = std::find(ring.begin(), ring.end(), neighbors[1]) != ring.end();
+    bool isTrans = false;
     if (stype == RDKit::Bond::STEREOTRANS || stype == RDKit::Bond::STEREOE) {
       if (leftIsIn == rightIsIn) {
         // trans, both neighbors in the ring (or both out)
-        res.push_back(atom1);
+        isTrans = true;
       }
     } else if (leftIsIn != rightIsIn) {
       // cis, but one of the neighbors is outside the ring
-      res.push_back(atom1);
+      isTrans = true;
     }
-  }
-  return res;
+    if (!isTrans) {
+      continue;
+    }
 
+
+    // Mirror one atom in each trans bond across the line defined by its two
+    // neighbors. This bumps it into the ring
+    const auto left = ring[(i + ring.size() - 1) % ring.size()];
+    const auto right = atom2;
+
+    const auto last = coords[left];
+    const auto ref = coords[right];
+    const auto interest = coords[atom1];
+    const auto d = last - ref;
+    const double a = (d.x * d.x - d.y * d.y) / d.dotProduct(d);
+    const double b = 2 * d.x * d.y / d.dotProduct(d);
+    const double x = a * (interest.x - ref.x) + b * (interest.y - ref.y) + ref.x;
+    const double y = b * (interest.x - ref.x) - a * (interest.y - ref.y) + ref.y;
+    coords[atom1] = RDGeom::Point2D(x, y);
+  }
 }
 
 //
@@ -488,8 +508,9 @@ void EmbeddedFrag::embedFusedRings(const RDKit::VECT_INT_VECT &fusedRings,
   auto firstRingId = pickFirstRingToEmbed(*dp_mol, fusedRings);
 
   for (const auto &ring : fusedRings) {
-    const auto transRingAtoms = findTransRingAtoms(*dp_mol, ring);
-    coords.push_back(embedRing(ring, transRingAtoms));
+    auto ring_coords = embedRing(ring);
+    mirrorTransRingAtoms(*dp_mol, ring, ring_coords);
+    coords.push_back(ring_coords);
   }
 
   this->initFromRingCoords(fusedRings[firstRingId], coords[firstRingId]);


### PR DESCRIPTION
If there is a trans double bond in a ring, it's important to add a trans 2d depiction! This is important for visualization, but it is also important for chemical accuracy. SDF uses the 2D coordinates to discern bond stereochemistry, and some 3D embedding techniques may start from 2D.

Without this commit, trans double bonds in rings invert on roundtrip through SDF.

Here's a very simple assertion that fails before this commit and passes after:

    smi = "C1=C/CCCCCCCCCCCC/1"
    assert smi == Chem.MolToSmiles(Chem.MolFromMolBlock(Chem.MolToMolBlock(Chem.MolFromSmiles(smi))))


<img width="491" alt="trans_bonds_in_rings" src="https://github.com/rdkit/rdkit/assets/3013277/e7e8b6b8-560e-41ea-8f56-c5c51ca6e7ce">


And here's what a couple odd molecules look like now:

<img width="634" alt="more exciting examples" src="https://github.com/rdkit/rdkit/assets/3013277/7c28cf2d-6417-4e1e-88be-92840d473a81">

