### PR TITLE
Deprecate some of the ancient python-based ML code

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -21,9 +21,14 @@ GitHub)
   Please use the implementation in `rdkit.Chem.MolStandardize.rdMolStandardize` instead.
 - The rdkit.six module, a leftover from the days when we supported both python 2
   and python 3, has been removed
+- The RDKit implementation of standard machine learning algorithms has been
+  removed. The affected packages include: rdkit.ML.Composite, rdkit.ML.DecTree,
+  rdkit.ML.KNN, rdkit.ML.ModelPackage, rdkit.ML.NaiveBayes, rdkit.ML.Neural
+  rdkit.ML.{Analyze,Screen,Grow,Build}Composite, rdkit.ML.CompositeRun,
+  rdkit.ML.EnrichPlot
 
 ## Deprecated code (to be removed in a future release):
-- The RDKit implementation of standard machine learning algorithsm has been deprecated and will be removed in the 2024.09 release. The affected packages include: rdkit.ML.Composite, rdkit.ML.DecTree, rdkit.ML.KNN, rdkit.ML.ModelPackage, rdkit.ML.NaiveBayes, rdkit.ML.Neural rdkit.ML.{Analyze,Screen,Grow,Build}Composite, rdkit.ML.CompositeRun, rdkit.ML.EnrichPlot
+
 
 # Release_2023.09.1
 (Changes relative to Release_2023.03.1)

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -23,7 +23,7 @@ GitHub)
   and python 3, has been removed
 
 ## Deprecated code (to be removed in a future release):
-
+- The RDKit implementation of standard machine learning algorithsm has been deprecated and will be removed in the 2024.09 release. The affected packages include: rdkit.ML.Composite, rdkit.ML.DecTree, rdkit.ML.KNN, rdkit.ML.ModelPackage, rdkit.ML.NaiveBayes, rdkit.ML.Neural rdkit.ML.{Analyze,Screen,Grow,Build}Composite, rdkit.ML.CompositeRun, rdkit.ML.EnrichPlot
 
 # Release_2023.09.1
 (Changes relative to Release_2023.03.1)

--- a/rdkit/ML/AnalyzeComposite.py
+++ b/rdkit/ML/AnalyzeComposite.py
@@ -26,6 +26,10 @@ Usage:  AnalyzeComposite [optional args] <models>
 
       -v: be verbose whilst screening
 """
+from warnings import warn
+
+warn('This module is deprecated and will be removed in the 2024.03 release', DeprecationWarning,
+     stacklevel=2)
 
 import pickle
 import sys

--- a/rdkit/ML/BuildComposite.py
+++ b/rdkit/ML/BuildComposite.py
@@ -198,6 +198,10 @@ a QDAT file.
 
 
 """
+from warnings import warn
+
+warn('This module is deprecated and will be removed in the 2024.03 release', DeprecationWarning,
+     stacklevel=2)
 
 import pickle
 import sys

--- a/rdkit/ML/Composite/__init__.py
+++ b/rdkit/ML/Composite/__init__.py
@@ -1,0 +1,4 @@
+from warnings import warn
+
+warn('This module is deprecated and will be removed in the 2024.03 release', DeprecationWarning,
+     stacklevel=2)

--- a/rdkit/ML/CompositeRun.py
+++ b/rdkit/ML/CompositeRun.py
@@ -12,6 +12,11 @@
 Composite building
 
 """
+from warnings import warn
+
+warn('This module is deprecated and will be removed in the 2024.03 release', DeprecationWarning,
+     stacklevel=2)
+
 from rdkit import RDConfig
 from rdkit.Dbase import DbModule
 from rdkit.Dbase.DbConnection import DbConnect

--- a/rdkit/ML/DecTree/__init__.py
+++ b/rdkit/ML/DecTree/__init__.py
@@ -5,3 +5,7 @@ Here we're implementing the Decision Tree stuff found in Chapter 3 of
 Tom Mitchell's Machine Learning Book.
 
 """
+from warnings import warn
+
+warn('This module is deprecated and will be removed in the 2024.03 release', DeprecationWarning,
+     stacklevel=2)

--- a/rdkit/ML/EnrichPlot.py
+++ b/rdkit/ML/EnrichPlot.py
@@ -64,6 +64,10 @@ Optional Arguments:
     displayed in gnuplot.
 
 """
+from warnings import warn
+
+warn('This module is deprecated and will be removed in the 2024.03 release', DeprecationWarning,
+     stacklevel=2)
 # from rdkit.Dbase.DbConnection import DbConnect
 
 import pickle

--- a/rdkit/ML/GrowComposite.py
+++ b/rdkit/ML/GrowComposite.py
@@ -92,6 +92,10 @@
   - -V: print the version number and exit
 
 """
+from warnings import warn
+
+warn('This module is deprecated and will be removed in the 2024.03 release', DeprecationWarning,
+     stacklevel=2)
 
 import pickle
 import sys

--- a/rdkit/ML/KNN/__init__.py
+++ b/rdkit/ML/KNN/__init__.py
@@ -4,3 +4,7 @@
 Here is the implementation for K-nearest neighbors
 
 """
+from warnings import warn
+
+warn('This module is deprecated and will be removed in the 2024.03 release', DeprecationWarning,
+     stacklevel=2)

--- a/rdkit/ML/ModelPackage/__init__.py
+++ b/rdkit/ML/ModelPackage/__init__.py
@@ -1,0 +1,4 @@
+from warnings import warn
+
+warn('This module is deprecated and will be removed in the 2024.03 release', DeprecationWarning,
+     stacklevel=2)

--- a/rdkit/ML/NaiveBayes/__init__.py
+++ b/rdkit/ML/NaiveBayes/__init__.py
@@ -4,4 +4,9 @@
 An implementation of the Naive Bayes Classifier
 
 """
+from warnings import warn
+
+warn('This module is deprecated and will be removed in the 2024.03 release', DeprecationWarning,
+     stacklevel=2)
+
 from rdkit import rdBase

--- a/rdkit/ML/Neural/__init__.py
+++ b/rdkit/ML/Neural/__init__.py
@@ -1,0 +1,4 @@
+from warnings import warn
+
+warn('This module is deprecated and will be removed in the 2024.03 release', DeprecationWarning,
+     stacklevel=2)

--- a/rdkit/ML/ScreenComposite.py
+++ b/rdkit/ML/ScreenComposite.py
@@ -108,6 +108,10 @@ a file containing a pickled composite model and _filename_ is a QDAT file.
 
 
 """
+from warnings import warn
+
+warn('This module is deprecated and will be removed in the 2024.03 release', DeprecationWarning,
+     stacklevel=2)
 
 import os
 import pickle


### PR DESCRIPTION
I don't think there's any reason for people to be using this code. scikit-learn has been better than anything here for a very long time.

Unless someone has an objection, the plan would be to add the deprecation now, for the 2023.09.3 release, and remove the code in the 2024.03 release