### PR TITLE
change the handling of autocommit flag to support sqlite3 connections

### DIFF
--- a/rdkit/Dbase/DbUtils.py
+++ b/rdkit/Dbase/DbUtils.py
@@ -355,12 +355,16 @@ def _AddDataToDb(dBase, table, user, password, colDefs, colTypes, data, nullMark
     block.append(tuple(entries))
     if len(block) >= blockSize:
       nDone += _insertBlock(cn, sqlStr, block)
-      if not hasattr(cn, 'autocommit') or not cn.autocommit:
+      # note: in Python 3.12 `cn.autocommit != True`
+      # is different from `not cn.autocommit` (GH #7009)
+      if not hasattr(cn, 'autocommit') or cn.autocommit != True:
         cn.commit()
       block = []
   if len(block):
     nDone += _insertBlock(cn, sqlStr, block)
-  if not hasattr(cn, 'autocommit') or not cn.autocommit:
+  # note: in Python 3.12 `cn.autocommit != True`
+  # is different from `not cn.autocommit` (GH #7009)
+  if not hasattr(cn, 'autocommit') or cn.autocommit != True:
     cn.commit()
 
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! 
-->
#### Reference Issue
Fixes #7009

#### What does this implement/fix? Explain your changes.
In Python 3.12 sqlite connection objects have an `autocommit` attribute with possible values `False`, `True` and `LEGACY_TRANSACTION_CONTROL`. This PR introduces a small change in `rdkit/Dbase/DbUtils.py` so that an explicit commit is executed when the sqlite connection's `autocommit` "flag" has value `LEGACY_TRANSACTION_CONTROL` (the default value in Python 3.12).

#### Any other comments?
Maybe there are better ways to address this issue, I don't find this one particularly pretty, but it's simple and I think should preserve the original behavior.
