### PR TITLE
SWIG builds failing on Windows

### DIFF
--- a/Code/JavaWrappers/FMCS.i
+++ b/Code/JavaWrappers/FMCS.i
@@ -35,6 +35,7 @@
 %}
 
 %ignore MCSParameters;
+%ignore MCSParametersInternal;
 %ignore findMCS(const std::vector<ROMOL_SPTR>& mols, const MCSParameters* params);
 %ignore checkAtomRingMatch(const MCSAtomCompareParameters& p,
                            const ROMol& mol1, unsigned int atom1,


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! 
-->

#### What does this implement/fix? Explain your changes.

Currently it is not possible it build the C# wrappers on Windows.  SWIG tries to output a file called `SWIGTYPE_p_f_a___q_const__unsigned_int_a___q_const__unsigned_int_r_q_const__RDKit__ROMol_r_q_const__FMCS__Graph_r_q_const__RDKit__ROMol_r_q_const__FMCS__Graph_p_q_const__RDKit__MCSParameters__bool.cs`.  This fails presumably because the file name is too long for NTFS.  I expect you get the same error when building the Java wrappers on Windows.

It is fixed by excluding the `MCSParametersInternal` class from the SWIG build.

#### Any other comments?

