### PR TITLE
fixes #7083

### DIFF
--- a/Code/Numerics/testConrec.cpp
+++ b/Code/Numerics/testConrec.cpp
@@ -109,7 +109,7 @@ TEST_CASE("connectLineSegments", "[conrec]") {
         for (const auto &pt : pts) {
           auto dv = loc - pt;
           auto r = dv.length();
-          if (r > 0) {
+          if (r > 1e-4) {
             val += 1 / r;
           }
         }


### PR DESCRIPTION
This was caused by a zero-tolerance problem in the setup for one of the tests.

The change is only to the affected test.