### PR TITLE
Fix a pathological slow case with the new getMolFrags()

### DIFF
--- a/Code/GraphMol/CMakeLists.txt
+++ b/Code/GraphMol/CMakeLists.txt
@@ -147,9 +147,8 @@ rdkit_test(graphmoltestPicklerGlobalSetting testPicklerGlobalSettings.cpp
 
 rdkit_test(graphmolIterTest itertest.cpp LINK_LIBRARIES SmilesParse GraphMol)
 
-find_package(Boost COMPONENTS timer REQUIRED)
 rdkit_test(hanoiTest hanoitest.cpp LINK_LIBRARIES
-        SubstructMatch SmilesParse FileParsers GraphMol Boost::timer
+        SubstructMatch SmilesParse FileParsers GraphMol
         )
 
 rdkit_test(graphmolMemTest1 memtest1.cpp LINK_LIBRARIES SmilesParse GraphMol)

--- a/Code/GraphMol/CMakeLists.txt
+++ b/Code/GraphMol/CMakeLists.txt
@@ -147,8 +147,9 @@ rdkit_test(graphmoltestPicklerGlobalSetting testPicklerGlobalSettings.cpp
 
 rdkit_test(graphmolIterTest itertest.cpp LINK_LIBRARIES SmilesParse GraphMol)
 
+find_package(Boost COMPONENTS timer REQUIRED)
 rdkit_test(hanoiTest hanoitest.cpp LINK_LIBRARIES
-        SubstructMatch SmilesParse FileParsers GraphMol
+        SubstructMatch SmilesParse FileParsers GraphMol Boost::timer
         )
 
 rdkit_test(graphmolMemTest1 memtest1.cpp LINK_LIBRARIES SmilesParse GraphMol)

--- a/Code/GraphMol/MolOps.cpp
+++ b/Code/GraphMol/MolOps.cpp
@@ -724,8 +724,12 @@ std::vector<ROMOL_SPTR> getMolFrags(const ROMol &mol, bool sanitizeFrags,
         return false;
       };
       if (comp.size() == 1 ||
-          !fragmentHasChallengingFeatures(comp, atomsInFrag)) {
-        // special case for very small fragments
+          (nFrags > 3 && !fragmentHasChallengingFeatures(comp, atomsInFrag))) {
+        // special case for a small, simple fragments when a bunch of fragments
+        // are present. The check on the number of fragments is purely
+        // empirical. This is mainly intended to catch situations like proteins
+        // where you have a bunch of single-atom fragments (waters); the
+        // standard approach below ends up being horribly inefficient there
         RWMOL_SPTR frag(new RWMol());
         res.push_back(frag);
         std::map<unsigned int, unsigned int> atomIdxMap;

--- a/Code/GraphMol/MolOps.cpp
+++ b/Code/GraphMol/MolOps.cpp
@@ -672,9 +672,6 @@ std::vector<ROMOL_SPTR> getMolFrags(const ROMol &mol, bool sanitizeFrags,
   } else {
     res.reserve(nFrags);
     for (int i = 0; i < nFrags; ++i) {
-      RWMOL_SPTR frag(new RWMol(mol));
-      res.push_back(frag);
-      frag->beginBatchEdit();
       boost::dynamic_bitset<> atomsInFrag(mol.getNumAtoms());
       INT_VECT comp;
       for (unsigned int idx = 0; idx < mol.getNumAtoms(); ++idx) {
@@ -683,15 +680,95 @@ std::vector<ROMOL_SPTR> getMolFrags(const ROMol &mol, bool sanitizeFrags,
           atomsInFrag.set(idx);
         }
       }
-      for (unsigned int idx = 0; idx < mol.getNumAtoms(); ++idx) {
-        if (!atomsInFrag[idx]) {
-          frag->removeAtom(idx);
+      auto fragmentHasChallengingFeatures =
+          [&](const INT_VECT &comp,
+              const boost::dynamic_bitset<> &atomsInFrag) -> bool {
+        for (auto idx : comp) {
+          // check for atoms with stereochem:
+          const auto atom = mol.getAtomWithIdx(idx);
+          if (atom->getChiralTag() != Atom::ChiralType::CHI_UNSPECIFIED &&
+              atom->getChiralTag() != Atom::ChiralType::CHI_OTHER) {
+            return true;
+          }
+          for (auto bnd : mol.atomBonds(atom)) {
+            if (atomsInFrag[bnd->getOtherAtomIdx(idx)]) {
+              if (bnd->getStereo() != Bond::BondStereo::STEREONONE &&
+                  bnd->getStereo() != Bond::BondStereo::STEREOANY) {
+                return true;
+              }
+            }
+          }
         }
+        for (auto sgroup : getSubstanceGroups(mol)) {
+          for (auto aid : sgroup.getAtoms()) {
+            if (atomsInFrag[aid]) {
+              return true;
+            }
+          }
+          for (auto aid : sgroup.getParentAtoms()) {
+            if (atomsInFrag[aid]) {
+              return true;
+            }
+          }
+        }
+        // doesn't seem like this should be necessary, but in case
+        // we ever need stereogroups where the atoms aren't marked
+        // with stereo...
+        for (auto stereoGroup : mol.getStereoGroups()) {
+          for (auto atom : stereoGroup.getAtoms()) {
+            if (atomsInFrag[atom->getIdx()]) {
+              return true;
+            }
+          }
+        }
+        return false;
+      };
+      if (comp.size() == 1 ||
+          !fragmentHasChallengingFeatures(comp, atomsInFrag)) {
+        // special case for very small fragments
+        RWMOL_SPTR frag(new RWMol());
+        res.push_back(frag);
+        std::map<unsigned int, unsigned int> atomIdxMap;
+        for (auto aid : comp) {
+          atomIdxMap[aid] =
+              frag->addAtom(mol.getAtomWithIdx(aid)->copy(), false, true);
+        }
+        for (auto bond : mol.bonds()) {
+          if (atomsInFrag[bond->getBeginAtomIdx()] &&
+              atomsInFrag[bond->getEndAtomIdx()]) {
+            auto bondCopy = bond->copy();
+            bondCopy->setBeginAtomIdx(atomIdxMap[bond->getBeginAtomIdx()]);
+            bondCopy->setEndAtomIdx(atomIdxMap[bond->getEndAtomIdx()]);
+            frag->addBond(bondCopy, true);
+          }
+        }
+        if (copyConformers) {
+          for (auto cit = mol.beginConformers(); cit != mol.endConformers();
+               ++cit) {
+            auto *conf = new Conformer(frag->getNumAtoms());
+            conf->setId((*cit)->getId());
+            conf->set3D((*cit)->is3D());
+            unsigned int cidx = 0;
+            for (auto ai : comp) {
+              conf->setAtomPos(cidx++, (*cit)->getAtomPos(ai));
+            }
+            frag->addConformer(conf);
+          }
+        }
+      } else {
+        RWMOL_SPTR frag(new RWMol(mol));
+        res.push_back(frag);
+        frag->beginBatchEdit();
+        for (unsigned int idx = 0; idx < mol.getNumAtoms(); ++idx) {
+          if (!atomsInFrag[idx]) {
+            frag->removeAtom(idx);
+          }
+        }
+        frag->commitBatchEdit();
       }
       if (fragsMolAtomMapping) {
         (*fragsMolAtomMapping).push_back(comp);
       }
-      frag->commitBatchEdit();
     }
   }
   if (!copyConformers) {

--- a/Code/GraphMol/hanoitest.cpp
+++ b/Code/GraphMol/hanoitest.cpp
@@ -12,7 +12,6 @@
 #include <RDGeneral/RDLog.h>
 #include <RDGeneral/Invariant.h>
 #include <RDGeneral/hanoiSort.h>
-#include <boost/timer/timer.hpp>
 
 #include <GraphMol/RDKitBase.h>
 #include <GraphMol/SmilesParse/SmilesParse.h>
@@ -1520,15 +1519,15 @@ void test12() {
         rdbase + "/Code/GraphMol/FileParsers/test_data/2FVD.pdb";
     ROMol *m = PDBFileToMol(fName);
     TEST_ASSERT(m);
-    // std::string smi1 = MolToSmiles(*m, true);
+    std::string smi1 = MolToSmiles(*m, true);
     delete m;
 
-    // m = SmilesToMol(smi1);
-    // TEST_ASSERT(m);
-    // std::string smi2 = MolToSmiles(*m, true);
-    // delete m;
-    // // std::cout << smi1 << "\n" << smi2 << std::endl;
-    // TEST_ASSERT(smi1 == smi2);
+    m = SmilesToMol(smi1);
+    TEST_ASSERT(m);
+    std::string smi2 = MolToSmiles(*m, true);
+    delete m;
+    // std::cout << smi1 << "\n" << smi2 << std::endl;
+    TEST_ASSERT(smi1 == smi2);
   }
   BOOST_LOG(rdInfoLog) << "Finished" << std::endl;
 }
@@ -1605,70 +1604,23 @@ int main() {
   RDLog::InitLogs();
   boost::logging::enable_logs("rdApp.info");
 #if 1
-  {
-    boost::timer::auto_cpu_timer t;
-    test1();
-  }
-  {
-    boost::timer::auto_cpu_timer t;
-    test2();
-  }
-  {
-    boost::timer::auto_cpu_timer t;
-    test3();
-  }
-  {
-    boost::timer::auto_cpu_timer t;
-    test4();
-  }
-  {
-    boost::timer::auto_cpu_timer t;
-    test5();
-  }
-  {
-    boost::timer::auto_cpu_timer t;
-    test6();
-  }
-  {
-    boost::timer::auto_cpu_timer t;
-    test7a();
-  }
-  {
-    boost::timer::auto_cpu_timer t;
-    test9();
-  }
-  {
-    boost::timer::auto_cpu_timer t;
-    test10();
-  }
-  {
-    boost::timer::auto_cpu_timer t;
-    test11();
-  }
-  {
-    boost::timer::auto_cpu_timer t;
-    test12();
-  }
-  {
-    boost::timer::auto_cpu_timer t;
-    test7();
-  }
-  {
-    boost::timer::auto_cpu_timer t;
-    test8();
-  }
-  {
-    boost::timer::auto_cpu_timer t;
-    testGithub1567();
+  test1();
+  test2();
+  test3();
+  test4();
+  test5();
+  test6();
+  test7a();
+  test9();
+  test10();
+  test11();
+  test12();
+  test7();
+  test8();
+  testGithub1567();
 #endif
-  }
-  {
-    boost::timer::auto_cpu_timer t;
-    testRingsAndDoubleBonds();
-  }
-  {
-    boost::timer::auto_cpu_timer t;
-    testCanonicalDiastereomers();
-  }
+  testRingsAndDoubleBonds();
+  testCanonicalDiastereomers();
+
   return 0;
 }

--- a/Code/GraphMol/hanoitest.cpp
+++ b/Code/GraphMol/hanoitest.cpp
@@ -12,6 +12,7 @@
 #include <RDGeneral/RDLog.h>
 #include <RDGeneral/Invariant.h>
 #include <RDGeneral/hanoiSort.h>
+#include <boost/timer/timer.hpp>
 
 #include <GraphMol/RDKitBase.h>
 #include <GraphMol/SmilesParse/SmilesParse.h>
@@ -1519,15 +1520,15 @@ void test12() {
         rdbase + "/Code/GraphMol/FileParsers/test_data/2FVD.pdb";
     ROMol *m = PDBFileToMol(fName);
     TEST_ASSERT(m);
-    std::string smi1 = MolToSmiles(*m, true);
+    // std::string smi1 = MolToSmiles(*m, true);
     delete m;
 
-    m = SmilesToMol(smi1);
-    TEST_ASSERT(m);
-    std::string smi2 = MolToSmiles(*m, true);
-    delete m;
-    // std::cout << smi1 << "\n" << smi2 << std::endl;
-    TEST_ASSERT(smi1 == smi2);
+    // m = SmilesToMol(smi1);
+    // TEST_ASSERT(m);
+    // std::string smi2 = MolToSmiles(*m, true);
+    // delete m;
+    // // std::cout << smi1 << "\n" << smi2 << std::endl;
+    // TEST_ASSERT(smi1 == smi2);
   }
   BOOST_LOG(rdInfoLog) << "Finished" << std::endl;
 }
@@ -1602,23 +1603,72 @@ void testRingsAndDoubleBonds() {
 
 int main() {
   RDLog::InitLogs();
+  boost::logging::enable_logs("rdApp.info");
 #if 1
-  test1();
-  test2();
-  test3();
-  test4();
-  test5();
-  test6();
-  test7a();
-  test9();
-  test10();
-  test11();
-  test12();
-  test7();
-  test8();
-  testGithub1567();
+  {
+    boost::timer::auto_cpu_timer t;
+    test1();
+  }
+  {
+    boost::timer::auto_cpu_timer t;
+    test2();
+  }
+  {
+    boost::timer::auto_cpu_timer t;
+    test3();
+  }
+  {
+    boost::timer::auto_cpu_timer t;
+    test4();
+  }
+  {
+    boost::timer::auto_cpu_timer t;
+    test5();
+  }
+  {
+    boost::timer::auto_cpu_timer t;
+    test6();
+  }
+  {
+    boost::timer::auto_cpu_timer t;
+    test7a();
+  }
+  {
+    boost::timer::auto_cpu_timer t;
+    test9();
+  }
+  {
+    boost::timer::auto_cpu_timer t;
+    test10();
+  }
+  {
+    boost::timer::auto_cpu_timer t;
+    test11();
+  }
+  {
+    boost::timer::auto_cpu_timer t;
+    test12();
+  }
+  {
+    boost::timer::auto_cpu_timer t;
+    test7();
+  }
+  {
+    boost::timer::auto_cpu_timer t;
+    test8();
+  }
+  {
+    boost::timer::auto_cpu_timer t;
+    testGithub1567();
 #endif
-  testRingsAndDoubleBonds();
-  testCanonicalDiastereomers();
+  }
+  {
+    boost::timer::auto_cpu_timer t;
+    testRingsAndDoubleBonds();
+  }
+  {
+    boost::timer::auto_cpu_timer t;
+    testCanonicalDiastereomers();
+  }
   return 0;
 }


### PR DESCRIPTION
Fixes #7104

The new implementation of `getMolFrags()` was amazingly inefficient for molecules with a bunch of very small fragments, like a protein with crystallographic waters.

This fixes that.

There was some discussion of performance in the comments on the PR, so here are some numbers.

Here's a mol file for a recent protein + ligands + waters I pulled down from the PDB this morning. [pdb_8jhl.mol.txt](https://github.com/rdkit/rdkit/files/14162327/pdb_8jhl.mol.txt) That structure has 128 fragments, most of which are water.

Here's the same structure with the single atom fragments (water and Mg) stripped: 
[pdb_8jhl.stripped.mol.txt](https://github.com/rdkit/rdkit/files/14162369/pdb_8jhl.stripped.mol.txt) That structure only has two fragments.

Here's timing info with v2023.09.3 of the RDKit (which is before the change which made this PR necessary):
```
In [10]: %timeit Chem.GetMolFrags(m,asMols=True,sanitizeFrags=False)
1.32 ms ± 5.56 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)

In [11]: %timeit Chem.GetMolFrags(sm,asMols=True,sanitizeFrags=False)
773 µs ± 1.76 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
```
Here's master just before this PR:
```
In [4]: %timeit Chem.GetMolFrags(m,asMols=True,sanitizeFrags=False)
5.52 s ± 25.1 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

In [5]: %timeit Chem.GetMolFrags(sm,asMols=True,sanitizeFrags=False)
35.1 ms ± 247 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
```
And then with this PR applied:
```
In [10]: %timeit Chem.GetMolFrags(m,asMols=True,sanitizeFrags=False)
9.15 ms ± 25.3 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)

In [11]: %timeit Chem.GetMolFrags(sm,asMols=True,sanitizeFrags=False)
34.6 ms ± 133 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
```
We can no doubt do more to improve the performance of this, but the performance for `getMolFrags()` is no longer quite so horribly slow, both for cases with a lot of very small fragments (the full molecule) and those with <3 fragments (when the special case I added for this PR is not used).
