### PR TITLE
Update distance bounds calculation for conjugated double bonds in macrocycles

### DIFF
--- a/Code/GraphMol/DistGeomHelpers/BoundsMatrixBuilder.cpp
+++ b/Code/GraphMol/DistGeomHelpers/BoundsMatrixBuilder.cpp
@@ -1076,8 +1076,8 @@ void _setChain14Bounds(const ROMol &mol, const Bond *bnd1, const Bond *bnd2,
           dl -= GEN_DIST_TOL;
           du += GEN_DIST_TOL;
           path14.type = Path14Configuration::TRANS;
-          transPaths[static_cast<unsigned long>(bid1)*nb*nb + bid2*nb + bid3] = 1;
-          transPaths[static_cast<unsigned long>(bid3)*nb*nb + bid2*nb + bid1] = 1;
+          accumData.transPaths[static_cast<unsigned long>(bid1)*nb*nb + bid2*nb + bid3] = 1;
+          accumData.transPaths[static_cast<unsigned long>(bid3)*nb*nb + bid2*nb + bid1] = 1;
         } else
 #endif
       if ((atm2->getAtomicNum() == 16) && (atm3->getAtomicNum() == 16)) {
@@ -1333,18 +1333,6 @@ void _setMacrocycleTwoInSameRing14Bounds(const ROMol &mol, const Bond *bnd1,
     du = dl;
     dl -= GEN_DIST_TOL;
     du += GEN_DIST_TOL;
-  } else if ((ahyb2 == Atom::SP2) &&
-             (ahyb3 == Atom::SP2)) {  // FIX: check for trans
-    // here we will assume 180 degrees: basically flat ring with an external
-    // substituent
-    dl = RDGeom::compute14DistTrans(bl1, bl2, bl3, ba12, ba23);
-    du = dl;
-    dl -= GEN_DIST_TOL;
-    du += GEN_DIST_TOL;
-    path14.type = Path14Configuration::TRANS;
-    accumData.transPaths[bid1 * nb * nb + bid2 * nb + bid3] = 1;
-    accumData.transPaths[bid3 * nb * nb + bid2 * nb + bid1] = 1;
-
   } else {
     // here we will assume anything is possible
     dl = RDGeom::compute14DistCis(bl1, bl2, bl3, ba12, ba23);
@@ -1479,8 +1467,8 @@ void _setMacrocycleAllInSameRing14Bounds(const ROMol &mol, const Bond *bnd1,
           dl -= GEN_DIST_TOL;
           du += GEN_DIST_TOL;
           path14.type = Path14Configuration::TRANS;
-          transPaths[static_cast<unsigned long>(bid1)*nb*nb + bid2*nb + bid3] = 1;
-          transPaths[static_cast<unsigned long>(bid3)*nb*nb + bid2*nb + bid1] = 1;
+          accumData.transPaths[static_cast<unsigned long>(bid1)*nb*nb + bid2*nb + bid3] = 1;
+          accumData.transPaths[static_cast<unsigned long>(bid3)*nb*nb + bid2*nb + bid1] = 1;
         } else
 #endif
 

--- a/Code/GraphMol/DistGeomHelpers/BoundsMatrixBuilder.cpp
+++ b/Code/GraphMol/DistGeomHelpers/BoundsMatrixBuilder.cpp
@@ -1304,9 +1304,6 @@ void _setMacrocycleTwoInSameRing14Bounds(const ROMol &mol, const Bond *bnd1,
     return;
   }
 
-  Atom::HybridizationType ahyb3 = atm3->getHybridization();
-  Atom::HybridizationType ahyb2 = atm2->getHybridization();
-
   double bl1 = accumData.bondLengths[bid1];
   double bl2 = accumData.bondLengths[bid2];
   double bl3 = accumData.bondLengths[bid3];

--- a/Code/GraphMol/DistGeomHelpers/Wrap/rdDistGeom.cpp
+++ b/Code/GraphMol/DistGeomHelpers/Wrap/rdDistGeom.cpp
@@ -31,7 +31,8 @@ int EmbedMolecule(ROMol &mol, unsigned int maxAttempts, int seed,
                   bool ignoreSmoothingFailures, bool enforceChirality,
                   bool useExpTorsionAnglePrefs, bool useBasicKnowledge,
                   bool printExpTorsionAngles, bool useSmallRingTorsions,
-                  bool useMacrocycleTorsions, unsigned int ETversion) {
+                  bool useMacrocycleTorsions, unsigned int ETversion,
+                  bool useMacrocycle14config) {
   std::map<int, RDGeom::Point3D> pMap;
   python::list ks = coordMap.keys();
   unsigned int nKeys = python::extract<unsigned int>(ks.attr("__len__")());
@@ -54,7 +55,7 @@ int EmbedMolecule(ROMol &mol, unsigned int maxAttempts, int seed,
       randNegEig, numZeroFail, pMapPtr, forceTol, ignoreSmoothingFailures,
       enforceChirality, useExpTorsionAnglePrefs, useBasicKnowledge, verbose,
       basinThresh, pruneRmsThresh, onlyHeavyAtomsForRMS, ETversion, nullptr,
-      true, useSmallRingTorsions, useMacrocycleTorsions);
+      true, useSmallRingTorsions, useMacrocycleTorsions, useMacrocycle14config);
 
   int res;
   {
@@ -80,7 +81,8 @@ INT_VECT EmbedMultipleConfs(
     double forceTol, bool ignoreSmoothingFailures, bool enforceChirality,
     int numThreads, bool useExpTorsionAnglePrefs, bool useBasicKnowledge,
     bool printExpTorsionAngles, bool useSmallRingTorsions,
-    bool useMacrocycleTorsions, unsigned int ETversion) {
+    bool useMacrocycleTorsions, unsigned int ETversion,
+    bool useMacrocycle14config) {
   std::map<int, RDGeom::Point3D> pMap;
   python::list ks = coordMap.keys();
   unsigned int nKeys = python::extract<unsigned int>(ks.attr("__len__")());
@@ -100,7 +102,7 @@ INT_VECT EmbedMultipleConfs(
       randNegEig, numZeroFail, pMapPtr, forceTol, ignoreSmoothingFailures,
       enforceChirality, useExpTorsionAnglePrefs, useBasicKnowledge, verbose,
       basinThresh, pruneRmsThresh, onlyHeavyAtomsForRMS, ETversion, nullptr,
-      true, useSmallRingTorsions, useMacrocycleTorsions);
+      true, useSmallRingTorsions, useMacrocycleTorsions, useMacrocycle14config);
 
   INT_VECT res;
   {
@@ -295,7 +297,7 @@ BOOST_PYTHON_MODULE(rdDistGeom) {
     - clearConfs : clear all existing conformations on the molecule\n\
     - useRandomCoords : Start the embedding from random coordinates instead of\n\
                         using eigenvalues of the distance matrix.\n\
-    - boxSizeMult    Determines the size of the box that is used for\n\
+    - boxSizeMult :  Determines the size of the box that is used for\n\
                      random coordinates. If this is a positive number, the \n\
                      side length will equal the largest element of the distance\n\
                      matrix times boxSizeMult. If this is a negative number,\n\
@@ -316,6 +318,11 @@ BOOST_PYTHON_MODULE(rdDistGeom) {
     - useExpTorsionAnglePrefs : impose experimental torsion angle preferences\n\
     - useBasicKnowledge : impose basic knowledge such as flat rings\n\
     - printExpTorsionAngles : print the output from the experimental torsion angles\n\
+    - useMacrocycleTorsions : use additional torsion profiles for macrocycles\n\
+    - ETversion : version of the standard torsion definitions to use. NOTE for both\n\
+                  ETKDGv2 and ETKDGv3 this should be 2 since ETKDGv3 uses the ETKDGv2\n\
+                  definitions for standard torsions\n\
+    - useMacrocycle14config : use the 1-4 distance bounds from ETKDGv3\n\
 \n\
  RETURNS:\n\n\
     ID of the new conformation added to the molecule \n\
@@ -334,7 +341,8 @@ BOOST_PYTHON_MODULE(rdDistGeom) {
        python::arg("printExpTorsionAngles") = false,
        python::arg("useSmallRingTorsions") = false,
        python::arg("useMacrocycleTorsions") = true,
-       python::arg("ETversion") = 2),
+       python::arg("ETversion") = 2,
+       python::arg("useMacrocycle14config") = true),
       docString.c_str());
 
   docString =
@@ -403,7 +411,8 @@ BOOST_PYTHON_MODULE(rdDistGeom) {
        python::arg("printExpTorsionAngles") = false,
        python::arg("useSmallRingTorsions") = false,
        python::arg("useMacrocycleTorsions") = true,
-       python::arg("ETversion") = 2),
+       python::arg("ETversion") = 2,
+       python::arg("useMacrocycle14config") = true),
       docString.c_str());
 
   python::enum_<RDKit::DGeomHelpers::EmbedFailureCauses>("EmbedFailureCauses")
@@ -503,6 +512,10 @@ BOOST_PYTHON_MODULE(rdDistGeom) {
           "useMacrocycleTorsions",
           &RDKit::DGeomHelpers::EmbedParameters::useMacrocycleTorsions,
           "impose macrocycle torsion angle preferences")
+      .def_readwrite(
+          "useMacrocycle14config",
+          &RDKit::DGeomHelpers::EmbedParameters::useMacrocycle14config,
+          "use the 1-4 distance bounds from ETKDGv3")
       .def_readwrite(
           "boundsMatForceScaling",
           &RDKit::DGeomHelpers::EmbedParameters::boundsMatForceScaling,

--- a/Code/GraphMol/DistGeomHelpers/Wrap/testDistGeom.py
+++ b/Code/GraphMol/DistGeomHelpers/Wrap/testDistGeom.py
@@ -649,7 +649,7 @@ class TestCase(unittest.TestCase):
     smiles_mol = Chem.MolFromSmiles(smiles)
     mol = Chem.AddHs(smiles_mol)
     params = AllChem.ETKDGv3()
-    params.seed = 42
+    params.randomSeed = 0
     AllChem.EmbedMolecule(mol, params)
     conf = mol.GetConformer(0)
     for torsion in get_atom_mapping(mol):

--- a/Code/GraphMol/DistGeomHelpers/catch_tests.cpp
+++ b/Code/GraphMol/DistGeomHelpers/catch_tests.cpp
@@ -746,3 +746,30 @@ TEST_CASE("Sequential random seeds") {
     compareConfs(mol.get(), &mol2, 5, 0);
   }
 }
+
+TEST_CASE("Macrocycle bounds matrix") {
+  SECTION("basics") {
+    auto mol = "C1/C=C/C=C/CCCCCCCCC1"_smiles;
+    REQUIRE(mol);
+    MolOps::addHs(*mol);
+
+    DistGeom::BoundsMatPtr bm{new DistGeom::BoundsMatrix(mol->getNumAtoms())};
+    DGeomHelpers::initBoundsMat(bm, 0.0, 1000.0);
+    DGeomHelpers::setTopolBounds(*mol, bm, true, false, true);
+    CHECK(bm->getLowerBound(1, 18) > 2.6);
+    CHECK(bm->getLowerBound(1, 18) < 2.7);
+    CHECK(bm->getLowerBound(4, 17) > 2.6);
+    CHECK(bm->getLowerBound(4, 17) < 2.7);
+
+    DGeomHelpers::EmbedParameters ps = DGeomHelpers::ETKDGv3;
+    ps.randomSeed = 0;
+
+    auto cid = DGeomHelpers::EmbedMolecule(*mol, ps);
+    CHECK(cid >= 0);
+    const auto conf = mol->getConformer(cid);
+    RDGeom::Point3D pos_1 = conf.getAtomPos(1);
+    RDGeom::Point3D pos_4 = conf.getAtomPos(4);
+    CHECK((pos_1 - pos_4).length() < 3.6);
+    CHECK((pos_1 - pos_4).length() > 3.5);
+  }
+}


### PR DESCRIPTION
# Summary
In a system with conjugated double bonds, the single bond in the middle can be either "trans" (180 degrees) or "cis" (0 degrees). In a non-cyclic system, the trans configuration is preferred. In a small ring (like benzene), the single bond needs to be cis. However, in a macroycle both options should be possible. However, ETKDG previously only generated the "cis" conformer.

# Changes
* Previously, `C=C([#1])C([#1])=C` groups in a macrocycle were always cis because of a bug in the bounds calculation. Although the bounds within the main chain (carbon-carbon) allowed cis or trans, the 1-4 bounds of the H atoms were always set to trans, which forces the carbons into the cis position. This change fixes this behavior to allow cis or trans conformations.
* Furthermore, the useMacrocycle14config flag could only be used from Python by creating an ETKDGv3 object, and defaulted to False otherwise. This change adds the flag to EmbedMolecule, EmbedMultipleConfs, and the EmbedParameters Python interface.
* This also adds a test case for the changed behavior. The test uses the molecule `C1/C=C/C=C/CCCCCCCCC1` (fails with the old code, but succeeds with the new one)
* I also updated the docstring in EmbedMolecule according to https://www.rdkit.org/docs/RDKit_Book.html#parameters-controlling-conformer-generation (copying the description of useMacrocycleTorsions and useMacrocycle14config)

I made the default `useMacrocycle14config=True` in EmbedMolecule, to be consistent with the default for useMacrocycleTorsion. However, it was previously False, so this could change the behavior of existing scripts. How should we deal with this?

# To-do
* I only made a test case from the C++ side, but if you want, I could also add a test case with the same content for the Python side to test the useMacrocycle14config flag.
* Run the macrocycle conformer generation test set.