### PR TITLE
Don't reset computed properties if already empty

### DIFF
--- a/Code/RDGeneral/RDProps.h
+++ b/Code/RDGeneral/RDProps.h
@@ -148,7 +148,7 @@ class RDProps {
   //! clears all of our \c computed \c properties
   void clearComputedProps() const {
     STR_VECT compLst;
-    if (getPropIfPresent(RDKit::detail::computedPropName, compLst)) {
+    if (getPropIfPresent(RDKit::detail::computedPropName, compLst) && !compLst.empty()) {
       for (const auto &sv : compLst) {
         d_props.clearVal(sv);
       }


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

We noticed in a performance test that hydrogen removal was taking a surprising amount of time, with over half in `setVal`:

<img width="944" alt="image" src="https://github.com/rdkit/rdkit/assets/39069546/a4bc3373-5385-4557-bca7-5f43a2c884cf">


It looks like the problematic `ROMol::clearComputedProps` call is done every time an atom is removed, which I think means the computed properties should only need to be cleared once. These changes brought the runtime for these particularly large structures from ~25s to ~9s. Here is a smaller/more reasonable example:

```
from rdkit import Chem
import time

smiles = "CC[C@@H](C)C[C@H](C)CCCCCCCCC(=O)N[C@H](C[C@@H](O)[C@H](NCCN)NC(=O)[C@H](N12)[C@H](O)CC1)C(=O)N[C@H]([C@H](O)C)C(=O)N3[C@H](C[C@@H](O)C3)C(=O)N[C@@H](C(=O)N[C@@H](C2=O)[C@H](O)CCN)[C@@H](O)[C@H](O)c4ccc(O)cc4"
m = Chem.MolFromSmiles(smiles)
mhs = Chem.AddHs(m)

st = time.time()
Chem.RemoveHs(mhs)
print(time.time()-st)
```
This example went from 0.00168s -> 0.00059s on my machine.