### PR TITLE
Fixes #6983

### DIFF
--- a/Code/GraphMol/Substruct/SubstructMatch.cpp
+++ b/Code/GraphMol/Substruct/SubstructMatch.cpp
@@ -634,8 +634,9 @@ unsigned int RecursiveMatcher(const ROMol &mol, const ROMol &query,
       bool found=boost::ullmann_all(query.getTopology(),mol.getTopology(),
 				    atomLabeler,bondLabeler,pms);
 #else
-  bool found = boost::vf2_all(query.getTopology(), mol.getTopology(),
-                              atomLabeler, bondLabeler, matchChecker, pms);
+  bool found =
+      boost::vf2_all(query.getTopology(), mol.getTopology(), atomLabeler,
+                     bondLabeler, matchChecker, pms, lparams.maxMatches);
 #endif
   unsigned int res = 0;
   if (found) {

--- a/Code/GraphMol/Substruct/catch_tests.cpp
+++ b/Code/GraphMol/Substruct/catch_tests.cpp
@@ -514,3 +514,30 @@ TEST_CASE("Github #6017: add maxRecursiveMatches to SubstructMatchParameters") {
     }
   }
 }
+
+TEST_CASE(
+    "GitHub Issue #6983: SubstructMatch maxRecursiveMatches is not being honored",
+    "[bug][substruct]") {
+  constexpr unsigned num_atoms = 1005;
+  std::string smiles;
+  smiles.reserve(num_atoms * 2);
+
+  // 'smiles' already contains 1 O, so start from 1
+  // so we end up with 'num_atoms' water mols
+  smiles += "O";
+  for (unsigned i = 1; i < num_atoms; ++i) {
+    smiles += ".O";
+  }
+  std::unique_ptr<RWMol> m(SmilesToMol(smiles));
+  auto q = "[$(O)]"_smarts;
+  REQUIRE(m);
+  REQUIRE(q);
+
+  SubstructMatchParameters ps;
+  ps.maxMatches = num_atoms * 2;
+  ps.maxRecursiveMatches = ps.maxMatches;
+  {
+    auto matches = SubstructMatch(*m, *q, ps);
+    CHECK(matches.size() == num_atoms);
+  }
+}


### PR DESCRIPTION
Fixes #6983

After all the discussion in #6825 about what max to use, we failed to notice that we never passed any max matches argument to `vf2_all` in RecursiveMatcher... 