### PR TITLE
Fixes #7115

### DIFF
--- a/Code/GraphMol/Chirality.cpp
+++ b/Code/GraphMol/Chirality.cpp
@@ -1368,7 +1368,7 @@ bool atomIsCandidateForRingStereochem(const ROMol &mol, const Atom *atom) {
       //   in a ring of size 3  (from InChI)
       // OR
       //   a bridgehead (RDKit extension)
-      if (atom->getAtomicNum() == 7 && atom->getDegree() == 3 &&
+      if (atom->getAtomicNum() == 7 && atom->getTotalDegree() == 3 &&
           !ringInfo->isAtomInRingOfSize(atom->getIdx(), 3) &&
           !queryIsAtomBridgehead(atom)) {
         return false;

--- a/Code/GraphMol/testChirality.cpp
+++ b/Code/GraphMol/testChirality.cpp
@@ -3203,6 +3203,35 @@ M  END)CTAB";
   TEST_ASSERT(double_bonds_seen == 6);
 }
 
+void testGithub7115() {
+    BOOST_LOG(rdInfoLog) << "-------------------------------------" << std::endl;
+    BOOST_LOG(rdInfoLog)
+    << "GitHub #7115: Quaternary nitrogens with hydrogens are not a candidate for stereo."
+    << std::endl;
+    
+    {
+        auto s = "C[C@]1(F)C[N@H+](O)C1"_smiles;
+        auto smi = MolToSmiles(*s);
+        TEST_ASSERT(smi == "C[C@]1(F)C[N@H+](O)C1");
+    }
+    {
+        auto s = "C[C@]1(F)C[N@+]([H])(O)C1"_smiles;
+        auto smi = MolToSmiles(*s);
+        TEST_ASSERT(smi == "C[C@]1(F)C[N@H+](O)C1");
+    }
+    {
+        auto insmi = "C[C@]1(F)C[N@+]([H])(O)C1";
+        SmilesParserParams params;
+        params.removeHs = false;
+        std::unique_ptr<RWMol> s(SmilesToMol(insmi, params));
+        auto smi = MolToSmiles(*s);
+        TEST_ASSERT(smi == "[H][N@+]1(O)C[C@](C)(F)C1");
+        // round trip
+        std::unique_ptr<RWMol> s2(SmilesToMol(smi));
+        TEST_ASSERT(MolToSmiles(*s2) == "C[C@]1(F)C[N@H+](O)C1");
+    }
+}
+
 int main() {
   RDLog::InitLogs();
   // boost::logging::enable_logs("rdApp.debug");
@@ -3239,5 +3268,6 @@ int main() {
   testIncorrectBondDirsOnWedging();
   testGithub3314();
   testGithub4494();
+  testGithub7115();
   return 0;
 }


### PR DESCRIPTION
Fixes #7115 

Small fix to allow 4-coordinated nitrogens to be considered for stereo  in > 3 membered rings