### PR TITLE
fix duplicate SPS descriptor in Descriptors.descList #6928

### DIFF
--- a/rdkit/Chem/Descriptors.py
+++ b/rdkit/Chem/Descriptors.py
@@ -67,8 +67,6 @@ def _setupDescriptors(namespace):
           namespace[name] = thing
           _descList.append((name, thing))
 
-  # add a few by hand
-  _descList.append(('SPS', SpacialScore.SPS))
   descList = _descList
 
 


### PR DESCRIPTION
Fixes #6928 

This fixes the duplicate `SPS` descriptor in `descList`. I thought this might require a conditional check for `SPS`, but I think it was as simple as not manually adding the `SPS`. So, a very minor change. :)

Vin

