### PR TITLE
Github6968

### DIFF
--- a/Code/GraphMol/MolDraw2D/DrawMol.cpp
+++ b/Code/GraphMol/MolDraw2D/DrawMol.cpp
@@ -3373,16 +3373,14 @@ void DrawMol::makeHighlightEnd(const Atom *end1, const Atom *end2,
     auto b1 = end2Cds.directionVector(end1Cds);
     auto b2 = end2Cds.directionVector(end3Cds);
     if (1.0 - fabs(b1.dotProduct(b2)) < 1.0e-4) {
-      // rotate end3 about end2 by a small amount to create
-      // an inner and outer
-      end3Cds -= end2Cds;
-      RDGeom::Transform2D trans;
-      trans.SetTransform(Point2D(0, 0), M_PI / 20.0);
-      trans.TransformPoint(end3Cds);
-      end3Cds += end2Cds;
+      // move end3 by a small amount to create an inner and outer
+      auto d32 = end3Cds - end2Cds;
+      Point2D d32transp(d32.y, -d32.x);
+      d32transp *= 0.1;
+      end3Cds += d32transp;
     }
-    // The rotated end is only used to construct ins1 and ins2 wrt
-    // end1Cds and end2Cds so there's no need to rotate them back.
+    // The moved end is only used to construct ins1 and ins2 wrt
+    // end1Cds and end2Cds so there's no need do anything more.
     auto ins1 = innerPoint(end1Cds, end2Cds, end3Cds, 1.0);
     points.push_back(ins1);
     auto ins2 = innerPoint(end1Cds, end2Cds, end3Cds, -1.0);

--- a/Code/GraphMol/MolDraw2D/DrawMol.cpp
+++ b/Code/GraphMol/MolDraw2D/DrawMol.cpp
@@ -2250,7 +2250,6 @@ void DrawMol::makeBondHighlightLines(double lineWidth, double scale) {
           // occur in practice.
           // Sort so the lowest y point is first, with lowest x as
           // tie-breaker.
-#if 0
           std::sort(points.begin(), points.end(),
                     [](Point2D &p1, Point2D &p2) -> bool {
                       if (p1.y < p2.y) {
@@ -2275,7 +2274,6 @@ void DrawMol::makeBondHighlightLines(double lineWidth, double scale) {
                         return false;
                       }
                     });
-#endif
           DrawShape *hb = new DrawShapePolyLine(
               points, 0, false, col, true, thisIdx + activeAtmIdxOffset_,
               nbrIdx + activeAtmIdxOffset_,

--- a/Code/GraphMol/MolDraw2D/DrawMol.cpp
+++ b/Code/GraphMol/MolDraw2D/DrawMol.cpp
@@ -2250,6 +2250,7 @@ void DrawMol::makeBondHighlightLines(double lineWidth, double scale) {
           // occur in practice.
           // Sort so the lowest y point is first, with lowest x as
           // tie-breaker.
+#if 0
           std::sort(points.begin(), points.end(),
                     [](Point2D &p1, Point2D &p2) -> bool {
                       if (p1.y < p2.y) {
@@ -2274,6 +2275,7 @@ void DrawMol::makeBondHighlightLines(double lineWidth, double scale) {
                         return false;
                       }
                     });
+#endif
           DrawShape *hb = new DrawShapePolyLine(
               points, 0, false, col, true, thisIdx + activeAtmIdxOffset_,
               nbrIdx + activeAtmIdxOffset_,
@@ -3370,6 +3372,19 @@ void DrawMol::makeHighlightEnd(const Atom *end1, const Atom *end2,
     // There is only 1 intersection to deal with, which is easier - just
     // a slanted end.
     auto end3Cds = atCds_[end1HighNbrs[0]->getIdx()];
+    auto b1 = end2Cds.directionVector(end1Cds);
+    auto b2 = end2Cds.directionVector(end3Cds);
+    if (1.0 - fabs(b1.dotProduct(b2)) < 1.0e-4) {
+      // rotate end3 about end2 by a small amount to create
+      // an inner and outer
+      end3Cds -= end2Cds;
+      RDGeom::Transform2D trans;
+      trans.SetTransform(Point2D(0, 0), M_PI / 20.0);
+      trans.TransformPoint(end3Cds);
+      end3Cds += end2Cds;
+    }
+    // The rotated end is only used to construct ins1 and ins2 wrt
+    // end1Cds and end2Cds so there's no need to rotate them back.
     auto ins1 = innerPoint(end1Cds, end2Cds, end3Cds, 1.0);
     points.push_back(ins1);
     auto ins2 = innerPoint(end1Cds, end2Cds, end3Cds, -1.0);

--- a/Code/GraphMol/MolDraw2D/catch_tests.cpp
+++ b/Code/GraphMol/MolDraw2D/catch_tests.cpp
@@ -323,7 +323,7 @@ static const std::map<std::string, std::hash_result_t> SVG_HASHES = {
     {"testGithub6685_3.svg", 409385402U},
     {"testGithub6685_4.svg", 1239628830U},
     {"bad_lasso_1.svg", 726527516U},
-    {"testGithub6869.svg", 1554428830U}};
+    {"testGithub6968.svg", 1554428830U}};
 
 // These PNG hashes aren't completely reliable due to floating point cruft,
 // but they can still reduce the number of drawings that need visual
@@ -9337,9 +9337,6 @@ TEST_CASE("Github6968 - bad bond highlights with triple bonds") {
       drawer.drawMolecule(*mol, "", &highlightAtoms, &highlightBonds);
       drawer.finishDrawing();
       auto text = drawer.getDrawingText();
-      std::ofstream outs("testGithub6869.svg");
-      outs << text;
-      outs.close();
       std::regex bond(
           "<path class='bond-(\\d+) atom-(\\d+) atom-(\\d+)' d='M (-?\\d+.\\d+),"
           "(-?\\d+.\\d+) L (-?\\d+.\\d+),(-?\\d+.\\d+) L (-?\\d+.\\d+),"
@@ -9361,7 +9358,10 @@ TEST_CASE("Github6968 - bad bond highlights with triple bonds") {
         }
       }
       if (testNum == 0) {
-        check_file_hash("testGithub6869.svg");
+        std::ofstream outs("testGithub6968.svg");
+        outs << text;
+        outs.close();
+        check_file_hash("testGithub6968.svg");
       }
       std::shuffle(atOrder.begin(), atOrder.end(),
                    std::mt19937{std::random_device{}()});

--- a/Code/GraphMol/MolDraw2D/catch_tests.cpp
+++ b/Code/GraphMol/MolDraw2D/catch_tests.cpp
@@ -8,6 +8,8 @@
 //  of the RDKit source tree.
 //
 #include <catch2/catch_all.hpp>
+#include <numeric>
+#include <random>
 
 #include <GraphMol/RDKitBase.h>
 
@@ -9309,4 +9311,59 @@ TEST_CASE("Github 6749 : various bad things in the lasso highlighting") {
                     std::sregex_iterator()));
   CHECK(match_count == 3);
   check_file_hash(baseName + "1.svg");
+}
+
+TEST_CASE("Github6968 - bad bond highlights with triple bonds") {
+  // The issue is that in the linear highlight across the triple bond,
+  // some of the highlights didn't appear, and others were
+  // triangular - the corners of the rectangle weren't all distinct.
+  auto m = "ClCC#CCOC(=O)Nc1cccc(c1)Cl"_smiles;
+  std::vector<unsigned int> atOrder(m->getNumAtoms(), 0);
+  std::iota(atOrder.begin(), atOrder.end(), 0);
+  REQUIRE(m);
+  {
+    // Because I worried about the atom order giving a non-general
+    // result, repeat it 10 times with atoms in random order.
+    for (int testNum = 0; testNum < 10; ++testNum) {
+      std::unique_ptr<ROMol> mol(MolOps::renumberAtoms(*m, atOrder));
+      MolDraw2DSVG drawer(350, 300);
+      std::vector<int> highlightAtoms = {};
+      // Helpfully, the atoms are scrambled but not the bonds.
+      std::vector<int> highlightBonds = {1, 2, 3};
+
+      drawer.drawOptions().addAtomIndices = true;
+      drawer.drawOptions().addBondIndices = true;
+      drawer.drawMolecule(*mol, "", &highlightAtoms, &highlightBonds);
+      drawer.finishDrawing();
+      auto text = drawer.getDrawingText();
+      std::ofstream outs("testGithub6869.svg");
+      outs << text;
+      outs.close();
+      std::regex bond(
+          "<path class='bond-(\\d+) atom-(\\d+) atom-(\\d+)' d='M (-?\\d+.\\d+),"
+          "(-?\\d+.\\d+) L (-?\\d+.\\d+),(-?\\d+.\\d+) L (-?\\d+.\\d+),"
+          "(-?\\d+.\\d+) L (-?\\d+.\\d+),(-?\\d+.\\d+) Z' style=");
+
+      auto match_begin = std::sregex_iterator(text.begin(), text.end(), bond);
+      auto match_end = std::sregex_iterator();
+      for (std::sregex_iterator i = match_begin; i != match_end; ++i) {
+        std::smatch match = *i;
+        std::vector<Point2D> pts;
+        for (int j = 4; j < 12; j += 2) {
+          pts.push_back(Point2D(stod(match[j]), stod(match[j + 1])));
+        }
+        // None of the points should be on top of each other
+        for (size_t j = 0; j < 3; ++j) {
+          for (size_t k = j + 1; k < 4; ++k) {
+            CHECK((pts[j] - pts[k]).lengthSq() > 1.0e-4);
+          }
+        }
+      }
+      if (testNum == 0) {
+        check_file_hash("testGithub6869.svg");
+      }
+      std::shuffle(atOrder.begin(), atOrder.end(),
+                   std::mt19937{std::random_device{}()});
+    }
+  }
 }

--- a/Code/GraphMol/MolDraw2D/catch_tests.cpp
+++ b/Code/GraphMol/MolDraw2D/catch_tests.cpp
@@ -322,7 +322,8 @@ static const std::map<std::string, std::hash_result_t> SVG_HASHES = {
     {"testGithub6685_2.svg", 116380465U},
     {"testGithub6685_3.svg", 409385402U},
     {"testGithub6685_4.svg", 1239628830U},
-    {"bad_lasso_1.svg", 726527516U}};
+    {"bad_lasso_1.svg", 726527516U},
+    {"testGithub6869.svg", 1554428830U}};
 
 // These PNG hashes aren't completely reliable due to floating point cruft,
 // but they can still reduce the number of drawings that need visual


### PR DESCRIPTION

#### Reference Issue
Fixes #6968

#### What does this implement/fix? Explain your changes.
The linear system about the triple bond was confusing the code that matched the ends of the highlight rectangles up.  This just rotates one of the atoms a bit to break the linearity during construction.  Obviously not permanently.

#### Any other comments?
It now looks like this (bonds highlighted only).
<img width="344" alt="image" src="https://github.com/rdkit/rdkit/assets/9198870/fc04e530-0e86-4f36-b711-86a4ad67f66d">

I suspect that in the process of discussing and filing the bug, @thwelln's credit for the report has got lost.
