### PR TITLE
Fixes #7123

### DIFF
--- a/Code/GraphMol/AddHs.cpp
+++ b/Code/GraphMol/AddHs.cpp
@@ -566,11 +566,6 @@ void addHs(RWMol &mol, bool explicitOnly, bool addCoords,
           ++isoH;
         }
       }
-      // be very clear about implicits not being allowed in this
-      // representation
-      newAt->setProp(common_properties::origNoImplicit, newAt->getNoImplicit(),
-                     true);
-      newAt->setNoImplicit(true);
     }
     // update the atom's derived properties (valence count, etc.)
     // no sense in being strict here (was github #2782)

--- a/Code/GraphMol/molopstest.cpp
+++ b/Code/GraphMol/molopstest.cpp
@@ -621,6 +621,13 @@ void test8() {
   // BOOST_LOG(rdInfoLog) << "1" << std::endl;
   m2 = MolOps::addHs(*m);
   CHECK_INVARIANT(m2->getNumAtoms() == 11, "");
+
+  // addHs should not set the noImplicit flag.
+  // This was Github Issue #7123
+  for (auto at : m2->atoms()) {
+    TEST_ASSERT(at->getNoImplicit() == false);
+  }
+
   delete m;
   delete m2;
 

--- a/Code/GraphMol/molopstest.cpp
+++ b/Code/GraphMol/molopstest.cpp
@@ -8006,8 +8006,8 @@ void testRemoveAndTrackIsotopes() {
   TEST_ASSERT(SubstructMatch(*m, *mH2, matchH2));
   TEST_ASSERT(matchH2.size() == m->getNumAtoms());
   TEST_ASSERT(mH2_isotopicHsPerHeavy->total() == 12);
-  TEST_ASSERT(mH2_numExplicitHs == 28);
-  TEST_ASSERT(mH2_numImplicitHs == 0);
+  TEST_ASSERT(mH2_numExplicitHs == 0);
+  TEST_ASSERT(mH2_numImplicitHs == 28);
   for (auto p : matchH2) {
     TEST_ASSERT(mH2_isotopicHsPerHeavy->at(p.first) ==
                 m_isotopicHsPerHeavy->at(p.second));
@@ -8040,8 +8040,8 @@ void testRemoveAndTrackIsotopes() {
   TEST_ASSERT(matchH2 != matchH2Ren);
   TEST_ASSERT(matchH2.size() == matchH2Ren.size());
   TEST_ASSERT(mH2_isotopicHsPerHeavy->total() == 12);
-  TEST_ASSERT(mH2_numExplicitHs == 28);
-  TEST_ASSERT(mH2_numImplicitHs == 0);
+  TEST_ASSERT(mH2_numExplicitHs == 0);
+  TEST_ASSERT(mH2_numImplicitHs == 28);
   for (auto p : matchH2Ren) {
     TEST_ASSERT(mH2_isotopicHsPerHeavy->at(p.first) ==
                 m_isotopicHsPerHeavy->at(p.second));

--- a/Code/RDGeneral/types.cpp
+++ b/Code/RDGeneral/types.cpp
@@ -112,7 +112,6 @@ const std::string molRxnRole = "molRxnRole";
 const std::string molTotValence = "molTotValence";
 const std::string molFileLinkNodes = "_molLinkNodes";
 const std::string numArom = "numArom";
-const std::string origNoImplicit = "origNoImplicit";
 const std::string ringMembership = "ringMembership";
 const std::string smilesSymbol = "smilesSymbol";
 const std::string atomLabel = "atomLabel";

--- a/Code/RDGeneral/types.h
+++ b/Code/RDGeneral/types.h
@@ -71,7 +71,6 @@ RDKIT_RDGENERAL_EXPORT extern const std::string _NeedsQueryScan;  // int (bool)
 RDKIT_RDGENERAL_EXPORT extern const std::string _fragSMARTS;      // std::string
 RDKIT_RDGENERAL_EXPORT extern const std::string
     maxAttachIdx;  // int TemplEnumTools.cpp
-RDKIT_RDGENERAL_EXPORT extern const std::string origNoImplicit;  // int (bool)
 RDKIT_RDGENERAL_EXPORT extern const std::string
     ringMembership;  //? unused (molopstest.cpp)
 


### PR DESCRIPTION
Fixes #7123

The fix is very simple: just remove the code that sets the flag. I'm also removing the property we were setting on the atoms, `origNoImplicit`, as it isn't used anywhere else.

After making the change, just one test needs to be updated (the H count flips from explicit Hs to implicit ones).

This is a fairly simple bug, so instead of adding a new test, I'm adding an additional check to one of the tests for `addHs`.