### PR TITLE
Fix leaking Bonds on unmatched ring closures

### DIFF
--- a/Code/GraphMol/SmilesParse/SmilesParse.cpp
+++ b/Code/GraphMol/SmilesParse/SmilesParse.cpp
@@ -256,10 +256,11 @@ std::unique_ptr<RWMol> toMol(const std::string &inp,
     }
     BOOST_LOG(rdErrorLog) << nm << " Parse Error: " << e.what()
                           << " for input: '" << origInp << "'" << std::endl;
-    res.reset();
-    if (!molVect.empty()) {
-      molVect[0] = nullptr;
-    }
+
+    // reset res so that we return a nullptr. We don't want to reset(),
+    // because that would delete the mol and leak any unmatched
+    // ring closure bonds. These will be cleaned up in the loop below.
+    res.release();
   }
   for (auto *molPtr : molVect) {
     if (molPtr) {
@@ -402,7 +403,7 @@ void handleCXPartAndName(RWMol *res, const T &params, const std::string &cxPart,
 }  // namespace
 
 std::unique_ptr<RWMol> MolFromSmiles(const std::string &smiles,
-                                   const SmilesParserParams &params) {
+                                     const SmilesParserParams &params) {
   // Calling MolFromSmiles in a multithreaded context is generally safe *unless*
   // the value of debugParse is different for different threads. The if
   // statement below avoids a TSAN warning in the case where multiple threads
@@ -525,7 +526,7 @@ std::unique_ptr<Bond> BondFromSmarts(const std::string &smiles) {
 };
 
 std::unique_ptr<RWMol> MolFromSmarts(const std::string &smarts,
-                                   const SmartsParserParams &params) {
+                                     const SmartsParserParams &params) {
   // Calling MolFromSmarts in a multithreaded context is generally safe *unless*
   // the value of debugParse is different for different threads. The if
   // statement below avoids a TSAN warning in the case where multiple threads

--- a/Code/GraphMol/SmilesParse/catch_tests.cpp
+++ b/Code/GraphMol/SmilesParse/catch_tests.cpp
@@ -2769,3 +2769,25 @@ M  END)CTAB";
     CHECK(MolToSmiles(*m2) == osmi);
   }
 }
+
+TEST_CASE("leaks on unclosed rings") {
+  // These are Ok except for the unmatched ring closures
+  SECTION("Ok SMARTS") {
+    auto m = "C1.C2.C3.C4.C5"_smarts;
+    REQUIRE(!m);
+  }
+  SECTION("Ok SMILES") {
+    auto m = "C1.C2.C3.C4.C5"_smiles;
+    REQUIRE(!m);
+  }
+  // These are bogus, but fail parsing AFTER we've seen
+  // the unmatched ring closure
+  SECTION("Bad SMARTS") {
+    auto m = "C1C)foo"_smarts;
+    REQUIRE(!m);
+  }
+  SECTION("Bad SMILES") {
+    auto m = "C1C)foo"_smiles;
+    REQUIRE(!m);
+  }
+}


### PR DESCRIPTION
This cleans up the bonds that leak when you try to parse (incorrect) SMILES or SMARTS that contain unmatched ring closures. 

Background story:
For ring closures, the parsers create "half bonds" that are attached to a begin atom, but not an end one. These cannot be added to the mol because of the lack of an end atom. When we run `CloseMolRings` it tries to close the rings by adding the end atom with the matching bookmark to these half bonds. For unmatched closures, there's no such atom, so `CloseMolRings` it triggers a parsing failure.

The error:
When `CloseMolRings` triggers the failure, it raises an exception that we catch to print the error message and clean up. But the clean up is faulty: we reset `rest`, which deletes the problematic mol, without deleting the unmatched ring closure bonds first. Since they haven't been add to the mol, its destructor doesn't clean them up, and we need to do it by calling `CleanupAfterParseError`, which we do in the loop right after the catch. But, since we have reset `res` and zeroed the corresponding pointer in `molVect`, we never clean them up.

The fix:
Instead of `res.reset()`, we can use `res.release()`, which resets the `unique_ptr`, but without destroying the contained object. Then, we need to remove the code that resets the first pointer in `molVect`, because that would directly leak the mol.
