### PR TITLE
Change the defaults for the conformer generation to be ETKDGv3

### DIFF
--- a/Code/GraphMol/DistGeomHelpers/Embedder.h
+++ b/Code/GraphMol/DistGeomHelpers/Embedder.h
@@ -133,7 +133,7 @@ struct RDKIT_DISTGEOMHELPERS_EXPORT EmbedParameters {
   bool verbose{false};
   double basinThresh{5.0};
   double pruneRmsThresh{-1.0};
-  bool onlyHeavyAtomsForRMS{false};
+  bool onlyHeavyAtomsForRMS{true};
   unsigned int ETversion{1};
   boost::shared_ptr<const DistGeom::BoundsMatrix> boundsMat;
   bool embedFragmentsSeparately{true};

--- a/Code/GraphMol/DistGeomHelpers/Embedder.h
+++ b/Code/GraphMol/DistGeomHelpers/Embedder.h
@@ -158,7 +158,7 @@ struct RDKIT_DISTGEOMHELPERS_EXPORT EmbedParameters {
       bool ignoreSmoothingFailures, bool enforceChirality,
       bool useExpTorsionAnglePrefs, bool useBasicKnowledge, bool verbose,
       double basinThresh, double pruneRmsThresh, bool onlyHeavyAtomsForRMS,
-      unsigned int ETversion = 1,
+      unsigned int ETversion = 2,
       const DistGeom::BoundsMatrix *boundsMat = nullptr,
       bool embedFragmentsSeparately = true, bool useSmallRingTorsions = false,
       bool useMacrocycleTorsions = false, bool useMacrocycle14config = false,
@@ -285,12 +285,13 @@ inline int EmbedMolecule(ROMol &mol, EmbedParameters &params) {
   \param onlyHeavyAtomsForRMS  only use the heavy atoms when doing RMS filtering
   \param ETversion	version of torsion preferences to use
   \param useSmallRingTorsions	optional torsions to improve small ring
-  conformer sampling
-
+                              conformer sampling
   \param useMacrocycleTorsions	optional torsions to improve macrocycle
-  conformer sampling \param useMacrocycle14config  If 1-4 distances bound
-  heuristics for macrocycles is used \return ID of the conformations added to
-  the molecule, -1 if the emdedding failed
+                                conformer sampling 
+  \param useMacrocycle14config  If 1-4 distances bound heuristics for macrocycles 
+                                is used 
+  
+  \return ID of the conformer added to the molecule, -1 if the emdedding failed
 */
 inline int EmbedMolecule(
     ROMol &mol, unsigned int maxIterations = 0, int seed = -1,
@@ -302,8 +303,8 @@ inline int EmbedMolecule(
     bool enforceChirality = true, bool useExpTorsionAnglePrefs = false,
     bool useBasicKnowledge = false, bool verbose = false,
     double basinThresh = 5.0, bool onlyHeavyAtomsForRMS = false,
-    unsigned int ETversion = 1, bool useSmallRingTorsions = false,
-    bool useMacrocycleTorsions = false, bool useMacrocycle14config = false) {
+    unsigned int ETversion = 2, bool useSmallRingTorsions = false,
+    bool useMacrocycleTorsions = true, bool useMacrocycle14config = true) {
   EmbedParameters params(
       maxIterations, 1, seed, clearConfs, useRandomCoords, boxSizeMult,
       randNegEig, numZeroFail, coordMap, optimizerForceTol,
@@ -383,11 +384,11 @@ inline int EmbedMolecule(
   \param onlyHeavyAtomsForRMS  only use the heavy atoms when doing RMS filtering
   \param ETversion	version of torsion preferences to use
   \param useSmallRingTorsions	optional torsions to improve small ring
-  conformer sampling
-
+                              conformer sampling
   \param useMacrocycleTorsions	optional torsions to improve macrocycle
-  conformer sampling \param useMacrocycle14config  If 1-4 distances bound
-  heuristics for macrocycles is used
+                                conformer sampling 
+  \param useMacrocycle14config  If 1-4 distances bound heuristics for macrocycles 
+                                is used 
 
 */
 inline void EmbedMultipleConfs(
@@ -401,8 +402,8 @@ inline void EmbedMultipleConfs(
     bool enforceChirality = true, bool useExpTorsionAnglePrefs = false,
     bool useBasicKnowledge = false, bool verbose = false,
     double basinThresh = 5.0, bool onlyHeavyAtomsForRMS = false,
-    unsigned int ETversion = 1, bool useSmallRingTorsions = false,
-    bool useMacrocycleTorsions = false, bool useMacrocycle14config = false) {
+    unsigned int ETversion = 2, bool useSmallRingTorsions = false,
+    bool useMacrocycleTorsions = true, bool useMacrocycle14config = true) {
   EmbedParameters params(
       maxIterations, numThreads, seed, clearConfs, useRandomCoords, boxSizeMult,
       randNegEig, numZeroFail, coordMap, optimizerForceTol,
@@ -423,7 +424,7 @@ inline INT_VECT EmbedMultipleConfs(
     bool enforceChirality = true, bool useExpTorsionAnglePrefs = false,
     bool useBasicKnowledge = false, bool verbose = false,
     double basinThresh = 5.0, bool onlyHeavyAtomsForRMS = false,
-    unsigned int ETversion = 1, bool useSmallRingTorsions = false,
+    unsigned int ETversion = 2, bool useSmallRingTorsions = false,
     bool useMacrocycleTorsions = false, bool useMacrocycle14config = false) {
   EmbedParameters params(
       maxIterations, 1, seed, clearConfs, useRandomCoords, boxSizeMult,

--- a/Code/GraphMol/DistGeomHelpers/Wrap/rdDistGeom.cpp
+++ b/Code/GraphMol/DistGeomHelpers/Wrap/rdDistGeom.cpp
@@ -333,8 +333,8 @@ BOOST_PYTHON_MODULE(rdDistGeom) {
        python::arg("useBasicKnowledge") = true,
        python::arg("printExpTorsionAngles") = false,
        python::arg("useSmallRingTorsions") = false,
-       python::arg("useMacrocycleTorsions") = false,
-       python::arg("ETversion") = 1),
+       python::arg("useMacrocycleTorsions") = true,
+       python::arg("ETversion") = 2),
       docString.c_str());
 
   docString =
@@ -402,8 +402,8 @@ BOOST_PYTHON_MODULE(rdDistGeom) {
        python::arg("useBasicKnowledge") = true,
        python::arg("printExpTorsionAngles") = false,
        python::arg("useSmallRingTorsions") = false,
-       python::arg("useMacrocycleTorsions") = false,
-       python::arg("ETversion") = 1),
+       python::arg("useMacrocycleTorsions") = true,
+       python::arg("ETversion") = 2),
       docString.c_str());
 
   python::enum_<RDKit::DGeomHelpers::EmbedFailureCauses>("EmbedFailureCauses")

--- a/Code/GraphMol/DistGeomHelpers/Wrap/testDistGeom.py
+++ b/Code/GraphMol/DistGeomHelpers/Wrap/testDistGeom.py
@@ -210,8 +210,7 @@ class TestCase(unittest.TestCase):
     ]
 
     nconfs = []
-    expected = [4, 5, 5, 4, 5, 4]
-    expected = [3, 3, 5, 4, 4, 4]
+    expected = [4, 3, 6, 6, 4, 4]
     for smi in smiles:
       mol = Chem.MolFromSmiles(smi)
       cids = rdDistGeom.EmbedMultipleConfs(mol, 50, maxAttempts=30, randomSeed=100,
@@ -588,8 +587,9 @@ class TestCase(unittest.TestCase):
 
       conf1 = m1.GetConformer()
       conf2 = m2.GetConformer()
-      self.assertTrue((conf2.GetAtomPosition(3) - conf2.GetAtomPosition(0)).Length() > (
-        conf1.GetAtomPosition(3) - conf1.GetAtomPosition(0)).Length())
+      self.assertTrue((conf2.GetAtomPosition(3) -
+                       conf2.GetAtomPosition(0)).Length() > (conf1.GetAtomPosition(3) -
+                                                             conf1.GetAtomPosition(0)).Length())
 
   def testScaleBoundsMatForce(self):
     """

--- a/Docs/Book/GettingStartedInPython.rst
+++ b/Docs/Book/GettingStartedInPython.rst
@@ -323,7 +323,9 @@ molecule before generating the conformer. This is essential to get good structur
 .. doctest::
 
   >>> m3 = Chem.AddHs(m2)
-  >>> AllChem.EmbedMolecule(m3,randomSeed=0xf00d)   # optional random seed for reproducibility)
+  >>> params = AllChem.ETKDGv3()
+  >>> params.randomSeed = 0xf00d # optional random seed for reproducibility
+  >>> AllChem.EmbedMolecule(m3, params)   
   0
   >>> print(Chem.MolToMolBlock(m3))    # doctest: +NORMALIZE_WHITESPACE
   cyclobutane
@@ -691,7 +693,8 @@ minimisation step to clean up the structures.
 More detailed information about the conformer generator and the parameters
 controlling it can be found in the "RDKit Book".
 
-Since the 2018.09 release of the RDKit, ETKDG is the default conformer generation method.
+Since the 2018.09 release of the RDKit, ETKDG is the default conformer
+generation method. Since the 2024.03 release ETKDGv3 is the default.
 
 The full process of embedding a molecule is easier than all the above verbiage makes it sound:
 
@@ -771,7 +774,9 @@ via the `numThreads` argument:
 
 .. doctest::
 
-  >>> cids = AllChem.EmbedMultipleConfs(m2, numThreads=0)
+  >>> params = AllChem.ETKDGv3()
+  >>> params.numThreads = 0
+  >>> cids = AllChem.EmbedMultipleConfs(m2, 10, params)
   >>> res = AllChem.MMFFOptimizeMoleculeConfs(m2, numThreads=0)
 
 Setting `numThreads` to zero causes the software to use the maximum number

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -9,6 +9,8 @@ GitHub)
 ## Highlights
 
 ## Backwards incompatible changes
+- Two changes to improve the defaults for conformer generation: the functions EmbedMolecule() and EmbedMultipleConfis() now use ETKDGv3 by default (previously they were using ETKDGV1) and only consider heavy atoms when calculating RMSD for conformer pruning (previously Hs were alos considered).
+
 
 ## New Features and Enhancements:
 

--- a/rdkit/Chem/UnitTestDescriptors.py
+++ b/rdkit/Chem/UnitTestDescriptors.py
@@ -169,9 +169,9 @@ class TestCase(unittest.TestCase):
       f = getattr(Descriptors, n)
       self.assertEqual(results[i], f(m))
 
-  @unittest.skipIf(not hasattr(rdMolDescriptors, 'BCUT2D')
-                   or not hasattr(rdMolDescriptors, 'CalcAUTOCORR2D'),
-                   "BCUT or AUTOCORR descriptors not available")
+  @unittest.skipIf(
+    not hasattr(rdMolDescriptors, 'BCUT2D') or not hasattr(rdMolDescriptors, 'CalcAUTOCORR2D'),
+    "BCUT or AUTOCORR descriptors not available")
   def testVectorDescriptorsInDescList(self):
     # First try only bcuts should exist
     descriptors = set([n for n, _ in Descriptors.descList])
@@ -213,7 +213,8 @@ class TestCase(unittest.TestCase):
     AllChem.EmbedMolecule(mol, randomSeed=0xf00d)
     descs = Descriptors3D.CalcMolDescriptors3D(mol)
     self.assertTrue('InertialShapeFactor' in descs)
-    self.assertEqual(descs['PMI1'], 20.954531335493417)
+    self.assertAlmostEqual(descs['PMI1'], 20.954531335493417, delta=1e-4)
+
 
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
Also changes the default behavior to only consider heavy atoms when calculating the RMS during pruning

These are both in the spirit of having good defaults.

Neither change affects code which uses the explicit parameter objects.