### PR TITLE
[WIP] Optimize batch remove atoms bonds

### DIFF
--- a/Code/GraphMol/CMakeLists.txt
+++ b/Code/GraphMol/CMakeLists.txt
@@ -147,9 +147,8 @@ rdkit_test(graphmoltestPicklerGlobalSetting testPicklerGlobalSettings.cpp
 
 rdkit_test(graphmolIterTest itertest.cpp LINK_LIBRARIES SmilesParse GraphMol)
 
-find_package(Boost COMPONENTS timer REQUIRED)
 rdkit_test(hanoiTest hanoitest.cpp LINK_LIBRARIES
-        SubstructMatch SmilesParse FileParsers GraphMol Boost::timer
+        SubstructMatch SmilesParse FileParsers GraphMol
         )
 
 rdkit_test(graphmolMemTest1 memtest1.cpp LINK_LIBRARIES SmilesParse GraphMol)

--- a/Code/GraphMol/CMakeLists.txt
+++ b/Code/GraphMol/CMakeLists.txt
@@ -147,8 +147,9 @@ rdkit_test(graphmoltestPicklerGlobalSetting testPicklerGlobalSettings.cpp
 
 rdkit_test(graphmolIterTest itertest.cpp LINK_LIBRARIES SmilesParse GraphMol)
 
+find_package(Boost COMPONENTS timer REQUIRED)
 rdkit_test(hanoiTest hanoitest.cpp LINK_LIBRARIES
-        SubstructMatch SmilesParse FileParsers GraphMol
+        SubstructMatch SmilesParse FileParsers GraphMol Boost::timer
         )
 
 rdkit_test(graphmolMemTest1 memtest1.cpp LINK_LIBRARIES SmilesParse GraphMol)

--- a/Code/GraphMol/Conformer.cpp
+++ b/Code/GraphMol/Conformer.cpp
@@ -48,8 +48,8 @@ const RDGeom::POINT3D_VECT &Conformer::getPositions() const {
   return d_positions;
 }
 
-RDGeom::POINT3D_VECT &Conformer::getPositions() {
-  if (dp_mol) {
+RDGeom::POINT3D_VECT &Conformer::getPositions(bool force) {
+  if (dp_mol && !force) {
     PRECONDITION(dp_mol->getNumAtoms() == d_positions.size(), "");
   }
   return d_positions;

--- a/Code/GraphMol/Conformer.h
+++ b/Code/GraphMol/Conformer.h
@@ -103,7 +103,7 @@ class RDKIT_GRAPHMOL_EXPORT Conformer : public RDProps {
   const RDGeom::POINT3D_VECT &getPositions() const;
 
   //! Get a reference to the atom positions
-  RDGeom::POINT3D_VECT &getPositions();
+  RDGeom::POINT3D_VECT &getPositions(bool force=false);
 
   //! Get the position of the specified atom
   const RDGeom::Point3D &getAtomPos(unsigned int atomId) const;

--- a/Code/GraphMol/MolOps.cpp
+++ b/Code/GraphMol/MolOps.cpp
@@ -724,8 +724,12 @@ std::vector<ROMOL_SPTR> getMolFrags(const ROMol &mol, bool sanitizeFrags,
         return false;
       };
       if (comp.size() == 1 ||
-          !fragmentHasChallengingFeatures(comp, atomsInFrag)) {
-        // special case for very small fragments
+          (nFrags > 3 && !fragmentHasChallengingFeatures(comp, atomsInFrag))) {
+        // special case for a small, simple fragments when a bunch of fragments
+        // are present. The check on the number of fragments is purely
+        // empirical. This is mainly intended to catch situations like proteins
+        // where you have a bunch of single-atom fragments (waters); the
+        // standard approach below ends up being horribly inefficient there
         RWMOL_SPTR frag(new RWMol());
         res.push_back(frag);
         std::map<unsigned int, unsigned int> atomIdxMap;

--- a/Code/GraphMol/MolOps.cpp
+++ b/Code/GraphMol/MolOps.cpp
@@ -672,9 +672,6 @@ std::vector<ROMOL_SPTR> getMolFrags(const ROMol &mol, bool sanitizeFrags,
   } else {
     res.reserve(nFrags);
     for (int i = 0; i < nFrags; ++i) {
-      RWMOL_SPTR frag(new RWMol(mol));
-      res.push_back(frag);
-      frag->beginBatchEdit();
       boost::dynamic_bitset<> atomsInFrag(mol.getNumAtoms());
       INT_VECT comp;
       for (unsigned int idx = 0; idx < mol.getNumAtoms(); ++idx) {
@@ -683,15 +680,95 @@ std::vector<ROMOL_SPTR> getMolFrags(const ROMol &mol, bool sanitizeFrags,
           atomsInFrag.set(idx);
         }
       }
-      for (unsigned int idx = 0; idx < mol.getNumAtoms(); ++idx) {
-        if (!atomsInFrag[idx]) {
-          frag->removeAtom(idx);
+      auto fragmentHasChallengingFeatures =
+          [&](const INT_VECT &comp,
+              const boost::dynamic_bitset<> &atomsInFrag) -> bool {
+        for (auto idx : comp) {
+          // check for atoms with stereochem:
+          const auto atom = mol.getAtomWithIdx(idx);
+          if (atom->getChiralTag() != Atom::ChiralType::CHI_UNSPECIFIED &&
+              atom->getChiralTag() != Atom::ChiralType::CHI_OTHER) {
+            return true;
+          }
+          for (auto bnd : mol.atomBonds(atom)) {
+            if (atomsInFrag[bnd->getOtherAtomIdx(idx)]) {
+              if (bnd->getStereo() != Bond::BondStereo::STEREONONE &&
+                  bnd->getStereo() != Bond::BondStereo::STEREOANY) {
+                return true;
+              }
+            }
+          }
         }
+        for (auto sgroup : getSubstanceGroups(mol)) {
+          for (auto aid : sgroup.getAtoms()) {
+            if (atomsInFrag[aid]) {
+              return true;
+            }
+          }
+          for (auto aid : sgroup.getParentAtoms()) {
+            if (atomsInFrag[aid]) {
+              return true;
+            }
+          }
+        }
+        // doesn't seem like this should be necessary, but in case
+        // we ever need stereogroups where the atoms aren't marked
+        // with stereo...
+        for (auto stereoGroup : mol.getStereoGroups()) {
+          for (auto atom : stereoGroup.getAtoms()) {
+            if (atomsInFrag[atom->getIdx()]) {
+              return true;
+            }
+          }
+        }
+        return false;
+      };
+      if (comp.size() == 1 ||
+          !fragmentHasChallengingFeatures(comp, atomsInFrag)) {
+        // special case for very small fragments
+        RWMOL_SPTR frag(new RWMol());
+        res.push_back(frag);
+        std::map<unsigned int, unsigned int> atomIdxMap;
+        for (auto aid : comp) {
+          atomIdxMap[aid] =
+              frag->addAtom(mol.getAtomWithIdx(aid)->copy(), false, true);
+        }
+        for (auto bond : mol.bonds()) {
+          if (atomsInFrag[bond->getBeginAtomIdx()] &&
+              atomsInFrag[bond->getEndAtomIdx()]) {
+            auto bondCopy = bond->copy();
+            bondCopy->setBeginAtomIdx(atomIdxMap[bond->getBeginAtomIdx()]);
+            bondCopy->setEndAtomIdx(atomIdxMap[bond->getEndAtomIdx()]);
+            frag->addBond(bondCopy, true);
+          }
+        }
+        if (copyConformers) {
+          for (auto cit = mol.beginConformers(); cit != mol.endConformers();
+               ++cit) {
+            auto *conf = new Conformer(frag->getNumAtoms());
+            conf->setId((*cit)->getId());
+            conf->set3D((*cit)->is3D());
+            unsigned int cidx = 0;
+            for (auto ai : comp) {
+              conf->setAtomPos(cidx++, (*cit)->getAtomPos(ai));
+            }
+            frag->addConformer(conf);
+          }
+        }
+      } else {
+        RWMOL_SPTR frag(new RWMol(mol));
+        res.push_back(frag);
+        frag->beginBatchEdit();
+        for (unsigned int idx = 0; idx < mol.getNumAtoms(); ++idx) {
+          if (!atomsInFrag[idx]) {
+            frag->removeAtom(idx);
+          }
+        }
+        frag->commitBatchEdit();
       }
       if (fragsMolAtomMapping) {
         (*fragsMolAtomMapping).push_back(comp);
       }
-      frag->commitBatchEdit();
     }
   }
   if (!copyConformers) {

--- a/Code/GraphMol/RWMol.cpp
+++ b/Code/GraphMol/RWMol.cpp
@@ -565,9 +565,10 @@ void RWMol::beginBatchEdit() {
 }
 
 void RWMol::commitBatchEdit() {
-    if (!dp_delBonds || !dp_delAtoms) {
+    if (!(dp_delBonds || dp_delAtoms)) {
         return;
     }
+
     batchRemoveBonds();
     batchRemoveAtoms();
     
@@ -576,6 +577,15 @@ void RWMol::commitBatchEdit() {
     
     // fix properties
     clearComputedProps(true);
+    dp_delBonds.reset();
+    dp_delAtoms.reset();
+    
+    if (dp_delAtoms || dp_delBonds) {
+      BOOST_LOG(rdWarningLog) << "batchEdit mode already enabled, ignoring "
+                                 "additional call to beginBatchEdit()"
+                              << std::endl;
+      throw ValueErrorException("Attempt to re-enter batchEdit mode");
+    }
 }
 
 void RWMol::batchRemoveBonds() {

--- a/Code/GraphMol/RWMol.h
+++ b/Code/GraphMol/RWMol.h
@@ -211,6 +211,9 @@ class RDKIT_GRAPHMOL_EXPORT RWMol : public ROMol {
     dp_delBonds.reset();
   }
   void commitBatchEdit();
+private:
+  void batchRemoveBonds();
+  void batchRemoveAtoms();
 };
 
 typedef boost::shared_ptr<RWMol> RWMOL_SPTR;

--- a/Code/GraphMol/hanoitest.cpp
+++ b/Code/GraphMol/hanoitest.cpp
@@ -12,7 +12,6 @@
 #include <RDGeneral/RDLog.h>
 #include <RDGeneral/Invariant.h>
 #include <RDGeneral/hanoiSort.h>
-#include <boost/timer/timer.hpp>
 
 #include <GraphMol/RDKitBase.h>
 #include <GraphMol/SmilesParse/SmilesParse.h>
@@ -1520,15 +1519,15 @@ void test12() {
         rdbase + "/Code/GraphMol/FileParsers/test_data/2FVD.pdb";
     ROMol *m = PDBFileToMol(fName);
     TEST_ASSERT(m);
-    // std::string smi1 = MolToSmiles(*m, true);
+    std::string smi1 = MolToSmiles(*m, true);
     delete m;
 
-    // m = SmilesToMol(smi1);
-    // TEST_ASSERT(m);
-    // std::string smi2 = MolToSmiles(*m, true);
-    // delete m;
-    // // std::cout << smi1 << "\n" << smi2 << std::endl;
-    // TEST_ASSERT(smi1 == smi2);
+    m = SmilesToMol(smi1);
+    TEST_ASSERT(m);
+    std::string smi2 = MolToSmiles(*m, true);
+    delete m;
+    // std::cout << smi1 << "\n" << smi2 << std::endl;
+    TEST_ASSERT(smi1 == smi2);
   }
   BOOST_LOG(rdInfoLog) << "Finished" << std::endl;
 }
@@ -1605,70 +1604,23 @@ int main() {
   RDLog::InitLogs();
   boost::logging::enable_logs("rdApp.info");
 #if 1
-  {
-    boost::timer::auto_cpu_timer t;
-    test1();
-  }
-  {
-    boost::timer::auto_cpu_timer t;
-    test2();
-  }
-  {
-    boost::timer::auto_cpu_timer t;
-    test3();
-  }
-  {
-    boost::timer::auto_cpu_timer t;
-    test4();
-  }
-  {
-    boost::timer::auto_cpu_timer t;
-    test5();
-  }
-  {
-    boost::timer::auto_cpu_timer t;
-    test6();
-  }
-  {
-    boost::timer::auto_cpu_timer t;
-    test7a();
-  }
-  {
-    boost::timer::auto_cpu_timer t;
-    test9();
-  }
-  {
-    boost::timer::auto_cpu_timer t;
-    test10();
-  }
-  {
-    boost::timer::auto_cpu_timer t;
-    test11();
-  }
-  {
-    boost::timer::auto_cpu_timer t;
-    test12();
-  }
-  {
-    boost::timer::auto_cpu_timer t;
-    test7();
-  }
-  {
-    boost::timer::auto_cpu_timer t;
-    test8();
-  }
-  {
-    boost::timer::auto_cpu_timer t;
-    testGithub1567();
+  test1();
+  test2();
+  test3();
+  test4();
+  test5();
+  test6();
+  test7a();
+  test9();
+  test10();
+  test11();
+  test12();
+  test7();
+  test8();
+  testGithub1567();
 #endif
-  }
-  {
-    boost::timer::auto_cpu_timer t;
-    testRingsAndDoubleBonds();
-  }
-  {
-    boost::timer::auto_cpu_timer t;
-    testCanonicalDiastereomers();
-  }
+  testRingsAndDoubleBonds();
+  testCanonicalDiastereomers();
+
   return 0;
 }

--- a/Code/GraphMol/hanoitest.cpp
+++ b/Code/GraphMol/hanoitest.cpp
@@ -12,6 +12,7 @@
 #include <RDGeneral/RDLog.h>
 #include <RDGeneral/Invariant.h>
 #include <RDGeneral/hanoiSort.h>
+#include <boost/timer/timer.hpp>
 
 #include <GraphMol/RDKitBase.h>
 #include <GraphMol/SmilesParse/SmilesParse.h>
@@ -1519,15 +1520,15 @@ void test12() {
         rdbase + "/Code/GraphMol/FileParsers/test_data/2FVD.pdb";
     ROMol *m = PDBFileToMol(fName);
     TEST_ASSERT(m);
-    std::string smi1 = MolToSmiles(*m, true);
+    // std::string smi1 = MolToSmiles(*m, true);
     delete m;
 
-    m = SmilesToMol(smi1);
-    TEST_ASSERT(m);
-    std::string smi2 = MolToSmiles(*m, true);
-    delete m;
-    // std::cout << smi1 << "\n" << smi2 << std::endl;
-    TEST_ASSERT(smi1 == smi2);
+    // m = SmilesToMol(smi1);
+    // TEST_ASSERT(m);
+    // std::string smi2 = MolToSmiles(*m, true);
+    // delete m;
+    // // std::cout << smi1 << "\n" << smi2 << std::endl;
+    // TEST_ASSERT(smi1 == smi2);
   }
   BOOST_LOG(rdInfoLog) << "Finished" << std::endl;
 }
@@ -1602,23 +1603,72 @@ void testRingsAndDoubleBonds() {
 
 int main() {
   RDLog::InitLogs();
+  boost::logging::enable_logs("rdApp.info");
 #if 1
-  test1();
-  test2();
-  test3();
-  test4();
-  test5();
-  test6();
-  test7a();
-  test9();
-  test10();
-  test11();
-  test12();
-  test7();
-  test8();
-  testGithub1567();
+  {
+    boost::timer::auto_cpu_timer t;
+    test1();
+  }
+  {
+    boost::timer::auto_cpu_timer t;
+    test2();
+  }
+  {
+    boost::timer::auto_cpu_timer t;
+    test3();
+  }
+  {
+    boost::timer::auto_cpu_timer t;
+    test4();
+  }
+  {
+    boost::timer::auto_cpu_timer t;
+    test5();
+  }
+  {
+    boost::timer::auto_cpu_timer t;
+    test6();
+  }
+  {
+    boost::timer::auto_cpu_timer t;
+    test7a();
+  }
+  {
+    boost::timer::auto_cpu_timer t;
+    test9();
+  }
+  {
+    boost::timer::auto_cpu_timer t;
+    test10();
+  }
+  {
+    boost::timer::auto_cpu_timer t;
+    test11();
+  }
+  {
+    boost::timer::auto_cpu_timer t;
+    test12();
+  }
+  {
+    boost::timer::auto_cpu_timer t;
+    test7();
+  }
+  {
+    boost::timer::auto_cpu_timer t;
+    test8();
+  }
+  {
+    boost::timer::auto_cpu_timer t;
+    testGithub1567();
 #endif
-  testRingsAndDoubleBonds();
-  testCanonicalDiastereomers();
+  }
+  {
+    boost::timer::auto_cpu_timer t;
+    testRingsAndDoubleBonds();
+  }
+  {
+    boost::timer::auto_cpu_timer t;
+    testCanonicalDiastereomers();
+  }
   return 0;
 }


### PR DESCRIPTION
Optimize atom and bond removals

  1. add two new private functions, batchRemoveBonds, batchRemoveAtoms
  2. minimizes calls to expensive functions, clearComputedProps(true), renumbering atoms/bonds, conformers
  3. calls to removeBond  queues up atom removals (which didn't happen before, the makes book keeping easier)