### PR TITLE
Adding missing headers in ReactionParser.h

### DIFF
--- a/Code/GraphMol/ChemReactions/ReactionParser.h
+++ b/Code/GraphMol/ChemReactions/ReactionParser.h
@@ -36,7 +36,6 @@
 #ifndef RD_REACTIONPARSER_H_21Aug2006
 #define RD_REACTIONPARSER_H_21Aug2006
 
-#include <GraphMol/ROMol.h>
 #include <string>
 #include <iostream>
 #include <fstream>
@@ -49,6 +48,7 @@
 #include <GraphMol/FileParsers/FileParsers.h>
 
 namespace RDKit {
+class ROMol;
 class ChemicalReaction;
 
 //! used to indicate an error in parsing reaction data

--- a/Code/GraphMol/ChemReactions/ReactionParser.h
+++ b/Code/GraphMol/ChemReactions/ReactionParser.h
@@ -36,9 +36,11 @@
 #ifndef RD_REACTIONPARSER_H_21Aug2006
 #define RD_REACTIONPARSER_H_21Aug2006
 
+#include <GraphMol/ROMol.h>
 #include <string>
 #include <iostream>
 #include <fstream>
+#include <map>
 #include <sstream>
 #include <utility>
 #include <boost/format.hpp>


### PR DESCRIPTION
I am developping a C++ package using rdkit as a lib and I noticed there is a few missing headers causing a compilation error. This small PR fixes it.

