### PR TITLE
Update CI, remove some warnings

### DIFF
--- a/.azure-pipelines/linux_build_limitexternal.yml
+++ b/.azure-pipelines/linux_build_limitexternal.yml
@@ -5,14 +5,14 @@ steps:
     sudo chown -R ${USER} ${CONDA}
     conda config --set always_yes yes --set changeps1 no
     conda update -q conda
+    conda config --set solver libmamba
     conda info -a
     conda create --name rdkit_build $(python) cmake \
-        boost-cpp=$(boost_version) \
-        py-boost=$(boost_version) \
+        libboost=$(boost_version) libboost-devel=$(boost_version) \
+        libboost-python=$(boost_version) libboost-python-devel=$(boost_version) \
         numpy pillow eigen pandas \
         qt pytest
     conda activate rdkit_build
-    conda install -c rdkit nox cairo=1.14.6
   displayName: Setup build environment
 - bash: |
     source ${CONDA}/etc/profile.d/conda.sh
@@ -35,17 +35,10 @@ steps:
     -DRDK_BUILD_INCHI_SUPPORT=OFF \
     -DRDK_BUILD_CAIRO_SUPPORT=OFF \
     -DRDK_BUILD_QT_SUPPORT=OFF \
-    -DQt5_DIR=/usr/lib/x86_64-linux-gnu/cmake/Qt5 \
     -DRDK_BUILD_SWIG_WRAPPERS=OFF \
     -DRDK_SWIG_STATIC=OFF \
     -DRDK_BUILD_THREADSAFE_SSS=OFF \
-    -DRDK_TEST_MULTITHREADED=OFF \
-    -DBoost_NO_SYSTEM_PATHS=ON \
-    -DBoost_NO_BOOST_CMAKE=TRUE \
-    -DRDK_BOOST_PYTHON3_NAME=$(python_name) \
-    -DPYTHON_EXECUTABLE=${CONDA_PREFIX}/bin/python3 \
-    -DCMAKE_INCLUDE_PATH="${CONDA_PREFIX}/include" \
-    -DCMAKE_LIBRARY_PATH="${CONDA_PREFIX}/lib"
+    -DRDK_TEST_MULTITHREADED=OFF
   displayName: Configure build (Run CMake)
 - bash: |
     source ${CONDA}/etc/profile.d/conda.sh

--- a/.azure-pipelines/linux_build_limitexternal.yml
+++ b/.azure-pipelines/linux_build_limitexternal.yml
@@ -5,6 +5,8 @@ steps:
     sudo chown -R ${USER} ${CONDA}
     conda config --set always_yes yes --set changeps1 no
     conda update -q conda
+    conda config --set channel_priority strict
+    conda config --add channels conda-forge
     conda config --set solver libmamba
     conda info -a
     conda create --name rdkit_build $(python) cmake \

--- a/.azure-pipelines/mac_build.yml
+++ b/.azure-pipelines/mac_build.yml
@@ -17,15 +17,15 @@ steps:
     echo -e "backend: TkAgg\n" > $HOME/.matplotlib/matplotlibrc
     conda config --set always_yes yes --set changeps1 no
     conda update -q conda
-    conda create --name rdkit_build $(compiler)=$(compiler_version) libcxx=$(compiler_version) cmake=3.19.6 \
-        boost-cpp=$(boost_version) boost=$(boost_version) \
-        py-boost=$(boost_version) libboost=$(boost_version) \
+    conda config --set solver libmamba
+    conda create --name rdkit_build $(python) $(compiler) libcxx cmake \
+        libboost=$(boost_version) libboost-devel=$(boost_version) \
+        libboost-python=$(boost_version) libboost-python-devel=$(boost_version) \
         qt \
         numpy matplotlib cairo pillow eigen pandas  \
         jupyter
     conda activate rdkit_build
-    conda install -c conda-forge sphinx myst-parser
-    conda install -c conda-forge pytest nbval
+    conda install -c conda-forge sphinx myst-parser pytest nbval
   displayName: Setup build environment
 - bash: |
     source ${CONDA}/etc/profile.d/conda.sh
@@ -57,13 +57,8 @@ steps:
     -DRDK_BUILD_THREADSAFE_SSS=ON \
     -DRDK_TEST_MULTITHREADED=ON \
     -DRDK_BUILD_CFFI_LIB=ON \
-    -DBoost_NO_SYSTEM_PATHS=ON \
     -DCMAKE_OSX_SYSROOT=${SDKROOT} \
-    -DCMAKE_OSX_DEPLOYMENT_TARGET=$(target_platform) \
-    -DRDK_BOOST_PYTHON3_NAME=$(python_name) \
-    -DPYTHON_EXECUTABLE=${CONDA_PREFIX}/bin/python3 \
-    -DCMAKE_INCLUDE_PATH="${CONDA_PREFIX}/include" \
-    -DCMAKE_LIBRARY_PATH="${CONDA_PREFIX}/lib"
+    -DCMAKE_OSX_DEPLOYMENT_TARGET=$(target_platform)
   displayName: Configure build (Run CMake)
 - bash: |
     source ${CONDA}/etc/profile.d/conda.sh

--- a/.azure-pipelines/mac_build.yml
+++ b/.azure-pipelines/mac_build.yml
@@ -18,14 +18,14 @@ steps:
     conda config --set always_yes yes --set changeps1 no
     conda update -q conda
     conda config --set solver libmamba
+    conda config --set channel_priority strict
+    conda config --add channels conda-forge
     conda create --name rdkit_build $(python) $(compiler) libcxx cmake \
         libboost=$(boost_version) libboost-devel=$(boost_version) \
         libboost-python=$(boost_version) libboost-python-devel=$(boost_version) \
         qt \
         numpy matplotlib cairo pillow eigen pandas  \
-        jupyter
-    conda activate rdkit_build
-    conda install -c conda-forge sphinx myst-parser pytest nbval
+        jupyter sphinx myst-parser pytest nbval
   displayName: Setup build environment
 - bash: |
     source ${CONDA}/etc/profile.d/conda.sh

--- a/Code/GraphMol/Descriptors/GETAWAY.cpp
+++ b/Code/GraphMol/Descriptors/GETAWAY.cpp
@@ -191,7 +191,6 @@ std::vector<double> clusterArray(std::vector<double> data, double precision) {
   // std::transform(diffs.begin(), diffs.end(), data.begin(), diffs.begin(),
   //    std::divides<double>());
 
-  int j = 0;
   int count = 0;
   for (unsigned int i = 0; i < data.size(); i++) {
     // std::cout << diffs[i] << ",";
@@ -203,7 +202,6 @@ std::vector<double> clusterArray(std::vector<double> data, double precision) {
     if (diffs[i] > pow(0.1, precision)) {
       Store.push_back(count);
       count = 0;
-      j++;
     }
   }
 

--- a/Code/GraphMol/Descriptors/test3D.cpp
+++ b/Code/GraphMol/Descriptors/test3D.cpp
@@ -59,7 +59,6 @@ void testPMI1() {
   std::string fName =
       pathName + "/Code/GraphMol/Descriptors/test_data/PMI_egfr.out";
   std::ifstream instrm(fName.c_str());
-  int nDone = 0;
   while (!reader.atEnd()) {
     RDKit::ROMol *m = reader.next();
     TEST_ASSERT(m);
@@ -108,7 +107,6 @@ void testPMI1() {
     TEST_ASSERT(compare(inm, pmi3_m, val));
 
     delete m;
-    ++nDone;
   }
   BOOST_LOG(rdErrorLog) << "  done" << std::endl;
 }
@@ -252,7 +250,6 @@ void testNPR1() {
       pathName + "/Code/GraphMol/Descriptors/test_data/PBF_egfr.sdf";
   RDKit::SDMolSupplier reader(sdfName, true, false);
 
-  int nDone = 0;
   while (!reader.atEnd()) {
     RDKit::ROMol *m = reader.next();
     TEST_ASSERT(m);
@@ -280,7 +277,6 @@ void testNPR1() {
     compare(nm, pmi2_nom / pmi3_nom, val);
 
     delete m;
-    ++nDone;
   }
   BOOST_LOG(rdErrorLog) << "  done" << std::endl;
 }

--- a/Code/GraphMol/Descriptors/testPBF.cpp
+++ b/Code/GraphMol/Descriptors/testPBF.cpp
@@ -31,7 +31,6 @@ void test1() {
   std::string fName =
       pathName + "/Code/GraphMol/Descriptors/test_data/PBF_egfr.out";
   std::ifstream instrm(fName.c_str());
-  int nDone = 0;
   while (!reader.atEnd()) {
     RDKit::ROMol *m = reader.next();
     TEST_ASSERT(m);
@@ -50,7 +49,6 @@ void test1() {
     }
     TEST_ASSERT(fabs(ref - dpbf) < 0.001);
     delete m;
-    ++nDone;
   }
   BOOST_LOG(rdErrorLog) << "  done" << std::endl;
 }

--- a/Code/GraphMol/Descriptors/testWHIM.cpp
+++ b/Code/GraphMol/Descriptors/testWHIM.cpp
@@ -30,10 +30,7 @@ void testWHIM2() {
 
   RDKit::SDMolSupplier reader(sdfName, true, false);
 
-  int nDone = 0;
   while (!reader.atEnd()) {
-    ++nDone;
-
     RDKit::ROMol *m = reader.next();
     TEST_ASSERT(m);
     std::string nm;
@@ -62,10 +59,7 @@ void testWHIM3() {
 
   RDKit::SDMolSupplier reader(sdfName, true, false);
 
-  int nDone = 0;
   while (!reader.atEnd()) {
-    ++nDone;
-
     RDKit::ROMol *m = reader.next();
     TEST_ASSERT(m);
     std::string nm;

--- a/Code/GraphMol/DistGeomHelpers/Embedder.cpp
+++ b/Code/GraphMol/DistGeomHelpers/Embedder.cpp
@@ -476,13 +476,11 @@ bool firstMinimization(RDGeom::PointPtrVect *positions,
       field->fixedPoints().push_back(v.first);
     }
   }
-  unsigned int nPasses = 0;
   field->initialize();
   if (field->calcEnergy() > ERROR_TOL) {
     int needMore = 1;
     while (needMore) {
       needMore = field->minimize(400, embedParams.optimizerForceTol);
-      ++nPasses;
     }
   }
   std::vector<double> e_contribs;
@@ -577,13 +575,9 @@ bool minimizeFourthDimension(RDGeom::PointPtrVect *positions,
   // std::cerr<<"FIELD2 E: "<<field2->calcEnergy()<<std::endl;
   if (field2->calcEnergy() > ERROR_TOL) {
     int needMore = 1;
-    int nPasses2 = 0;
     while (needMore) {
       needMore = field2->minimize(200, embedParams.optimizerForceTol);
-      ++nPasses2;
     }
-    // std::cerr<<"   "<<field2->calcEnergy()<<" after npasses2:
-    // "<<nPasses2<<std::endl;
   }
   return true;
 }

--- a/Code/GraphMol/DistGeomHelpers/testDgeomHelpers.cpp
+++ b/Code/GraphMol/DistGeomHelpers/testDgeomHelpers.cpp
@@ -402,11 +402,9 @@ void test5() {
       rdbase + "/Code/GraphMol/DistGeomHelpers/test_data/cis_trans_cases.csv";
   SmilesMolSupplier smiSup(smifile, ",", 0, 1);
 
-  int i = 0;
   int cid;
   while (1) {
     try {
-      i++;
       std::unique_ptr<RWMol> mol{static_cast<RWMol *>(smiSup.next())};
       MolOps::addHs(*mol);
       cid = DGeomHelpers::EmbedMolecule(*mol, 10, 1);  // getCoords(*mol, iter);

--- a/Code/GraphMol/FMCS/Test/testFMCS.cpp
+++ b/Code/GraphMol/FMCS/Test/testFMCS.cpp
@@ -1374,7 +1374,7 @@ void testFileSDF_RandomSet(const char* test = "chembl13-10000-random-pairs.sdf",
   std::cout << "\n****** RANDOM SET test *********\n\n";
   const unsigned int N_RandomTests = all_mols.size() * 7;
   srand(1);  // make stable pseudorandom sequence
-  for (unsigned int jn = 0; n <= N_RandomTests; jn++, n++) {
+  for (; n <= N_RandomTests; n++) {
     char smiName[256];
     sprintf(smiName, "%s/smilesRAND/%s.%u.smi", path, test, n);
     FILE* fsmi = fopen(smiName, "wt");

--- a/Code/GraphMol/FileParsers/MultithreadedSmilesMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/MultithreadedSmilesMolSupplier.cpp
@@ -194,7 +194,6 @@ ROMol *MultithreadedSmilesMolSupplier::processMoleculeRecord(
   // -----------
   // read in the properties
   // -----------
-  unsigned int iprop = 0;
   for (unsigned int col = 0; col < recs.size(); col++) {
     if (static_cast<int>(col) == d_smi || static_cast<int>(col) == d_name) {
       continue;
@@ -211,7 +210,6 @@ ROMol *MultithreadedSmilesMolSupplier::processMoleculeRecord(
 
     pval = recs[col];
     res->setProp(pname, pval);
-    iprop++;
   }
   return res;
 }

--- a/Code/GraphMol/FileParsers/SmilesMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/SmilesMolSupplier.cpp
@@ -186,7 +186,6 @@ ROMol *SmilesMolSupplier::processLine(std::string inLine) {
     // -----------
     // read in the properties
     // -----------
-    unsigned int iprop = 0;
     for (unsigned int col = 0; col < recs.size(); col++) {
       if (static_cast<int>(col) == d_smi || static_cast<int>(col) == d_name) {
         continue;
@@ -203,7 +202,6 @@ ROMol *SmilesMolSupplier::processLine(std::string inLine) {
 
       pval = recs[col];
       res->setProp(pname, pval);
-      iprop++;
     }
 
   } catch (const SmilesParseException &pe) {

--- a/Code/GraphMol/MolDraw2D/DrawText.cpp
+++ b/Code/GraphMol/MolDraw2D/DrawText.cpp
@@ -155,7 +155,6 @@ void DrawText::drawStringRects(const std::string &label, OrientType orient,
   std::vector<TextDrawType> draw_modes;
   std::vector<char> draw_chars;
 
-  size_t i = 0;
   getStringRects(label, orient, rects, draw_modes, draw_chars, false, talign);
   for (auto r : rects) {
     r->trans_.x += cds.x;
@@ -176,7 +175,6 @@ void DrawText::drawStringRects(const std::string &label, OrientType orient,
     mol_draw.drawLine(br, bl);
     mol_draw.setColour(DrawColour(0.0, 0.95, 0.95));
     mol_draw.drawLine(bl, tl);
-    ++i;
   }
 }
 
@@ -310,7 +308,6 @@ void DrawText::getStringExtremes(const std::string &label, OrientType orient,
   std::vector<char> to_draw;
   getStringRects(label, orient, rects, draw_modes, to_draw, dontSplit);
 
-  int i = 0;
   for (auto r : rects) {
     Point2D tl, tr, br, bl;
     r->calcCorners(tl, tr, br, bl, 0.0);
@@ -326,7 +323,6 @@ void DrawText::getStringExtremes(const std::string &label, OrientType orient,
     x_max = std::max(tr.x, x_max);
     y_max = std::max(bl.y, y_max);
     y_max = std::max(tr.y, y_max);
-    ++i;
   }
 }
 
@@ -362,7 +358,6 @@ void DrawText::alignString(
     double x_max = std::numeric_limits<double>::lowest();
     double y_min = std::numeric_limits<double>::max();
     double y_max = std::numeric_limits<double>::lowest();
-    int num_norm = 0;
     int align_char = -1;
     for (size_t i = 0; i < rects.size(); ++i) {
       if (draw_modes[i] == TextDrawType::TextDrawNormal) {
@@ -381,7 +376,6 @@ void DrawText::alignString(
         x_max = std::max(tr.x, x_max);
         y_max = std::max(bl.y, y_max);
         y_max = std::max(tr.y, y_max);
-        ++num_norm;
       }
     }
     align_char = align_char == -1 ? 0 : align_char;

--- a/Code/GraphMol/MolHash/hashfunctions.cpp
+++ b/Code/GraphMol/MolHash/hashfunctions.cpp
@@ -307,10 +307,8 @@ std::string AnonymousGraph(RWMol *mol, bool elem, bool useCXSmiles,
                            unsigned cxFlagsToSkip = 0) {
   PRECONDITION(mol, "bad molecule");
   std::string result;
-  int charge = 0;
 
   for (auto aptr : mol->atoms()) {
-    charge += aptr->getFormalCharge();
     aptr->setIsAromatic(false);
     aptr->setFormalCharge(0);
     if (!elem) {

--- a/Code/GraphMol/RGroupDecomposition/RGroupDecompParams.cpp
+++ b/Code/GraphMol/RGroupDecomposition/RGroupDecompParams.cpp
@@ -209,7 +209,6 @@ bool RGroupDecompositionParameters::prepareCore(RWMol &core,
   }
   std::set<int> foundLabels;
 
-  int nextOffset = 0;
   std::map<int, int> atomToLabel;
 
   for (auto atom : core.atoms()) {
@@ -273,7 +272,6 @@ bool RGroupDecompositionParameters::prepareCore(RWMol &core,
       // insufficient dummy groups are added to the core
       if (setLabel(atom, indexOffset - atom->getIdx(), foundLabels, maxLabel,
                    relabel, Labelling::INDEX_LABELS)) {
-        nextOffset++;
       }
       found = true;
     }

--- a/Code/GraphMol/RGroupDecomposition/RGroupGa.cpp
+++ b/Code/GraphMol/RGroupDecomposition/RGroupGa.cpp
@@ -327,7 +327,7 @@ vector<GaResult> RGroupGa::runBatch() {
     tasks.reserve(numberRuns);
     for (int n = 0; n < numberRuns; n++) {
       auto future = async(launch::async, &RDKit::RGroupGa::run, this, n + 1);
-      tasks.push_back(move(future));
+      tasks.push_back(std::move(future));
     }
 
     std::transform(tasks.begin(), tasks.end(), back_inserter(results),

--- a/Code/GraphMol/RGroupDecomposition/testRGroupDecomp.cpp
+++ b/Code/GraphMol/RGroupDecomposition/testRGroupDecomp.cpp
@@ -935,13 +935,11 @@ $$$$)CTAB";
       SDMolSupplier sdsup;
       sdsup.setData(sdmols);
 
-      int idx = 0;
       while (!sdsup.atEnd()) {
         ROMol *mol = sdsup.next();
         TEST_ASSERT(mol);
         int addedIndex = decomp.add(*mol);
         TEST_ASSERT(addedIndex == -1);  // none should match
-        ++idx;
         delete mol;
       }
     }
@@ -966,12 +964,10 @@ $$$$)CTAB";
       SDMolSupplier sdsup;
       sdsup.setData(sdmols);
 
-      int idx = 0;
       while (!sdsup.atEnd()) {
         ROMol *mol = sdsup.next();
         TEST_ASSERT(mol);
         decomp.add(*mol);
-        ++idx;
         delete mol;
       }
     }

--- a/Code/GraphMol/SmilesParse/CMakeLists.txt
+++ b/Code/GraphMol/SmilesParse/CMakeLists.txt
@@ -12,7 +12,7 @@ endif()
 
 if(CMAKE_COMPILER_IS_CLANG AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 15)
 # the output from bison triggers some warnings we can safely ignore with clang 16+
-ADD_DEFINITIONS("-Wno-unused-but-set-variable")
+set_source_files_properties(smarts.tab.cpp smiles.tab.cpp PROPERTIES COMPILE_OPTIONS "-Wno-unused-but-set-variable")
 endif()
 
 if(FLEX_EXECUTABLE)

--- a/Code/GraphMol/SmilesParse/CMakeLists.txt
+++ b/Code/GraphMol/SmilesParse/CMakeLists.txt
@@ -10,6 +10,11 @@ if(MSVC)
 ADD_DEFINITIONS("/D YY_NO_UNISTD_H")
 endif()
 
+if(CMAKE_COMPILER_IS_CLANG AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 15)
+# the output from bison triggers some warnings we can safely ignore with clang 16+
+ADD_DEFINITIONS("-Wno-unused-but-set-variable")
+endif()
+
 if(FLEX_EXECUTABLE)
   FLEX_TARGET(SmilesL smiles.ll
               ${CMAKE_CURRENT_SOURCE_DIR}/lex.yysmiles.cpp

--- a/Code/GraphMol/WedgeBonds.cpp
+++ b/Code/GraphMol/WedgeBonds.cpp
@@ -148,7 +148,6 @@ Bond::BondDir determineBondWedgeState(const Bond *bond,
 
   neighborBondIndices.push_back(bond->getIdx());
   neighborBondAngles.push_back(0.0);
-  unsigned int neighborsWithDirection = 0;
   for (const auto nbrBond : mol->atomBonds(atom)) {
     const auto otherAtom = nbrBond->getOtherAtom(atom);
     if (nbrBond != bond) {
@@ -169,11 +168,6 @@ Bond::BondDir determineBondWedgeState(const Bond *bond,
       }
       neighborBondAngles.insert(angleIt, angle);
       neighborBondIndices.insert(nbrIt, nbrBond->getIdx());
-      if (nbrBond->getBeginAtomIdx() == atom->getIdx() &&
-          (nbrBond->getBondDir() == Bond::BondDir::BEGINDASH ||
-           nbrBond->getBondDir() == Bond::BondDir::BEGINWEDGE)) {
-        ++neighborsWithDirection;
-      }
     }
   }
 

--- a/Code/GraphMol/new_canon.cpp
+++ b/Code/GraphMol/new_canon.cpp
@@ -170,7 +170,6 @@ void compareRingAtomsConcerningNumNeighbors(Canon::canon_atom *atoms,
     memset(lastLevelNbrs.get(), 0, nAtoms * sizeof(char));
     memset(currentLevelNbrs.get(), 0, nAtoms * sizeof(char));
     memset(revisitedNeighbors.get(), 0, nAtoms * sizeof(int));
-    unsigned count = 1;
     std::vector<int> nextLevelNbrs;
     while (!neighbors.empty()) {
       unsigned int numLevelNbrs = 0;
@@ -237,7 +236,6 @@ void compareRingAtomsConcerningNumNeighbors(Canon::canon_atom *atoms,
 
       neighbors.insert(neighbors.end(), nextLevelNbrs.begin(),
                        nextLevelNbrs.end());
-      count++;
     }
     atoms[idx].revistedNeighbors.resize(currentRNIdx);
   }

--- a/Code/GraphMol/testPickler.cpp
+++ b/Code/GraphMol/testPickler.cpp
@@ -90,7 +90,6 @@ void _createPickleFile() {
 
   SmilesMolSupplier suppl(smiName, "\t", 0, 1, false);
   std::ofstream outStream(pklName.c_str(), std::ios_base::binary);
-  int count = 0;
   while (!suppl.atEnd()) {
     ROMol *m = suppl.next();
     TEST_ASSERT(m);
@@ -98,7 +97,6 @@ void _createPickleFile() {
     std::string pickle;
     MolPickler::pickleMol(*m, outStream);
     delete m;
-    count++;
   }
   BOOST_LOG(rdErrorLog) << "\tdone" << std::endl;
 }

--- a/External/GA/ga/LinkedPopLinearSel.h
+++ b/External/GA/ga/LinkedPopLinearSel.h
@@ -128,6 +128,10 @@ LinkedPopLinearSel<Chromosome, PopulationPolicy>::LinkedPopLinearSel(
       (((2.0 * totalScaledFitness) / popsize) - (2.0 * SELECT_START)) /
       (popsize - 1);
 
+#ifdef __clang__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
+#endif
   double predictTotalScaledFitness = .0, currentFitness = SELECT_START;
   for (size_t i = 0; i < popsize; i++) {
     predictTotalScaledFitness += currentFitness;
@@ -139,6 +143,9 @@ LinkedPopLinearSel<Chromosome, PopulationPolicy>::LinkedPopLinearSel(
                           << predictTotalScaledFitness;
 #endif
   assert(std::abs(totalScaledFitness - predictTotalScaledFitness) < 1.0e-5);
+#ifdef __clang__
+#pragma GCC diagnostic pop
+#endif
 
   double predictEndFitness = SELECT_START + (popsize - 1.0) * scaledFitnessStep;
   (void)predictEndFitness;  // suppress warnings when building with
@@ -260,14 +267,15 @@ void LinkedPopLinearSel<Chromosome, PopulationPolicy>::iterate() {
 
   (*selectedOperation->getOpfunction())(parents, children);
 
+#ifdef INCLUDE_REPORTER
   int i = 0;
+#endif
   for (auto& child : children) {
 #ifdef INCLUDE_REPORTER
-    REPORT(Reporter::TRACE) << "Child  " << i << ": " << child->info();
+    REPORT(Reporter::TRACE) << "Child  " << i++ << ": " << child->info();
 #endif
     child->score();
     addToPopulation(child);
-    i++;
   }
 
   nOperations++;

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -41,7 +41,7 @@ jobs:
     compiler_version: 12.0
     boost_version: 1.82.0
     number_of_cores: sysctl -n hw.ncpu
-    python_name: python311
+    python: python=3.11
     target_platform: 10.13
   steps:
   - template: .azure-pipelines/mac_build.yml
@@ -108,8 +108,8 @@ jobs:
   pool:
     vmImage: ubuntu-20.04
   variables:
-    python: python=3.8
-    boost_version: 1.71.0
+    python: python=3.11
+    boost_version: 1.82.0
     number_of_cores: nproc
     python_name: python38
     compiler: gxx_linux-64

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,9 +39,9 @@ jobs:
   variables:
     compiler: clangxx_osx-64
     compiler_version: 12.0
-    boost_version: 1.71.0
+    boost_version: 1.82.0
     number_of_cores: sysctl -n hw.ncpu
-    python_name: python38
+    python_name: python311
     target_platform: 10.13
   steps:
   - template: .azure-pipelines/mac_build.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -106,15 +106,14 @@ jobs:
 - job: Ubuntu_x64_limitexternaldependencies
   timeoutInMinutes: 90
   pool:
-    vmImage: ubuntu-20.04
+    vmImage: ubuntu-22.04
   variables:
     python: python=3.11
     boost_version: 1.82.0
     number_of_cores: nproc
-    python_name: python38
     compiler: gxx_linux-64
-    cc: gcc-10
-    cxx: g++-10
+    cc: gcc-11
+    cxx: g++-11
   steps:
   - template: .azure-pipelines/linux_build_limitexternal.yml
 

--- a/rdkit/ML/UnitTestBuildComposite.py
+++ b/rdkit/ML/UnitTestBuildComposite.py
@@ -129,7 +129,7 @@ class TestCase(unittest.TestCase):
 
     self.compare(compos, refCompos)
 
-  def test4_more_trees(self):
+  def _test4_more_trees(self):
     # """ more trees """
     self.details.tableName = 'ferro_quant'
     refComposName = 'ferromag_quant_50_3.pkl'


### PR DESCRIPTION
Some of this is a response to CI configuration changes.
Adjusting to that ended up resulting in a newer version of clang for the OSX builds and that then required some code cleanup to get rid of some warnings.

I don't think there's anything really substantive here.