### PR TITLE
Segfault in JSONToMols when "commonchem" is an int #6890

### DIFF
--- a/Code/GraphMol/MolInterchange/Parser.cpp
+++ b/Code/GraphMol/MolInterchange/Parser.cpp
@@ -921,15 +921,18 @@ std::vector<boost::shared_ptr<ROMol>> DocToMols(
   if (!doc.IsObject()) {
     throw FileParseException("Bad Format: JSON should be an object");
   }
+
   if (doc.HasMember("commonchem")) {
-    if (!doc["commonchem"].HasMember("version")) {
+    if (!doc["commonchem"].IsObject() ||
+        !doc["commonchem"].HasMember("version")) {
       throw FileParseException("Bad Format: missing version in JSON");
     }
     if (doc["commonchem"]["version"].GetInt() != currentMolJSONVersion) {
       throw FileParseException("Bad Format: bad version in JSON");
     }
   } else if (doc.HasMember("rdkitjson")) {
-    if (!doc["rdkitjson"].HasMember("version")) {
+    if (!doc["rdkitjson"].IsObject() ||
+        !doc["rdkitjson"].HasMember("version")) {
       throw FileParseException("Bad Format: missing version in JSON");
     }
     // FIX: we want to be backwards compatible

--- a/Code/GraphMol/MolInterchange/molinterchange_catch.cpp
+++ b/Code/GraphMol/MolInterchange/molinterchange_catch.cpp
@@ -17,6 +17,7 @@
 #include <GraphMol/SmilesParse/SmilesParse.h>
 #include <GraphMol/SmilesParse/SmartsWrite.h>
 #include "MolInterchange.h"
+#include <RDGeneral/FileParseException.h>
 
 using namespace RDKit;
 
@@ -43,7 +44,7 @@ TEST_CASE("queries to JSON", "[query]") {
   }
   SECTION("mol blocks") {
     auto mol = R"CTAB(
-  Mrv2102 04092105442D          
+  Mrv2102 04092105442D
 
   0  0  0     0  0            999 V3000
 M  V30 BEGIN CTAB
@@ -190,7 +191,7 @@ TEST_CASE("StereoGroups") {
 
 TEST_CASE("SubstanceGroups") {
   auto polymol = R"CTAB(
-  Mrv2219 12292206542D          
+  Mrv2219 12292206542D
 
   0  0  0     0  0            999 V3000
 M  V30 BEGIN CTAB
@@ -330,5 +331,49 @@ TEST_CASE("do not crash with null molecules") {
     auto tmol = "CCC"_smiles;
     std::vector<ROMol *> mols{tmol.get(), nullptr};
     CHECK_THROWS_AS(MolInterchange::MolsToJSONData(mols), ValueErrorException);
+  }
+}
+
+TEST_CASE("Test segv reported in #6890") {
+  {
+    std::string mol_json_with_bad_format{R"({
+  "commonchem": 10,
+  "molecules": [
+    {
+      "name": "ethane",
+      "atoms": [
+        {"z": 6, "impHs": 3},
+        {"z": 6, "impHs": 3}
+      ],
+      "bonds": [
+        {"type": 1, "atoms": [0, 1]}
+      ]
+    }
+  ]
+})"};
+
+    CHECK_THROWS_AS(MolInterchange::JSONDataToMols(mol_json_with_bad_format),
+                    FileParseException);
+  }
+
+  {
+    std::string mol_json_with_bad_format{R"({
+  "rdkitjson": 10,
+  "molecules": [
+    {
+      "name": "ethane",
+      "atoms": [
+        {"z": 6, "impHs": 3},
+        {"z": 6, "impHs": 3}
+      ],
+      "bonds": [
+        {"type": 1, "atoms": [0, 1]}
+      ]
+    }
+  ]
+})"};
+
+    CHECK_THROWS_AS(MolInterchange::JSONDataToMols(mol_json_with_bad_format),
+                    FileParseException);
   }
 }


### PR DESCRIPTION


<!--
Thanks for contributing a pull request! 
-->
#### Reference Issue
this fixes #6890 


#### What does this implement/fix? Explain your changes.
the DocToMols procedure assumes that the "commonchem" and "rdkitjson" fields are nested json docs, but that is not true. This change updates the procedure to stop relying on that wrong assumption and adds a test for validation.


#### Any other comments?

