### PR TITLE
Enable in-tree builds and improve overloaded constructor docstrings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,6 @@ add_library(rdkit_base INTERFACE)
 
 option(RDK_BUILD_SWIG_WRAPPERS "build the SWIG wrappers" OFF )
 option(RDK_BUILD_PYTHON_WRAPPERS "build the standard python wrappers" ON )
-option(RDK_BUILD_PYTHON_STUBS "build the python stubs" OFF )
 option(RDK_BUILD_COMPRESSED_SUPPLIERS "build in support for compressed MolSuppliers" OFF )
 option(RDK_BUILD_INCHI_SUPPORT "build the rdkit inchi wrapper" OFF )
 option(RDK_BUILD_AVALON_SUPPORT "install support for the avalon toolkit. Use the variable AVALONTOOLS_DIR to set the location of the source." OFF )

--- a/Code/DataStructs/ExplicitBitVect.h
+++ b/Code/DataStructs/ExplicitBitVect.h
@@ -38,7 +38,7 @@ class RDKIT_DATASTRUCTS_EXPORT ExplicitBitVect : public BitVect {
   ExplicitBitVect(unsigned int size, bool bitsSet);
   ExplicitBitVect(const ExplicitBitVect &other);
   //! construct from a string pickle
-  ExplicitBitVect(const std::string &);
+  ExplicitBitVect(const std::string &pkl);
   //! construct from a text pickle
   ExplicitBitVect(const char *, const unsigned int);
   //! construct directly from a dynamic_bitset pointer

--- a/Code/DataStructs/SparseBitVect.h
+++ b/Code/DataStructs/SparseBitVect.h
@@ -48,7 +48,7 @@ class RDKIT_DATASTRUCTS_EXPORT SparseBitVect : public BitVect {
     std::copy(bv->begin(), bv->end(), std::inserter(*dp_bits, dp_bits->end()));
   }
   //! construct from a string pickle
-  SparseBitVect(const std::string &);
+  SparseBitVect(const std::string &pkl);
   //! construct from a text pickle
   SparseBitVect(const char *data, const unsigned int dataLen);
 

--- a/Code/DataStructs/Wrap/DiscreteValueVect.cpp
+++ b/Code/DataStructs/Wrap/DiscreteValueVect.cpp
@@ -58,7 +58,7 @@ struct discreteValVec_wrapper {
     python::class_<DiscreteValueVect>(
         "DiscreteValueVect", disValVectDoc.c_str(),
         python::init<DiscreteValueVect::DiscreteValueType, unsigned int>(
-            python::args("self", "pkl", "len"), "Constructor"))
+            python::args("self", "valType", "length"), "Constructor"))
         .def(python::init<std::string>(python::args("self", "pkl")))
         .def("__len__", &DiscreteValueVect::getLength, python::args("self"),
              "Get the number of entries in the vector")

--- a/Code/DataStructs/Wrap/wrap_ExplicitBV.cpp
+++ b/Code/DataStructs/Wrap/wrap_ExplicitBV.cpp
@@ -67,7 +67,7 @@ struct EBV_wrapper {
     python::class_<ExplicitBitVect, boost::shared_ptr<ExplicitBitVect>>(
         "ExplicitBitVect", ebvClassDoc.c_str(),
         python::init<unsigned int>(python::args("self", "size")))
-        .def(python::init<std::string>(python::args("self", "size")))
+        .def(python::init<std::string>(python::args("self", "pkl")))
         .def(python::init<unsigned int, bool>(
             python::args("self", "size", "bitsSet")))
         .def("SetBit", (bool(EBV::*)(unsigned int)) & EBV::setBit,

--- a/Code/DataStructs/Wrap/wrap_SparseBV.cpp
+++ b/Code/DataStructs/Wrap/wrap_SparseBV.cpp
@@ -62,7 +62,7 @@ struct SBV_wrapper {
     python::class_<SparseBitVect, boost::shared_ptr<SparseBitVect>>(
         "SparseBitVect", sbvClassDoc.c_str(),
         python::init<unsigned int>(python::args("self", "size")))
-        .def(python::init<std::string>(python::args("self", "size")))
+        .def(python::init<std::string>(python::args("self", "pkl")))
         .def("SetBit", (bool(SBV::*)(unsigned int)) & SBV::setBit,
              python::args("self", "which"),
              "Turns on a particular bit.  Returns the original state of the "

--- a/Code/GraphMol/ChemReactions/Wrap/rdChemReactions.cpp
+++ b/Code/GraphMol/ChemReactions/Wrap/rdChemReactions.cpp
@@ -587,7 +587,7 @@ Sample Usage:
       python::init<>(python::args("self"), "Constructor, takes no arguments"))
       .def(python::init<const std::string &>(python::args("self", "binStr")))
       .def(python::init<const RDKit::ChemicalReaction &>(
-          python::args("self", "binStr")))
+          python::args("self", "other")))
       .def("GetNumReactantTemplates",
            &RDKit::ChemicalReaction::getNumReactantTemplates,
            python::args("self"),

--- a/Code/GraphMol/FilterCatalog/Wrap/FilterCatalog.cpp
+++ b/Code/GraphMol/FilterCatalog/Wrap/FilterCatalog.cpp
@@ -354,7 +354,7 @@ struct filtercat_wrapper {
                    python::bases<FilterMatcherBase>>(
         "SmartsMatcher", SmartsMatcherDoc,
         python::init<const std::string &>(python::args("self", "name")))
-        .def(python::init<const ROMol &>(python::args("self", "name"),
+        .def(python::init<const ROMol &>(python::args("self", "rhs"),
                                          "Construct from a molecule"))
         .def(python::init<const std::string &, const ROMol &, unsigned int,
                           unsigned int>(
@@ -532,7 +532,7 @@ struct filtercat_wrapper {
                                   python::init<>(python::args("self")))
         .def(python::init<const std::string &>(python::args("self", "binStr")))
         .def(python::init<const FilterCatalogParams &>(
-            python::args("self", "catalogs")))
+            python::args("self", "params")))
         .def(python::init<FilterCatalogParams::FilterCatalogs>(
             python::args("self", "catalogs")))
         .def("Serialize", &FilterCatalog_Serialize, python::args("self"))

--- a/Code/GraphMol/Fingerprints/Wrap/MHFPWrapper.cpp
+++ b/Code/GraphMol/Fingerprints/Wrap/MHFPWrapper.cpp
@@ -149,8 +149,8 @@ BOOST_PYTHON_FUNCTION_OVERLOADS(EncodeSECFPMolsBulkOverloads,
 
 BOOST_PYTHON_MODULE(rdMHFPFingerprint) {
   python::class_<MHFPEncoder>(
-      "MHFPEncoder",
-      python::init<python::optional<unsigned int, unsigned int>>())
+      "MHFPEncoder", python::init<python::optional<unsigned int, unsigned int>>(
+                         python::args("self", "n_permutations", "seed")))
       .def("FromStringArray", FromStringArray, python::args("self", "vec"),
            "Creates a MHFP vector from a list of arbitrary strings.")
       .def("FromArray", FromArray, python::args("self", "vec"),

--- a/Code/GraphMol/SubstructLibrary/Wrap/SubstructLibraryWrap.cpp
+++ b/Code/GraphMol/SubstructLibrary/Wrap/SubstructLibraryWrap.cpp
@@ -636,7 +636,8 @@ struct substructlibrary_wrapper {
              "    - idx: which molecule to return\n\n"
              "    - sanitize: if sanitize is False, return the internal "
              "molecule state [default True]\n\n"
-             "  NOTE: molecule indices start at 0\n");
+             "  NOTE: molecule indices start at 0\n")
+        .def("__len__", &MolHolderBase::size, python::args("self"));
 
     python::class_<MolHolder, boost::shared_ptr<MolHolder>,
                    python::bases<MolHolderBase>>(
@@ -753,7 +754,7 @@ struct substructlibrary_wrapper {
             python::args("self", "molecules", "fingerprints")))
         .def(python::init<boost::shared_ptr<MolHolderBase>,
                           boost::shared_ptr<KeyHolderBase>>(
-            python::args("self", "molecules", "fingerprints")))
+            python::args("self", "molecules", "keys")))
         .def(python::init<boost::shared_ptr<MolHolderBase>,
                           boost::shared_ptr<FPHolderBase>,
                           boost::shared_ptr<KeyHolderBase>>(

--- a/Code/GraphMol/Wrap/Atom.cpp
+++ b/Code/GraphMol/Wrap/Atom.cpp
@@ -140,10 +140,11 @@ Note that, though it is possible to create one, having an Atom on its own\n\
 (i.e not associated with a molecule) is not particularly useful.\n";
 struct atom_wrapper {
   static void wrap() {
-    python::class_<Atom>("Atom", atomClassDoc.c_str(),
-                         python::init<std::string>(python::args("self", "num")))
+    python::class_<Atom>(
+        "Atom", atomClassDoc.c_str(),
+        python::init<std::string>(python::args("self", "what")))
 
-        .def(python::init<const Atom &>(python::args("self", "num")))
+        .def(python::init<const Atom &>(python::args("self", "other")))
         .def(python::init<unsigned int>(
             python::args("self", "num"),
             "Constructor, takes the atomic number"))

--- a/Code/GraphMol/Wrap/Conformer.cpp
+++ b/Code/GraphMol/Wrap/Conformer.cpp
@@ -71,7 +71,7 @@ struct conformer_wrapper {
         .def(python::init<unsigned int>(
             python::args("self", "numAtoms"),
             "Constructor with the number of atoms specified"))
-        .def(python::init<const Conformer &>(python::args("self", "numAtoms")))
+        .def(python::init<const Conformer &>(python::args("self", "other")))
 
         .def("GetNumAtoms", &Conformer::getNumAtoms, python::args("self"),
              "Get the number of atoms in the conformer\n")

--- a/Scripts/gen_rdkit_stubs/__main__.py
+++ b/Scripts/gen_rdkit_stubs/__main__.py
@@ -37,7 +37,7 @@ def parse_args():
     default_n_cpus = max(1, multiprocessing.cpu_count() - 2)
     default_output_dirs = [os.getcwd()]
     parser = argparse.ArgumentParser()
-    parser.add_argument("--concurrency",
+    parser.add_argument("--concurrency", type=int,
                         help=f"max number of CPUs to be used (defaults to {default_n_cpus})",
                         default=default_n_cpus)
     parser.add_argument("--verbose",

--- a/rdkit-stubs/CMakeLists.txt
+++ b/rdkit-stubs/CMakeLists.txt
@@ -1,25 +1,36 @@
-if(RDK_BUILD_PYTHON_STUBS)
-  string(REGEX REPLACE "\\\\" "/" CMAKE_SOURCE_DIR_FWDSLASH ${CMAKE_SOURCE_DIR})
-  string(REGEX REPLACE "\\\\" "/" CMAKE_CURRENT_BINARY_DIR_FWDSLASH ${CMAKE_CURRENT_BINARY_DIR})
+string(REGEX REPLACE "\\\\" "/" CMAKE_SOURCE_DIR_FWDSLASH ${CMAKE_SOURCE_DIR})
+set(CMAKE_SOURCE_DIR_FWDSLASH_QUOTED "\"${CMAKE_SOURCE_DIR_FWDSLASH}\" ")
+string(REGEX REPLACE "\\\\" "/" CMAKE_CURRENT_BINARY_DIR_FWDSLASH ${CMAKE_CURRENT_BINARY_DIR})
+set(PYTHON_INSTDIR_FWDSLASH_QUOTED "")
+set(DIR_OR_DIRS "y")
+set(STUB_LOCATIONS "${CMAKE_SOURCE_DIR_FWDSLASH}")
+if (PYTHON_INSTDIR)
   string(REGEX REPLACE "\\\\" "/" PYTHON_INSTDIR_FWDSLASH ${PYTHON_INSTDIR})
-  string(CONCAT RUN_GEN_RDKIT_STUBS_PY "message("
-    "\"-- Installing rdkit-stubs into the following directories: "
-    "${CMAKE_SOURCE_DIR_FWDSLASH}, "
-    "${PYTHON_INSTDIR_FWDSLASH}\")\n"
-    "set (SEPARATOR \"=====================================================================\n\")\n"
-    "set (COMMON_FILENAME ${CMAKE_CURRENT_BINARY_DIR_FWDSLASH}/gen_rdkit_stubs)\n"
-    "execute_process("
-    "COMMAND "
-    "${PYTHON_EXECUTABLE} -m Scripts.gen_rdkit_stubs "
-    "\"${CMAKE_SOURCE_DIR_FWDSLASH}\" \"${PYTHON_INSTDIR_FWDSLASH}\" "
-    "WORKING_DIRECTORY \"${CMAKE_SOURCE_DIR_FWDSLASH}\" "
-    "OUTPUT_FILE \"\${COMMON_FILENAME}.out\" "
-    "ERROR_FILE \"\${COMMON_FILENAME}.err\" "
-    "RESULT_VARIABLE RETCODE)\n"
-    "if (NOT \"\${RETCODE}\" EQUAL 0)\n"
-    "  file(READ \"\${COMMON_FILENAME}.err\" ERROR_STRING)\n"
-    "  message(\"\n\${SEPARATOR}Installation of rdkit-stubs failed.\n\${ERROR_STRING}\${SEPARATOR}\")\n"
-    "endif()\n"
-  )
-  install(CODE "${RUN_GEN_RDKIT_STUBS_PY}" COMPONENT python)
-endif(RDK_BUILD_PYTHON_STUBS)
+  set(PYTHON_INSTDIR_FWDSLASH_QUOTED "\"${PYTHON_INSTDIR_FWDSLASH}\" ")
+  set(DIR_OR_DIRS "ies")
+  set(STUB_LOCATIONS "${STUB_LOCATIONS}, ${PYTHON_INSTDIR_FWDSLASH}")
+endif()
+set(CONCURRENCY "")
+if (DEFINED ENV{CMAKE_BUILD_PARALLEL_LEVEL})
+  set(CONCURRENCY "--concurrency $ENV{CMAKE_BUILD_PARALLEL_LEVEL} ")
+endif()
+string(CONCAT RUN_GEN_RDKIT_STUBS_PY "message("
+  "\"-- Building and Installing rdkit-stubs into the following director${DIR_OR_DIRS}: ${STUB_LOCATIONS}\")\n"
+  "set (SEPARATOR \"=====================================================================\n\")\n"
+  "set (COMMON_FILENAME ${CMAKE_CURRENT_BINARY_DIR_FWDSLASH}/gen_rdkit_stubs)\n"
+  "execute_process("
+  "COMMAND "
+  "${PYTHON_EXECUTABLE} -m Scripts.gen_rdkit_stubs ${CONCURRENCY}"
+  "${CMAKE_SOURCE_DIR_FWDSLASH_QUOTED}${PYTHON_INSTDIR_FWDSLASH_QUOTED}"
+  "WORKING_DIRECTORY \"${CMAKE_SOURCE_DIR_FWDSLASH}\" "
+  "OUTPUT_FILE \"\${COMMON_FILENAME}.out\" "
+  "ERROR_FILE \"\${COMMON_FILENAME}.err\" "
+  "RESULT_VARIABLE RETCODE)\n"
+  "if (NOT \"\${RETCODE}\" EQUAL 0)\n"
+  "  file(READ \"\${COMMON_FILENAME}.err\" ERROR_STRING)\n"
+  "  message(\"\n\${SEPARATOR}Installation of rdkit-stubs failed.\n\${ERROR_STRING}\${SEPARATOR}\")\n"
+  "endif()\n"
+)
+set(BUILD_STUBS_SCRIPT "${CMAKE_CURRENT_BINARY_DIR_FWDSLASH}/build_stubs.cmake")
+file(GENERATE OUTPUT ${BUILD_STUBS_SCRIPT} CONTENT "${RUN_GEN_RDKIT_STUBS_PY}")
+add_custom_target(stubs ${CMAKE_COMMAND} -P ${BUILD_STUBS_SCRIPT})


### PR DESCRIPTION
This PR enables building stubs in both in-tree and out-of-tree builds with `cmake --build . --target stubs` (`make stubs` will also work on *NIX).
This PR also features improvements to the patching script to do a better assignment of overloaded constructor parameters, which results in a number of fixes to docstring parameters which were previously incorrectly assigned or in some cases even re-assigned.
