### PR TITLE
Fixes #6472 - remove aromatic bond flags in Molhash anonymous graph

### DIFF
--- a/Code/GraphMol/MolHash/catch_tests.cpp
+++ b/Code/GraphMol/MolHash/catch_tests.cpp
@@ -752,3 +752,45 @@ TEST_CASE("Github Issue #6855 MakeScaffoldGeneric isotope removal") {
     }
   }
 }
+
+TEST_CASE("Github Issue #6472 non-matching element and anononymous graph") {
+  SECTION("Element graph test1") {
+    auto mol = "C1COC(C1)C1=NC=NC=C1"_smiles;
+    REQUIRE(mol);
+    {
+      RWMol cp(*mol);
+      auto hsh = MolHash::MolHash(&cp, MolHash::HashFunction::ElementGraph);
+      CHECK(hsh == "C1COC(C2CCNCN2)C1");
+    }
+  }
+  SECTION("Element graph test2") {
+    auto mol = "C1CC(N=CN1)C1=CC=CO1"_smiles;
+    REQUIRE(mol);
+    {
+      RWMol cp(*mol);
+      auto hsh = MolHash::MolHash(&cp, MolHash::HashFunction::ElementGraph);
+      CHECK(hsh == "C1COC(C2CCNCN2)C1");
+    }
+  }
+  SECTION("Anonymous graph test 1") {
+    auto mol = "C1COC(C1)C1=NC=NC=C1"_smiles;
+    REQUIRE(mol);
+
+    {
+      RWMol cp(*mol);
+      auto hsh = MolHash::MolHash(&cp, MolHash::HashFunction::AnonymousGraph);
+      CHECK(hsh == "*1***(*2****2)**1");
+    }
+  }
+   SECTION("Anonymous graph test 2") {
+    auto mol = "C1CC(N=CN1)C1=CC=CO1"_smiles;
+    REQUIRE(mol);
+
+    {
+      RWMol cp(*mol);
+      auto hsh = MolHash::MolHash(&cp, MolHash::HashFunction::AnonymousGraph);
+      CHECK(hsh == "*1***(*2****2)**1");
+    }
+  }
+}
+

--- a/Code/GraphMol/MolHash/hashfunctions.cpp
+++ b/Code/GraphMol/MolHash/hashfunctions.cpp
@@ -323,6 +323,7 @@ std::string AnonymousGraph(RWMol *mol, bool elem, bool useCXSmiles,
 
   for (auto bptr : mol->bonds()) {
     bptr->setBondType(Bond::SINGLE);
+    bptr->setIsAromatic(false); // clear aromatic flags
   }
   MolOps::assignRadicals(*mol);
 

--- a/Docs/Book/Cookbook.rst
+++ b/Docs/Book/Cookbook.rst
@@ -1568,7 +1568,7 @@ Molecule Hash Strings
 .. testoutput::
    :options: -ELLIPSIS, +NORMALIZE_WHITESPACE
 
-   AnonymousGraph **(***1*****1)*(*)*(*)*(*)*1***(*)*(*)*1
+   AnonymousGraph **1***(*(*)*(*)*(*)*(*)***2*****2)**1*
    ElementGraph CC(C(O)C1CCC(O)C(O)C1)N(C)C(O)OCC1CCCCC1
    CanonicalSmiles CC(C(O)c1ccc(O)c(O)c1)N(C)C(=O)OCc1ccccc1
    MurckoScaffold c1ccc(CCNCOCc2ccccc2)cc1


### PR DESCRIPTION
#### Reference Issue

This is discussed in #6470. 

#### What does this fix?

I believe this fixes #6472, where aromatic bond flags were causing different MolHash ElementGraph and AnonymousGraph hashes for molecules where they are expected to match.

#### Any other comments?

1. The hashed ElementGraphs and AnonymousGraphs are now the same for the test case as expected (and some others that I tried), but they do not necessarily match the MolHash binary CLI hash atom order. I am assuming this is unrelated and a result of RDKit's canonicalization.

2. Thank you for tagging this issue with "Good for Beginners". It was fun to test and (hopefully) offer the correct fix.

Vin

