### PR TITLE
Add 2022 and 2023 UGM links to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@
   * [2019 UGM](https://github.com/rdkit/UGM_2019)
   * [2020 UGM](https://github.com/rdkit/UGM_2020)
   * [2021 UGM](https://github.com/rdkit/UGM_2021)
+  * [2022 UGM](https://github.com/rdkit/UGM_2022)
+  * [2023 UGM](https://github.com/rdkit/UGM_2023)
 
 ## Documentation
 Available on the [RDKit page](https://www.rdkit.org/docs/index.html)


### PR DESCRIPTION
This PR updates the README to include links to the 2022 and 2023 UGMs' respective repostories