### PR TITLE
Added fingerprints to GeneralizedSubstruct search and extended SWIG wrappers

### DIFF
--- a/Code/GraphMol/GeneralizedSubstruct/CMakeLists.txt
+++ b/Code/GraphMol/GeneralizedSubstruct/CMakeLists.txt
@@ -1,7 +1,7 @@
 
 rdkit_library(GeneralizedSubstruct 
               XQMol.cpp TextIO.cpp
-              LINK_LIBRARIES MolEnumerator TautomerQuery SubstructMatch SmilesParse GraphMol) 
+              LINK_LIBRARIES MolEnumerator TautomerQuery SubstructMatch SmilesParse GraphMol Fingerprints)
 target_compile_definitions(GeneralizedSubstruct PRIVATE RDKIT_GENERALIZEDSUBSTRUCT_BUILD)
 
 rdkit_headers(XQMol.h DEST GraphMol/GeneralizedSubstruct)

--- a/Code/GraphMol/GeneralizedSubstruct/Wrap/rdGeneralizedSubstruct.cpp
+++ b/Code/GraphMol/GeneralizedSubstruct/Wrap/rdGeneralizedSubstruct.cpp
@@ -114,8 +114,7 @@ BOOST_PYTHON_MODULE(rdGeneralizedSubstruct) {
       .def("ToJSON", &ExtendedQueryMol::toJSON, python::args("self"))
       .def("PatternFingerprintQuery",
            &ExtendedQueryMol::patternFingerprintQuery,
-           (python::arg("self"), python::arg("fingerprintSize") = 2048),
-           python::return_value_policy<python::manage_new_object>());
+           (python::arg("self"), python::arg("fingerprintSize") = 2048));
 
   python::def(
       "MolHasSubstructMatch", &hasSubstructHelper,
@@ -136,7 +135,6 @@ BOOST_PYTHON_MODULE(rdGeneralizedSubstruct) {
   python::def(
       "PatternFingerprintTarget", &patternFingerprintTargetMol,
       (python::arg("target"), python::arg("fingerprintSize") = 2048),
-      python::return_value_policy<python::manage_new_object>(),
       "Creates a pattern fingerprint for a target molecule that is compatible with an extended query");
 
   python::def("CreateExtendedQueryMol", createExtendedQueryMolHelper,

--- a/Code/GraphMol/GeneralizedSubstruct/Wrap/rdGeneralizedSubstruct.cpp
+++ b/Code/GraphMol/GeneralizedSubstruct/Wrap/rdGeneralizedSubstruct.cpp
@@ -111,7 +111,11 @@ BOOST_PYTHON_MODULE(rdGeneralizedSubstruct) {
       .def("InitFromJSON", &ExtendedQueryMol::initFromJSON,
            python::args("self", "text"))
       .def("ToBinary", XQMolToBinary, python::args("self"))
-      .def("ToJSON", &ExtendedQueryMol::toJSON, python::args("self"));
+      .def("ToJSON", &ExtendedQueryMol::toJSON, python::args("self"))
+      .def("PatternFingerprintQuery",
+           &ExtendedQueryMol::patternFingerprintQuery,
+           (python::arg("self"), python::arg("fingerprintSize") = 2048),
+           python::return_value_policy<python::manage_new_object>());
 
   python::def(
       "MolHasSubstructMatch", &hasSubstructHelper,
@@ -128,6 +132,12 @@ BOOST_PYTHON_MODULE(rdGeneralizedSubstruct) {
       (python::arg("mol"), python::arg("query"),
        python::arg("params") = python::object()),
       "returns all matches (if any) of a molecule to a generalized substructure query");
+
+  python::def(
+      "PatternFingerprintTarget", &patternFingerprintTargetMol,
+      (python::arg("target"), python::arg("fingerprintSize") = 2048),
+      python::return_value_policy<python::manage_new_object>(),
+      "Creates a pattern fingerprint for a target molecule that is compatible with an extended query");
 
   python::def("CreateExtendedQueryMol", createExtendedQueryMolHelper,
               (python::arg("mol"), python::arg("doEnumeration") = true,

--- a/Code/GraphMol/GeneralizedSubstruct/XQMol.cpp
+++ b/Code/GraphMol/GeneralizedSubstruct/XQMol.cpp
@@ -55,16 +55,22 @@ void ExtendedQueryMol::initFromOther(const ExtendedQueryMol &other) {
   }
 }
 
-ExplicitBitVect *ExtendedQueryMol::patternFingerprintQuery(
+std::unique_ptr<ExplicitBitVect> ExtendedQueryMol::patternFingerprintQuery(
     unsigned fpSize) const {
-  if (std::holds_alternative<ExtendedQueryMol::RWMol_T>(xqmol)) {
-    return PatternFingerprintMol(*std::get<RWMol_T>(xqmol), fpSize, nullptr,
+  if (std::holds_alternative<RWMol_T>(xqmol)) {
+    const auto raw =  PatternFingerprintMol(*std::get<RWMol_T>(xqmol), fpSize, nullptr,
                                  nullptr, true);
+    std::unique_ptr<ExplicitBitVect> ptr(raw);
+    return ptr;
   } if (std::holds_alternative<MolBundle_T>(xqmol)) {
-    return PatternFingerprintMol(*std::get<MolBundle_T>(xqmol), fpSize, nullptr,
+    const auto raw = PatternFingerprintMol(*std::get<MolBundle_T>(xqmol), fpSize, nullptr,
                                  true);
+    std::unique_ptr<ExplicitBitVect> ptr(raw);
+    return ptr;
   } if (std::holds_alternative<TautomerQuery_T>(xqmol)) {
-    return std::get<TautomerQuery_T>(xqmol)->patternFingerprintTemplate(fpSize);
+    const auto raw = std::get<TautomerQuery_T>(xqmol)->patternFingerprintTemplate(fpSize);
+    std::unique_ptr<ExplicitBitVect> ptr(raw);
+    return ptr;
   } if (std::holds_alternative<TautomerBundle_T>(xqmol)) {
     const auto &tautomerBundle = std::get<TautomerBundle_T>(xqmol);
     ExplicitBitVect *res = nullptr;
@@ -77,7 +83,8 @@ ExplicitBitVect *ExtendedQueryMol::patternFingerprintQuery(
         delete molfp;
       }
     }
-    return res;
+    std::unique_ptr<ExplicitBitVect> ptr(res);
+    return ptr;
   }
 
   throw std::invalid_argument("Unknown extended query molecule type");
@@ -184,9 +191,11 @@ ExtendedQueryMol createExtendedQueryMol(const RWMol &mol, bool doEnumeration,
   }
 }
 
-ExplicitBitVect* patternFingerprintTargetMol(
+std::unique_ptr<ExplicitBitVect> patternFingerprintTargetMol(
   const ROMol& mol, unsigned fpSize) {
-  return PatternFingerprintMol(mol, fpSize, nullptr, nullptr, true);
+  const auto raw= PatternFingerprintMol(mol, fpSize, nullptr, nullptr, true);
+  std::unique_ptr<ExplicitBitVect> ptr(raw);
+  return ptr;
 }
 }  // namespace GeneralizedSubstruct
 }  // namespace RDKit

--- a/Code/GraphMol/GeneralizedSubstruct/XQMol.h
+++ b/Code/GraphMol/GeneralizedSubstruct/XQMol.h
@@ -68,6 +68,11 @@ struct RDKIT_GENERALIZEDSUBSTRUCT_EXPORT ExtendedQueryMol {
   ContainedType xqmol;
   std::string toBinary() const;
   std::string toJSON() const;
+
+  // Query fingerprint, caller owns fingerprint
+  ExplicitBitVect *patternFingerprintQuery(unsigned int fpSize = 2048U) const;
+
+
 };
 
 //! Creates an ExtendedQueryMol from the input molecule
@@ -101,6 +106,10 @@ RDKIT_GENERALIZEDSUBSTRUCT_EXPORT ExtendedQueryMol createExtendedQueryMol(
 RDKIT_GENERALIZEDSUBSTRUCT_EXPORT std::vector<MatchVectType> SubstructMatch(
     const ROMol &mol, const ExtendedQueryMol &query,
     const SubstructMatchParameters &params = SubstructMatchParameters());
+
+//! Fingerprints a target molecule, caller owns fingerprint
+RDKIT_GENERALIZEDSUBSTRUCT_EXPORT ExplicitBitVect *patternFingerprintTargetMol(const ROMol &mol,
+                                                   unsigned int fpSize = 2048U);
 
 //! checks if a molecule has a match to an ExtendedQueryMol
 inline bool hasSubstructMatch(

--- a/Code/GraphMol/GeneralizedSubstruct/XQMol.h
+++ b/Code/GraphMol/GeneralizedSubstruct/XQMol.h
@@ -69,10 +69,9 @@ struct RDKIT_GENERALIZEDSUBSTRUCT_EXPORT ExtendedQueryMol {
   std::string toBinary() const;
   std::string toJSON() const;
 
-  // Query fingerprint, caller owns fingerprint
-  ExplicitBitVect *patternFingerprintQuery(unsigned int fpSize = 2048U) const;
-
-
+  // Query fingerprint
+  std::unique_ptr<ExplicitBitVect> patternFingerprintQuery(
+      unsigned int fpSize = 2048U) const;
 };
 
 //! Creates an ExtendedQueryMol from the input molecule
@@ -107,9 +106,9 @@ RDKIT_GENERALIZEDSUBSTRUCT_EXPORT std::vector<MatchVectType> SubstructMatch(
     const ROMol &mol, const ExtendedQueryMol &query,
     const SubstructMatchParameters &params = SubstructMatchParameters());
 
-//! Fingerprints a target molecule, caller owns fingerprint
-RDKIT_GENERALIZEDSUBSTRUCT_EXPORT ExplicitBitVect *patternFingerprintTargetMol(const ROMol &mol,
-                                                   unsigned int fpSize = 2048U);
+//! Fingerprints a target molecule
+RDKIT_GENERALIZEDSUBSTRUCT_EXPORT std::unique_ptr<ExplicitBitVect>
+patternFingerprintTargetMol(const ROMol &mol, unsigned int fpSize = 2048U);
 
 //! checks if a molecule has a match to an ExtendedQueryMol
 inline bool hasSubstructMatch(

--- a/Code/GraphMol/GeneralizedSubstruct/catch_tests.cpp
+++ b/Code/GraphMol/GeneralizedSubstruct/catch_tests.cpp
@@ -33,8 +33,6 @@ bool fingerprintsMatch(const ROMol& target, const ExtendedQueryMol& xqm) {
   CHECK(queryFingerprint->getNumOnBits() > 0);
   CHECK(targetFingerprint->getNumOnBits() > 0);
   const auto match = AllProbeBitsMatch(*queryFingerprint, *targetFingerprint);
-  delete queryFingerprint;
-  delete targetFingerprint;
   return match;
 }
 

--- a/Code/GraphMol/GeneralizedSubstruct/catch_tests.cpp
+++ b/Code/GraphMol/GeneralizedSubstruct/catch_tests.cpp
@@ -27,6 +27,17 @@
 using namespace RDKit;
 using namespace RDKit::GeneralizedSubstruct;
 
+bool fingerprintsMatch(const ROMol& target, const ExtendedQueryMol& xqm) {
+  const auto queryFingerprint = xqm.patternFingerprintQuery();
+  const auto targetFingerprint = patternFingerprintTargetMol(target);
+  CHECK(queryFingerprint->getNumOnBits() > 0);
+  CHECK(targetFingerprint->getNumOnBits() > 0);
+  const auto match = AllProbeBitsMatch(*queryFingerprint, *targetFingerprint);
+  delete queryFingerprint;
+  delete targetFingerprint;
+  return match;
+}
+
 TEST_CASE("molecule basics") {
   auto mol = "Cc1n[nH]c(F)c1"_smarts;
   REQUIRE(mol);
@@ -39,6 +50,7 @@ TEST_CASE("molecule basics") {
       CHECK(SubstructMatch(*"CCc1[nH]nc(F)c1"_smiles, *xq).empty());
       CHECK(hasSubstructMatch(*"CCc1n[nH]c(F)c1"_smiles, *xq));
       CHECK(!hasSubstructMatch(*"CCc1[nH]nc(F)c1"_smiles, *xq));
+      CHECK(fingerprintsMatch(*"CCc1n[nH]c(F)c1"_smiles, *xq));
     }
   }
 }
@@ -57,6 +69,9 @@ TEST_CASE("enumeration basics") {
       CHECK(SubstructMatch(*"COOCC"_smiles, *xq).size() == 1);
       CHECK(SubstructMatch(*"COOOCC"_smiles, *xq).size() == 1);
       CHECK(SubstructMatch(*"COOOOCC"_smiles, *xq).empty());
+      CHECK(fingerprintsMatch(*"COCC"_smiles, *xq));
+      CHECK(fingerprintsMatch(*"COOCC"_smiles, *xq));
+      CHECK(fingerprintsMatch(*"COOOCC"_smiles, *xq));
     }
   }
 }
@@ -76,6 +91,9 @@ TEST_CASE("result counts") {
       CHECK(SubstructMatch(*"COOCC"_smiles, *xq, ps).size() == 2);
       CHECK(SubstructMatch(*"COOOCC"_smiles, *xq, ps).size() == 2);
       CHECK(SubstructMatch(*"COOOOCC"_smiles, *xq, ps).empty());
+      CHECK(fingerprintsMatch(*"COCC"_smiles, *xq));
+      CHECK(fingerprintsMatch(*"COOCC"_smiles, *xq));
+      CHECK(fingerprintsMatch(*"COOOCC"_smiles, *xq));
     }
   }
 }
@@ -93,6 +111,9 @@ TEST_CASE("tautomer basics") {
       CHECK(SubstructMatch(*"CCc1n[nH]c(F)c1"_smiles, *xq).size() == 1);
       CHECK(SubstructMatch(*"CCc1[nH]nc(F)c1"_smiles, *xq).size() == 1);
       CHECK(SubstructMatch(*"CCc1[nH]ncc1"_smiles, *xq).empty());
+      CHECK(fingerprintsMatch(*"CCc1n[nH]c(F)c1"_smiles, *xq));
+      CHECK(fingerprintsMatch(*"CCc1[nH]nc(F)c1"_smiles, *xq));
+      CHECK(!fingerprintsMatch(*"CCc1[nH]ncc1"_smiles, *xq));
     }
   }
 }
@@ -119,6 +140,11 @@ TEST_CASE("tautomer bundle basics") {
       CHECK(SubstructMatch(*"CCc1[nH]ncc1F"_smiles, *xq).size() == 1);
       CHECK(SubstructMatch(*"CCc1n[nH]cc1F"_smiles, *xq).size() == 1);
       CHECK(SubstructMatch(*"CCc1[nH]ncc1"_smiles, *xq).empty());
+      CHECK(fingerprintsMatch(*"CCc1n[nH]c(F)c1"_smiles, *xq));
+      CHECK(fingerprintsMatch(*"CCc1[nH]nc(F)c1"_smiles, *xq));
+      CHECK(fingerprintsMatch(*"CCc1[nH]ncc1F"_smiles, *xq));
+      CHECK(fingerprintsMatch(*"CCc1n[nH]cc1F"_smiles, *xq));
+      CHECK(!fingerprintsMatch(*"CCc1[nH]ncc1"_smiles, *xq));
     }
   }
 }
@@ -136,6 +162,8 @@ TEST_CASE("createExtendedQueryMol and copy ctors") {
       CHECK(std::holds_alternative<ExtendedQueryMol::RWMol_T>(xqm.xqmol));
       CHECK(SubstructMatch(*"COCC"_smiles, xqm).size() == 1);
       CHECK(SubstructMatch(*"COOCC"_smiles, xqm).empty());
+      CHECK(fingerprintsMatch(*"COCC"_smiles, xqm));
+      CHECK(!fingerprintsMatch(*"COOCC"_smiles, xqm));
     }
   }
   SECTION("MolBundle") {
@@ -152,6 +180,9 @@ TEST_CASE("createExtendedQueryMol and copy ctors") {
       CHECK(SubstructMatch(*"COOCC"_smiles, xqm).size() == 1);
       CHECK(SubstructMatch(*"COOOCC"_smiles, xqm).size() == 1);
       CHECK(SubstructMatch(*"COOOOCC"_smiles, xqm).empty());
+      CHECK(fingerprintsMatch(*"COCC"_smiles, xqm));
+      CHECK(fingerprintsMatch(*"COOCC"_smiles, xqm));
+      CHECK(fingerprintsMatch(*"COOOCC"_smiles, xqm));
     }
   }
   SECTION("TautomerQuery") {
@@ -169,6 +200,9 @@ TEST_CASE("createExtendedQueryMol and copy ctors") {
       CHECK(SubstructMatch(*"CCC1OC(=N)N1"_smiles, *mol1).empty());
       CHECK(SubstructMatch(*"CCC1OC(=N)N1"_smiles, xqm).size() == 1);
       CHECK(SubstructMatch(*"c1[nH]ncc1"_smiles, xqm).empty());
+      CHECK(fingerprintsMatch(*"CCC1OC(N)=N1"_smiles, xqm));
+      CHECK(fingerprintsMatch(*"CCC1OC(=N)N1"_smiles, xqm));
+      CHECK(!fingerprintsMatch(*"c1[nH]ncc1"_smiles, xqm));
     }
   }
   SECTION("TautomerBundle") {
@@ -186,6 +220,9 @@ TEST_CASE("createExtendedQueryMol and copy ctors") {
       CHECK(SubstructMatch(*"COOCC1(F)OC(=N)N1"_smiles, xqm).size() == 1);
       CHECK(SubstructMatch(*"COCC1OC(N)=N1"_smiles, xqm).size() == 1);
       CHECK(SubstructMatch(*"COOOOCC1OC(=N)N1"_smiles, xqm).empty());
+      CHECK(fingerprintsMatch(*"COCC1(F)OC(N)=N1"_smiles, xqm));
+      CHECK(fingerprintsMatch(*"COOCC1(F)OC(=N)N1"_smiles, xqm));
+      CHECK(fingerprintsMatch(*"COCC1OC(N)=N1"_smiles, xqm));
     }
   }
 }
@@ -200,6 +237,8 @@ TEST_CASE("test SRUs") {
     // we won't test limits here.
     CHECK(SubstructMatch(*"FCN(C)CC"_smiles, xqm).size() == 1);
     CHECK(SubstructMatch(*"FCN(O)N(C)CC"_smiles, xqm).size() == 1);
+    CHECK(fingerprintsMatch(*"FCN(C)CC"_smiles, xqm));
+    CHECK(fingerprintsMatch(*"FCN(O)N(C)CC"_smiles, xqm));
   }
 }
 
@@ -232,6 +271,14 @@ TEST_CASE("adjustQueryProperties") {
     CHECK(SubstructMatch(*"COC1OC1"_smiles, xqm1).empty());
     CHECK(SubstructMatch(*"COC1OC1"_smiles, xqm2).empty());
     CHECK(SubstructMatch(*"COC1OC1"_smiles, xqm3).size() == 1);
+    CHECK(fingerprintsMatch(*"COC1CC1"_smiles, xqm1));
+    CHECK(fingerprintsMatch(*"COC1CC1"_smiles, xqm2));
+    CHECK(fingerprintsMatch(*"COC1CC1"_smiles, xqm3));
+    CHECK(fingerprintsMatch(*"COC1C(C)C1"_smiles, xqm1));
+    CHECK(fingerprintsMatch(*"COC1C(C)C1"_smiles, xqm3));
+    CHECK(!fingerprintsMatch(*"COC1OC1"_smiles, xqm1));
+    CHECK(!fingerprintsMatch(*"COC1OC1"_smiles, xqm2));
+    CHECK(fingerprintsMatch(*"COC1OC1"_smiles, xqm3));
   }
   SECTION("MolBundle") {
     auto mol = "COCC |LN:1:1.3|"_smiles;
@@ -248,6 +295,10 @@ TEST_CASE("adjustQueryProperties") {
     CHECK(SubstructMatch(*"COOC=C"_smiles, xqm1).empty());
     CHECK(SubstructMatch(*"COC=C"_smiles, xqm2).size() == 1);
     CHECK(SubstructMatch(*"COOC=C"_smiles, xqm2).size() == 1);
+    CHECK(!fingerprintsMatch(*"COC=C"_smiles, xqm1));
+    CHECK(!fingerprintsMatch(*"COOC=C"_smiles, xqm1));
+    CHECK(fingerprintsMatch(*"COC=C"_smiles, xqm2));
+    CHECK(fingerprintsMatch(*"COOC=C"_smiles, xqm2));
   }
   SECTION("TautomerQuery") {
     auto mol1 = "CC1OC(N)=N1"_smiles;
@@ -266,6 +317,10 @@ TEST_CASE("adjustQueryProperties") {
     CHECK(SubstructMatch(*"CC1(F)OC(=N)N1"_smiles, xqm1).size() == 1);
     CHECK(SubstructMatch(*"CC1(F)OC(N)=N1"_smiles, xqm2).empty());
     CHECK(SubstructMatch(*"CC1(F)OC(=N)N1"_smiles, xqm2).empty());
+    CHECK(fingerprintsMatch(*"CC1OC(N)=N1"_smiles, xqm1));
+    CHECK(fingerprintsMatch(*"CC1OC(N)=N1"_smiles, xqm2));
+    CHECK(fingerprintsMatch(*"CC1(F)OC(N)=N1"_smiles, xqm1));
+    CHECK(fingerprintsMatch(*"CC1(F)OC(=N)N1"_smiles, xqm1));
   }
   SECTION("TautomerBundle") {
     auto mol1 = "COCC1OC(N)=N1 |LN:1:1.3|"_smiles;
@@ -283,6 +338,12 @@ TEST_CASE("adjustQueryProperties") {
     CHECK(SubstructMatch(*"COOCC1(F)OC(=N)N1"_smiles, xqm1).size() == 1);
     CHECK(SubstructMatch(*"COCC1(F)OC(N)=N1"_smiles, xqm2).empty());
     CHECK(SubstructMatch(*"COOCC1(F)OC(=N)N1"_smiles, xqm2).empty());
+    CHECK(fingerprintsMatch(*"COCC1OC(N)=N1"_smiles, xqm1));
+    CHECK(fingerprintsMatch(*"COOCC1OC(=N)N1"_smiles, xqm1));
+    CHECK(fingerprintsMatch(*"COCC1OC(N)=N1"_smiles, xqm2));
+    CHECK(fingerprintsMatch(*"COOCC1OC(=N)N1"_smiles, xqm2));
+    CHECK(fingerprintsMatch(*"COCC1(F)OC(N)=N1"_smiles, xqm1));
+    CHECK(fingerprintsMatch(*"COOCC1(F)OC(=N)N1"_smiles, xqm1));
   }
 }
 

--- a/Code/JavaWrappers/GeneralizedSubstruct.i
+++ b/Code/JavaWrappers/GeneralizedSubstruct.i
@@ -1,4 +1,7 @@
 
+%include <std_unique_ptr.i>
+%unique_ptr(ExplicitBitVect)
+
 %{
 #include <GraphMol/GeneralizedSubstruct/XQMol.h>
 %}

--- a/Code/JavaWrappers/GeneralizedSubstruct.i
+++ b/Code/JavaWrappers/GeneralizedSubstruct.i
@@ -17,10 +17,8 @@
 %include "GraphMol/GeneralizedSubstruct/XQMol.h";
 
 %extend RDKit::GeneralizedSubstruct::ExtendedQueryMol  {
-
   std::vector< std::vector<std::pair<int, int> > > getSubstructMatches(RDKit::ROMol &target,RDKit::SubstructMatchParameters ps = RDKit::SubstructMatchParameters()){
     std::vector<RDKit::MatchVectType> mvs = SubstructMatch(target, *($self),ps);
     return mvs;
   };
-
 }

--- a/Code/JavaWrappers/GeneralizedSubstruct.i
+++ b/Code/JavaWrappers/GeneralizedSubstruct.i
@@ -1,12 +1,20 @@
 
+
+#if SWIG_VERSION >= 0x040101                 
 %include <std_unique_ptr.i>
 %unique_ptr(ExplicitBitVect)
+#endif
 
 %{
 #include <GraphMol/GeneralizedSubstruct/XQMol.h>
 %}
 // %include "std_unique_ptr.i"
 // %unique_ptr(ExtendedQueryMol)
+
+#if SWIG_VERSION < 0x040101                 
+%ignore patternFingerprintTargetMol(const ROMol &mol, unsigned int fpSize = 2048U);
+%ignore patternFingerprintQuery(unsigned int fpSize = 2048U) const;
+#endif
 
 %ignore ExtendedQueryMol(std::unique_ptr<RWMol> mol);
 %ignore ExtendedQueryMol(std::unique_ptr<MolBundle> mol);

--- a/Code/JavaWrappers/GeneralizedSubstruct.i
+++ b/Code/JavaWrappers/GeneralizedSubstruct.i
@@ -11,6 +11,16 @@
 %ignore ExtendedQueryMol(
       std::unique_ptr<std::vector<std::unique_ptr<TautomerQuery>>> tqs);
 %ignore xqmol;
+%newobject RDKit::GeneralizedSubstruct::ExtendedQueryMol::patternFingerprintQuery; 
+%newobject RDKit::GeneralizedSubstruct::patternFingerprintTargetMol;
 
 %include "GraphMol/GeneralizedSubstruct/XQMol.h";
 
+%extend RDKit::GeneralizedSubstruct::ExtendedQueryMol  {
+
+  std::vector< std::vector<std::pair<int, int> > > getSubstructMatches(RDKit::ROMol &target,RDKit::SubstructMatchParameters ps = RDKit::SubstructMatchParameters()){
+    std::vector<RDKit::MatchVectType> mvs = SubstructMatch(target, *($self),ps);
+    return mvs;
+  };
+
+}

--- a/Code/JavaWrappers/GeneralizedSubstruct.i
+++ b/Code/JavaWrappers/GeneralizedSubstruct.i
@@ -14,8 +14,6 @@
 %ignore ExtendedQueryMol(
       std::unique_ptr<std::vector<std::unique_ptr<TautomerQuery>>> tqs);
 %ignore xqmol;
-%newobject RDKit::GeneralizedSubstruct::ExtendedQueryMol::patternFingerprintQuery; 
-%newobject RDKit::GeneralizedSubstruct::patternFingerprintTargetMol;
 
 %include "GraphMol/GeneralizedSubstruct/XQMol.h";
 

--- a/Code/JavaWrappers/csharp_wrapper/GraphMolCSharp.i
+++ b/Code/JavaWrappers/csharp_wrapper/GraphMolCSharp.i
@@ -245,6 +245,7 @@ typedef unsigned long long int	uintmax_t;
 %include "../MolHash.i"
 %include "../Abbreviations.i"
 %include "../Streams.i"
+%include "../GeneralizedSubstruct.i"
 
 
 // Create a class to throw various sorts of errors for testing.  Required for unit tests in ErrorHandlingTests.java

--- a/Code/JavaWrappers/csharp_wrapper/RDKitCSharpTest/GeneralizedSubstructTest.cs
+++ b/Code/JavaWrappers/csharp_wrapper/RDKitCSharpTest/GeneralizedSubstructTest.cs
@@ -1,0 +1,56 @@
+﻿using GraphMolWrap;
+using Xunit;
+
+namespace RdkitTests
+{
+    public class GeneralizedSubstructTest
+    {
+        private bool FingerprintsMatch(ExtendedQueryMol queryMol, RWMol target)
+        {
+            var queryFingerprint = queryMol.patternFingerprintQuery();
+            var targetFingerprint = RDKFuncs.patternFingerprintTargetMol(target);
+            Assert.True(queryFingerprint.getNumOnBits() > 0);
+            Assert.True(targetFingerprint.getNumOnBits() > 0);
+            var match = RDKFuncs.AllProbeBitsMatch(queryFingerprint, targetFingerprint);
+            return match;
+        }
+
+        [Fact]
+        public void TestControlSteps()
+        {
+            var queryMol = RWMol.MolFromSmiles("COCC1OC(N)=N1 |LN:1:1.3|");
+            var xqm1 = RDKFuncs.createExtendedQueryMol(queryMol);
+            var xqm2 = RDKFuncs.createExtendedQueryMol(queryMol, false);
+            var xqm3 = RDKFuncs.createExtendedQueryMol(queryMol, true, false);
+            var xqm4 = RDKFuncs.createExtendedQueryMol(queryMol, false, false);
+
+            var mol1 = RWMol.MolFromSmiles("COCC1OC(N)=N1");
+            Assert.Equal(1, xqm1.getSubstructMatches(mol1).Count);
+            Assert.Equal(1, xqm2.getSubstructMatches(mol1).Count);
+            Assert.Equal(1, xqm3.getSubstructMatches(mol1).Count);
+            Assert.Equal(1, xqm4.getSubstructMatches(mol1).Count);
+            Assert.True(FingerprintsMatch(xqm1, mol1));
+            Assert.True(FingerprintsMatch(xqm2, mol1));
+            Assert.True(FingerprintsMatch(xqm3, mol1));
+            Assert.True(FingerprintsMatch(xqm4, mol1));
+
+            var mol2 = RWMol.MolFromSmiles("COCC1OC(=N)N1");
+            Assert.Equal(1, xqm1.getSubstructMatches(mol2).Count);
+            Assert.Equal(1, xqm2.getSubstructMatches(mol2).Count);
+            Assert.Equal(0, xqm3.getSubstructMatches(mol2).Count);
+            Assert.Equal(0, xqm4.getSubstructMatches(mol2).Count);
+            Assert.True(FingerprintsMatch(xqm1, mol2));
+            Assert.True(FingerprintsMatch(xqm2, mol2));
+            Assert.False(FingerprintsMatch(xqm3, mol2));
+            Assert.False(FingerprintsMatch(xqm4, mol2));
+
+            var mol3 = RWMol.MolFromSmiles("COOCC1OC(N)=N1");
+            Assert.Equal(1, xqm1.getSubstructMatches(mol3).Count);
+            Assert.Equal(0, xqm2.getSubstructMatches(mol3).Count);
+            Assert.Equal(1, xqm3.getSubstructMatches(mol3).Count);
+            Assert.Equal(0, xqm4.getSubstructMatches(mol3).Count);
+            Assert.True(FingerprintsMatch(xqm1, mol3));
+            Assert.True(FingerprintsMatch(xqm3, mol3));
+        }
+    }
+}


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! 
-->

#### What does this implement/fix? Explain your changes.

Adds pattern fingerprint capability to `GeneralizedSubstruct` search.

Use `ExtendedQueryMol::patternFingerprintQuery` to get a pattern fingerprint for the query.

Target molecules can get a compatible fingerprint from `patternFingerprintTargetMol`

I have added these functions to the Python and SWIG wrappers.  The SWIG wrapper now exposes full matching by adding a `getSubstructMatch` method to `ExtendedQueryMol`.

Extended C++ tests for fingerprinting and there is a C# test (though no way yet to run it)


