### PR TITLE
Update MinimalLib Dockerfiles

### DIFF
--- a/Code/MinimalLib/docker/Dockerfile
+++ b/Code/MinimalLib/docker/Dockerfile
@@ -21,10 +21,18 @@
 
 ARG RDKIT_GIT_URL="https://github.com/rdkit/rdkit.git"
 ARG RDKIT_BRANCH="master"
+ARG EMSDK_VERSION="latest"
+ARG BOOST_MAJOR_VERSION="1"
+ARG BOOST_MINOR_VERSION="84"
+ARG BOOST_PATCH_VERSION="0"
 
 FROM debian:buster as build-stage
 ARG RDKIT_GIT_URL
 ARG RDKIT_BRANCH
+ARG EMSDK_VERSION
+ARG BOOST_MAJOR_VERSION
+ARG BOOST_MINOR_VERSION
+ARG BOOST_PATCH_VERSION
 
 LABEL maintainer="Greg Landrum <greg.landrum@t5informatics.com>"
 
@@ -43,9 +51,11 @@ RUN apt-get update && apt-get upgrade -y && apt install -y \
 ENV LANG C
 
 WORKDIR /opt
-RUN wget -q https://boostorg.jfrog.io/artifactory/main/release/1.72.0/source/boost_1_72_0.tar.gz && \
-  tar xzf boost_1_72_0.tar.gz 
-WORKDIR /opt/boost_1_72_0
+ARG BOOST_DOT_VERSION="${BOOST_MAJOR_VERSION}.${BOOST_MINOR_VERSION}.${BOOST_PATCH_VERSION}"
+ARG BOOST_UNDERSCORE_VERSION="${BOOST_MAJOR_VERSION}_${BOOST_MINOR_VERSION}_${BOOST_PATCH_VERSION}"
+RUN wget -q https://boostorg.jfrog.io/artifactory/main/release/${BOOST_DOT_VERSION}/source/boost_${BOOST_UNDERSCORE_VERSION}.tar.gz && \
+  tar xzf boost_${BOOST_UNDERSCORE_VERSION}.tar.gz
+WORKDIR /opt/boost_${BOOST_UNDERSCORE_VERSION}
 RUN ./bootstrap.sh --prefix=/opt/boost --with-libraries=system && \
   ./b2 install
 
@@ -54,9 +64,8 @@ WORKDIR /opt
 RUN git clone https://github.com/emscripten-core/emsdk.git
 
 WORKDIR /opt/emsdk
-RUN ./emsdk update-tags && \
-  ./emsdk install latest && \
-  ./emsdk activate latest
+RUN ./emsdk install ${EMSDK_VERSION} && \
+  ./emsdk activate ${EMSDK_VERSION}
 
 #RUN source ./emsdk_env.sh
 
@@ -69,7 +78,7 @@ RUN git fetch --all --tags && \
   git checkout ${RDKIT_BRANCH}
 
 RUN mkdir build
-WORKDIR build
+WORKDIR $RDBASE/build
 
 RUN echo "source /opt/emsdk/emsdk_env.sh > /dev/null 2>&1" >> ~/.bashrc
 SHELL ["/bin/bash", "-c", "-l"]

--- a/Code/MinimalLib/docker/Dockerfile_legacy_browsers
+++ b/Code/MinimalLib/docker/Dockerfile_legacy_browsers
@@ -4,15 +4,22 @@
 # 1. cd to Code/MinimalLib/docker
 # cd Code/MinimalLib/docker
 #
-# 2. generate an image of the build-stage from the main Dockerfile
-#    (the build-arg arguments are all optional)
+# 2. generate an image of the build-stage from the main Dockerfile.
+#    The build-arg arguments are all optional and have appropriate
+#    defaults. Regarding EMSDK_VERSION, 3.1.50 is the last
+#    emsdk version that supports the MIN_IE_VERSION=11 flag.
 # docker build --target build-stage -t rdkit-minimallib-build-stage --network=host \
+#  --build-arg "EMSDK_VERSION=3.1.50" \
 #  --build-arg "RDKIT_GIT_URL=https://github.com/myfork/rdkit.git" \
 #  --build-arg "RDKIT_BRANCH=mybranch" .
 #
 # 3. build the JS-only version of MinimalLib for legacy browsers
-#    (requires the rdkit-minimallib-build-stage image built in step 2)
-# docker build -t rdkit-minimallib-legacy --network=host -f Dockerfile_legacy_browsers .
+#    (requires the rdkit-minimallib-build-stage image built in step 2).
+#    The build-arg arguments are all optional and have appropriate
+#    defaults.
+# docker build -t rdkit-minimallib-legacy --network=host \
+#   --build-arg "EXTRA_CMAKE_EXE_LINKER_FLAGS=-s MIN_IE_VERSION=11" \
+#   -f Dockerfile_legacy_browsers .
 #
 # 4. create a temporary container and copy built libraries
 #    from the container to your local filesystem, then destroy
@@ -27,10 +34,11 @@
 
 
 FROM rdkit-minimallib-build-stage as build-stage-legacy
+ARG EXTRA_CMAKE_EXE_LINKER_FLAGS=""
 
 WORKDIR $RDBASE/build
 RUN emcmake cmake -DRDK_MINIMAL_LIB_SUPPORT_LEGACY_BROWSERS=ON \
-  -DCMAKE_EXE_LINKER_FLAGS="-s SINGLE_FILE=1 -s LEGACY_VM_SUPPORT=1 -s MIN_IE_VERSION=11 -s WASM=0 --memory-init-file 0 -s MODULARIZE=1 -s EXPORT_NAME=\"'initRDKitModule'\"" ..
+  -DCMAKE_EXE_LINKER_FLAGS="-s SINGLE_FILE=1 -s LEGACY_VM_SUPPORT=1 ${EXTRA_CMAKE_EXE_LINKER_FLAGS} -s WASM=0 --memory-init-file 0 -s MODULARIZE=1 -s EXPORT_NAME=\"'initRDKitModule'\"" ..
 
 # build and "install"
 RUN make -j2 RDKit_minimal && echo -e '\


### PR DESCRIPTION
This PR updates the MinimalLib `Dockerfile` Boost version 1.84.0.
The other changes are only cleanup, plus changing some parameters from being hardcoded to being configurable.

- added a few optional configurable parameters to the MinimalLib Dockerfiles (all have defaults)
- updated Boost to version 1.84.0
- removed obsolete `./emsdk update-tags` which was triggering a warning during the build
- `WORKDIR` should always be absolute, so changed `build` to `$RDBASE/build`
- updated the `Dockerfile_legacy_browsers` help text
