### PR TITLE
Fix unclosed resource in BuildFuncGroupHierarchy

### DIFF
--- a/rdkit/Chem/FunctionalGroups.py
+++ b/rdkit/Chem/FunctionalGroups.py
@@ -33,7 +33,6 @@
 import os
 import re
 import weakref
-from io import StringIO
 
 from rdkit import Chem, RDConfig
 
@@ -87,16 +86,17 @@ def BuildFuncGroupHierarchy(fileNm=None, data=None, force=False):
     fileNm = os.path.join(RDConfig.RDDataDir, 'Functional_Group_Hierarchy.txt')
 
   if fileNm:
-    inF = open(fileNm, 'r')
+    with open(fileNm, 'r') as inF:
+      data = inF.readlines()
     lastFilename = fileNm
   elif data:
-    inF = StringIO(data)
+    data = data.splitlines()
   else:
     raise ValueError("need data or filename")
 
   groupDefns = {}
   res = []
-  for lineNo, line in enumerate(inF.readlines(), 1):
+  for lineNo, line in enumerate(data, 1):
     line = line.strip()
     line = line.split('//')[0]
     if not line:


### PR DESCRIPTION
This fixes the unclosed resource warning that gets triggered when you run `BuildFuncGroupHierarchy`:

```
from rdkit.Chem import FunctionalGroups
group_hierarchy = FunctionalGroups.BuildFuncGroupHierarchy()

##########################################
<ipython-input-1-8e0f104e2c1c>:2: ResourceWarning: unclosed file <_io.TextIOWrapper name='/home/rodrigue/Documents/code/rdkit_builder/rdkit/Data/Functional_Group_Hierarchy.txt' mode='r' encoding='UTF-8'>
  group_hierarchy = FunctionalGroups.BuildFuncGroupHierarchy()
ResourceWarning: Enable tracemalloc to get the object allocation traceback
```

