### PR TITLE
Some small cleanups from the UGM Hackathon

### DIFF
--- a/Code/GraphMol/Atom.cpp
+++ b/Code/GraphMol/Atom.cpp
@@ -259,14 +259,10 @@ std::string Atom::getSymbol() const {
 }
 
 unsigned int Atom::getDegree() const {
-  PRECONDITION(dp_mol,
-               "degree not defined for atoms not associated with molecules");
   return getOwningMol().getAtomDegree(this);
 }
 
 unsigned int Atom::getTotalDegree() const {
-  PRECONDITION(dp_mol,
-               "degree not defined for atoms not associated with molecules");
   unsigned int res = this->getTotalNumHs(false) + this->getDegree();
   return res;
 }
@@ -276,8 +272,6 @@ unsigned int Atom::getTotalDegree() const {
 //   and include any of them that are Hs in the count here
 //
 unsigned int Atom::getTotalNumHs(bool includeNeighbors) const {
-  PRECONDITION(dp_mol,
-               "valence not defined for atoms not associated with molecules")
   int res = getNumExplicitHs() + getNumImplicitHs();
   if (includeNeighbors) {
     for (auto nbr : getOwningMol().atomNeighbors(this)) {
@@ -301,8 +295,6 @@ unsigned int Atom::getNumImplicitHs() const {
 }
 
 int Atom::getExplicitValence() const {
-  PRECONDITION(dp_mol,
-               "valence not defined for atoms not associated with molecules");
   PRECONDITION(
       d_explicitValence > -1,
       "getExplicitValence() called without call to calcExplicitValence()");
@@ -310,14 +302,10 @@ int Atom::getExplicitValence() const {
 }
 
 unsigned int Atom::getTotalValence() const {
-  PRECONDITION(dp_mol,
-               "valence not defined for atoms not associated with molecules");
   return getExplicitValence() + getImplicitValence();
 }
 
 int Atom::calcExplicitValence(bool strict) {
-  PRECONDITION(dp_mol,
-               "valence not defined for atoms not associated with molecules");
   unsigned int res;
   // FIX: contributions of bonds to valence are being done at best
   // approximately
@@ -431,8 +419,6 @@ int Atom::getImplicitValence() const {
 // NOTE: this uses the explicitValence, so it will call
 // calcExplictValence() if it hasn't already been called
 int Atom::calcImplicitValence(bool strict) {
-  PRECONDITION(dp_mol,
-               "valence not defined for atoms not associated with molecules");
   if (df_noImplicit) {
     return 0;
   }
@@ -444,9 +430,7 @@ int Atom::calcImplicitValence(bool strict) {
     d_implicitValence = 0;
     return 0;
   }
-  for (const auto &nbri :
-       boost::make_iterator_range(getOwningMol().getAtomBonds(this))) {
-    const auto bnd = getOwningMol()[nbri];
+  for (const auto bnd : getOwningMol().atomBonds(this)) {
     if (QueryOps::hasComplexBondTypeQuery(*bnd)) {
       d_implicitValence = 0;
       return 0;
@@ -679,9 +663,6 @@ bool Atom::needsUpdatePropertyCache() const {
 //   getPerturbationOrder([1,2,3,0]) = 3
 //   getPerturbationOrder([1,2,0,3]) = 2
 int Atom::getPerturbationOrder(const INT_LIST &probe) const {
-  PRECONDITION(
-      dp_mol,
-      "perturbation order not defined for atoms not associated with molecules")
   INT_LIST ref;
   ROMol::OEDGE_ITER beg, end;
   boost::tie(beg, end) = getOwningMol().getAtomBonds(this);

--- a/Code/GraphMol/Atom.cpp
+++ b/Code/GraphMol/Atom.cpp
@@ -664,14 +664,10 @@ bool Atom::needsUpdatePropertyCache() const {
 //   getPerturbationOrder([1,2,0,3]) = 2
 int Atom::getPerturbationOrder(const INT_LIST &probe) const {
   INT_LIST ref;
-  ROMol::OEDGE_ITER beg, end;
-  boost::tie(beg, end) = getOwningMol().getAtomBonds(this);
-  while (beg != end) {
-    ref.push_back(getOwningMol()[*beg]->getIdx());
-    ++beg;
+  for (const auto bnd : getOwningMol().atomBonds(this)) {
+    ref.push_back(bnd->getIdx());
   }
-  int nSwaps = static_cast<int>(countSwapsToInterconvert(probe, ref));
-  return nSwaps;
+  return static_cast<int>(countSwapsToInterconvert(probe, ref));
 }
 
 static const unsigned char octahedral_invert[31] = {
@@ -782,7 +778,7 @@ void setAtomRLabel(Atom *atm, int rlabel) {
   if (rlabel) {
     atm->setProp(common_properties::_MolFileRLabel,
                  static_cast<unsigned int>(rlabel));
-  } else if (atm->hasProp(common_properties::_MolFileRLabel)) {
+  } else {
     atm->clearProp(common_properties::_MolFileRLabel);
   }
 }
@@ -798,7 +794,7 @@ void setAtomAlias(Atom *atom, const std::string &alias) {
   PRECONDITION(atom, "bad atom");
   if (alias != "") {
     atom->setProp(common_properties::molFileAlias, alias);
-  } else if (atom->hasProp(common_properties::molFileAlias)) {
+  } else {
     atom->clearProp(common_properties::molFileAlias);
   }
 }
@@ -814,7 +810,7 @@ void setAtomValue(Atom *atom, const std::string &value) {
   PRECONDITION(atom, "bad atom");
   if (value != "") {
     atom->setProp(common_properties::molFileValue, value);
-  } else if (atom->hasProp(common_properties::molFileValue)) {
+  } else {
     atom->clearProp(common_properties::molFileValue);
   }
 }
@@ -830,7 +826,7 @@ void setSupplementalSmilesLabel(Atom *atom, const std::string &label) {
   PRECONDITION(atom, "bad atom");
   if (label != "") {
     atom->setProp(common_properties::_supplementalSmilesLabel, label);
-  } else if (atom->hasProp(common_properties::_supplementalSmilesLabel)) {
+  } else {
     atom->clearProp(common_properties::_supplementalSmilesLabel);
   }
 }

--- a/Code/GraphMol/ROMol.cpp
+++ b/Code/GraphMol/ROMol.cpp
@@ -246,8 +246,7 @@ ROMol::ATOM_PTR_LIST &ROMol::getAllAtomsWithBookmark(int mark) {
 // returns the unique atom with the given bookmark
 Atom *ROMol::getUniqueAtomWithBookmark(int mark) {
   auto lu = d_atomBookmarks.find(mark);
-  PRECONDITION((lu != d_atomBookmarks.end()),
-               "multiple atoms with same bookmark");
+  PRECONDITION((lu != d_atomBookmarks.end()), "bookmark not found");
   return lu->second.front();
 }
 
@@ -269,8 +268,7 @@ ROMol::BOND_PTR_LIST &ROMol::getAllBondsWithBookmark(int mark) {
 // returns the unique bond with the given bookmark
 Bond *ROMol::getUniqueBondWithBookmark(int mark) {
   auto lu = d_bondBookmarks.find(mark);
-  PRECONDITION((lu != d_bondBookmarks.end()),
-               "multiple bonds with same bookmark");
+  PRECONDITION((lu != d_bondBookmarks.end()), "bookmark not found");
   return lu->second.front();
 }
 
@@ -327,28 +325,30 @@ unsigned int ROMol::getNumBonds(bool onlyHeavy) const {
 }
 
 Bond *ROMol::getBondWithIdx(unsigned int idx) {
-  PRECONDITION(getNumBonds() > 0, "no bonds");
   URANGE_CHECK(idx, getNumBonds());
 
-  auto bIter = getEdges();
+  // boost::graph doesn't give us random-access to edges,
+  // so we have to iterate to it
+  auto [iter, end] = getEdges();
   for (unsigned int i = 0; i < idx; i++) {
-    ++bIter.first;
+    ++iter;
   }
-  Bond *res = d_graph[*(bIter.first)];
+  Bond *res = d_graph[*iter];
 
   POSTCONDITION(res != nullptr, "Invalid bond requested");
   return res;
 }
 
 const Bond *ROMol::getBondWithIdx(unsigned int idx) const {
-  PRECONDITION(getNumBonds() > 0, "no bonds");
   URANGE_CHECK(idx, getNumBonds());
 
-  auto bIter = getEdges();
+  // boost::graph doesn't give us random-access to edges,
+  // so we have to iterate to it
+  auto [iter, end] = getEdges();
   for (unsigned int i = 0; i < idx; i++) {
-    ++bIter.first;
+    ++iter;
   }
-  const Bond *res = d_graph[*(bIter.first)];
+  const Bond *res = d_graph[*iter];
 
   POSTCONDITION(res != nullptr, "Invalid bond requested");
   return res;

--- a/Code/GraphMol/SubstanceGroup.cpp
+++ b/Code/GraphMol/SubstanceGroup.cpp
@@ -276,7 +276,7 @@ bool SubstanceGroup::includesBond(unsigned int bondIdx) const {
 }
 
 namespace SubstanceGroupChecks {
-const std::vector<std::string> sGroupTypes = {
+const std::vector<const char *> sGroupTypes = {
     // polymer sgroups:
     "SRU", "MON", "COP", "CRO", "GRA", "MOD", "MER", "ANY",
     // formulations/mixtures:
@@ -284,22 +284,17 @@ const std::vector<std::string> sGroupTypes = {
     // other
     "SUP", "MUL", "DAT", "GEN"};
 
-const std::vector<std::string> sGroupSubtypes = {"ALT", "RAN", "BLO"};
-const std::vector<std::string> sGroupConnectTypes = {"HH", "HT", "EU"};
-
 bool isValidType(const std::string &type) {
   return std::find(sGroupTypes.begin(), sGroupTypes.end(), type) !=
          sGroupTypes.end();
 }
 
 bool isValidSubType(const std::string &type) {
-  return std::find(sGroupSubtypes.begin(), sGroupSubtypes.end(), type) !=
-         sGroupSubtypes.end();
+  return type == "ALT" || type == "RAN" || type == "BLO";
 }
 
 bool isValidConnectType(const std::string &type) {
-  return std::find(sGroupConnectTypes.begin(), sGroupConnectTypes.end(),
-                   type) != sGroupConnectTypes.end();
+  return type == "HH" || type == "HT" || type == "EU";
 }
 
 bool isSubstanceGroupIdFree(const ROMol &mol, unsigned int id) {

--- a/Code/GraphMol/SubstanceGroup.cpp
+++ b/Code/GraphMol/SubstanceGroup.cpp
@@ -275,26 +275,34 @@ bool SubstanceGroup::includesBond(unsigned int bondIdx) const {
   return false;
 }
 
-bool SubstanceGroupChecks::isValidType(const std::string &type) {
-  return std::find(SubstanceGroupChecks::sGroupTypes.begin(),
-                   SubstanceGroupChecks::sGroupTypes.end(),
-                   type) != SubstanceGroupChecks::sGroupTypes.end();
+namespace SubstanceGroupChecks {
+const std::vector<std::string> sGroupTypes = {
+    // polymer sgroups:
+    "SRU", "MON", "COP", "CRO", "GRA", "MOD", "MER", "ANY",
+    // formulations/mixtures:
+    "COM", "MIX", "FOR",
+    // other
+    "SUP", "MUL", "DAT", "GEN"};
+
+const std::vector<std::string> sGroupSubtypes = {"ALT", "RAN", "BLO"};
+const std::vector<std::string> sGroupConnectTypes = {"HH", "HT", "EU"};
+
+bool isValidType(const std::string &type) {
+  return std::find(sGroupTypes.begin(), sGroupTypes.end(), type) !=
+         sGroupTypes.end();
 }
 
-bool SubstanceGroupChecks::isValidSubType(const std::string &type) {
-  return std::find(SubstanceGroupChecks::sGroupSubtypes.begin(),
-                   SubstanceGroupChecks::sGroupSubtypes.end(),
-                   type) != SubstanceGroupChecks::sGroupSubtypes.end();
+bool isValidSubType(const std::string &type) {
+  return std::find(sGroupSubtypes.begin(), sGroupSubtypes.end(), type) !=
+         sGroupSubtypes.end();
 }
 
-bool SubstanceGroupChecks::isValidConnectType(const std::string &type) {
-  return std::find(SubstanceGroupChecks::sGroupConnectTypes.begin(),
-                   SubstanceGroupChecks::sGroupConnectTypes.end(),
-                   type) != SubstanceGroupChecks::sGroupConnectTypes.end();
+bool isValidConnectType(const std::string &type) {
+  return std::find(sGroupConnectTypes.begin(), sGroupConnectTypes.end(),
+                   type) != sGroupConnectTypes.end();
 }
 
-bool SubstanceGroupChecks::isSubstanceGroupIdFree(const ROMol &mol,
-                                                  unsigned int id) {
+bool isSubstanceGroupIdFree(const ROMol &mol, unsigned int id) {
   auto match_sgroup = [id](const SubstanceGroup &sg) {
     unsigned int storedId;
     return sg.getPropIfPresent("ID", storedId) && id == storedId;
@@ -304,6 +312,7 @@ bool SubstanceGroupChecks::isSubstanceGroupIdFree(const ROMol &mol,
   return std::find_if(sgroups.begin(), sgroups.end(), match_sgroup) ==
          sgroups.end();
 }
+}  // namespace SubstanceGroupChecks
 
 std::vector<SubstanceGroup> &getSubstanceGroups(ROMol &mol) {
   return mol.d_sgroups;

--- a/Code/GraphMol/SubstanceGroup.h
+++ b/Code/GraphMol/SubstanceGroup.h
@@ -242,17 +242,6 @@ class RDKIT_GRAPHMOL_EXPORT SubstanceGroup : public RDProps {
 
 namespace SubstanceGroupChecks {
 
-const std::vector<std::string> sGroupTypes = {
-    // polymer sgroups:
-    "SRU", "MON", "COP", "CRO", "GRA", "MOD", "MER", "ANY",
-    // formulations/mixtures:
-    "COM", "MIX", "FOR",
-    // other
-    "SUP", "MUL", "DAT", "GEN"};
-
-const std::vector<std::string> sGroupSubtypes = {"ALT", "RAN", "BLO"};
-const std::vector<std::string> sGroupConnectTypes = {"HH", "HT", "EU"};
-
 RDKIT_GRAPHMOL_EXPORT bool isValidType(const std::string &type);
 
 RDKIT_GRAPHMOL_EXPORT bool isValidSubType(const std::string &type);


### PR DESCRIPTION
1. Removes some redundant PRECONDITION calls.  In cases where function A has a precondition and calls function B which has the same precondition, the precondition can be safely removed from function A
2. Modernizes some code in Atom.cpp and ROMol.cpp
3. Moves a const std::vector from the header into a .cpp file in SubstanceGroups (this is something @rogersayle pointed out at the UGM)

As a reference point for future cleanup passes, this loop:
```
      for (auto ai = mol->beginAtoms(); ai != mol->endAtoms(); ++ai) {
        if ((*ai)->getAtomicNum() > 1) {
          ++sum;
        }
      }
```
takes 25 times as long to execute as this one:
```
      for (const auto atom : mol->atoms()) {
        if (atom->getAtomicNum() > 1) {
          ++sum;
        }
      }
```
I've tested this on both linux (GCC) and windows (MSVC++) and see similar differences on both