### PR TITLE
Fixes #7028

### DIFF
--- a/Code/GraphMol/ChemReactions/Reaction.h
+++ b/Code/GraphMol/ChemReactions/Reaction.h
@@ -504,7 +504,7 @@ namespace RDDepict {
 
 */
 RDKIT_CHEMREACTIONS_EXPORT void compute2DCoordsForReaction(
-    RDKit::ChemicalReaction &rxn, double spacing = 2.0, bool updateProps = true,
+    RDKit::ChemicalReaction &rxn, double spacing = 1.0, bool updateProps = true,
     bool canonOrient = false, unsigned int nFlipsPerSample = 0,
     unsigned int nSamples = 0, int sampleSeed = 0,
     bool permuteDeg4Nodes = false);

--- a/Code/GraphMol/ChemReactions/ReactionDepict.cpp
+++ b/Code/GraphMol/ChemReactions/ReactionDepict.cpp
@@ -41,41 +41,41 @@ void compute2DCoordsForReaction(RDKit::ChemicalReaction &rxn, double spacing,
                                 unsigned int nSamples, int sampleSeed,
                                 bool permuteDeg4Nodes) {
   double xOffset = 0.0;
-  for (auto templIt = rxn.beginReactantTemplates();
-       templIt != rxn.endReactantTemplates(); ++templIt) {
+  for (auto &reactant : rxn.getReactants()) {
     if (updateProps) {
-      (*templIt)->updatePropertyCache(false);
-      RDKit::MolOps::setConjugation(**templIt);
-      RDKit::MolOps::setHybridization(**templIt);
+      reactant->updatePropertyCache(false);
+      RDKit::MolOps::setConjugation(*reactant);
+      RDKit::MolOps::setHybridization(*reactant);
     }
-    compute2DCoords(**templIt, nullptr, canonOrient, true, nFlipsPerSample,
+    compute2DCoords(*reactant, nullptr, canonOrient, true, nFlipsPerSample,
                     nSamples, sampleSeed, permuteDeg4Nodes);
-    double minX = 100., maxX = -100.;
-    for (auto &pt : (*templIt)->getConformer().getPositions()) {
+    double minX = 1e8, maxX = -1e8;
+    for (auto &pt : reactant->getConformer().getPositions()) {
       minX = std::min(pt.x, minX);
+      maxX = std::max(pt.x, maxX);
     }
-    xOffset += minX;
-    for (auto &pt : (*templIt)->getConformer().getPositions()) {
+    xOffset += (maxX - minX) / 2;
+    for (auto &pt : reactant->getConformer().getPositions()) {
       pt.x += xOffset;
       maxX = std::max(pt.x, maxX);
     }
     xOffset = maxX + spacing;
   }
-  for (auto templIt = rxn.beginProductTemplates();
-       templIt != rxn.endProductTemplates(); ++templIt) {
+  for (auto &product : rxn.getProducts()) {
     if (updateProps) {
-      (*templIt)->updatePropertyCache(false);
-      RDKit::MolOps::setConjugation(**templIt);
-      RDKit::MolOps::setHybridization(**templIt);
+      product->updatePropertyCache(false);
+      RDKit::MolOps::setConjugation(*product);
+      RDKit::MolOps::setHybridization(*product);
     }
-    compute2DCoords(**templIt, nullptr, canonOrient, true, nFlipsPerSample,
+    compute2DCoords(*product, nullptr, canonOrient, true, nFlipsPerSample,
                     nSamples, sampleSeed, permuteDeg4Nodes);
     double minX = 100., maxX = -100.;
-    for (auto &pt : (*templIt)->getConformer().getPositions()) {
+    for (auto &pt : product->getConformer().getPositions()) {
       minX = std::min(pt.x, minX);
+      maxX = std::max(pt.x, maxX);
     }
-    xOffset += minX;
-    for (auto &pt : (*templIt)->getConformer().getPositions()) {
+    xOffset += (maxX - minX) / 2;
+    for (auto &pt : product->getConformer().getPositions()) {
       pt.x += xOffset;
       maxX = std::max(pt.x, maxX);
     }

--- a/Code/GraphMol/ChemReactions/Wrap/rdChemReactions.cpp
+++ b/Code/GraphMol/ChemReactions/Wrap/rdChemReactions.cpp
@@ -1016,7 +1016,7 @@ of the replacements argument.",
 )DOC";
   python::def(
       "Compute2DCoordsForReaction", RDKit::Compute2DCoordsForReaction,
-      (python::arg("reaction"), python::arg("spacing") = 2.0,
+      (python::arg("reaction"), python::arg("spacing") = 1.0,
        python::arg("updateProps") = true, python::arg("canonOrient") = true,
        python::arg("nFlipsPerSample") = 0, python::arg("nSample") = 0,
        python::arg("sampleSeed") = 0, python::arg("permuteDeg4Nodes") = false,


### PR DESCRIPTION
The calculation of the offset between reactants/products was just wrong.

With the offset corrected, the old default spacing of 2.0 seems quite high, so this also lowers that to 1.0
