### PR TITLE
Extract the core matching logic into a separate function

### DIFF
--- a/Code/GraphMol/RGroupDecomposition/RGroupDecomp.cpp
+++ b/Code/GraphMol/RGroupDecomposition/RGroupDecomp.cpp
@@ -294,9 +294,7 @@ int RGroupDecomposition::add(const ROMol &inmol) {
       // clean any existing R group numbers
       atom->setIsotope(0);
       atom->setAtomMapNum(0);
-      if (atom->hasProp(common_properties::_MolFileRLabel)) {
-        atom->clearProp(common_properties::_MolFileRLabel);
-      }
+      atom->clearProp(common_properties::_MolFileRLabel);
       atom->setProp(common_properties::dummyLabel, "*");
     }
   }

--- a/Code/GraphMol/RGroupDecomposition/RGroupDecomp.cpp
+++ b/Code/GraphMol/RGroupDecomposition/RGroupDecomp.cpp
@@ -82,29 +82,37 @@ RGroupDecomposition::RGroupDecomposition(
 
 RGroupDecomposition::~RGroupDecomposition() { delete data; }
 
-int RGroupDecomposition::add(const ROMol &inmol) {
-  // get the sidechains if possible
-  //  Add hs for better symmetrization
-  RWMol mol(inmol);
+int RGroupDecomposition::getMatchingCoreIdx(
+    const ROMol &mol, std::vector<MatchVectType> *matches) {
+  RWMol rwmol(mol);
+  std::vector<MatchVectType> matchesTmp;
+  const RCore *rcore;
+  auto coreIdx = getMatchingCoreInternal(rwmol, rcore, matchesTmp);
+  if (matches) {
+    std::set<MatchVectType> uniqueMatches;
+    int numAtoms = mol.getNumAtoms();
+    for (const auto &match : matchesTmp) {
+      MatchVectType heavyMatch;
+      heavyMatch.reserve(match.size());
+      std::copy_if(
+          match.begin(), match.end(), std::back_inserter(heavyMatch),
+          [numAtoms](const auto &pair) { return pair.second < numAtoms; });
+      std::sort(heavyMatch.begin(), heavyMatch.end());
+      uniqueMatches.insert(heavyMatch);
+    }
+    *matches =
+        std::vector<MatchVectType>(uniqueMatches.begin(), uniqueMatches.end());
+  }
+  return coreIdx;
+}
+
+int RGroupDecomposition::getMatchingCoreInternal(
+    RWMol &mol, const RCore *&rcore, std::vector<MatchVectType> &matches) {
+  rcore = nullptr;
+  int core_idx = -1;
   const bool explicitOnly = false;
   const bool addCoords = true;
   MolOps::addHs(mol, explicitOnly, addCoords);
-
-  // mark any wildcards in input molecule:
-  for (auto &atom : mol.atoms()) {
-    if (atom->getAtomicNum() == 0) {
-      atom->setProp(_rgroupInputDummy, true);
-      // clean any existing R group numbers
-      atom->setIsotope(0);
-      atom->setAtomMapNum(0);
-      if (atom->hasProp(common_properties::_MolFileRLabel)) {
-        atom->clearProp(common_properties::_MolFileRLabel);
-      }
-      atom->setProp(common_properties::dummyLabel, "*");
-    }
-  }
-  int core_idx = 0;
-  const RCore *rcore = nullptr;
   std::vector<MatchVectType> tmatches;
   std::vector<MatchVectType> tmatches_filtered;
 
@@ -148,6 +156,16 @@ int RGroupDecomposition::add(const ROMol &inmol) {
         // Match the R Groups
         auto matchesWithDummy =
             core.second.matchTerminalUserRGroups(mol, baseMatch, sssparams);
+        /*
+        std::cerr << "baseMatch ";
+        for (const auto &pair : baseMatch) std::cerr << "(" << pair.first <<","
+        << pair.second << "),"; std::cerr << std::endl; std::cerr <<
+        "matchesWithDummy "; for (const auto &matchWithDummy : matchesWithDummy)
+        { for (const auto &pair : matchWithDummy) std::cerr << "(" << pair.first
+        <<"," << pair.second << "),"; std::cerr << " /// ";
+        }
+        std::cerr << std::endl;
+        */
         tmatches.insert(tmatches.end(), matchesWithDummy.cbegin(),
                         matchesWithDummy.cend());
       }
@@ -240,7 +258,24 @@ int RGroupDecomposition::add(const ROMol &inmol) {
       break;
     }
   }
-  tmatches = std::move(tmatches_filtered);
+  if (rcore) {
+    matches = std::move(tmatches_filtered);
+  }
+  return core_idx;
+}
+
+int RGroupDecomposition::add(const ROMol &inmol) {
+  // get the sidechains if possible
+  //  Add hs for better symmetrization
+  RWMol mol(inmol);
+  const RCore *rcore;
+  std::vector<MatchVectType> tmatches;
+  auto core_idx = getMatchingCoreInternal(mol, rcore, tmatches);
+  if (rcore == nullptr) {
+    BOOST_LOG(rdDebugLog) << "No core matches" << std::endl;
+    return -1;
+  }
+
   if (tmatches.size() > 1) {
     if (data->params.matchingStrategy == NoSymmetrization) {
       tmatches.resize(1);
@@ -252,10 +287,18 @@ int RGroupDecomposition::add(const ROMol &inmol) {
       }
     }
   }
-
-  if (rcore == nullptr) {
-    BOOST_LOG(rdDebugLog) << "No core matches" << std::endl;
-    return -1;
+  // mark any wildcards in input molecule:
+  for (auto &atom : mol.atoms()) {
+    if (atom->getAtomicNum() == 0) {
+      atom->setProp(_rgroupInputDummy, true);
+      // clean any existing R group numbers
+      atom->setIsotope(0);
+      atom->setAtomMapNum(0);
+      if (atom->hasProp(common_properties::_MolFileRLabel)) {
+        atom->clearProp(common_properties::_MolFileRLabel);
+      }
+      atom->setProp(common_properties::dummyLabel, "*");
+    }
   }
 
   // strategies

--- a/Code/GraphMol/RGroupDecomposition/RGroupDecomp.h
+++ b/Code/GraphMol/RGroupDecomposition/RGroupDecomp.h
@@ -51,6 +51,7 @@ class UsedLabelMap {
 };
 
 struct RGroupDecompData;
+struct RCore;
 class RDKIT_RGROUPDECOMPOSITION_EXPORT RGroupDecomposition {
  private:
   RGroupDecompData *data;                            // implementation details
@@ -59,6 +60,8 @@ class RDKIT_RGROUPDECOMPOSITION_EXPORT RGroupDecomposition {
       const RGroupDecomposition &);  // Prevent assignment
   RWMOL_SPTR outputCoreMolecule(const RGroupMatch &match,
                                 const UsedLabelMap &usedRGroupMap) const;
+  int getMatchingCoreInternal(RWMol &mol, const RCore *&rcore,
+                              std::vector<MatchVectType> &matches);
 
  public:
   RGroupDecomposition(const ROMol &core,
@@ -70,13 +73,27 @@ class RDKIT_RGROUPDECOMPOSITION_EXPORT RGroupDecomposition {
 
   ~RGroupDecomposition();
 
+  //! Returns the index of the core matching the passed molecule
+  //! and optionally the matching atom indices
+  /*!
+      \param mol Molecule to check for matches
+      \param matches Optional pointer to std::vector<MatchVectType>
+                     where core matches will be stored
+
+      \return the index of the matching core, or -1 if none matches
+  */
+  int getMatchingCoreIdx(const ROMol &mol,
+                         std::vector<MatchVectType> *matches = nullptr);
   //! Returns the index of the added molecule in the RGroupDecomposition
-  ///  or a negative error code
-  /// :param mol: Molecule to add to the decomposition
-  /// :result: index of the molecle or
-  ///             -1 if none of the core matches
-  ///             -2 if the matched molecule has no sidechains, i.e. is the
-  ///                same as the scaffold
+  //! or a negative error code
+  /*!
+      \param mol Molecule to add to the decomposition
+
+      \return index of the molecule or
+              -1 if none of the core matches
+              -2 if the matched molecule has no sidechains, i.e. is the
+              same as the scaffold
+  */
   int add(const ROMol &mol);
   RGroupDecompositionProcessResult processAndScore();
   bool process();

--- a/Code/GraphMol/RGroupDecomposition/Wrap/test_rgroups.py
+++ b/Code/GraphMol/RGroupDecomposition/Wrap/test_rgroups.py
@@ -697,6 +697,33 @@ M  END
         {'Core': 'O=c1cc([*:1])c([*:2])c[nH]1', 'R1': 'F[*:1]', 'R2': 'C[*:2]'}]
     self.assertEqual(rows, expected_rows)
 
+  def testMolMatchesCore(self):
+    core = Chem.MolFromSmarts("[*:1]c1[!#1]([*:2])cc([*:3])n([*:4])c(=O)1")
+    cmol = Chem.MolFromSmiles("Clc1c(C)cc(F)n(CC)c(=O)1")
+    nmol = Chem.MolFromSmiles("Clc1ncc(F)n(CC)c(=O)1")
+    smol = Chem.MolFromSmiles("Clc1ncc(F)n(CC)c(=S)1")
+    params = RGroupDecompositionParameters()
+    params.onlyMatchAtRGroups = True
+    rgd = RGroupDecomposition(core, params)
+    self.assertEqual(rgd.GetMatchingCoreIdx(cmol), 0)
+    self.assertEqual(rgd.GetMatchingCoreIdx(nmol), 0)
+    self.assertEqual(rgd.GetMatchingCoreIdx(smol), -1)
+    matches = []
+    self.assertEqual(rgd.GetMatchingCoreIdx(cmol, matches), 0)
+    self.assertEqual(len(matches), 1)
+    self.assertEqual(len(matches[0]), core.GetNumAtoms())
+    matches = []
+    self.assertEqual(rgd.GetMatchingCoreIdx(nmol, matches), 0)
+    self.assertEqual(len(matches), 1)
+    self.assertEqual(len(matches[0]), core.GetNumAtoms() - 1)
+    matches = []
+    self.assertEqual(rgd.GetMatchingCoreIdx(smol, matches), -1)
+    self.assertEqual(len(matches), 0)
+    cmol_h = Chem.AddHs(cmol)
+    nmol_h = Chem.AddHs(nmol)
+    self.assertTrue(cmol_h.HasSubstructMatch(core))
+    self.assertEqual(len(cmol_h.GetSubstructMatch(core)), core.GetNumAtoms())
+    self.assertFalse(nmol_h.HasSubstructMatch(core))
 
 
 if __name__ == '__main__':

--- a/Code/GraphMol/RGroupDecomposition/catch_rgd.cpp
+++ b/Code/GraphMol/RGroupDecomposition/catch_rgd.cpp
@@ -779,3 +779,32 @@ TEST_CASE("MDL R labels from original core") {
     }
   }
 }
+
+TEST_CASE("Mol matches core") {
+  auto core = "[*:1]c1[!#1]([*:2])cc([*:3])n([*:4])c(=O)1"_smarts;
+  auto cmol = "Clc1c(C)cc(F)n(CC)c(=O)1"_smiles;
+  auto nmol = "Clc1ncc(F)n(CC)c(=O)1"_smiles;
+  auto smol = "Clc1ncc(F)n(CC)c(=S)1"_smiles;
+  RGroupDecompositionParameters params;
+  params.onlyMatchAtRGroups = true;
+  RGroupDecomposition decomp(*core, params);
+  CHECK(decomp.getMatchingCoreIdx(*cmol) == 0);
+  CHECK(decomp.getMatchingCoreIdx(*nmol) == 0);
+  CHECK(decomp.getMatchingCoreIdx(*smol) == -1);
+  std::vector<MatchVectType> matches;
+  CHECK(decomp.getMatchingCoreIdx(*cmol, &matches) == 0);
+  CHECK(matches.size() == 1);
+  CHECK(matches.front().size() == core->getNumAtoms());
+  CHECK(decomp.getMatchingCoreIdx(*nmol, &matches) == 0);
+  CHECK(matches.size() == 1);
+  CHECK(matches.front().size() == core->getNumAtoms() - 1);
+  CHECK(decomp.getMatchingCoreIdx(*smol, &matches) == -1);
+  CHECK(matches.empty());
+  MolOps::addHs(*cmol);
+  MolOps::addHs(*nmol);
+  MatchVectType match;
+  CHECK(SubstructMatch(*cmol, *core, match));
+  CHECK(match.size() == core->getNumAtoms());
+  match.clear();
+  CHECK(!SubstructMatch(*nmol, *core, match));
+}


### PR DESCRIPTION
This PR extracts the RGD core matching logic into a separate `getMatchingCoreIdx()` function, which can take an optional `std::vector<MatchVectType>` pointer to retrieve the atom idx matches if desired.
This is very useful to quickly attribute the matching core to a molecule using the same parameters that will be used for RGD without actually running the more compute-intensive RGD stage of sorting out the most appropriate mapping of R labels to substituents.