### PR TITLE
[WIP] ring info on demand

### DIFF
--- a/Code/GraphMol/FindRings.cpp
+++ b/Code/GraphMol/FindRings.cpp
@@ -1164,7 +1164,7 @@ int symmetrizeSSSR(const ROMol &mol, RingInfo &ri, VECT_INT_VECT &res, bool incl
 
   // FIX: need to set flag here the symmetrization has been done in order to
   // avoid repeating this work
-  findSSSR(mol, sssrs, includeDativeBonds);
+  findSSSR(mol, ri, sssrs, includeDativeBonds);
 
   res.reserve(sssrs.size());
   for (const auto &r : sssrs) {

--- a/Code/GraphMol/MolOps.h
+++ b/Code/GraphMol/MolOps.h
@@ -747,6 +747,14 @@ RDKIT_GRAPHMOL_EXPORT int findSSSR(const ROMol &mol,
                                    std::vector<std::vector<int>> *res = nullptr,
                                    bool includeDativeBonds = false);
 
+RDKIT_GRAPHMOL_EXPORT int findSSSR(const ROMol &mol, RingInfo &ri,
+                                   std::vector<std::vector<int>> &res,
+                                   bool includeDativeBonds = false);
+//! \overload
+RDKIT_GRAPHMOL_EXPORT int findSSSR(const ROMol &mol, RingInfo &ri,
+                                   std::vector<std::vector<int>> *res = nullptr,
+                                   bool includeDativeBonds = false);
+  
 //! use a DFS algorithm to identify ring bonds and atoms in a molecule
 /*!
   \b NOTE: though the RingInfo structure is populated by this function,
@@ -755,6 +763,7 @@ RDKIT_GRAPHMOL_EXPORT int findSSSR(const ROMol &mol,
   return values >0
 */
 RDKIT_GRAPHMOL_EXPORT void fastFindRings(const ROMol &mol);
+RDKIT_GRAPHMOL_EXPORT void fastFindRings(const ROMol &mol, RingInfo &ri);  
 
 RDKIT_GRAPHMOL_EXPORT void findRingFamilies(const ROMol &mol);
 
@@ -790,6 +799,14 @@ RDKIT_GRAPHMOL_EXPORT int symmetrizeSSSR(ROMol &mol,
 //! \overload
 RDKIT_GRAPHMOL_EXPORT int symmetrizeSSSR(ROMol &mol,
                                          bool includeDativeBonds = false);
+
+RDKIT_GRAPHMOL_EXPORT int symmetrizeSSSR(const ROMol &mol, RingInfo &ri,
+                                         std::vector<std::vector<int>> &res,
+                                         bool includeDativeBonds = false);
+//! \overload
+RDKIT_GRAPHMOL_EXPORT int symmetrizeSSSR(const ROMol &mol, RingInfo &ri,
+                                         bool includeDativeBonds = false);
+  
 
 //! @}
 

--- a/Code/GraphMol/ROMol.cpp
+++ b/Code/GraphMol/ROMol.cpp
@@ -698,15 +698,21 @@ unsigned int ROMol::addConformer(Conformer *conf, bool assignId) {
 }
 
 RingInfo *ROMol::getRingInfo() const {
-    if (!dp_ringInfo) {
-        // To be threadsafe there should be a lock here...
-        RingInfo *ri = new RingInfo();
-        // IF DEFAULT==findSSSR MolOps::findSSSR(*this, ri);
-        // IF DEFAULT==symm
-        MolOps::symmetrizeSSSR(*this, *ri);
-        dp_ringInfo = ri;
-    }
-    return dp_ringInfo;
+#ifdef RDK_BUILD_THREADSAFE_SSS
+  d_mutex.lock();
+#endif
+  if (!dp_ringInfo) {
+    // To be threadsafe there should be a lock here...
+    RingInfo *ri = new RingInfo();
+    // IF DEFAULT==findSSSR MolOps::findSSSR(*this, ri);
+    // IF DEFAULT==symm
+    MolOps::symmetrizeSSSR(*this, *ri);
+    dp_ringInfo = ri;
+  }
+#ifdef RDK_BUILD_THREADSAFE_SSS
+  d_mutex.unlock();
+#endif
+  return dp_ringInfo;
 }
   
 #ifdef RDK_USE_BOOST_SERIALIZATION

--- a/Code/GraphMol/ROMol.cpp
+++ b/Code/GraphMol/ROMol.cpp
@@ -715,7 +715,7 @@ RingInfo *ROMol::getRingInfo() const {
   return dp_ringInfo;
 }
 
-void ROMol::setRingInfo(std::unique_ptr<RingInfo> ri) {
+void ROMol::setRingInfo(std::unique_ptr<RingInfo> &ri) {
 #ifdef RDK_BUILD_THREADSAFE_SSS
   d_mutex.lock();
 #endif

--- a/Code/GraphMol/ROMol.cpp
+++ b/Code/GraphMol/ROMol.cpp
@@ -714,7 +714,20 @@ RingInfo *ROMol::getRingInfo() const {
 #endif
   return dp_ringInfo;
 }
-  
+
+void ROMol::setRingInfo(std::unique_ptr<RingInfo> ri) {
+#ifdef RDK_BUILD_THREADSAFE_SSS
+  d_mutex.lock();
+#endif
+  if (dp_ringInfo) {
+    delete dp_ringInfo;
+  }
+  dp_ringInfo = ri.release();
+#ifdef RDK_BUILD_THREADSAFE_SSS
+  d_mutex.unlock();
+#endif    
+}
+ 
 #ifdef RDK_USE_BOOST_SERIALIZATION
 template <class Archive>
 void ROMol::save(Archive &ar, const unsigned int) const {

--- a/Code/GraphMol/ROMol.cpp
+++ b/Code/GraphMol/ROMol.cpp
@@ -21,6 +21,7 @@
 #include "MolPickler.h"
 #include "Conformer.h"
 #include "SubstanceGroup.h"
+#include "MolOps.h"
 
 #ifdef RDK_USE_BOOST_SERIALIZATION
 #include <RDGeneral/BoostStartInclude.h>
@@ -696,6 +697,18 @@ unsigned int ROMol::addConformer(Conformer *conf, bool assignId) {
   return conf->getId();
 }
 
+RingInfo *ROMol::getRingInfo() const {
+    if (!dp_ringInfo) {
+        // To be threadsafe there should be a lock here...
+        RingInfo *ri = new RingInfo();
+        // IF DEFAULT==findSSSR MolOps::findSSSR(*this, ri);
+        // IF DEFAULT==symm
+        MolOps::symmetrizeSSSR(*this, *ri);
+        dp_ringInfo = ri;
+    }
+    return dp_ringInfo;
+}
+  
 #ifdef RDK_USE_BOOST_SERIALIZATION
 template <class Archive>
 void ROMol::save(Archive &ar, const unsigned int) const {

--- a/Code/GraphMol/ROMol.h
+++ b/Code/GraphMol/ROMol.h
@@ -35,6 +35,10 @@
 #endif
 #include <RDGeneral/BoostEndInclude.h>
 
+#ifdef RDK_BUILD_THREADSAFE_SSS
+#include <mutex>
+#endif
+
 // our stuff
 #include <RDGeneral/types.h>
 #include <RDGeneral/RDProps.h>
@@ -574,7 +578,7 @@ class RDKIT_GRAPHMOL_EXPORT ROMol : public RDProps {
 
   //! returns a pointer to our RingInfo structure
   //! <b>Note:</b> the client should not delete this.
-  RingInfo *getRingInfo() const;// { return dp_ringInfo; }
+  RingInfo *getRingInfo() const;
 
   //! provides access to all neighbors around an Atom
   /*!
@@ -815,6 +819,9 @@ class RDKIT_GRAPHMOL_EXPORT ROMol : public RDProps {
   MolGraph d_graph;
   ATOM_BOOKMARK_MAP d_atomBookmarks;
   BOND_BOOKMARK_MAP d_bondBookmarks;
+#ifdef RDK_BUILD_THREADSAFE_SSS
+  mutable std::mutex d_mutex;
+#endif
   mutable RingInfo *dp_ringInfo = nullptr;
   CONF_SPTR_LIST d_confs;
   std::vector<SubstanceGroup> d_sgroups;

--- a/Code/GraphMol/ROMol.h
+++ b/Code/GraphMol/ROMol.h
@@ -574,7 +574,7 @@ class RDKIT_GRAPHMOL_EXPORT ROMol : public RDProps {
 
   //! returns a pointer to our RingInfo structure
   //! <b>Note:</b> the client should not delete this.
-  RingInfo *getRingInfo() const { return dp_ringInfo; }
+  RingInfo *getRingInfo() const;// { return dp_ringInfo; }
 
   //! provides access to all neighbors around an Atom
   /*!
@@ -815,7 +815,7 @@ class RDKIT_GRAPHMOL_EXPORT ROMol : public RDProps {
   MolGraph d_graph;
   ATOM_BOOKMARK_MAP d_atomBookmarks;
   BOND_BOOKMARK_MAP d_bondBookmarks;
-  RingInfo *dp_ringInfo = nullptr;
+  mutable RingInfo *dp_ringInfo = nullptr;
   CONF_SPTR_LIST d_confs;
   std::vector<SubstanceGroup> d_sgroups;
   std::vector<StereoGroup> d_stereo_groups;

--- a/Code/GraphMol/ROMol.h
+++ b/Code/GraphMol/ROMol.h
@@ -580,6 +580,9 @@ class RDKIT_GRAPHMOL_EXPORT ROMol : public RDProps {
   //! <b>Note:</b> the client should not delete this.
   RingInfo *getRingInfo() const;
 
+  //! Set non-default ring information for this molecue
+  void setRingInfo(std::unique_ptr<RingInfo> ri);
+  
   //! provides access to all neighbors around an Atom
   /*!
     \param at the atom whose neighbors we are looking for

--- a/Code/GraphMol/ROMol.h
+++ b/Code/GraphMol/ROMol.h
@@ -581,7 +581,7 @@ class RDKIT_GRAPHMOL_EXPORT ROMol : public RDProps {
   RingInfo *getRingInfo() const;
 
   //! Set non-default ring information for this molecue
-  void setRingInfo(std::unique_ptr<RingInfo> ri);
+  void setRingInfo(std::unique_ptr<RingInfo> &ri);
   
   //! provides access to all neighbors around an Atom
   /*!

--- a/Code/GraphMol/Wrap/MolOps.cpp
+++ b/Code/GraphMol/Wrap/MolOps.cpp
@@ -1179,7 +1179,7 @@ struct molops_wrapper {
 \n\
   RETURNS: Nothing\n\
 \n";
-    python::def("FastFindRings", MolOps::fastFindRings, docString.c_str());
+    python::def("FastFindRings",  (void (*)(const ROMol &))MolOps::fastFindRings, docString.c_str());
 #ifdef RDK_USE_URF
     python::def("FindRingFamilies", MolOps::findRingFamilies,
                 "generate Unique Ring Families");

--- a/Code/GraphMol/catch_graphmol.cpp
+++ b/Code/GraphMol/catch_graphmol.cpp
@@ -2546,7 +2546,7 @@ void check_dest(RWMol *m1, const ROMol &m2) {
   CHECK(m1->getDict().getData().empty());
   CHECK(m1->getStereoGroups().empty());
   CHECK(getSubstanceGroups(*m1).empty());
-  CHECK(m1->getRingInfo() == nullptr);
+  //CHECK(m1->getRingInfo() == nullptr);
 
   // make sure we can still do something with m1:
   *m1 = m2;

--- a/Code/JavaWrappers/ROMol.i
+++ b/Code/JavaWrappers/ROMol.i
@@ -260,8 +260,8 @@ void setAllowNontetrahedralChirality(bool);
     return self->addConformer(ownedConf, assignId);
   }
 
-  void RDKit::ROMol::setRingInformation(RingInfo *ring) {
-    std::unique_ptr<RingInfo> ri(ring);
+  void RDKit::ROMol::setRingInformation(RDKit::RingInfo *ring) {
+    std::unique_ptr<RDKit::RingInfo> ri(ring);
     self->setRingInfo(ri);
   }
   

--- a/Code/JavaWrappers/ROMol.i
+++ b/Code/JavaWrappers/ROMol.i
@@ -66,7 +66,7 @@
 #include <GraphMol/MolBundle.h>
 #include <GraphMol/Chirality.h>
 #include <sstream>
-#include <unique_ptr>
+#include <memory>
 %}
 
 %template(ROMol_Vect) std::vector< boost::shared_ptr<RDKit::ROMol> >;

--- a/Code/JavaWrappers/ROMol.i
+++ b/Code/JavaWrappers/ROMol.i
@@ -123,7 +123,7 @@
 %ignore addConformer(Conformer * conf, bool assignId=false);
 %rename(addConformer) RDKit::ROMol::addConf;
 
-%ignore setRingInfo(std::unique_ptr<RingInfo>);
+%ignore setRingInfo(std::unique_ptr<RingInfo>&);
 %rename(setRingInfo) RDKit::ROMol::setRingInformation;
 
 %typemap(javain) RDKit::Conformer * ownedConf "getCPtrAndReleaseControl($javainput)"

--- a/Code/JavaWrappers/ROMol.i
+++ b/Code/JavaWrappers/ROMol.i
@@ -66,6 +66,7 @@
 #include <GraphMol/MolBundle.h>
 #include <GraphMol/Chirality.h>
 #include <sstream>
+#include <unique_ptr>
 %}
 
 %template(ROMol_Vect) std::vector< boost::shared_ptr<RDKit::ROMol> >;
@@ -121,6 +122,10 @@
  */
 %ignore addConformer(Conformer * conf, bool assignId=false);
 %rename(addConformer) RDKit::ROMol::addConf;
+
+%ignore setRingInfo();
+%rename(setRingInfo) RDKit::ROMol::setRingInformation;
+
 %typemap(javain) RDKit::Conformer * ownedConf "getCPtrAndReleaseControl($javainput)"
 %typemap(javacode) RDKit::ROMol %{
   // Ensure that the GC doesn't collect this item,
@@ -255,6 +260,11 @@ void setAllowNontetrahedralChirality(bool);
     return self->addConformer(ownedConf, assignId);
   }
 
+  void RDKit::ROMol::setRingInformation(RingInfo *ring) {
+    std::unique_ptr<RingInfo> ri(ring);
+    self->setRingInfo(ri);
+  }
+  
   std::string MolToSmiles(bool doIsomericSmiles=true, bool doKekule=false, int rootedAtAtom=-1, bool canonical=true,
                           bool allBondsExplicit=false, bool allHsExplicit=false, bool doRandom=false) {
     return RDKit::MolToSmiles(*($self), doIsomericSmiles, doKekule, rootedAtAtom, canonical, allBondsExplicit, allHsExplicit, doRandom);

--- a/Code/JavaWrappers/ROMol.i
+++ b/Code/JavaWrappers/ROMol.i
@@ -123,7 +123,7 @@
 %ignore addConformer(Conformer * conf, bool assignId=false);
 %rename(addConformer) RDKit::ROMol::addConf;
 
-%ignore setRingInfo();
+%ignore setRingInfo(std::unique_ptr<RingInfo>);
 %rename(setRingInfo) RDKit::ROMol::setRingInformation;
 
 %typemap(javain) RDKit::Conformer * ownedConf "getCPtrAndReleaseControl($javainput)"


### PR DESCRIPTION
The RDKit's ring information system has grown over many years.

Rationale
=======
One of its current deficiencies is that one can make rings on a const molecule which can cause headaches when multi-threading.

This PR puts the default logic into ROMol::getRingInfo


when called, this creates, in a thread-safe manner, the default ring information.  One of the larger benefits is that the ring generation code can now be used independently of a molecule.   

Examples
========
For example, if you want to just fast find a ring for some purpose but not save it to the molecule:

```
RingInfo info;
MolOps::fastFindRings(mol, info);
```

Also, ROMol has grown a thread safe setRingInfo in case you want to perform a non default ring finding

```
std::unique_ptr<RingInfo> info;
MolOps::fastFindRings(mol, *info);
mol.setRingInfo(info);

mol.setRingInfo(nullptr); // delete the existing ring info
```


With these changes, getRingInfo can be changed to:

```
const RingInfo & getRingInfo() const;
```

n.b. this isn't done yet.

Missing:
======

1. Check to see if the rings have been initialized.
2. Performance checks to see the impact of the mutex

