### PR TITLE
Drop unrequired zlib include which may break the windows build

### DIFF
--- a/Code/GraphMol/FileParsers/PNGParser.cpp
+++ b/Code/GraphMol/FileParsers/PNGParser.cpp
@@ -22,7 +22,6 @@
 
 #include "FileParsers.h"
 #ifdef RDK_USE_BOOST_IOSTREAMS
-#include <zlib.h>
 #include <boost/iostreams/filtering_streambuf.hpp>
 #include <boost/iostreams/copy.hpp>
 #include <boost/iostreams/filter/zlib.hpp>


### PR DESCRIPTION
This `zlib.h` include is not required. After the changes in https://github.com/rdkit/rdkit/pull/6814, zlib is only required on windows if building with static libraries, so if the header is not in one of the include directories we have already added (e.g. system or conda directories), and needs to be specified separately, it will break the build.