### PR TITLE
fix: add PandasTools support for pandas 2.2

### DIFF
--- a/rdkit/Chem/PandasPatcher.py
+++ b/rdkit/Chem/PandasPatcher.py
@@ -51,6 +51,8 @@ for get_adjustment_module_name in ("format", "printing"):
       if hasattr(get_adjustment_module, get_adjustment_name):
         orig_get_adjustment = getattr(get_adjustment_module, get_adjustment_name)
         break
+    if orig_get_adjustment is not None:
+        break
 if orig_get_adjustment is None:
   log.warning("Failed to find the pandas get_adjustment() function to patch")
   raise AttributeError

--- a/rdkit/Chem/PandasPatcher.py
+++ b/rdkit/Chem/PandasPatcher.py
@@ -44,10 +44,13 @@ if (hasattr(pandas_formats.format, "DataFrameFormatter")
 if orig_get_formatter is None:
   log.warning("Failed to find the pandas _get_formatter() function to patch")
 orig_get_adjustment = None
-for get_adjustment_name in ("get_adjustment", "_get_adjustment"):
-  if hasattr(pandas_formats.format, get_adjustment_name):
-    orig_get_adjustment = getattr(pandas_formats.format, get_adjustment_name)
-    break
+for get_adjustment_module_name in ("format", "printing"):
+  if hasattr(pandas_formats, get_adjustment_module_name):
+    get_adjustment_module = getattr(pandas_formats, get_adjustment_module_name)
+    for get_adjustment_name in ("get_adjustment", "_get_adjustment"):
+      if hasattr(get_adjustment_module, get_adjustment_name):
+        orig_get_adjustment = getattr(get_adjustment_module, get_adjustment_name)
+        break
 if orig_get_adjustment is None:
   log.warning("Failed to find the pandas get_adjustment() function to patch")
   raise AttributeError


### PR DESCRIPTION
Fixes #7159

Starting from `pandas 2.2.0`, the `get_adjustment` function is no longer in the `pandas.io.formats.format` module, but in the `pandas.io.formats.printing` module (cf. [pandas/blob/2.2.x/pandas/io/formats/format.py#L223](https://github.com/pandas-dev/pandas/blob/3dca4f0f8d583c67d2df56bf9ba51839cdaa6d26/pandas/io/formats/format.py#L223) vs [pandas/blob/2.1.x/pandas/io/formats/format.py#L293](https://github.com/pandas-dev/pandas/blob/a671b5a8bf5dd13fb19f0e88edc679bc9e15c673/pandas/io/formats/format.py#L293)).

This PR adds the new location to the search locations that RDKit looks for the function,
so that `PandasTools` works with `pandas 2.2.x` as well.  
