### PR TITLE
Used const reference to prevent copying in PositionVariationOp::getVariationCounts() (#6906)

### DIFF
--- a/Code/GraphMol/MolEnumerator/PositionVariation.cpp
+++ b/Code/GraphMol/MolEnumerator/PositionVariation.cpp
@@ -77,9 +77,7 @@ std::vector<size_t> PositionVariationOp::getVariationCounts() const {
   std::vector<size_t> res(d_variationPoints.size());
   std::transform(
       d_variationPoints.begin(), d_variationPoints.end(), res.begin(),
-      [](std::pair<unsigned int, std::vector<unsigned int>> pr) -> size_t {
-        return pr.second.size();
-      });
+      [](const auto&  pr) -> size_t { return pr.second.size(); });
   return res;
 }
 


### PR DESCRIPTION


<!--
Thanks for contributing a pull request! 
-->
#### Reference Issue 
#6906 


#### What does this implement/fix? Explain your changes.
updated procedure to prevent unnecessary  copying 


