### PR TITLE
Fix code formatting in docstrings for a few functions

### DIFF
--- a/rdkit/Chem/AtomPairs/Pairs.py
+++ b/rdkit/Chem/AtomPairs/Pairs.py
@@ -74,32 +74,32 @@ def pyScorePair(at1, at2, dist, atomCodes=None, includeChirality=False):
 
 def ExplainPairScore(score, includeChirality=False):
   """
-  >>> from rdkit import Chem
-  >>> m = Chem.MolFromSmiles('C=CC')
-  >>> score = pyScorePair(m.GetAtomWithIdx(0), m.GetAtomWithIdx(1), 1)
-  >>> ExplainPairScore(score)
+    >>> from rdkit import Chem
+    >>> m = Chem.MolFromSmiles('C=CC')
+    >>> score = pyScorePair(m.GetAtomWithIdx(0), m.GetAtomWithIdx(1), 1)
+    >>> ExplainPairScore(score)
   (('C', 1, 1), 1, ('C', 2, 1))
-  >>> score = pyScorePair(m.GetAtomWithIdx(0), m.GetAtomWithIdx(2), 2)
-  >>> ExplainPairScore(score)
+    >>> score = pyScorePair(m.GetAtomWithIdx(0), m.GetAtomWithIdx(2), 2)
+    >>> ExplainPairScore(score)
   (('C', 1, 0), 2, ('C', 1, 1))
-  >>> score = pyScorePair(m.GetAtomWithIdx(1), m.GetAtomWithIdx(2), 1)
-  >>> ExplainPairScore(score)
+    >>> score = pyScorePair(m.GetAtomWithIdx(1), m.GetAtomWithIdx(2), 1)
+    >>> ExplainPairScore(score)
   (('C', 1, 0), 1, ('C', 2, 1))
-  >>> score = pyScorePair(m.GetAtomWithIdx(2), m.GetAtomWithIdx(1), 1)
-  >>> ExplainPairScore(score)
+    >>> score = pyScorePair(m.GetAtomWithIdx(2), m.GetAtomWithIdx(1), 1)
+    >>> ExplainPairScore(score)
   (('C', 1, 0), 1, ('C', 2, 1))
 
   We can optionally deal with chirality too
-  >>> m = Chem.MolFromSmiles('C[C@H](F)Cl')
-  >>> score = pyScorePair(m.GetAtomWithIdx(0), m.GetAtomWithIdx(1), 1)
-  >>> ExplainPairScore(score)
+    >>> m = Chem.MolFromSmiles('C[C@H](F)Cl')
+    >>> score = pyScorePair(m.GetAtomWithIdx(0), m.GetAtomWithIdx(1), 1)
+    >>> ExplainPairScore(score)
   (('C', 1, 0), 1, ('C', 3, 0))
-  >>> score = pyScorePair(m.GetAtomWithIdx(0), m.GetAtomWithIdx(1), 1, includeChirality=True)
-  >>> ExplainPairScore(score, includeChirality=True)
+    >>> score = pyScorePair(m.GetAtomWithIdx(0), m.GetAtomWithIdx(1), 1, includeChirality=True)
+    >>> ExplainPairScore(score, includeChirality=True)
   (('C', 1, 0, ''), 1, ('C', 3, 0, 'R'))
-  >>> m = Chem.MolFromSmiles('F[C@@H](Cl)[C@H](F)Cl')
-  >>> score = pyScorePair(m.GetAtomWithIdx(1), m.GetAtomWithIdx(3), 1, includeChirality=True)
-  >>> ExplainPairScore(score, includeChirality=True)
+    >>> m = Chem.MolFromSmiles('F[C@@H](Cl)[C@H](F)Cl')
+    >>> score = pyScorePair(m.GetAtomWithIdx(1), m.GetAtomWithIdx(3), 1, includeChirality=True)
+    >>> ExplainPairScore(score, includeChirality=True)
   (('C', 3, 0, 'R'), 1, ('C', 3, 0, 'S'))
 
   """

--- a/rdkit/Chem/Draw/__init__.py
+++ b/rdkit/Chem/Draw/__init__.py
@@ -94,9 +94,9 @@ def _legacyMolToImage(mol, size, kekulize, wedgeBonds, fitImage, options, canvas
             use 'matplotlib.colors.to_rgb()' to convert string and
             HTML color codes into the RGB tuple representation, eg.
 
-              from matplotlib.colors import ColorConverter
-              img = Draw.MolToImage(m, highlightAtoms=[1,2], highlightColor=ColorConverter().to_rgb('aqua'))
-              img.save("molecule.png")
+              >>> from matplotlib.colors import ColorConverter
+              >>> img = Draw.MolToImage(m, highlightAtoms=[1,2], highlightColor=ColorConverter().to_rgb('aqua'))
+              >>> img.save("molecule.png")
 
       RETURNS:
 
@@ -729,40 +729,38 @@ def MolsMatrixToGridImage(molsMatrix, subImgSize=(200, 200), legendsMatrix=None,
 
       EXAMPLES:
 
-        from rdkit import Chem
-        from rdkit.Chem.Draw import MolsMatrixToGridImage, rdMolDraw2D
-        FCl = Chem.MolFromSmiles("FCl")
-        molsMatrix = [[FCl, FCl], [FCl, None, FCl]]
+        >>> from rdkit import Chem
+        >>> from rdkit.Chem.Draw import MolsMatrixToGridImage, rdMolDraw2D
+        >>> FCl = Chem.MolFromSmiles("FCl")
+        >>> molsMatrix = [[FCl, FCl], [FCl, None, FCl]]
 
-        # Minimal example: Only molsMatrix is supplied,
-        # result will be a drawing containing (where each row contains molecules):
-        # F-Cl    F-Cl
-        # F-Cl            F-Cl
-        img = MolsMatrixToGridImage(molsMatrix)
-        img.save("MolsMatrixToGridImageMinimal.png")
-        # img is a PIL object for a PNG image file like:
-        # <PIL.PngImagePlugin.PngImageFile image mode=RGB size=600x200 at 0x1648CC390>
-        # Drawing will be saved as PNG file MolsMatrixToGridImageMinimal.png
+        >>> # Minimal example: Only molsMatrix is supplied,
+        >>> # result will be a drawing containing (where each row contains molecules):
+        >>> # F-Cl    F-Cl
+        >>> # F-Cl            F-Cl
+        >>> img = MolsMatrixToGridImage(molsMatrix)
+        >>> img.save("MolsMatrixToGridImageMinimal.png")
+        >>> # img is a PIL object for a PNG image file like:
+        >>> # <PIL.PngImagePlugin.PngImageFile image mode=RGB size=600x200 at 0x1648CC390>
+        >>> # Drawing will be saved as PNG file MolsMatrixToGridImageMinimal.png
 
-        # Exhaustive example: All parameters are supplied,
-        # result will be a drawing containing (where each row of molecules is followed by a row of legends):
-        # 1 F-Cl 0              1 F-Cl 0
-        # no highlighting       bond highlighted         
-        # 1 F-Cl 0                                  1 F-Cl 0
-        # sodium highlighted                        chloride and bond highlighted
-        legendsMatrix = [["no highlighting", "bond highlighted"], 
-        ["F highlighted", "", "Cl and bond highlighted"]]
-        highlightAtomListsMatrix = [[[],[]], [[0], None, [1]]]
-        highlightBondListsMatrix = [[[],[0]], [[], None, [0]]]
+        >>> # Exhaustive example: All parameters are supplied,
+        >>> # result will be a drawing containing (where each row of molecules is followed by a row of legends):
+        >>> # 1 F-Cl 0              1 F-Cl 0
+        >>> # no highlighting       bond highlighted         
+        >>> # 1 F-Cl 0                                  1 F-Cl 0
+        >>> # sodium highlighted                        chloride and bond highlighted
+        >>> legendsMatrix = [["no highlighting", "bond highlighted"], 
+        >>> ["F highlighted", "", "Cl and bond highlighted"]]
+        >>> highlightAtomListsMatrix = [[[],[]], [[0], None, [1]]]
+        >>> highlightBondListsMatrix = [[[],[0]], [[], None, [0]]]
 
-        dopts = rdMolDraw2D.MolDrawOptions()
-        dopts.addAtomIndices = True
+        >>> dopts = rdMolDraw2D.MolDrawOptions()
+        >>> dopts.addAtomIndices = True
 
-        img_binary = MolsMatrixToGridImage(molsMatrix=molsMatrix, subImgSize=(300, 400), 
-        legendsMatrix=legendsMatrix, highlightAtomListsMatrix=highlightAtomListsMatrix, 
-        highlightBondListsMatrix=highlightBondListsMatrix, useSVG=False, returnPNG=True, drawOptions=dopts)
-        print(img_binary[:20])
-        # Prints a binary string: b'\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x03\x84'
+        >>> img_exhaustive = MolsMatrixToGridImage(molsMatrix=molsMatrix, subImgSize=(300, 400), legendsMatrix=legendsMatrix, highlightAtomListsMatrix=highlightAtomListsMatrix, highlightBondListsMatrix=highlightBondListsMatrix, useSVG=False, returnPNG=False, drawOptions=dopts)
+        >>> img.save("MolsMatrixToGridImageExhaustive.png")
+        >>> # Drawing will be saved as PNG file MolsMatrixToGridImageExhaustive.png
   """
   mols, molsPerRow, legends, highlightAtomLists, highlightBondLists = _MolsNestedToLinear(
     molsMatrix, legendsMatrix, highlightAtomListsMatrix, highlightBondListsMatrix)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! 
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.
Format code in docstrings as code blocks by adding `  >>> ` before lines of code

#### Any other comments?
I noticed this issue in the documentation for the [MolsMatrixToGridImage](https://www.rdkit.org/docs/source/rdkit.Chem.Draw.html#rdkit.Chem.Draw.MolsMatrixToGridImage) code I submitted (scroll down to EXAMPLES), then discovered that other docstrings had similar issues, so I addressed the couple that I found.







