### PR TITLE
fix check of python version when updating Filters.cpp

### DIFF
--- a/Code/GraphMol/FilterCatalog/CMakeLists.txt
+++ b/Code/GraphMol/FilterCatalog/CMakeLists.txt
@@ -4,7 +4,7 @@ endif()
 
 find_package(PythonInterp)
 if (PYTHONINTERP_FOUND)
-  if(DEFINED ${PYTHON_VERSION_STRING} AND ${PYTHON_VERSION_STRING} VERSION_GREATER "2.6" )
+  if(DEFINED PYTHON_VERSION_STRING AND ${PYTHON_VERSION_STRING} VERSION_GREATER "2.6" )
         message("== Updating Filters.cpp from pains file")
         execute_process(
           COMMAND


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
I noticed that the update of FilterCatalog's `Filters.cpp` at cmake configuration time is no longer working. I think this is because line

    if(DEFINED ${PYTHON_VERSION_STRING} AND ${PYTHON_VERSION_STRING} VERSION_GREATER "2.6" )

should have been

    if(DEFINED PYTHON_VERSION_STRING AND ${PYTHON_VERSION_STRING} VERSION_GREATER "2.6" )

#### Any other comments?
Would it be preferable to just remove the if clause?
