### PR TITLE
Sanitize parameter for LoadSDF (#7019)

### DIFF
--- a/rdkit/Chem/PandasTools.py
+++ b/rdkit/Chem/PandasTools.py
@@ -235,11 +235,14 @@ else:
 
   def LoadSDF(filename, idName='ID', molColName='ROMol', includeFingerprints=False,
               isomericSmiles=True, smilesName=None, embedProps=False, removeHs=True,
-              strictParsing=True):
+              strictParsing=True, sanitize=True):
     '''Read file in SDF format and return as Pandas data frame.
       If embedProps=True all properties also get embedded in Mol objects in the molecule column.
       If molColName=None molecules would not be present in resulting DataFrame (only properties
       would be read).
+      
+      Sanitize boolean is passed on to Chem.ForwardSDMolSupplier sanitize. 
+      If neither molColName nor smilesName are set, sanitize=false.
       '''
     if isinstance(filename, str):
       if filename.lower()[-3:] == ".gz":
@@ -253,7 +256,8 @@ else:
       close = None  # don't close an open file that was passed in
     records = []
     indices = []
-    sanitize = bool(molColName is not None or smilesName is not None)
+    if molColName is None and smilesName is None:
+      sanitize = False
     for i, mol in enumerate(
         Chem.ForwardSDMolSupplier(f, sanitize=sanitize, removeHs=removeHs,
                                   strictParsing=strictParsing)):

--- a/rdkit/Chem/UnitTestPandasTools.py
+++ b/rdkit/Chem/UnitTestPandasTools.py
@@ -295,6 +295,7 @@ class TestLoadSDF(unittest.TestCase):
     df = PandasTools.LoadSDF(sio, sanitize=False)
     self.assertEqual(len(df), 3)
     self.assertEqual(df.iloc[1]["ROMol"].GetNumAtoms(), 6)
+    self.assertEqual(df.iloc[1]["ROMol"].GetAtomWithIdx(5).GetDegree(), 5)
 
 
 @unittest.skipIf((not hasattr(PandasTools, 'pd')) or PandasTools.pd is None,

--- a/rdkit/Chem/UnitTestPandasTools.py
+++ b/rdkit/Chem/UnitTestPandasTools.py
@@ -286,6 +286,15 @@ class TestLoadSDF(unittest.TestCase):
     df = PandasTools.LoadSDF(sio, molColName=None)
     self.assertEqual(set(df.columns), set("ID prop1 prop2 prop3".split()))
 
+  def test_sanitize_flag(self):
+    sio = getStreamIO(pentavalentCarbon)
+    df = PandasTools.LoadSDF(sio, sanitize=False)
+    self.assertEqual(len(df), 1)
+    self.assertEqual(df.iloc[0]["ROMol"].GetNumAtoms(), 6)
+
+    df = PandasTools.LoadSDF(sio, sanitize=True)
+    self.assertEqual(len(df), 0)
+
 
 @unittest.skipIf((not hasattr(PandasTools, 'pd')) or PandasTools.pd is None,
                  'Pandas not installed, skipping')
@@ -440,6 +449,32 @@ rtz
 
 > <prop3>
 yxcv
+
+$$$$
+"""
+
+pentavalentCarbon = """\
+PentavalentCarbon
+     RDKit          2D
+
+  6  5  0  0  0  0  0  0  0  0999 V2000
+    0.0000    0.0000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    2.5981   -0.0000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    1.2990    2.2500    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    2.5981    1.5000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    0.0000    1.5000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    1.2990    0.7500    0.0000 C   0  0  0  0  0  5  0  0  0  0  0  0
+  1  6  1  0
+  2  6  1  0
+  3  6  1  0
+  4  6  1  0
+  5  6  1  0
+M  END
+> <prop 2>
+uio
+
+> prop 4>
+lkjh
 
 $$$$
 """

--- a/rdkit/Chem/UnitTestPandasTools.py
+++ b/rdkit/Chem/UnitTestPandasTools.py
@@ -286,14 +286,15 @@ class TestLoadSDF(unittest.TestCase):
     df = PandasTools.LoadSDF(sio, molColName=None)
     self.assertEqual(set(df.columns), set("ID prop1 prop2 prop3".split()))
 
-  def test_sanitize_flag(self):
-    sio = getStreamIO(pentavalentCarbon)
-    df = PandasTools.LoadSDF(sio, sanitize=False)
-    self.assertEqual(len(df), 1)
-    self.assertEqual(df.iloc[0]["ROMol"].GetNumAtoms(), 6)
-
+  def test_sanitize_flag(self) -> None:
+    sio: BytesIO = getStreamIO(methane + pentavalentCarbon + peroxide)
     df = PandasTools.LoadSDF(sio, sanitize=True)
-    self.assertEqual(len(df), 0)
+    self.assertEqual(len(df), 2)
+
+    sio: BytesIO = getStreamIO(methane + pentavalentCarbon + peroxide)
+    df = PandasTools.LoadSDF(sio, sanitize=False)
+    self.assertEqual(len(df), 3)
+    self.assertEqual(df.iloc[1]["ROMol"].GetNumAtoms(), 6)
 
 
 @unittest.skipIf((not hasattr(PandasTools, 'pd')) or PandasTools.pd is None,
@@ -470,10 +471,10 @@ PentavalentCarbon
   4  6  1  0
   5  6  1  0
 M  END
-> <prop 2>
+> <prop2>
 uio
 
-> prop 4>
+> <prop4>
 lkjh
 
 $$$$

--- a/rdkit/RDLogger.py
+++ b/rdkit/RDLogger.py
@@ -12,7 +12,7 @@
 import sys
 import traceback
 
-from rdkit.rdBase import AttachFileToLog, DisableLog, EnableLog, LogMessage
+from rdkit.rdBase import DisableLog, EnableLog, LogMessage
 
 _levels = ['rdApp.debug', 'rdApp.info', 'rdApp.warning', 'rdApp.error']
 DEBUG = 0


### PR DESCRIPTION
#### Reference Issue
Fixes #7019

#### What does this implement/fix? Explain your changes.
Allows users to set sanitize in PandasTools.LoadSDF. I describe in #7019 what I hope to change with this PR.

Also an unused import is removed in RDLogger.py. Unsure if it should be part of this PR.

