### PR TITLE
Fixes #6975

### DIFF
--- a/Code/GraphMol/Canon.cpp
+++ b/Code/GraphMol/Canon.cpp
@@ -10,6 +10,7 @@
 #include <GraphMol/RDKitBase.h>
 #include <GraphMol/Canon.h>
 #include <GraphMol/Chirality.h>
+#include <GraphMol/new_canon.h>
 
 #include <GraphMol/SmilesParse/SmilesParseOps.h>
 #include <GraphMol/RDKitQueries.h>
@@ -1265,9 +1266,6 @@ void canonicalizeFragment(ROMol &mol, int atomIdx,
     std::cerr<<"----------------------------------------->"<<std::endl;
 #endif
 }
-void rankMolAtoms(const ROMol &mol, std::vector<unsigned int> &res,
-                  bool breakTies = true, bool includeChirality = true,
-                  bool includeIsotopes = true);
 void canonicalizeEnhancedStereo(ROMol &mol,
                                 const std::vector<unsigned int> *atomRanks) {
   const auto &sgs = mol.getStereoGroups();

--- a/Code/GraphMol/FindStereo.cpp
+++ b/Code/GraphMol/FindStereo.cpp
@@ -1015,6 +1015,9 @@ std::vector<StereoInfo> runCleanup(ROMol &mol, bool flagPossible,
     const bool includeIsotopes = false;
     const bool breakTies = false;
     const bool includeAtomMaps = false;
+    // Now apply the canonical atom ranking code with basic connectivity
+    // invariants The necessary condition for chirality is that an atom's
+    // neighbors must have unique ranks
     Canon::rankFragmentAtoms(
         mol, aranks, atomsInPlay, bondsInPlay, &atomSymbols, &bondSymbols,
         breakTies, includeChirality, includeIsotopes, includeAtomMaps);

--- a/Code/GraphMol/FindStereo.cpp
+++ b/Code/GraphMol/FindStereo.cpp
@@ -1014,9 +1014,10 @@ std::vector<StereoInfo> runCleanup(ROMol &mol, bool flagPossible,
     const bool includeChirality = false;
     const bool includeIsotopes = false;
     const bool breakTies = false;
-    Canon::rankFragmentAtoms(mol, aranks, atomsInPlay, bondsInPlay,
-                             &atomSymbols, &bondSymbols, breakTies,
-                             includeChirality, includeIsotopes);
+    const bool includeAtomMaps = false;
+    Canon::rankFragmentAtoms(
+        mol, aranks, atomsInPlay, bondsInPlay, &atomSymbols, &bondSymbols,
+        breakTies, includeChirality, includeIsotopes, includeAtomMaps);
 #endif
     // check if any new atoms definitely now have stereo; do another loop if so
     needAnotherRound = updateAtoms(
@@ -1094,9 +1095,10 @@ std::vector<StereoInfo> runCleanup(ROMol &mol, bool flagPossible,
         const bool breakTies = false;
         const bool includeChirality = false;
         const bool includeIsotopes = false;
-        Canon::rankFragmentAtoms(mol, aranks, atomsInPlay, bondsInPlay,
-                                 &atomSymbols, &bondSymbols, breakTies,
-                                 includeChirality, includeIsotopes);
+        const bool includeAtomMaps = false;
+        Canon::rankFragmentAtoms(
+            mol, aranks, atomsInPlay, bondsInPlay, &atomSymbols, &bondSymbols,
+            breakTies, includeChirality, includeIsotopes, includeAtomMaps);
 #endif
         // fixedAtoms.reset();
         // fixedBonds.reset();

--- a/Code/GraphMol/Wrap/rdmolfiles.cpp
+++ b/Code/GraphMol/Wrap/rdmolfiles.cpp
@@ -397,18 +397,19 @@ std::string MolFragmentToSmilesHelper2(
 std::vector<unsigned int> CanonicalRankAtoms(const ROMol &mol,
                                              bool breakTies = true,
                                              bool includeChirality = true,
-                                             bool includeIsotopes = true) {
+                                             bool includeIsotopes = true,
+                                             bool includeAtomMaps = true) {
   std::vector<unsigned int> ranks(mol.getNumAtoms());
-  Canon::rankMolAtoms(mol, ranks, breakTies, includeChirality, includeIsotopes);
+  Canon::rankMolAtoms(mol, ranks, breakTies, includeChirality, includeIsotopes,
+                      includeAtomMaps);
   return ranks;
 }
 
 std::vector<int> CanonicalRankAtomsInFragment(
     const ROMol &mol, python::object atomsToUse, python::object bondsToUse,
     python::object atomSymbols, bool breakTies = true,
-    bool includeChirality = true, bool includeIsotopes = true)
-
-{
+    bool includeChirality = true, bool includeIsotopes = true,
+    bool includeAtomMaps = true) {
   std::unique_ptr<std::vector<int>> avect =
       pythonObjectToVect(atomsToUse, static_cast<int>(mol.getNumAtoms()));
   if (!avect.get() || !(avect->size())) {
@@ -1991,6 +1992,7 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
     - breakTies: (optional) force breaking of ranked ties [default=True]\n\
     - includeChirality: (optional) use chiral information when computing rank [default=True]\n\
     - includeIsotopes: (optional) use isotope information when computing rank [default=True]\n\
+    - includeAtomMaps: (optional) use atom map information when computing rank [default=True]\n\
 \n\
   RETURNS:\n\
 \n\
@@ -1999,7 +2001,8 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
   python::def("CanonicalRankAtoms", CanonicalRankAtoms,
               (python::arg("mol"), python::arg("breakTies") = true,
                python::arg("includeChirality") = true,
-               python::arg("includeIsotopes") = true),
+               python::arg("includeIsotopes") = true,
+               python::arg("includeAtomMaps") = true),
               docString.c_str());
 
   docString =
@@ -2024,6 +2027,7 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
     - breakTies: (optional) force breaking of ranked ties\n\
     - includeChirality: (optional) use chiral information when computing rank [default=True]\n\
     - includeIsotopes: (optional) use isotope information when computing rank [default=True]\n\
+    - includeAtomMaps: (optional) use atom map information when computing rank [default=True]\n\
 \n\
   RETURNS:\n\
 \n\
@@ -2034,7 +2038,8 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
       (python::arg("mol"), python::arg("atomsToUse"),
        python::arg("bondsToUse") = 0, python::arg("atomSymbols") = 0,
        python::arg("breakTies") = true, python::arg("includeChirality") = true,
-       python::arg("includeIsotopes") = true),
+       python::arg("includeIsotopes") = true,
+       python::arg("includeAtomMaps") = true),
       docString.c_str());
 
   python::def("CanonicalizeEnhancedStereo", CanonicalizeEnhancedStereo,

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -7414,6 +7414,14 @@ CAS<~>
     self.assertIsNotNone(mol)
     self.assertEqual(mol.GetNumAtoms(), 13)
 
+  def testAtomMapsInCanonicalization(self):
+    mol = Chem.MolFromSmiles("[F:1]C([F:2])O")
+    ranks = Chem.CanonicalRankAtoms(mol,breakTies=False,includeAtomMaps=True)
+    self.assertNotEqual(ranks[0],ranks[2])
+    ranks = Chem.CanonicalRankAtoms(mol,breakTies=False,includeAtomMaps=False)
+    self.assertEqual(ranks[0],ranks[2])
+
+
 
 if __name__ == '__main__':
   if "RDTESTCASE" in os.environ:

--- a/Code/GraphMol/catch_canon.cpp
+++ b/Code/GraphMol/catch_canon.cpp
@@ -539,3 +539,22 @@ M  END)CTAB";
 
   CHECK(countStereoBonds(*mol) == 2);
 }
+
+TEST_CASE("atom mapping in canonicalization") {
+  SECTION("basics") {
+    auto m = "[F:1]C([F:2])O"_smiles;
+    REQUIRE(m);
+    std::vector<unsigned int> ranks;
+    bool breakTies = false;
+    bool includeChirality = true;
+    bool includeIsotopes = true;
+    bool includeAtomMaps = true;
+    Canon::rankMolAtoms(*m, ranks, breakTies, includeChirality, includeIsotopes,
+                        includeAtomMaps);
+    CHECK(ranks[0] != ranks[2]);
+    includeAtomMaps = false;
+    Canon::rankMolAtoms(*m, ranks, breakTies, includeChirality, includeIsotopes,
+                        includeAtomMaps);
+    CHECK(ranks[0] == ranks[2]);
+  }
+}

--- a/Code/GraphMol/catch_chirality.cpp
+++ b/Code/GraphMol/catch_chirality.cpp
@@ -1245,25 +1245,29 @@ TEST_CASE("ring stereo finding is overly aggressive", "[chirality][bug]") {
         Chirality::findPotentialStereo(*mol, cleanIt, flagPossible);
     CHECK(stereoInfo.size() == 2);
   }
-  SECTION("Removal of stereoatoms requires removing CIS/TRANS when using legacy stereo") {
-      UseLegacyStereoPerceptionFixture reset_stereo_perception;
-      Chirality::setUseLegacyStereoPerception(false);
+  SECTION(
+      "Removal of stereoatoms requires removing CIS/TRANS when using legacy stereo") {
+    UseLegacyStereoPerceptionFixture reset_stereo_perception;
+    Chirality::setUseLegacyStereoPerception(false);
 
     {
       auto mol = "N/C=C/C"_smiles;
-      CHECK(mol->getBondWithIdx(1)->getStereo() == Bond::BondStereo::STEREOTRANS);
-      auto rwmol = dynamic_cast<RWMol*>(mol.get());
-      rwmol->removeBond(0,1);
-      CHECK(mol->getBondWithIdx(0)->getStereo() == Bond::BondStereo::STEREONONE);
+      CHECK(mol->getBondWithIdx(1)->getStereo() ==
+            Bond::BondStereo::STEREOTRANS);
+      auto rwmol = dynamic_cast<RWMol *>(mol.get());
+      rwmol->removeBond(0, 1);
+      CHECK(mol->getBondWithIdx(0)->getStereo() ==
+            Bond::BondStereo::STEREONONE);
     }
     {
       auto mol = "N/C=C/C"_smiles;
-      CHECK(mol->getBondWithIdx(1)->getStereo() == Bond::BondStereo::STEREOTRANS);
-      auto rwmol = dynamic_cast<RWMol*>(mol.get());
-      rwmol->removeBond(2,3);
-      CHECK(mol->getBondWithIdx(1)->getStereo() == Bond::BondStereo::STEREONONE);
+      CHECK(mol->getBondWithIdx(1)->getStereo() ==
+            Bond::BondStereo::STEREOTRANS);
+      auto rwmol = dynamic_cast<RWMol *>(mol.get());
+      rwmol->removeBond(2, 3);
+      CHECK(mol->getBondWithIdx(1)->getStereo() ==
+            Bond::BondStereo::STEREONONE);
     }
-	  
   }
 }
 
@@ -3796,19 +3800,18 @@ M  V30 8 1 1 8
 M  V30 END BOND
 M  V30 END CTAB
 M  END)CTAB"_ctab;
-      //mol->debugMol(std::cerr);
-      std::string smi = MolToCXSmiles(*mol, SmilesWriteParams());
-      std::unique_ptr<ROMol> f(SmilesToMol(smi));
-      mol->getBondWithIdx(3)->setStereo(Bond::BondStereo::STEREOCIS);
-      f->getBondWithIdx(0)->setStereo(Bond::BondStereo::STEREOCIS);
-      CHECK(MolToSmiles(*mol) == "C1=C\\CCCCCC/1");
-      CHECK(MolToSmiles(*f) == "C1=C\\CCCCCC/1");
-      mol->getBondWithIdx(3)->setStereo(Bond::BondStereo::STEREOTRANS);
-      f->getBondWithIdx(0)->setStereo(Bond::BondStereo::STEREOTRANS);
-      CHECK(MolToSmiles(*mol) == "C1=C/CCCCCC/1");
-      CHECK(MolToSmiles(*f) == "C1=C/CCCCCC/1");
+    // mol->debugMol(std::cerr);
+    std::string smi = MolToCXSmiles(*mol, SmilesWriteParams());
+    std::unique_ptr<ROMol> f(SmilesToMol(smi));
+    mol->getBondWithIdx(3)->setStereo(Bond::BondStereo::STEREOCIS);
+    f->getBondWithIdx(0)->setStereo(Bond::BondStereo::STEREOCIS);
+    CHECK(MolToSmiles(*mol) == "C1=C\\CCCCCC/1");
+    CHECK(MolToSmiles(*f) == "C1=C\\CCCCCC/1");
+    mol->getBondWithIdx(3)->setStereo(Bond::BondStereo::STEREOTRANS);
+    f->getBondWithIdx(0)->setStereo(Bond::BondStereo::STEREOTRANS);
+    CHECK(MolToSmiles(*mol) == "C1=C/CCCCCC/1");
+    CHECK(MolToSmiles(*f) == "C1=C/CCCCCC/1");
   }
-    
 }
 TEST_CASE("adding two wedges to chiral centers") {
   SECTION("basics") {
@@ -4949,5 +4952,21 @@ M  END)CTAB"_ctab;
           Atom::ChiralType::CHI_UNSPECIFIED);
     CHECK(m->getAtomWithIdx(2)->getChiralTag() !=
           Atom::ChiralType::CHI_UNSPECIFIED);
+  }
+}
+
+TEST_CASE("github #6931: atom maps influencing chirality perception") {
+  SECTION("basics") {
+    auto m = "[CH3:1]C([CH3:2])(O)F"_smiles;
+    REQUIRE(m);
+    bool cleanIt = true;
+    bool force = true;
+    bool flagPossibleStereoCenters = true;
+    UseLegacyStereoPerceptionFixture reset_stereo_perception;
+    Chirality::setUseLegacyStereoPerception(false);
+    MolOps::assignStereochemistry(*m, cleanIt, force,
+                                  flagPossibleStereoCenters);
+    CHECK(
+        !m->getAtomWithIdx(1)->hasProp(common_properties::_ChiralityPossible));
   }
 }

--- a/Code/GraphMol/new_canon.cpp
+++ b/Code/GraphMol/new_canon.cpp
@@ -730,7 +730,8 @@ void updateAtomNeighborNumSwaps(
 }
 
 void rankMolAtoms(const ROMol &mol, std::vector<unsigned int> &res,
-                  bool breakTies, bool includeChirality, bool includeIsotopes) {
+                  bool breakTies, bool includeChirality, bool includeIsotopes,
+                  bool includeAtomMaps) {
   if (!mol.getNumAtoms()) {
     return;
   }
@@ -748,6 +749,7 @@ void rankMolAtoms(const ROMol &mol, std::vector<unsigned int> &res,
   ftor.df_useIsotopes = includeIsotopes;
   ftor.df_useChirality = includeChirality;
   ftor.df_useChiralityRings = includeChirality;
+  ftor.df_useAtomMaps = includeAtomMaps;
 
   auto order = std::make_unique<int[]>(mol.getNumAtoms());
   detail::rankWithFunctor(ftor, breakTies, order.get(), true, includeChirality);
@@ -767,7 +769,7 @@ void rankFragmentAtoms(const ROMol &mol, std::vector<unsigned int> &res,
                        const std::vector<std::string> *atomSymbols,
                        const std::vector<std::string> *bondSymbols,
                        bool breakTies, bool includeChirality,
-                       bool includeIsotopes) {
+                       bool includeIsotopes, bool includeAtomMaps) {
   PRECONDITION(atomsInPlay.size() == mol.getNumAtoms(), "bad atomsInPlay size");
   PRECONDITION(bondsInPlay.size() == mol.getNumBonds(), "bad bondsInPlay size");
   PRECONDITION(!atomSymbols || atomSymbols->size() == mol.getNumAtoms(),
@@ -793,6 +795,7 @@ void rankFragmentAtoms(const ROMol &mol, std::vector<unsigned int> &res,
   AtomCompareFunctor ftor(&atoms.front(), mol, &atomsInPlay, &bondsInPlay);
   ftor.df_useIsotopes = includeIsotopes;
   ftor.df_useChirality = includeChirality;
+  ftor.df_useAtomMaps = includeAtomMaps;
 
   auto order = std::make_unique<int[]>(mol.getNumAtoms());
   detail::rankWithFunctor(ftor, breakTies, order.get(), true, includeChirality,

--- a/Code/GraphMol/new_canon.h
+++ b/Code/GraphMol/new_canon.h
@@ -307,21 +307,19 @@ class RDKIT_GRAPHMOL_EXPORT AtomCompareFunctor {
     } else if (ivi > ivj) {
       return 1;
     }
-    // use the atom-mapping numbers if they were assigned
-    /* boost::any_cast FILED here:
-            std::string molAtomMapNumber_i="";
-            std::string molAtomMapNumber_j="";
-    */
-    int molAtomMapNumber_i = 0;
-    int molAtomMapNumber_j = 0;
-    dp_atoms[i].atom->getPropIfPresent(common_properties::molAtomMapNumber,
-                                       molAtomMapNumber_i);
-    dp_atoms[j].atom->getPropIfPresent(common_properties::molAtomMapNumber,
-                                       molAtomMapNumber_j);
-    if (molAtomMapNumber_i < molAtomMapNumber_j) {
-      return -1;
-    } else if (molAtomMapNumber_i > molAtomMapNumber_j) {
-      return 1;
+    if (df_useAtomMaps) {
+      // use the atom-mapping numbers if they were assigned
+      int molAtomMapNumber_i = 0;
+      int molAtomMapNumber_j = 0;
+      dp_atoms[i].atom->getPropIfPresent(common_properties::molAtomMapNumber,
+                                         molAtomMapNumber_i);
+      dp_atoms[j].atom->getPropIfPresent(common_properties::molAtomMapNumber,
+                                         molAtomMapNumber_j);
+      if (molAtomMapNumber_i < molAtomMapNumber_j) {
+        return -1;
+      } else if (molAtomMapNumber_i > molAtomMapNumber_j) {
+        return 1;
+      }
     }
     // start by comparing degree
     ivi = dp_atoms[i].degree;
@@ -464,6 +462,7 @@ class RDKIT_GRAPHMOL_EXPORT AtomCompareFunctor {
   bool df_useIsotopes{true};
   bool df_useChirality{true};
   bool df_useChiralityRings{true};
+  bool df_useAtomMaps{true};
 
   AtomCompareFunctor() {}
   AtomCompareFunctor(Canon::canon_atom *atoms, const ROMol &m,
@@ -476,7 +475,8 @@ class RDKIT_GRAPHMOL_EXPORT AtomCompareFunctor {
         df_useNbrs(false),
         df_useIsotopes(true),
         df_useChirality(true),
-        df_useChiralityRings(true) {}
+        df_useChiralityRings(true),
+        df_useAtomMaps(true) {}
   int operator()(int i, int j) const {
     if (dp_atomsInPlay && !((*dp_atomsInPlay)[i] || (*dp_atomsInPlay)[j])) {
       return 0;
@@ -806,7 +806,8 @@ RDKIT_GRAPHMOL_EXPORT void rankMolAtoms(const ROMol &mol,
                                         std::vector<unsigned int> &res,
                                         bool breakTies = true,
                                         bool includeChirality = true,
-                                        bool includeIsotopes = true);
+                                        bool includeIsotopes = true,
+                                        bool includeAtomMaps = true);
 
 RDKIT_GRAPHMOL_EXPORT void rankFragmentAtoms(
     const ROMol &mol, std::vector<unsigned int> &res,
@@ -814,7 +815,7 @@ RDKIT_GRAPHMOL_EXPORT void rankFragmentAtoms(
     const boost::dynamic_bitset<> &bondsInPlay,
     const std::vector<std::string> *atomSymbols,
     const std::vector<std::string> *bondSymbols, bool breakTies,
-    bool includeChirality, bool includeIsotope);
+    bool includeChirality, bool includeIsotope, bool includeAtomMaps);
 
 inline void rankFragmentAtoms(
     const ROMol &mol, std::vector<unsigned int> &res,
@@ -822,9 +823,10 @@ inline void rankFragmentAtoms(
     const boost::dynamic_bitset<> &bondsInPlay,
     const std::vector<std::string> *atomSymbols = nullptr,
     bool breakTies = true, bool includeChirality = true,
-    bool includeIsotopes = true) {
+    bool includeIsotopes = true, bool includeAtomMaps = true) {
   rankFragmentAtoms(mol, res, atomsInPlay, bondsInPlay, atomSymbols, nullptr,
-                    breakTies, includeChirality, includeIsotopes);
+                    breakTies, includeChirality, includeIsotopes,
+                    includeAtomMaps);
 };
 
 RDKIT_GRAPHMOL_EXPORT void chiralRankMolAtoms(const ROMol &mol,


### PR DESCRIPTION
adds the option to use atom map numbers in the canonical ranking and exposes that to python

Needs more testing of the new functionality pre-merge

Fixes #6975 


