### PR TITLE
Fix build error when serialization is off.

### DIFF
--- a/Code/GraphMol/ChemReactions/Enumerate/EvenSamplePairs.h
+++ b/Code/GraphMol/ChemReactions/Enumerate/EvenSamplePairs.h
@@ -182,6 +182,8 @@ class RDKIT_CHEMREACTIONS_EXPORT EvenSamplePairsStrategy
 };
 }  // namespace RDKit
 
+#ifdef RDK_USE_BOOST_SERIALIZATION
 BOOST_CLASS_VERSION(RDKit::EvenSamplePairsStrategy, 1)
+#endif
 
 #endif


### PR DESCRIPTION
Unlike other files that use the `RDK_USE_BOOST_SERIALIZATION` flag, EvenSamplePairs.h does not wrap the `BOOST_CLASS_VERSION` boilerplate in an #ifdef.

This happens to work anyway when built against older versions of boost, where the required header is being made visible by other boost includes, but this causes a build breakage when compiled against Boost 1.82 or later and with serialization off.
