### PR TITLE
Fixes #5923

### DIFF
--- a/Code/GraphMol/SubstanceGroup.cpp
+++ b/Code/GraphMol/SubstanceGroup.cpp
@@ -60,10 +60,48 @@ unsigned int SubstanceGroup::getIndexInMol() const {
   return sgroupItr - sgroups.begin();
 }
 
+void SubstanceGroup::setAtoms(std::vector<unsigned int> atoms) {
+  PRECONDITION(dp_mol, "bad mol");
+  auto natoms = dp_mol->getNumAtoms();
+  for (auto atomIdx : atoms) {
+    if (atomIdx >= natoms) {
+      std::ostringstream errout;
+      errout << "Atom index " << atomIdx << " is out of range";
+      throw ValueErrorException(errout.str());
+    }
+  }
+  d_atoms = std::move(atoms);
+}
+void SubstanceGroup::setParentAtoms(std::vector<unsigned int> patoms) {
+  PRECONDITION(dp_mol, "bad mol");
+  auto natoms = dp_mol->getNumAtoms();
+  for (auto atomIdx : patoms) {
+    if (atomIdx >= natoms) {
+      std::ostringstream errout;
+      errout << "Atom index " << atomIdx << " is out of range";
+      throw ValueErrorException(errout.str());
+    }
+  }
+  d_patoms = std::move(patoms);
+}
+void SubstanceGroup::setBonds(std::vector<unsigned int> bonds) {
+  PRECONDITION(dp_mol, "bad mol");
+  auto nbonds = dp_mol->getNumBonds();
+  for (auto bondIdx : bonds) {
+    if (bondIdx >= nbonds) {
+      std::ostringstream errout;
+      errout << "Bond index " << bondIdx << " is out of range";
+      throw ValueErrorException(errout.str());
+    }
+  }
+  d_bonds = std::move(bonds);
+}
+
 void SubstanceGroup::addAtomWithIdx(unsigned int idx) {
   PRECONDITION(dp_mol, "bad mol");
-  PRECONDITION(dp_mol->getAtomWithIdx(idx), "wrong atom index");
-
+  if (idx >= dp_mol->getNumAtoms()) {
+    throw ValueErrorException("Atom index out of range");
+  }
   d_atoms.push_back(idx);
 }
 
@@ -76,7 +114,9 @@ void SubstanceGroup::addAtomWithBookmark(int mark) {
 
 void SubstanceGroup::addParentAtomWithIdx(unsigned int idx) {
   PRECONDITION(dp_mol, "bad mol");
-
+  if (idx >= dp_mol->getNumAtoms()) {
+    throw ValueErrorException("Atom index out of range");
+  }
   if (std::find(d_atoms.begin(), d_atoms.end(), idx) == d_atoms.end()) {
     std::ostringstream errout;
     errout << "Atom " << idx << " is not a member of current SubstanceGroup";
@@ -103,7 +143,9 @@ void SubstanceGroup::addParentAtomWithBookmark(int mark) {
 
 void SubstanceGroup::addBondWithIdx(unsigned int idx) {
   PRECONDITION(dp_mol, "bad mol");
-  PRECONDITION(dp_mol->getBondWithIdx(idx), "wrong bond index");
+  if (idx >= dp_mol->getNumBonds()) {
+    throw ValueErrorException("Bond index out of range");
+  }
 
   d_bonds.push_back(idx);
 }

--- a/Code/GraphMol/SubstanceGroup.h
+++ b/Code/GraphMol/SubstanceGroup.h
@@ -171,11 +171,9 @@ class RDKIT_GRAPHMOL_EXPORT SubstanceGroup : public RDProps {
   const std::vector<unsigned int> &getParentAtoms() const { return d_patoms; }
   const std::vector<unsigned int> &getBonds() const { return d_bonds; }
 
-  void setAtoms(std::vector<unsigned int> atoms) { d_atoms = std::move(atoms); }
-  void setParentAtoms(std::vector<unsigned int> patoms) {
-    d_patoms = std::move(patoms);
-  }
-  void setBonds(std::vector<unsigned int> bonds) { d_bonds = std::move(bonds); }
+  void setAtoms(std::vector<unsigned int> atoms);
+  void setParentAtoms(std::vector<unsigned int> patoms);
+  void setBonds(std::vector<unsigned int> bonds);
 
   const std::vector<Bracket> &getBrackets() const { return d_brackets; }
   const std::vector<CState> &getCStates() const { return d_cstates; }

--- a/Code/GraphMol/catch_sgroups.cpp
+++ b/Code/GraphMol/catch_sgroups.cpp
@@ -16,6 +16,7 @@
 #include <GraphMol/Chirality.h>
 #include <GraphMol/SmilesParse/SmilesParse.h>
 #include "GraphMol/FileParsers/FileParsers.h"
+#include "GraphMol/MolInterchange/MolInterchange.h"
 
 using namespace RDKit;
 
@@ -507,4 +508,16 @@ M  END
       TEST_ASSERT(index == count);
     }
   }
+}
+
+TEST_CASE("github #5923: add more error checking to substance groups") {
+  auto mol = "CCCO"_smiles;
+  REQUIRE(mol);
+  SubstanceGroup sg(mol.get(), "SUP");
+  CHECK_THROWS_AS(sg.addAtomWithIdx(4), ValueErrorException);
+  CHECK_THROWS_AS(sg.addParentAtomWithIdx(4), ValueErrorException);
+  CHECK_THROWS_AS(sg.addBondWithIdx(4), ValueErrorException);
+  CHECK_THROWS_AS(sg.setAtoms({1, 4}), ValueErrorException);
+  CHECK_THROWS_AS(sg.setParentAtoms({1, 4}), ValueErrorException);
+  CHECK_THROWS_AS(sg.setBonds({1, 4}), ValueErrorException);
 }


### PR DESCRIPTION
This adds error checking to `setAtoms()`, `setParentAtoms()`, and `setBonds()`
It also changes `addAtomWithIdx()`, `addParentAtomWithIdx()`,  and `addBondWithIdx()` to throw a ValueError instead of failing a precondition when a bad index is provided