### PR TITLE
optimize batch operations when editing molecules

### DIFF
--- a/Code/GraphMol/Conformer.cpp
+++ b/Code/GraphMol/Conformer.cpp
@@ -48,8 +48,8 @@ const RDGeom::POINT3D_VECT &Conformer::getPositions() const {
   return d_positions;
 }
 
-RDGeom::POINT3D_VECT &Conformer::getPositions() {
-  if (dp_mol) {
+RDGeom::POINT3D_VECT &Conformer::getPositions(bool force) {
+  if (dp_mol && !force) {
     PRECONDITION(dp_mol->getNumAtoms() == d_positions.size(), "");
   }
   return d_positions;

--- a/Code/GraphMol/Conformer.cpp
+++ b/Code/GraphMol/Conformer.cpp
@@ -48,10 +48,7 @@ const RDGeom::POINT3D_VECT &Conformer::getPositions() const {
   return d_positions;
 }
 
-RDGeom::POINT3D_VECT &Conformer::getPositions(bool force) {
-  if (dp_mol && !force) {
-    PRECONDITION(dp_mol->getNumAtoms() == d_positions.size(), "");
-  }
+RDGeom::POINT3D_VECT &Conformer::getPositions() {
   return d_positions;
 }
 

--- a/Code/GraphMol/Conformer.h
+++ b/Code/GraphMol/Conformer.h
@@ -103,7 +103,7 @@ class RDKIT_GRAPHMOL_EXPORT Conformer : public RDProps {
   const RDGeom::POINT3D_VECT &getPositions() const;
 
   //! Get a reference to the atom positions
-  RDGeom::POINT3D_VECT &getPositions(bool force=false);
+  RDGeom::POINT3D_VECT &getPositions();
 
   //! Get the position of the specified atom
   const RDGeom::Point3D &getAtomPos(unsigned int atomId) const;

--- a/Code/GraphMol/Conformer.h
+++ b/Code/GraphMol/Conformer.h
@@ -103,7 +103,7 @@ class RDKIT_GRAPHMOL_EXPORT Conformer : public RDProps {
   const RDGeom::POINT3D_VECT &getPositions() const;
 
   //! Get a reference to the atom positions
-  RDGeom::POINT3D_VECT &getPositions();
+  RDGeom::POINT3D_VECT &getPositions(bool force=false);
 
   //! Get the position of the specified atom
   const RDGeom::Point3D &getAtomPos(unsigned int atomId) const;

--- a/Code/GraphMol/RWMol.cpp
+++ b/Code/GraphMol/RWMol.cpp
@@ -705,8 +705,7 @@ void RWMol::batchRemoveBonds() {
 void RWMol::batchRemoveAtoms() {
     if(!dp_delAtoms)
         return;
-    std::vector<Atom*> oldIndices;
-    oldIndices.reserve(getNumAtoms());
+    std::vector<Atom*> oldIndices(getNumAtoms());
     for(auto *atom: atoms()) {
         oldIndices[atom->getIdx()] = atom;
     }
@@ -832,9 +831,9 @@ void RWMol::batchRemoveAtoms() {
     // do the same with the coordinates in the conformations
     const bool force=true;
     for (auto conf : d_confs) {
-        RDGeom::POINT3D_VECT &positions = conf->getPositions(force);
+        RDGeom::POINT3D_VECT &positions = conf->getPositions();
         RDGeom::POINT3D_VECT newPositions;
-        positions.reserve(getNumAtoms());
+        newPositions.reserve(getNumAtoms());
         
         for(RDGeom::POINT3D_VECT::size_type i=0; i< positions.size(); ++i) {
             if(oldIndices[i] != nullptr) {

--- a/Code/GraphMol/RWMol.cpp
+++ b/Code/GraphMol/RWMol.cpp
@@ -829,7 +829,6 @@ void RWMol::batchRemoveAtoms() {
     }
     
     // do the same with the coordinates in the conformations
-    const bool force=true;
     for (auto conf : d_confs) {
         RDGeom::POINT3D_VECT &positions = conf->getPositions();
         RDGeom::POINT3D_VECT newPositions;

--- a/Code/GraphMol/RWMol.cpp
+++ b/Code/GraphMol/RWMol.cpp
@@ -578,9 +578,10 @@ void RWMol::beginBatchEdit() {
 }
 
 void RWMol::commitBatchEdit() {
-    if (!dp_delBonds || !dp_delAtoms) {
+    if (!(dp_delBonds || dp_delAtoms)) {
         return;
     }
+
     batchRemoveBonds();
     batchRemoveAtoms();
     
@@ -589,6 +590,15 @@ void RWMol::commitBatchEdit() {
     
     // fix properties
     clearComputedProps(true);
+    dp_delBonds.reset();
+    dp_delAtoms.reset();
+    
+    if (dp_delAtoms || dp_delBonds) {
+      BOOST_LOG(rdWarningLog) << "batchEdit mode already enabled, ignoring "
+                                 "additional call to beginBatchEdit()"
+                              << std::endl;
+      throw ValueErrorException("Attempt to re-enter batchEdit mode");
+    }
 }
 
 void RWMol::batchRemoveBonds() {

--- a/Code/GraphMol/RWMol.cpp
+++ b/Code/GraphMol/RWMol.cpp
@@ -595,8 +595,9 @@ void RWMol::commitBatchEdit() {
 }
 
 void RWMol::batchRemoveBonds() {
-    if(!dp_delBonds)
+    if(!dp_delBonds) {
         return;
+    }
     
     auto &delBonds = *dp_delBonds;
     unsigned int min_idx = getNumBonds();
@@ -703,8 +704,9 @@ void RWMol::batchRemoveBonds() {
 }
 
 void RWMol::batchRemoveAtoms() {
-    if(!dp_delAtoms)
+    if(!dp_delAtoms) {
         return;
+    }
     std::vector<Atom*> oldIndices(getNumAtoms());
     for(auto *atom: atoms()) {
         oldIndices[atom->getIdx()] = atom;

--- a/Code/GraphMol/RWMol.cpp
+++ b/Code/GraphMol/RWMol.cpp
@@ -797,11 +797,6 @@ void RWMol::batchRemoveAtoms() {
         
         // Remove this atom from any stereo group
         removeAtomFromGroups(atom, d_stereo_groups);
-        
-        // clear computed properties and reset our ring info structure
-        // they are pretty likely to be wrong now:
-        clearComputedProps(true);
-        
         atom->setOwningMol(nullptr);
         
         // remove all connections to the atom:
@@ -829,6 +824,16 @@ void RWMol::batchRemoveAtoms() {
         CHECK_INVARIANT(end, "Atom mapping failed");
         bond->setBeginAtomIdx(bgn->getIdx());
         bond->setEndAtomIdx(end->getIdx());
+        INT_VECT stereoAtoms;
+        INT_VECT &oldStereoAtoms = bond->getStereoAtoms();
+        if(oldStereoAtoms.size()) {
+            for(auto &idx: oldStereoAtoms) {
+                if(oldIndices[idx]) {
+                    stereoAtoms.push_back(oldIndices[idx]->getIdx());
+                }
+            }
+            bond->getStereoAtoms().swap(stereoAtoms);
+        }
     }
     
     // do the same with the coordinates in the conformations

--- a/Code/GraphMol/RWMol.cpp
+++ b/Code/GraphMol/RWMol.cpp
@@ -244,6 +244,20 @@ void RWMol::removeAtom(Atom *atom) {
   PRECONDITION(static_cast<RWMol *>(&atom->getOwningMol()) == this,
                "atom not owned by this molecule");
   unsigned int idx = atom->getIdx();
+
+  // remove bonds attached to the atom
+  //  In batch mode this will schedule bond removal
+  std::vector<std::pair<unsigned int, unsigned int>> nbrs;
+  ADJ_ITER b1, b2;
+  boost::tie(b1, b2) = getAtomNeighbors(atom);
+  while (b1 != b2) {
+      nbrs.emplace_back(atom->getIdx(), rdcast<unsigned int>(*b1));
+      ++b1;
+  }
+  for (auto &nbr : nbrs) {
+     removeBond(nbr.first, nbr.second);
+  }
+    
   if (dp_delAtoms) {
     // we're in a batch edit
     // if atoms have been added since we started, resize dp_delAtoms
@@ -267,18 +281,6 @@ void RWMol::removeAtom(Atom *atom) {
     if (std::find(atoms.begin(), atoms.end(), atom) != atoms.end()) {
       clearAtomBookmark(tmpI->first, atom);
     }
-  }
-
-  // remove bonds attached to the atom
-  std::vector<std::pair<unsigned int, unsigned int>> nbrs;
-  ADJ_ITER b1, b2;
-  boost::tie(b1, b2) = getAtomNeighbors(atom);
-  while (b1 != b2) {
-    nbrs.emplace_back(atom->getIdx(), rdcast<unsigned int>(*b1));
-    ++b1;
-  }
-  for (auto &nbr : nbrs) {
-    removeBond(nbr.first, nbr.second);
   }
 
   // loop over all atoms with higher indices and update their indices
@@ -574,26 +576,268 @@ void RWMol::beginBatchEdit() {
   dp_delAtoms.reset(new boost::dynamic_bitset<>(getNumAtoms()));
   dp_delBonds.reset(new boost::dynamic_bitset<>(getNumBonds()));
 }
+
 void RWMol::commitBatchEdit() {
-  if (!dp_delBonds || !dp_delAtoms) {
-    return;
-  }
-  auto delBonds = *dp_delBonds;
-  dp_delBonds.reset();
-  for (unsigned int i = delBonds.size(); i > 0; --i) {
-    if (delBonds[i - 1]) {
-      const auto bnd = getBondWithIdx(i - 1);
-      CHECK_INVARIANT(bnd, "bond not found");
-      removeBond(bnd->getBeginAtomIdx(), bnd->getEndAtomIdx());
+    if (!dp_delBonds || !dp_delAtoms) {
+        return;
     }
-  }
-  auto delAtoms = *dp_delAtoms;
-  dp_delAtoms.reset();
-  for (unsigned int i = delAtoms.size(); i > 0; --i) {
-    if (delAtoms[i - 1]) {
-      removeAtom(i - 1);
+    batchRemoveBonds();
+    batchRemoveAtoms();
+    
+    // remove ring info
+    dp_ringInfo->reset();
+    
+    // fix properties
+    clearComputedProps(true);
+}
+
+void RWMol::batchRemoveBonds() {
+    if(!dp_delBonds)
+        return;
+    
+    auto &delBonds = *dp_delBonds;
+    unsigned int min_idx = rdcast<unsigned int>(delBonds.size());
+    for (unsigned int i = rdcast<unsigned int>(delBonds.size()); i > 0; --i) {
+        if( !delBonds[i-1] )
+            continue;
+        unsigned int idx = rdcast<unsigned int>(i-1);
+        Bond *bnd = getBondWithIdx(idx);
+        if(!bnd) {
+            continue;
+        }
+        
+        min_idx = idx;
+        // remove any bookmarks which point to this bond:
+        BOND_BOOKMARK_MAP *marks = getBondBookmarks();
+        auto markI = marks->begin();
+        while (markI != marks->end()) {
+            BOND_PTR_LIST &bonds = markI->second;
+            // we need to copy the iterator then increment it, because the
+            // deletion we're going to do in clearBondBookmark will invalidate
+            // it.
+            auto tmpI = markI;
+            ++markI;
+            if (std::find(bonds.begin(), bonds.end(), bnd) != bonds.end()) {
+                clearBondBookmark(tmpI->first, bnd);
+            }
+        }
+        
+        // loop over neighboring double bonds and remove their stereo atom
+        //  information. This is definitely now invalid (was github issue 8)
+        ADJ_ITER a1, a2;
+        auto aid1 = bnd->getBeginAtomIdx();
+        auto aid2 = bnd->getEndAtomIdx();
+        boost::tie(a1, a2) = boost::adjacent_vertices(aid1, d_graph);
+        while (a1 != a2) {
+            auto oIdx = rdcast<unsigned int>(*a1);
+            ++a1;
+            if (oIdx == aid2) {
+                continue;
+            }
+            Bond *obnd = getBondBetweenAtoms(aid1, oIdx);
+            
+            // See if the bond is already gone or if we are going to delete the nbrbond anyway.
+            if (!obnd || delBonds[obnd->getIdx()]) {
+                continue;
+            }
+            if (std::find(obnd->getStereoAtoms().begin(), obnd->getStereoAtoms().end(),
+                          aid2) != obnd->getStereoAtoms().end()) {
+                // github #6900 if we remove stereo atoms we need to remove
+                //  the CIS and or TRANS since this requires stereo atoms
+                if (obnd->getStereo() == Bond::BondStereo::STEREOCIS ||
+                    obnd->getStereo() == Bond::BondStereo::STEREOTRANS) {
+                    obnd->setStereo(Bond::BondStereo::STEREONONE);
+                }
+                obnd->getStereoAtoms().clear();
+            }
+        }
+        boost::tie(a1, a2) = boost::adjacent_vertices(aid2, d_graph);
+        while (a1 != a2) {
+            auto oIdx = rdcast<unsigned int>(*a1);
+            ++a1;
+            if (oIdx == aid1) {
+                continue;
+            }
+            Bond *obnd = getBondBetweenAtoms(aid2, oIdx);
+            // See if the bond is already gone or if we are going to delete the nbrbond anyway.
+            if (!obnd || delBonds[obnd->getIdx()]) {
+                continue;
+            }
+            if (std::find(obnd->getStereoAtoms().begin(), obnd->getStereoAtoms().end(),
+                          aid1) != obnd->getStereoAtoms().end()) {
+                // github #6900 if we remove stereo atoms we need to remove
+                //  the CIS and or TRANS since this requires stereo atoms
+                if (obnd->getStereo() == Bond::BondStereo::STEREOCIS ||
+                    obnd->getStereo() == Bond::BondStereo::STEREOTRANS) {
+                    obnd->setStereo(Bond::BondStereo::STEREONONE);
+                }
+                obnd->getStereoAtoms().clear();
+            }
+        }
+        
+        removeSubstanceGroupsReferencingBond(*this, idx);
+        
+        bnd->setOwningMol(nullptr);
+        
+        MolGraph::vertex_descriptor vd1 = boost::vertex(aid1, d_graph);
+        MolGraph::vertex_descriptor vd2 = boost::vertex(aid2, d_graph);
+        boost::remove_edge(vd1, vd2, d_graph);
+        delete bnd;
+        --numBonds;
     }
-  }
+    
+    // loop over all bonds with higher indices than the minimum modified and update their indices
+    ROMol::EDGE_ITER firstB, lastB;
+    boost::tie(firstB, lastB) = this->getEdges();
+    unsigned int next_idx = min_idx;
+    while (firstB != lastB) {
+        Bond *bond = (*this)[*firstB];
+        if (bond->getIdx() > min_idx) {
+            bond->setIdx(next_idx++);
+        }
+        ++firstB;
+    }
+}
+
+void RWMol::batchRemoveAtoms() {
+    if(!dp_delAtoms)
+        return;
+    std::vector<Atom*> oldIndices;
+    oldIndices.reserve(getNumAtoms());
+    for(auto *atom: atoms()) {
+        oldIndices[atom->getIdx()] = atom;
+    }
+    
+    auto &delAtoms = *dp_delAtoms;
+    unsigned int min_idx =  rdcast<unsigned int>(delAtoms.size());
+    for (unsigned int i = rdcast<unsigned int>(delAtoms.size()); i > 0; --i) {
+        if( !delAtoms[i-1] )
+            continue;
+        unsigned int idx = i-1;
+        min_idx = idx;
+        Atom * atom = getAtomWithIdx(idx);
+        if (!atom)
+            continue;
+        
+        // remove any bookmarks which point to this atom:
+        ATOM_BOOKMARK_MAP *marks = getAtomBookmarks();
+        auto markI = marks->begin();
+        while (markI != marks->end()) {
+            const ATOM_PTR_LIST &atoms = markI->second;
+            // we need to copy the iterator then increment it, because the
+            // deletion we're going to do in clearAtomBookmark will invalidate
+            // it.
+            auto tmpI = markI;
+            ++markI;
+            if (std::find(atoms.begin(), atoms.end(), atom) != atoms.end()) {
+                clearAtomBookmark(tmpI->first, atom);
+            }
+        }
+        
+        // now deal with bonds:
+        //   their end indices may need to be decremented and their
+        //   indices will need to be handled and if they have an
+        //   ENDPTS prop that includes idx, it will need updating.
+        EDGE_ITER beg, end;
+        boost::tie(beg, end) = getEdges();
+        std::string sprop;
+        while (beg != end) {
+            Bond *bond = d_graph[*beg++];
+            if (bond->getPropIfPresent(RDKit::common_properties::_MolFileBondEndPts,
+                                       sprop)) {
+                // This would ideally use ParseV3000Array but I'm buggered if I can get
+                // the linker to find it.
+                //      std::vector<unsigned int> oats =
+                //          RDKit::SGroupParsing::ParseV3000Array<unsigned int>(sprop);
+                if ('(' == sprop.front() && ')' == sprop.back()) {
+                    sprop = sprop.substr(1, sprop.length() - 2);
+                    
+                    // This is doing what ParseV3000Array would do.
+                    boost::char_separator<char> sep(" ");
+                    boost::tokenizer<boost::char_separator<char>> tokens(sprop, sep);
+                    unsigned int num_ats = std::stod(*tokens.begin());
+                    std::vector<unsigned int> oats;
+                    auto beg = tokens.begin();
+                    ++beg;
+                    std::transform(beg, tokens.end(), std::back_inserter(oats),
+                                   [](const std::string &a) { return std::stod(a); });
+                    
+                    auto idx_pos = std::find(oats.begin(), oats.end(), idx + 1);
+                    if (idx_pos != oats.end()) {
+                        oats.erase(idx_pos);
+                        --num_ats;
+                    }
+                    if (!num_ats) {
+                        bond->clearProp(RDKit::common_properties::_MolFileBondEndPts);
+                        bond->clearProp(common_properties::_MolFileBondAttach);
+                    } else {
+                        sprop = "(" + std::to_string(num_ats) + " ";
+                        for (auto &i : oats) {
+                            if (i > idx + 1) {
+                                --i;
+                            }
+                            sprop += std::to_string(i) + " ";
+                        }
+                        sprop[sprop.length() - 1] = ')';
+                        bond->setProp(RDKit::common_properties::_MolFileBondEndPts, sprop);
+                    }
+                }
+            }
+        }
+        
+        removeSubstanceGroupsReferencingAtom(*this, idx);
+        
+        // Remove this atom from any stereo group
+        removeAtomFromGroups(atom, d_stereo_groups);
+        
+        // clear computed properties and reset our ring info structure
+        // they are pretty likely to be wrong now:
+        clearComputedProps(true);
+        
+        atom->setOwningMol(nullptr);
+        
+        // remove all connections to the atom:
+        MolGraph::vertex_descriptor vd = boost::vertex(idx, d_graph);
+        boost::clear_vertex(vd, d_graph);
+        // finally remove the vertex itself
+        boost::remove_vertex(vd, d_graph);
+        delete atom;
+        oldIndices[idx] = nullptr;
+    }
+    
+    // reassign atom indices
+    for (unsigned int i = 0; i < getNumAtoms(); i++) {
+        Atom *atm = getAtomWithIdx(i);
+        atm->setIdx(i);
+    }
+    
+    // reassign atom indices in bonds
+    for(auto bond: bonds()) {
+        auto bgnidx = bond->getBeginAtomIdx();
+        auto endidx = bond->getEndAtomIdx();
+        Atom *bgn = oldIndices[bgnidx];
+        Atom *end = oldIndices[endidx];
+        CHECK_INVARIANT(bgn, "Atom mapping failed");
+        CHECK_INVARIANT(end, "Atom mapping failed");
+        bond->setBeginAtomIdx(bgn->getIdx());
+        bond->setEndAtomIdx(end->getIdx());
+    }
+    
+    // do the same with the coordinates in the conformations
+    const bool force=true;
+    for (auto conf : d_confs) {
+        RDGeom::POINT3D_VECT &positions = conf->getPositions(force);
+        RDGeom::POINT3D_VECT newPositions;
+        positions.reserve(getNumAtoms());
+        
+        for(RDGeom::POINT3D_VECT::size_type i=0; i< positions.size(); ++i) {
+            if(oldIndices[i] != nullptr) {
+                newPositions.push_back(positions[i]);
+            }
+        }
+        CHECK_INVARIANT(newPositions.size() == getNumAtoms(), "Lost coordinates!");
+        positions.swap(newPositions);
+    }
 }
 
 }  // namespace RDKit

--- a/Code/GraphMol/RWMol.cpp
+++ b/Code/GraphMol/RWMol.cpp
@@ -719,12 +719,10 @@ void RWMol::batchRemoveAtoms() {
     }
     
     auto &delAtoms = *dp_delAtoms;
-    unsigned int min_idx =  rdcast<unsigned int>(delAtoms.size());
     for (unsigned int i = rdcast<unsigned int>(delAtoms.size()); i > 0; --i) {
         if( !delAtoms[i-1] )
             continue;
         unsigned int idx = i-1;
-        min_idx = idx;
         Atom * atom = getAtomWithIdx(idx);
         if (!atom)
             continue;

--- a/Code/GraphMol/RWMol.cpp
+++ b/Code/GraphMol/RWMol.cpp
@@ -599,7 +599,7 @@ void RWMol::batchRemoveBonds() {
         return;
     
     auto &delBonds = *dp_delBonds;
-    unsigned int min_idx = rdcast<unsigned int>(getNumBonds());
+    unsigned int min_idx = getNumBonds();
     for (unsigned int i = rdcast<unsigned int>(delBonds.size()); i > 0; --i) {
         if( !delBonds[i-1] )
             continue;

--- a/Code/GraphMol/RWMol.cpp
+++ b/Code/GraphMol/RWMol.cpp
@@ -592,13 +592,6 @@ void RWMol::commitBatchEdit() {
     clearComputedProps(true);
     dp_delBonds.reset();
     dp_delAtoms.reset();
-    
-    if (dp_delAtoms || dp_delBonds) {
-      BOOST_LOG(rdWarningLog) << "batchEdit mode already enabled, ignoring "
-                                 "additional call to beginBatchEdit()"
-                              << std::endl;
-      throw ValueErrorException("Attempt to re-enter batchEdit mode");
-    }
 }
 
 void RWMol::batchRemoveBonds() {

--- a/Code/GraphMol/RWMol.cpp
+++ b/Code/GraphMol/RWMol.cpp
@@ -599,7 +599,7 @@ void RWMol::batchRemoveBonds() {
         return;
     
     auto &delBonds = *dp_delBonds;
-    unsigned int min_idx = rdcast<unsigned int>(delBonds.size());
+    unsigned int min_idx = rdcast<unsigned int>(getNumBonds());
     for (unsigned int i = rdcast<unsigned int>(delBonds.size()); i > 0; --i) {
         if( !delBonds[i-1] )
             continue;

--- a/Code/GraphMol/RWMol.h
+++ b/Code/GraphMol/RWMol.h
@@ -211,6 +211,9 @@ class RDKIT_GRAPHMOL_EXPORT RWMol : public ROMol {
     dp_delBonds.reset();
   }
   void commitBatchEdit();
+private:
+  void batchRemoveBonds();
+  void batchRemoveAtoms();
 };
 
 typedef boost::shared_ptr<RWMol> RWMOL_SPTR;


### PR DESCRIPTION
Optimize atom and bond removals

 1. add two new private functions, batchRemoveBonds, batchRemoveAtoms
 2. minimizes calls to expensive functions, clearComputedProps(true), renumbering atoms/bonds, conformers
 3. calls to removeBond queues up atom removals (which didn't happen before, the makes book keeping easier)