### PR TITLE
Fixes #7131

### DIFF
--- a/Code/GraphMol/Chirality.cpp
+++ b/Code/GraphMol/Chirality.cpp
@@ -123,8 +123,11 @@ void controllingBondFromAtom(const ROMol &mol,
     if (tBond == dblBond) {
       continue;
     }
-    if (tBond->getBondType() == Bond::SINGLE ||
-        tBond->getBondType() == Bond::AROMATIC) {
+    if ((tBond->getBondType() == Bond::SINGLE ||
+         tBond->getBondType() == Bond::AROMATIC) &&
+        (tBond->getBondDir() == Bond::BondDir::NONE ||
+         tBond->getBondDir() == Bond::BondDir::ENDDOWNRIGHT ||
+         tBond->getBondDir() == Bond::BondDir::ENDUPRIGHT)) {
       // prefer bonds that already have their directionality set
       // or that are adjacent to more double bonds:
       if (!bond) {
@@ -3381,21 +3384,21 @@ void setDoubleBondNeighborDirections(ROMol &mol, const Conformer *conf) {
               // candidate for stereo
               isCandidate = false;
             } else {
+              needsDir[bond->getIdx()] = 1;
               if (nbrDir == Bond::BondDir::NONE ||
                   nbrDir == Bond::BondDir::ENDDOWNRIGHT ||
                   nbrDir == Bond::BondDir::ENDUPRIGHT) {
                 needsDir[nbrBond->getIdx()] = 1;
-              }
-              needsDir[bond->getIdx()] = 1;
-              dblBondNbrs[bond->getIdx()].push_back(nbrBond->getIdx());
-              // the search may seem inefficient, but these vectors are going to
-              // be at most 2 long (with very few exceptions). It's just not
-              // worth using a different data structure
-              if (std::find(singleBondNbrs[nbrBond->getIdx()].begin(),
-                            singleBondNbrs[nbrBond->getIdx()].end(),
-                            bond->getIdx()) ==
-                  singleBondNbrs[nbrBond->getIdx()].end()) {
-                singleBondNbrs[nbrBond->getIdx()].push_back(bond->getIdx());
+                dblBondNbrs[bond->getIdx()].push_back(nbrBond->getIdx());
+                // the search may seem inefficient, but these vectors are going
+                // to be at most 2 long (with very few exceptions). It's just
+                // not worth using a different data structure
+                if (std::find(singleBondNbrs[nbrBond->getIdx()].begin(),
+                              singleBondNbrs[nbrBond->getIdx()].end(),
+                              bond->getIdx()) ==
+                    singleBondNbrs[nbrBond->getIdx()].end()) {
+                  singleBondNbrs[nbrBond->getIdx()].push_back(bond->getIdx());
+                }
               }
             }
           }

--- a/Code/GraphMol/catch_graphmol.cpp
+++ b/Code/GraphMol/catch_graphmol.cpp
@@ -3542,3 +3542,39 @@ $$$$
     CHECK(end_atom->getTotalValence() == 4);
   }
 }
+
+TEST_CASE(
+    "GitHub Issue #7131: Adding Wedge/Dash bond neighboring a stereo double bond causes a Precondition Violation",
+    "[stereochemistry][bug]") {
+  auto m = R"CTAB(
+     RDKit          2D
+
+  0  0  0  0  0  0  0  0  0  0999 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 6 5 0 0 0
+M  V30 BEGIN ATOM
+M  V30 1 C -6.942857 2.885714 0.000000 0
+M  V30 2 C -5.705678 2.171429 0.000000 0
+M  V30 3 C -5.705678 0.742857 0.000000 0
+M  V30 4 C -4.468499 0.028571 0.000000 0
+M  V30 5 N -4.468499 2.885714 0.000000 0
+M  V30 6 N -6.942857 0.028571 0.000000 0
+M  V30 END ATOM
+M  V30 BEGIN BOND
+M  V30 1 1 1 2
+M  V30 2 2 2 3
+M  V30 3 1 3 4
+M  V30 4 1 2 5
+M  V30 5 1 3 6
+M  V30 END BOND
+M  V30 END CTAB
+M  END
+$$$$)CTAB"_ctab;
+  REQUIRE(m);
+  auto b = m->getBondWithIdx(0);
+  b->setBondDir(Bond::BondDir::BEGINDASH);
+
+  MolOps::setDoubleBondNeighborDirections(*m);
+
+  CHECK(b->getBondDir() == Bond::BondDir::BEGINDASH);
+}


### PR DESCRIPTION
Fixes #7131

This fixes the issue by not considering wedge/dash bonds when choosing which bonds to flag as `ENDDOWNRIGHT` or `ENDUPRIGHT` around double bonds in `controllingBondFromAtom()`. I also updated `setDoubleBondNeighborDirections()` to not consider these bonds when deciding the order in which double bonds should be assigned stereo directions.
