### PR TITLE
Fixes #7181

### DIFF
--- a/Code/DistGeom/DistGeomUtils.cpp
+++ b/Code/DistGeom/DistGeomUtils.cpp
@@ -355,7 +355,7 @@ ForceFields::ForceField *construct3DForceField(
         fdist = etkdgDetails.boundsMatForceScaling * 10.0;
         double l = mmat.getLowerBound(i, j);
         double u = mmat.getUpperBound(i, j);
-        if (etkdgDetails.constrainedAtoms.size() &&
+        if (!etkdgDetails.constrainedAtoms.empty() &&
             etkdgDetails.constrainedAtoms[i] &&
             etkdgDetails.constrainedAtoms[j]) {
           // we're constrained, so use very tight bounds

--- a/Code/DistGeom/DistGeomUtils.cpp
+++ b/Code/DistGeom/DistGeomUtils.cpp
@@ -360,8 +360,9 @@ ForceFields::ForceField *construct3DForceField(
             etkdgDetails.constrainedAtoms[j]) {
           // we're constrained, so use very tight bounds
           l = u = ((*positions[i]) - (*positions[j])).length();
-          l -= 0.01;
-          u += 0.01;
+          constexpr double INCR = 0.01;
+          l -= INCR;
+          u += INCR;
           fdist = knownDistanceConstraintForce;
         }
         auto *contrib = new ForceFields::UFF::DistanceConstraintContrib(

--- a/Code/GraphMol/DistGeomHelpers/Embedder.cpp
+++ b/Code/GraphMol/DistGeomHelpers/Embedder.cpp
@@ -1447,6 +1447,12 @@ void EmbedMultipleConfs(ROMol &mol, INT_VECT &res, unsigned int numConfs,
         << std::endl;
     coordMap = nullptr;
   }
+  boost::dynamic_bitset<> constrainedAtoms(mol.getNumAtoms());
+  if (coordMap) {
+    for (const auto &entry : *coordMap) {
+      constrainedAtoms.set(entry.first);
+    }
+  }
 
   if (molFrags.size() > 1 && params.boundsMat != nullptr) {
     BOOST_LOG(rdWarningLog)
@@ -1465,6 +1471,7 @@ void EmbedMultipleConfs(ROMol &mol, INT_VECT &res, unsigned int numConfs,
     unsigned int nAtoms = piece->getNumAtoms();
 
     ForceFields::CrystalFF::CrystalFFDetails etkdgDetails;
+    etkdgDetails.constrainedAtoms = constrainedAtoms;
     EmbeddingOps::initETKDG(piece.get(), params, etkdgDetails);
 
     DistGeom::BoundsMatPtr mmat;

--- a/Code/GraphMol/ForceFieldHelpers/CrystalFF/TorsionPreferences.cpp
+++ b/Code/GraphMol/ForceFieldHelpers/CrystalFF/TorsionPreferences.cpp
@@ -230,6 +230,15 @@ void getExperimentalTorsions(
           doneBonds[bid2] = 1;
         }
         if (!doneBonds[bid2]) {
+          // do not add ET terms between constrained atoms
+          // REVIEW: do we really need to check all 4 atoms?
+          if (!details.constrainedAtoms.empty() &&
+              details.constrainedAtoms[aid1] &&
+              details.constrainedAtoms[aid2] &&
+              details.constrainedAtoms[aid3] &&
+              details.constrainedAtoms[aid4]) {
+            continue;
+          }
           std::vector<unsigned int> aids{aid1, aid2, aid3, aid4};
           torsionBonds.emplace_back(bid2, aids, &param);
           doneBonds[bid2] = 1;

--- a/Code/GraphMol/ForceFieldHelpers/CrystalFF/TorsionPreferences.h
+++ b/Code/GraphMol/ForceFieldHelpers/CrystalFF/TorsionPreferences.h
@@ -13,6 +13,7 @@
 #include <vector>
 #include <string>
 #include <memory>
+#include <boost/dynamic_bitset.hpp>
 
 namespace RDKit {
 class ROMol;
@@ -40,6 +41,7 @@ struct CrystalFFDetails {
   std::vector<std::vector<int>> angles;
   std::vector<int> atomNums;
   double boundsMatForceScaling;
+  boost::dynamic_bitset<> constrainedAtoms;
 };
 
 //! Get the experimental torsional angles in a molecule


### PR DESCRIPTION
The problem was that ET terms were being applied within the atoms that were in the coordmap. This disables that and adds tighter distance constraints between coordMap atoms when doing the ETK minimization.


