### PR TITLE
support sanitization of reaction product templates

### DIFF
--- a/Code/GraphMol/ChemReactions/CDXMLParser.cpp
+++ b/Code/GraphMol/ChemReactions/CDXMLParser.cpp
@@ -87,8 +87,10 @@ CDXMLDataStreamToChemicalReactions(std::istream &inStream, bool sanitize,
     if (!sanitize) {  // we still need to fix the reaction for smarts style
                       // matching
       unsigned int failed;
-      sanitizeRxn(*res, failed, RxnOps::SANITIZE_ADJUST_REACTANTS,
-                  RxnOps::ChemDrawRxnAdjustParams());
+      RxnOps::sanitizeRxn(
+          *res, failed,
+          RxnOps::SANITIZE_ADJUST_REACTANTS | RxnOps::SANITIZE_ADJUST_PRODUCTS,
+          RxnOps::MatchOnlyAtRgroupsAdjustParams());
     }
   }
   return result;

--- a/Code/GraphMol/ChemReactions/SanitizeRxn.cpp
+++ b/Code/GraphMol/ChemReactions/SanitizeRxn.cpp
@@ -366,11 +366,10 @@ void fixHs(ChemicalReaction &rxn) {
   }
 }
 
-void adjustTemplates(ChemicalReaction &rxn,
+void adjustTemplates(const MOL_SPTR_VECT &templates,
                      const MolOps::AdjustQueryParameters &params) {
-  for (auto it = rxn.beginReactantTemplates(); it != rxn.endReactantTemplates();
-       ++it) {
-    auto *rw = dynamic_cast<RWMol *>(it->get());
+  for (auto &templ : templates) {
+    auto *rw = dynamic_cast<RWMol *>(templ.get());
     if (rw) {
       adjustQueryProperties(*rw, &params);
     } else
@@ -391,10 +390,13 @@ void sanitizeRxn(ChemicalReaction &rxn, unsigned int &operationsThatFailed,
     operationsThatFailed = SANITIZE_ATOM_MAPS;
     fixAtomMaps(rxn);
   }
-
   if (ops & SANITIZE_ADJUST_REACTANTS) {
     operationsThatFailed = SANITIZE_ADJUST_REACTANTS;
-    adjustTemplates(rxn, params);
+    adjustTemplates(rxn.getReactants(), params);
+  }
+  if (ops & SANITIZE_ADJUST_PRODUCTS) {
+    operationsThatFailed = SANITIZE_ADJUST_PRODUCTS;
+    adjustTemplates(rxn.getProducts(), params);
   }
   if (ops & SANITIZE_MERGEHS) {
     operationsThatFailed = SANITIZE_MERGEHS;

--- a/Code/GraphMol/ChemReactions/SanitizeRxn.h
+++ b/Code/GraphMol/ChemReactions/SanitizeRxn.h
@@ -66,7 +66,8 @@ RDKIT_CHEMREACTIONS_EXPORT void fixAtomMaps(ChemicalReaction &rxn);
 
 //! Adjusts the reactant templates to properly match reagents
 RDKIT_CHEMREACTIONS_EXPORT void adjustTemplates(
-    ChemicalReaction &rxn, const MolOps::AdjustQueryParameters &params);
+    const MOL_SPTR_VECT &templates,
+    const MolOps::AdjustQueryParameters &params);
 
 //! merge query Hs if appropriate
 RDKIT_CHEMREACTIONS_EXPORT void fixHs(ChemicalReaction &rxn);
@@ -117,6 +118,7 @@ typedef enum {
   SANITIZE_ATOM_MAPS = 0x2,
   SANITIZE_ADJUST_REACTANTS = 0x4,
   SANITIZE_MERGEHS = 0x8,
+  SANITIZE_ADJUST_PRODUCTS = 0x10,
   SANITIZE_ALL = 0xFFFFFFFF
 } SanitizeRxnFlags;
 

--- a/Code/GraphMol/ChemReactions/Wrap/testReactionWrapper.py
+++ b/Code/GraphMol/ChemReactions/Wrap/testReactionWrapper.py
@@ -35,7 +35,7 @@ import os
 import pickle
 import sys
 import unittest
-import tempfile 
+import tempfile
 
 from rdkit import Chem, Geometry, RDConfig, rdBase
 from rdkit.Chem import AllChem, rdChemReactions
@@ -687,7 +687,7 @@ M  END
     rxn.Initialize()
     res = rdChemReactions.PreprocessReaction(rxn)
     self.assertEqual(res,
-                      (0, 0, 2, 1, (((0, 'halogen.bromine.aromatic'), ), ((1, 'boronicacid'), ))))
+                     (0, 0, 2, 1, (((0, 'halogen.bromine.aromatic'), ), ((1, 'boronicacid'), ))))
 
   def testProperties(self):
     smirks_thiourea = "[N;$(N-[#6]):3]=[C;$(C=S):1].[N;$(N[#6]);!$(N=*);!$([N-]);!$(N#*);!$([ND3]);!$([ND4]);!$(N[O,N]);!$(N[C,S]=[S,O,N]):2]>>[N:3]-[C:1]-[N+0:2]"
@@ -731,8 +731,8 @@ M  END
       _reacts = [Chem.MolToSmarts(r) for r in _rxn.GetReactants()]
       _prods = [Chem.MolToSmarts(p) for p in _rxn.GetProducts()]
 
-  @unittest.skipUnless(hasattr(rdChemReactions,'ReactionFromPNGFile'),
-                     "RDKit not built with iostreams support")
+  @unittest.skipUnless(hasattr(rdChemReactions, 'ReactionFromPNGFile'),
+                       "RDKit not built with iostreams support")
   def test_PNGMetadata(self):
     fname = os.path.join(self.dataDir, 'reaction1.smarts.png')
     rxn = rdChemReactions.ReactionFromPNGFile(fname)
@@ -1034,7 +1034,7 @@ M  END
     self.assertEqual(Chem.MolToSmiles(reactant), 'CCOC(C)=O')
     self.assertFalse(rxn.RunReactantInPlace(reactant))
     self.assertEqual(Chem.MolToSmiles(reactant), 'CCOC(C)=O')
-    
+
     rxn = rdChemReactions.ReactionFromSmarts('CC[N:1]>>[N:1]')
     self.assertIsNotNone(rxn)
     reactant = Chem.MolFromSmiles('CCCN.Cl')
@@ -1043,11 +1043,9 @@ M  END
     self.assertEqual(Chem.MolToSmiles(reactant), 'N')
 
     reactant = Chem.MolFromSmiles('CCCN.Cl')
-    self.assertTrue(rxn.RunReactantInPlace(reactant,removeUnmatchedAtoms=False))
+    self.assertTrue(rxn.RunReactantInPlace(reactant, removeUnmatchedAtoms=False))
     Chem.SanitizeMol(reactant)
     self.assertEqual(Chem.MolToSmiles(reactant), 'C.Cl.N')
-
-
 
   def testGithub4651(self):
     mol_sulfonylchloride = Chem.MolFromSmiles("Nc1c(CCCSNCC)cc(cc1)S(=O)(=O)Cl")
@@ -1120,22 +1118,24 @@ M  END
     self.assertEqual(len(rxn.RunReactants((mol, ))), 0)
 
   def testMrvBlockContainsReaction(self):
-    fn1 = os.path.join(RDConfig.RDBaseDir,'Code','GraphMol','MarvinParse','test_data','aspirin.mrv')
-    with open(fn1,'r') as inf:
+    fn1 = os.path.join(RDConfig.RDBaseDir, 'Code', 'GraphMol', 'MarvinParse', 'test_data',
+                       'aspirin.mrv')
+    with open(fn1, 'r') as inf:
       ind1 = inf.read()
-    fn2 = os.path.join(RDConfig.RDBaseDir,'Code','GraphMol','MarvinParse','test_data','aspirineSynthesisWithAttributes.mrv')   
-    with open(fn2,'r') as inf:
+    fn2 = os.path.join(RDConfig.RDBaseDir, 'Code', 'GraphMol', 'MarvinParse', 'test_data',
+                       'aspirineSynthesisWithAttributes.mrv')
+    with open(fn2, 'r') as inf:
       ind2 = inf.read()
 
     self.assertFalse(rdChemReactions.MrvFileIsReaction(fn1))
     self.assertTrue(rdChemReactions.MrvFileIsReaction(fn2))
 
-
     self.assertFalse(rdChemReactions.MrvBlockIsReaction(ind1))
     self.assertTrue(rdChemReactions.MrvBlockIsReaction(ind2))
 
   def testMrvOutput(self):
-    fn2 = os.path.join(RDConfig.RDBaseDir,'Code','GraphMol','MarvinParse','test_data','aspirineSynthesisWithAttributes.mrv')   
+    fn2 = os.path.join(RDConfig.RDBaseDir, 'Code', 'GraphMol', 'MarvinParse', 'test_data',
+                       'aspirineSynthesisWithAttributes.mrv')
     rxn = rdChemReactions.ReactionFromMrvFile(fn2)
     self.assertIsNotNone(rxn)
     rxnb = rdChemReactions.ReactionToMrvBlock(rxn)
@@ -1143,31 +1143,33 @@ M  END
 
     fName = tempfile.NamedTemporaryFile(suffix='.mrv').name
     self.assertFalse(os.path.exists(fName))
-    rdChemReactions.ReactionToMrvFile(rxn,fName)
+    rdChemReactions.ReactionToMrvFile(rxn, fName)
     self.assertTrue(os.path.exists(fName))
     os.unlink(fName)
 
   def testCDXML(self):
-    fname = os.path.join(RDConfig.RDBaseDir,'Code','GraphMol',
-                         'test_data','CDXML','rxn2.cdxml')
+    fname = os.path.join(RDConfig.RDBaseDir, 'Code', 'GraphMol', 'test_data', 'CDXML', 'rxn2.cdxml')
     rxns = AllChem.ReactionsFromCDXMLFile(fname)
-    self.assertEqual(len(rxns),1)
-    self.assertEqual(AllChem.ReactionToSmarts(rxns[0]),
-                     "[#6&D2:2]1:[#6&D2:3]:[#6&D2:4]:[#6&D3:1](:[#6&D2:5]:[#6&D2:6]:1)-[#17&D1].[#6&D3](-[#5&D2]-[#6&D3:7]1:[#6&D2:8]:[#6&D2:9]:[#6&D2:10]:[#6&D2:11]:[#6&D2:12]:1)(-[#8&D1])-[#8&D1]>>[#6:1]1=[#6:5]-[#6:6](=[#6:2]-[#6:3]=[#6:4]-1)-[#6:7]1-[#6:8]=[#6:9]-[#6:10]=[#6:11]-[#6:12]=1")
-    
+    self.assertEqual(len(rxns), 1)
+    self.assertEqual(
+      AllChem.ReactionToSmarts(rxns[0]),
+      "[#6&D2:2]1:[#6&D2:3]:[#6&D2:4]:[#6&D3:1](:[#6&D2:5]:[#6&D2:6]:1)-[#17&D1].[#6&D3](-[#5&D2]-[#6&D3:7]1:[#6&D2:8]:[#6&D2:9]:[#6&D2:10]:[#6&D2:11]:[#6&D2:12]:1)(-[#8&D1])-[#8&D1]>>[#6&D2:1]1:[#6&D2:5]:[#6&D3:6](:[#6&D2:2]:[#6&D2:3]:[#6&D2:4]:1)-[#6&D3:7]1:[#6&D2:8]:[#6&D2:9]:[#6&D2:10]:[#6&D2:11]:[#6&D2:12]:1"
+    )
+
     rxns = AllChem.ReactionsFromCDXMLFile('does-not-exist.cdxml')
-    self.assertEqual(len(rxns),0)
+    self.assertEqual(len(rxns), 0)
 
-
-    with open(fname,'r') as inf:
+    with open(fname, 'r') as inf:
       cdxml = inf.read()
     rxns = AllChem.ReactionsFromCDXMLBlock(cdxml)
-    self.assertEqual(len(rxns),1)
-    self.assertEqual(AllChem.ReactionToSmarts(rxns[0]),
-                     "[#6&D2:2]1:[#6&D2:3]:[#6&D2:4]:[#6&D3:1](:[#6&D2:5]:[#6&D2:6]:1)-[#17&D1].[#6&D3](-[#5&D2]-[#6&D3:7]1:[#6&D2:8]:[#6&D2:9]:[#6&D2:10]:[#6&D2:11]:[#6&D2:12]:1)(-[#8&D1])-[#8&D1]>>[#6:1]1=[#6:5]-[#6:6](=[#6:2]-[#6:3]=[#6:4]-1)-[#6:7]1-[#6:8]=[#6:9]-[#6:10]=[#6:11]-[#6:12]=1")
+    self.assertEqual(len(rxns), 1)
+    self.assertEqual(
+      AllChem.ReactionToSmarts(rxns[0]),
+      "[#6&D2:2]1:[#6&D2:3]:[#6&D2:4]:[#6&D3:1](:[#6&D2:5]:[#6&D2:6]:1)-[#17&D1].[#6&D3](-[#5&D2]-[#6&D3:7]1:[#6&D2:8]:[#6&D2:9]:[#6&D2:10]:[#6&D2:11]:[#6&D2:12]:1)(-[#8&D1])-[#8&D1]>>[#6&D2:1]1:[#6&D2:5]:[#6&D3:6](:[#6&D2:2]:[#6&D2:3]:[#6&D2:4]:1)-[#6&D3:7]1:[#6&D2:8]:[#6&D2:9]:[#6&D2:10]:[#6&D2:11]:[#6&D2:12]:1"
+    )
 
     rxns = AllChem.ReactionsFromCDXMLBlock('')
-    self.assertEqual(len(rxns),0)
+    self.assertEqual(len(rxns), 0)
 
 
 if __name__ == '__main__':

--- a/Code/GraphMol/ChemReactions/catch_tests.cpp
+++ b/Code/GraphMol/ChemReactions/catch_tests.cpp
@@ -24,6 +24,7 @@
 #include <GraphMol/ChemReactions/ReactionRunner.h>
 #include <GraphMol/ChemReactions/ReactionUtils.h>
 #include <GraphMol/ChemReactions/ReactionPickler.h>
+#include <GraphMol/ChemReactions/SanitizeRxn.h>
 #include <GraphMol/FileParsers/PNGParser.h>
 #include <GraphMol/FileParsers/FileParserUtils.h>
 
@@ -1276,7 +1277,7 @@ TEST_CASE("CDXML Parser") {
       auto fname = cdxmlbase + "rxn2.cdxml";
       std::vector<std::string> expected = {"Cl[c:1]1[cH:4][cH:3][cH:2][cH:6][cH:5]1",
            "OC(O)B[c:7]1[cH:8][cH:9][cH:10][cH:11][cH:12]1",
-           "[CH:1]1=[CH:5][C:6]([C:7]2=[CH:12][CH:11]=[CH:10][CH:9]=[CH:8]2)=[CH:2][CH:3]=[CH:4]1"};
+           "[cH:1]1[cH:4][cH:3][cH:2][c:6](-[c:7]2[cH:8][cH:9][cH:10][cH:11][cH:12]2)[cH:5]1"};
       
        auto rxns = CDXMLFileToChemicalReactions(fname);
        CHECK(rxns.size() == 1);
@@ -1297,7 +1298,7 @@ TEST_CASE("CDXML Parser") {
        }
    
        auto smarts = ChemicalReactionToRxnSmarts(*rxns[0]);
-       CHECK(smarts == "[#6&D2:2]1:[#6&D2:3]:[#6&D2:4]:[#6&D3:1](:[#6&D2:5]:[#6&D2:6]:1)-[#17&D1].[#6&D3](-[#5&D2]-[#6&D3:7]1:[#6&D2:8]:[#6&D2:9]:[#6&D2:10]:[#6&D2:11]:[#6&D2:12]:1)(-[#8&D1])-[#8&D1]>>[#6:1]1=[#6:5]-[#6:6](=[#6:2]-[#6:3]=[#6:4]-1)-[#6:7]1-[#6:8]=[#6:9]-[#6:10]=[#6:11]-[#6:12]=1");
+       CHECK(smarts == "[#6&D2:2]1:[#6&D2:3]:[#6&D2:4]:[#6&D3:1](:[#6&D2:5]:[#6&D2:6]:1)-[#17&D1].[#6&D3](-[#5&D2]-[#6&D3:7]1:[#6&D2:8]:[#6&D2:9]:[#6&D2:10]:[#6&D2:11]:[#6&D2:12]:1)(-[#8&D1])-[#8&D1]>>[#6&D2:1]1:[#6&D2:5]:[#6&D3:6](:[#6&D2:2]:[#6&D2:3]:[#6&D2:4]:1)-[#6&D3:7]1:[#6&D2:8]:[#6&D2:9]:[#6&D2:10]:[#6&D2:11]:[#6&D2:12]:1");
   }
 }
 
@@ -1675,5 +1676,33 @@ TEST_CASE("Github #6492: In place transforms incorrectly change atomic numbers")
     REQUIRE(m);
     rxn->runReactant(*m);
     CHECK(MolToSmiles(*m)=="CN(C)c1cc[nH+]cc1");
+  }
+}
+
+TEST_CASE("allow sanitization of reaction products") {
+  std::string smi="C1=CC=CC=C1>>C1=CC=CC=N1";
+  bool useSmiles=true;
+  auto rxn = std::unique_ptr<ChemicalReaction>(RxnSmartsToChemicalReaction(smi,nullptr,useSmiles));
+  REQUIRE(rxn);
+  rxn->initReactantMatchers();
+  CHECK(rxn->getReactants()[0]->getBondWithIdx(0)->getIsAromatic()==false);
+  CHECK(rxn->getProducts()[0]->getBondWithIdx(0)->getIsAromatic()==false);
+  {
+    // by default we do product sanitization
+    ChemicalReaction rxncp(*rxn);
+    RxnOps::sanitizeRxn(rxncp);
+    CHECK(rxncp.getReactants()[0]->getBondWithIdx(0)->getIsAromatic()==true);
+    CHECK(rxncp.getProducts()[0]->getBondWithIdx(0)->getIsAromatic()==true);
+
+  }
+  {
+    // but we can turn it off
+    ChemicalReaction rxncp(*rxn);
+    unsigned int sanitizeOps = RxnOps::SANITIZE_ALL ^ RxnOps::SANITIZE_ADJUST_PRODUCTS;
+    unsigned int failed;
+    RxnOps::sanitizeRxn(rxncp,failed,sanitizeOps);
+    CHECK(rxncp.getReactants()[0]->getBondWithIdx(0)->getIsAromatic()==true);
+    CHECK(rxncp.getProducts()[0]->getBondWithIdx(0)->getIsAromatic()==false);
+
   }
 }


### PR DESCRIPTION
previously only reactant templates could be sanitized

the change is enabled by default 

also removes a deprecated usage from the CDXML reaction parser
