### PR TITLE
C sharp failing to build

### DIFF
--- a/Code/JavaWrappers/ROMol.i
+++ b/Code/JavaWrappers/ROMol.i
@@ -34,6 +34,10 @@
 %include "std_pair.i"
 %include "std_string.i"
 %include "std_vector.i"
+
+%include <std_unique_ptr.i>
+%unique_ptr(RDKit::RWMol)
+
 %{
 #include <RDGeneral/types.h>
 #include <GraphMol/ROMol.h>

--- a/Code/JavaWrappers/ROMol.i
+++ b/Code/JavaWrappers/ROMol.i
@@ -35,8 +35,10 @@
 %include "std_string.i"
 %include "std_vector.i"
 
+#ifdef SWIGCSHARP
 %include <std_unique_ptr.i>
 %unique_ptr(RDKit::RWMol)
+#endif
 
 %{
 #include <RDGeneral/types.h>

--- a/Code/JavaWrappers/RWMol.i
+++ b/Code/JavaWrappers/RWMol.i
@@ -48,19 +48,10 @@
 %ignore RDKit::RWMol::addAtom(Atom *atom,bool updateLabel,bool takeOwnership);
 %ignore RDKit::RWMol::addBond(Bond *bond,bool takeOwnership);
 
-%newobject RDKit::SmilesToMol;
-%newobject RDKit::SmartsToMol;
-%newobject RDKit::MolBlockToMol;
-%newobject RDKit::MolFileToMol;
-%newobject RDKit::MolFromMolFile;
-%newobject RDKit::MolFromTPLFIle;
-%newobject RDKit::MolFromMol2File;
-%newobject RDKit::MolFromMol2Block;
-%newobject RDKit::MolFromPDBBlock;
-%newobject RDKit::MolFromPDBFile;
-%newobject RDKit::MolFromSequence;
-%newobject RDKit::MolFromFasta;
-
+%newobject RDKit::v1::SmilesToMol;
+%newobject RDKit::v1::SmartsToMol;
+%newobject RDKit::v1::MolBlockToMol;
+%newobject RDKit::v1::MolFileToMol;
 
 %shared_ptr(RDKit::RWMol)
 %include "enums.swg"


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! 
-->

#### What does this implement/fix? Explain your changes.

The csharp wrappers are currently not building.  The various `ROMol::MolFrom*DataStream` functions require the `std_unique_ptr.i` SWIG file. 

#### Any other comments?

I also updated the namespace for the raw pointers in `RWMol.i` that end up in functions like `RDKFuncs.SmilesToMol`.

I think I'm going to take the time to write a pipeline for the C# build!

