### PR TITLE
Some Clang-specific build instructions skip some clang compilers on mac

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -529,7 +529,7 @@ else(RDK_TEST_COVERAGE)
     SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
   endif()
  endif()
- if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang") # there's at least Clang and AppleClang
    # We don't on C_FLAGS warnings to keep Avalon compiling quiet
    SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-array-bounds -fPIC -Wno-parentheses -Wno-logical-op-parentheses -Wno-format")
    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wno-deprecated -Wno-unused-function -fno-strict-aliasing -Wno-format -Wno-logical-op-parentheses -fPIC")

--- a/Code/cmake/Modules/CodeCoverage.cmake
+++ b/Code/cmake/Modules/CodeCoverage.cmake
@@ -19,10 +19,10 @@
 # 2. Add the following line to your CMakeLists.txt:
 #      INCLUDE(CodeCoverage)
 #
-# 3. Set compiler flags to turn off optimization and enable coverage: 
+# 3. Set compiler flags to turn off optimization and enable coverage:
 #    SET(CMAKE_CXX_FLAGS "-g -O0 -fprofile-arcs -ftest-coverage")
 #	 SET(CMAKE_C_FLAGS "-g -O0 -fprofile-arcs -ftest-coverage")
-#  
+#
 # 3. Use the function SETUP_TARGET_FOR_COVERAGE to create a custom make target
 #    which runs your test executable and produces a lcov code coverage report:
 #    Example:
@@ -54,8 +54,8 @@ ENDIF() # NOT GCOV_PATH
 IF(NOT CMAKE_COMPILER_IS_GNUCXX)
 	# Clang version 3.0.0 and greater now supports gcov as well.
 	MESSAGE(WARNING "Compiler is not GNU gcc! Clang Version 3.0.0 and greater supports gcov as well, but older versions don't.")
-	
-	IF(NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+
+    IF(NOT "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang") # there's at least Clang and AppleClang
 		MESSAGE(FATAL_ERROR "Compiler is not GNU gcc! Aborting...")
 	ENDIF()
 ENDIF() # NOT CMAKE_COMPILER_IS_GNUCXX
@@ -89,7 +89,7 @@ ENDIF() # NOT CMAKE_BUILD_TYPE STREQUAL "Debug"
 
 # Param _targetname     The name of new the custom make target
 # Param _testrunner     The name of the target which runs the tests.
-#						MUST return ZERO always, even on errors. 
+#						MUST return ZERO always, even on errors.
 #						If not, no coverage report will be created!
 # Param _outputname     lcov output is generated as _outputname.info
 #                       HTML report is generated in _outputname/index.html
@@ -109,10 +109,10 @@ FUNCTION(SETUP_TARGET_FOR_COVERAGE _targetname _testrunner _outputname)
 
 	# Setup target
 	ADD_CUSTOM_TARGET(${_targetname}
-		
+
 		# Cleanup lcov
 		${LCOV_PATH} --directory . --zerocounters
-		
+
 		# Run tests
 		COMMAND ${_testrunner} ${ARGV3}
 		# Capturing lcov counters and generating report
@@ -122,7 +122,7 @@ FUNCTION(SETUP_TARGET_FOR_COVERAGE _targetname _testrunner _outputname)
 
 		COMMAND ${GENHTML_PATH} -o ${_outputname} ${_outputname}.info.cleaned
 		COMMAND ${CMAKE_COMMAND} -E remove ${_outputname}.info ${_outputname}.info.cleaned
-		
+
 		WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
 		COMMENT "Resetting code coverage counters to zero.\nProcessing code coverage counters and generating report."
 	)


### PR DESCRIPTION

#### Reference Issue
Fixes #6941


#### What does this implement/fix? Explain your changes.
Updated compiler id comparisons to do a regex comparison against "Clang" instead of doing a direct string comparison. This allows us to match compiler ids like "AppleClang"
