### PR TITLE
Fixes #6017

### DIFF
--- a/Code/GraphMol/Substruct/SubstructMatch.cpp
+++ b/Code/GraphMol/Substruct/SubstructMatch.cpp
@@ -490,10 +490,10 @@ std::vector<MatchVectType> SubstructMatch(
   if (params.recursionPossible) {
     detail::SUBQUERY_MAP subqueryMap;
     ROMol::ConstAtomIterator atIt;
-    for (atIt = query.beginAtoms(); atIt != query.endAtoms(); atIt++) {
-      if ((*atIt)->getQuery()) {
+    for (const auto atom : query.atoms()) {
+      if (atom->hasQuery()) {
         // std::cerr<<"recurse from atom "<<(*atIt)->getIdx()<<std::endl;
-        detail::MatchSubqueries(mol, (*atIt)->getQuery(), params, subqueryMap,
+        detail::MatchSubqueries(mol, atom->getQuery(), params, subqueryMap,
                                 locker.locked);
       }
     }
@@ -515,12 +515,10 @@ std::vector<MatchVectType> SubstructMatch(
   if (found) {
     unsigned int nQueryAtoms = query.getNumAtoms();
     matches.reserve(pms.size());
-    for (std::list<detail::ssPairType>::const_iterator iter1 = pms.begin();
-         iter1 != pms.end(); ++iter1) {
-      MatchVectType matchVect;
-      matchVect.resize(nQueryAtoms);
-      for (const auto &iter2 : *iter1) {
-        matchVect[iter2.first] = std::pair<int, int>(iter2.first, iter2.second);
+    MatchVectType matchVect(nQueryAtoms);
+    for (const auto &pairs : pms) {
+      for (const auto &pair : pairs) {
+        matchVect[pair.first] = pair;
       }
       matches.push_back(matchVect);
     }
@@ -620,10 +618,9 @@ unsigned int RecursiveMatcher(const ROMol &mol, const ROMol &query,
   // use the maxRecursiveMatches parameter if it's set, otherwise use maxMatches
   lparams.maxMatches = params.maxRecursiveMatches;
   lparams.uniquify = false;
-  ROMol::ConstAtomIterator atIt;
-  for (atIt = query.beginAtoms(); atIt != query.endAtoms(); atIt++) {
-    if ((*atIt)->getQuery()) {
-      MatchSubqueries(mol, (*atIt)->getQuery(), lparams, subqueryMap, locked);
+  for (auto qAtom : query.atoms()) {
+    if (qAtom->hasQuery()) {
+      MatchSubqueries(mol, qAtom->getQuery(), lparams, subqueryMap, locked);
     }
   }
 
@@ -644,15 +641,14 @@ unsigned int RecursiveMatcher(const ROMol &mol, const ROMol &query,
   unsigned int res = 0;
   if (found) {
     matches.reserve(pms.size());
-    for (std::list<detail::ssPairType>::const_iterator iter1 = pms.begin();
-         iter1 != pms.end(); ++iter1) {
+    for (const auto &pairs : pms) {
       if (!query.hasProp(common_properties::_queryRootAtom)) {
-        matches.push_back(iter1->begin()->second);
+        matches.push_back(pairs.begin()->second);
       } else {
         int rootIdx;
         query.getProp(common_properties::_queryRootAtom, rootIdx);
         bool found = false;
-        for (const auto &pairIter : *iter1) {
+        for (const auto &pairIter : pairs) {
           if (pairIter.first == static_cast<unsigned int>(rootIdx)) {
             matches.push_back(pairIter.second);
             found = true;
@@ -679,7 +675,7 @@ void MatchSubqueries(const ROMol &mol, QueryAtom::QUERYATOM_QUERY *query,
                      SUBQUERY_MAP &subqueryMap,
                      std::vector<RecursiveStructureQuery *> &locked) {
   PRECONDITION(query, "bad query");
-  // std::cout << "*-*-* MS: " << (int)query << std::endl;
+  // std::cout << "*-*-* MS: " << query << std::endl;
   // std::cout << "\t\t" << typeid(*query).name() << std::endl;
   if (query->getDescription() == "RecursiveStructure") {
     auto *rsq = (RecursiveStructureQuery *)query;
@@ -694,7 +690,7 @@ void MatchSubqueries(const ROMol &mol, QueryAtom::QUERYATOM_QUERY *query,
       // we've matched an equivalent serial number before, just
       // copy in the matches:
       matchDone = true;
-      const RecursiveStructureQuery *orsq =
+      auto orsq =
           (const RecursiveStructureQuery *)subqueryMap[rsq->getSerialNumber()];
       for (auto setIter = orsq->beginSet(); setIter != orsq->endSet();
            ++setIter) {
@@ -719,8 +715,9 @@ void MatchSubqueries(const ROMol &mol, QueryAtom::QUERYATOM_QUERY *query,
       }
       if (rsq->getSerialNumber()) {
         subqueryMap[rsq->getSerialNumber()] = query;
-        // std::cerr<<" storing results for query serial number:
-        // "<<rsq->getSerialNumber()<<std::endl;
+        // std::cerr << " storing results for query serial number: "
+        //           << rsq->getSerialNumber() << " " << rsq->size() <<
+        //           std::endl;
       }
     }
   } else {
@@ -731,8 +728,8 @@ void MatchSubqueries(const ROMol &mol, QueryAtom::QUERYATOM_QUERY *query,
   Queries::Query<int, Atom const *, true>::CHILD_VECT_CI childIt;
   // std::cout << query << " " << query->endChildren()-query->beginChildren() <<
   // std::endl;
-  for (childIt = query->beginChildren(); childIt != query->endChildren();
-       childIt++) {
+  for (auto childIt = query->beginChildren(); childIt != query->endChildren();
+       ++childIt) {
     MatchSubqueries(mol, childIt->get(), params, subqueryMap, locked);
   }
   // std::cout << "<<- back " << (int)query << std::endl;

--- a/Code/GraphMol/Substruct/SubstructMatch.cpp
+++ b/Code/GraphMol/Substruct/SubstructMatch.cpp
@@ -725,9 +725,6 @@ void MatchSubqueries(const ROMol &mol, QueryAtom::QUERYATOM_QUERY *query,
   }
 
   // now recurse over our children (these things can be nested)
-  Queries::Query<int, Atom const *, true>::CHILD_VECT_CI childIt;
-  // std::cout << query << " " << query->endChildren()-query->beginChildren() <<
-  // std::endl;
   for (auto childIt = query->beginChildren(); childIt != query->endChildren();
        ++childIt) {
     MatchSubqueries(mol, childIt->get(), params, subqueryMap, locked);

--- a/Code/GraphMol/Substruct/SubstructMatch.cpp
+++ b/Code/GraphMol/Substruct/SubstructMatch.cpp
@@ -617,12 +617,8 @@ unsigned int RecursiveMatcher(const ROMol &mol, const ROMol &query,
                               const SubstructMatchParameters &params,
                               std::vector<RecursiveStructureQuery *> &locked) {
   SubstructMatchParameters lparams = params;
-  // NOTE: maxMatches and recursive queries is problematic. To make this really
-  // cover all cases we'd need a separate parameter for the number of possible
-  // recursive matches. We will add that for the 2023.03 release; for now
-  // we can still fix #888 without introducing any new problems using this
-  // heuristic:
-  lparams.maxMatches = std::max(1000u, params.maxMatches);
+  // use the maxRecursiveMatches parameter if it's set, otherwise use maxMatches
+  lparams.maxMatches = params.maxRecursiveMatches;
   lparams.uniquify = false;
   ROMol::ConstAtomIterator atIt;
   for (atIt = query.beginAtoms(); atIt != query.endAtoms(); atIt++) {
@@ -667,6 +663,9 @@ unsigned int RecursiveMatcher(const ROMol &mol, const ROMol &query,
           BOOST_LOG(rdErrorLog)
               << "no match found for queryRootAtom" << std::endl;
         }
+      }
+      if (matches.size() == lparams.maxMatches) {
+        break;
       }
     }
     res = matches.size();

--- a/Code/GraphMol/Substruct/SubstructMatch.cpp
+++ b/Code/GraphMol/Substruct/SubstructMatch.cpp
@@ -615,8 +615,7 @@ unsigned int RecursiveMatcher(const ROMol &mol, const ROMol &query,
                               const SubstructMatchParameters &params,
                               std::vector<RecursiveStructureQuery *> &locked) {
   SubstructMatchParameters lparams = params;
-  // use the maxRecursiveMatches parameter if it's set, otherwise use maxMatches
-  lparams.maxMatches = params.maxRecursiveMatches;
+  lparams.maxMatches = std::max(params.maxRecursiveMatches, params.maxMatches);
   lparams.uniquify = false;
   for (auto qAtom : query.atoms()) {
     if (qAtom->hasQuery()) {

--- a/Code/GraphMol/Substruct/SubstructMatch.h
+++ b/Code/GraphMol/Substruct/SubstructMatch.h
@@ -58,14 +58,16 @@ struct RDKIT_SUBSTRUCTMATCH_EXPORT SubstructMatchParameters {
                        //!< negative values are added to the number of
                        //!< concurrent threads supported by the hardware
   std::vector<std::string> atomProperties;  //!< atom properties that must be
-                                                 //!< equivalent in order to match
+                                            //!< equivalent in order to match
   std::vector<std::string> bondProperties;  //!< bond properties that must be
-                                                 //!< equivalent in order to match
+                                            //!< equivalent in order to match
   std::function<bool(const ROMol &mol,
                      const std::vector<unsigned int> &match)>
       extraFinalCheck;  //!< a function to be called at the end to validate a
                         //!< match
-
+  unsigned int maxRecursiveMatches =
+      1000;  //!< maximum number of matches that the recursive substructure
+             //!< matching should return
   SubstructMatchParameters() {}
 };
 

--- a/Code/GraphMol/Substruct/SubstructUtils.cpp
+++ b/Code/GraphMol/Substruct/SubstructUtils.cpp
@@ -104,22 +104,22 @@ class ScoreMatchesByDegreeOfCoreSubstitution {
 }  // namespace detail
 
 bool propertyCompat(const RDProps *r1, const RDProps *r2,
-                    const std::vector<std::string>& properties) {
-  PRECONDITION(r1,"bad RDProps");
-  PRECONDITION(r2,"bad RDProps");
-  
+                    const std::vector<std::string> &properties) {
+  PRECONDITION(r1, "bad RDProps");
+  PRECONDITION(r2, "bad RDProps");
+
   for (const auto &prop : properties) {
     std::string prop1;
     bool hasprop1 = r1->getPropIfPresent<std::string>(prop, prop1);
     std::string prop2;
     bool hasprop2 = r2->getPropIfPresent<std::string>(prop, prop2);
     if (hasprop1 && hasprop2) {
-        if (prop1 != prop2) {
-            return false;
-        }
-    } else if (hasprop1 || hasprop2) {
-        // only one has the property
+      if (prop1 != prop2) {
         return false;
+      }
+    } else if (hasprop1 || hasprop2) {
+      // only one has the property
+      return false;
     }
   }
   return true;
@@ -272,6 +272,7 @@ void updateSubstructMatchParamsFromJSON(SubstructMatchParameters &params,
   PT_OPT_GET(recursionPossible);
   PT_OPT_GET(uniquify);
   PT_OPT_GET(maxMatches);
+  PT_OPT_GET(maxRecursiveMatches);
   PT_OPT_GET(numThreads);
 }
 
@@ -285,6 +286,7 @@ std::string substructMatchParamsToJSON(const SubstructMatchParameters &params) {
   PT_OPT_PUT(recursionPossible);
   PT_OPT_PUT(uniquify);
   PT_OPT_PUT(maxMatches);
+  PT_OPT_PUT(maxRecursiveMatches);
   PT_OPT_PUT(numThreads);
 
   std::stringstream ss;

--- a/Code/GraphMol/Substruct/catch_tests.cpp
+++ b/Code/GraphMol/Substruct/catch_tests.cpp
@@ -136,7 +136,7 @@ TEST_CASE("substructure parameters", "[substruct]") {
   SECTION("atom properties") {
     std::vector<matchCase> examples;
     examples.push_back(
-        std::make_tuple(std::string("CCCCCCCCC"),std::string("CCC"), 7));
+        std::make_tuple(std::string("CCCCCCCCC"), std::string("CCC"), 7));
     examples.push_back(
         std::make_tuple(std::string("CCCCCCCCC |atomProp:0.test_prop.1|"),
                         std::string("CCC |atomProp:0.test_prop.1|"), 1));
@@ -475,6 +475,26 @@ TEST_CASE(
       SubstructMatchParameters ps;
       auto matches = SubstructMatch(*m, *q, ps);
       CHECK(matches.empty());
+    }
+  }
+}
+
+TEST_CASE("Github #6017: add maxRecursiveMatches to SubstructMatchParameters") {
+  SECTION("Basics") {
+    auto m = "OCC(O)C(O)C(O)C(O)CO"_smiles;
+    auto q = "[$(CO)]C"_smarts;
+    REQUIRE(m);
+    REQUIRE(q);
+    SubstructMatchParameters ps;
+    ps.uniquify = true;
+    {
+      auto matches = SubstructMatch(*m, *q, ps);
+      CHECK(matches.size() == 5);
+    }
+    ps.maxRecursiveMatches = 3;
+    {
+      auto matches = SubstructMatch(*m, *q, ps);
+      CHECK(matches.size() == 3);
     }
   }
 }

--- a/Code/GraphMol/Substruct/catch_tests.cpp
+++ b/Code/GraphMol/Substruct/catch_tests.cpp
@@ -482,7 +482,7 @@ TEST_CASE(
 TEST_CASE("Github #6017: add maxRecursiveMatches to SubstructMatchParameters") {
   SECTION("Basics") {
     auto m = "OCC(O)C(O)C(O)C(O)CO"_smiles;
-    auto q = "[$(CO)]C"_smarts;
+    auto q = "[$(CO)][$(CO)]"_smarts;
     REQUIRE(m);
     REQUIRE(q);
     SubstructMatchParameters ps;
@@ -491,7 +491,7 @@ TEST_CASE("Github #6017: add maxRecursiveMatches to SubstructMatchParameters") {
       auto matches = SubstructMatch(*m, *q, ps);
       CHECK(matches.size() == 5);
     }
-    ps.maxRecursiveMatches = 3;
+    ps.maxMatches = 3;
     {
       auto matches = SubstructMatch(*m, *q, ps);
       CHECK(matches.size() == 3);

--- a/Code/GraphMol/Substruct/catch_tests.cpp
+++ b/Code/GraphMol/Substruct/catch_tests.cpp
@@ -491,7 +491,23 @@ TEST_CASE("Github #6017: add maxRecursiveMatches to SubstructMatchParameters") {
       auto matches = SubstructMatch(*m, *q, ps);
       CHECK(matches.size() == 5);
     }
+
+    // if maxRecursiveMatches isn't larger than maxMatches this will fail
     ps.maxMatches = 3;
+    {
+      auto matches = SubstructMatch(*m, *q, ps);
+      CHECK(matches.size() == 3);
+    }
+  }
+  SECTION("maxMatches larger than maxRecursiveMatches") {
+    auto m = "OCC(O)C(O)C(O)C(O)CO"_smiles;
+    auto q = "[$(CO)]C"_smarts;
+    REQUIRE(m);
+    REQUIRE(q);
+    SubstructMatchParameters ps;
+    ps.uniquify = true;
+    ps.maxMatches = 3;
+    ps.maxRecursiveMatches = 2;
     {
       auto matches = SubstructMatch(*m, *q, ps);
       CHECK(matches.size() == 3);

--- a/Code/GraphMol/Wrap/Mol.cpp
+++ b/Code/GraphMol/Wrap/Mol.cpp
@@ -325,6 +325,9 @@ struct mol_wrapper {
         .def_readwrite("maxMatches",
                        &RDKit::SubstructMatchParameters::maxMatches,
                        "maximum number of matches to return")
+        .def_readwrite("maxRecursiveMatches",
+                       &RDKit::SubstructMatchParameters::maxRecursiveMatches,
+                       "maximum number of recursive matches to find")
         .def_readwrite(
             "numThreads", &RDKit::SubstructMatchParameters::numThreads,
             "number of threads to use when multi-threading is possible."


### PR DESCRIPTION
There's a bit of cleanup in here too. The fix itself is in 74e68bd.

One question here is if we want to always honor the limit on recursive queries that's used to `maxRecursiveMatches` or to `std::max(maxRecursiveMatches,maxMatches)` (which is what's done here).
i..e is there a real use case where you would want `maxRecursiveMatches` to be smaller than `maxMatches` (the use case where it's larger is easy for me to imagine)