### PR TITLE
Fixes #7128

### DIFF
--- a/Code/GraphMol/catch_graphmol.cpp
+++ b/Code/GraphMol/catch_graphmol.cpp
@@ -3463,3 +3463,71 @@ TEST_CASE(
   CHECK(bnd->getStereo() == Bond::BondStereo::STEREONONE);
   CHECK(bnd->getStereoAtoms().empty());
 }
+
+TEST_CASE(
+    "Github Issue #7128: ReplaceBond may cause valence issues in specific edge cases",
+    "[bug][RWMol]") {
+  auto m = R"CTAB(
+     RDKit          2D
+
+  0  0  0  0  0  0  0  0  0  0999 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 4 3 0 0 0
+M  V30 BEGIN ATOM
+M  V30 1 C 1.787879 0.909091 0.000000 0
+M  V30 2 C 3.287879 0.909091 0.000000 0
+M  V30 3 N 1.037879 2.208129 0.000000 0
+M  V30 4 O 1.037879 -0.389947 0.000000 0
+M  V30 END ATOM
+M  V30 BEGIN BOND
+M  V30 1 1 1 2 CFG=3
+M  V30 2 1 1 3
+M  V30 3 1 1 4
+M  V30 END BOND
+M  V30 END CTAB
+M  END
+$$$$
+)CTAB"_ctab;
+  REQUIRE(m);
+
+  // This bond was a dashed bond (dash is removed when parity is resolved)
+  auto bond = m->getBondWithIdx(0);
+  int bond_dir = 0;
+  REQUIRE(bond->getPropIfPresent("_MolFileBondCfg", bond_dir) == true);
+  REQUIRE(bond_dir == 3);  // dashed bond
+
+  auto begin_atom = bond->getBeginAtom();
+  REQUIRE(begin_atom->getNumExplicitHs() == 1);
+  REQUIRE(begin_atom->getTotalValence() == 4);
+
+  auto end_atom = bond->getEndAtom();
+  REQUIRE(end_atom->getNumExplicitHs() == 0);
+  REQUIRE(end_atom->getTotalValence() == 4);
+
+  bool strict_valences = false;
+
+  SECTION("replace with a double bond") {
+    m->replaceBond(1, new Bond(Bond::BondType::DOUBLE));
+    m->updatePropertyCache(strict_valences);
+    CHECK(begin_atom->getNumExplicitHs() == 0);
+    CHECK(begin_atom->getTotalValence() == 4);
+    CHECK(end_atom->getNumExplicitHs() == 0);
+    CHECK(end_atom->getTotalValence() == 4);
+  }
+  SECTION("replace with a triple bond") {
+    m->replaceBond(1, new Bond(Bond::BondType::TRIPLE));
+    m->updatePropertyCache(strict_valences);
+    CHECK(begin_atom->getNumExplicitHs() == 0);
+    CHECK(begin_atom->getTotalValence() == 5);  // Yeah, this is expected
+    CHECK(end_atom->getNumExplicitHs() == 0);
+    CHECK(end_atom->getTotalValence() == 4);
+  }
+  SECTION("replace with a dative bond") {
+    m->replaceBond(1, new Bond(Bond::BondType::DATIVE));
+    m->updatePropertyCache(strict_valences);
+    CHECK(begin_atom->getNumExplicitHs() == 1);
+    CHECK(begin_atom->getTotalValence() == 4);
+    CHECK(end_atom->getNumExplicitHs() == 0);
+    CHECK(end_atom->getTotalValence() == 4);
+  }
+}


### PR DESCRIPTION
Fixes #7128

This fixes the issue by updating the Explicit Hs according to the change in bond orders when we replace a bond. We only care about the case in which the bond order increases, as for a decrease, implicit Hs should be able to compensate the difference.