### PR TITLE
fix #6958

### DIFF
--- a/Code/GraphMol/Fingerprints/AtomPairs.cpp
+++ b/Code/GraphMol/Fingerprints/AtomPairs.cpp
@@ -45,6 +45,37 @@ void setAtomPairBit(std::uint32_t i, std::uint32_t j, std::uint32_t nAtoms,
   }
 }
 
+namespace {
+std::unique_ptr<SparseIntVect<std::uint32_t>> getAtomPairFingerprintInternal(
+    const ROMol &mol, unsigned int nBits, unsigned int minLength,
+    unsigned int maxLength, const std::vector<std::uint32_t> *fromAtoms,
+    const std::vector<std::uint32_t> *ignoreAtoms,
+    const std::vector<std::uint32_t> *atomInvariants, bool includeChirality,
+    bool use2D, int confId, bool sparse) {
+  PRECONDITION(minLength <= maxLength, "bad lengths provided");
+  PRECONDITION(!atomInvariants || atomInvariants->size() >= mol.getNumAtoms(),
+               "bad atomInvariants size");
+  const ROMol *lmol = &mol;
+  std::unique_ptr<ROMol> tmol;
+  if (includeChirality && !mol.hasProp(common_properties::_StereochemDone)) {
+    tmol = std::unique_ptr<ROMol>(new ROMol(mol));
+    MolOps::assignStereochemistry(*tmol);
+    lmol = tmol.get();
+  }
+  FingerprintFuncArguments args;
+  args.fromAtoms = fromAtoms;
+  args.ignoreAtoms = ignoreAtoms;
+  args.customAtomInvariants = atomInvariants;
+  args.confId = confId;
+  std::unique_ptr<FingerprintGenerator<std::uint32_t>> fpgen{
+      RDKit::AtomPair::getAtomPairGenerator<std::uint32_t>(
+          minLength, maxLength, includeChirality, use2D, nullptr, true, nBits)};
+  return std::unique_ptr<SparseIntVect<std::uint32_t>>(
+      sparse ? fpgen->getSparseCountFingerprint(*lmol, args)
+             : fpgen->getCountFingerprint(*lmol, args));
+}
+}  // end of anonymous namespace
+
 SparseIntVect<std::int32_t> *getAtomPairFingerprint(
     const ROMol &mol, const std::vector<std::uint32_t> *fromAtoms,
     const std::vector<std::uint32_t> *ignoreAtoms,
@@ -61,71 +92,11 @@ SparseIntVect<std::int32_t> *getAtomPairFingerprint(
     const std::vector<std::uint32_t> *ignoreAtoms,
     const std::vector<std::uint32_t> *atomInvariants, bool includeChirality,
     bool use2D, int confId) {
-  PRECONDITION(minLength <= maxLength, "bad lengths provided");
-  PRECONDITION(!atomInvariants || atomInvariants->size() >= mol.getNumAtoms(),
-               "bad atomInvariants size");
-
-  const ROMol *lmol = &mol;
-  std::unique_ptr<ROMol> tmol;
-  if (includeChirality && !mol.hasProp(common_properties::_StereochemDone)) {
-    tmol = std::unique_ptr<ROMol>(new ROMol(mol));
-    MolOps::assignStereochemistry(*tmol);
-    lmol = tmol.get();
-  }
-
-  auto *res = new SparseIntVect<std::int32_t>(
-      1 << (numAtomPairFingerprintBits + 2 * (includeChirality ? 2 : 0)));
-  const double *dm;
-  if (use2D) {
-    dm = MolOps::getDistanceMat(*lmol);
-  } else {
-    dm = MolOps::get3DDistanceMat(*lmol, confId);
-  }
-  const unsigned int nAtoms = lmol->getNumAtoms();
-
-  std::vector<std::uint32_t> atomCodes;
-  for (ROMol::ConstAtomIterator atomItI = lmol->beginAtoms();
-       atomItI != lmol->endAtoms(); ++atomItI) {
-    if (!atomInvariants) {
-      atomCodes.push_back(getAtomCode(*atomItI, 0, includeChirality));
-    } else {
-      atomCodes.push_back((*atomInvariants)[(*atomItI)->getIdx()] %
-                          ((1 << codeSize) - 1));
-    }
-  }
-
-  for (ROMol::ConstAtomIterator atomItI = lmol->beginAtoms();
-       atomItI != lmol->endAtoms(); ++atomItI) {
-    unsigned int i = (*atomItI)->getIdx();
-    if (ignoreAtoms && std::find(ignoreAtoms->begin(), ignoreAtoms->end(), i) !=
-                           ignoreAtoms->end()) {
-      continue;
-    }
-    if (!fromAtoms) {
-      for (ROMol::ConstAtomIterator atomItJ = atomItI + 1;
-           atomItJ != lmol->endAtoms(); ++atomItJ) {
-        unsigned int j = (*atomItJ)->getIdx();
-        if (ignoreAtoms && std::find(ignoreAtoms->begin(), ignoreAtoms->end(),
-                                     j) != ignoreAtoms->end()) {
-          continue;
-        }
-        setAtomPairBit(i, j, nAtoms, atomCodes, dm, res, minLength, maxLength,
-                       includeChirality);
-      }
-    } else {
-      for (auto j : *fromAtoms) {
-        if (j != i) {
-          if (ignoreAtoms && std::find(ignoreAtoms->begin(), ignoreAtoms->end(),
-                                       j) != ignoreAtoms->end()) {
-            continue;
-          }
-          setAtomPairBit(i, j, nAtoms, atomCodes, dm, res, minLength, maxLength,
-                         includeChirality);
-        }
-      }
-    }
-  }
-  return res;
+  return reinterpret_cast<SparseIntVect<std::int32_t> *>(
+      getAtomPairFingerprintInternal(mol, 0, minLength, maxLength, fromAtoms,
+                                     ignoreAtoms, atomInvariants,
+                                     includeChirality, use2D, confId, true)
+          .release());
 }
 
 SparseIntVect<std::int32_t> *getHashedAtomPairFingerprint(
@@ -134,26 +105,9 @@ SparseIntVect<std::int32_t> *getHashedAtomPairFingerprint(
     const std::vector<std::uint32_t> *ignoreAtoms,
     const std::vector<std::uint32_t> *atomInvariants, bool includeChirality,
     bool use2D, int confId) {
-  PRECONDITION(minLength <= maxLength, "bad lengths provided");
-  PRECONDITION(!atomInvariants || atomInvariants->size() >= mol.getNumAtoms(),
-               "bad atomInvariants size");
-  const ROMol *lmol = &mol;
-  std::unique_ptr<ROMol> tmol;
-  if (includeChirality && !mol.hasProp(common_properties::_StereochemDone)) {
-    tmol = std::unique_ptr<ROMol>(new ROMol(mol));
-    MolOps::assignStereochemistry(*tmol);
-    lmol = tmol.get();
-  }
-
-  std::unique_ptr<FingerprintGenerator<std::uint32_t>> fpgen{
-      RDKit::AtomPair::getAtomPairGenerator<std::uint32_t>(
-          minLength, maxLength, includeChirality, use2D, nullptr, true, nBits)};
-  FingerprintFuncArguments args;
-  args.fromAtoms = fromAtoms;
-  args.ignoreAtoms = ignoreAtoms;
-  args.customAtomInvariants = atomInvariants;
-  args.confId = confId;
-  auto siv = fpgen->getCountFingerprint(*lmol, args);
+  auto siv = getAtomPairFingerprintInternal(
+      mol, nBits, minLength, maxLength, fromAtoms, ignoreAtoms, atomInvariants,
+      includeChirality, use2D, confId, false);
   auto *res = new SparseIntVect<std::int32_t>(nBits);
   for (auto v : siv->getNonzeroElements()) {
     res->setVal(v.first, v.second);

--- a/Code/GraphMol/Fingerprints/testFingerprintGenerators.cpp
+++ b/Code/GraphMol/Fingerprints/testFingerprintGenerators.cpp
@@ -2449,8 +2449,8 @@ void testAtomPairFPDifference() {
   std::sort(fpFromGeneratorAsVectOfPairs.begin(),
             fpFromGeneratorAsVectOfPairs.end());
   if (fpFromFreeFuncAsVectOfPairs != fpFromGeneratorAsVectOfPairs) {
-    for (const auto &fpFromFreeFuncPair : fpFromFreeFuncAsVectOfPairs) {
-      auto i = &fpFromFreeFuncPair - &fpFromFreeFuncAsVectOfPairs.front();
+    for (auto i = 0u; i < fpFromFreeFuncAsVectOfPairs.size(); ++i) {
+      const auto &fpFromFreeFuncPair = fpFromFreeFuncAsVectOfPairs.at(i);
       const auto &fpFromGeneratorPair = fpFromGeneratorAsVectOfPairs.at(i);
       if (fpFromFreeFuncPair != fpFromGeneratorPair) {
         std::cerr << "fpFromFreeFuncPair (" << fpFromFreeFuncPair.first << ", "

--- a/Code/GraphMol/Fingerprints/testFingerprintGenerators.cpp
+++ b/Code/GraphMol/Fingerprints/testFingerprintGenerators.cpp
@@ -2423,6 +2423,46 @@ void testBulkFP() {
   BOOST_LOG(rdErrorLog) << "  done" << std::endl;
 }
 
+void testAtomPairFPDifference() {
+  BOOST_LOG(rdErrorLog) << "-------------------------------------" << std::endl;
+  BOOST_LOG(rdErrorLog) << "    Test GitHub Issue #6958" << std::endl;
+  auto zinc36905137 = "Nc1nncc(-c2ccc(OC(F)F)cc2)n1"_smiles;
+  const unsigned int minLength = 1;
+  const unsigned int maxLength = 30;
+  const std::vector<std::uint32_t> fromAtoms{12, 13};
+  std::unique_ptr<SparseIntVect<std::int32_t>> fpFromFreeFunc(
+      RDKit::AtomPairs::getAtomPairFingerprint(*zinc36905137, minLength,
+                                               maxLength, &fromAtoms));
+  std::unique_ptr<FingerprintGenerator<std::uint32_t>> atomPairGenerator(
+      AtomPair::getAtomPairGenerator<std::uint32_t>(minLength, maxLength));
+  std::unique_ptr<SparseIntVect<std::uint32_t>> fpFromGenerator(
+      atomPairGenerator->getSparseCountFingerprint(*zinc36905137, &fromAtoms));
+  TEST_ASSERT(fpFromFreeFunc->size() == fpFromGenerator->size());
+  const auto &fpFromFreeFuncNonZero = fpFromFreeFunc->getNonzeroElements();
+  std::vector<std::pair<std::uint32_t, int>> fpFromFreeFuncAsVectOfPairs(
+      fpFromFreeFuncNonZero.begin(), fpFromFreeFuncNonZero.end());
+  std::sort(fpFromFreeFuncAsVectOfPairs.begin(),
+            fpFromFreeFuncAsVectOfPairs.end());
+  const auto &fpFromGeneratorNonZero = fpFromGenerator->getNonzeroElements();
+  std::vector<std::pair<std::uint32_t, int>> fpFromGeneratorAsVectOfPairs(
+      fpFromGeneratorNonZero.begin(), fpFromGeneratorNonZero.end());
+  std::sort(fpFromGeneratorAsVectOfPairs.begin(),
+            fpFromGeneratorAsVectOfPairs.end());
+  if (fpFromFreeFuncAsVectOfPairs != fpFromGeneratorAsVectOfPairs) {
+    for (const auto &fpFromFreeFuncPair : fpFromFreeFuncAsVectOfPairs) {
+      auto i = &fpFromFreeFuncPair - &fpFromFreeFuncAsVectOfPairs.front();
+      const auto &fpFromGeneratorPair = fpFromGeneratorAsVectOfPairs.at(i);
+      if (fpFromFreeFuncPair != fpFromGeneratorPair) {
+        std::cerr << "fpFromFreeFuncPair (" << fpFromFreeFuncPair.first << ", "
+                  << fpFromFreeFuncPair.second << ")"
+                  << "\nfpFromGeneratorPair (" << fpFromGeneratorPair.first
+                  << ", " << fpFromGeneratorPair.second << ")" << std::endl;
+      }
+    }
+  }
+  TEST_ASSERT(fpFromFreeFuncAsVectOfPairs == fpFromGeneratorAsVectOfPairs);
+}
+
 int main(int argc, char *argv[]) {
   (void)argc;
   (void)argv;
@@ -2462,6 +2502,7 @@ int main(int argc, char *argv[]) {
   testGitHubIssue334();
   testGitHubIssue811();
   testBulkFP();
+  testAtomPairFPDifference();
 
   return 0;
 }

--- a/Code/GraphMol/Fingerprints/testFingerprintGenerators.cpp
+++ b/Code/GraphMol/Fingerprints/testFingerprintGenerators.cpp
@@ -2453,7 +2453,7 @@ void testAtomPairFPDifference() {
       const auto &fpFromFreeFuncPair = fpFromFreeFuncAsVectOfPairs.at(i);
       const auto &fpFromGeneratorPair = fpFromGeneratorAsVectOfPairs.at(i);
       if (fpFromFreeFuncPair != fpFromGeneratorPair) {
-        std::cerr << "fpFromFreeFuncPair (" << fpFromFreeFuncPair.first << ", "
+        BOOST_LOG(rdErrorLog) << "fpFromFreeFuncPair (" << fpFromFreeFuncPair.first << ", "
                   << fpFromFreeFuncPair.second << ")"
                   << "\nfpFromGeneratorPair (" << fpFromGeneratorPair.first
                   << ", " << fpFromGeneratorPair.second << ")" << std::endl;


### PR DESCRIPTION
This PR fixes #6958.
The old implementation was not checking that pairs involving atoms from the `fromAtoms` list had not already been computed before. The fix for the old implementation would have been the following:
```diff
diff --git a/Code/GraphMol/Fingerprints/AtomPairs.cpp b/Code/GraphMol/Fingerprints/AtomPairs.cpp
index 46eb924..879ca10 100644
--- a/Code/GraphMol/Fingerprints/AtomPairs.cpp
+++ b/Code/GraphMol/Fingerprints/AtomPairs.cpp
@@ -119,6 +120,9 @@ SparseIntVect<std::int32_t> *getAtomPairFingerprint(
                                        j) != ignoreAtoms->end()) {
             continue;
           }
+          if (i > j && std::find(fromAtoms->begin(), fromAtoms->end(), i) != fromAtoms->end()) {
+            continue;
+          }
           setAtomPairBit(i, j, nAtoms, atomCodes, dm, res, minLength, maxLength,
                          includeChirality);
         }

```
However, I think it makes more sense to rather use the new generator implementation, as was already happening for the hashed version, to avoid maintaining different implementations and avoid code duplication.