### PR TITLE
lock the versions of a bunch of stuff used in the CI builds

### DIFF
--- a/.azure-pipelines/linux_build.yml
+++ b/.azure-pipelines/linux_build.yml
@@ -9,7 +9,7 @@ steps:
     conda create --name rdkit_build $(python) cmake \
         boost-cpp=$(boost_version) \
         py-boost=$(boost_version) \
-        numpy pillow eigen pandas matplotlib-base \
+        numpy pillow eigen pandas=2.0 matplotlib-base=3.7 \
         qt=5.9.7 cairo
     conda activate rdkit_build
     conda install -c conda-forge pytest nbval ipykernel>=6.0
@@ -69,8 +69,7 @@ steps:
 - bash: |
     source ${CONDA}/etc/profile.d/conda.sh
     conda activate rdkit_build
-    conda install ipython matplotlib-base
-    conda install -c conda-forge sphinx myst-parser
+    conda install -c conda-forge ipython=8.12 sphinx myst-parser
     export RDBASE=`pwd`
     export PYTHONPATH=${RDBASE}:${PYTHONPATH}
     export LD_LIBRARY_PATH=${RDBASE}/lib:${LD_LIBRARY_PATH}

--- a/.azure-pipelines/linux_build_limitexternal.yml
+++ b/.azure-pipelines/linux_build_limitexternal.yml
@@ -12,7 +12,7 @@ steps:
     conda create --name rdkit_build $(python) cmake \
         libboost=$(boost_version) libboost-devel=$(boost_version) \
         libboost-python=$(boost_version) libboost-python-devel=$(boost_version) \
-        numpy pillow eigen pandas \
+        numpy pillow eigen pandas=2.1 \
         qt pytest
     conda activate rdkit_build
   displayName: Setup build environment

--- a/.azure-pipelines/linux_build_py311.yml
+++ b/.azure-pipelines/linux_build_py311.yml
@@ -9,10 +9,10 @@ steps:
     conda create --name rdkit_build -c conda-forge $(python) cmake \
         boost-cpp=$(boost_version) \
         boost=$(boost_version) \
-        numpy=1.24.3 pillow eigen pandas matplotlib-base \
+        numpy=1.24.3 pillow eigen pandas=2.1 matplotlib-base=3.8 \
         cairo
     conda activate rdkit_build
-    conda install -c conda-forge nbval ipykernel>=6.0
+    conda install -c conda-forge ipython=8.20 jupyter nbval ipykernel>=6.0
   displayName: Setup build environment (no Qt due to versioning problems)
 - bash: |
     source ${CONDA}/etc/profile.d/conda.sh
@@ -66,7 +66,6 @@ steps:
 - bash: |
     source ${CONDA}/etc/profile.d/conda.sh
     conda activate rdkit_build
-    conda install ipython matplotlib-base
     conda install -c conda-forge sphinx myst-parser
     export RDBASE=`pwd`
     export PYTHONPATH=${RDBASE}:${PYTHONPATH}

--- a/.azure-pipelines/mac_build.yml
+++ b/.azure-pipelines/mac_build.yml
@@ -24,8 +24,8 @@ steps:
         libboost=$(boost_version) libboost-devel=$(boost_version) \
         libboost-python=$(boost_version) libboost-python-devel=$(boost_version) \
         qt \
-        numpy matplotlib cairo pillow eigen pandas  \
-        jupyter sphinx myst-parser pytest nbval
+        numpy matplotlib=3.8 cairo pillow eigen pandas=2.1  \
+        jupyter=1.0 ipython=8.2 sphinx myst-parser pytest nbval
   displayName: Setup build environment
 - bash: |
     source ${CONDA}/etc/profile.d/conda.sh

--- a/.azure-pipelines/mac_build.yml
+++ b/.azure-pipelines/mac_build.yml
@@ -25,7 +25,7 @@ steps:
         libboost-python=$(boost_version) libboost-python-devel=$(boost_version) \
         qt \
         numpy matplotlib=3.8 cairo pillow eigen pandas=2.1  \
-        jupyter=1.0 ipython=8.2 sphinx myst-parser pytest nbval
+        jupyter=1.0 ipython=8.20 sphinx myst-parser pytest nbval
   displayName: Setup build environment
 - bash: |
     source ${CONDA}/etc/profile.d/conda.sh

--- a/.azure-pipelines/vs_build.yml
+++ b/.azure-pipelines/vs_build.yml
@@ -9,9 +9,9 @@ steps:
     conda create --name rdkit_build ^
         boost-cpp=$(boost_version) boost=$(boost_version) ^
         py-boost=$(boost_version) libboost=$(boost_version) ^
-        numpy matplotlib cairo pillow eigen pandas jupyter
+        numpy matplotlib=3.8 cairo pillow eigen pandas=2.1
     call activate rdkit_build
-    conda install -c conda-forge sphinx myst-parser jupyter pytest nbval
+    conda install -c conda-forge sphinx myst-parser ipython=8.20 jupyter pytest nbval
     conda install -c conda-forge cmake
   displayName: Install dependencies
 - script: |

--- a/.azure-pipelines/vs_build_dll.yml
+++ b/.azure-pipelines/vs_build_dll.yml
@@ -9,9 +9,9 @@ steps:
     conda create --name rdkit_build ^
         boost-cpp=$(boost_version) boost=$(boost_version) ^
         libboost=$(boost_version) ^
-        cairo eigen
+        numpy matplotlib=3.8 cairo pillow eigen pandas=2.1
     call activate rdkit_build
-    conda install -c conda-forge cmake pytest nbval
+    conda install -c conda-forge cmake ipython=8.20 pytest nbval
   displayName: Install dependencies
 - script: |
     set Boost_ROOT=


### PR DESCRIPTION
The CI builds run on PRs are not the place to find that things have changed in new releases of our dependencies