### PR TITLE
Fix #7157

### DIFF
--- a/Code/GraphMol/MolOps.h
+++ b/Code/GraphMol/MolOps.h
@@ -1025,11 +1025,15 @@ RDKIT_GRAPHMOL_EXPORT void clearDirFlags(ROMol &mol,
 //! directions
 RDKIT_GRAPHMOL_EXPORT void setBondStereoFromDirections(ROMol &mol);
 
-//! Assign stereochemistry tags to atoms (i.e. R/S) and bonds (i.e. Z/E)
+//! Assign stereochemistry tags to atoms and bonds.
 /*!
-  Does the CIP stereochemistry assignment for the molecule's atoms
-  (R/S) and double bond (Z/E). Chiral atoms will have a property
-  '_CIPCode' indicating their chiral code.
+  If useLegacyStereoPerception is true, it also does the CIP stereochemistry
+  assignment for the molecule's atoms (R/S) and double bonds (Z/E).
+  This assignment is based on legacy code which is fast, but is
+  known to incorrectly assign CIP labels in some cases.
+  instead, to assign CIP labels based on an accurate, though slower,
+  implementation of the CIP rules, call CIPLabeler::assignCIPLabels().
+  Chiral atoms will have a property '_CIPCode' indicating their chiral code.
 
   \param mol     the molecule to use
   \param cleanIt if true, any existing values of the property `_CIPCode`

--- a/Code/GraphMol/Wrap/MolOps.cpp
+++ b/Code/GraphMol/Wrap/MolOps.cpp
@@ -2043,10 +2043,14 @@ RETURNS:
 
     // ------------------------------------------------------------------------
     docString =
-        R"DOC(Does the CIP stereochemistry assignment 
-  for the molecule's atoms (R/S) and double bond (Z/E).
-  Chiral atoms will have a property '_CIPCode' indicating
-  their chiral code.
+        R"DOC(Assign stereochemistry tags to atoms and bonds.
+  If useLegacyStereoPerception is true, it also does the CIP stereochemistry
+  assignment for the molecule's atoms (R/S) and double bonds (Z/E).
+  This assignment is based on legacy code which is fast, but is
+  known to incorrectly assign CIP labels in some cases.
+  instead, to assign CIP labels based on an accurate, though slower,
+  implementation of the CIP rules, call CIPLabeler::assignCIPLabels().
+  Chiral atoms will have a property '_CIPCode' indicating their chiral code.
 
   ARGUMENTS:
 

--- a/Code/MinimalLib/cffi_test.c
+++ b/Code/MinimalLib/cffi_test.c
@@ -2235,6 +2235,23 @@ void test_relabel_mapped_dummies() {
   free(mpkl);
 }
 
+unsigned int count_matches(const char *svg, const char **stereo_array,
+                           size_t stereo_array_len) {
+  char *svg_copy = strdup(svg);
+  unsigned int i = 0;
+  char *line = strtok(svg_copy, "\n");
+  while (line && i < stereo_array_len) {
+    if (strstr(line, stereo_array[i])) {
+      ++i;
+    } else if (i) {
+      break;
+    }
+    line = strtok(NULL, "\n");
+  }
+  free(svg_copy);
+  return i;
+}
+
 void test_assign_cip_labels() {
   printf("--------------------------\n");
   printf("  test_assign_cip_labels\n");
@@ -2244,22 +2261,6 @@ void test_assign_cip_labels() {
   static const char *STEREO_SMI = "C/C=C/c1ccccc1[S@@](C)=O";
   static const char *S_STEREO[3] = {">(<", ">S<", ">)<"};
   static const char *R_STEREO[3] = {">(<", ">R<", ">)<"};
-  unsigned int count_matches(const char *svg, const char **stereo_array,
-                             size_t stereo_array_len) {
-    char *svg_copy = strdup(svg);
-    unsigned int i = 0;
-    char *line = strtok(svg_copy, "\n");
-    while (line && i < stereo_array_len) {
-      if (strstr(line, stereo_array[i])) {
-        ++i;
-      } else if (i) {
-        break;
-      }
-      line = strtok(NULL, "\n");
-    }
-    free(svg_copy);
-    return i;
-  }
   short orig_setting = use_legacy_stereo_perception(1);
   mpkl = get_mol(STEREO_SMI, &mpkl_size, "");
   svg = get_svg(mpkl, mpkl_size,

--- a/Code/MinimalLib/cffi_test.c
+++ b/Code/MinimalLib/cffi_test.c
@@ -2235,6 +2235,57 @@ void test_relabel_mapped_dummies() {
   free(mpkl);
 }
 
+void test_assign_cip_labels() {
+  printf("--------------------------\n");
+  printf("  test_assign_cip_labels\n");
+  char *mpkl;
+  size_t mpkl_size;
+  char *svg;
+  static const char *STEREO_SMI = "C/C=C/c1ccccc1[S@@](C)=O";
+  static const char *S_STEREO[3] = {">(<", ">S<", ">)<"};
+  static const char *R_STEREO[3] = {">(<", ">R<", ">)<"};
+  unsigned int count_matches(const char *svg, const char **stereo_array,
+                             size_t stereo_array_len) {
+    char *svg_copy = strdup(svg);
+    unsigned int i = 0;
+    char *line = strtok(svg_copy, "\n");
+    while (line && i < stereo_array_len) {
+      if (strstr(line, stereo_array[i])) {
+        ++i;
+      } else if (i) {
+        break;
+      }
+      line = strtok(NULL, "\n");
+    }
+    free(svg_copy);
+    return i;
+  }
+  short orig_setting = use_legacy_stereo_perception(1);
+  mpkl = get_mol(STEREO_SMI, &mpkl_size, "");
+  svg = get_svg(mpkl, mpkl_size,
+                "{\"noFreetype\":true,\"addStereoAnnotation\":true}");
+  assert(count_matches(svg, S_STEREO, 3) == 3);
+  assert(count_matches(svg, R_STEREO, 3) < 3);
+  free(svg);
+  free(mpkl);
+  use_legacy_stereo_perception(0);
+  mpkl = get_mol(STEREO_SMI, &mpkl_size, "");
+  svg = get_svg(mpkl, mpkl_size,
+                "{\"noFreetype\":true,\"addStereoAnnotation\":true}");
+  assert(count_matches(svg, S_STEREO, 3) < 3);
+  assert(count_matches(svg, R_STEREO, 3) < 3);
+  free(svg);
+  free(mpkl);
+  mpkl = get_mol(STEREO_SMI, &mpkl_size, "{\"assignCIPLabels\":true}");
+  svg = get_svg(mpkl, mpkl_size,
+                "{\"noFreetype\":true,\"addStereoAnnotation\":true}");
+  assert(count_matches(svg, S_STEREO, 3) < 3);
+  assert(count_matches(svg, R_STEREO, 3) == 3);
+  free(svg);
+  free(mpkl);
+  use_legacy_stereo_perception(orig_setting);
+}
+
 int main() {
   enable_logging();
   char *vers = version();
@@ -2263,5 +2314,6 @@ int main() {
   test_partial_sanitization();
   test_capture_logs();
   test_relabel_mapped_dummies();
+  test_assign_cip_labels();
   return 0;
 }

--- a/Code/MinimalLib/common.h
+++ b/Code/MinimalLib/common.h
@@ -50,6 +50,7 @@
 #include <GraphMol/ChemReactions/SanitizeRxn.h>
 #include <GraphMol/RGroupDecomposition/RGroupUtils.h>
 #include <RDGeneral/RDLog.h>
+#include "common_defs.h"
 
 #include <sstream>
 #include <RDGeneral/BoostStartInclude.h>
@@ -73,18 +74,15 @@
 #endif
 #endif
 
-#define GET_JSON_VALUE(doc, key, type)                                     \
+#define GET_JSON_VALUE(doc, drawingDetails, key, type)                     \
   const auto key##It = doc.FindMember(#key);                               \
   if (key##It != doc.MemberEnd()) {                                        \
     if (!key##It->value.Is##type()) {                                      \
       return "JSON contains '" #key "' field, but its type is not '" #type \
              "'";                                                          \
     }                                                                      \
-    key = key##It->value.Get##type();                                      \
+    drawingDetails.key = key##It->value.Get##type();                       \
   }
-
-#define GET_JSON_VALUE_WITH_DEFAULT(doc, key, type, defaultValue) \
-  GET_JSON_VALUE(doc, key, type) else key = defaultValue;
 
 namespace rj = rapidjson;
 
@@ -106,6 +104,7 @@ RWMol *mol_from_input(const std::string &input,
   bool setAromaticity = true;
   bool fastFindRings = true;
   bool assignStereo = true;
+  bool assignCIPLabels = false;
   bool mappedDummiesAreRGroups = false;
   RWMol *res = nullptr;
   boost::property_tree::ptree pt;
@@ -120,6 +119,7 @@ RWMol *mol_from_input(const std::string &input,
     LPT_OPT_GET(setAromaticity);
     LPT_OPT_GET(fastFindRings);
     LPT_OPT_GET(assignStereo);
+    LPT_OPT_GET(assignCIPLabels);
     LPT_OPT_GET(mappedDummiesAreRGroups);
   }
   try {
@@ -170,6 +170,9 @@ RWMol *mol_from_input(const std::string &input,
       }
       if (assignStereo) {
         MolOps::assignStereochemistry(*res, true, true, true);
+      }
+      if (assignCIPLabels) {
+        CIPLabeler::assignCIPLabels(*res);
       }
       if (mergeQueryHs) {
         MolOps::mergeQueryHs(*res);
@@ -363,63 +366,79 @@ std::string parse_highlight_colors(const rj::Document &doc,
 }
 
 std::string process_details(rj::Document &doc, const std::string &details,
-                            int &width, int &height, int &offsetx, int &offsety,
-                            std::string &legend, std::vector<int> &atomIds,
-                            std::vector<int> &bondIds, bool &kekulize,
-                            bool &addChiralHs, bool &wedgeBonds,
-                            bool &forceCoords, bool &wavyBonds) {
+                            DrawingDetails &drawingDetails) {
   doc.Parse(details.c_str());
   if (!doc.IsObject()) {
     return "Invalid JSON";
   }
   std::string problems;
-  problems = parse_int_array(doc, atomIds, "atoms", "Atom IDs");
+  problems = parse_int_array(doc, drawingDetails.atomIds, "atoms", "Atom IDs");
   if (!problems.empty()) {
     return problems;
   }
 
-  problems = parse_int_array(doc, bondIds, "bonds", "Bond IDs");
+  problems = parse_int_array(doc, drawingDetails.bondIds, "bonds", "Bond IDs");
   if (!problems.empty()) {
     return problems;
   }
 
-  GET_JSON_VALUE(doc, width, Int)
-  GET_JSON_VALUE(doc, height, Int)
-  GET_JSON_VALUE(doc, offsetx, Int)
-  GET_JSON_VALUE(doc, offsety, Int)
-  GET_JSON_VALUE(doc, legend, String)
-  GET_JSON_VALUE_WITH_DEFAULT(doc, kekulize, Bool, true)
-  GET_JSON_VALUE_WITH_DEFAULT(doc, addChiralHs, Bool, true)
-  GET_JSON_VALUE_WITH_DEFAULT(doc, wedgeBonds, Bool, true)
-  GET_JSON_VALUE_WITH_DEFAULT(doc, forceCoords, Bool, false)
-  GET_JSON_VALUE_WITH_DEFAULT(doc, wavyBonds, Bool, false)
+  GET_JSON_VALUE(doc, drawingDetails, width, Int)
+  GET_JSON_VALUE(doc, drawingDetails, height, Int)
+  GET_JSON_VALUE(doc, drawingDetails, offsetx, Int)
+  GET_JSON_VALUE(doc, drawingDetails, offsety, Int)
+  GET_JSON_VALUE(doc, drawingDetails, panelWidth, Int)
+  GET_JSON_VALUE(doc, drawingDetails, panelHeight, Int)
+  GET_JSON_VALUE(doc, drawingDetails, noFreetype, Bool)
+  GET_JSON_VALUE(doc, drawingDetails, legend, String)
+  GET_JSON_VALUE(doc, drawingDetails, kekulize, Bool)
+  GET_JSON_VALUE(doc, drawingDetails, addChiralHs, Bool)
+  GET_JSON_VALUE(doc, drawingDetails, wedgeBonds, Bool)
+  GET_JSON_VALUE(doc, drawingDetails, forceCoords, Bool)
+  GET_JSON_VALUE(doc, drawingDetails, wavyBonds, Bool)
 
   return "";
 }
 
-std::string process_mol_details(const std::string &details, int &width,
-                                int &height, int &offsetx, int &offsety,
-                                std::string &legend, std::vector<int> &atomIds,
-                                std::vector<int> &bondIds,
-                                std::map<int, DrawColour> &atomMap,
-                                std::map<int, DrawColour> &bondMap,
-                                std::map<int, double> &radiiMap, bool &kekulize,
-                                bool &addChiralHs, bool &wedgeBonds,
-                                bool &forceCoords, bool &wavyBonds) {
+[[deprecated(
+    "please use the overload taking DrawingDetails& as parameter")]] std::string
+process_details(rj::Document &doc, const std::string &details, int &width,
+                int &height, int &offsetx, int &offsety, std::string &legend,
+                std::vector<int> &atomIds, std::vector<int> &bondIds,
+                bool &kekulize, bool &addChiralHs, bool &wedgeBonds,
+                bool &forceCoords, bool &wavyBonds) {
+  DrawingDetails drawingDetails;
+  auto problems = process_details(doc, details, drawingDetails);
+  width = drawingDetails.width;
+  height = drawingDetails.height;
+  offsetx = drawingDetails.offsetx;
+  offsety = drawingDetails.offsety;
+  legend = drawingDetails.legend;
+  atomIds = drawingDetails.atomIds;
+  bondIds = drawingDetails.bondIds;
+  kekulize = drawingDetails.kekulize;
+  addChiralHs = drawingDetails.addChiralHs;
+  wedgeBonds = drawingDetails.wedgeBonds;
+  forceCoords = drawingDetails.forceCoords;
+  wavyBonds = drawingDetails.wavyBonds;
+  return problems;
+}
+
+std::string process_mol_details(const std::string &details,
+                                MolDrawingDetails &molDrawingDetails) {
   rj::Document doc;
-  auto problems = process_details(
-      doc, details, width, height, offsetx, offsety, legend, atomIds, bondIds,
-      kekulize, addChiralHs, wedgeBonds, forceCoords, wavyBonds);
+  auto problems = process_details(doc, details, molDrawingDetails);
   if (!problems.empty()) {
     return problems;
   }
 
-  problems = parse_highlight_colors(doc, atomMap, "highlightAtomColors");
+  problems = parse_highlight_colors(doc, molDrawingDetails.atomMap,
+                                    "highlightAtomColors");
   if (!problems.empty()) {
     return problems;
   }
 
-  problems = parse_highlight_colors(doc, bondMap, "highlightBondColors");
+  problems = parse_highlight_colors(doc, molDrawingDetails.bondMap,
+                                    "highlightBondColors");
   if (!problems.empty()) {
     return problems;
   }
@@ -435,29 +454,39 @@ std::string process_mol_details(const std::string &details, int &width,
                "are not floats";
       }
       int idx = std::atoi(entry.name.GetString());
-      radiiMap[idx] = entry.value.GetDouble();
+      molDrawingDetails.radiiMap[idx] = entry.value.GetDouble();
     }
   }
   return "";
 }
 
-std::string process_rxn_details(
-    const std::string &details, int &width, int &height, int &offsetx,
-    int &offsety, std::string &legend, std::vector<int> &atomIds,
-    std::vector<int> &bondIds, bool &kekulize, bool &highlightByReactant,
-    std::vector<DrawColour> &highlightColorsReactants) {
+[[deprecated(
+    "please use the overload taking MolDrawingDetails& as parameter")]] std::
+    string
+    process_mol_details(const std::string &details, int &width, int &height,
+                        int &offsetx, int &offsety, std::string &legend,
+                        std::vector<int> &atomIds, std::vector<int> &bondIds,
+                        std::map<int, DrawColour> &atomMap,
+                        std::map<int, DrawColour> &bondMap,
+                        std::map<int, double> &radiiMap, bool &kekulize,
+                        bool &addChiralHs, bool &wedgeBonds, bool &forceCoords,
+                        bool &wavyBonds) {
+  MolDrawingDetails molDrawingDetails;
+  auto problems = process_mol_details(details, molDrawingDetails);
+  atomMap = molDrawingDetails.atomMap;
+  bondMap = molDrawingDetails.bondMap;
+  radiiMap = molDrawingDetails.radiiMap;
+  return problems;
+}
+
+std::string process_rxn_details(const std::string &details,
+                                RxnDrawingDetails &rxnDrawingDetails) {
   rj::Document doc;
-  bool addChiralHs;
-  bool wedgeBonds;
-  bool forceCoords;
-  bool wavyBonds;
-  auto problems = process_details(
-      doc, details, width, height, offsetx, offsety, legend, atomIds, bondIds,
-      kekulize, addChiralHs, wedgeBonds, forceCoords, wavyBonds);
+  auto problems = process_details(doc, details, rxnDrawingDetails);
   if (!problems.empty()) {
     return problems;
   }
-  GET_JSON_VALUE_WITH_DEFAULT(doc, highlightByReactant, Bool, false)
+  GET_JSON_VALUE(doc, rxnDrawingDetails, highlightByReactant, Bool)
   auto highlightColorsReactantsIt = doc.FindMember("highlightColorsReactants");
   if (highlightColorsReactantsIt != doc.MemberEnd()) {
     if (!highlightColorsReactantsIt->value.IsArray()) {
@@ -470,10 +499,33 @@ std::string process_rxn_details(
       if (!problems.empty()) {
         return problems;
       }
-      highlightColorsReactants.push_back(std::move(color));
+      rxnDrawingDetails.highlightColorsReactants.push_back(std::move(color));
     }
   }
   return "";
+}
+
+[[deprecated(
+    "please use the overload taking RxnDrawingDetails& as parameter")]] std::
+    string
+    process_rxn_details(const std::string &details, int &width, int &height,
+                        int &offsetx, int &offsety, std::string &legend,
+                        std::vector<int> &atomIds, std::vector<int> &bondIds,
+                        bool &kekulize, bool &highlightByReactant,
+                        std::vector<DrawColour> &highlightColorsReactants) {
+  RxnDrawingDetails rxnDrawingDetails;
+  auto problems = process_rxn_details(details, rxnDrawingDetails);
+  width = rxnDrawingDetails.width;
+  height = rxnDrawingDetails.height;
+  offsetx = rxnDrawingDetails.offsetx;
+  offsety = rxnDrawingDetails.offsety;
+  legend = rxnDrawingDetails.legend;
+  atomIds = rxnDrawingDetails.atomIds;
+  bondIds = rxnDrawingDetails.bondIds;
+  kekulize = rxnDrawingDetails.kekulize;
+  highlightByReactant = rxnDrawingDetails.highlightByReactant;
+  highlightColorsReactants = rxnDrawingDetails.highlightColorsReactants;
+  return problems;
 }
 
 std::string molblock_helper(RWMol &mol, const char *details_json,
@@ -531,75 +583,65 @@ void get_sss_json(const ROMol &d_mol, const ROMol &q_mol,
   obj.AddMember("bonds", rjBonds, doc.GetAllocator());
 }
 
-std::string mol_to_svg(const ROMol &m, int w, int h,
+std::string mol_to_svg(const ROMol &m, int w = -1, int h = -1,
                        const std::string &details = "") {
-  std::vector<int> atomIds;
-  std::vector<int> bondIds;
-  std::map<int, DrawColour> atomMap;
-  std::map<int, DrawColour> bondMap;
-  std::map<int, double> radiiMap;
-  std::string legend = "";
-  std::string problems;
-  int offsetx = 0;
-  int offsety = 0;
-  bool kekulize = true;
-  bool addChiralHs = true;
-  bool wedgeBonds = true;
-  bool forceCoords = false;
-  bool wavyBonds = false;
+  MolDrawingDetails molDrawingDetails;
+  molDrawingDetails.width = w;
+  molDrawingDetails.height = h;
   if (!details.empty()) {
-    problems =
-        process_mol_details(details, w, h, offsetx, offsety, legend, atomIds,
-                            bondIds, atomMap, bondMap, radiiMap, kekulize,
-                            addChiralHs, wedgeBonds, forceCoords, wavyBonds);
+    auto problems = process_mol_details(details, molDrawingDetails);
     if (!problems.empty()) {
       return problems;
     }
   }
-  MolDraw2DSVG drawer(w, h);
+  MolDraw2DSVG drawer(molDrawingDetails.width, molDrawingDetails.height,
+                      molDrawingDetails.panelWidth,
+                      molDrawingDetails.panelHeight,
+                      molDrawingDetails.noFreetype);
   if (!details.empty()) {
     MolDraw2DUtils::updateDrawerParamsFromJSON(drawer, details);
   }
-  drawer.setOffset(offsetx, offsety);
+  drawer.setOffset(molDrawingDetails.offsetx, molDrawingDetails.offsety);
 
-  MolDraw2DUtils::prepareAndDrawMolecule(drawer, m, legend, &atomIds, &bondIds,
-                                         atomMap.empty() ? nullptr : &atomMap,
-                                         bondMap.empty() ? nullptr : &bondMap,
-                                         radiiMap.empty() ? nullptr : &radiiMap,
-                                         -1, kekulize, addChiralHs, wedgeBonds,
-                                         forceCoords, wavyBonds);
+  MolDraw2DUtils::prepareAndDrawMolecule(
+      drawer, m, molDrawingDetails.legend, &molDrawingDetails.atomIds,
+      &molDrawingDetails.bondIds,
+      molDrawingDetails.atomMap.empty() ? nullptr : &molDrawingDetails.atomMap,
+      molDrawingDetails.bondMap.empty() ? nullptr : &molDrawingDetails.bondMap,
+      molDrawingDetails.radiiMap.empty() ? nullptr
+                                         : &molDrawingDetails.radiiMap,
+      -1, molDrawingDetails.kekulize, molDrawingDetails.addChiralHs,
+      molDrawingDetails.wedgeBonds, molDrawingDetails.forceCoords,
+      molDrawingDetails.wavyBonds);
   drawer.finishDrawing();
 
   return drawer.getDrawingText();
 }
 
-std::string rxn_to_svg(const ChemicalReaction &rxn, int w, int h,
+std::string rxn_to_svg(const ChemicalReaction &rxn, int w = -1, int h = -1,
                        const std::string &details = "") {
-  std::vector<int> atomIds;
-  std::vector<int> bondIds;
-  std::string legend = "";
-  int offsetx = 0;
-  int offsety = 0;
-  bool kekulize = true;
-  bool highlightByReactant = false;
-  std::vector<DrawColour> highlightColorsReactants;
+  RxnDrawingDetails rxnDrawingDetails;
+  rxnDrawingDetails.width = w;
+  rxnDrawingDetails.height = h;
   if (!details.empty()) {
-    auto problems = process_rxn_details(
-        details, w, h, offsetx, offsety, legend, atomIds, bondIds, kekulize,
-        highlightByReactant, highlightColorsReactants);
+    auto problems = process_rxn_details(details, rxnDrawingDetails);
     if (!problems.empty()) {
       return problems;
     }
   }
 
-  MolDraw2DSVG drawer(w, h);
-  if (!kekulize) {
+  MolDraw2DSVG drawer(rxnDrawingDetails.width, rxnDrawingDetails.height,
+                      rxnDrawingDetails.panelWidth,
+                      rxnDrawingDetails.panelHeight,
+                      rxnDrawingDetails.noFreetype);
+  if (!rxnDrawingDetails.kekulize) {
     drawer.drawOptions().prepareMolsBeforeDrawing = false;
   }
-  drawer.drawReaction(rxn, highlightByReactant,
-                      !highlightByReactant || highlightColorsReactants.empty()
+  drawer.drawReaction(rxn, rxnDrawingDetails.highlightByReactant,
+                      !rxnDrawingDetails.highlightByReactant ||
+                              rxnDrawingDetails.highlightColorsReactants.empty()
                           ? nullptr
-                          : &highlightColorsReactants);
+                          : &rxnDrawingDetails.highlightColorsReactants);
   drawer.finishDrawing();
   return drawer.getDrawingText();
 }

--- a/Code/MinimalLib/common.h
+++ b/Code/MinimalLib/common.h
@@ -473,9 +473,21 @@ std::string process_mol_details(const std::string &details,
                         bool &wavyBonds) {
   MolDrawingDetails molDrawingDetails;
   auto problems = process_mol_details(details, molDrawingDetails);
+  width = molDrawingDetails.width;
+  height = molDrawingDetails.height;
+  offsetx = molDrawingDetails.offsetx;
+  offsety = molDrawingDetails.offsety;
+  legend = molDrawingDetails.legend;
+  atomIds = molDrawingDetails.atomIds;
+  bondIds = molDrawingDetails.bondIds;
   atomMap = molDrawingDetails.atomMap;
   bondMap = molDrawingDetails.bondMap;
   radiiMap = molDrawingDetails.radiiMap;
+  kekulize = molDrawingDetails.kekulize;
+  addChiralHs = molDrawingDetails.addChiralHs;
+  wedgeBonds = molDrawingDetails.wedgeBonds;
+  forceCoords = molDrawingDetails.forceCoords;
+  wavyBonds = molDrawingDetails.wavyBonds;
   return problems;
 }
 

--- a/Code/MinimalLib/common_defs.h
+++ b/Code/MinimalLib/common_defs.h
@@ -1,0 +1,72 @@
+//
+//  Copyright (C) 2024 Novartis and other RDKit contributors
+//
+//   @@ All Rights Reserved @@
+//  This file is part of the RDKit.
+//  The contents are covered by the terms of the BSD license
+//  which is included in the file license.txt, found at the root
+//  of the RDKit source tree.
+//
+#include <GraphMol/MolDraw2D/MolDraw2DHelpers.h>
+#include <string>
+#include <vector>
+
+namespace RDKit {
+namespace MinimalLib {
+
+struct DrawingDetails {
+  int width = -1;
+  int height = -1;
+  int offsetx = 0;
+  int offsety = 0;
+  int panelWidth = -1;
+  int panelHeight = -1;
+  bool noFreetype = false;
+  bool kekulize = true;
+  bool addChiralHs = true;
+  bool wedgeBonds = true;
+  bool forceCoords = false;
+  bool wavyBonds = false;
+  std::string legend;
+  std::vector<int> atomIds;
+  std::vector<int> bondIds;
+};
+
+struct MolDrawingDetails : public DrawingDetails {
+  std::map<int, DrawColour> atomMap;
+  std::map<int, DrawColour> bondMap;
+  std::map<int, double> radiiMap;
+};
+
+struct RxnDrawingDetails : public DrawingDetails {
+  bool highlightByReactant = false;
+  std::vector<DrawColour> highlightColorsReactants;
+};
+
+extern std::string process_mol_details(const std::string &details,
+                                       MolDrawingDetails &molDrawingDetails);
+[[deprecated(
+    "please use the overload taking MolDrawingDetails& as parameter")]] extern std::
+    string
+    process_mol_details(const std::string &details, int &width, int &height,
+                        int &offsetx, int &offsety, std::string &legend,
+                        std::vector<int> &atomIds, std::vector<int> &bondIds,
+                        std::map<int, DrawColour> &atomMap,
+                        std::map<int, DrawColour> &bondMap,
+                        std::map<int, double> &radiiMap, bool &kekulize,
+                        bool &addChiralHs, bool &wedgeBonds, bool &forceCoords,
+                        bool &wavyBonds);
+
+extern std::string process_rxn_details(const std::string &details,
+                                       RxnDrawingDetails &rxnDrawingDetails);
+[[deprecated(
+    "please use the overload taking RxnDrawingDetails& as parameter")]] extern std::
+    string
+    process_rxn_details(const std::string &details, int &width, int &height,
+                        int &offsetx, int &offsety, std::string &legend,
+                        std::vector<int> &atomIds, std::vector<int> &bondIds,
+                        bool &kekulize, bool &highlightByReactant,
+                        std::vector<DrawColour> &highlightColorsReactants);
+
+}  // namespace MinimalLib
+}  // namespace RDKit


### PR DESCRIPTION
- fix #7157
- add the `assignCIPLabels` flag to MinimalLib's `mol_from_input()`
- added cffi and JS tests
- refactored `process_details()`, `process_mol_details()` and `process_rxn_details()` to take a `struct` reference as parameter rather than a long list of parameters
- this also allowed to get rid of one of the ugly `GET_JSON` macros
- exposed `panelWidth`, `panelHeight `and `noFreetype` (the latter is useful for testing)
- made `width` and `height` to default to -1 in `mol_to_svg` since we now support flexicanvas

<!--
Thanks for contributing a pull request! 
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.


#### Any other comments?

