### PR TITLE
WIP Multi conformer MolFileParser

### DIFF
--- a/Code/GraphMol/FileParsers/MolFileParser.cpp
+++ b/Code/GraphMol/FileParsers/MolFileParser.cpp
@@ -3517,23 +3517,28 @@ RWMol *MolDataStreamToMol(std::istream *inStream, unsigned int &line,
 RWMol *MolDataStreamToMol(std::istream &inStream, unsigned int &line,
                           bool sanitize, bool removeHs, bool strictParsing,
                           bool multiConformer) {
+  RWMol *m;
   if (!multiConformer) {
-    return MolDataStreamToMol(&inStream, line, sanitize, removeHs,
+    m = MolDataStreamToMol(&inStream, line, sanitize, removeHs,
                               strictParsing);
   }
   else {
-    RWMol *m1 = MolDataStreamToMol(&inStream, line, sanitize, removeHs, strictParsing);
+    m = MolDataStreamToMol(&inStream, line, sanitize, removeHs, strictParsing);
     while (true) {
       RWMol *m2 = MolDataStreamToMol(&inStream, line, sanitize, removeHs, strictParsing);
-      if (!m2) {
+      if (m2 == nullptr) {
         break;
       }
-      // todo: check m1 and m2 are "the same"
+      // check m1 and m2 are "the same", this is only check size of mol
+      if (m->getNumAtoms() != m2->getNumAtoms()) {
+        break;
+      }
 
       auto c = m2->getConformer();
-      m1->addConformer(&c, true);
+      m->addConformer(&c, true);
     }
   }
+  return m;
 }
 //------------------------------------------------
 //


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! 
-->
#### Reference Issue
Fixes #1125 


#### What does this implement/fix? Explain your changes.

Reads multiple conformers from an SDF.

#### Any other comments?

This is inefficient as it rereads the molecule each time, but this makes it a few line change rather than reimplementing a different code path that only reads conformers (but also reads enough to determine if it is the "same molecule").

There's a TODO about defining "equality" between different blocks in the mol.  The laziest approach is just checking n_atoms, working upwards from there there's a sliding scale of different equalities.