### PR TITLE
fix GCC 13.2 warnings about redundant move in return statement

### DIFF
--- a/Code/GraphMol/FMCS/Wrap/rdFMCS.cpp
+++ b/Code/GraphMol/FMCS/Wrap/rdFMCS.cpp
@@ -643,7 +643,7 @@ python::object degenerateSmartsQueryMolDictHelper(
   for (const auto &pair : self.DegenerateSmartsQueryMolDict) {
     res[pair.first] = pair.second;
   }
-  return std::move(res);
+  return res;
 }
 struct mcsresult_wrapper {
   static void wrap() {

--- a/Code/GraphMol/Fingerprints/Wrap/FingerprintGeneratorWrapper.cpp
+++ b/Code/GraphMol/Fingerprints/Wrap/FingerprintGeneratorWrapper.cpp
@@ -449,7 +449,7 @@ python::object getBitPathsHelper(const AdditionalOutput &ao) {
     }
     res[pr.first] = python::tuple(local);
   }
-  return std::move(res);
+  return res;
 }
 python::object getBitInfoMapHelper(const AdditionalOutput &ao) {
   if (!ao.bitInfoMap) {
@@ -464,7 +464,7 @@ python::object getBitInfoMapHelper(const AdditionalOutput &ao) {
     }
     res[pr.first] = python::tuple(local);
   }
-  return std::move(res);
+  return res;
 }
 
 namespace {

--- a/Code/GraphMol/ForceFieldHelpers/Wrap/rdForceFields.cpp
+++ b/Code/GraphMol/ForceFieldHelpers/Wrap/rdForceFields.cpp
@@ -46,7 +46,7 @@ python::object UFFConfsHelper(ROMol &mol, int numThreads, int maxIters,
   for (auto &itm : res) {
     pyres.append(python::make_tuple(itm.first, itm.second));
   }
-  return std::move(pyres);
+  return pyres;
 }
 
 python::object MMFFConfsHelper(ROMol &mol, int numThreads, int maxIters,
@@ -63,7 +63,7 @@ python::object MMFFConfsHelper(ROMol &mol, int numThreads, int maxIters,
   for (auto &itm : res) {
     pyres.append(python::make_tuple(itm.first, itm.second));
   }
-  return std::move(pyres);
+  return pyres;
 }
 
 int FFHelper(ForceFields::PyForceField &ff, int maxIters) {
@@ -83,7 +83,7 @@ python::object FFConfsHelper(ROMol &mol, ForceFields::PyForceField &ff,
   for (auto &itm : res) {
     pyres.append(python::make_tuple(itm.first, itm.second));
   }
-  return std::move(pyres);
+  return pyres;
 }
 
 ForceFields::PyForceField *UFFGetMoleculeForceField(

--- a/Code/GraphMol/MolChemicalFeatures/Wrap/ChemicalFeatureUtils.cpp
+++ b/Code/GraphMol/MolChemicalFeatures/Wrap/ChemicalFeatureUtils.cpp
@@ -42,7 +42,7 @@ python::object GetAtomMatch(python::object featMatch, int maxAts = 1024) {
     }
     res.append(local);
   }
-  return std::move(res);
+  return res;
 }
 
 #if 0

--- a/External/FreeSASA/Wrap/rdFreeSASA.cpp
+++ b/External/FreeSASA/Wrap/rdFreeSASA.cpp
@@ -53,9 +53,9 @@ python::object classifyAtomsHelper(RDKit::ROMol &mol,
     for (double &i : radii) {
       l.append(i);
     }
-    return std::move(l);
+    return l;
   }
-  return std::move(l);
+  return l;
 }
 
 double calcSASAHelper(const RDKit::ROMol &mol, python::object radii,


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
This PR just removes a few calls to `std::move` that the compiler reports to be redundant.

#### Any other comments?
Warnings were observed with GCC 13.2 and boost 1.81.0
