### PR TITLE
Fixes #6818

### DIFF
--- a/Code/GraphMol/ChemReactions/Wrap/rdChemReactions.cpp
+++ b/Code/GraphMol/ChemReactions/Wrap/rdChemReactions.cpp
@@ -942,6 +942,7 @@ of the replacements argument.",
       (python::arg("reaction"), python::arg("separateAgents") = false),
       "construct a string in MDL v3000 rxn format for a ChemicalReaction");
 
+#ifdef RDK_USE_BOOST_IOSTREAMS
   python::def("ReactionFromPNGFile", RDKit::PNGFileToChemicalReaction,
               "construct a ChemicalReaction from metadata in a PNG file",
               python::return_value_policy<python::manage_new_object>());
@@ -962,7 +963,7 @@ of the replacements argument.",
        python::arg("includeSmarts") = false, python::arg("includeRxn") = false),
       "Adds metadata about a reaction to the PNG string passed in."
       "The modified string is returned.");
-
+#endif
   python::def("ReactionFromMolecule", RDKit::RxnMolToChemicalReaction,
               "construct a ChemicalReaction from an molecule if the RXN role "
               "property of the molecule is set",

--- a/Code/GraphMol/ChemReactions/Wrap/testReactionWrapper.py
+++ b/Code/GraphMol/ChemReactions/Wrap/testReactionWrapper.py
@@ -731,6 +731,8 @@ M  END
       _reacts = [Chem.MolToSmarts(r) for r in _rxn.GetReactants()]
       _prods = [Chem.MolToSmarts(p) for p in _rxn.GetProducts()]
 
+  @unittest.skipUnless(hasattr(rdChemReactions,'ReactionFromPNGFile'),
+                     "RDKit not built with iostreams support")
   def test_PNGMetadata(self):
     fname = os.path.join(self.dataDir, 'reaction1.smarts.png')
     rxn = rdChemReactions.ReactionFromPNGFile(fname)

--- a/Code/GraphMol/ChemReactions/catch_tests.cpp
+++ b/Code/GraphMol/ChemReactions/catch_tests.cpp
@@ -278,6 +278,7 @@ TEST_CASE("GithHub #3119: partial reacting atom detection", "[Reaction][Bug]") {
   }
 }
 
+#ifdef RDK_USE_BOOST_IOSTREAMS
 TEST_CASE("reaction data in PNGs 1", "[Reaction][PNG]") {
   std::string pathName = getenv("RDBASE");
   pathName += "/Code/GraphMol/ChemReactions/testData/";
@@ -371,6 +372,7 @@ TEST_CASE("reaction data in PNGs 1", "[Reaction][PNG]") {
     }
   }
 }
+#endif
 
 TEST_CASE("Github #2891", "[Reaction][chirality][bug]") {
   SECTION("reaction parsing inversion logic") {

--- a/Code/GraphMol/FileParsers/GeneralFileReader.h
+++ b/Code/GraphMol/FileParsers/GeneralFileReader.h
@@ -106,10 +106,11 @@ std::unique_ptr<MolSupplier> getSupplier(const std::string& path,
   if (compressionFormat.empty()) {
     strm = new std::ifstream(path.c_str(), std::ios::in | std::ios::binary);
   } else {
-#if RDK_USE_BOOST_IOSTREAMS
+#ifdef RDK_USE_BOOST_IOSTREAMS
     strm = new gzstream(path);
 #else
-    throw BadFileException("Unsupported fileFormat: " + fileFormat);
+    throw BadFileException(
+        "compressed files are only supported if the RDKit is built with boost::iostreams support");
 #endif
   }
 
@@ -162,7 +163,7 @@ std::unique_ptr<MolSupplier> getSupplier(const std::string& path,
     std::unique_ptr<MolSupplier> p(tdtsup);
     return p;
   }
-  throw BadFileException("Unsupported fileFormat: " + fileFormat);
+  throw BadFileException("Unsupported file format: " + fileFormat);
 }
 
 }  // namespace GeneralMolSupplier

--- a/Code/GraphMol/FileParsers/file_parsers_catch.cpp
+++ b/Code/GraphMol/FileParsers/file_parsers_catch.cpp
@@ -2498,6 +2498,7 @@ M  END
   }
 }
 
+#ifdef RDK_USE_BOOST_IOSTREAMS
 TEST_CASE("read metadata from PNG", "[reader][PNG]") {
   std::string rdbase = getenv("RDBASE");
   SECTION("basics") {
@@ -2551,7 +2552,6 @@ TEST_CASE("read metadata from PNG", "[reader][PNG]") {
     REQUIRE_THROWS_AS(PNGStringToMetadata(data.substr(1000)),
                       FileParseException);
   }
-#ifdef RDK_USE_BOOST_IOSTREAMS
   SECTION("compressed metadata") {
     std::string fname =
         rdbase + "/Code/GraphMol/FileParsers/test_data/colchicine.mrv.png";
@@ -2564,7 +2564,6 @@ TEST_CASE("read metadata from PNG", "[reader][PNG]") {
     REQUIRE(iter != metadata.end());
     CHECK(iter->second.find("<MChemicalStruct>") != std::string::npos);
   }
-#endif
 }
 
 TEST_CASE("write metadata to PNG", "[writer][PNG]") {
@@ -2625,6 +2624,7 @@ TEST_CASE("read molecule from PNG", "[reader][PNG]") {
     REQUIRE_THROWS_AS(PNGFileToMol(fname), FileParseException);
   }
 }
+#endif
 
 TEST_CASE("write molecule to PNG", "[writer][PNG]") {
   std::string rdbase = getenv("RDBASE");
@@ -2740,6 +2740,7 @@ TEST_CASE("multiple molecules in the PNG, second example", "[writer][PNG]") {
   for (const auto &smi : smiles) {
     mols.emplace_back(SmilesToMol(smi));
   }
+#ifdef RDK_USE_BOOST_IOSTREAMS
   SECTION("pickles") {
     std::string fname =
         rdbase + "/Code/GraphMol/FileParsers/test_data/multiple_mols.png";
@@ -2750,6 +2751,7 @@ TEST_CASE("multiple molecules in the PNG, second example", "[writer][PNG]") {
       CHECK(MolToSmiles(*molsRead[i]) == MolToSmiles(*mols[i]));
     }
   }
+#endif
   SECTION("SMILES") {
     std::vector<std::pair<std::string, std::string>> metadata;
     for (const auto &mol : mols) {

--- a/Code/GraphMol/FileParsers/testGeneralFileReader.cpp
+++ b/Code/GraphMol/FileParsers/testGeneralFileReader.cpp
@@ -104,6 +104,7 @@ void testSdf() {
   }
   TEST_ASSERT(i == 16);
 
+#ifdef RDK_USE_BOOST_IOSTREAMS
   //! Open compressed SDF file format
   fname = rdbase + "/Code/GraphMol/FileParsers/test_data/NCI_aids_few.sdf.gz";
   opt.takeOwnership = false;
@@ -119,6 +120,7 @@ void testSdf() {
     }
   }
   TEST_ASSERT(i == 16);
+#endif
 }
 
 void testSmi() {
@@ -216,7 +218,7 @@ void testMae() {
                 std::to_string(19 - i));
   }
   TEST_ASSERT(maesup->atEnd());
-
+#ifdef RDK_USE_BOOST_IOSTREAMS
   //! Open compressed MAE file, .maegz format
   fname = rdbase + "/Code/GraphMol/FileParsers/test_data/1kv1.maegz";
   auto cmaesup = getSupplier(fname, opt);
@@ -228,6 +230,7 @@ void testMae() {
   TEST_ASSERT(info->getResidueName() == "ARG ");
   TEST_ASSERT(info->getChainId() == "A");
   TEST_ASSERT(info->getResidueNumber() == 5);
+#endif
 #endif
 }
 

--- a/Code/GraphMol/MolDraw2D/Wrap/testMolDraw2D.py
+++ b/Code/GraphMol/MolDraw2D/Wrap/testMolDraw2D.py
@@ -622,6 +622,8 @@ M  END
       do_a_picture(smi, smarts, 'pyTest3')
 
     @unittest.skipUnless(hasattr(Draw, 'MolDraw2DCairo'), 'Cairo support not enabled')
+    @unittest.skipUnless(hasattr(Chem,'MolFromPNGString'),
+                     "RDKit not built with iostreams support")
     def testPNGMetadata(self):
         m = Chem.MolFromMolBlock('''
   Mrv2014 08172015242D          

--- a/Code/GraphMol/Wrap/rdmolfiles.cpp
+++ b/Code/GraphMol/Wrap/rdmolfiles.cpp
@@ -2075,7 +2075,7 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
        python::arg("allBondsExplicit") = false,
        python::arg("allHsExplicit") = false),
       "returns a list of SMILES generated using the randomSmiles algorithm");
-
+#ifdef RDK_USE_BOOST_IOSTREAMS
   docString =
       R"DOC(Construct a molecule from metadata in a PNG string.
 
@@ -2121,6 +2121,7 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
               (python::arg("filename"), python::arg("tag") = PNGData::pklTag,
                python::arg("params") = python::object()),
               "returns a tuple of molecules constructed from the PNG file");
+#endif
 
   docString =
       R"DOC(Construct a molecule from a cdxml file.
@@ -2167,6 +2168,7 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
                python::arg("removeHs") = true),
               docString.c_str());
 
+#ifdef RDK_USE_BOOST_IOSTREAMS
   docString =
       R"DOC(Adds molecular metadata to PNG data read from a file.
 
@@ -2254,7 +2256,7 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
               (python::arg("png")),
               "Returns a dict with all metadata from the PNG string. Keys are "
               "strings, values are bytes.");
-
+#endif
 /********************************************************
  * MolSupplier stuff
  *******************************************************/

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -6560,6 +6560,8 @@ M  END
     self.assertEqual(len(ctrs), 2)
     self.assertEqual(ctrs, [(1, 'S'), (5, '?')])
 
+  @unittest.skipUnless(hasattr(Chem,'MolFromPNGFile'),
+                     "RDKit not built with iostreams support")
   def testMolFromPNG(self):
     fileN = os.path.join(RDConfig.RDBaseDir, 'Code', 'GraphMol', 'FileParsers', 'test_data',
                          'colchicine.png')
@@ -6573,6 +6575,8 @@ M  END
     self.assertIsNotNone(mol)
     self.assertEqual(mol.GetNumAtoms(), 29)
 
+  @unittest.skipUnless(hasattr(Chem,'MolFromPNGFile'),
+                     "RDKit not built with iostreams support")
   def testMolToPNG(self):
     fileN = os.path.join(RDConfig.RDBaseDir, 'Code', 'GraphMol', 'FileParsers', 'test_data',
                          'colchicine.no_metadata.png')
@@ -6593,6 +6597,8 @@ M  END
     self.assertIsNotNone(mol)
     self.assertEqual(mol.GetNumAtoms(), 29)
 
+  @unittest.skipUnless(hasattr(Chem,'MolFromPNGFile'),
+                     "RDKit not built with iostreams support")
   def testMolsFromPNG(self):
     refMols = [Chem.MolFromSmiles(x) for x in ('c1ccccc1', 'CCO', 'CC(=O)O', 'c1ccccn1')]
     fileN = os.path.join(RDConfig.RDBaseDir, 'Code', 'GraphMol', 'FileParsers', 'test_data',
@@ -6602,6 +6608,8 @@ M  END
     for mol, refMol in zip(mols, refMols):
       self.assertEqual(Chem.MolToSmiles(mol), Chem.MolToSmiles(refMol))
 
+  @unittest.skipUnless(hasattr(Chem,'MolFromPNGFile'),
+                     "RDKit not built with iostreams support")
   def testMetadataToPNG(self):
     fileN = os.path.join(RDConfig.RDBaseDir, 'Code', 'GraphMol', 'FileParsers', 'test_data',
                          'colchicine.png')

--- a/Docs/Book/GettingStartedInPython.rst
+++ b/Docs/Book/GettingStartedInPython.rst
@@ -37,6 +37,7 @@ Reading single molecules
   IPythonConsole.UninstallIPythonRenderer()
   from rdkit.Chem import rdDepictor
   rdDepictor.SetPreferCoordGen(False)
+  
 
 The majority of the basic molecular functionality is found in module :py:mod:`rdkit.Chem`:
 
@@ -1042,6 +1043,7 @@ metadata about the molecule(s) or chemical reaction included in the drawing.
 This metadata can be used later to reconstruct the molecule(s) or reaction.
 
 .. doctest::
+  :skipif: not hasattr(Chem,'MolFromPNGString')
 
   >>> template = Chem.MolFromSmiles('c1nccc2n1ccc2')
   >>> AllChem.Compute2DCoords(template)
@@ -1065,6 +1067,7 @@ If the PNG contains multiple molecules we can retrieve them all at once using
 `Chem.MolsFromPNGString()`:
 
 .. doctest::
+  :skipif: not hasattr(Chem,'MolsFromPNGString')
 
   >>> from rdkit.Chem import Draw
   >>> png = Draw.MolsToGridImage(ms,returnPNG=True)
@@ -2538,6 +2541,7 @@ As of the 2020.09 release, PNG images of reactions include metadata allowing the
 reaction to be reconstructed:
 
 .. doctest::
+  :skipif: not hasattr(AllChem,'ReactionFromPNGString')
 
   >>> newRxn = AllChem.ReactionFromPNGString(png)
   >>> AllChem.ReactionToSmarts(newRxn)

--- a/Docs/Book/conf.py
+++ b/Docs/Book/conf.py
@@ -29,6 +29,10 @@ sys.path.insert(0, os.path.abspath('exts'))
 extensions = ['sphinx.ext.autodoc', 'sphinx.ext.doctest', 'myst_parser']  # , 'extapi']
 #autosummary_generate = True
 doctest_test_doctest_blocks = ""
+doctest_global_setup = '''
+from rdkit import Chem
+from rdkit.Chem import AllChem
+'''
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/rdkit/Chem/Draw/UnitTestDraw.py
+++ b/rdkit/Chem/Draw/UnitTestDraw.py
@@ -399,7 +399,7 @@ class TestCase(unittest.TestCase):
     with self.assertRaises(KeyError):
       Draw.DrawMorganBit(m, 32, bi)
 
-    if hasattr(Draw, 'MolDraw2DCairo'):
+    if hasattr(Draw, 'MolDraw2DCairo') and hasattr(Draw,'MolFromPNGString'):
       # Github #3796: make sure we aren't trying to generate metadata:
       png = Draw.DrawMorganBit(m, 872, bi, useSVG=False)
       self.assertIn(b'PNG', png)
@@ -420,7 +420,7 @@ class TestCase(unittest.TestCase):
     with self.assertRaises(KeyError):
       Draw.DrawRDKitBit(m, 32, bi)
 
-    if hasattr(Draw, 'MolDraw2DCairo'):
+    if hasattr(Draw, 'MolDraw2DCairo') and hasattr(Draw,'MolFromPNGString'):
       # Github #3796: make sure we aren't trying to generate metadata:
       png = Draw.DrawRDKitBit(m, 1553, bi, useSVG=False)
       self.assertIn(b'PNG', png)


### PR DESCRIPTION
make sure that a full build and test can work when we don't build with boost::iostreams support

Hopefully nobody ever actually needs this, but as long as we supply the option, the tests should actually work

