### PR TITLE
Fixes 7036 - middle line of triple bond meeting wedge

### DIFF
--- a/Code/GraphMol/MolDraw2D/DrawMol.cpp
+++ b/Code/GraphMol/MolDraw2D/DrawMol.cpp
@@ -3231,6 +3231,14 @@ void DrawMol::adjustBondsOnSolidWedgeEnds() {
           otherNeighbor(bond->getEndAtom(), bond->getBeginAtom(), 0, *drawMol_);
       auto bond1 = drawMol_->getBondBetweenAtoms(bond->getEndAtomIdx(),
                                                  thirdAtom->getIdx());
+      // If the bonds a co-linear, don't do anything (Github7036)
+      auto b1 = atCds_[bond->getEndAtomIdx()].directionVector(
+          atCds_[bond->getBeginAtomIdx()]);
+      auto b2 = atCds_[bond1->getEndAtomIdx()].directionVector(
+          atCds_[bond1->getBeginAtomIdx()]);
+      if (fabs(1.0 - b1.dotProduct(b2)) < 0.001) {
+        continue;
+      }
       DrawShape *wedge = nullptr;
       DrawShape *bondLine = nullptr;
       double closestDist = 1.0;

--- a/Code/GraphMol/MolDraw2D/catch_tests.cpp
+++ b/Code/GraphMol/MolDraw2D/catch_tests.cpp
@@ -9447,6 +9447,9 @@ TEST_CASE("Github7036 - triple bond to wedge not right") {
     drawer.drawMolecule(*m);
     drawer.finishDrawing();
     auto text = drawer.getDrawingText();
+    std::ofstream outs("testGithub7036.svg");
+    outs << text;
+    outs.close();
 
     std::regex bond(
         "<path class='bond-8 atom-8 atom-9' d='M (-?\\d+.\\d+),(-?\\d+.\\d+)"
@@ -9465,9 +9468,6 @@ TEST_CASE("Github7036 - triple bond to wedge not right") {
     double dot = pts[0].directionVector(pts[1]).dotProduct(
         pts[2].directionVector(pts[3]));
     CHECK_THAT(fabs(dot), Catch::Matchers::WithinAbs(1.0, 0.001));
-    std::ofstream outs("testGithub7036.svg");
-    outs << text;
-    outs.close();
     check_file_hash("testGithub7036.svg");
   }
 }

--- a/Code/GraphMol/MolDraw2D/catch_tests.cpp
+++ b/Code/GraphMol/MolDraw2D/catch_tests.cpp
@@ -47,12 +47,12 @@ namespace {
 // The hand-drawn pictures will fail this frequently due to the use
 // of random numbers to draw the lines.  As well as all the testHandDrawn
 // files, this includes testBrackets-5a.svg and testPositionVariation-1b.svg
-static const bool DELETE_WITH_GOOD_HASH = true;
+const bool DELETE_WITH_GOOD_HASH = true;
 // The expected hash code for a file may be included in these maps, or
 // provided in the call to check_file_hash().
 // These values are for a build with FreeType, so expect them all to be
 // wrong when building without.
-static const std::map<std::string, std::hash_result_t> SVG_HASHES = {
+const std::map<std::string, std::hash_result_t> SVG_HASHES = {
     {"testAtomTags_1.svg", 3187798125U},
     {"testAtomTags_2.svg", 822910240U},
     {"testAtomTags_3.svg", 2244078420U},
@@ -325,7 +325,8 @@ static const std::map<std::string, std::hash_result_t> SVG_HASHES = {
     {"bad_lasso_1.svg", 726527516U},
     {"AtropCanon1.svg", 1587179714U},
     {"AtropManyChiralsEnhanced.svg", 3871032500U},
-    {"testGithub6968.svg", 1554428830U}};
+    {"testGithub6968.svg", 1554428830U},
+    {"testGithub7036.svg", 2355702607U}};
 
 // These PNG hashes aren't completely reliable due to floating point cruft,
 // but they can still reduce the number of drawings that need visual
@@ -334,7 +335,7 @@ static const std::map<std::string, std::hash_result_t> SVG_HASHES = {
 // give different results on my MBP and Ubuntu 20.04 VM.  The SVGs work
 // better because the floats are all output to only 1 decimal place so there
 // is a much smaller chance of different systems producing different files.
-static const std::map<std::string, std::hash_result_t> PNG_HASHES = {
+const std::map<std::string, std::hash_result_t> PNG_HASHES = {
     {"testGithub3226_1.png", 2350054896U},
     {"testGithub3226_2.png", 606206725U},
     {"testGithub3226_3.png", 2282880418U},
@@ -8317,7 +8318,7 @@ TEST_CASE("Lasso highlights") {
     std::map<int, std::vector<DrawColour>> ha_map;
     std::map<int, std::vector<DrawColour>> hb_map;
 
-       for (size_t i = 0; i < smarts.size(); ++i) {
+    for (size_t i = 0; i < smarts.size(); ++i) {
       std::vector<int> hit_atoms = get_all_hit_atoms(*m, smarts[i]);
       update_colour_map(hit_atoms, colours[i], ha_map);
     }
@@ -9376,6 +9377,7 @@ TEST_CASE("atropisomers") {
     }
   }
 }
+
 TEST_CASE("Github6968 - bad bond highlights with triple bonds") {
   // The issue is that in the linear highlight across the triple bond,
   // some of the highlights didn't appear, and others were
@@ -9428,5 +9430,44 @@ TEST_CASE("Github6968 - bad bond highlights with triple bonds") {
       std::shuffle(atOrder.begin(), atOrder.end(),
                    std::mt19937{std::random_device{}()});
     }
+  }
+}
+
+TEST_CASE("Github7036 - triple bond to wedge not right") {
+  // The issue is that the middle line of a triple bond
+  // ends in the wrong place when the incident bond is
+  // a wedge.  Wedge to single bond included for visual
+  // check that that isn't broken in the fix.
+  auto m = "C1[C@@H](CN)CCN[C@H]1C#N"_smiles;
+  REQUIRE(m);
+  {
+    MolDraw2DSVG drawer(350, 300);
+    drawer.drawOptions().addAtomIndices = true;
+    drawer.drawOptions().addBondIndices = true;
+    drawer.drawMolecule(*m);
+    drawer.finishDrawing();
+    auto text = drawer.getDrawingText();
+
+    std::regex bond(
+        "<path class='bond-8 atom-8 atom-9' d='M (-?\\d+.\\d+),(-?\\d+.\\d+)"
+        " L (-?\\d+.\\d+),(-?\\d+.\\d+)' style=");
+    // The problem is the first line in the bond, which comes in 2 parts
+    // that should be co-linear.
+    auto match_begin = std::sregex_iterator(text.begin(), text.end(), bond);
+    std::smatch match = *match_begin;
+    std::vector<Point2D> pts;
+    pts.push_back(Point2D(stod(match[1]), stod(match[2])));
+    pts.push_back(Point2D(stod(match[3]), stod(match[4])));
+    ++match_begin;
+    match = *match_begin;
+    pts.push_back(Point2D(stod(match[1]), stod(match[2])));
+    pts.push_back(Point2D(stod(match[3]), stod(match[4])));
+    double dot = pts[0].directionVector(pts[1]).dotProduct(
+        pts[2].directionVector(pts[3]));
+    CHECK_THAT(fabs(dot), Catch::Matchers::WithinAbs(1.0, 0.001));
+    std::ofstream outs("testGithub7036.svg");
+    outs << text;
+    outs.close();
+    check_file_hash("testGithub7036.svg");
   }
 }


### PR DESCRIPTION

#### Reference Issue
Fixes #7036


#### What does this implement/fix? Explain your changes.
Normally, a wedged bond is altered so there's no gap between it and an incident single bond.  This is not appropriate for a wedge onto a triple bond where they are co-linear, and the reported effect was a consequence.  It's a simple check to skip the process in this case.

![image](https://github.com/rdkit/rdkit/assets/9198870/4efd45cf-042a-4ff2-9439-8215e3edfb61)

#### Any other comments?
There's also some minor tidying suggested by clang.