### PR TITLE
Use the connect-the-dots algorithm by default in DetermineBonds

### DIFF
--- a/Code/GraphMol/DetermineBonds/CMakeLists.txt
+++ b/Code/GraphMol/DetermineBonds/CMakeLists.txt
@@ -1,6 +1,6 @@
 
 rdkit_library(DetermineBonds DetermineBonds.cpp
-              LINK_LIBRARIES EHTLib GraphMol RDGeneral)
+              LINK_LIBRARIES EHTLib FileParsers GraphMol RDGeneral)
 
 target_compile_definitions(DetermineBonds PRIVATE RDKIT_DETERMINEBONDS_BUILD)
 

--- a/Code/GraphMol/DetermineBonds/DetermineBonds.cpp
+++ b/Code/GraphMol/DetermineBonds/DetermineBonds.cpp
@@ -22,6 +22,7 @@
 #include <boost/graph/max_cardinality_matching.hpp>
 #include <boost/multiprecision/cpp_int.hpp>
 #include <RDGeneral/BoostEndInclude.h>
+#include <GraphMol/FileParsers/ProximityBonds.h>
 
 typedef boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS>
     Graph;
@@ -159,7 +160,7 @@ void connectivityVdW(RWMol &mol, double covFactor) {
 }  // connectivityVdW()
 
 void determineConnectivity(RWMol &mol, bool useHueckel, int charge,
-                           double covFactor) {
+                           double covFactor, bool useVdw) {
   auto numAtoms = mol.getNumAtoms();
   for (unsigned int i = 0; i < numAtoms; i++) {
     for (unsigned int j = i + 1; j < numAtoms; j++) {
@@ -170,8 +171,10 @@ void determineConnectivity(RWMol &mol, bool useHueckel, int charge,
   }
   if (useHueckel) {
     connectivityHueckel(mol, charge);
-  } else {
+  } else if (useVdw) {
     connectivityVdW(mol, covFactor);
+  } else {
+    ConnectTheDots(&mol, ctdIGNORE_H_H_CONTACTS);
   }
 }  // determineConnectivity()
 
@@ -442,11 +445,11 @@ void determineBondOrders(RWMol &mol, int charge, bool allowChargedFragments,
 
 void determineBonds(RWMol &mol, bool useHueckel, int charge, double covFactor,
                     bool allowChargedFragments, bool embedChiral,
-                    bool useAtomMap) {
+                    bool useAtomMap, bool useVdw) {
   if (mol.getNumAtoms() <= 1) {
     return;
   }
-  determineConnectivity(mol, useHueckel, charge, covFactor);
+  determineConnectivity(mol, useHueckel, charge, covFactor, useVdw);
   determineBondOrders(mol, charge, allowChargedFragments, embedChiral,
                       useAtomMap);
 }  // determineBonds()

--- a/Code/GraphMol/DetermineBonds/DetermineBonds.h
+++ b/Code/GraphMol/DetermineBonds/DetermineBonds.h
@@ -35,7 +35,7 @@ RDKIT_DETERMINEBONDS_EXPORT void determineConnectivity(RWMol &mol,
                                                        bool useHueckel = false,
                                                        int charge = 0,
                                                        double covFactor = 1.3,
-                                                       bool useVdw = true);
+                                                       bool useVdw = false);
 
 // ! assigns bond ordering to a molecule that has atomic connectivity defined;
 // it is recommended to sanitize the molecule after calling this function if
@@ -90,7 +90,7 @@ RDKIT_DETERMINEBONDS_EXPORT void determineBondOrders(
 RDKIT_DETERMINEBONDS_EXPORT void determineBonds(
     RWMol &mol, bool useHueckel = false, int charge = 0, double covFactor = 1.3,
     bool allowChargedFragments = true, bool embedChiral = true,
-    bool useAtomMap = false, bool useVdw = true);
+    bool useAtomMap = false, bool useVdw = false);
 
 }  // namespace RDKit
 

--- a/Code/GraphMol/DetermineBonds/DetermineBonds.h
+++ b/Code/GraphMol/DetermineBonds/DetermineBonds.h
@@ -22,16 +22,20 @@ namespace RDKit {
 
    \param mol is the molecule of interest; it must have a 3D conformer
    \param useHueckel (optional) if this is  \c true, extended Hueckel theory
-   will be used to determine connectivity rather than the van der Waals method
+   will be used to determine connectivity rather than the van der Waals or
+   connect-the-dots method
    \param charge (optional) the charge of the molecule; it must be provided if
    the Hueckel method is used and charge is non-zero
    \param covFactor (optional) the factor with which to multiply each covalent
    radius if the van der Waals method is used
+   \param useVdw (optional) if this is  \c false, the connect-the-dots method
+    will be used instead of the van der Waals method
  */
 RDKIT_DETERMINEBONDS_EXPORT void determineConnectivity(RWMol &mol,
                                                        bool useHueckel = false,
                                                        int charge = 0,
-                                                       double covFactor = 1.3);
+                                                       double covFactor = 1.3,
+                                                       bool useVdw = true);
 
 // ! assigns bond ordering to a molecule that has atomic connectivity defined;
 // it is recommended to sanitize the molecule after calling this function if
@@ -66,7 +70,8 @@ RDKIT_DETERMINEBONDS_EXPORT void determineBondOrders(
 
    \param mol is the molecule of interest; it must have a 3D conformer
    \param useHueckel (optional) if this is  \c true, extended Hueckel theory
-   will be used to determine connectivity rather than the van der Waals method
+   will be used to determine connectivity rather than the van der Waals or
+   connect-the-dots method
    \param charge (optional) the charge of the molecule; it must be provided if
    charge is non-zero
    \param covFactor (optional) the factor with which to multiply each covalent
@@ -79,11 +84,13 @@ RDKIT_DETERMINEBONDS_EXPORT void determineBondOrders(
    true
    \param useAtomMap (optional) if this is \c true, an atom map will be created
    for the molecule
+   \param useVdw (optional) if this is  \c false, the connect-the-dots method
+    will be used instead of the van der Waals method
  */
 RDKIT_DETERMINEBONDS_EXPORT void determineBonds(
     RWMol &mol, bool useHueckel = false, int charge = 0, double covFactor = 1.3,
     bool allowChargedFragments = true, bool embedChiral = true,
-    bool useAtomMap = false);
+    bool useAtomMap = false, bool useVdw = true);
 
 }  // namespace RDKit
 

--- a/Code/GraphMol/DetermineBonds/Wrap/rdDetermineBonds.cpp
+++ b/Code/GraphMol/DetermineBonds/Wrap/rdDetermineBonds.cpp
@@ -19,9 +19,9 @@ using namespace RDKit;
 
 namespace {
 void determineConnectivityHelper(ROMol &mol, bool useHueckel, int charge,
-                                 double covFactor) {
+                                 double covFactor, bool useVdw) {
   auto &wmol = static_cast<RWMol &>(mol);
-  determineConnectivity(wmol, useHueckel, charge, covFactor);
+  determineConnectivity(wmol, useHueckel, charge, covFactor, useVdw);
 }
 void determineBondOrdersHelper(ROMol &mol, int charge,
                                bool allowChargedFragments, bool embedChiral,
@@ -32,10 +32,10 @@ void determineBondOrdersHelper(ROMol &mol, int charge,
 }
 void determineBondsHelper(ROMol &mol, bool useHueckel, int charge,
                           double covFactor, bool allowChargedFragments,
-                          bool embedChiral, bool useAtomMap) {
+                          bool embedChiral, bool useAtomMap, bool useVdw) {
   auto &wmol = static_cast<RWMol &>(mol);
   determineBonds(wmol, useHueckel, charge, covFactor, allowChargedFragments,
-                 embedChiral, useAtomMap);
+                 embedChiral, useAtomMap, useVdw);
 }
 }  // namespace
 
@@ -51,15 +51,19 @@ disregarding pre-existing bonds
 Args:
    mol : the molecule of interest; it must have a 3D conformer
    useHueckel : (optional) if this is  \c true, extended Hueckel theory
-       will be used to determine connectivity rather than the van der Waals method
+       will be used to determine connectivity rather than the van der Waals 
+       or connect-the-dots methods
    charge : (optional) the charge of the molecule; it must be provided if
        the Hueckel method is used and charge is non-zero
    covFactor : (optional) the factor with which to multiply each covalent
        radius if the van der Waals method is used
+   useVdw: (optional) if this is false, the connect-the-dots method
+       will be used instead of the van der Waals method
 )DOC";
   python::def("DetermineConnectivity", &determineConnectivityHelper,
               (python::arg("mol"), python::arg("useHueckel") = false,
-               python::arg("charge") = 0, python::arg("covFactor") = 1.3),
+               python::arg("charge") = 0, python::arg("covFactor") = 1.3,
+               python::arg("useVdw") = true),
               docs.c_str());
 
   docs =
@@ -92,8 +96,9 @@ disregarding pre-existing bonds
 
 Args:
    mol : the molecule of interest; it must have a 3D conformer
-   useHueckel : (optional) if this is  \c true, extended Hueckel theory
-       will be used to determine connectivity rather than the van der Waals method
+   useHueckel : (optional) if this is true, extended Hueckel theory
+       will be used to determine connectivity rather than the van der Waals 
+       or connect-the-dots methods
    charge : (optional) the charge of the molecule; it must be provided if
        the Hueckel method is used and charge is non-zero
    covFactor : (optional) the factor with which to multiply each covalent
@@ -106,12 +111,15 @@ Args:
       sanitizeMol() when this is true
    useAtomMap : (optional) if this is true, an atom map will be created for the 
       molecule
+   useVdw: (optional) if this is false, the connect-the-dots method
+       will be used instead of the van der Waals method
 )DOC";
   python::def(
       "DetermineBonds", &determineBondsHelper,
       (python::arg("mol"), python::arg("useHueckel") = false,
        python::arg("charge") = 0, python::arg("covFactor") = 1.3,
        python ::arg("allowChargedFragments") = true,
-       python::arg("embedChiral") = true, python::arg("useAtomMap") = false),
+       python::arg("embedChiral") = true, python::arg("useAtomMap") = false, 
+       python::arg("useVdw") = true),
       docs.c_str());
 }

--- a/Code/GraphMol/DetermineBonds/Wrap/rdDetermineBonds.cpp
+++ b/Code/GraphMol/DetermineBonds/Wrap/rdDetermineBonds.cpp
@@ -63,7 +63,7 @@ Args:
   python::def("DetermineConnectivity", &determineConnectivityHelper,
               (python::arg("mol"), python::arg("useHueckel") = false,
                python::arg("charge") = 0, python::arg("covFactor") = 1.3,
-               python::arg("useVdw") = true),
+               python::arg("useVdw") = false),
               docs.c_str());
 
   docs =
@@ -119,7 +119,7 @@ Args:
       (python::arg("mol"), python::arg("useHueckel") = false,
        python::arg("charge") = 0, python::arg("covFactor") = 1.3,
        python ::arg("allowChargedFragments") = true,
-       python::arg("embedChiral") = true, python::arg("useAtomMap") = false, 
-       python::arg("useVdw") = true),
+       python::arg("embedChiral") = true, python::arg("useAtomMap") = false,
+       python::arg("useVdw") = false),
       docs.c_str());
 }

--- a/Code/GraphMol/DetermineBonds/Wrap/testDetermineBonds.py
+++ b/Code/GraphMol/DetermineBonds/Wrap/testDetermineBonds.py
@@ -36,6 +36,25 @@ class TestCase(unittest.TestCase):
           if omol.GetBondBetweenAtoms(aid1, aid2):
             self.assertIsNotNone(mol.GetBondBetweenAtoms(aid1, aid2))
 
+  def testCtDConnectivity(self):
+    testDir = os.path.join(RDConfig.RDBaseDir, 'Code', 'GraphMol', 'DetermineBonds', 'test_data',
+                           'connectivity')
+    for fn in glob.glob(os.path.join(testDir, 'test*.xyz')):
+      mol = Chem.MolFromXYZFile(fn)
+      self.assertIsNotNone(mol)
+      smi = mol.GetProp('_FileComments')
+      omol = Chem.MolFromSmiles(smi)
+      self.assertIsNotNone(omol)
+
+      rdDetermineBonds.DetermineConnectivity(mol, useHueckel=False, useVdw=False)
+      mol = Chem.RemoveAllHs(mol, sanitize=False)
+      self.assertEqual(mol.GetNumAtoms(), omol.GetNumAtoms())
+      self.assertEqual(mol.GetNumBonds(), omol.GetNumBonds())
+      for aid1 in range(mol.GetNumAtoms()):
+        for aid2 in range(aid1 + 1, mol.GetNumAtoms()):
+          if omol.GetBondBetweenAtoms(aid1, aid2):
+            self.assertIsNotNone(mol.GetBondBetweenAtoms(aid1, aid2))
+
   def testHueckelConnectivity(self):
     testDir = os.path.join(RDConfig.RDBaseDir, 'Code', 'GraphMol', 'DetermineBonds', 'test_data',
                            'connectivity')

--- a/Code/GraphMol/DetermineBonds/catch_tests.cpp
+++ b/Code/GraphMol/DetermineBonds/catch_tests.cpp
@@ -48,6 +48,42 @@ TEST_CASE("Determine Connectivity") {
     }
   }  // SECTION
 
+  SECTION("connect the dots") {
+    unsigned int numTests = 39;
+    for (unsigned int i = 0; i < numTests; i++) {
+      std::string rdbase = getenv("RDBASE");
+      std::string fName =
+          rdbase + "/Code/GraphMol/DetermineBonds/test_data/connectivity/" +
+          "test" + std::to_string(i) + ".xyz";
+      std::unique_ptr<RWMol> mol(XYZFileToMol(fName));
+      REQUIRE(mol);
+      std::string smiles = mol->getProp<std::string>("_FileComments");
+      std::unique_ptr<RWMol> orig(SmilesToMol(smiles));
+      REQUIRE(orig);
+      bool useHueckel = false;
+      int charge = 0;
+      double factor = 1.3;  // not actually used here
+      bool useVdw = false;
+      determineConnectivity(*mol, useHueckel, charge, factor, useVdw);
+      MolOps::removeAllHs(*mol, false);
+
+      auto numAtoms = mol->getNumAtoms();
+
+      REQUIRE(orig->getNumAtoms() == numAtoms);
+      for (unsigned int i = 0; i < numAtoms; i++) {
+        for (unsigned int j = i + 1; j < numAtoms; j++) {
+          const auto origBond = orig->getBondBetweenAtoms(i, j);
+          const auto molBond = mol->getBondBetweenAtoms(i, j);
+          if (origBond) {
+            CHECK(molBond);
+          } else {
+            CHECK(!molBond);
+          }
+        }
+      }
+    }
+  }  // SECTION
+
   SECTION("Hueckel") {
     unsigned int numTests = 39;
     for (unsigned int i = 0; i < numTests; i++) {

--- a/Code/GraphMol/DetermineBonds/catch_tests.cpp
+++ b/Code/GraphMol/DetermineBonds/catch_tests.cpp
@@ -28,6 +28,11 @@ TEST_CASE("Determine Connectivity") {
       std::unique_ptr<RWMol> orig(SmilesToMol(smiles));
       REQUIRE(orig);
 
+      bool useHueckel = false;
+      int charge = 0;
+      double factor = 1.3;
+      bool useVdw = true;
+      determineConnectivity(*mol, useHueckel, charge, factor, useVdw);
       determineConnectivity(*mol, false);
       MolOps::removeAllHs(*mol, false);
 
@@ -62,7 +67,7 @@ TEST_CASE("Determine Connectivity") {
       REQUIRE(orig);
       bool useHueckel = false;
       int charge = 0;
-      double factor = 1.3;  // not actually used here
+      double factor = 1.3;
       bool useVdw = false;
       determineConnectivity(*mol, useHueckel, charge, factor, useVdw);
       MolOps::removeAllHs(*mol, false);

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -40,6 +40,10 @@ different meaning in chemistry.
 - The error messages from failed type conversions in calls to `GetProp()` now
 differ slightly between compilers. Instead of always including "boost::bad_any
 cast", they now need to be matched with the regex `[B,b]ad any[\ ,_]cast`
+- The functions for determining connectivity in DetermineBonds now use a more
+efficient method by default. To go back to the old behavior, set the useVdw argument
+to True.
+
 
 ## Bug Fixes:
 


### PR DESCRIPTION
This was a suggestion by @rogersayle at the 2023 RDKit UGM: use the connect the dots algorithm instead of the xyz2mol VdW method by default in DetermineBonds

