### PR TITLE
Fixes #6946

### DIFF
--- a/External/CoordGen/CMakeLists.txt
+++ b/External/CoordGen/CMakeLists.txt
@@ -84,11 +84,15 @@ if(RDK_BUILD_COORDGEN_SUPPORT)
     set(coordgen_INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}
         CACHE STRING "CoordGen Include File" FORCE)
     file(GLOB CGSOURCES "${COORDGEN_DIR}/*.cpp")
-    rdkit_library(coordgen ${CGSOURCES} SHARED LINK_LIBRARIES MolAlign maeparser )
+    rdkit_library(coordgen ${CGSOURCES} SHARED)
     install(TARGETS coordgen DESTINATION ${RDKit_LibDir})
     set(RDK_COORDGEN_LIBS coordgen CACHE STRING "the external libraries" FORCE)
 
-  endif(COORDGEN_FORCE_BUILD OR (NOT coordgen_FOUND))
+  elseif(coordgen_FOUND)
+
+    set(RDK_COORDGEN_LIBS "${coordgen_LIBRARIES}" CACHE STRING "the external libraries" FORCE)
+
+  endif(COORDGEN_FORCE_BUILD OR(NOT coordgen_FOUND))
 
   include_directories(${coordgen_INCLUDE_DIRS})
 
@@ -100,7 +104,7 @@ if(RDK_BUILD_COORDGEN_SUPPORT)
 
   rdkit_test(testCoordGen test.cpp
     LINK_LIBRARIES
-    coordgen Depictor ChemTransforms
+    "${RDK_COORDGEN_LIBS}" Depictor ChemTransforms
     FileParsers SmilesParse SubstructMatch GraphMol
     RDGeneral DataStructs RDGeneral RDGeometryLib
     ${RDKit_THREAD_LIBS})


### PR DESCRIPTION
This should fix #6946.

Also, I don't think we need `MolAlign` to build coordgen, and `maeparser` is no longer a required dependency of Coordgen. Maybe we should split it into a separate directory?