### PR TITLE
Add support for writing chirality and stereo in MaeWriter

### DIFF
--- a/Code/GraphMol/FileParsers/MaeWriter.cpp
+++ b/Code/GraphMol/FileParsers/MaeWriter.cpp
@@ -35,6 +35,8 @@ namespace RDKit {
 
 namespace {
 const std::string MAE_BOND_DATIVE_MARK = "b_sPrivate_dative_bond";
+const std::string MAE_BOND_PARITY = "i_sd_original_parity";
+const std::string MAE_STEREO_STATUS = "i_m_ct_stereo_status";
 const std::string PDB_ATOM_NAME = "s_m_pdb_atom_name";
 const std::string PDB_RESIDUE_NAME = "s_m_pdb_residue_name";
 const std::string PDB_CHAIN_NAME = "s_m_chain_name";
@@ -221,6 +223,61 @@ int bondTypeToOrder(const Bond& bond) {
   }
 }
 
+static bool is_double_any_bond(const RDKit::Bond& b)
+{
+    if (b.getBondType() == RDKit::Bond::DOUBLE) {
+        if (b.getStereo() == RDKit::Bond::BondStereo::STEREOANY ||
+            b.getBondDir() == RDKit::Bond::EITHERDOUBLE) {
+            return true;
+        }
+
+        // Check v3000/v2000 stereo either props
+        auto has_either_prop = [&b](const auto& prop, const int& either_value) {
+            return b.hasProp(prop) && b.getProp<int>(prop) == either_value;
+        };
+
+        return has_either_prop(RDKit::common_properties::_MolFileBondCfg, 2) ||
+               has_either_prop(RDKit::common_properties::_MolFileBondStereo, 3);
+    }
+    return false;
+}
+
+static void copyAtomNumChirality(const ROMol& mol, mae::Block& stBlock) {
+  // This property tells Schrodinger software that the stereo and chirality in
+  // the mae file are valid
+  stBlock.setIntProperty(MAE_STEREO_STATUS, 1);
+
+  // Set atom numbering chirality
+  int chiralAts = 0;
+  for (const auto at : mol.atoms()) {
+    std::string atomNumChirality;
+    if (at->getChiralTag() == Atom::CHI_TETRAHEDRAL_CW) {
+      atomNumChirality = "ANR";
+    } else if (at->getChiralTag() == Atom::CHI_TETRAHEDRAL_CCW) {
+      atomNumChirality = "ANS";
+    } else {
+      continue;
+    }
+    chiralAts++;
+    std::string propName = mae::CT_CHIRALITY_PROP_PREFIX + std::to_string(chiralAts);
+    std::string propVal = std::to_string(at->getIdx() + 1) + "_" + atomNumChirality;
+
+    // We don't know CIP ranks of atoms, so instead we use atom numbering
+    // chirality and adjacent atoms will just be sorted by index.
+    std::vector<int> neighbors;
+    for (const auto nb : mol.atomNeighbors(at)) {
+      neighbors.push_back(nb->getIdx());
+    }
+
+    std::sort(neighbors.begin(), neighbors.end());
+    for (const auto nb : neighbors) {
+      propVal += "_" + std::to_string(nb + 1);
+    }
+    stBlock.setStringProperty(propName, propVal);
+  }
+
+}
+
 void mapMolProperties(const ROMol& mol, const STR_VECT& propNames,
                       mae::Block& stBlock) {
   // We always write a title, even if the mol doesn't have one
@@ -230,7 +287,7 @@ void mapMolProperties(const ROMol& mol, const STR_VECT& propNames,
   stBlock.setStringProperty(mae::CT_TITLE, molName);
   mol.clearProp(common_properties::_Name);
 
-  // TO DO: Map stereo properties
+  copyAtomNumChirality(mol, stBlock);
 
   auto boolSetter = [&stBlock](const std::string& prop, unsigned, bool value) {
     stBlock.setBoolProperty(prop, value);
@@ -362,6 +419,12 @@ void mapBond(
   setPropertyValue(bondBlock, mae::BOND_ATOM_2, numBonds, idx, bondTo);
   setPropertyValue(bondBlock, mae::BOND_ORDER, numBonds, idx,
                    bondTypeToOrder(bond));
+
+  // Only set double bond stereo if stereo is 'unspecified', otherwise
+  // users can calculate double bond stereo from the coordinates.
+  if (is_double_any_bond(bond)) {
+    setPropertyValue(bondBlock, MAE_BOND_PARITY, numBonds, idx, 2);
+  }
 
   if (dativeBondMark != nullptr) {
     dativeBondMark->set(idx, (bond.getBondType() == Bond::BondType::DATIVE));

--- a/Code/GraphMol/FileParsers/MaeWriter.cpp
+++ b/Code/GraphMol/FileParsers/MaeWriter.cpp
@@ -223,7 +223,7 @@ int bondTypeToOrder(const Bond& bond) {
   }
 }
 
-static bool is_double_any_bond(const RDKit::Bond& b)
+static bool isDoubleAnyBond(const RDKit::Bond& b)
 {
     if (b.getBondType() == RDKit::Bond::DOUBLE) {
         if (b.getStereo() == RDKit::Bond::BondStereo::STEREOANY ||
@@ -232,12 +232,12 @@ static bool is_double_any_bond(const RDKit::Bond& b)
         }
 
         // Check v3000/v2000 stereo either props
-        auto has_either_prop = [&b](const auto& prop, const int& either_value) {
+        auto hasPropValue = [&b](const auto& prop, const int& either_value) {
             return b.hasProp(prop) && b.getProp<int>(prop) == either_value;
         };
 
-        return has_either_prop(RDKit::common_properties::_MolFileBondCfg, 2) ||
-               has_either_prop(RDKit::common_properties::_MolFileBondStereo, 3);
+        return hasPropValue(RDKit::common_properties::_MolFileBondCfg, 2) ||
+               hasPropValue(RDKit::common_properties::_MolFileBondStereo, 3);
     }
     return false;
 }
@@ -258,7 +258,7 @@ static void copyAtomNumChirality(const ROMol& mol, mae::Block& stBlock) {
     } else {
       continue;
     }
-    chiralAts++;
+    ++chiralAts;
     std::string propName = mae::CT_CHIRALITY_PROP_PREFIX + std::to_string(chiralAts);
     std::string propVal = std::to_string(at->getIdx() + 1) + "_" + atomNumChirality;
 
@@ -422,7 +422,7 @@ void mapBond(
 
   // Only set double bond stereo if stereo is 'unspecified', otherwise
   // users can calculate double bond stereo from the coordinates.
-  if (is_double_any_bond(bond)) {
+  if (isDoubleAnyBond(bond)) {
     setPropertyValue(bondBlock, MAE_BOND_PARITY, numBonds, idx, 2);
   }
 

--- a/Code/GraphMol/FileParsers/file_parsers_catch.cpp
+++ b/Code/GraphMol/FileParsers/file_parsers_catch.cpp
@@ -6214,7 +6214,7 @@ TEST_CASE("MaeWriter basic testing", "[mae][MaeWriter][writer]") {
       // Skip ahead to the ct block
     }
 
-    // The only ct level should be the title and stereo status
+    // The only ct level property should be the title and stereo status
     std::getline(*oss, line);
     CHECK(line.find("i_m_ct_stereo_status") != std::string::npos);
     std::getline(*oss, line);

--- a/Code/GraphMol/FileParsers/file_parsers_catch.cpp
+++ b/Code/GraphMol/FileParsers/file_parsers_catch.cpp
@@ -5860,6 +5860,70 @@ void check_roundtripped_properties(RDProps &original, RDProps &roundtrip) {
   }
 }
 
+TEST_CASE("MaeWriter atom numbering chirality", "[mae][MaeWriter][writer]") {
+  SECTION("R") {
+    auto mol = "C/C=C/[C@@H](CO)C(C)C"_smiles;
+    auto oss = new std::ostringstream;
+    MaeWriter w(oss);
+    w.write(*mol);
+    w.flush();
+    auto iss = new std::istringstream(oss->str());
+    auto roundtrip = MaeMolSupplier(iss).next();
+    CHECK(roundtrip->getAtomWithIdx(3)->getChiralTag() == Atom::CHI_TETRAHEDRAL_CW);
+  }
+
+  SECTION("S") {
+    auto mol = "C/C=C/[C@H](CO)C(C)C"_smiles;
+    auto oss = new std::ostringstream;
+    MaeWriter w(oss);
+    w.write(*mol);
+    w.flush();
+    auto iss = new std::istringstream(oss->str());
+    auto roundtrip = MaeMolSupplier(iss).next();
+    CHECK(roundtrip->getAtomWithIdx(3)->getChiralTag() == Atom::CHI_TETRAHEDRAL_CCW);
+  }
+}
+
+TEST_CASE("MaeWriter any stereo", "[mae][MaeWriter][writer]") {
+  auto m = R"CTAB(
+     RDKit          2D
+
+  0  0  0  0  0  0  0  0  0  0999 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 6 5 0 0 0
+M  V30 BEGIN ATOM
+M  V30 1 C -2.942857 -0.857143 0.000000 0
+M  V30 2 C -1.514286 -0.857143 0.000000 0
+M  V30 3 H -3.657143 0.380036 0.000000 0
+M  V30 4 Br -3.657143 -2.094322 0.000000 0
+M  V30 5 F -0.800000 -2.094322 0.000000 0
+M  V30 6 Cl -0.800000 0.380036 0.000000 0
+M  V30 END ATOM
+M  V30 BEGIN BOND
+M  V30 1 2 1 2 CFG=2
+M  V30 2 1 1 3
+M  V30 3 1 1 4
+M  V30 4 1 2 5
+M  V30 5 1 2 6
+M  V30 END BOND
+M  V30 END CTAB
+M  END
+$$$$
+)CTAB"_ctab;
+  REQUIRE(m);
+
+  // Currently, MaeMolSupplier does not recognize "either" double bonds, this just
+  // tests that the bond will be recognizable by schrodinger software
+  auto oss = new std::ostringstream;
+  MaeWriter w(oss);
+  w.write(*m);
+  w.flush();
+  auto maeblock = oss->str();
+  CHECK(maeblock.find("i_sd_original_parity") != std::string::npos);
+  // expected bond line -- include RDKit cfg properties
+  CHECK(maeblock.find("1 1 2 2 2 2 2") != std::string::npos);
+}
+
 TEST_CASE("MaeWriter basic testing", "[mae][MaeWriter][writer]") {
   auto mol = "C1CCCCC1"_smiles;
   REQUIRE(mol);
@@ -6150,7 +6214,9 @@ TEST_CASE("MaeWriter basic testing", "[mae][MaeWriter][writer]") {
       // Skip ahead to the ct block
     }
 
-    // The only ct level should be the title
+    // The only ct level should be the title and stereo status
+    std::getline(*oss, line);
+    CHECK(line.find("i_m_ct_stereo_status") != std::string::npos);
     std::getline(*oss, line);
     CHECK(line.find("s_m_title") != std::string::npos);
 


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
This updates the MaeWriter to include chirality and double bond stereo. Since there doesn't seem to be a great way to get CIP rankings, this sets atom numbering chirality and will allow schrodinger software and RDKit's MaeMolSupplier to interpret chiral centers.

I also added a property that sets bond parity for "any stereo" double bonds. For now, this is just so the output can be used with schrodinger software -- we will need to update the MaeMolSupplier to recognize this property.