### PR TITLE
Fix Mol block parser by resetting atomic number to 0 for COMPOSITE_OR query atoms (#6349)

### DIFF
--- a/Code/GraphMol/Aromaticity.cpp
+++ b/Code/GraphMol/Aromaticity.cpp
@@ -809,18 +809,12 @@ int aromaticityHelper(RWMol &mol, const VECT_INT_VECT &srings,
       continue;
     }
 
-    auto isDummyAtom = [](const Atom &atom) {
-      return (!atom.hasQuery() && atom.getAtomicNum() == 0) ||
-             (atom.hasQuery() &&
-              atom.getQuery()->getDescription() == "AtomNull");
-    };
-
     bool allAromatic = true;
     bool allDummy = true;
     for (auto firstIdx : sring) {
       const auto at = mol.getAtomWithIdx(firstIdx);
 
-      if (allDummy && !isDummyAtom(*at)) {
+      if (allDummy && !isAtomDummy(at)) {
         allDummy = false;
       }
 

--- a/Code/GraphMol/Aromaticity.cpp
+++ b/Code/GraphMol/Aromaticity.cpp
@@ -809,12 +809,18 @@ int aromaticityHelper(RWMol &mol, const VECT_INT_VECT &srings,
       continue;
     }
 
+    auto isDummyAtom = [](const Atom &atom) {
+      return (!atom.hasQuery() && atom.getAtomicNum() == 0) ||
+             (atom.hasQuery() &&
+              atom.getQuery()->getDescription() == "AtomNull");
+    };
+
     bool allAromatic = true;
     bool allDummy = true;
     for (auto firstIdx : sring) {
       const auto at = mol.getAtomWithIdx(firstIdx);
 
-      if (allDummy && at->getAtomicNum() != 0) {
+      if (allDummy && !isDummyAtom(*at)) {
         allDummy = false;
       }
 

--- a/Code/GraphMol/FileParsers/MolFileParser.cpp
+++ b/Code/GraphMol/FileParsers/MolFileParser.cpp
@@ -1172,6 +1172,9 @@ void ParseNewAtomList(RWMol *mol, const std::string &text, unsigned int line) {
       a->setQuery(makeAtomNumQuery(atNum));
     } else {
       a->expandQuery(makeAtomNumQuery(atNum), Queries::COMPOSITE_OR, true);
+      // For COMPOSITE_OR query atoms, reset atomic num to 0 such that they are
+      // exported as "*" in SMILES
+      a->setAtomicNum(0);
     }
   }
   ASSERT_INVARIANT(a, "no atom built");

--- a/Code/GraphMol/FileParsers/test1.cpp
+++ b/Code/GraphMol/FileParsers/test1.cpp
@@ -47,8 +47,12 @@ void test1() {
   TEST_ASSERT(m);
 
   TEST_ASSERT(m->getNumAtoms() == 6);
+
+  std::string sma = MolToSmarts(*m);
+  TEST_ASSERT(sma == "[#6]1=[#6]-[#6]=[#6]-[#6]=[#6,#7,#15]-1");
+
   std::string smi = MolToSmiles(*m);
-  TEST_ASSERT(smi == "C1=CC=CC=C1");
+  TEST_ASSERT(smi == "*1=CC=CC=C1");
 
   m->updatePropertyCache();
   smi = MolToSmarts(*m);

--- a/Code/GraphMol/QueryOps.h
+++ b/Code/GraphMol/QueryOps.h
@@ -1084,6 +1084,17 @@ RDKIT_GRAPHMOL_EXPORT bool isAtomListQuery(const Atom *a);
 RDKIT_GRAPHMOL_EXPORT void getAtomListQueryVals(const Atom::QUERYATOM_QUERY *q,
                                                 std::vector<int> &vals);
 
+// Checks if an atom is dummy or not.
+// 1. A dummy non-query atom (e.g., "*" in SMILES) is defined by its zero atomic 
+//    number. This rule breaks for query atoms because a COMPOSITE_OR query atom 
+//    also has a zero atomic number (#6349).
+// 2. A dummy query atom (e.g., "*" in SMARTS) is defined by its explicit 
+//    description: "AtomNull".
+inline bool isAtomDummy(const Atom *a) {
+  return (!a->hasQuery() && a->getAtomicNum() == 0) ||
+         (a->hasQuery() && a->getQuery()->getDescription() == "AtomNull");
+}
+
 namespace QueryOps {
 RDKIT_GRAPHMOL_EXPORT void completeMolQueries(
     RWMol *mol, unsigned int magicVal = 0xDEADBEEF);

--- a/Code/GraphMol/QueryOps.h
+++ b/Code/GraphMol/QueryOps.h
@@ -1085,14 +1085,15 @@ RDKIT_GRAPHMOL_EXPORT void getAtomListQueryVals(const Atom::QUERYATOM_QUERY *q,
                                                 std::vector<int> &vals);
 
 // Checks if an atom is dummy or not.
-// 1. A dummy non-query atom (e.g., "*" in SMILES) is defined by its zero atomic 
-//    number. This rule breaks for query atoms because a COMPOSITE_OR query atom 
+// 1. A dummy non-query atom (e.g., "*" in SMILES) is defined by its zero atomic
+//    number. This rule breaks for query atoms because a COMPOSITE_OR query atom
 //    also has a zero atomic number (#6349).
-// 2. A dummy query atom (e.g., "*" in SMARTS) is defined by its explicit 
+// 2. A dummy query atom (e.g., "*" in SMARTS) is defined by its explicit
 //    description: "AtomNull".
 inline bool isAtomDummy(const Atom *a) {
   return (!a->hasQuery() && a->getAtomicNum() == 0) ||
-         (a->hasQuery() && a->getQuery()->getDescription() == "AtomNull");
+         (a->hasQuery() && !a->getQuery()->getNegation() &&
+          a->getQuery()->getDescription() == "AtomNull");
 }
 
 namespace QueryOps {

--- a/Code/GraphMol/RGroupDecomposition/testRGroupDecomp.cpp
+++ b/Code/GraphMol/RGroupDecomposition/testRGroupDecomp.cpp
@@ -2510,6 +2510,8 @@ M  ALS   6  2 F C   N
 M  END
 )CTAB"_ctab;
   TEST_ASSERT(core);
+  std::string sma = MolToSmarts(*core);
+  TEST_ASSERT(sma == "[#6,#7]1:[#6,#7]:[#6,#7]:[#6,#7]:[#6,#7]:[#6,#7]:1");
 
   auto structure = "ClC1=CN=C(C=C1)N1CCCC1"_smiles;
   RGroupDecomposition decomp(*core);

--- a/Code/GraphMol/SmilesParse/test.cpp
+++ b/Code/GraphMol/SmilesParse/test.cpp
@@ -4390,15 +4390,14 @@ void testGithub6349() {
 
   auto checkSmartsToSmiles = [](const std::string &sma,
                                 const std::string &refSmi) {
-    ROMol *molFromSmarts = SmartsToMol(sma);
+    std::unique_ptr<ROMol> molFromSmarts(SmartsToMol(sma));
     {
       std::string smi = MolToSmiles(*molFromSmarts);
       TEST_ASSERT(smi == refSmi);
     }
 
     std::string molBlock = MolToMolBlock(*molFromSmarts);
-    ROMol *molFromBlock =
-        MolBlockToMol(molBlock, /*sanitize =*/false, /*removeHs =*/false);
+    std::unique_ptr<ROMol> molFromBlock(MolBlockToMol(molBlock, /*sanitize =*/false, /*removeHs =*/false));
     {
       std::string smi = MolToSmiles(*molFromBlock);
       TEST_ASSERT(smi == refSmi);

--- a/Code/GraphMol/SmilesParse/test.cpp
+++ b/Code/GraphMol/SmilesParse/test.cpp
@@ -4382,6 +4382,36 @@ void testGithub3967() {
   BOOST_LOG(rdInfoLog) << "\tdone" << std::endl;
 }
 
+void testGithub6349() {
+  BOOST_LOG(rdInfoLog) << "-------------------------------------" << std::endl;
+  BOOST_LOG(rdInfoLog)
+      << "Testing Github Issue 6349: Different SMARTS input formats lead to different SMILES outputs."
+      << std::endl;
+
+  auto checkSmartsToSmiles = [](const std::string &sma,
+                                const std::string &refSmi) {
+    ROMol *molFromSmarts = SmartsToMol(sma);
+    {
+      std::string smi = MolToSmiles(*molFromSmarts);
+      TEST_ASSERT(smi == refSmi);
+    }
+
+    std::string molBlock = MolToMolBlock(*molFromSmarts);
+    ROMol *molFromBlock =
+        MolBlockToMol(molBlock, /*sanitize =*/false, /*removeHs =*/false);
+    {
+      std::string smi = MolToSmiles(*molFromBlock);
+      TEST_ASSERT(smi == refSmi);
+    }
+  };
+  checkSmartsToSmiles("[C]", "C");
+  checkSmartsToSmiles("[C,N]", "*");
+  checkSmartsToSmiles("[C,N]~[O,S]", "*~*");
+  checkSmartsToSmiles("C-C(-[Cl,F,Br])-C", "*C(C)C");
+
+  BOOST_LOG(rdInfoLog) << "done" << std::endl;
+}
+
 int main(int argc, char *argv[]) {
   (void)argc;
   (void)argv;
@@ -4461,6 +4491,7 @@ int main(int argc, char *argv[]) {
   testGithub1028();
   testGithub3139();
   testGithub3967();
+  testGithub6349();
 #endif
   testOSSFuzzFailures();
 }

--- a/Code/GraphMol/Substruct/SubstructUtils.cpp
+++ b/Code/GraphMol/Substruct/SubstructUtils.cpp
@@ -246,11 +246,7 @@ std::vector<MatchVectType> sortMatchesByDegreeOfCoreSubstitution(
 }
 
 bool isAtomTerminalRGroupOrQueryHydrogen(const Atom *atom) {
-  auto isDummyAtom = [](const Atom &atom) {
-    return (!atom.hasQuery() && atom.getAtomicNum() == 0) ||
-           (atom.hasQuery() && atom.getQuery()->getDescription() == "AtomNull");
-  };
-  return (atom->getDegree() == 1 && isDummyAtom(*atom)) ||
+  return (atom->getDegree() == 1 && isAtomDummy(atom)) ||
          (atom->hasQuery() &&
           describeQuery(atom).find("AtomAtomicNum 1 = val") !=
               std::string::npos);

--- a/Code/GraphMol/Substruct/SubstructUtils.cpp
+++ b/Code/GraphMol/Substruct/SubstructUtils.cpp
@@ -246,11 +246,14 @@ std::vector<MatchVectType> sortMatchesByDegreeOfCoreSubstitution(
 }
 
 bool isAtomTerminalRGroupOrQueryHydrogen(const Atom *atom) {
-  return atom->getDegree() == 1 &&
-         (atom->getAtomicNum() == 0 ||
-          (atom->hasQuery() &&
-           describeQuery(atom).find("AtomAtomicNum 1 = val") !=
-               std::string::npos));
+  auto isDummyAtom = [](const Atom &atom) {
+    return (!atom.hasQuery() && atom.getAtomicNum() == 0) ||
+           (atom.hasQuery() && atom.getQuery()->getDescription() == "AtomNull");
+  };
+  return (atom->getDegree() == 1 && isDummyAtom(*atom)) ||
+         (atom->hasQuery() &&
+          describeQuery(atom).find("AtomAtomicNum 1 = val") !=
+              std::string::npos);
 }
 
 #define PT_OPT_GET(opt) params.opt = pt.get(#opt, params.opt)

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -838,7 +838,7 @@ class TestCase(unittest.TestCase):
                          'list-query.mol')
     query = Chem.MolFromMolFile(fileN)
     smi = Chem.MolToSmiles(query)
-    self.assertEqual(smi, 'c1ccccc1')
+    self.assertEqual(smi, '*1ccccc1')
     smi = Chem.MolToSmarts(query)
     self.assertEqual(smi, '[#6]1:[#6]:[#6]:[#6]:[#6]:[#6,#7,#15]:1')
     smi = Chem.MolToSmarts(query, rootedAtAtom=5)
@@ -846,7 +846,7 @@ class TestCase(unittest.TestCase):
 
     query = Chem.MolFromMolFile(fileN, sanitize=False)
     smi = Chem.MolToSmiles(query)
-    self.assertEqual(smi, 'C1=CC=CC=C1')
+    self.assertEqual(smi, '*1=CC=CC=C1')
     query.UpdatePropertyCache()
     smi = Chem.MolToSmarts(query)
     self.assertEqual(smi, '[#6]1=[#6]-[#6]=[#6]-[#6]=[#6,#7,#15]-1')


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! 
-->
#### Reference Issue

Fixes #6349 

#### What does this implement/fix? Explain your changes.

For a query with OR atoms, such as `[C,N]`, we can construct a Mol object from either a SMARTS (via `MolFromSmarts`) or a Mol block (via `MolFromMolBlock`), but the exported SMILES (via `MolToSmiles`) from these two approaches are inconsistent:

```python
from rdkit import Chem
m = Chem.MolFromSmarts("[C,N]")
print(Chem.MolToSmiles(m)) # *
mb = Chem.MolToMolBlock(m)
m2 = Chem.MolFromMolBlock(mb)
print(Chem.MolToSmiles(m2)) # C
```
where `*` is the expected output. There is a bug in Mol block parser that always logs the atomic number of the first atom (i.e., `C` in `[C,N]`) as that of the query atom. 

The fix is very straightfoward. When we load the first atom (e.g., `C`), the atomic number of the query atom is set to 6. If there are OR atoms in the brackets (e.g., `[C,N]`), the atomic number of the query atom is reset to 0, corresponding to `*`. This is the behavior of `MolFromSmarts`.

```python
m = Chem.MolFromSmarts("[C]")
print(Chem.MolToSmiles(m)) # C
mb = Chem.MolToMolBlock(m)
m2 = Chem.MolFromMolBlock(mb)
print(Chem.MolToSmiles(m2)) # C
```

A unittest `testGithub6349` is added to `Code/GraphMol/SmilesParse/test.cpp`.

#### Any other comments?

I also find out that the query atom from these two approaches are in different representations:
1. `MolFromSmarts` uses `AtomType`, while
2. `MolFromMolBlock` uses `AtomAtomicNum`.

```python
m1 = Chem.MolFromSmarts("[C,N]")
at1 = m1.GetAtomWithIdx(0)
print(at1.DescribeQuery())
# AtomOr
#   AtomType 6 = val
#   AtomType 7 = val

mb = Chem.MolToMolBlock(m1)
m2 = Chem.MolFromMolBlock(mb)
at2 = m2.GetAtomWithIdx(0)
print(at2.DescribeQuery())
# AtomOr
#   AtomAtomicNum 6 = val
#   AtomAtomicNum 7 = val
```

Not sure if they should be the same or not, but it seems to be out of the scope of this bug fix.