### PR TITLE
Fixes #7001

### DIFF
--- a/Code/SimDivPickers/HierarchicalClusterPicker.cpp
+++ b/Code/SimDivPickers/HierarchicalClusterPicker.cpp
@@ -96,7 +96,7 @@ RDKit::VECT_INT_VECT HierarchicalClusterPicker::cluster(
   RDKit::VECT_INT_VECT res;
   unsigned int j = 0;
   for (unsigned int i = 0; i < poolSize; i++) {
-    if (static_cast<int>(i) == removed[j]) {
+    if (j < removed.size() && static_cast<int>(i) == removed[j]) {
       j++;
       continue;
     }


### PR DESCRIPTION
Fixes #7001

This fixes the cause of the Invariant Violation: accessing an array index out of bounds.

The explanation of the problem is simple: when the last proper removal happens, `j` is incremented one final time, so that `j == removed.size()`, which causes the following iterations to access`removed[j]`, which is out of bounds, and will likely contain some random value. If, by chance, this value happens to be equal to `i`, then an additional and unexpected "removal" will happen, returning a result that will not contain the number of clusters we expect, and will trigger the invariant violation in line 113, right after the call to `cluster()`: https://github.com/rdkit/rdkit/blob/31de6b09fba6cb62f51c6c1253b6744c8a42a2dd/Code/SimDivPickers/HierarchicalClusterPicker.cpp#L112-L113




I wonder if this is the cause of the random SimDivPickers test failure that we randomly see...