### PR TITLE
MakeScaffoldGeneric isotope removal

### DIFF
--- a/Code/GraphMol/MolHash/catch_tests.cpp
+++ b/Code/GraphMol/MolHash/catch_tests.cpp
@@ -744,4 +744,3 @@ TEST_CASE("Github #6855 MakeScaffoldGeneric isotope removal") {
     }
   }
 }
-

--- a/Code/GraphMol/MolHash/catch_tests.cpp
+++ b/Code/GraphMol/MolHash/catch_tests.cpp
@@ -731,16 +731,27 @@ TEST_CASE("GitHub Issue #6505") {
   }
 }
 
-TEST_CASE("Github #6855 MakeScaffoldGeneric isotope removal") {
+TEST_CASE("Github Issue #6855 MakeScaffoldGeneric isotope removal") {
   SECTION("Extended Murcko") {
     auto mol =
-        "[235U]1CC1"_smiles;
+        "[235U]C1CC1"_smiles;
     REQUIRE(mol);
     {
       RWMol cp(*mol);
       auto hsh =
-          MolHash::MolHash(&cp, MolHash::HashFunction::ExtendedMurcko, true);
-      CHECK(hsh == "C1CC1");
+          MolHash::MolHash(&cp, MolHash::HashFunction::ExtendedMurcko);
+      CHECK(hsh == "*C1CC1");
+    }
+  }
+  SECTION("Anonymous") {
+    auto mol =
+        "[235U]1CC1"_smiles;
+    REQUIRE(mol);
+
+    {
+      RWMol cp(*mol);
+      auto hsh = MolHash::MolHash(&cp, MolHash::HashFunction::AnonymousGraph);
+      CHECK(hsh == "*1**1");
     }
   }
 }

--- a/Code/GraphMol/MolHash/catch_tests.cpp
+++ b/Code/GraphMol/MolHash/catch_tests.cpp
@@ -730,3 +730,18 @@ TEST_CASE("GitHub Issue #6505") {
     CHECK(hsh2 == "[CH3]-[CH2]-[CH2]-[CH2]-[CH2]-[CH2]-[NH3+]_0_0");
   }
 }
+
+TEST_CASE("Github #6855 MakeScaffoldGeneric isotope removal") {
+  SECTION("Extended Murcko") {
+    auto mol =
+        "[235U]1CC1"_smiles;
+    REQUIRE(mol);
+    {
+      RWMol cp(*mol);
+      auto hsh =
+          MolHash::MolHash(&cp, MolHash::HashFunction::ExtendedMurcko, true);
+      CHECK(hsh == "C1CC1");
+    }
+  }
+}
+

--- a/Code/GraphMol/MolHash/hashfunctions.cpp
+++ b/Code/GraphMol/MolHash/hashfunctions.cpp
@@ -317,6 +317,7 @@ std::string AnonymousGraph(RWMol *mol, bool elem, bool useCXSmiles,
       aptr->setNumExplicitHs(0);
       aptr->setNoImplicit(true);
       aptr->setAtomicNum(0);
+      aptr->setIsotope(0);
     } else {
       NormalizeHCount(aptr);
     }

--- a/Code/GraphMol/MolHash/hashfunctions.cpp
+++ b/Code/GraphMol/MolHash/hashfunctions.cpp
@@ -795,6 +795,7 @@ std::string ExtendedMurckoScaffold(RWMol *mol, bool useCXSmiles,
       aptr->setFormalCharge(0);
       aptr->setNoImplicit(true);
       aptr->setNumExplicitHs(0);
+      aptr->setIsotope(0);
     } else {
       for_deletion.push_back(aptr);
     }

--- a/Code/GraphMol/ScaffoldNetwork/ScaffoldNetwork.cpp
+++ b/Code/GraphMol/ScaffoldNetwork/ScaffoldNetwork.cpp
@@ -59,6 +59,7 @@ ROMol *makeScaffoldGeneric(const ROMol &mol, bool doAtoms, bool doBonds) {
       atom->setAtomicNum(0);
       atom->setNumExplicitHs(0);
       atom->setNoImplicit(false);
+      atom->setIsotope(0);
     }
   }
   if (doBonds) {

--- a/Code/GraphMol/ScaffoldNetwork/catch_tests.cpp
+++ b/Code/GraphMol/ScaffoldNetwork/catch_tests.cpp
@@ -910,4 +910,5 @@ TEST_CASE("Github #6855 MakeScaffoldGeneric isotope removal", "[bug]") {
     REQUIRE(pm);
     auto smiles = MolToSmiles(*pm);
     CHECK(smiles == "C1CC1");
+  }
 }

--- a/Code/GraphMol/ScaffoldNetwork/catch_tests.cpp
+++ b/Code/GraphMol/ScaffoldNetwork/catch_tests.cpp
@@ -900,3 +900,14 @@ TEST_CASE("molCounts", "[scaffolds]") {
     }
   }
 }
+
+TEST_CASE("Github #6855 MakeScaffoldGeneric isotope removal", "[bug]") {
+  auto m = "[235U]1CC1"_smiles;
+  REQUIRE(m);
+  SECTION("basics") {
+    std::unique_ptr<ROMol> pm(
+        ScaffoldNetwork::detail::makeScaffoldGeneric(*m, true, false));
+    REQUIRE(pm);
+    auto smiles = MolToSmiles(*pm);
+    CHECK(smiles == "C1CC1");
+}

--- a/Code/GraphMol/ScaffoldNetwork/catch_tests.cpp
+++ b/Code/GraphMol/ScaffoldNetwork/catch_tests.cpp
@@ -909,6 +909,6 @@ TEST_CASE("Github #6855 MakeScaffoldGeneric isotope removal", "[bug]") {
         ScaffoldNetwork::detail::makeScaffoldGeneric(*m, true, false));
     REQUIRE(pm);
     auto smiles = MolToSmiles(*pm);
-    CHECK(smiles == "C1CC1");
+    CHECK(smiles == "*1**1");
   }
 }

--- a/rdkit/Chem/Scaffolds/MurckoScaffold.py
+++ b/rdkit/Chem/Scaffolds/MurckoScaffold.py
@@ -39,6 +39,7 @@ def MakeScaffoldGeneric(mol):
     if atom.GetAtomicNum() != 1:
       atom.SetAtomicNum(6)
     atom.SetIsAromatic(False)
+    atom.SetIsotope(0)
     atom.SetFormalCharge(0)
     atom.SetChiralTag(Chem.ChiralType.CHI_UNSPECIFIED)
     atom.SetNoImplicit(0)

--- a/rdkit/Chem/Scaffolds/UnitTestMurckoScaffold.py
+++ b/rdkit/Chem/Scaffolds/UnitTestMurckoScaffold.py
@@ -71,6 +71,9 @@ class TestCase(unittest.TestCase):
     self.assertEqual(testSmiles('c1[nH]ccc1'), 'C1CCCC1')
     self.assertEqual(testSmiles('C1[NH2+]C1'), 'C1CC1')
     self.assertEqual(testSmiles('C1[C@](Cl)(F)O1'), 'CC1(C)CC1')
+    
+    # Examples from github issue 6855
+    self.assertEqual(testSmiles('[235U]1CC1'), 'C1CC1')
 
   testMolecules = [
     TestMolecule('CC1CCC1', 'C1CCC1'),
@@ -106,8 +109,6 @@ class TestCase(unittest.TestCase):
     TestMolecule('Cn1cccc1', 'c1ccc[nH]1'),
     # Explicit hydrogens are removed
     TestMolecule('C1CC1[CH](C)C1CC1', 'C1CC1CC1CC1'),
-    # Isotope is reset
-    TestMolecule('[235U]1CC1','C1CC1'),
   ]
 
   testMolecules2 = [

--- a/rdkit/Chem/Scaffolds/UnitTestMurckoScaffold.py
+++ b/rdkit/Chem/Scaffolds/UnitTestMurckoScaffold.py
@@ -106,6 +106,8 @@ class TestCase(unittest.TestCase):
     TestMolecule('Cn1cccc1', 'c1ccc[nH]1'),
     # Explicit hydrogens are removed
     TestMolecule('C1CC1[CH](C)C1CC1', 'C1CC1CC1CC1'),
+    # Isotope is reset
+    TestMolecule('[235U]1CC1','C1CC1'),
   ]
 
   testMolecules2 = [


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! 
-->
#### Reference Issue
Fixes #6836 
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.
reseting the isotope to 0 for every atom to fix unintended retention of isotope labels during generation of generic scaffolds

