### PR TITLE
Update C# exception handling

### DIFF
--- a/Code/JavaWrappers/csharp_wrapper/GraphMolCSharp.i
+++ b/Code/JavaWrappers/csharp_wrapper/GraphMolCSharp.i
@@ -77,39 +77,47 @@
       std::string err="ChemicalReactionException: ";
       err+=e.what();
       SWIG_CSharpSetPendingException(SWIG_CSharpApplicationException, err.c_str());
+      return $null;
     }
     catch (RDKit::ChemicalReactionParserException &e) {
       std::string err="ChemicalReactionParserException: ";
       err+=e.what();
       SWIG_CSharpSetPendingException(SWIG_CSharpApplicationException, err.c_str());
+      return $null;
     }
     catch (RDKit::ConformerException &e) {
       std::string err="ConformerException: ";
       err+=e.what();
       SWIG_CSharpSetPendingException(SWIG_CSharpApplicationException, err.c_str());
+      return $null;
     }
     catch (RDKit::MolPicklerException &e) {
       std::string err="MolPicklerException: ";
       err+=e.what();
       SWIG_CSharpSetPendingException(SWIG_CSharpApplicationException, err.c_str());
+      return $null;
     }
     catch (RDKit::MolSanitizeException &e) {
       std::string err="MolSanitizeException: ";
       err+=e.what();
       SWIG_CSharpSetPendingException(SWIG_CSharpApplicationException, err.c_str());
+      return $null;
     }
     catch (RDKit::SmilesParseException e) {
       std::string err="SmilesParseException: ";
       err+=e.what();
       SWIG_CSharpSetPendingException(SWIG_CSharpApplicationException, err.c_str());
+      return $null;
     }
     catch (KeyErrorException e) {
       std::string err="KeyError: ";
       err+=e.key();
       SWIG_CSharpSetPendingException(SWIG_CSharpApplicationException, err.c_str());
+      return $null;
     }
     catch (std::exception e) {
       SWIG_CSharpSetPendingException(SWIG_CSharpApplicationException, "error");
+      return $null;
     }
 }
 

--- a/Code/JavaWrappers/csharp_wrapper/RDKitCSharpTest/GeneralizedSubstructTest.cs
+++ b/Code/JavaWrappers/csharp_wrapper/RDKitCSharpTest/GeneralizedSubstructTest.cs
@@ -1,4 +1,5 @@
-﻿using GraphMolWrap;
+﻿using System;
+using GraphMolWrap;
 using Xunit;
 
 namespace RdkitTests
@@ -51,6 +52,103 @@ namespace RdkitTests
             Assert.Equal(0, xqm4.getSubstructMatches(mol3).Count);
             Assert.True(FingerprintsMatch(xqm1, mol3));
             Assert.True(FingerprintsMatch(xqm3, mol3));
+        }
+
+        [Fact]
+        public void TestBundle1()
+        {
+            var block = @"
+  ChemDraw01052411352D
+
+  0  0  0     0  0              0 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 9 8 0 0 0
+M  V30 BEGIN ATOM
+M  V30 1 C 0.247500 0.428587 0.000000 0
+M  V30 2 C -0.466950 0.016087 0.000000 0
+M  V30 3 C -0.466950 -0.808913 0.000000 0
+M  V30 4 C 0.247500 -1.221413 0.000000 0
+M  V30 5 N 0.961950 -0.808913 0.000000 0
+M  V30 6 C 0.961950 0.016087 0.000000 0
+M  V30 7 C -1.181400 0.428587 0.000000 0
+M  V30 8 * 0.604725 0.222337 0.000000 0
+M  V30 9 Cl 1.181400 1.221413 0.000000 0
+M  V30 END ATOM
+M  V30 BEGIN BOND
+M  V30 1 1 1 2
+M  V30 2 2 2 3
+M  V30 3 1 3 4
+M  V30 4 2 4 5
+M  V30 5 1 5 6
+M  V30 6 2 1 6
+M  V30 7 1 2 7
+M  V30 8 1 8 9 ENDPTS=(2 6 1) ATTACH=ANY
+M  V30 END BOND
+M  V30 END CTAB
+M  END
+";
+            var query = RWMol.MolFromMolBlock(block);
+            var xqm = RDKFuncs.createExtendedQueryMol(query, true, true, false);
+            var mol = RWMol.MolFromSmiles("Cc1c(cc([nH]1)C(=O)NC2CCN(CC2)c3cc(cc(n3)Cl)C(=O)N)Br");
+            var matches = xqm.getSubstructMatches(mol);
+            Assert.True(matches.Count > 0);
+        }
+
+        [Fact]
+        public void TestKekulizeError()
+        {
+            var block = @"
+  ChemDraw01052410132D
+
+  0  0  0     0  0              0 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 9 8 0 0 0
+M  V30 BEGIN ATOM
+M  V30 1 C 0.247500 0.428587 0.000000 0
+M  V30 2 C -0.466950 0.016087 0.000000 0
+M  V30 3 C -0.466950 -0.808913 0.000000 0
+M  V30 4 C 0.247500 -1.221413 0.000000 0
+M  V30 5 N 0.961950 -0.808913 0.000000 0
+M  V30 6 C 0.961950 0.016087 0.000000 0
+M  V30 7 C -1.181400 0.428587 0.000000 0
+M  V30 8 * 0.604725 0.222337 0.000000 0
+M  V30 9 Cl 1.181400 1.221413 0.000000 0
+M  V30 END ATOM
+M  V30 BEGIN BOND
+M  V30 1 1 1 2
+M  V30 2 2 2 3
+M  V30 3 1 3 4
+M  V30 4 2 4 5
+M  V30 5 1 5 6
+M  V30 6 2 1 6
+M  V30 7 1 2 7
+M  V30 8 1 8 9 ENDPTS=(2 6 1) ATTACH=ANY
+M  V30 END BOND
+M  V30 END CTAB
+M  END
+";
+            var query = RWMol.MolFromMolBlock(block);
+            ExtendedQueryMol xqm = null;
+            var adjustQueryParameters = new AdjustQueryParameters()
+            {
+                aromatizeIfPossible = false,
+                adjustDegree = false,
+                adjustSingleBondsBetweenAromaticAtoms = true,
+                adjustSingleBondsToDegreeOneNeighbors = true,
+                makeDummiesQueries = true,
+                adjustConjugatedFiveRings = true
+            };
+            try
+            {
+                xqm = RDKFuncs.createExtendedQueryMol(query, true, true, true,
+                    adjustQueryParameters);
+            }
+            catch (ApplicationException ex) when (ex.Message.Contains("MolSanitizeException: Can't kekulize mol"))
+            {
+                Assert.True(true);
+            }
+
+            Assert.Null(xqm);
         }
     }
 }


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! 
-->
#### Reference Issue

Fixes #7069 

#### What does this implement/fix? Explain your changes.

Currently, after posting `SWIG_CSharpSetPendingException`, execution of wrapped methods continues.  This can result in memory access errors as seen in #7069.

In SWIG you can use `return $null` to return from the wrapped method immediately after posting `SWIG_CSharpSetPendingException`.  `$null` resolves to the appropriate null value or pointer (or nothing for a void method).  I've added it to all the catch clauses.


