### PR TITLE
Add Atom::hasValenceViolation (Take 2)

### DIFF
--- a/Code/GraphMol/Atom.cpp
+++ b/Code/GraphMol/Atom.cpp
@@ -301,31 +301,41 @@ int Atom::getExplicitValence() const {
   return d_explicitValence;
 }
 
+int Atom::getImplicitValence() const {
+  PRECONDITION(dp_mol,
+               "valence not defined for atoms not associated with molecules");
+  if (df_noImplicit) {
+    return 0;
+  }
+  return d_implicitValence;
+}
+
 unsigned int Atom::getTotalValence() const {
   return getExplicitValence() + getImplicitValence();
 }
 
-int Atom::calcExplicitValence(bool strict) {
+static int calculate_explicit_valence(const Atom &atom, bool strict) {
   unsigned int res;
   // FIX: contributions of bonds to valence are being done at best
   // approximately
   double accum = 0;
-  for (const auto bnd : getOwningMol().atomBonds(this)) {
-    accum += bnd->getValenceContrib(this);
+  for (const auto bnd : atom.getOwningMol().atomBonds(&atom)) {
+    accum += bnd->getValenceContrib(&atom);
   }
-  accum += getNumExplicitHs();
+  accum += atom.getNumExplicitHs();
 
   // check accum is greater than the default valence
-  unsigned int dv = PeriodicTable::getTable()->getDefaultValence(d_atomicNum);
-  int chr = getFormalCharge();
-  if (isEarlyAtom(d_atomicNum)) {
+  auto atomic_num = atom.getAtomicNum();
+  unsigned int dv = PeriodicTable::getTable()->getDefaultValence(atomic_num);
+  int chr = atom.getFormalCharge();
+  if (isEarlyAtom(atomic_num)) {
     chr *= -1;  // <- the usual correction for early atoms
   }
   // special case for carbon - see GitHub #539
-  if (d_atomicNum == 6 && chr > 0) {
+  if (atomic_num == 6 && chr > 0) {
     chr = -chr;
   }
-  if (accum > (dv + chr) && isAromaticAtom(*this)) {
+  if (accum > (dv + chr) && isAromaticAtom(atom)) {
     // this needs some explanation : if the atom is aromatic and
     // accum > (dv + chr) we assume that no hydrogen can be added
     // to this atom.  We set x = (v + chr) such that x is the
@@ -338,7 +348,7 @@ int Atom::calcExplicitValence(bool strict) {
 
     int pval = dv + chr;
     const INT_VECT &valens =
-        PeriodicTable::getTable()->getValenceList(d_atomicNum);
+        PeriodicTable::getTable()->getValenceList(atomic_num);
     for (auto val : valens) {
       if (val == -1) {
         break;
@@ -378,15 +388,15 @@ int Atom::calcExplicitValence(bool strict) {
 
   if (strict) {
     int effectiveValence;
-    if (PeriodicTable::getTable()->getNouterElecs(d_atomicNum) >= 4) {
-      effectiveValence = res - getFormalCharge();
+    if (PeriodicTable::getTable()->getNouterElecs(atomic_num) >= 4) {
+      effectiveValence = res - atom.getFormalCharge();
     } else {
       // for boron and co, we move to the right in the PT, so adding
       // extra valences means adding negative charge
-      effectiveValence = res + getFormalCharge();
+      effectiveValence = res + atom.getFormalCharge();
     }
     const INT_VECT &valens =
-        PeriodicTable::getTable()->getValenceList(d_atomicNum);
+        PeriodicTable::getTable()->getValenceList(atomic_num);
 
     int maxValence = valens.back();
     // maxValence == -1 signifies that we'll take anything at the high end
@@ -394,66 +404,55 @@ int Atom::calcExplicitValence(bool strict) {
       // the explicit valence is greater than any
       // allowed valence for the atoms - raise an error
       std::ostringstream errout;
-      errout << "Explicit valence for atom # " << getIdx() << " "
-             << PeriodicTable::getTable()->getElementSymbol(d_atomicNum) << ", "
+      errout << "Explicit valence for atom # " << atom.getIdx() << " "
+             << PeriodicTable::getTable()->getElementSymbol(atomic_num) << ", "
              << effectiveValence << ", is greater than permitted";
       std::string msg = errout.str();
       BOOST_LOG(rdErrorLog) << msg << std::endl;
-      throw AtomValenceException(msg, getIdx());
+      throw AtomValenceException(msg, atom.getIdx());
     }
   }
-  d_explicitValence = res;
-
   return res;
 }
 
-int Atom::getImplicitValence() const {
-  PRECONDITION(dp_mol,
-               "valence not defined for atoms not associated with molecules");
-  if (df_noImplicit) {
-    return 0;
-  }
-  return d_implicitValence;
-}
-
 // NOTE: this uses the explicitValence, so it will call
-// calcExplictValence() if it hasn't already been called
-int Atom::calcImplicitValence(bool strict) {
-  if (df_noImplicit) {
+// calculate_explicit_valence if it is not set on the given atom
+static int calculate_implicit_valence(const Atom &atom, bool strict) {
+  if (atom.getNoImplicit()) {
     return 0;
   }
-  if (d_explicitValence == -1) {
-    this->calcExplicitValence(strict);
+  auto explicit_valence = atom.getExplicitValence();
+  if (explicit_valence == -1) {
+    explicit_valence = calculate_explicit_valence(atom, strict);
   }
   // special cases
-  if (d_atomicNum == 0) {
-    d_implicitValence = 0;
+  auto atomic_num = atom.getAtomicNum();
+  if (atomic_num == 0) {
     return 0;
   }
-  for (const auto bnd : getOwningMol().atomBonds(this)) {
+  for (const auto &nbri :
+       boost::make_iterator_range(atom.getOwningMol().getAtomBonds(&atom))) {
+    const auto bnd = atom.getOwningMol()[nbri];
     if (QueryOps::hasComplexBondTypeQuery(*bnd)) {
-      d_implicitValence = 0;
       return 0;
     }
   }
-  if (d_explicitValence == 0 && d_atomicNum == 1 &&
-      d_numRadicalElectrons == 0) {
-    if (d_formalCharge == 1 || d_formalCharge == -1) {
-      d_implicitValence = 0;
+  auto formal_charge = atom.getFormalCharge();
+  auto num_radical_electrons = atom.getNumRadicalElectrons();
+  if (explicit_valence == 0 && atomic_num == 1 && num_radical_electrons == 0) {
+    if (formal_charge == 1 || formal_charge == -1) {
       return 0;
-    } else if (d_formalCharge == 0) {
-      d_implicitValence = 1;
+    } else if (formal_charge == 0) {
       return 1;
     } else {
       if (strict) {
         std::ostringstream errout;
-        errout << "Unreasonable formal charge on hydrogen # " << getIdx()
+        errout << "Unreasonable formal charge on hydrogen # " << atom.getIdx()
                << ".";
         std::string msg = errout.str();
         BOOST_LOG(rdErrorLog) << msg << std::endl;
-        throw AtomValenceException(msg, getIdx());
+        throw AtomValenceException(msg, atom.getIdx());
       } else {
-        d_implicitValence = 0;
         return 0;
       }
     }
@@ -467,9 +466,8 @@ int Atom::calcImplicitValence(bool strict) {
 
   // The d-block and f-block of the periodic table (i.e. transition metals,
   // lanthanoids and actinoids) have no default valence.
-  int dv = PeriodicTable::getTable()->getDefaultValence(d_atomicNum);
+  int dv = PeriodicTable::getTable()->getDefaultValence(atomic_num);
   if (dv == -1) {
-    d_implicitValence = 0;
     return 0;
   }
 
@@ -485,10 +483,11 @@ int Atom::calcImplicitValence(bool strict) {
   // finally aromatic cases are dealt with differently - these atoms are allowed
   // only default valences
   const INT_VECT &valens =
-      PeriodicTable::getTable()->getValenceList(d_atomicNum);
+      PeriodicTable::getTable()->getValenceList(atomic_num);
 
-  int explicitPlusRadV = getExplicitValence() + getNumRadicalElectrons();
-  int chg = getFormalCharge();
+  int explicitPlusRadV =
+      atom.getExplicitValence() + atom.getNumRadicalElectrons();
+  int chg = atom.getFormalCharge();
 
   // NOTE: this is here to take care of the difference in element on
   // the right side of the carbon vs left side of carbon
@@ -519,16 +518,16 @@ int Atom::calcImplicitValence(bool strict) {
   //
   // So assuming you read all the above stuff - you know why we are
   // changing signs for "chg" here
-  if (isEarlyAtom(d_atomicNum)) {
+  if (isEarlyAtom(atomic_num)) {
     chg *= -1;
   }
   // special case for carbon - see GitHub #539
-  if (d_atomicNum == 6 && chg > 0) {
+  if (atomic_num == 6 && chg > 0) {
     chg = -chg;
   }
 
   // if we have an aromatic case treat it differently
-  if (isAromaticAtom(*this)) {
+  if (isAromaticAtom(atom)) {
     if (explicitPlusRadV <= (static_cast<int>(dv) + chg)) {
       res = dv + chg - explicitPlusRadV;
     } else {
@@ -550,11 +549,11 @@ int Atom::calcImplicitValence(bool strict) {
       }
       if (strict && !satis) {
         std::ostringstream errout;
-        errout << "Explicit valence for aromatic atom # " << getIdx()
+        errout << "Explicit valence for aromatic atom # " << atom.getIdx()
                << " not equal to any accepted valence\n";
         std::string msg = errout.str();
         BOOST_LOG(rdErrorLog) << msg << std::endl;
-        throw AtomValenceException(msg, getIdx());
+        throw AtomValenceException(msg, atom.getIdx());
       }
       res = 0;
     }
@@ -574,20 +573,31 @@ int Atom::calcImplicitValence(bool strict) {
         // this means that the explicit valence is greater than any
         // allowed valence for the atoms - raise an error
         std::ostringstream errout;
-        errout << "Explicit valence for atom # " << getIdx() << " "
-               << PeriodicTable::getTable()->getElementSymbol(d_atomicNum)
+        errout << "Explicit valence for atom # " << atom.getIdx() << " "
+               << PeriodicTable::getTable()->getElementSymbol(atomic_num)
                << " greater than permitted";
         std::string msg = errout.str();
         BOOST_LOG(rdErrorLog) << msg << std::endl;
-        throw AtomValenceException(msg, getIdx());
+        throw AtomValenceException(msg, atom.getIdx());
       } else {
         res = 0;
       }
     }
   }
-
-  d_implicitValence = res;
   return res;
+}
+
+int Atom::calcExplicitValence(bool strict) {
+  d_explicitValence = calculate_explicit_valence(*this, strict);
+  return d_explicitValence;
+}
+
+int Atom::calcImplicitValence(bool strict) {
+  if (d_explicitValence == -1) {
+    calcExplicitValence(strict);
+  }
+  d_implicitValence = calculate_implicit_valence(*this, strict);
+  return d_implicitValence;
 }
 
 void Atom::setIsotope(unsigned int what) { d_isotope = what; }
@@ -603,6 +613,24 @@ double Atom::getMass() const {
   } else {
     return PeriodicTable::getTable()->getAtomicWeight(d_atomicNum);
   }
+}
+
+bool Atom::hasValenceViolation() const {
+  // Ignore dummy atoms, query atoms, or atoms attached to query bonds
+  auto bonds = getOwningMol().atomBonds(this);
+  auto is_query = [](auto b) { return b->hasQuery(); };
+  if (getAtomicNum() == 0 || hasQuery() ||
+      std::any_of(bonds.begin(), bonds.end(), is_query)) {
+    return false;
+  }
+
+  try {
+    calculate_explicit_valence(*this, true);
+    calculate_implicit_valence(*this, true);
+  } catch (const RDKit::AtomValenceException &) {
+    return true;
+  }
+  return false;
 }
 
 void Atom::setQuery(Atom::QUERYATOM_QUERY *) {

--- a/Code/GraphMol/Atom.cpp
+++ b/Code/GraphMol/Atom.cpp
@@ -314,6 +314,8 @@ unsigned int Atom::getTotalValence() const {
   return getExplicitValence() + getImplicitValence();
 }
 
+namespace {
+
 int calculateExplicitValence(const Atom &atom, bool strict, bool checkIt) {
   unsigned int res;
   // FIX: contributions of bonds to valence are being done at best
@@ -602,6 +604,8 @@ int calculateImplicitValence(const Atom &atom, bool strict, bool checkIt) {
   }
   return res;
 }
+
+}  // unnamed namespace
 
 int Atom::calcExplicitValence(bool strict) {
   bool checkIt = false;

--- a/Code/GraphMol/Atom.h
+++ b/Code/GraphMol/Atom.h
@@ -202,6 +202,13 @@ class RDKIT_GRAPHMOL_EXPORT Atom : public RDProps {
   */
   int getImplicitValence() const;
 
+  //! returns whether the atom has a valency violation or not
+  /*!
+    <b>Notes:</b>
+      - requires an owning molecule
+  */
+  bool hasValenceViolation() const;
+
   //! returns the number of radical electrons for this Atom
   /*!
     <b>Notes:</b>

--- a/Code/GraphMol/Wrap/Atom.cpp
+++ b/Code/GraphMol/Wrap/Atom.cpp
@@ -198,6 +198,8 @@ struct atom_wrapper {
              "Returns the number of implicit Hs on the atom.\n")
         .def("GetTotalValence", &Atom::getTotalValence, python::args("self"),
              "Returns the total valence (explicit + implicit) of the atom.\n\n")
+        .def("HasValenceViolation", &Atom::hasValenceViolation,
+             "Returns whether the atom has a valence violation or not.\n\n")
 
         .def("GetFormalCharge", &Atom::getFormalCharge, python::args("self"))
         .def("SetFormalCharge", &Atom::setFormalCharge,

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -7004,6 +7004,11 @@ CAS<~>
       self.assertTrue(bond.GetIsAromatic())
       self.assertEqual(bond.GetBondType(), Chem.BondType.AROMATIC)
 
+  def testHasValenceViolation(self):
+    mol = Chem.MolFromSmiles('C(C)(C)(C)(C)C', sanitize=False)
+    mol.UpdatePropertyCache(strict=False)
+    self.assertTrue(any(a.HasValenceViolation() for a in mol.GetAtoms()))
+
   def testgithub4992(self):
     if not hasattr(Chem, "Chem.MultithreadedSDMolSupplier"):
       return

--- a/Code/GraphMol/test1.cpp
+++ b/Code/GraphMol/test1.cpp
@@ -1245,8 +1245,8 @@ void testAtomListLineWithOtherQueries() {
   4  1  1  0  0  0  8
 M  CHG  2   1   1   4  -1
 M  SUB  1   4   1
-M  ALS   2  2 F O   S   
-M  ALS   4  2 F O   S   
+M  ALS   2  2 F O   S   0
+M  ALS   4  2 F O   S   0
 M  END
 )MOL",
                                          R"MOL(
@@ -1261,8 +1261,8 @@ M  END
   1  3  1  0  0  0  2
   4  1  1  0  0  0  8
 M  CHG  2   1   1   4  -1
-M  ALS   2  2 F O   S   
-M  ALS   4  2 F O   S   
+M  ALS   2  2 F O   S   0
+M  ALS   4  2 F O   S   0
 M  SUB  1   4   1
 M  END
   )MOL"};
@@ -1574,11 +1574,101 @@ void testGithub1843() {
   BOOST_LOG(rdErrorLog) << "Finished" << std::endl;
 }
 
+void testHasValenceViolation() {
+  BOOST_LOG(rdInfoLog) << " ----------> Testing Atom::hasValenceViolation()"
+                       << std::endl;
+
+  auto to_mol = [](const auto &smiles) {
+    int debugParse = 0;
+    bool sanitize = false;
+    auto mol = RDKit::SmilesToMol(smiles, debugParse, sanitize);
+    TEST_ASSERT(mol != nullptr);
+    mol->updatePropertyCache(false);
+    return mol;
+  };
+
+  //  All valid atoms
+  for (const auto &smiles : {
+           "C",
+           "C(C)(C)(C)C",
+           "S(C)(C)(C)(C)(C)C",
+           "O(C)C",
+           "[H]",
+           "[H+]",  // proton
+           "[H-]",
+           "[HH]",
+           "[He]",
+           "[C][C] |^5:0,1|",
+           "[H][Si] |^5:1|",
+           "[CH3+]",
+           "[CH3-]",
+           "[NH4+]",
+           "[Na]",
+           "[Na][H]",
+           "[Na]([H])[H]",
+           "[Og][Og]([Og])([Og])([Og])([Og])([Og])[Og]",
+           "[Lv-2]",
+           "[Lv-4]",
+           "[Lv+4]",
+           "[Lv+8]"
+           "*",              // dummy atom, which also accounts for wildcards
+           "*C |$_AP1;$|]",  // attachment point
+           "[*] |$_R1$|",    // rgroup
+       }) {
+    auto mol = to_mol(smiles);
+    for (auto atom : mol->atoms()) {
+      TEST_ASSERT(!atom->hasValenceViolation());
+    }
+  }
+
+  // First atom has a valence error!
+  for (const auto &smiles : {
+           // FIXME: commented out cases do not raise AtomValenceException
+           // when passing through the valence calculation code; will file
+           // RDKit issues to address within the valence code separately.
+           // "[C+5]",
+           "C(C)(C)(C)(C)C", "S(C)(C)(C)(C)(C)(C)C",
+           // "[C+](C)(C)(C)C",
+           "[C-](C)(C)(C)C",
+           // "[C](C)(C)(C)C |^1:0|",  //  pentavalent due to unpaired electron
+           "O(C)=C",
+           // "[H+] |^1:0|",  // same as [H]
+           // "[H+] |^2:0|",  // non-physical radical count
+           "[H+2]",
+           // "[H-2]",
+           // "[He+]",
+           // "[He+2]",
+           // "[He][He]",
+           "[O-3]",
+           // "[O+7]",
+           "[F-2]",
+           // "[F+2]",
+       }) {
+    auto mol = to_mol(smiles);
+    auto atom = mol->getAtomWithIdx(0);
+    TEST_ASSERT(atom->hasValenceViolation());
+  }
+
+  // Queries never have valence errors
+  for (const auto &smarts : {
+           "[#6](C)(C)(C)(C)C",          // query pentavalent carbon
+           "[#8](-,=[#6])=[#6]",         // S/D query bond present
+           "[!#6&!#1](-[#6])=[#6]",      // Q query atom
+           "[#6,#7,#8](-[#6])=[#6]",     // allowed list
+           "[!#6&!#7&!#8](-[#6])=[#6]",  // disallowed list
+           "[#6&R](-[#6])=[#6]",         // advanced query features
+       }) {
+    auto mol = RDKit::SmartsToMol(smarts);
+    for (auto atom : mol->atoms()) {
+      TEST_ASSERT(!atom->hasValenceViolation());
+    }
+  }
+}
+
 // -------------------------------------------------------------------
 int main() {
   RDLog::InitLogs();
-// boost::logging::enable_logs("rdApp.info");
-#if 1
+  // boost::logging::enable_logs("rdApp.info");
   test1();
   testPropLeak();
   testMolProps();
@@ -1604,10 +1694,9 @@ int main() {
   testRanges();
   testGithub1642();
   testGithub1843();
-#endif
   testAtomListLineRoundTrip();
   testAtomListLineWithOtherQueries();
   testReplaceChargedAtomWithQueryAtom();
-
+  testHasValenceViolation();
   return 0;
 }


### PR DESCRIPTION
**Reference Issue**

Fixes https://github.com/rdkit/rdkit/issues/6242

**What does this implement/fix? Explain your changes.**

Implementation of Atom::hasValenceViolation which calls out to the calculation of explicit and implicit valences with strict=True -- which require refactoring this code to create two static functions for those calculations.

The function always returns false for dummy atoms, query atoms, and query bonds.