### PR TITLE
Stereochemistry of implicit neighbours

### DIFF
--- a/Code/GraphMol/Canon.cpp
+++ b/Code/GraphMol/Canon.cpp
@@ -70,13 +70,26 @@ bool atomHasFourthValence(const Atom *atom) {
 }  // namespace details
 
 bool chiralAtomNeedsTagInversion(const RDKit::ROMol &mol,
-                                 const RDKit::Atom *atom, bool isAtomFirst,
+                                 const RDKit::Atom *atom, 
+                                 bool isAtomFirst,
                                  size_t numClosures) {
   PRECONDITION(atom, "bad atom");
-  return atom->getDegree() == 3 &&
+  bool newCondition = atom->getDegree() == 3 && isAtomFirst;
+
+  bool oldCondition = atom->getDegree() == 3 &&
          ((isAtomFirst && atom->getNumExplicitHs() == 1) ||
           (!details::atomHasFourthValence(atom) && numClosures == 1 &&
-           !details::isUnsaturated(atom, mol)));
+           !details::isUnsaturated(atom, mol)));  
+
+  // to be removed in future but handy to let the user know something has
+  // have changed!
+  if (newCondition != oldCondition) {
+    BOOST_LOG(rdWarningLog) << 
+      "Warning: A change in handling of implicit neighbors means a tetrahedral "
+      "center (usually the first atom) inverted meaning!\n";
+  }
+
+  return newCondition;           
 }
 
 auto _possibleCompare = [](const PossibleType &arg1, const PossibleType &arg2) {

--- a/Code/GraphMol/Substruct/test1.cpp
+++ b/Code/GraphMol/Substruct/test1.cpp
@@ -985,7 +985,7 @@ void testChiralMatch() {
     bool matched = SubstructMatch(*mol, *query, matchV, true, true);
     delete mol;
     delete query;
-    TEST_ASSERT(!matched);
+    TEST_ASSERT(matched);
   }
   {
     std::string qSmi = "[C@@](C)(F)Br";
@@ -996,7 +996,161 @@ void testChiralMatch() {
     bool matched = SubstructMatch(*mol, *query, matchV, true, true);
     delete mol;
     delete query;
+    TEST_ASSERT(!matched);
+  }
+  {
+    std::string qSmi = "[C@!H0](C)(F)Br";
+    std::string mSmi = "[C@H](C)(F)Br";
+    ROMol *query = SmartsToMol(qSmi);
+    ROMol *mol = SmilesToMol(mSmi);
+    MatchVectType matchV;
+    bool matched = SubstructMatch(*mol, *query, matchV, true, true);
+    delete mol;
+    delete query;
     TEST_ASSERT(matched);
+  }
+  {
+    std::string qSmi = "[C@@!H0](C)(F)Br";
+    std::string mSmi = "[C@H](C)(F)Br";
+    ROMol *query = SmartsToMol(qSmi);
+    ROMol *mol = SmilesToMol(mSmi);
+    MatchVectType matchV;
+    bool matched = SubstructMatch(*mol, *query, matchV, true, true);
+    delete mol;
+    delete query;
+    TEST_ASSERT(!matched);
+  }
+  {
+    std::string qSmi = "[C@h](C)(F)Br";
+    std::string mSmi = "[C@H](C)(F)Br";
+    ROMol *query = SmartsToMol(qSmi);
+    ROMol *mol = SmilesToMol(mSmi);
+    MatchVectType matchV;
+    bool matched = SubstructMatch(*mol, *query, matchV, true, true);
+    delete mol;
+    delete query;
+    TEST_ASSERT(matched);
+  }
+  {
+    std::string qSmi = "[C@@h](C)(F)Br";
+    std::string mSmi = "[C@H](C)(F)Br";
+    ROMol *query = SmartsToMol(qSmi);
+    ROMol *mol = SmilesToMol(mSmi);
+    MatchVectType matchV;
+    bool matched = SubstructMatch(*mol, *query, matchV, true, true);
+    delete mol;
+    delete query;
+    TEST_ASSERT(!matched);
+  }
+  {
+    std::string qSmi = "[C@h](C)(F)Br";
+    std::string mSmi = "[C@H](C)(F)Br";
+    ROMol *query = SmartsToMol(qSmi);
+    ROMol *mol = SmilesToMol(mSmi);
+    MatchVectType matchV;
+    bool matched = SubstructMatch(*mol, *query, matchV, true, true);
+    delete mol;
+    delete query;
+    TEST_ASSERT(matched);
+  }
+  {
+    std::string qSmi = "[S@@](=O)(C)CC";
+    std::string mSmi = "[S@@](=O)(C)CC";
+    ROMol *query = SmartsToMol(qSmi);
+    ROMol *mol = SmilesToMol(mSmi);
+    MatchVectType matchV;
+    bool matched = SubstructMatch(*mol, *query, matchV, true, true);
+    delete mol;
+    delete query;
+    TEST_ASSERT(matched);
+  }
+  {
+    std::string qSmi = "[S@](=O)(C)CC";
+    std::string mSmi = "[S@](=O)(C)CC";
+    ROMol *query = SmartsToMol(qSmi);
+    ROMol *mol = SmilesToMol(mSmi);
+    MatchVectType matchV;
+    bool matched = SubstructMatch(*mol, *query, matchV, true, true);
+    delete mol;
+    delete query;
+    TEST_ASSERT(matched);
+  }
+  {
+    std::string qSmi = "[S@](=O)(C)CC";
+    std::string mSmi = "[S@@](=O)(C)CC";
+    ROMol *query = SmartsToMol(qSmi);
+    ROMol *mol = SmilesToMol(mSmi);
+    MatchVectType matchV;
+    bool matched = SubstructMatch(*mol, *query, matchV, true, true);
+    delete mol;
+    delete query;
+    TEST_ASSERT(!matched);
+  }
+  {
+    std::string qSmi = "[S@@](=O)(C)CC";
+    std::string mSmi = "[S@@](=O)(C)CC";
+    ROMol *query = SmartsToMol(qSmi);
+    ROMol *mol = SmilesToMol(mSmi);
+    MatchVectType matchV;
+    bool matched = SubstructMatch(*mol, *query, matchV, true, true);
+    delete mol;
+    delete query;
+    TEST_ASSERT(matched);
+  }
+  {
+    std::string qSmi = "[S@@](=O)(C)CC";
+    std::string mSmi = "[S@](=O)(C)CC";
+    ROMol *query = SmartsToMol(qSmi);
+    ROMol *mol = SmilesToMol(mSmi);
+    MatchVectType matchV;
+    bool matched = SubstructMatch(*mol, *query, matchV, true, true);
+    delete mol;
+    delete query;
+    TEST_ASSERT(!matched);
+  }
+  {
+    std::string qSmi = "[S@](=O)(C)CC";
+    std::string mSmi = "O=[S@@](C)CC";
+    ROMol *query = SmartsToMol(qSmi);
+    ROMol *mol = SmilesToMol(mSmi);
+    MatchVectType matchV;
+    bool matched = SubstructMatch(*mol, *query, matchV, true, true);
+    delete mol;
+    delete query;
+    TEST_ASSERT(matched);
+  }
+  {
+    std::string qSmi = "[S@](=O)(C)CC";
+    std::string mSmi = "O=[S@](C)CC";
+    ROMol *query = SmartsToMol(qSmi);
+    ROMol *mol = SmilesToMol(mSmi);
+    MatchVectType matchV;
+    bool matched = SubstructMatch(*mol, *query, matchV, true, true);
+    delete mol;
+    delete query;
+    TEST_ASSERT(!matched);
+  }
+  {
+    std::string qSmi = "[S@@](=O)(C)CC";
+    std::string mSmi = "O=[S@](C)CC";
+    ROMol *query = SmartsToMol(qSmi);
+    ROMol *mol = SmilesToMol(mSmi);
+    MatchVectType matchV;
+    bool matched = SubstructMatch(*mol, *query, matchV, true, true);
+    delete mol;
+    delete query;
+    TEST_ASSERT(matched);
+  }
+  {
+    std::string qSmi = "[S@@](=O)(C)CC";
+    std::string mSmi = "O=[S@@](C)CC";
+    ROMol *query = SmartsToMol(qSmi);
+    ROMol *mol = SmilesToMol(mSmi);
+    MatchVectType matchV;
+    bool matched = SubstructMatch(*mol, *query, matchV, true, true);
+    delete mol;
+    delete query;
+    TEST_ASSERT(!matched);
   }
   {
     std::string qSmi = "C[C@](F)Br";
@@ -1444,8 +1598,7 @@ void testGitHubIssue688() {
     TEST_ASSERT(SubstructMatch(*mol, *qmol, match, true, false));
     TEST_ASSERT(match.size() == qmol->getNumAtoms());
 
-    TEST_ASSERT(SubstructMatch(*mol, *qmol, match, true, true));
-    TEST_ASSERT(match.size() == qmol->getNumAtoms());
+    TEST_ASSERT(!SubstructMatch(*mol, *qmol, match, true, true));
 
     delete mol;
     delete qmol;
@@ -1466,7 +1619,8 @@ void testGitHubIssue688() {
     TEST_ASSERT(SubstructMatch(*mol, *qmol, match, true, false));
     TEST_ASSERT(match.size() == qmol->getNumAtoms());
 
-    TEST_ASSERT(!SubstructMatch(*mol, *qmol, match, true, true));
+    TEST_ASSERT(SubstructMatch(*mol, *qmol, match, true, true));
+    TEST_ASSERT(match.size() == qmol->getNumAtoms());
 
     delete mol;
     delete qmol;
@@ -1615,26 +1769,26 @@ void testGithub2570() {
     {
       const auto query = R"([C@](Cl)(Br)F)"_smarts;
       std::vector<MatchVectType> matches;
-      TEST_ASSERT(!SubstructMatch(*mol, *query, matches, uniquify,
-                                  recursionPossible, useChirality));
+      TEST_ASSERT(SubstructMatch(*mol, *query, matches, uniquify,
+                                 recursionPossible, useChirality));
     }
     {
       const auto query = R"([C@@](Cl)(Br)F)"_smarts;
       std::vector<MatchVectType> matches;
-      TEST_ASSERT(SubstructMatch(*mol, *query, matches, uniquify,
+      TEST_ASSERT(!SubstructMatch(*mol, *query, matches, uniquify,
                                  recursionPossible, useChirality));
     }
     {  // Swap order of a pair of atoms
       const auto query = R"([C@](Br)(Cl)F)"_smarts;
       std::vector<MatchVectType> matches;
-      TEST_ASSERT(SubstructMatch(*mol, *query, matches, uniquify,
-                                 recursionPossible, useChirality));
+      TEST_ASSERT(!SubstructMatch(*mol, *query, matches, uniquify,
+                                  recursionPossible, useChirality));
     }
     {
       const auto query = R"([C@@](Br)(Cl)F)"_smarts;
       std::vector<MatchVectType> matches;
-      TEST_ASSERT(!SubstructMatch(*mol, *query, matches, uniquify,
-                                  recursionPossible, useChirality));
+      TEST_ASSERT(SubstructMatch(*mol, *query, matches, uniquify,
+                                recursionPossible, useChirality));
     }
     {  // Smaller fragments should always match as long as they have have a
        // chiral tag,
@@ -1667,38 +1821,38 @@ void testGithub2570() {
     {
       const auto query = R"([C@](C)(Cl)Br)"_smarts;
       std::vector<MatchVectType> matches;
-      TEST_ASSERT(SubstructMatch(*mol, *query, matches, uniquify,
-                                 recursionPossible, useChirality));
+      TEST_ASSERT(!SubstructMatch(*mol, *query, matches, uniquify,
+                                  recursionPossible, useChirality));
     }
     {
       const auto query = R"([C@@](C)(Cl)Br)"_smarts;
       std::vector<MatchVectType> matches;
-      TEST_ASSERT(!SubstructMatch(*mol, *query, matches, uniquify,
-                                  recursionPossible, useChirality));
+      TEST_ASSERT(SubstructMatch(*mol, *query, matches, uniquify,
+                                recursionPossible, useChirality));
     }
     {
       const auto query = R"([C@](Cl)(Br)F)"_smarts;
       std::vector<MatchVectType> matches;
-      TEST_ASSERT(!SubstructMatch(*mol, *query, matches, uniquify,
-                                  recursionPossible, useChirality));
+      TEST_ASSERT(SubstructMatch(*mol, *query, matches, uniquify,
+                                recursionPossible, useChirality));
     }
     {
       const auto query = R"([C@@](Cl)(Br)F)"_smarts;
       std::vector<MatchVectType> matches;
-      TEST_ASSERT(SubstructMatch(*mol, *query, matches, uniquify,
-                                 recursionPossible, useChirality));
+      TEST_ASSERT(!SubstructMatch(*mol, *query, matches, uniquify,
+                                  recursionPossible, useChirality));
     }
     {  // Swap order of a pair of atoms
       const auto query = R"([C@](Br)(Cl)F)"_smarts;
       std::vector<MatchVectType> matches;
-      TEST_ASSERT(SubstructMatch(*mol, *query, matches, uniquify,
-                                 recursionPossible, useChirality));
+      TEST_ASSERT(!SubstructMatch(*mol, *query, matches, uniquify,
+                                  recursionPossible, useChirality));
     }
     {
       const auto query = R"([C@@](Br)(Cl)F)"_smarts;
       std::vector<MatchVectType> matches;
-      TEST_ASSERT(!SubstructMatch(*mol, *query, matches, uniquify,
-                                  recursionPossible, useChirality));
+      TEST_ASSERT(SubstructMatch(*mol, *query, matches, uniquify,
+                                 recursionPossible, useChirality));
     }
   }
 

--- a/rdkit/Chem/UnitTestSmiles.py
+++ b/rdkit/Chem/UnitTestSmiles.py
@@ -163,9 +163,9 @@ class TestCase(unittest.TestCase):
       # non-ring cases with no hydrogen property
       ('Cl[C@](F)(Br)(O)', '[C@](Cl)(F)(Br)(O)'),
 
-      # OpenBabel and Indigo have issues with sulfur chirality
-      ('Cl[S@](C)=O', '[S@](Cl)(C)=O'),  # ChemAxon flips this chirality
-      ('Cl[S@](C)=CCCC', '[S@](Cl)(C)=CCCC'),  # ChemAxon removes this chirality entirely
+      # Note: Different toolkits handle implicit/missing neighbors on tetrahedral differently
+      ('Cl[S@@](C)=O', '[S@](Cl)(C)=O'),  # ChemAxon flips this chirality
+      ('Cl[S@@](C)=CCCC', '[S@](Cl)(C)=CCCC'), # ChemAxon removes this chirality entirely
 
       # ring cases, RDKit parsed these as different isomers before https://github.com/rdkit/rdkit/issues/1652 was fixed
       ('Cl[C@](F)1CC[C@H](F)CC1', '[C@](Cl)(F)1CC[C@H](F)CC1'),


### PR DESCRIPTION
#### Reference Issue

Extends on from: #6730

#### What does this implement/fix? Explain your changes.

Treat any implicit/missing neighbours in SMARTS and SMILES as being attached to the central (chiral) atom rather than being at the end. This is mostly a no-op expect for when the atom appears first and doesn't fit the criteria of ``chiralAtomNeedsTagInversion``. The meaning of some stereocenters (mostly first atoms) does change but I would argue this makes more sense.

Sometimes this is just a case of "*you say this I say that*" but there are cases (marked with **!?**) that I think demonstrate why this logic make sense.

| SMILES                  | SMARTS                    | Current        | This | Comment
| ----------------------- | ------------------------- | -------------- | ---- | ---------
``[C@H](Cl)(F)C``         | ``[C@H](Cl)(F)C``         | N/Y (#6730)    | Y    |  
``[C@H](Cl)(F)C``         | ``[C@H1](Cl)(F)C``        | N/Y (#6730)    | Y    |  
``[C@H](Cl)(F)C``         | ``[C@&H1](Cl)(F)C``       | N              | Y    | !? (isAtomFirst && details::atomHasFourthValence(atom)) is a band-aid for this
``[C@H](Cl)(F)C``         | ``[C@!H0](Cl)(F)C``       | N              | Y    | !?
``[C@H](Cl)(F)C``         | ``[C@h](Cl)(F)C``         | N              | Y    | !?
``[C@]([H])(Cl)(F)C``     | ``[C@$(*[H])](Cl)(F)C``   | N              | Y    | !?parma.removeHs=False
``[C@]([H])(Cl)(F)C``     | ``[C@H](Cl)(F)C``         | N/Y (#6730)    | Y    | parma.removeHs=False
``O=[S@@](CC)C``          | ``[S@](=O)(CC)C``         | N              | Y    |
``[S@](=O)(CC)C``         | ``[S@](=O)(CC)C``         | Y              | Y    |
``O=[S@](CC)C``           | ``[S@](=O)(CC)C``         | Y              | N    |
``O=[S@](CC)C``           | ``[S@](=O)(CC)C``         | Y              | N    |
``O=[S@]1CCCO1``          | ``O~[S@]1CCCO1``          | N              | Y    | !?
``O=[S@@]1CCCO1``         | ``O~[S@]1CCCO1``          | Y              | N    | !?
``[S@@]1(=O)CCCO1``       | ``[S@@]1(~O)CCCO1``       | N              | Y    | !?
``[S@@]1(=O)CCCO1``       | ``[S@]1(~O)CCCO1``        | Y              | N    | !?
``N[C@]1(Cl)CCCO1``       | ``N[C@]1CCCO1``           | Y              | N    |
``N[C@]1(Cl)CCCO1``       | ``N[C@](OC1)CC1``         | N              | N    |  BFS but should be same as previous
``N[C@]1(Cl)CCCO1``       | ``N[C@@]1CCCO1``          | N              | Y    | 
``N[C@]1(Cl)CCCO1``       | ``N[C@@](OC1)CC1``        | Y              | Y    | BFS but should be same as previous
``N[C@H]1CCCO1``          | ``N[C@H]1CCCO1``          | Y              | Y    |
``N[C@H]1CCCO1``          | ``N[C@]1CCCO1``           | N              | Y    | !?

#### Any other comments?

I am also going to also look at the ``@SP``/``@TB``/``@OH`` etc's are handled.

