### PR TITLE
Fix Uncharger applying to already neutralized perhalic groups

### DIFF
--- a/Code/GraphMol/MolStandardize/testCharge.cpp
+++ b/Code/GraphMol/MolStandardize/testCharge.cpp
@@ -285,6 +285,12 @@ void testInorganicAcids() {
     TEST_ASSERT(perhalate);
     res.reset(uncharger.uncharge(*perhalate));
     TEST_ASSERT(MolToSmiles(*res) == "[O-][" + halogen + "+3]([O-])([O-])O");
+    // also test uncharging the already neutralized acid
+    std::unique_ptr<ROMol> perhalic_acid(
+        SmilesToMol("[" + halogen + "](=O)(=O)(=O)O"));
+    TEST_ASSERT(perhalic_acid);
+    res.reset(uncharger.uncharge(*perhalic_acid));
+    TEST_ASSERT(MolToSmiles(*res) == "[O-][" + halogen + "+3]([O-])([O-])O");
   }
   {
     auto hyponitrite = "[O-]N=N[O-]"_smiles;


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
This PR fixes the neutralization of groups containing halogens in higher oxidation states. The neutralization of the negatively charged oxigen atoms sorrounding the halogen was supposed to happen at most once, but it was actually applied also to the already neutralized group.

#### Any other comments?
The problem addressed by this PR is probably a regression introduced with #7088.

