### PR TITLE
Refactoring of MolStandardize::ValidationErrorInfo

### DIFF
--- a/Code/GraphMol/MolStandardize/Validate.cpp
+++ b/Code/GraphMol/MolStandardize/Validate.cpp
@@ -37,7 +37,7 @@ std::vector<ValidationErrorInfo> RDKitValidation::validate(
   unsigned int na = mol.getNumAtoms();
 
   if (!na) {
-    errors.emplace_back("ERROR: [NoAtomValidation] Molecule has no atoms");
+    errors.push_back({"ERROR", "NoAtomValidation", "Molecule has no atoms"});
   }
 
   // loop over atoms
@@ -51,7 +51,7 @@ std::vector<ValidationErrorInfo> RDKitValidation::validate(
     try {
       atom->calcExplicitValence();
     } catch (const MolSanitizeException &e) {
-      errors.emplace_back("INFO: [ValenceValidation] " + std::string(e.what()));
+      errors.push_back({"INFO", "ValenceValidation", e.what()});
     }
   }
   return errors;
@@ -62,7 +62,7 @@ void NoAtomValidation::run(const ROMol &mol, bool,
   unsigned int na = mol.getNumAtoms();
 
   if (!na) {
-    errors.emplace_back("ERROR: [NoAtomValidation] Molecule has no atoms");
+    errors.push_back({"ERROR", "NoAtomValidation", "Molecule has no atoms"});
   }
 }
 
@@ -117,7 +117,7 @@ void FragmentValidation::run(const ROMol &mol, bool reportAllFailures,
           //					//
           if ((molfragidx == substructidx) && !fpresent) {
             std::string msg = fname + " is present";
-            errors.emplace_back("INFO: [FragmentValidation] " + msg);
+            errors.push_back({"INFO", "FragmentValidation", msg});
             fpresent = true;
           }
         }
@@ -137,7 +137,7 @@ void NeutralValidation::run(const ROMol &mol, bool,
       charge_str = std::to_string(charge);
     }
     std::string msg = "Not an overall neutral system (" + charge_str + ')';
-    errors.emplace_back("INFO: [NeutralValidation] " + msg);
+    errors.push_back({"INFO", "NeutralValidation", msg});
   }
 }
 
@@ -162,8 +162,8 @@ void IsotopeValidation::run(const ROMol &mol, bool reportAllFailures,
   }
 
   for (auto &isotope : isotopes) {
-    errors.emplace_back("INFO: [IsotopeValidation] Molecule contains isotope " +
-                        isotope);
+    errors.push_back({"INFO", "IsotopeValidation",
+                      "Molecule contains isotope " + isotope});
   }
 }
 
@@ -224,8 +224,8 @@ std::vector<ValidationErrorInfo> AllowedAtomsValidation::validate(
     // if no match, append to list of errors.
     if (!match) {
       std::string symbol = qatom->getSymbol();
-      errors.emplace_back("INFO: [AllowedAtomsValidation] Atom " + symbol +
-                          " is not in allowedAtoms list");
+      errors.push_back({"INFO", "AllowedAtomsValidation",
+                        "Atom " + symbol + " is not in allowedAtoms list"});
     }
   }
   return errors;
@@ -253,8 +253,8 @@ std::vector<ValidationErrorInfo> DisallowedAtomsValidation::validate(
     // if no match, append to list of errors.
     if (match) {
       std::string symbol = qatom->getSymbol();
-      errors.emplace_back("INFO: [DisallowedAtomsValidation] Atom " + symbol +
-                          " is in disallowedAtoms list");
+      errors.push_back({"INFO", "DisallowedAtomsValidation",
+                        "Atom " + symbol + " is in disallowedAtoms list"});
     }
   }
   return errors;

--- a/Code/GraphMol/MolStandardize/Validate.cpp
+++ b/Code/GraphMol/MolStandardize/Validate.cpp
@@ -37,7 +37,7 @@ std::vector<ValidationErrorInfo> RDKitValidation::validate(
   unsigned int na = mol.getNumAtoms();
 
   if (!na) {
-    errors.push_back({"ERROR", "NoAtomValidation", "Molecule has no atoms"});
+    errors.emplace_back("ERROR", "NoAtomValidation", "Molecule has no atoms");
   }
 
   // loop over atoms
@@ -51,7 +51,7 @@ std::vector<ValidationErrorInfo> RDKitValidation::validate(
     try {
       atom->calcExplicitValence();
     } catch (const MolSanitizeException &e) {
-      errors.push_back({"INFO", "ValenceValidation", e.what()});
+      errors.emplace_back("INFO", "ValenceValidation", e.what());
     }
   }
   return errors;
@@ -62,7 +62,7 @@ void NoAtomValidation::run(const ROMol &mol, bool,
   unsigned int na = mol.getNumAtoms();
 
   if (!na) {
-    errors.push_back({"ERROR", "NoAtomValidation", "Molecule has no atoms"});
+    errors.emplace_back("ERROR", "NoAtomValidation", "Molecule has no atoms");
   }
 }
 
@@ -117,7 +117,7 @@ void FragmentValidation::run(const ROMol &mol, bool reportAllFailures,
           //					//
           if ((molfragidx == substructidx) && !fpresent) {
             std::string msg = fname + " is present";
-            errors.push_back({"INFO", "FragmentValidation", msg});
+            errors.emplace_back("INFO", "FragmentValidation", msg);
             fpresent = true;
           }
         }
@@ -137,7 +137,7 @@ void NeutralValidation::run(const ROMol &mol, bool,
       charge_str = std::to_string(charge);
     }
     std::string msg = "Not an overall neutral system (" + charge_str + ')';
-    errors.push_back({"INFO", "NeutralValidation", msg});
+    errors.emplace_back("INFO", "NeutralValidation", msg);
   }
 }
 
@@ -162,8 +162,8 @@ void IsotopeValidation::run(const ROMol &mol, bool reportAllFailures,
   }
 
   for (auto &isotope : isotopes) {
-    errors.push_back({"INFO", "IsotopeValidation",
-                      "Molecule contains isotope " + isotope});
+    errors.emplace_back("INFO", "IsotopeValidation",
+                        "Molecule contains isotope " + isotope);
   }
 }
 
@@ -224,8 +224,8 @@ std::vector<ValidationErrorInfo> AllowedAtomsValidation::validate(
     // if no match, append to list of errors.
     if (!match) {
       std::string symbol = qatom->getSymbol();
-      errors.push_back({"INFO", "AllowedAtomsValidation",
-                        "Atom " + symbol + " is not in allowedAtoms list"});
+      errors.emplace_back("INFO", "AllowedAtomsValidation",
+                          "Atom " + symbol + " is not in allowedAtoms list");
     }
   }
   return errors;
@@ -253,8 +253,8 @@ std::vector<ValidationErrorInfo> DisallowedAtomsValidation::validate(
     // if no match, append to list of errors.
     if (match) {
       std::string symbol = qatom->getSymbol();
-      errors.push_back({"INFO", "DisallowedAtomsValidation",
-                        "Atom " + symbol + " is in disallowedAtoms list"});
+      errors.emplace_back("INFO", "DisallowedAtomsValidation",
+                          "Atom " + symbol + " is in disallowedAtoms list");
     }
   }
   return errors;

--- a/Code/GraphMol/MolStandardize/Validate.h
+++ b/Code/GraphMol/MolStandardize/Validate.h
@@ -35,17 +35,19 @@ namespace MolStandardize {
 
 //! The ValidationErrorInfo class is used to store the information returned by a
 /// ValidationMethod validate.
-class RDKIT_MOLSTANDARDIZE_EXPORT ValidationErrorInfo : public std::exception {
- public:
-  ValidationErrorInfo(std::string msg) : d_msg(std::move(msg)) {
-    BOOST_LOG(rdInfoLog) << d_msg << std::endl;
-  }
-  const char *what() const noexcept override { return d_msg.c_str(); }
-  ~ValidationErrorInfo() noexcept override = default;
+struct RDKIT_MOLSTANDARDIZE_EXPORT ValidationErrorInfo {
+  std::string level;
+  std::string component;
+  std::string message;
 
- private:
-  std::string d_msg;
-};  // class ValidationErrorInfo
+  bool operator==(const ValidationErrorInfo & other) const {
+    return (this == &other) || (
+      level == other.level &&
+      component == other.component &&
+      message == other.message
+    );
+  }
+};
 
 //! The ValidationMethod class is the abstract base class upon which all the
 /// four different ValidationMethods inherit from.

--- a/Code/GraphMol/MolStandardize/Validate.h
+++ b/Code/GraphMol/MolStandardize/Validate.h
@@ -41,7 +41,7 @@ struct RDKIT_MOLSTANDARDIZE_EXPORT ValidationErrorInfo {
   std::string message;
 
   bool operator==(const ValidationErrorInfo & other) const {
-    return (this == &other) || (
+    return (
       level == other.level &&
       component == other.component &&
       message == other.message

--- a/Code/GraphMol/MolStandardize/Validate.h
+++ b/Code/GraphMol/MolStandardize/Validate.h
@@ -40,6 +40,11 @@ struct RDKIT_MOLSTANDARDIZE_EXPORT ValidationErrorInfo {
   std::string component;
   std::string message;
 
+  ValidationErrorInfo(std::string level, std::string component, std::string message)
+    : level(std::move(level)), component(std::move(component)), message(std::move(message))
+  {
+  }
+
   bool operator==(const ValidationErrorInfo & other) const {
     return (
       level == other.level &&

--- a/Code/GraphMol/MolStandardize/Wrap/Validate.cpp
+++ b/Code/GraphMol/MolStandardize/Wrap/Validate.cpp
@@ -12,6 +12,17 @@
 #include <GraphMol/RDKitBase.h>
 #include <GraphMol/MolStandardize/Validate.h>
 
+namespace RDKit {
+namespace MolStandardize {
+std::ostream &operator<<(std::ostream &ostr, const MolStandardize::ValidationErrorInfo &vei)
+{
+  ostr
+    << "ValidationErrorInfo('" << vei.level << "', '" << vei.component << "', '" << vei.message << "')";
+  return ostr;
+}
+}
+}
+
 namespace python = boost::python;
 using namespace RDKit;
 
@@ -121,10 +132,16 @@ struct validate_wrapper {
   static void wrap() {
     std::string docString = "";
 
-    python::class_<MolStandardize::ValidationErrorInfo>("ValidationErrorInfo")
+    python::class_<MolStandardize::ValidationErrorInfo>(
+          "ValidationErrorInfo",
+          python::init<std::string, std::string, std::string>(
+            python::args("self", "level", "component", "message"))
+        )
         .def_readwrite("level", &MolStandardize::ValidationErrorInfo::level)
         .def_readwrite("component", &MolStandardize::ValidationErrorInfo::component)
         .def_readwrite("message", &MolStandardize::ValidationErrorInfo::message)
+        .def(python::self == python::self)
+        .def(python::self_ns::repr(python::self))
         ;
 
     python::class_<MolStandardize::RDKitValidation, boost::noncopyable>(

--- a/Code/GraphMol/MolStandardize/Wrap/Validate.cpp
+++ b/Code/GraphMol/MolStandardize/Wrap/Validate.cpp
@@ -23,8 +23,7 @@ python::list rdkitValidate(MolStandardize::RDKitValidation &self,
   std::vector<MolStandardize::ValidationErrorInfo> errout =
       self.validate(mol, reportAllFailures);
   for (auto &query : errout) {
-    std::string msg = query.what();
-    res.append(msg);
+    res.append(query);
   }
   return res;
 }
@@ -51,7 +50,7 @@ python::list molVSvalidateHelper(MolStandardize::MolVSValidation &self,
   std::vector<MolStandardize::ValidationErrorInfo> errout =
       self.validate(mol, reportAllFailures);
   for (auto &query : errout) {
-    s.append(query.what());
+    s.append(query);
   }
   return s;
 }
@@ -76,8 +75,7 @@ python::list allowedAtomsValidate(MolStandardize::AllowedAtomsValidation &self,
   std::vector<MolStandardize::ValidationErrorInfo> errout =
       self.validate(mol, reportAllFailures);
   for (auto &query : errout) {
-    std::string msg = query.what();
-    res.append(msg);
+    res.append(query);
   }
   return res;
 }
@@ -102,8 +100,7 @@ python::list disallowedAtomsValidate(
   std::vector<MolStandardize::ValidationErrorInfo> errout =
       self.validate(mol, reportAllFailures);
   for (auto &query : errout) {
-    std::string msg = query.what();
-    res.append(msg);
+    res.append(query);
   }
   return res;
 }
@@ -113,8 +110,7 @@ python::list standardizeSmilesHelper(const std::string &smiles) {
   std::vector<MolStandardize::ValidationErrorInfo> errout =
       MolStandardize::validateSmiles(smiles);
   for (auto &query : errout) {
-    std::string msg = query.what();
-    res.append(msg);
+    res.append(query);
   }
   return res;
 }
@@ -124,6 +120,12 @@ python::list standardizeSmilesHelper(const std::string &smiles) {
 struct validate_wrapper {
   static void wrap() {
     std::string docString = "";
+
+    python::class_<MolStandardize::ValidationErrorInfo>("ValidationErrorInfo")
+        .def_readwrite("level", &MolStandardize::ValidationErrorInfo::level)
+        .def_readwrite("component", &MolStandardize::ValidationErrorInfo::component)
+        .def_readwrite("message", &MolStandardize::ValidationErrorInfo::message)
+        ;
 
     python::class_<MolStandardize::RDKitValidation, boost::noncopyable>(
         "RDKitValidation", python::init<>(python::args("self")))

--- a/Code/GraphMol/MolStandardize/Wrap/testMolStandardize.py
+++ b/Code/GraphMol/MolStandardize/Wrap/testMolStandardize.py
@@ -269,10 +269,10 @@ class TestCase(unittest.TestCase):
     mol = Chem.MolFromSmiles("CO(C)C", sanitize=False)
     errors = vm.validate(mol)
     self.assertEqual(len(errors), 1)
-    error = errors[0]
     self.assertEqual(
-      (error.level, error.component, error.message),
-      ("INFO", "ValenceValidation", "Explicit valence for atom # 1 O, 3, is greater than permitted"))
+      errors[0],
+      rdMolStandardize.ValidationErrorInfo(
+        "INFO", "ValenceValidation", "Explicit valence for atom # 1 O, 3, is greater than permitted"))
 
     vm2 = rdMolStandardize.MolVSValidation([rdMolStandardize.FragmentValidation()])
     # with no argument it also works
@@ -280,22 +280,23 @@ class TestCase(unittest.TestCase):
     mol2 = Chem.MolFromSmiles("COc1cccc(C=N[N-]C(N)=O)c1[O-].O.O.O.O=[U+2]=O")
     errors2 = vm2.validate(mol2)
     self.assertEqual(len(errors2), 1)
-    error2 = errors2[0]
     self.assertEqual(
-      (error2.level, error2.component, error2.message),
-      ("INFO", "FragmentValidation", "water/hydroxide is present"))
+      errors2[0],
+      rdMolStandardize.ValidationErrorInfo(
+        "INFO", "FragmentValidation", "water/hydroxide is present"))
 
     vm3 = rdMolStandardize.MolVSValidation()
     mol3 = Chem.MolFromSmiles("C1COCCO1.O=C(NO)NO")
     errors3 = vm3.validate(mol3)
     self.assertEqual(len(errors3), 2)
-    error3a, error3b = errors3
     self.assertEqual(
-      (error3a.level, error3a.component, error3a.message),
-      ("INFO", "FragmentValidation", "1,2-dimethoxyethane is present"))
+      errors3[0],
+      rdMolStandardize.ValidationErrorInfo(
+        "INFO", "FragmentValidation", "1,2-dimethoxyethane is present"))
     self.assertEqual(
-      (error3b.level, error3b.component, error3b.message),
-      ("INFO", "FragmentValidation", "1,4-dioxane is present"))
+      errors3[1],
+      rdMolStandardize.ValidationErrorInfo(
+        "INFO", "FragmentValidation", "1,4-dioxane is present"))
 
     atomic_no = [6, 7, 8]
     allowed_atoms = [Atom(i) for i in atomic_no]
@@ -303,10 +304,10 @@ class TestCase(unittest.TestCase):
     mol4 = Chem.MolFromSmiles("CC(=O)CF")
     errors4 = vm4.validate(mol4)
     self.assertEqual(len(errors4), 1)
-    error4 = errors4[0]
     self.assertEqual(
-      (error4.level, error4.component, error4.message),
-      ("INFO", "AllowedAtomsValidation", "Atom F is not in allowedAtoms list"))
+      errors4[0],
+      rdMolStandardize.ValidationErrorInfo(
+        "INFO", "AllowedAtomsValidation", "Atom F is not in allowedAtoms list"))
 
     atomic_no = [9, 17, 35]
     disallowed_atoms = [Atom(i) for i in atomic_no]
@@ -314,17 +315,17 @@ class TestCase(unittest.TestCase):
     mol5 = Chem.MolFromSmiles("CC(=O)CF")
     errors5 = vm5.validate(mol5)
     self.assertEqual(len(errors5), 1)
-    error5 = errors5[0]
     self.assertEqual(
-      (error5.level, error5.component, error5.message),
-      ("INFO", "DisallowedAtomsValidation", "Atom F is in disallowedAtoms list"))
+      errors5[0],
+      rdMolStandardize.ValidationErrorInfo(
+        "INFO", "DisallowedAtomsValidation", "Atom F is in disallowedAtoms list"))
 
     errors6 = rdMolStandardize.ValidateSmiles("ClCCCl.c1ccccc1O")
     self.assertEqual(len(errors6), 1)
-    error6 = errors6[0]
     self.assertEqual(
-      (error6.level, error6.component, error6.message),
-      ("INFO", "FragmentValidation", "1,2-dichloroethane is present"))
+      errors6[0],
+      rdMolStandardize.ValidationErrorInfo(
+        "INFO", "FragmentValidation", "1,2-dichloroethane is present"))
 
   def test10NormalizeFromData(self):
     data = """//	Name	SMIRKS

--- a/Code/GraphMol/MolStandardize/Wrap/testMolStandardize.py
+++ b/Code/GraphMol/MolStandardize/Wrap/testMolStandardize.py
@@ -267,52 +267,64 @@ class TestCase(unittest.TestCase):
   def test9Validate(self):
     vm = rdMolStandardize.RDKitValidation()
     mol = Chem.MolFromSmiles("CO(C)C", sanitize=False)
-    msg = vm.validate(mol)
-    self.assertEqual(len(msg), 1)
-    self.assertEqual
-    ("""INFO: [ValenceValidation] Explicit valence for atom # 1 O, 3, is greater than permitted""",
-     msg[0])
+    errors = vm.validate(mol)
+    self.assertEqual(len(errors), 1)
+    error = errors[0]
+    self.assertEqual(
+      (error.level, error.component, error.message),
+      ("INFO", "ValenceValidation", "Explicit valence for atom # 1 O, 3, is greater than permitted"))
 
     vm2 = rdMolStandardize.MolVSValidation([rdMolStandardize.FragmentValidation()])
     # with no argument it also works
     #    vm2 = rdMolStandardize.MolVSValidation()
     mol2 = Chem.MolFromSmiles("COc1cccc(C=N[N-]C(N)=O)c1[O-].O.O.O.O=[U+2]=O")
-    msg2 = vm2.validate(mol2)
-    self.assertEqual(len(msg2), 1)
-    self.assertEqual
-    ("""INFO: [FragmentValidation] water/hydroxide is present""", msg2[0])
+    errors2 = vm2.validate(mol2)
+    self.assertEqual(len(errors2), 1)
+    error2 = errors2[0]
+    self.assertEqual(
+      (error2.level, error2.component, error2.message),
+      ("INFO", "FragmentValidation", "water/hydroxide is present"))
 
     vm3 = rdMolStandardize.MolVSValidation()
     mol3 = Chem.MolFromSmiles("C1COCCO1.O=C(NO)NO")
-    msg3 = vm3.validate(mol3)
-    self.assertEqual(len(msg3), 2)
-    self.assertEqual
-    ("""INFO: [FragmentValidation] 1,2-dimethoxyethane is present""", msg3[0])
-    self.assertEqual
-    ("""INFO: [FragmentValidation] 1,4-dioxane is present""", msg3[1])
+    errors3 = vm3.validate(mol3)
+    self.assertEqual(len(errors3), 2)
+    error3a, error3b = errors3
+    self.assertEqual(
+      (error3a.level, error3a.component, error3a.message),
+      ("INFO", "FragmentValidation", "1,2-dimethoxyethane is present"))
+    self.assertEqual(
+      (error3b.level, error3b.component, error3b.message),
+      ("INFO", "FragmentValidation", "1,4-dioxane is present"))
 
     atomic_no = [6, 7, 8]
     allowed_atoms = [Atom(i) for i in atomic_no]
     vm4 = rdMolStandardize.AllowedAtomsValidation(allowed_atoms)
     mol4 = Chem.MolFromSmiles("CC(=O)CF")
-    msg4 = vm4.validate(mol4)
-    self.assertEqual(len(msg4), 1)
-    self.assertEqual
-    ("""INFO: [AllowedAtomsValidation] Atom F is not in allowedAtoms list""", msg4[0])
+    errors4 = vm4.validate(mol4)
+    self.assertEqual(len(errors4), 1)
+    error4 = errors4[0]
+    self.assertEqual(
+      (error4.level, error4.component, error4.message),
+      ("INFO", "AllowedAtomsValidation", "Atom F is not in allowedAtoms list"))
 
     atomic_no = [9, 17, 35]
     disallowed_atoms = [Atom(i) for i in atomic_no]
     vm5 = rdMolStandardize.DisallowedAtomsValidation(disallowed_atoms)
     mol5 = Chem.MolFromSmiles("CC(=O)CF")
-    msg5 = vm4.validate(mol5)
-    self.assertEqual(len(msg5), 1)
-    self.assertEqual
-    ("""INFO: [DisallowedAtomsValidation] Atom F is in disallowedAtoms list""", msg5[0])
+    errors5 = vm5.validate(mol5)
+    self.assertEqual(len(errors5), 1)
+    error5 = errors5[0]
+    self.assertEqual(
+      (error5.level, error5.component, error5.message),
+      ("INFO", "DisallowedAtomsValidation", "Atom F is in disallowedAtoms list"))
 
-    msg6 = rdMolStandardize.ValidateSmiles("ClCCCl.c1ccccc1O")
-    self.assertEqual(len(msg6), 1)
-    self.assertEqual
-    ("""INFO: [FragmentValidation] 1,2-dichloroethane is present""", msg6[0])
+    errors6 = rdMolStandardize.ValidateSmiles("ClCCCl.c1ccccc1O")
+    self.assertEqual(len(errors6), 1)
+    error6 = errors6[0]
+    self.assertEqual(
+      (error6.level, error6.component, error6.message),
+      ("INFO", "FragmentValidation", "1,2-dichloroethane is present"))
 
   def test10NormalizeFromData(self):
     data = """//	Name	SMIRKS

--- a/Code/GraphMol/MolStandardize/test2.cpp
+++ b/Code/GraphMol/MolStandardize/test2.cpp
@@ -66,11 +66,10 @@ void testValidate() {
     RWMOL_SPTR m(SmilesToMol(smi, 0, false));
     std::vector<ValidationErrorInfo> errout = vm.validate(*m, true);
     for (auto &query : errout) {
-      std::string msg = query.what();
-      TEST_ASSERT(
-          msg ==
-          "INFO: [ValenceValidation] Explicit valence for atom # 1 O, 3, "
-          "is greater than permitted");
+      TEST_ASSERT(query == ValidationErrorInfo({
+        "INFO", "ValenceValidation",
+        "Explicit valence for atom # 1 O, 3, is greater than permitted"
+      }));
     }
   }
   //**************************
@@ -80,10 +79,9 @@ void testValidate() {
     RWMOL_SPTR m(SmilesToMol(smi, 0, false));
     std::vector<ValidationErrorInfo> errout = vm.validate(*m, true);
     for (auto &query : errout) {
-      std::string msg = query.what();
-      TEST_ASSERT(
-          msg ==
-          "INFO: [NeutralValidation] Not an overall neutral system (-1)");
+      TEST_ASSERT(query == ValidationErrorInfo({
+        "INFO", "NeutralValidation", "Not an overall neutral system (-1)"
+      }));
     }
   }
   // ************************
@@ -100,10 +98,9 @@ void testValidate() {
     RWMOL_SPTR m = "CC(=O)CF"_smiles;
     std::vector<ValidationErrorInfo> errout = vm.validate(*m, true);
     for (auto &query : errout) {
-      std::string msg = query.what();
-      TEST_ASSERT(
-          msg ==
-          "INFO: [AllowedAtomsValidation] Atom F is not in allowedAtoms list");
+      TEST_ASSERT(query == ValidationErrorInfo({
+        "INFO", "AllowedAtomsValidation", "Atom F is not in allowedAtoms list"
+      }));
     }
   }
   //********************************
@@ -120,10 +117,9 @@ void testValidate() {
     RWMOL_SPTR m = "CC(=O)CF"_smiles;
     std::vector<ValidationErrorInfo> errout = vm.validate(*m, true);
     for (auto &query : errout) {
-      std::string msg = query.what();
-      TEST_ASSERT(msg ==
-                  "INFO: [DisallowedAtomsValidation] Atom F is in "
-                  "disallowedAtoms list");
+      TEST_ASSERT(query == ValidationErrorInfo({
+        "INFO", "DisallowedAtomsValidation", "Atom F is in disallowedAtoms list"
+      }));
     }
   }
   //********************************
@@ -135,9 +131,9 @@ void testValidate() {
     RWMOL_SPTR m(SmilesToMol(smi, 0, false));
     std::vector<ValidationErrorInfo> errout = vm.validate(*m, true);
     for (auto &query : errout) {
-      std::string msg = query.what();
-      TEST_ASSERT(msg ==
-                  "INFO: [FragmentValidation] 1,2-dichloroethane is present");
+      TEST_ASSERT(query == ValidationErrorInfo({
+        "INFO", "FragmentValidation", "1,2-dichloroethane is present"
+      }));
     }
     BOOST_LOG(rdInfoLog) << "Finished" << std::endl;
   }

--- a/Code/GraphMol/MolStandardize/test2.cpp
+++ b/Code/GraphMol/MolStandardize/test2.cpp
@@ -66,10 +66,10 @@ void testValidate() {
     RWMOL_SPTR m(SmilesToMol(smi, 0, false));
     std::vector<ValidationErrorInfo> errout = vm.validate(*m, true);
     for (auto &query : errout) {
-      TEST_ASSERT(query == ValidationErrorInfo({
+      TEST_ASSERT(query == ValidationErrorInfo(
         "INFO", "ValenceValidation",
-        "Explicit valence for atom # 1 O, 3, is greater than permitted"
-      }));
+        "Explicit valence for atom # 1 O, 3, is greater than permitted")
+        );
     }
   }
   //**************************
@@ -79,9 +79,9 @@ void testValidate() {
     RWMOL_SPTR m(SmilesToMol(smi, 0, false));
     std::vector<ValidationErrorInfo> errout = vm.validate(*m, true);
     for (auto &query : errout) {
-      TEST_ASSERT(query == ValidationErrorInfo({
-        "INFO", "NeutralValidation", "Not an overall neutral system (-1)"
-      }));
+      TEST_ASSERT(query == ValidationErrorInfo(
+        "INFO", "NeutralValidation", "Not an overall neutral system (-1)")
+        );
     }
   }
   // ************************
@@ -98,9 +98,9 @@ void testValidate() {
     RWMOL_SPTR m = "CC(=O)CF"_smiles;
     std::vector<ValidationErrorInfo> errout = vm.validate(*m, true);
     for (auto &query : errout) {
-      TEST_ASSERT(query == ValidationErrorInfo({
-        "INFO", "AllowedAtomsValidation", "Atom F is not in allowedAtoms list"
-      }));
+      TEST_ASSERT(query == ValidationErrorInfo(
+        "INFO", "AllowedAtomsValidation", "Atom F is not in allowedAtoms list")
+        );
     }
   }
   //********************************
@@ -117,9 +117,9 @@ void testValidate() {
     RWMOL_SPTR m = "CC(=O)CF"_smiles;
     std::vector<ValidationErrorInfo> errout = vm.validate(*m, true);
     for (auto &query : errout) {
-      TEST_ASSERT(query == ValidationErrorInfo({
-        "INFO", "DisallowedAtomsValidation", "Atom F is in disallowedAtoms list"
-      }));
+      TEST_ASSERT(query == ValidationErrorInfo(
+        "INFO", "DisallowedAtomsValidation", "Atom F is in disallowedAtoms list")
+        );
     }
   }
   //********************************
@@ -131,9 +131,9 @@ void testValidate() {
     RWMOL_SPTR m(SmilesToMol(smi, 0, false));
     std::vector<ValidationErrorInfo> errout = vm.validate(*m, true);
     for (auto &query : errout) {
-      TEST_ASSERT(query == ValidationErrorInfo({
-        "INFO", "FragmentValidation", "1,2-dichloroethane is present"
-      }));
+      TEST_ASSERT(query == ValidationErrorInfo(
+        "INFO", "FragmentValidation", "1,2-dichloroethane is present")
+        );
     }
     BOOST_LOG(rdInfoLog) << "Finished" << std::endl;
   }

--- a/Code/GraphMol/MolStandardize/testValidate.cpp
+++ b/Code/GraphMol/MolStandardize/testValidate.cpp
@@ -33,10 +33,10 @@ void testRDKitValidation() {
   unique_ptr<ROMol> m1(SmilesToMol(smi1, 0, false));
   vector<ValidationErrorInfo> errout1 = vm.validate(*m1, true);
   for (auto &query : errout1) {
-    std::string msg = query.what();
-    TEST_ASSERT(msg ==
-                "INFO: [ValenceValidation] Explicit valence for atom # 1 O, 3, "
-                "is greater than permitted");
+    TEST_ASSERT(query == ValidationErrorInfo({
+      "INFO", "ValenceValidation",
+      "Explicit valence for atom # 1 O, 3, is greater than permitted"
+    }));
   }
 
   // testing for molecule with no atoms
@@ -44,38 +44,30 @@ void testRDKitValidation() {
   unique_ptr<ROMol> m2(SmilesToMol(smi2, 0, false));
   vector<ValidationErrorInfo> errout2 = vm.validate(*m2, true);
   for (auto &query : errout2) {
-    std::string msg = query.what();
-    TEST_ASSERT(msg == "ERROR: [NoAtomValidation] Molecule has no atoms");
+    TEST_ASSERT(query == ValidationErrorInfo({
+      "ERROR", "NoAtomValidation", "Molecule has no atoms"
+    }));
   }
 
   // testing molecule with multiple valency errors
   smi3 = "CO(C)CCN(=O)=O";
   unique_ptr<ROMol> m3(SmilesToMol(smi3, 0, false));
   vector<ValidationErrorInfo> errout3 = vm.validate(*m3, true);
-  std::vector<string> msgs1;
-  std::vector<string> ans1 = {
-      "INFO: [ValenceValidation] Explicit valence for atom # 1 O, 3, is "
-      "greater than permitted",
-      "INFO: [ValenceValidation] Explicit valence for atom # 5 N, 5, is "
-      "greater than permitted"};
-  for (auto &query : errout3) {
-    msgs1.emplace_back(query.what());
-  }
-  TEST_ASSERT(msgs1 == ans1);
+  std::vector<ValidationErrorInfo> ans1 = {
+    {"INFO", "ValenceValidation", "Explicit valence for atom # 1 O, 3, is greater than permitted"},
+    {"INFO", "ValenceValidation", "Explicit valence for atom # 5 N, 5, is greater than permitted"}
+  };
+  TEST_ASSERT(errout3 == ans1);
 
   // testing molecule with multiple valency errors and only outputting
   // first error
   smi4 = "CO(C)CCN(=O)=O";
   unique_ptr<ROMol> m4(SmilesToMol(smi4, 0, false));
   vector<ValidationErrorInfo> errout4 = vm.validate(*m4, false);
-  std::vector<string> msgs2;
-  std::vector<string> ans2 = {
-      "INFO: [ValenceValidation] Explicit valence for atom # 1 O, 3, is "
-      "greater than permitted"};
-  for (auto &query : errout4) {
-    msgs2.emplace_back(query.what());
-  }
-  TEST_ASSERT(msgs2 == ans2);
+  std::vector<ValidationErrorInfo> ans2 = {
+    {"INFO", "ValenceValidation", "Explicit valence for atom # 1 O, 3, is greater than permitted"}
+  };
+  TEST_ASSERT(errout4 == ans2);
   BOOST_LOG(rdInfoLog) << "Finished" << std::endl;
 }
 
@@ -91,58 +83,54 @@ void testMolVSValidation() {
   unique_ptr<ROMol> m1(SmilesToMol(smi1, 0, false));
   vector<ValidationErrorInfo> errout1 = vm.validate(*m1, true);
   for (auto &query : errout1) {
-    std::string msg = query.what();
-    TEST_ASSERT(msg == "ERROR: [NoAtomValidation] Molecule has no atoms");
+    TEST_ASSERT(query == ValidationErrorInfo({
+      "ERROR", "NoAtomValidation", "Molecule has no atoms"
+    }));
   }
 
   smi2 = "O=C([O-])c1ccccc1";
   unique_ptr<ROMol> m2(SmilesToMol(smi2, 0, false));
   vector<ValidationErrorInfo> errout2 = vm.validate(*m2, true);
   for (auto &query : errout2) {
-    std::string msg = query.what();
-    TEST_ASSERT(msg ==
-                "INFO: [NeutralValidation] Not an overall neutral system (-1)");
+    TEST_ASSERT(query == ValidationErrorInfo({
+      "INFO", "NeutralValidation", "Not an overall neutral system (-1)"
+    }))
   }
 
   smi3 = "CN=[NH+]CN=N";
   unique_ptr<ROMol> m3(SmilesToMol(smi3, 0, false));
   vector<ValidationErrorInfo> errout3 = vm.validate(*m3, true);
   for (auto &query : errout3) {
-    std::string msg = query.what();
-    TEST_ASSERT(
-        msg ==
-        "INFO: [NeutralValidation] Not an overall neutral system (+1)");  // fix
-                                                                          // to
-                                                                          // show
-                                                                          // +
-                                                                          // sign
+    TEST_ASSERT(query == ValidationErrorInfo({
+      "INFO", "NeutralValidation", "Not an overall neutral system (+1)"
+    }));
   }
 
   smi4 = "[13CH4]";
   unique_ptr<ROMol> m4(SmilesToMol(smi4, 0, false));
   vector<ValidationErrorInfo> errout4 = vm.validate(*m4, true);
   for (auto &query : errout4) {
-    std::string msg = query.what();
-    TEST_ASSERT(msg ==
-                "INFO: [IsotopeValidation] Molecule contains isotope 13C");
+    TEST_ASSERT(query == ValidationErrorInfo({
+      "INFO", "IsotopeValidation", "Molecule contains isotope 13C"
+    }));
   }
 
   smi5 = "[2H]C(Cl)(Cl)Cl";
   unique_ptr<ROMol> m5(SmilesToMol(smi5, 0, false));
   vector<ValidationErrorInfo> errout5 = vm.validate(*m5, true);
   for (auto &query : errout5) {
-    std::string msg = query.what();
-    TEST_ASSERT(msg ==
-                "INFO: [IsotopeValidation] Molecule contains isotope 2H");
+    TEST_ASSERT(query == ValidationErrorInfo({
+      "INFO", "IsotopeValidation", "Molecule contains isotope 2H"
+    }));
   }
 
   smi6 = "[2H]OC([2H])([2H])[2H]";
   unique_ptr<ROMol> m6(SmilesToMol(smi6, 0, false));
   vector<ValidationErrorInfo> errout6 = vm.validate(*m6, true);
   for (auto &query : errout6) {
-    std::string msg = query.what();
-    TEST_ASSERT(msg ==
-                "INFO: [IsotopeValidation] Molecule contains isotope 2H");
+    TEST_ASSERT(query == ValidationErrorInfo({
+      "INFO", "IsotopeValidation", "Molecule contains isotope 2H"
+    }));
   }
 
   std::string smi7 = "COc1cccc(C=N[N-]C(N)=O)c1[O-].O.O.O.O=[U+2]=O";
@@ -150,8 +138,9 @@ void testMolVSValidation() {
   vector<ValidationErrorInfo> errout7 = vm.validate(*m7, true);
   TEST_ASSERT(errout7.size() != 0);
   for (auto &query : errout7) {
-    std::string msg = query.what();
-    TEST_ASSERT(msg == "INFO: [FragmentValidation] water/hydroxide is present");
+    TEST_ASSERT(query == ValidationErrorInfo({
+      "INFO", "FragmentValidation", "water/hydroxide is present"
+    }));
   }
 
   std::string smi8 = "CC(=O)O.NCC(=O)NCCCCCCCCCCNC(=O)CN";
@@ -159,32 +148,29 @@ void testMolVSValidation() {
   vector<ValidationErrorInfo> errout8 = vm.validate(*m8, true);
   TEST_ASSERT(errout8.size() != 0);
   for (auto &query : errout8) {
-    std::string msg = query.what();
-    TEST_ASSERT(msg ==
-                "INFO: [FragmentValidation] acetate/acetic acid is present");
+    TEST_ASSERT(query == ValidationErrorInfo({
+      "INFO", "FragmentValidation", "acetate/acetic acid is present"
+    }));
   }
 
   std::string smi9 = "N#CC(Br)(Br)C#N.[Br-].[K+]";
   unique_ptr<ROMol> m9(SmilesToMol(smi9, 0, false));
   vector<ValidationErrorInfo> errout9 = vm.validate(*m9, true);
-  std::vector<std::string> ans = {
-      "INFO: [FragmentValidation] bromine is present",
-      "INFO: [FragmentValidation] potassium is present"};
-  TEST_ASSERT(errout9.size() == ans.size());
-  for (size_t i = 0; i < errout9.size(); ++i) {
-    TEST_ASSERT(errout9[i].what() == ans[i]);
-  }
+  std::vector<ValidationErrorInfo> ans = {
+    {"INFO", "FragmentValidation", "bromine is present"},
+    {"INFO", "FragmentValidation", "potassium is present"}
+  };
+  TEST_ASSERT(errout9 == ans);
 
   std::string smi10 = "C1COCCO1.O=C(NO)NO";
   unique_ptr<ROMol> m10(SmilesToMol(smi10, 0, false));
   vector<ValidationErrorInfo> errout10 = vm.validate(*m10, true);
-  std::vector<std::string> ans10 = {
-      "INFO: [FragmentValidation] 1,2-dimethoxyethane is present",
-      "INFO: [FragmentValidation] 1,4-dioxane is present"};
-  TEST_ASSERT(errout10.size() == ans10.size());
-  for (size_t i = 0; i < errout10.size(); ++i) {
-    TEST_ASSERT(errout10[i].what() == ans10[i]);
-  }
+  std::vector<ValidationErrorInfo> ans10 = {
+    {"INFO", "FragmentValidation", "1,2-dimethoxyethane is present"},
+    {"INFO", "FragmentValidation", "1,4-dioxane is present"}
+  };
+  TEST_ASSERT(errout10 == ans10);
+
   BOOST_LOG(rdInfoLog) << "Finished" << std::endl;
 }
 
@@ -201,7 +187,7 @@ void testMolVSOptions() {
   unique_ptr<ROMol> m1(SmilesToMol(smi1, 0, false));
   vector<ValidationErrorInfo> errout1 = vm.validate(*m1, true);
   for (auto &query : errout1) {
-    std::string msg = query.what();
+    std::string msg = query.message; /// FIXME
     //    TEST_ASSERT(msg == "ERROR: [NoAtomValidation] Molecule has no atoms");
     TEST_ASSERT(msg == "");
   }
@@ -210,7 +196,7 @@ void testMolVSOptions() {
   unique_ptr<ROMol> m2(SmilesToMol(smi2, 0, false));
   vector<ValidationErrorInfo> errout2 = vm.validate(*m2, true);
   for (auto &query : errout2) {
-    std::string msg = query.what();
+    std::string msg = query.message; /// FIXME
     //    TEST_ASSERT(msg ==
     //                "INFO: [NeutralValidation] Not an overall neutral system
     //                (-1)");
@@ -240,10 +226,9 @@ void testAllowedAtomsValidation() {
   unique_ptr<ROMol> m1(SmilesToMol(smi1));
   vector<ValidationErrorInfo> errout1 = vm.validate(*m1, true);
   for (auto &query : errout1) {
-    std::string msg = query.what();
-    TEST_ASSERT(
-        msg ==
-        "INFO: [AllowedAtomsValidation] Atom F is not in allowedAtoms list");
+    TEST_ASSERT(query == ValidationErrorInfo({
+      "INFO", "AllowedAtomsValidation", "Atom F is not in allowedAtoms list"
+    }));
   }
   BOOST_LOG(rdInfoLog) << "Finished" << std::endl;
 }
@@ -269,10 +254,9 @@ void testDisallowedAtomsValidation() {
   unique_ptr<ROMol> m1(SmilesToMol(smi1));
   vector<ValidationErrorInfo> errout1 = vm.validate(*m1, true);
   for (auto &query : errout1) {
-    std::string msg = query.what();
-    TEST_ASSERT(
-        msg ==
-        "INFO: [DisallowedAtomsValidation] Atom F is in disallowedAtoms list");
+    TEST_ASSERT(query == ValidationErrorInfo({
+      "INFO", "DisallowedAtomsValidation", "Atom F is in disallowedAtoms list"
+    }));
   }
   BOOST_LOG(rdInfoLog) << "Finished" << std::endl;
 }
@@ -290,18 +274,18 @@ void testFragment() {
   unique_ptr<ROMol> m1(SmilesToMol(smi1, 0, false));
   vector<ValidationErrorInfo> errout1 = vm.validate(*m1, true);
   for (auto &query : errout1) {
-    std::string msg = query.what();
-    TEST_ASSERT(msg ==
-                "INFO: [FragmentValidation] 1,2-dichloroethane is present");
+    TEST_ASSERT(query == ValidationErrorInfo({
+      "INFO", "FragmentValidation", "1,2-dichloroethane is present"
+    }));
   }
 
   smi2 = "COCCOC.CCCBr";
   unique_ptr<ROMol> m2(SmilesToMol(smi2, 0, false));
   vector<ValidationErrorInfo> errout2 = vm.validate(*m2, true);
   for (auto &query : errout2) {
-    std::string msg = query.what();
-    TEST_ASSERT(msg ==
-                "INFO: [FragmentValidation] 1,2-dimethoxyethane is present");
+    TEST_ASSERT(query == ValidationErrorInfo({
+      "INFO", "FragmentValidation", "1,2-dimethoxyethane is present"
+    }));
   }
   BOOST_LOG(rdInfoLog) << "Finished" << std::endl;
 }
@@ -321,15 +305,16 @@ void testValidateSmiles() {
 
   vector<ValidationErrorInfo> errout2 = validateSmiles("");
   for (auto &query : errout2) {
-    std::string msg = query.what();
-    TEST_ASSERT(msg == "ERROR: [NoAtomValidation] Molecule has no atoms");
+    TEST_ASSERT(query == ValidationErrorInfo({
+      "ERROR", "NoAtomValidation", "Molecule has no atoms"
+    }));
   }
 
   vector<ValidationErrorInfo> errout3 = validateSmiles("ClCCCl.c1ccccc1O");
   for (auto &query : errout3) {
-    std::string msg = query.what();
-    TEST_ASSERT(msg ==
-                "INFO: [FragmentValidation] 1,2-dichloroethane is present");
+    TEST_ASSERT(query == ValidationErrorInfo({
+      "INFO", "FragmentValidation", "1,2-dichloroethane is present"
+    }));
   }
   BOOST_LOG(rdInfoLog) << "Finished" << std::endl;
 }

--- a/Code/GraphMol/MolStandardize/testValidate.cpp
+++ b/Code/GraphMol/MolStandardize/testValidate.cpp
@@ -33,10 +33,10 @@ void testRDKitValidation() {
   unique_ptr<ROMol> m1(SmilesToMol(smi1, 0, false));
   vector<ValidationErrorInfo> errout1 = vm.validate(*m1, true);
   for (auto &query : errout1) {
-    TEST_ASSERT(query == ValidationErrorInfo({
+    TEST_ASSERT(query == ValidationErrorInfo(
       "INFO", "ValenceValidation",
-      "Explicit valence for atom # 1 O, 3, is greater than permitted"
-    }));
+      "Explicit valence for atom # 1 O, 3, is greater than permitted")
+      );
   }
 
   // testing for molecule with no atoms
@@ -44,9 +44,9 @@ void testRDKitValidation() {
   unique_ptr<ROMol> m2(SmilesToMol(smi2, 0, false));
   vector<ValidationErrorInfo> errout2 = vm.validate(*m2, true);
   for (auto &query : errout2) {
-    TEST_ASSERT(query == ValidationErrorInfo({
-      "ERROR", "NoAtomValidation", "Molecule has no atoms"
-    }));
+    TEST_ASSERT(query == ValidationErrorInfo(
+      "ERROR", "NoAtomValidation", "Molecule has no atoms")
+      );
   }
 
   // testing molecule with multiple valency errors
@@ -83,54 +83,54 @@ void testMolVSValidation() {
   unique_ptr<ROMol> m1(SmilesToMol(smi1, 0, false));
   vector<ValidationErrorInfo> errout1 = vm.validate(*m1, true);
   for (auto &query : errout1) {
-    TEST_ASSERT(query == ValidationErrorInfo({
-      "ERROR", "NoAtomValidation", "Molecule has no atoms"
-    }));
+    TEST_ASSERT(query == ValidationErrorInfo(
+      "ERROR", "NoAtomValidation", "Molecule has no atoms")
+      );
   }
 
   smi2 = "O=C([O-])c1ccccc1";
   unique_ptr<ROMol> m2(SmilesToMol(smi2, 0, false));
   vector<ValidationErrorInfo> errout2 = vm.validate(*m2, true);
   for (auto &query : errout2) {
-    TEST_ASSERT(query == ValidationErrorInfo({
-      "INFO", "NeutralValidation", "Not an overall neutral system (-1)"
-    }))
+    TEST_ASSERT(query == ValidationErrorInfo(
+      "INFO", "NeutralValidation", "Not an overall neutral system (-1)")
+      );
   }
 
   smi3 = "CN=[NH+]CN=N";
   unique_ptr<ROMol> m3(SmilesToMol(smi3, 0, false));
   vector<ValidationErrorInfo> errout3 = vm.validate(*m3, true);
   for (auto &query : errout3) {
-    TEST_ASSERT(query == ValidationErrorInfo({
-      "INFO", "NeutralValidation", "Not an overall neutral system (+1)"
-    }));
+    TEST_ASSERT(query == ValidationErrorInfo(
+      "INFO", "NeutralValidation", "Not an overall neutral system (+1)")
+      );
   }
 
   smi4 = "[13CH4]";
   unique_ptr<ROMol> m4(SmilesToMol(smi4, 0, false));
   vector<ValidationErrorInfo> errout4 = vm.validate(*m4, true);
   for (auto &query : errout4) {
-    TEST_ASSERT(query == ValidationErrorInfo({
-      "INFO", "IsotopeValidation", "Molecule contains isotope 13C"
-    }));
+    TEST_ASSERT(query == ValidationErrorInfo(
+      "INFO", "IsotopeValidation", "Molecule contains isotope 13C")
+      );
   }
 
   smi5 = "[2H]C(Cl)(Cl)Cl";
   unique_ptr<ROMol> m5(SmilesToMol(smi5, 0, false));
   vector<ValidationErrorInfo> errout5 = vm.validate(*m5, true);
   for (auto &query : errout5) {
-    TEST_ASSERT(query == ValidationErrorInfo({
-      "INFO", "IsotopeValidation", "Molecule contains isotope 2H"
-    }));
+    TEST_ASSERT(query == ValidationErrorInfo(
+      "INFO", "IsotopeValidation", "Molecule contains isotope 2H")
+      );
   }
 
   smi6 = "[2H]OC([2H])([2H])[2H]";
   unique_ptr<ROMol> m6(SmilesToMol(smi6, 0, false));
   vector<ValidationErrorInfo> errout6 = vm.validate(*m6, true);
   for (auto &query : errout6) {
-    TEST_ASSERT(query == ValidationErrorInfo({
-      "INFO", "IsotopeValidation", "Molecule contains isotope 2H"
-    }));
+    TEST_ASSERT(query == ValidationErrorInfo(
+      "INFO", "IsotopeValidation", "Molecule contains isotope 2H")
+      );
   }
 
   std::string smi7 = "COc1cccc(C=N[N-]C(N)=O)c1[O-].O.O.O.O=[U+2]=O";
@@ -138,9 +138,9 @@ void testMolVSValidation() {
   vector<ValidationErrorInfo> errout7 = vm.validate(*m7, true);
   TEST_ASSERT(errout7.size() != 0);
   for (auto &query : errout7) {
-    TEST_ASSERT(query == ValidationErrorInfo({
-      "INFO", "FragmentValidation", "water/hydroxide is present"
-    }));
+    TEST_ASSERT(query == ValidationErrorInfo(
+      "INFO", "FragmentValidation", "water/hydroxide is present")
+      );
   }
 
   std::string smi8 = "CC(=O)O.NCC(=O)NCCCCCCCCCCNC(=O)CN";
@@ -148,9 +148,9 @@ void testMolVSValidation() {
   vector<ValidationErrorInfo> errout8 = vm.validate(*m8, true);
   TEST_ASSERT(errout8.size() != 0);
   for (auto &query : errout8) {
-    TEST_ASSERT(query == ValidationErrorInfo({
-      "INFO", "FragmentValidation", "acetate/acetic acid is present"
-    }));
+    TEST_ASSERT(query == ValidationErrorInfo(
+      "INFO", "FragmentValidation", "acetate/acetic acid is present")
+      );
   }
 
   std::string smi9 = "N#CC(Br)(Br)C#N.[Br-].[K+]";
@@ -226,9 +226,9 @@ void testAllowedAtomsValidation() {
   unique_ptr<ROMol> m1(SmilesToMol(smi1));
   vector<ValidationErrorInfo> errout1 = vm.validate(*m1, true);
   for (auto &query : errout1) {
-    TEST_ASSERT(query == ValidationErrorInfo({
-      "INFO", "AllowedAtomsValidation", "Atom F is not in allowedAtoms list"
-    }));
+    TEST_ASSERT(query == ValidationErrorInfo(
+      "INFO", "AllowedAtomsValidation", "Atom F is not in allowedAtoms list")
+      );
   }
   BOOST_LOG(rdInfoLog) << "Finished" << std::endl;
 }
@@ -254,9 +254,9 @@ void testDisallowedAtomsValidation() {
   unique_ptr<ROMol> m1(SmilesToMol(smi1));
   vector<ValidationErrorInfo> errout1 = vm.validate(*m1, true);
   for (auto &query : errout1) {
-    TEST_ASSERT(query == ValidationErrorInfo({
-      "INFO", "DisallowedAtomsValidation", "Atom F is in disallowedAtoms list"
-    }));
+    TEST_ASSERT(query == ValidationErrorInfo(
+      "INFO", "DisallowedAtomsValidation", "Atom F is in disallowedAtoms list")
+      );
   }
   BOOST_LOG(rdInfoLog) << "Finished" << std::endl;
 }
@@ -274,18 +274,18 @@ void testFragment() {
   unique_ptr<ROMol> m1(SmilesToMol(smi1, 0, false));
   vector<ValidationErrorInfo> errout1 = vm.validate(*m1, true);
   for (auto &query : errout1) {
-    TEST_ASSERT(query == ValidationErrorInfo({
-      "INFO", "FragmentValidation", "1,2-dichloroethane is present"
-    }));
+    TEST_ASSERT(query == ValidationErrorInfo(
+      "INFO", "FragmentValidation", "1,2-dichloroethane is present")
+      );
   }
 
   smi2 = "COCCOC.CCCBr";
   unique_ptr<ROMol> m2(SmilesToMol(smi2, 0, false));
   vector<ValidationErrorInfo> errout2 = vm.validate(*m2, true);
   for (auto &query : errout2) {
-    TEST_ASSERT(query == ValidationErrorInfo({
-      "INFO", "FragmentValidation", "1,2-dimethoxyethane is present"
-    }));
+    TEST_ASSERT(query == ValidationErrorInfo(
+      "INFO", "FragmentValidation", "1,2-dimethoxyethane is present")
+      );
   }
   BOOST_LOG(rdInfoLog) << "Finished" << std::endl;
 }
@@ -305,16 +305,16 @@ void testValidateSmiles() {
 
   vector<ValidationErrorInfo> errout2 = validateSmiles("");
   for (auto &query : errout2) {
-    TEST_ASSERT(query == ValidationErrorInfo({
-      "ERROR", "NoAtomValidation", "Molecule has no atoms"
-    }));
+    TEST_ASSERT(query == ValidationErrorInfo(
+      "ERROR", "NoAtomValidation", "Molecule has no atoms")
+      );
   }
 
   vector<ValidationErrorInfo> errout3 = validateSmiles("ClCCCl.c1ccccc1O");
   for (auto &query : errout3) {
-    TEST_ASSERT(query == ValidationErrorInfo({
-      "INFO", "FragmentValidation", "1,2-dichloroethane is present"
-    }));
+    TEST_ASSERT(query == ValidationErrorInfo(
+      "INFO", "FragmentValidation", "1,2-dichloroethane is present")
+      );
   }
   BOOST_LOG(rdInfoLog) << "Finished" << std::endl;
 }


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
This PR implements a refactoring of `RDKit::MolStandardize::ValidationErrorInfo`. The changes are meant to remove the dependency from the `std::exception` base class, which is actually only used as a container for the error message, and also decompose this message so that the error level, the id of the failing validation step/component and the actual diagnostic info are assigned to different data members.

#### Any other comments?
I am actually wondering if it could make sense to remove the error level and component id, and make the validation method just return a vector of strings with the error details.