### PR TITLE
chore: fix blog link to new blog location

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 ## Web presence
 
   * [RDKit web page](https://rdkit.org)
-  * [Blog](https://rdkit.blogspot.com)
+  * [Blog](https://greglandrum.github.io/rdkit-blog/)
   * [Documentation](https://www.rdkit.org/docs/index.html)
 
 #### Materials from user group meetings


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! 
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.

The blog link on the README points to the old blog. Instead, point to the new blog (same link the old blog refers to).


#### Any other comments?

