### PR TITLE
Enable chemist-friendly depiction of R-groups

### DIFF
--- a/Code/GraphMol/MolDraw2D/MolDraw2DHelpers.h
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DHelpers.h
@@ -149,6 +149,12 @@ struct RDKIT_MOLDRAW2D_EXPORT MolDrawOptions {
   bool atomLabelDeuteriumTritium =
       false;  // toggles replacing 2H with D and 3H with T
   bool dummiesAreAttachments = false;  // draws "breaks" at dummy atoms
+  bool mappedDummiesAreRGroups =
+      false;  // mapped dummies are diplayed as "R#" rather than "*:#"
+  bool isotopeDummiesAreRGroups =
+      false;  // isotopic dummies are diplayed as "#R#" (if dummyIsotopeLabels
+              // is true) or "R#" (if dummyIsotopeLabels is false) rather than
+              // "#*"
   bool circleAtoms = true;             // draws circles under highlighted atoms
   bool splitBonds = false;             // split bonds into per atom segments
                             // most useful for dynamic manipulation of drawing

--- a/Code/GraphMol/MolDraw2D/MolDraw2DUtils.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DUtils.cpp
@@ -183,6 +183,8 @@ void updateMolDrawOptionsFromJSON(MolDrawOptions &opts,
   boost::property_tree::read_json(ss, pt);
   PT_OPT_GET(atomLabelDeuteriumTritium);
   PT_OPT_GET(dummiesAreAttachments);
+  PT_OPT_GET(mappedDummiesAreRGroups);
+  PT_OPT_GET(isotopeDummiesAreRGroups);
   PT_OPT_GET(circleAtoms);
   PT_OPT_GET(splitBonds);
   PT_OPT_GET(continuousHighlight);

--- a/Code/GraphMol/MolDraw2D/Wrap/rdMolDraw2D.cpp
+++ b/Code/GraphMol/MolDraw2D/Wrap/rdMolDraw2D.cpp
@@ -765,6 +765,10 @@ BOOST_PYTHON_MODULE(rdMolDraw2D) {
                                                             docString.c_str())
       .def_readwrite("dummiesAreAttachments",
                      &RDKit::MolDrawOptions::dummiesAreAttachments)
+      .def_readwrite("mappedDummiesAreRGroups",
+                     &RDKit::MolDrawOptions::mappedDummiesAreRGroups)
+      .def_readwrite("isotopeDummiesAreRGroups",
+                     &RDKit::MolDrawOptions::isotopeDummiesAreRGroups)
       .def_readwrite("circleAtoms", &RDKit::MolDrawOptions::circleAtoms)
       .def_readwrite("splitBonds", &RDKit::MolDrawOptions::splitBonds)
       .def("getBackgroundColour", &RDKit::getBgColour,

--- a/Code/MinimalLib/jswrapper.cpp
+++ b/Code/MinimalLib/jswrapper.cpp
@@ -21,15 +21,15 @@ using namespace RDKit;
 namespace RDKit {
 namespace MinimalLib {
 extern std::string process_mol_details(
-    const std::string &details, int &width, int &height, int &offsetx,
-    int &offsety, std::string &legend, std::vector<int> &atomIds,
+    const std::string &details, bool &noFreeType, int &width, int &height,
+    int &offsetx, int &offsety, std::string &legend, std::vector<int> &atomIds,
     std::vector<int> &bondIds, std::map<int, DrawColour> &atomMap,
     std::map<int, DrawColour> &bondMap, std::map<int, double> &radiiMap,
     bool &kekulize, bool &addChiralHs, bool &wedgeBonds, bool &forceCoords,
     bool &wavyBonds);
 extern std::string process_rxn_details(
-    const std::string &details, int &width, int &height, int &offsetx,
-    int &offsety, std::string &legend, std::vector<int> &atomIds,
+    const std::string &details, bool &noFreeType, int &width, int &height,
+    int &offsetx, int &offsety, std::string &legend, std::vector<int> &atomIds,
     std::vector<int> &bondIds, bool &kekulize, bool &highlightByReactant,
     std::vector<DrawColour> &highlightColorsReactants);
 }  // namespace MinimalLib
@@ -82,11 +82,12 @@ std::string draw_to_canvas_with_highlights(JSMol &self, emscripten::val canvas,
   bool wedgeBonds = true;
   bool forceCoords = false;
   bool wavyBonds = false;
+  bool noFreeType = false;
   if (!details.empty()) {
     auto problems = MinimalLib::process_mol_details(
-        details, w, h, offsetx, offsety, legend, atomIds, bondIds, atomMap,
-        bondMap, radiiMap, kekulize, addChiralHs, wedgeBonds, forceCoords,
-        wavyBonds);
+        details, noFreeType, w, h, offsetx, offsety, legend, atomIds, bondIds,
+        atomMap, bondMap, radiiMap, kekulize, addChiralHs, wedgeBonds,
+        forceCoords, wavyBonds);
     if (!problems.empty()) {
       return problems;
     }
@@ -149,11 +150,12 @@ std::string draw_rxn_to_canvas_with_highlights(JSReaction &self,
   int offsety = 0;
   bool kekulize = true;
   bool highlightByReactant = false;
+  bool noFreeType = false;
   std::vector<DrawColour> highlightColorsReactants;
   if (!details.empty()) {
     auto problems = MinimalLib::process_rxn_details(
-        details, w, h, offsetx, offsety, legend, atomIds, bondIds, kekulize,
-        highlightByReactant, highlightColorsReactants);
+        details, noFreeType, w, h, offsetx, offsety, legend, atomIds, bondIds,
+        kekulize, highlightByReactant, highlightColorsReactants);
     if (!problems.empty()) {
       return problems;
     }


### PR DESCRIPTION
- Added two `MolDrawOptions` (`mappedDummiesAreRGroups`, `isotopeDummiesAreRGroups`) to enable conveniently depicting R group labels in more chemist-friendly fashion (i.e., as `R#` rather than `#*` or `*:#`)
- Added relevant C++, Python and JS tests
- Added a `noFreeType` JSON parameter to enable generating non-FreeType SVGs in MinimalLib, mostly to make testing easier

# Current status
RDKit stores R group labels as either `atomMapNum` or isotope number. This results in a representation which is not very pretty, unless some post-procesing is applied.
For example, an R group decomposition currently looks like this in `PandasTools`:
```
from rdkit import Chem
from rdkit.Chem import PandasTools
from rdkit.Chem.Draw import IPythonConsole, rdDepictor
from rdkit.Chem import rdRGroupDecomposition

rdDepictor.SetPreferCoordGen(True)
mols = [Chem.MolFromSmiles(smi) for smi in 'c1c(F)cccn1 c1c(Cl)c(C)ccn1 c1c(F)cncn1 c1c(F)c(C)ccn1'.split()]
sma_scaffold = Chem.MolFromSmarts('c:1:c(-[*:1]):c(-[*:2]):*:c:n:1')
groups, unmatched = rdRGroupDecomposition.RGroupDecompose([sma_scaffold], mols, asSmiles=False, asRows=False)
df = PandasTools.RGroupDecompositionToFrame(groups, mols, include_core=True)
PandasTools.ChangeMoleculeRendering(df)
df
```
![image](https://github.com/rdkit/rdkit/assets/5244385/2c3361e3-88e9-4895-809a-51754f7e32a5)

This becomes even less chemist-friendly when R group decomposition results are generated from SMILES:
```
groups, unmatched = rdRGroupDecomposition.RGroupDecompose([sma_scaffold], mols, asSmiles=True, asRows=False)
df = PandasTools.RGroupDecompositionToFrame({k: [Chem.MolFromSmiles(smi) for smi in v] for k, v in groups.items()}, mols, include_core=True)
PandasTools.ChangeMoleculeRendering(df)
df
```
![image](https://github.com/rdkit/rdkit/assets/5244385/9ac822d4-fa57-4f57-8047-d3639fef176d)

# After this PR
This PR adds two `MolDrawOptions` to enable a more chemistry-friendly depiction with a single setting, e.g.:
```
IPythonConsole.drawOptions.mappedDummiesAreRGroups = True

groups, unmatched = rdRGroupDecomposition.RGroupDecompose([sma_scaffold], mols, asSmiles=False, asRows=False)
df = PandasTools.RGroupDecompositionToFrame(groups, mols, include_core=True)
PandasTools.ChangeMoleculeRendering(df)
df
```
![image](https://github.com/rdkit/rdkit/assets/5244385/6b7bca13-d311-4de4-94c5-8fe353847053)

```
groups, unmatched = rdRGroupDecomposition.RGroupDecompose([sma_scaffold], mols, asSmiles=True, asRows=False)
df = PandasTools.RGroupDecompositionToFrame({k: [Chem.MolFromSmiles(smi) for smi in v] for k, v in groups.items()}, mols, include_core=True)
PandasTools.ChangeMoleculeRendering(df)
df
```
![image](https://github.com/rdkit/rdkit/assets/5244385/54ac2c16-01a4-44a0-a4af-b5a7f6a9790f)
