### PR TITLE
Fix a few issues found while attempting to build stubs as part of a Windows conda build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -356,6 +356,7 @@ if(RDK_BUILD_PYTHON_WRAPPERS)
         OUTPUT_STRIP_TRAILING_WHITESPACE
       )
     endif (NOT PYTHON_INSTDIR)
+    string(REGEX REPLACE "\\\\" "/" PYTHON_INSTDIR ${PYTHON_INSTDIR})
     message("Python Install directory ${PYTHON_INSTDIR}")
     set(RDKit_PythonDir "${PYTHON_INSTDIR}/rdkit")
     if(RDK_INSTALL_PYTHON_TESTS)

--- a/Scripts/gen_rdkit_stubs/__init__.py
+++ b/Scripts/gen_rdkit_stubs/__init__.py
@@ -153,7 +153,11 @@ def clear_stubs(outer_dir):
         outer_dir (_type_): _description_
     """
     for entry in os.listdir(outer_dir):
-        if entry == "CMakeLists.txt":
+        if entry in (
+            "CMakeLists.txt",
+            "gen_rdkit_stubs.out",
+            "gen_rdkit_stubs.err"
+        ):
             continue
         entry = os.path.join(outer_dir, entry)
         if os.path.isdir(entry):

--- a/Scripts/gen_rdkit_stubs/worker.py
+++ b/Scripts/gen_rdkit_stubs/worker.py
@@ -68,7 +68,7 @@ if __name__ == "__main__":
                     args.module_name]
         pybind11_stubgen.main()
     except Exception as e:
-        if isinstance(e, AssertionError):
+        if isinstance(e, AssertionError) or isinstance(e, ImportError):
             raise
         else:
             print(str(e))


### PR DESCRIPTION
While testing the `conda` build of RDKit stubs on Windows using the `rdkit-feedstock` repo, I found a few issues that need to be fixed in the main RDKit repo.

1. A warning caused by backslash separators is issued during installation of Python packages into `PYTHON_INSTDIR`.<br>I have verified that the warning is actually harmless (the `conda` package generated by the build is identical to the one generated replacing backslashes with forward slashes), but I think it is still worth fixing it as it does not look good.
```
[ 97%] Built target SubstructLibrary
[ 98%] Built target rdRGroupDecomposition
[100%] Built target rdSubstructLibrary
Install the project...
-- Install configuration: "Release"
CMake Warning (dev) at cmake_install.cmake:41 (list):
  Syntax error in cmake code at

    M:/a3/envs/conda_build/conda-bld/rdkit_1708852563006/work/cmake_install.cmake:42

  when parsing string

    m:\a3\envs\conda_build\conda-bld\rdkit_1708852563006\_h_env\Lib\site-packages/rdkit

  Invalid escape sequence \a

  Policy CMP0010 is not set: Bad variable reference syntax is an error.  Run
  "cmake --help-policy CMP0010" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) at cmake_install.cmake:49 (file):
  Syntax error in cmake code at

    M:/a3/envs/conda_build/conda-bld/rdkit_1708852563006/work/cmake_install.cmake:49

  when parsing string

    m:\a3\envs\conda_build\conda-bld\rdkit_1708852563006\_h_env\Lib\site-packages

  Invalid escape sequence \a

  Policy CMP0010 is not set: Bad variable reference syntax is an error.  Run
  "cmake --help-policy CMP0010" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.
This warning is for project developers.  Use -Wno-dev to suppress it.

-- Installing: %PREFIX%\Lib\site-packages/rdkit
-- Installing: %PREFIX%\Lib\site-packages/rdkit/Avalon
-- Installing: %PREFIX%\Lib\site-packages/rdkit/Avalon/pyAvalonTools.pyd
```
2. The `conda` build is made in the source directory rather than in a separate `build` directory, i.e. `CMAKE_SOURCE_DIR` if the same as `CMAKE_BINARY_DIR`. As a result, the `gen_rdkit_stubs.out` and `gen_rdkit_stubs.err` are written into `CMAKE_SOURCE_DIR/rdkit-stubs`, from which the `clear_stubs()` function in the `gen_rdkit_stubs` module attempts to remove all files but `CMakeLists.txt`. However, on Windows the running process holds a lock on the `gen_rdkit_stubs.out` and `gen_rdkit_stubs.err`, so the attempt to remove these files triggers an exception that causes the stub build to fail. This PR adds `gen_rdkit_stubs.out` and `gen_rdkit_stubs.err` to `CMakeLists.txt` as a file which should not be deleted by `clear_stubs()`.
3. An exception should be raised if an import fails while stubs are being generated. This is almost certainly an error which should not be ignored. We can always revisit this in the future if we find a case where an import should be allowed to fail.