### PR TITLE
Fixes #7140

### DIFF
--- a/Code/GraphMol/CMakeLists.txt
+++ b/Code/GraphMol/CMakeLists.txt
@@ -176,7 +176,7 @@ rdkit_catch_test(graphmolAdjustQueryCatch catch_adjustquery.cpp
         LINK_LIBRARIES SubstructMatch FileParsers SmilesParse GraphMol)
 
 rdkit_catch_test(chiralityTestsCatch catch_chirality.cpp
-        LINK_LIBRARIES FileParsers SmilesParse GraphMol)
+        LINK_LIBRARIES CIPLabeler FileParsers SmilesParse GraphMol)
 
 rdkit_catch_test(canonTestsCatch catch_canon.cpp
         LINK_LIBRARIES FileParsers SmilesParse GraphMol)

--- a/Code/GraphMol/Chirality.cpp
+++ b/Code/GraphMol/Chirality.cpp
@@ -2660,7 +2660,8 @@ void removeNonExplicit3DChirality(ROMol &mol) {
   }
 }
 
-void addStereoAnnotations(ROMol &mol) {
+void addStereoAnnotations(ROMol &mol, std::string absLabel, std::string orLabel,
+                          std::string andLabel) {
   auto sgs = mol.getStereoGroups();
   assignStereoGroupIds(sgs);
   std::vector<unsigned int> doneAts(mol.getNumAtoms(), 0);
@@ -2680,21 +2681,26 @@ void addStereoAnnotations(ROMol &mol) {
       }
       switch (sg.getGroupType()) {
         case StereoGroupType::STEREO_ABSOLUTE:
-          lab = "abs";
+          lab = absLabel;
           break;
         case StereoGroupType::STEREO_OR:
-          lab = (boost::format("or%d") % sg.getWriteId()).str();
+          lab = orLabel;
+          if (lab.find("%d") != std::string::npos) {
+            lab = (boost::format(lab) % sg.getWriteId()).str();
+          }
           break;
         case StereoGroupType::STEREO_AND:
-          lab = (boost::format("and%d") % sg.getWriteId()).str();
-          break;
+          lab = andLabel;
+          if (lab.find("%d") != std::string::npos) {
+            lab = (boost::format(lab) % sg.getWriteId()).str();
+          }
         default:
           break;
       }
       if (!lab.empty()) {
         doneAts[atom->getIdx()] = 1;
-        if (!cip.empty()) {
-          lab += " (" + cip + ")";
+        if (!cip.empty() && lab.find("%s") != std::string::npos) {
+          lab = (boost::format(lab) % cip).str();
         }
         atom->setProp(common_properties::atomNote, lab);
       }

--- a/Code/GraphMol/Chirality.cpp
+++ b/Code/GraphMol/Chirality.cpp
@@ -2660,7 +2660,7 @@ void removeNonExplicit3DChirality(ROMol &mol) {
   }
 }
 
-void addStereoAnnotations(ROMol &mol, bool includeRelativeCIP) {
+void addStereoAnnotations(ROMol &mol) {
   auto sgs = mol.getStereoGroups();
   assignStereoGroupIds(sgs);
   std::vector<unsigned int> doneAts(mol.getNumAtoms(), 0);
@@ -2675,8 +2675,7 @@ void addStereoAnnotations(ROMol &mol, bool includeRelativeCIP) {
       }
       std::string lab;
       std::string cip;
-      if (includeRelativeCIP ||
-          sg.getGroupType() == StereoGroupType::STEREO_ABSOLUTE) {
+      if (sg.getGroupType() == StereoGroupType::STEREO_ABSOLUTE) {
         atom->getPropIfPresent(common_properties::_CIPCode, cip);
       }
       switch (sg.getGroupType()) {

--- a/Code/GraphMol/Chirality.h
+++ b/Code/GraphMol/Chirality.h
@@ -360,7 +360,9 @@ RDKIT_GRAPHMOL_EXPORT void GetMolFileBondStereoInfo(
  assigned to the molecule.
 
  */
-RDKIT_GRAPHMOL_EXPORT void addStereoAnnotations(ROMol &mol);
+RDKIT_GRAPHMOL_EXPORT void addStereoAnnotations(
+    ROMol &mol, std::string absLabel = "abs (%s)", std::string orLabel = "or%d",
+    std::string andLabel = "and%d");
 
 }  // namespace Chirality
 }  // namespace RDKit

--- a/Code/GraphMol/Chirality.h
+++ b/Code/GraphMol/Chirality.h
@@ -355,14 +355,12 @@ RDKIT_GRAPHMOL_EXPORT void GetMolFileBondStereoInfo(
 //! add R/S, relative stereo, and E/Z annotations to atoms and bonds
 /*!
  \param mol: molecule to modify
- \param includeRelativeCIP: include CIP labels on AND and OR stereo groups.
 
  Note that CIP labels will only be added if CIP stereochemistry has been
  assigned to the molecule.
 
  */
-RDKIT_GRAPHMOL_EXPORT void addStereoAnnotations(
-    ROMol &mol, bool includeRelativeCIP = false);
+RDKIT_GRAPHMOL_EXPORT void addStereoAnnotations(ROMol &mol);
 
 }  // namespace Chirality
 }  // namespace RDKit

--- a/Code/GraphMol/Chirality.h
+++ b/Code/GraphMol/Chirality.h
@@ -352,6 +352,18 @@ RDKIT_GRAPHMOL_EXPORT void GetMolFileBondStereoInfo(
         &wedgeBonds,
     const Conformer *conf, Bond::BondDir &dir, bool &reverse);
 
+//! add R/S, relative stereo, and E/Z annotations to atoms and bonds
+/*!
+ \param mol: molecule to modify
+ \param includeRelativeCIP: include CIP labels on AND and OR stereo groups.
+
+ Note that CIP labels will only be added if CIP stereochemistry has been
+ assigned to the molecule.
+
+ */
+RDKIT_GRAPHMOL_EXPORT void addStereoAnnotations(
+    ROMol &mol, bool includeRelativeCIP = false);
+
 }  // namespace Chirality
 }  // namespace RDKit
 #endif

--- a/Code/GraphMol/Chirality.h
+++ b/Code/GraphMol/Chirality.h
@@ -355,14 +355,26 @@ RDKIT_GRAPHMOL_EXPORT void GetMolFileBondStereoInfo(
 //! add R/S, relative stereo, and E/Z annotations to atoms and bonds
 /*!
  \param mol: molecule to modify
+ \param absLabel: label for atoms in an ABS stereo group
+ \param orLabel: label for atoms in an OR stereo group
+ \param andLabel: label for atoms in an AND stereo group
+ \param cipLabel: label for chiral atoms that aren't in a stereo group.
+ \param bondLabel: label for CIP stereochemistry on bonds
+
+ If any label is empty, the corresponding annotations will not be added.
+
+ The labels can contain the following placeholders:
+   {id} - the stereo group's index
+   {cip} - the atom or bond's CIP stereochemistry
 
  Note that CIP labels will only be added if CIP stereochemistry has been
  assigned to the molecule.
 
  */
 RDKIT_GRAPHMOL_EXPORT void addStereoAnnotations(
-    ROMol &mol, std::string absLabel = "abs (%s)", std::string orLabel = "or%d",
-    std::string andLabel = "and%d");
+    ROMol &mol, std::string absLabel = "abs ({cip})",
+    std::string orLabel = "or{id}", std::string andLabel = "and{id}",
+    std::string cipLabel = "({cip})", std::string bondLabel = "({cip})");
 
 }  // namespace Chirality
 }  // namespace RDKit

--- a/Code/GraphMol/MolDraw2D/DrawMol.cpp
+++ b/Code/GraphMol/MolDraw2D/DrawMol.cpp
@@ -195,7 +195,7 @@ void DrawMol::initDrawMolecule(const ROMol &mol) {
     prepareStereoGroups(*drawMol_);
   }
   if (drawOptions_.addStereoAnnotation) {
-    addStereoAnnotation(*drawMol_);
+    Chirality::addStereoAnnotations(*drawMol_);
   }
   if (drawOptions_.addAtomIndices) {
     addAtomIndices(*drawMol_);

--- a/Code/GraphMol/MolDraw2D/MolDraw2DDetails.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DDetails.cpp
@@ -47,10 +47,6 @@ void arcPoints(const Point2D &cds1, const Point2D &cds2,
   }
 }
 
-void addStereoAnnotation(const ROMol &mol, bool includeRelativeCIP) {
-  Chirality::addStereoAnnotations(const_cast<ROMol &>(mol), includeRelativeCIP);
-}
-
 namespace {
 // note, this is approximate since we're just using it for drawing
 bool lineSegmentsIntersect(const Point2D &s1, const Point2D &s2,

--- a/Code/GraphMol/MolDraw2D/MolDraw2DDetails.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DDetails.cpp
@@ -10,6 +10,7 @@
 
 #include <GraphMol/MolDraw2D/MolDraw2DDetails.h>
 #include <GraphMol/MolDraw2D/StringRect.h>
+#include <GraphMol/Chirality.h>
 
 #include <cmath>
 #ifndef M_PI
@@ -47,68 +48,7 @@ void arcPoints(const Point2D &cds1, const Point2D &cds2,
 }
 
 void addStereoAnnotation(const ROMol &mol, bool includeRelativeCIP) {
-  auto sgs = mol.getStereoGroups();
-  assignStereoGroupIds(sgs);
-  std::vector<unsigned int> doneAts(mol.getNumAtoms(), 0);
-  for (const auto &sg : sgs) {
-    for (const auto atom : sg.getAtoms()) {
-      if (doneAts[atom->getIdx()]) {
-        BOOST_LOG(rdWarningLog) << "Warning: atom " << atom->getIdx()
-                                << " is in more than one stereogroup. Only the "
-                                   "label from the first group will be used."
-                                << std::endl;
-        continue;
-      }
-      std::string lab;
-      std::string cip;
-      if (includeRelativeCIP ||
-          sg.getGroupType() == StereoGroupType::STEREO_ABSOLUTE) {
-        atom->getPropIfPresent(common_properties::_CIPCode, cip);
-      }
-      switch (sg.getGroupType()) {
-        case StereoGroupType::STEREO_ABSOLUTE:
-          lab = "abs";
-          break;
-        case StereoGroupType::STEREO_OR:
-          lab = (boost::format("or%d") % sg.getWriteId()).str();
-          break;
-        case StereoGroupType::STEREO_AND:
-          lab = (boost::format("and%d") % sg.getWriteId()).str();
-          break;
-        default:
-          break;
-      }
-      if (!lab.empty()) {
-        doneAts[atom->getIdx()] = 1;
-        if (!cip.empty()) {
-          lab += " (" + cip + ")";
-        }
-        atom->setProp(common_properties::atomNote, lab);
-      }
-    }
-  }
-  for (auto atom : mol.atoms()) {
-    std::string cip;
-    if (!doneAts[atom->getIdx()] &&
-        atom->getPropIfPresent(common_properties::_CIPCode, cip)) {
-      std::string lab = "(" + cip + ")";
-      atom->setProp(common_properties::atomNote, lab);
-    }
-  }
-  for (auto bond : mol.bonds()) {
-    std::string cip;
-    if (!bond->getPropIfPresent(common_properties::_CIPCode, cip)) {
-      if (bond->getStereo() == Bond::STEREOE) {
-        cip = "E";
-      } else if (bond->getStereo() == Bond::STEREOZ) {
-        cip = "Z";
-      }
-    }
-    if (!cip.empty()) {
-      std::string lab = "(" + cip + ")";
-      bond->setProp(common_properties::bondNote, lab);
-    }
-  }
+  Chirality::addStereoAnnotations(const_cast<ROMol &>(mol), includeRelativeCIP);
 }
 
 namespace {

--- a/Code/GraphMol/MolDraw2D/MolDraw2DDetails.h
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DDetails.h
@@ -56,9 +56,9 @@ RDKIT_MOLDRAW2D_EXPORT void arcPoints(const Point2D &cds1, const Point2D &cds2,
                                       std::vector<Point2D> &res,
                                       float startAng = 0, float extent = 360);
 
-//! add R/S, relative stereo, and E/Z annotations to atoms and bonds
-RDKIT_MOLDRAW2D_EXPORT void addStereoAnnotation(
-    const ROMol &mol, bool includeRelativeCIP = false);
+[[deprecated(
+    "please use Chirality::addStereoAnnotations instead")]] RDKIT_MOLDRAW2D_EXPORT void
+addStereoAnnotation(const ROMol &mol, bool includeRelativeCIP = false);
 
 //! add annotations with atom indices.
 RDKIT_MOLDRAW2D_EXPORT inline void addAtomIndices(const ROMol &mol) {

--- a/Code/GraphMol/MolDraw2D/MolDraw2DDetails.h
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DDetails.h
@@ -56,10 +56,6 @@ RDKIT_MOLDRAW2D_EXPORT void arcPoints(const Point2D &cds1, const Point2D &cds2,
                                       std::vector<Point2D> &res,
                                       float startAng = 0, float extent = 360);
 
-[[deprecated(
-    "please use Chirality::addStereoAnnotations instead")]] RDKIT_MOLDRAW2D_EXPORT void
-addStereoAnnotation(const ROMol &mol, bool includeRelativeCIP = false);
-
 //! add annotations with atom indices.
 RDKIT_MOLDRAW2D_EXPORT inline void addAtomIndices(const ROMol &mol) {
   // we don't need this in the global set of tags since it will only be used

--- a/Code/GraphMol/MolDraw2D/catch_tests.cpp
+++ b/Code/GraphMol/MolDraw2D/catch_tests.cpp
@@ -83,7 +83,7 @@ const std::map<std::string, std::hash_result_t> SVG_HASHES = {
     {"testGithub3226_1.svg", 831257877U},
     {"testGithub3226_2.svg", 3517325227U},
     {"testGithub3226_3.svg", 3609721552U},
-    {"testGithub3369_1.svg", 3091976328U},
+    {"testGithub3369_1.svg", 2194263901U},
     {"testIncludeRadicals_1a.svg", 1829641340U},
     {"testIncludeRadicals_1b.svg", 4184066907U},
     {"testLegendsAndDrawing-1.svg", 3563802758U},
@@ -1310,8 +1310,7 @@ TEST_CASE(
   SECTION("works with the drawing code") {
     MolDraw2DSVG drawer(300, 250);
     RWMol dm1(*m1);
-    bool includeRelativeCIP = true;
-    Chirality::addStereoAnnotations(dm1, includeRelativeCIP);
+    Chirality::addStereoAnnotations(dm1);
     drawer.drawMolecule(dm1);
     drawer.finishDrawing();
     std::string text = drawer.getDrawingText();

--- a/Code/GraphMol/Wrap/MolOps.cpp
+++ b/Code/GraphMol/Wrap/MolOps.cpp
@@ -3018,12 +3018,8 @@ A note on the flags controlling which atoms/bonds are modified:
 
     python::def(
         "AddStereoAnnotations", Chirality::addStereoAnnotations,
-        (python::arg("mol"), python::arg("includeRelativeCIP") = false),
+        (python::arg("mol")),
         R"DOC(add R/S, relative stereo, and E/Z annotations to atoms and bonds
-
-  Arguments:
-   - mol: molecule to modify
-   - includeRelativeCIP: include CIP labels on AND and OR stereo groups.
 
   Note that CIP labels will only be added if CIP stereochemistry has been
   assigned to the molecule.)DOC");

--- a/Code/GraphMol/Wrap/MolOps.cpp
+++ b/Code/GraphMol/Wrap/MolOps.cpp
@@ -3016,6 +3016,18 @@ A note on the flags controlling which atoms/bonds are modified:
   If there is no chiral flag set (i.e. the property is not present), the
   molecule will not be modified.)DOC");
 
+    python::def(
+        "AddStereoAnnotations", Chirality::addStereoAnnotations,
+        (python::arg("mol"), python::arg("includeRelativeCIP") = false),
+        R"DOC(add R/S, relative stereo, and E/Z annotations to atoms and bonds
+
+  Arguments:
+   - mol: molecule to modify
+   - includeRelativeCIP: include CIP labels on AND and OR stereo groups.
+
+  Note that CIP labels will only be added if CIP stereochemistry has been
+  assigned to the molecule.)DOC");
+
     python::def("_TestSetProps", testSetProps, python::arg("mol"));
   }
 };

--- a/Code/GraphMol/Wrap/MolOps.cpp
+++ b/Code/GraphMol/Wrap/MolOps.cpp
@@ -3018,11 +3018,29 @@ A note on the flags controlling which atoms/bonds are modified:
 
     python::def(
         "AddStereoAnnotations", Chirality::addStereoAnnotations,
-        (python::arg("mol")),
+        (python::arg("mol"), python::arg("absLabel") = "abs ({cip})",
+         python::arg("orLabel") = "or{id}", python::arg("andLabel") = "and{id}",
+         python::arg("cipLabel") = "({cip})",
+         python::arg("cipLabel") = "({cip})"),
         R"DOC(add R/S, relative stereo, and E/Z annotations to atoms and bonds
 
-  Note that CIP labels will only be added if CIP stereochemistry has been
-  assigned to the molecule.)DOC");
+  Arguments:
+   - mol: molecule to modify
+   - absLabel: label for atoms in an ABS stereo group
+   - orLabel: label for atoms in an OR stereo group
+   - andLabel: label for atoms in an AND stereo group
+   - cipLabel: label for chiral atoms that aren't in a stereo group.
+   - bondLabel: label for CIP stereochemistry on bonds
+
+ If any label is empty, the corresponding annotations will not be added.
+
+ The labels can contain the following placeholders:
+   - {id} - the stereo group's index
+   - {cip} - the atom or bond's CIP stereochemistry
+
+ Note that CIP labels will only be added if CIP stereochemistry has been
+ assigned to the molecule.
+)DOC");
 
     python::def("_TestSetProps", testSetProps, python::arg("mol"));
   }

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -8012,11 +8012,6 @@ CAS<~>
     self.assertEqual(mol.GetAtomWithIdx(5).GetProp("atomNote"), "abs (S)")
     self.assertEqual(mol.GetAtomWithIdx(3).GetProp("atomNote"), "and2")
 
-    Chem.AddStereoAnnotations(mol, includeRelativeCIP=True)
-    self.assertEqual(mol.GetAtomWithIdx(5).GetProp("atomNote"), "abs (S)")
-    self.assertEqual(mol.GetAtomWithIdx(3).GetProp("atomNote"), "and2 (R)")
-
-
 
 if __name__ == '__main__':
   if "RDTESTCASE" in os.environ:

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -8002,6 +8002,20 @@ CAS<~>
     ranks = Chem.CanonicalRankAtoms(mol,breakTies=False,includeAtomMaps=False)
     self.assertEqual(ranks[0],ranks[2])
 
+  def testAddStereoAnnotations(self):
+    mol = Chem.MolFromSmiles(
+      "C[C@@H]1N[C@H](C)[C@@H]([C@H](C)[C@@H]1C)C1[C@@H](C)O[C@@H](C)[C@@H](C)[C@H]1C/C=C/C |a:5,o1:1,8,o2:14,16,&1:11,18,&2:3,6,r|"
+    )
+    self.assertIsNotNone(mol)
+    Chem.rdCIPLabeler.AssignCIPLabels(mol)
+    Chem.AddStereoAnnotations(mol)
+    self.assertEqual(mol.GetAtomWithIdx(5).GetProp("atomNote"), "abs (S)")
+    self.assertEqual(mol.GetAtomWithIdx(3).GetProp("atomNote"), "and2")
+
+    Chem.AddStereoAnnotations(mol, includeRelativeCIP=True)
+    self.assertEqual(mol.GetAtomWithIdx(5).GetProp("atomNote"), "abs (S)")
+    self.assertEqual(mol.GetAtomWithIdx(3).GetProp("atomNote"), "and2 (R)")
+
 
 
 if __name__ == '__main__':

--- a/Code/GraphMol/catch_chirality.cpp
+++ b/Code/GraphMol/catch_chirality.cpp
@@ -5176,19 +5176,6 @@ TEST_CASE(
                                                  txt));
     CHECK(txt == "and2");
   }
-  SECTION("including CIP with relative stereo") {
-    ROMol m2(*m1);
-    bool includeRelativeCIP = true;
-    Chirality::addStereoAnnotations(m2, includeRelativeCIP);
-
-    std::string txt;
-    CHECK(m2.getAtomWithIdx(5)->getPropIfPresent(common_properties::atomNote,
-                                                 txt));
-    CHECK(txt == "abs (S)");
-    CHECK(m2.getAtomWithIdx(3)->getPropIfPresent(common_properties::atomNote,
-                                                 txt));
-    CHECK(txt == "and2 (R)");
-  }
   SECTION("new CIP labels") {
     ROMol m2(*m1);
     REQUIRE(m2.getBondBetweenAtoms(20, 21));

--- a/Code/GraphMol/catch_chirality.cpp
+++ b/Code/GraphMol/catch_chirality.cpp
@@ -5162,7 +5162,7 @@ M  END)CTAB";
 TEST_CASE(
     "github #3369: support new CIP code and StereoGroups in addStereoAnnotations()") {
   auto m1 =
-      "C[C@@H]1N[C@H](C)[C@@H]([C@H](C)[C@@H]1C)C1[C@@H](C)O[C@@H](C)[C@@H](C)[C@H]1C/C=C/C |a:5,o1:1,8,o2:14,16,&1:11,18,&2:3,6,r|"_smiles;
+      "C[C@@H]1N[C@H](C)[C@@H]([C@H](C)[C@@H]1C)C1[C@@H](C)O[C@@H](C)[C@@H](C)[C@H]1C/C=C/C |a:5,o1:1,8,o2:14,16,&1:18,&2:3,6,r|"_smiles;
   REQUIRE(m1);
   SECTION("defaults") {
     ROMol m2(*m1);
@@ -5176,7 +5176,7 @@ TEST_CASE(
                                                  txt));
     CHECK(txt == "and2");
   }
-  SECTION("new CIP labels") {
+  SECTION("double bonds") {
     ROMol m2(*m1);
     REQUIRE(m2.getBondBetweenAtoms(20, 21));
     m2.getBondBetweenAtoms(20, 21)->setStereo(Bond::BondStereo::STEREOTRANS);
@@ -5194,5 +5194,73 @@ TEST_CASE(
     CHECK(m2.getBondBetweenAtoms(20, 21)->getPropIfPresent(
         common_properties::bondNote, txt));
     CHECK(txt == "(E)");
+  }
+
+  SECTION("custom labels") {
+    ROMol m2(*m1);
+    CIPLabeler::assignCIPLabels(m2);
+
+    std::string absLabel = "abs [{cip}]";
+    std::string orLabel = "o{id} ({cip})";
+    std::string andLabel = "&{id} ({cip})";
+    std::string cipLabel = "[{cip}]";
+    std::string bondLabel = "[{cip}]";
+    Chirality::addStereoAnnotations(m2, absLabel, orLabel, andLabel, cipLabel,
+                                    bondLabel);
+
+    std::string txt;
+
+    CHECK(m2.getAtomWithIdx(5)->getPropIfPresent(common_properties::atomNote,
+                                                 txt));
+    CHECK(txt == "abs [S]");
+
+    CHECK(m2.getAtomWithIdx(3)->getPropIfPresent(common_properties::atomNote,
+                                                 txt));
+    CHECK(txt == "&2 (R)");
+
+    CHECK(m2.getAtomWithIdx(1)->getPropIfPresent(common_properties::atomNote,
+                                                 txt));
+    CHECK(txt == "o1 (S)");
+
+    CHECK(m2.getAtomWithIdx(11)->getPropIfPresent(common_properties::atomNote,
+                                                  txt));
+    CHECK(txt == "[R]");
+
+    CHECK(m2.getBondBetweenAtoms(20, 21)->getPropIfPresent(
+        common_properties::bondNote, txt));
+    CHECK(txt == "[E]");
+  }
+
+  SECTION("empty labels") {
+    ROMol m2(*m1);
+    CIPLabeler::assignCIPLabels(m2);
+
+    std::string absLabel = "";
+    std::string orLabel = "o{id} ({cip})";
+    std::string andLabel = "&{id} ({cip})";
+    std::string cipLabel = "[{cip}]";
+    std::string bondLabel = "";
+    Chirality::addStereoAnnotations(m2, absLabel, orLabel, andLabel, cipLabel,
+                                    bondLabel);
+
+    std::string txt;
+
+    CHECK(!m2.getAtomWithIdx(5)->getPropIfPresent(common_properties::atomNote,
+                                                  txt));
+
+    CHECK(m2.getAtomWithIdx(3)->getPropIfPresent(common_properties::atomNote,
+                                                 txt));
+    CHECK(txt == "&2 (R)");
+
+    CHECK(m2.getAtomWithIdx(1)->getPropIfPresent(common_properties::atomNote,
+                                                 txt));
+    CHECK(txt == "o1 (S)");
+
+    CHECK(m2.getAtomWithIdx(11)->getPropIfPresent(common_properties::atomNote,
+                                                  txt));
+    CHECK(txt == "[R]");
+
+    CHECK(!m2.getBondBetweenAtoms(20, 21)->getPropIfPresent(
+        common_properties::bondNote, txt));
   }
 }


### PR DESCRIPTION
deprecates the old version of `addStereoAnnotation()` and creates a new one, named `addStereoAnnotations()` (which is more accurate) in Chirality.h 

I also added this to the python wrappers
