### PR TITLE
Remove redundant argument and variable `hasCoreDummies` (#6779)

### DIFF
--- a/Code/GraphMol/RGroupDecomposition/RGroupCore.cpp
+++ b/Code/GraphMol/RGroupDecomposition/RGroupCore.cpp
@@ -64,7 +64,7 @@ void RCore::findIndicesWithRLabel() {
   }
 }
 
-std::pair<RWMOL_SPTR, bool> RCore::extractCoreFromMolMatch(
+RWMOL_SPTR RCore::extractCoreFromMolMatch(
     const ROMol &mol, const MatchVectType &match,
     const RGroupDecompositionParameters &params) const {
   auto extractedCore = boost::make_shared<RWMol>(mol);
@@ -72,7 +72,6 @@ std::pair<RWMOL_SPTR, bool> RCore::extractCoreFromMolMatch(
   std::vector<Bond *> newBonds;
   std::map<Atom *, int> dummyAtomMap;
   std::map<const Atom *, Atom *> molAtomMap;
-  bool hasCoreDummies = false;
   for (auto &pair : match) {
     const auto queryAtom = core->getAtomWithIdx(pair.first);
     auto const targetAtom = extractedCore->getAtomWithIdx(pair.second);
@@ -83,9 +82,6 @@ std::pair<RWMOL_SPTR, bool> RCore::extractCoreFromMolMatch(
       targetAtom->setProp(RLABEL_TYPE, rLabelType);
     }
 
-    if (!hasCoreDummies && queryAtom->getAtomicNum() == 0) {
-      hasCoreDummies = true;
-    }
     if (queryAtom->getAtomicNum() == 0 && queryAtom->hasProp(RLABEL) &&
         queryAtom->getDegree() == 1) {
       continue;
@@ -284,8 +280,7 @@ std::pair<RWMOL_SPTR, bool> RCore::extractCoreFromMolMatch(
   } catch (const MolSanitizeException &) {
   }
 
-  std::pair rtn(extractedCore, hasCoreDummies);
-  return rtn;
+  return extractedCore;
 }
 
 // Return a copy of core where dummy atoms are replaced by
@@ -293,14 +288,10 @@ std::pair<RWMOL_SPTR, bool> RCore::extractCoreFromMolMatch(
 // their aromatic flag and formal charge copied from
 // the respective matching atom in mol
 ROMOL_SPTR RCore::replaceCoreAtomsWithMolMatches(
-    bool &hasCoreDummies, const ROMol &mol, const MatchVectType &match) const {
+    const ROMol &mol, const MatchVectType &match) const {
   auto coreReplacedAtoms = boost::make_shared<RWMol>(*core);
-  hasCoreDummies = false;
   for (const auto &p : match) {
     auto atom = coreReplacedAtoms->getAtomWithIdx(p.first);
-    if (atom->getAtomicNum() == 0) {
-      hasCoreDummies = true;
-    }
     if (isAtomWithMultipleNeighborsOrNotDummyRGroupAttachment(*atom)) {
       auto molAtom = mol.getAtomWithIdx(p.second);
       replaceCoreAtom(*coreReplacedAtoms, *atom, *molAtom);
@@ -310,7 +301,6 @@ ROMOL_SPTR RCore::replaceCoreAtomsWithMolMatches(
   std::map<int, int> matchLookup(match.cbegin(), match.cend());
   for (auto bond : coreReplacedAtoms->bonds()) {
     if (bond->hasQuery()) {
-      hasCoreDummies = true;
       const auto molBond =
           mol.getBondBetweenAtoms(matchLookup[bond->getBeginAtomIdx()],
                                   matchLookup[bond->getEndAtomIdx()]);

--- a/Code/GraphMol/RGroupDecomposition/RGroupCore.h
+++ b/Code/GraphMol/RGroupDecomposition/RGroupCore.h
@@ -53,13 +53,12 @@ struct RCore {
   // the respective matching atom in mol, while other atoms have
   // their aromatic flag and formal charge copied from
   // the respective matching atom in mol
-  ROMOL_SPTR replaceCoreAtomsWithMolMatches(bool &hasCoreDummies,
-                                            const ROMol &mol,
+  ROMOL_SPTR replaceCoreAtomsWithMolMatches(const ROMol &mol,
                                             const MatchVectType &match) const;
 
   // Final core returned to user, created by extracting core from target
   // molecule
-  std::pair<RWMOL_SPTR, bool> extractCoreFromMolMatch(
+  RWMOL_SPTR extractCoreFromMolMatch(
       const ROMol &mol, const MatchVectType &match,
       const RGroupDecompositionParameters &params) const;
 

--- a/Code/GraphMol/RGroupDecomposition/RGroupDecomp.cpp
+++ b/Code/GraphMol/RGroupDecomposition/RGroupDecomp.cpp
@@ -150,7 +150,7 @@ int RGroupDecomposition::getMatchingCoreInternal(
       } else {
         baseMatches = SubstructMatch(mol, *core.second.matchingMol, sssparams);
       }
-      
+
       tmatches.clear();
       for (const auto &baseMatch : baseMatches) {
         // Match the R Groups
@@ -315,10 +315,8 @@ int RGroupDecomposition::add(const ROMol &inmol) {
     const bool replaceDummies = false;
     const bool labelByIndex = true;
     const bool requireDummyMatch = false;
-    bool hasCoreDummies = false;
     // TODO see if we need relaceCoreWithMolMatches or can just use rcore->core
-    auto coreCopy =
-        rcore->replaceCoreAtomsWithMolMatches(hasCoreDummies, mol, tmatche);
+    auto coreCopy = rcore->replaceCoreAtomsWithMolMatches(mol, tmatche);
     tMol.reset(replaceCore(mol, *coreCopy, tmatche, replaceDummies,
                            labelByIndex, requireDummyMatch));
 #ifdef VERBOSE
@@ -446,9 +444,8 @@ int RGroupDecomposition::add(const ROMol &inmol) {
             rcore->numberUserRGroups - numberUserGroupsInMatch;
         CHECK_INVARIANT(numberMissingUserGroups >= 0,
                         "Data error in missing user rgroup count");
-        const auto [extractedCore, hasDummies] =
+        const auto extractedCore =
             rcore->extractCoreFromMolMatch(mol, tmatche, params());
-        hasCoreDummies = hasDummies;
         potentialMatches.emplace_back(core_idx, numberMissingUserGroups, match,
                                       extractedCore);
       }


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! 
-->
#### Reference Issue

Fixes #6779

#### What does this implement/fix? Explain your changes.

When reading R-group decomposition codes, I find that the variable and function argument `hasCoreDummies` serves as a temporary variable and it only affects itself. Maybe it was useful during development and debugging, but I feel like at this stage it causes more confusion than benefits.
