### PR TITLE
refactoring of MolStandardize validation module

### DIFF
--- a/Code/GraphMol/MolStandardize/Validate.cpp
+++ b/Code/GraphMol/MolStandardize/Validate.cpp
@@ -67,7 +67,7 @@ std::vector<ValidationErrorInfo> RDKitValidation::validate(
     try {
       atom->calcExplicitValence();
     } catch (const MolSanitizeException &e) {
-      errors.emplace_back("INFO: [ValenceValidation] " + std::string(e.what()));
+      errors.push_back("INFO: [ValenceValidation] " + std::string(e.what()));
     }
   }
   return errors;
@@ -135,7 +135,7 @@ FragmentValidation::validate(const ROMol &mol, bool reportAllFailures) const {
           //					//
           if ((molfragidx == substructidx) && !fpresent) {
             std::string msg = fname + " is present";
-            errors.emplace_back("INFO: [FragmentValidation] " + msg);
+            errors.push_back("INFO: [FragmentValidation] " + msg);
             fpresent = true;
           }
         }
@@ -157,7 +157,7 @@ NeutralValidation::validate(const ROMol &mol, bool /*reportAllFailures*/) const 
       charge_str = std::to_string(charge);
     }
     std::string msg = "Not an overall neutral system (" + charge_str + ')';
-    errors.emplace_back("INFO: [NeutralValidation] " + msg);
+    errors.push_back("INFO: [NeutralValidation] " + msg);
   }
   return errors;
 }
@@ -184,8 +184,8 @@ IsotopeValidation::validate(const ROMol &mol, bool reportAllFailures) const {
   }
 
   for (auto &isotope : isotopes) {
-    errors.emplace_back("INFO: [IsotopeValidation] Molecule contains isotope " +
-                        isotope);
+    errors.push_back("INFO: [IsotopeValidation] Molecule contains isotope " +
+                     isotope);
   }
   return errors;
 }
@@ -231,8 +231,8 @@ std::vector<ValidationErrorInfo> AllowedAtomsValidation::validate(
     // if no match, append to list of errors.
     if (!match) {
       std::string symbol = qatom->getSymbol();
-      errors.emplace_back("INFO: [AllowedAtomsValidation] Atom " + symbol +
-                          " is not in allowedAtoms list");
+      errors.push_back("INFO: [AllowedAtomsValidation] Atom " + symbol +
+                       " is not in allowedAtoms list");
     }
   }
   return errors;
@@ -260,8 +260,8 @@ std::vector<ValidationErrorInfo> DisallowedAtomsValidation::validate(
     // if no match, append to list of errors.
     if (match) {
       std::string symbol = qatom->getSymbol();
-      errors.emplace_back("INFO: [DisallowedAtomsValidation] Atom " + symbol +
-                          " is in disallowedAtoms list");
+      errors.push_back("INFO: [DisallowedAtomsValidation] Atom " + symbol +
+                       " is in disallowedAtoms list");
     }
   }
   return errors;

--- a/Code/GraphMol/MolStandardize/Validate.cpp
+++ b/Code/GraphMol/MolStandardize/Validate.cpp
@@ -35,7 +35,7 @@ std::vector<ValidationErrorInfo> CompositeValidation::validate(
   std::vector<ValidationErrorInfo> errors;
   for (const auto & method : validations) {
     auto partial = method->validate(mol, reportAllFailures);
-    if (partial.size()) {
+    if (!partial.empty()) {
       std::copy(partial.begin(), partial.end(), std::back_inserter(errors));
       if (!reportAllFailures) {
         break;

--- a/Code/GraphMol/MolStandardize/Validate.h
+++ b/Code/GraphMol/MolStandardize/Validate.h
@@ -35,17 +35,7 @@ namespace MolStandardize {
 
 //! The ValidationErrorInfo class is used to store the information returned by a
 /// ValidationMethod validate.
-class RDKIT_MOLSTANDARDIZE_EXPORT ValidationErrorInfo : public std::exception {
- public:
-  ValidationErrorInfo(std::string msg) : d_msg(std::move(msg)) {
-    BOOST_LOG(rdInfoLog) << d_msg << std::endl;
-  }
-  const char *what() const noexcept override { return d_msg.c_str(); }
-  ~ValidationErrorInfo() noexcept override = default;
-
- private:
-  std::string d_msg;
-};  // class ValidationErrorInfo
+using ValidationErrorInfo = std::string;
 
 //! The ValidationMethod class is the abstract base class upon which all the
 /// four different ValidationMethods inherit from.

--- a/Code/GraphMol/MolStandardize/Validate.h
+++ b/Code/GraphMol/MolStandardize/Validate.h
@@ -56,6 +56,26 @@ class RDKIT_MOLSTANDARDIZE_EXPORT ValidationMethod {
 
   virtual std::vector<ValidationErrorInfo> validate(
       const ROMol &mol, bool reportAllFailures) const = 0;
+  virtual std::shared_ptr<ValidationMethod> copy() const = 0;
+};
+
+//! The CompositeValidation class provides a simple way to apply a collection of
+// ValidationMethod instances in sequence
+class RDKIT_MOLSTANDARDIZE_EXPORT CompositeValidation : public ValidationMethod {
+ public:
+  CompositeValidation(
+    const std::vector<std::shared_ptr<ValidationMethod>> & validations)
+    : validations(validations) {};
+
+  std::vector<ValidationErrorInfo> validate(
+      const ROMol &mol, bool reportAllFailures) const override;
+
+  std::shared_ptr<ValidationMethod> copy() const override {
+    return std::make_shared<CompositeValidation>(*this);
+  }
+
+ private:
+   std::vector<std::shared_ptr<ValidationMethod>> validations;
 };
 
 //! The RDKitValidation class throws an error when there are no atoms in the
@@ -70,93 +90,77 @@ class RDKIT_MOLSTANDARDIZE_EXPORT RDKitValidation : public ValidationMethod {
  public:
   std::vector<ValidationErrorInfo> validate(
       const ROMol &mol, bool reportAllFailures) const override;
+
+  std::shared_ptr<ValidationMethod> copy() const override {
+    return std::make_shared<RDKitValidation>(*this);
+  }
 };
 
 //////////////////////////////
 /// MolVS Validations
 //
-//! The MolVSValidations class includes most of the same validations as
-/// molvs.validations, namely NoAtomValidation, FragmentValidation,
-/// NeutralValidation, IsotopeValidation. MolVS also has IsNoneValidation and
-/// DichloroethaneValidation but these were not included here (yet).
-class RDKIT_MOLSTANDARDIZE_EXPORT MolVSValidations {
- public:
-  virtual void run(const ROMol &mol, bool reportAllFailures,
-                   std::vector<ValidationErrorInfo> &errors) const = 0;
-  virtual boost::shared_ptr<MolVSValidations> copy() const = 0;
-};
 
 //! The NoAtomValidation class throws an error if no atoms are present in the
 /// molecule.
-class RDKIT_MOLSTANDARDIZE_EXPORT NoAtomValidation final
-    : public MolVSValidations {
+class RDKIT_MOLSTANDARDIZE_EXPORT NoAtomValidation : public ValidationMethod {
  public:
-  void run(const ROMol &mol, bool reportAllFailures,
-           std::vector<ValidationErrorInfo> &errors) const override;
-  //! makes a copy of NoAtomValidation object and returns a MolVSValidations
-  //! pointer to it
-  boost::shared_ptr<MolVSValidations> copy() const override {
-    return boost::make_shared<NoAtomValidation>(*this);
+  std::vector<ValidationErrorInfo> validate(
+    const ROMol &mol, bool reportAllFailures) const override;
+
+  std::shared_ptr<ValidationMethod> copy() const override {
+    return std::make_shared<NoAtomValidation>(*this);
   }
 };
 
 //! The FragmentValidation class logs if certain fragments are present.
-class RDKIT_MOLSTANDARDIZE_EXPORT FragmentValidation final
-    : public MolVSValidations {
+class RDKIT_MOLSTANDARDIZE_EXPORT FragmentValidation : public ValidationMethod {
  public:
-  void run(const ROMol &mol, bool reportAllFailures,
-           std::vector<ValidationErrorInfo> &errors) const override;
-  //! makes a copy of FragmentValidation object and returns a MolVSValidations
-  //! pointer to it
-  boost::shared_ptr<MolVSValidations> copy() const override {
-    return boost::make_shared<FragmentValidation>(*this);
+  std::vector<ValidationErrorInfo> validate(
+    const ROMol &mol, bool reportAllFailures) const override;
+
+  std::shared_ptr<ValidationMethod> copy() const override {
+    return std::make_shared<FragmentValidation>(*this);
   }
 };
 
 //! The NeutralValidation class logs if not an overall neutral system.
-class RDKIT_MOLSTANDARDIZE_EXPORT NeutralValidation final
-    : public MolVSValidations {
+class RDKIT_MOLSTANDARDIZE_EXPORT NeutralValidation : public ValidationMethod {
  public:
-  void run(const ROMol &mol, bool reportAllFailures,
-           std::vector<ValidationErrorInfo> &errors) const override;
-  //! makes a copy of NeutralValidation object and returns a MolVSValidations
-  //! pointer to it
-  boost::shared_ptr<MolVSValidations> copy() const override {
-    return boost::make_shared<NeutralValidation>(*this);
+  std::vector<ValidationErrorInfo> validate(
+    const ROMol &mol, bool reportAllFailures) const override;
+
+  std::shared_ptr<ValidationMethod> copy() const override {
+    return std::make_shared<NeutralValidation>(*this);
   }
 };
 
 //! The IsotopeValidation class logs if molecule contains isotopes.
-class RDKIT_MOLSTANDARDIZE_EXPORT IsotopeValidation final
-    : public MolVSValidations {
+class RDKIT_MOLSTANDARDIZE_EXPORT IsotopeValidation : public ValidationMethod {
  public:
-  void run(const ROMol &mol, bool reportAllFailures,
-           std::vector<ValidationErrorInfo> &errors) const override;
-  //! makes a copy of IsotopeValidation object and returns a MolVSValidations
-  //! pointer to it
-  boost::shared_ptr<MolVSValidations> copy() const override {
-    return boost::make_shared<IsotopeValidation>(*this);
+  std::vector<ValidationErrorInfo> validate(
+    const ROMol &mol, bool reportAllFailures) const override;
+
+  std::shared_ptr<ValidationMethod> copy() const override {
+    return std::make_shared<IsotopeValidation>(*this);
   }
 };
 
 ////////////////////////////////
-
-//! The MolVSValidation class can be used to perform all MolVSValidions.
-class RDKIT_MOLSTANDARDIZE_EXPORT MolVSValidation : public ValidationMethod {
+//! The MolVSValidation class includes most of the same validations as
+/// molvs.validations, namely NoAtomValidation, FragmentValidation,
+/// NeutralValidation, IsotopeValidation. MolVS also has IsNoneValidation and
+/// DichloroethaneValidation but these were not included here (yet).
+class RDKIT_MOLSTANDARDIZE_EXPORT MolVSValidation : public CompositeValidation {
  public:
   // constructor
   MolVSValidation();
-  //! overloaded constructor to take in a user-defined list of MolVSValidations
+  //! overloaded constructor to take in a user-defined list of ValidationMethod
   MolVSValidation(
-      const std::vector<boost::shared_ptr<MolVSValidations>> validations);
-  MolVSValidation(const MolVSValidation &other);
-  ~MolVSValidation() override;
+      const std::vector<std::shared_ptr<ValidationMethod>> & validations);
 
-  std::vector<ValidationErrorInfo> validate(
-      const ROMol &mol, bool reportAllFailures) const override;
-
- private:
-  std::vector<boost::shared_ptr<MolVSValidations>> d_validations;
+  std::shared_ptr<ValidationMethod> copy() const override {
+    return std::make_shared<MolVSValidation>(*this);
+  }
 };
 
 //! The AllowedAtomsValidation class lets the user input a list of atoms,
@@ -169,6 +173,10 @@ class RDKIT_MOLSTANDARDIZE_EXPORT AllowedAtomsValidation
       : d_allowedList(std::move(atoms)) {}
   std::vector<ValidationErrorInfo> validate(
       const ROMol &mol, bool reportAllFailures) const override;
+
+  std::shared_ptr<ValidationMethod> copy() const override {
+    return std::make_shared<AllowedAtomsValidation>(*this);
+  }
 
  private:
   std::vector<std::shared_ptr<Atom>> d_allowedList;
@@ -184,6 +192,10 @@ class RDKIT_MOLSTANDARDIZE_EXPORT DisallowedAtomsValidation
       : d_disallowedList(std::move(atoms)) {}
   std::vector<ValidationErrorInfo> validate(
       const ROMol &mol, bool reportAllFailures) const override;
+
+  std::shared_ptr<ValidationMethod> copy() const override {
+    return std::make_shared<DisallowedAtomsValidation>(*this);
+  }
 
  private:
   std::vector<std::shared_ptr<Atom>> d_disallowedList;

--- a/Code/GraphMol/MolStandardize/Wrap/Validate.cpp
+++ b/Code/GraphMol/MolStandardize/Wrap/Validate.cpp
@@ -17,8 +17,25 @@ using namespace RDKit;
 
 namespace {
 
-python::list rdkitValidate(MolStandardize::RDKitValidation &self,
-                           const ROMol &mol, const bool reportAllFailures) {
+struct ValidationMethodWrap : MolStandardize::ValidationMethod, python::wrapper<MolStandardize::ValidationMethod>
+{
+    std::vector<MolStandardize::ValidationErrorInfo> validate(
+      const ROMol &mol, bool reportAllFailures) const override
+    {
+        return this->get_override("validate")(mol, reportAllFailures);
+    }
+
+    std::shared_ptr<MolStandardize::ValidationMethod> copy() const override
+    {
+        return this->get_override("copy")();
+    }
+};
+
+// Wrap ValidationMethod::validate and convert the returned
+// vector into a python list of strings
+python::list pythonValidateMethod(
+    const MolStandardize::ValidationMethod & self, const ROMol &mol,
+    bool reportAllFailures) {
   python::list res;
   std::vector<MolStandardize::ValidationErrorInfo> errout =
       self.validate(mol, reportAllFailures);
@@ -31,10 +48,10 @@ python::list rdkitValidate(MolStandardize::RDKitValidation &self,
 
 MolStandardize::MolVSValidation *getMolVSValidation(
     python::object validations) {
-  std::vector<boost::shared_ptr<MolStandardize::MolVSValidations>> vs;
+  std::vector<std::shared_ptr<MolStandardize::ValidationMethod>> vs;
 
   auto pvect =
-      pythonObjectToVect<boost::shared_ptr<MolStandardize::MolVSValidations>>(
+      pythonObjectToVect<std::shared_ptr<MolStandardize::ValidationMethod>>(
           validations);
   if (!pvect) {
     throw_value_error("validations argument must be non-empty");
@@ -43,17 +60,6 @@ MolStandardize::MolVSValidation *getMolVSValidation(
     vs.push_back(v->copy());
   }
   return new MolStandardize::MolVSValidation(vs);
-}
-
-python::list molVSvalidateHelper(MolStandardize::MolVSValidation &self,
-                                 const ROMol &mol, bool reportAllFailures) {
-  python::list s;
-  std::vector<MolStandardize::ValidationErrorInfo> errout =
-      self.validate(mol, reportAllFailures);
-  for (auto &query : errout) {
-    s.append(query.what());
-  }
-  return s;
 }
 
 MolStandardize::AllowedAtomsValidation *getAllowedAtomsValidation(
@@ -69,19 +75,6 @@ MolStandardize::AllowedAtomsValidation *getAllowedAtomsValidation(
   return new MolStandardize::AllowedAtomsValidation(satoms);
 }
 
-python::list allowedAtomsValidate(MolStandardize::AllowedAtomsValidation &self,
-                                  const ROMol &mol,
-                                  const bool reportAllFailures) {
-  python::list res;
-  std::vector<MolStandardize::ValidationErrorInfo> errout =
-      self.validate(mol, reportAllFailures);
-  for (auto &query : errout) {
-    std::string msg = query.what();
-    res.append(msg);
-  }
-  return res;
-}
-
 MolStandardize::DisallowedAtomsValidation *getDisallowedAtomsValidation(
     python::object atoms) {
   auto p_atomList = pythonObjectToVect<Atom *>(atoms);
@@ -93,19 +86,6 @@ MolStandardize::DisallowedAtomsValidation *getDisallowedAtomsValidation(
     satoms.push_back(std::shared_ptr<Atom>(ap->copy()));
   }
   return new MolStandardize::DisallowedAtomsValidation(satoms);
-}
-
-python::list disallowedAtomsValidate(
-    MolStandardize::DisallowedAtomsValidation &self, const ROMol &mol,
-    const bool reportAllFailures) {
-  python::list res;
-  std::vector<MolStandardize::ValidationErrorInfo> errout =
-      self.validate(mol, reportAllFailures);
-  for (auto &query : errout) {
-    std::string msg = query.what();
-    res.append(msg);
-  }
-  return res;
 }
 
 python::list standardizeSmilesHelper(const std::string &smiles) {
@@ -125,76 +105,63 @@ struct validate_wrapper {
   static void wrap() {
     std::string docString = "";
 
-    python::class_<MolStandardize::RDKitValidation, boost::noncopyable>(
-        "RDKitValidation", python::init<>(python::args("self")))
-        .def("validate", rdkitValidate,
-             (python::arg("self"), python::arg("mol"),
-              python::arg("reportAllFailures") = false),
-             "");
+    python::class_<ValidationMethodWrap, boost::noncopyable>("ValidationMethod")
+      .def("validate", pythonValidateMethod,
+            (python::arg("self"), python::arg("mol"),
+            python::arg("reportAllFailures") = false),
+            "")
+      ;
 
-    python::class_<MolStandardize::MolVSValidations, boost::noncopyable>(
-        "MolVSValidations", python::no_init)
-        .def("run", &MolStandardize::MolVSValidations::run,
-             (python::arg("self"), python::arg("mol"),
-              python::arg("reportAllFailures"), python::arg("errors")),
-             "");
+    python::class_<
+      MolStandardize::RDKitValidation,
+      python::bases<MolStandardize::ValidationMethod>,
+      boost::noncopyable>("RDKitValidation")
+      ;
 
-    python::class_<MolStandardize::NoAtomValidation,
-                   python::bases<MolStandardize::MolVSValidations>>(
-        "NoAtomValidation", python::init<>(python::args("self")))
-        .def("run", &MolStandardize::NoAtomValidation::run,
-             (python::arg("self"), python::arg("mol"),
-              python::arg("reportAllFailures"), python::arg("errors")),
-             "");
+    python::class_<
+      MolStandardize::NoAtomValidation,
+      python::bases<MolStandardize::ValidationMethod>,
+      boost::noncopyable>("NoAtomValidation")
+      ;
 
-    python::class_<MolStandardize::FragmentValidation,
-                   python::bases<MolStandardize::MolVSValidations>>(
-        "FragmentValidation", python::init<>(python::args("self")))
-        .def("run", &MolStandardize::FragmentValidation::run,
-             (python::arg("self"), python::arg("mol"),
-              python::arg("reportAllFailures"), python::arg("errors")),
-             "");
-    python::class_<MolStandardize::NeutralValidation,
-                   python::bases<MolStandardize::MolVSValidations>>(
-        "NeutralValidation", python::init<>(python::args("self")))
-        .def("run", &MolStandardize::NeutralValidation::run,
-             (python::arg("self"), python::arg("mol"),
-              python::arg("reportAllFailures"), python::arg("errors")),
-             "");
-    python::class_<MolStandardize::IsotopeValidation,
-                   python::bases<MolStandardize::MolVSValidations>>(
-        "IsotopeValidation", python::init<>(python::args("self")))
-        .def("run", &MolStandardize::IsotopeValidation::run,
-             (python::arg("self"), python::arg("mol"),
-              python::arg("reportAllFailures"), python::arg("errors")),
-             "");
+    python::class_<
+      MolStandardize::FragmentValidation,
+      python::bases<MolStandardize::ValidationMethod>,
+      boost::noncopyable>("FragmentValidation")
+      ;
 
-    python::class_<MolStandardize::MolVSValidation, boost::noncopyable>(
-        "MolVSValidation")
+    python::class_<
+      MolStandardize::NeutralValidation,
+      python::bases<MolStandardize::ValidationMethod>,
+      boost::noncopyable>("NeutralValidation")
+      ;
+
+    python::class_<
+      MolStandardize::IsotopeValidation,
+      python::bases<MolStandardize::ValidationMethod>,
+      boost::noncopyable>("IsotopeValidation")
+      ;
+
+    python::class_<
+      MolStandardize::MolVSValidation,
+      python::bases<MolStandardize::ValidationMethod>,
+      boost::noncopyable>("MolVSValidation")
         .def("__init__", python::make_constructor(&getMolVSValidation))
-        .def("validate", molVSvalidateHelper,
-             (python::arg("self"), python::arg("mol"),
-              python::arg("reportAllFailures") = false),
-             "");
+      ;
 
-    python::class_<MolStandardize::AllowedAtomsValidation, boost::noncopyable>(
-        "AllowedAtomsValidation", python::no_init)
+    python::class_<
+      MolStandardize::AllowedAtomsValidation,
+      python::bases<MolStandardize::ValidationMethod>,
+      boost::noncopyable>("AllowedAtomsValidation", python::no_init)
         .def("__init__", python::make_constructor(&getAllowedAtomsValidation))
-        .def("validate", allowedAtomsValidate,
-             (python::arg("self"), python::arg("mol"),
-              python::arg("reportAllFailures") = false),
-             "");
-    ;
+      ;
 
-    python::class_<MolStandardize::DisallowedAtomsValidation,
-                   boost::noncopyable>("DisallowedAtomsValidation",
-                                       python::no_init)
-        .def("__init__",
-             python::make_constructor(&getDisallowedAtomsValidation))
-        .def("validate", disallowedAtomsValidate,
-             (python::arg("self"), python::arg("mol"),
-              python::arg("reportAllFailures") = false),
-             "");
+    python::class_<
+      MolStandardize::DisallowedAtomsValidation,
+      python::bases<MolStandardize::ValidationMethod>,
+      boost::noncopyable>("DisallowedAtomsValidation", python::no_init)
+        .def("__init__", python::make_constructor(&getDisallowedAtomsValidation))
+      ;
 
     python::def("ValidateSmiles", standardizeSmilesHelper, (python::arg("mol")),
                 docString.c_str());

--- a/Code/GraphMol/MolStandardize/Wrap/Validate.cpp
+++ b/Code/GraphMol/MolStandardize/Wrap/Validate.cpp
@@ -39,8 +39,7 @@ python::list pythonValidateMethod(
   python::list res;
   std::vector<MolStandardize::ValidationErrorInfo> errout =
       self.validate(mol, reportAllFailures);
-  for (auto &query : errout) {
-    std::string msg = query.what();
+  for (const auto &msg : errout) {
     res.append(msg);
   }
   return res;
@@ -92,8 +91,7 @@ python::list standardizeSmilesHelper(const std::string &smiles) {
   python::list res;
   std::vector<MolStandardize::ValidationErrorInfo> errout =
       MolStandardize::validateSmiles(smiles);
-  for (auto &query : errout) {
-    std::string msg = query.what();
+  for (const auto &msg : errout) {
     res.append(msg);
   }
   return res;

--- a/Code/GraphMol/MolStandardize/test2.cpp
+++ b/Code/GraphMol/MolStandardize/test2.cpp
@@ -65,8 +65,7 @@ void testValidate() {
     std::string smi = "CO(C)C";
     RWMOL_SPTR m(SmilesToMol(smi, 0, false));
     std::vector<ValidationErrorInfo> errout = vm.validate(*m, true);
-    for (auto &query : errout) {
-      std::string msg = query.what();
+    for (const auto &msg : errout) {
       TEST_ASSERT(
           msg ==
           "INFO: [ValenceValidation] Explicit valence for atom # 1 O, 3, "
@@ -79,8 +78,7 @@ void testValidate() {
     std::string smi = "O=C([O-])c1ccccc1";
     RWMOL_SPTR m(SmilesToMol(smi, 0, false));
     std::vector<ValidationErrorInfo> errout = vm.validate(*m, true);
-    for (auto &query : errout) {
-      std::string msg = query.what();
+    for (const auto &msg : errout) {
       TEST_ASSERT(
           msg ==
           "INFO: [NeutralValidation] Not an overall neutral system (-1)");
@@ -99,8 +97,7 @@ void testValidate() {
     AllowedAtomsValidation vm(atomList);
     RWMOL_SPTR m = "CC(=O)CF"_smiles;
     std::vector<ValidationErrorInfo> errout = vm.validate(*m, true);
-    for (auto &query : errout) {
-      std::string msg = query.what();
+    for (const auto &msg : errout) {
       TEST_ASSERT(
           msg ==
           "INFO: [AllowedAtomsValidation] Atom F is not in allowedAtoms list");
@@ -119,8 +116,7 @@ void testValidate() {
     DisallowedAtomsValidation vm(atomList);
     RWMOL_SPTR m = "CC(=O)CF"_smiles;
     std::vector<ValidationErrorInfo> errout = vm.validate(*m, true);
-    for (auto &query : errout) {
-      std::string msg = query.what();
+    for (const auto &msg : errout) {
       TEST_ASSERT(msg ==
                   "INFO: [DisallowedAtomsValidation] Atom F is in "
                   "disallowedAtoms list");
@@ -134,8 +130,7 @@ void testValidate() {
     std::string smi = "ClCCCl.c1ccccc1O";
     RWMOL_SPTR m(SmilesToMol(smi, 0, false));
     std::vector<ValidationErrorInfo> errout = vm.validate(*m, true);
-    for (auto &query : errout) {
-      std::string msg = query.what();
+    for (const auto &msg : errout) {
       TEST_ASSERT(msg ==
                   "INFO: [FragmentValidation] 1,2-dichloroethane is present");
     }

--- a/Code/GraphMol/MolStandardize/testValidate.cpp
+++ b/Code/GraphMol/MolStandardize/testValidate.cpp
@@ -32,8 +32,7 @@ void testRDKitValidation() {
   smi1 = "CO(C)C";
   unique_ptr<ROMol> m1(SmilesToMol(smi1, 0, false));
   vector<ValidationErrorInfo> errout1 = vm.validate(*m1, true);
-  for (auto &query : errout1) {
-    std::string msg = query.what();
+  for (const auto &msg : errout1) {
     TEST_ASSERT(msg ==
                 "INFO: [ValenceValidation] Explicit valence for atom # 1 O, 3, "
                 "is greater than permitted");
@@ -43,8 +42,7 @@ void testRDKitValidation() {
   smi2 = "";
   unique_ptr<ROMol> m2(SmilesToMol(smi2, 0, false));
   vector<ValidationErrorInfo> errout2 = vm.validate(*m2, true);
-  for (auto &query : errout2) {
-    std::string msg = query.what();
+  for (const auto &msg : errout2) {
     TEST_ASSERT(msg == "ERROR: [NoAtomValidation] Molecule has no atoms");
   }
 
@@ -58,8 +56,8 @@ void testRDKitValidation() {
       "greater than permitted",
       "INFO: [ValenceValidation] Explicit valence for atom # 5 N, 5, is "
       "greater than permitted"};
-  for (auto &query : errout3) {
-    msgs1.emplace_back(query.what());
+  for (const auto &msg : errout3) {
+    msgs1.push_back(msg);
   }
   TEST_ASSERT(msgs1 == ans1);
 
@@ -72,8 +70,8 @@ void testRDKitValidation() {
   std::vector<string> ans2 = {
       "INFO: [ValenceValidation] Explicit valence for atom # 1 O, 3, is "
       "greater than permitted"};
-  for (auto &query : errout4) {
-    msgs2.emplace_back(query.what());
+  for (const auto &msg : errout4) {
+    msgs2.push_back(msg);
   }
   TEST_ASSERT(msgs2 == ans2);
   BOOST_LOG(rdInfoLog) << "Finished" << std::endl;
@@ -90,16 +88,14 @@ void testMolVSValidation() {
   smi1 = "";
   unique_ptr<ROMol> m1(SmilesToMol(smi1, 0, false));
   vector<ValidationErrorInfo> errout1 = vm.validate(*m1, true);
-  for (auto &query : errout1) {
-    std::string msg = query.what();
+  for (const auto &msg : errout1) {
     TEST_ASSERT(msg == "ERROR: [NoAtomValidation] Molecule has no atoms");
   }
 
   smi2 = "O=C([O-])c1ccccc1";
   unique_ptr<ROMol> m2(SmilesToMol(smi2, 0, false));
   vector<ValidationErrorInfo> errout2 = vm.validate(*m2, true);
-  for (auto &query : errout2) {
-    std::string msg = query.what();
+  for (const auto &msg : errout2) {
     TEST_ASSERT(msg ==
                 "INFO: [NeutralValidation] Not an overall neutral system (-1)");
   }
@@ -107,8 +103,7 @@ void testMolVSValidation() {
   smi3 = "CN=[NH+]CN=N";
   unique_ptr<ROMol> m3(SmilesToMol(smi3, 0, false));
   vector<ValidationErrorInfo> errout3 = vm.validate(*m3, true);
-  for (auto &query : errout3) {
-    std::string msg = query.what();
+  for (const auto &msg : errout3) {
     TEST_ASSERT(
         msg ==
         "INFO: [NeutralValidation] Not an overall neutral system (+1)");  // fix
@@ -121,8 +116,7 @@ void testMolVSValidation() {
   smi4 = "[13CH4]";
   unique_ptr<ROMol> m4(SmilesToMol(smi4, 0, false));
   vector<ValidationErrorInfo> errout4 = vm.validate(*m4, true);
-  for (auto &query : errout4) {
-    std::string msg = query.what();
+  for (const auto &msg : errout4) {
     TEST_ASSERT(msg ==
                 "INFO: [IsotopeValidation] Molecule contains isotope 13C");
   }
@@ -130,8 +124,7 @@ void testMolVSValidation() {
   smi5 = "[2H]C(Cl)(Cl)Cl";
   unique_ptr<ROMol> m5(SmilesToMol(smi5, 0, false));
   vector<ValidationErrorInfo> errout5 = vm.validate(*m5, true);
-  for (auto &query : errout5) {
-    std::string msg = query.what();
+  for (const auto &msg : errout5) {
     TEST_ASSERT(msg ==
                 "INFO: [IsotopeValidation] Molecule contains isotope 2H");
   }
@@ -139,8 +132,7 @@ void testMolVSValidation() {
   smi6 = "[2H]OC([2H])([2H])[2H]";
   unique_ptr<ROMol> m6(SmilesToMol(smi6, 0, false));
   vector<ValidationErrorInfo> errout6 = vm.validate(*m6, true);
-  for (auto &query : errout6) {
-    std::string msg = query.what();
+  for (const auto &msg : errout6) {
     TEST_ASSERT(msg ==
                 "INFO: [IsotopeValidation] Molecule contains isotope 2H");
   }
@@ -149,8 +141,7 @@ void testMolVSValidation() {
   unique_ptr<ROMol> m7(SmilesToMol(smi7, 0, false));
   vector<ValidationErrorInfo> errout7 = vm.validate(*m7, true);
   TEST_ASSERT(errout7.size() != 0);
-  for (auto &query : errout7) {
-    std::string msg = query.what();
+  for (const auto &msg : errout7) {
     TEST_ASSERT(msg == "INFO: [FragmentValidation] water/hydroxide is present");
   }
 
@@ -158,8 +149,7 @@ void testMolVSValidation() {
   unique_ptr<ROMol> m8(SmilesToMol(smi8, 0, false));
   vector<ValidationErrorInfo> errout8 = vm.validate(*m8, true);
   TEST_ASSERT(errout8.size() != 0);
-  for (auto &query : errout8) {
-    std::string msg = query.what();
+  for (const auto &msg : errout8) {
     TEST_ASSERT(msg ==
                 "INFO: [FragmentValidation] acetate/acetic acid is present");
   }
@@ -172,7 +162,7 @@ void testMolVSValidation() {
       "INFO: [FragmentValidation] potassium is present"};
   TEST_ASSERT(errout9.size() == ans.size());
   for (size_t i = 0; i < errout9.size(); ++i) {
-    TEST_ASSERT(errout9[i].what() == ans[i]);
+    TEST_ASSERT(errout9[i] == ans[i]);
   }
 
   std::string smi10 = "C1COCCO1.O=C(NO)NO";
@@ -183,7 +173,7 @@ void testMolVSValidation() {
       "INFO: [FragmentValidation] 1,4-dioxane is present"};
   TEST_ASSERT(errout10.size() == ans10.size());
   for (size_t i = 0; i < errout10.size(); ++i) {
-    TEST_ASSERT(errout10[i].what() == ans10[i]);
+    TEST_ASSERT(errout10[i] == ans10[i]);
   }
   BOOST_LOG(rdInfoLog) << "Finished" << std::endl;
 }
@@ -200,8 +190,7 @@ void testMolVSOptions() {
   string smi1 = "";
   unique_ptr<ROMol> m1(SmilesToMol(smi1, 0, false));
   vector<ValidationErrorInfo> errout1 = vm.validate(*m1, true);
-  for (auto &query : errout1) {
-    std::string msg = query.what();
+  for (const auto &msg : errout1) {
     //    TEST_ASSERT(msg == "ERROR: [NoAtomValidation] Molecule has no atoms");
     TEST_ASSERT(msg == "");
   }
@@ -209,8 +198,7 @@ void testMolVSOptions() {
   string smi2 = "O=C([O-])c1ccccc1";
   unique_ptr<ROMol> m2(SmilesToMol(smi2, 0, false));
   vector<ValidationErrorInfo> errout2 = vm.validate(*m2, true);
-  for (auto &query : errout2) {
-    std::string msg = query.what();
+  for (const auto &msg : errout2) {
     //    TEST_ASSERT(msg ==
     //                "INFO: [NeutralValidation] Not an overall neutral system
     //                (-1)");
@@ -239,8 +227,7 @@ void testAllowedAtomsValidation() {
   smi1 = "CC(=O)CF";
   unique_ptr<ROMol> m1(SmilesToMol(smi1));
   vector<ValidationErrorInfo> errout1 = vm.validate(*m1, true);
-  for (auto &query : errout1) {
-    std::string msg = query.what();
+  for (const auto &msg : errout1) {
     TEST_ASSERT(
         msg ==
         "INFO: [AllowedAtomsValidation] Atom F is not in allowedAtoms list");
@@ -268,8 +255,7 @@ void testDisallowedAtomsValidation() {
   smi1 = "CC(=O)CF";
   unique_ptr<ROMol> m1(SmilesToMol(smi1));
   vector<ValidationErrorInfo> errout1 = vm.validate(*m1, true);
-  for (auto &query : errout1) {
-    std::string msg = query.what();
+  for (const auto &msg : errout1) {
     TEST_ASSERT(
         msg ==
         "INFO: [DisallowedAtomsValidation] Atom F is in disallowedAtoms list");
@@ -289,8 +275,7 @@ void testFragment() {
   smi1 = "ClCCCl.c1ccccc1O";
   unique_ptr<ROMol> m1(SmilesToMol(smi1, 0, false));
   vector<ValidationErrorInfo> errout1 = vm.validate(*m1, true);
-  for (auto &query : errout1) {
-    std::string msg = query.what();
+  for (const auto &msg : errout1) {
     TEST_ASSERT(msg ==
                 "INFO: [FragmentValidation] 1,2-dichloroethane is present");
   }
@@ -298,8 +283,7 @@ void testFragment() {
   smi2 = "COCCOC.CCCBr";
   unique_ptr<ROMol> m2(SmilesToMol(smi2, 0, false));
   vector<ValidationErrorInfo> errout2 = vm.validate(*m2, true);
-  for (auto &query : errout2) {
-    std::string msg = query.what();
+  for (const auto &msg : errout2) {
     TEST_ASSERT(msg ==
                 "INFO: [FragmentValidation] 1,2-dimethoxyethane is present");
   }
@@ -320,14 +304,12 @@ void testValidateSmiles() {
   };
 
   vector<ValidationErrorInfo> errout2 = validateSmiles("");
-  for (auto &query : errout2) {
-    std::string msg = query.what();
+  for (const auto &msg : errout2) {
     TEST_ASSERT(msg == "ERROR: [NoAtomValidation] Molecule has no atoms");
   }
 
   vector<ValidationErrorInfo> errout3 = validateSmiles("ClCCCl.c1ccccc1O");
-  for (auto &query : errout3) {
-    std::string msg = query.what();
+  for (const auto &msg : errout3) {
     TEST_ASSERT(msg ==
                 "INFO: [FragmentValidation] 1,2-dichloroethane is present");
   }

--- a/Code/GraphMol/MolStandardize/testValidate.cpp
+++ b/Code/GraphMol/MolStandardize/testValidate.cpp
@@ -191,8 +191,8 @@ void testMolVSValidation() {
 void testMolVSOptions() {
   BOOST_LOG(rdInfoLog) << "-----------------------\n Testing MolVS Options"
                        << std::endl;
-  vector<boost::shared_ptr<MolVSValidations>> validations = {
-      boost::make_shared<IsotopeValidation>()};
+  vector<std::shared_ptr<ValidationMethod>> validations = {
+      std::make_shared<IsotopeValidation>()};
   MolVSValidation vm(validations);
 
   // testing MolVSDefault

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -11,6 +11,7 @@ GitHub)
 ## Backwards incompatible changes
 - Two changes to improve the defaults for conformer generation: the functions EmbedMolecule() and EmbedMultipleConfis() now use ETKDGv3 by default (previously they were using ETKDGV1) and only consider heavy atoms when calculating RMSD for conformer pruning (previously Hs were alos considered).
 - The way that the number of radical electrons is calculated for atoms coming from mol blocks has been changed. Systems like a `[CH]` marked as a `DOUBLET` will now have three radical electrons assigned. This is consistent with the value from SMILES.
+- The validation classes in MolStandardize were refactored in order to offer a simpler and more consistent API. In the C++ implementation, the `MolVSValidations` base class was removed and consolidated into `ValidationMethod`. Consequently, the `validate` method replaced `run` in the subclasses related to MolVS (namely `NoAtomValidation`, `FragmentValidation`, `NeutralValidation`, and `IsotopeValidation`) and all subclasses of `ValidationMethod` are now required to implement a `copy` method. Moreover, `MolStandardize::ValidationErrorInfo` was redefined as an alias for `std::string`. The changes related to the MolVS validation methods were similarly implemented in the Python API.
 
 ## New Features and Enhancements:
 


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
This PR implements a refactoring of the `MolStandardize` validation classes. The changes are mainly related to the reimplementation of `MolVSValidation` as a composite of `ValidationMethod` and the consequent harmonization of the API originally provided by `MolVSValidations` and `ValidationMethod`.

The new implementation should support a better usability of the validation criteria migrated from MolVS (which are this way easier to use directly) without a very significant impact on the existing client code.

The implementation of the python wrappers related to these classes was also streamlined in the process.

