### PR TITLE
RGD: Fix doEnumeration true for cores that are not bundles

### DIFF
--- a/Code/GraphMol/RGroupDecomposition/RGroupDecompData.cpp
+++ b/Code/GraphMol/RGroupDecomposition/RGroupDecompData.cpp
@@ -23,14 +23,7 @@ namespace RDKit {
 RGroupDecompData::RGroupDecompData(const RWMol &inputCore,
                                    RGroupDecompositionParameters inputParams)
     : params(std::move(inputParams)) {
-  if (inputParams.doEnumeration) {
-    auto bundle = MolEnumerator::enumerate(inputCore);
-    for (auto c: bundle.getMols()) {
-      addCore(*c);
-    }
-  } else {
-    addCore(inputCore);
-  }
+  addInputCore(inputCore);
   prepareCores();
 }
 
@@ -38,17 +31,26 @@ RGroupDecompData::RGroupDecompData(const std::vector<ROMOL_SPTR> &inputCores,
                                    RGroupDecompositionParameters inputParams)
     : params(std::move(inputParams)) {
   for (const auto &core : inputCores) {
-    if (inputParams.doEnumeration) {
-      auto bundle = MolEnumerator::enumerate(*core);
+    addInputCore(*core);
+  }
+  prepareCores();
+}
+
+void RGroupDecompData::addInputCore(const ROMol& inputCore) {
+  if (params.doEnumeration) {
+    if (const auto bundle = MolEnumerator::enumerate(inputCore);
+        !bundle.empty()) {
       for (auto c : bundle.getMols()) {
         addCore(*c);
       }
     } else {
-      addCore(*core);
+      addCore(inputCore);
     }
+  } else  {
+    addCore(inputCore);
   }
-  prepareCores();
 }
+
 
 void RGroupDecompData::addCore(const ROMol &inputCore) {
   if (params.allowMultipleRGroupsOnUnlabelled && !params.onlyMatchAtRGroups) {

--- a/Code/GraphMol/RGroupDecomposition/RGroupDecompData.h
+++ b/Code/GraphMol/RGroupDecomposition/RGroupDecompData.h
@@ -107,6 +107,9 @@ struct RGroupDecompData {
 
   RGroupDecompositionProcessResult process(bool pruneMatches,
                                            bool finalize = false);
+
+private:
+  void addInputCore(const ROMol &inputCore);
 };
 }  // namespace RDKit
 

--- a/Code/GraphMol/RGroupDecomposition/testRGroupDecomp.cpp
+++ b/Code/GraphMol/RGroupDecomposition/testRGroupDecomp.cpp
@@ -4124,7 +4124,6 @@ int main() {
   BOOST_LOG(rdInfoLog) << "Testing R-Group Decomposition \n";
 
 #if 1
-  testNotEnumeratedCore();
   testSymmetryMatching(FingerprintVariance);
   testSymmetryMatching();
   testRGroupOnlyMatching();
@@ -4181,6 +4180,7 @@ int main() {
   testTautomerCore();
   testEnumeratedCore();
   testStereoBondBug();
+  testNotEnumeratedCore();
   BOOST_LOG(rdInfoLog)
       << "********************************************************\n";
   return 0;

--- a/Code/GraphMol/RGroupDecomposition/testRGroupDecomp.cpp
+++ b/Code/GraphMol/RGroupDecomposition/testRGroupDecomp.cpp
@@ -4088,6 +4088,34 @@ M  END
   TEST_ASSERT(foundStereo);
 }
 
+void testNotEnumeratedCore() {
+  BOOST_LOG(rdInfoLog)
+      << "********************************************************\n";
+  BOOST_LOG(rdInfoLog) << "Test that enumerated setting for non enumerated cores behaves properly"
+                       << std::endl;
+  
+  const auto core = "C1CCCCC1"_smarts;
+  const auto mol =  "C1CCCCC1C"_smiles;
+  
+  RGroupDecompositionParameters params;
+  params.matchingStrategy = GreedyChunks;
+  params.allowMultipleRGroupsOnUnlabelled = true;
+  params.onlyMatchAtRGroups = false;
+  params.doEnumeration = true;
+  params.doTautomers = false;
+
+  const char *expected = "Core:C1CCC([*:1])CC1 R1:C[*:1]";
+
+  RGroupDecomposition decomp(*core, params);
+  const auto add11 = decomp.add(*mol);
+  TEST_ASSERT(add11 == 0);
+  decomp.process();
+  auto rows = decomp.getRGroupsAsRows();
+  TEST_ASSERT(rows.size() == 1);
+  RGroupRows::const_iterator it = rows.begin();
+  CHECK_RGROUP(it, expected);
+}
+
 int main() {
   RDLog::InitLogs();
   boost::logging::disable_logs("rdApp.debug");
@@ -4096,6 +4124,7 @@ int main() {
   BOOST_LOG(rdInfoLog) << "Testing R-Group Decomposition \n";
 
 #if 1
+  testNotEnumeratedCore();
   testSymmetryMatching(FingerprintVariance);
   testSymmetryMatching();
   testRGroupOnlyMatching();


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! 
-->

#### What does this implement/fix? Explain your changes.

If `doEnumeration` is set in RGD and a input core does not enumerate into a bundle that core is not added. This PR fixes this   by adding the original input core if it does not enumerate into a bundle.

#### Any other comments?

