### PR TITLE
v1 Mol Suppliers missing the moveTo method

### DIFF
--- a/Code/GraphMol/FileParsers/MolSupplier.h
+++ b/Code/GraphMol/FileParsers/MolSupplier.h
@@ -251,7 +251,7 @@ class RDKIT_FILEPARSERS_EXPORT SmilesMolSupplier : public MolSupplier {
    * file parser above
    * - As an when new molecules are read using "next" their
    *    positions in the file are noted.
-   *  - A call to the "length" will autamatically parse the entire
+   *  - A call to the "length" will automatically parse the entire
    *    file and cache all the mol block positions
    *  - [] operator is used to access a molecule at "idx", calling
    *    next following this will result in the next molecule after
@@ -343,7 +343,7 @@ class RDKIT_FILEPARSERS_EXPORT TDTMolSupplier : public MolSupplier {
    * file parser above
    * - As an when new molecules are read using "next" their
    *    positions in the file are noted.
-   *  - A call to the "length" will autamatically parse the entire
+   *  - A call to the "length" will automatically parse the entire
    *    file and cache all the mol block positions
    *  - [] operator is used to access a molecule at "idx", calling
    *    next following this will result in the next molecule after
@@ -399,7 +399,7 @@ class RDKIT_FILEPARSERS_EXPORT TDTMolSupplier : public MolSupplier {
   TDTMolSupplierParams d_params;
 };
 
-//! Deprectead, will be removed in 2024.09 release
+//! Deprecated, will be removed in 2024.09 release
 class RDKIT_FILEPARSERS_EXPORT PDBMolSupplier : public MolSupplier {
  public:
   explicit PDBMolSupplier(std::istream *inStream, bool takeOwnership = true,

--- a/Code/GraphMol/FileParsers/MolSupplier.v1API.h
+++ b/Code/GraphMol/FileParsers/MolSupplier.v1API.h
@@ -171,6 +171,10 @@ class RDKIT_FILEPARSERS_EXPORT SDMolSupplier : public ForwardSDMolSupplier {
         new v2::FileParsers::SDMolSupplier(inStream, takeOwnership, params));
   }
 
+  void moveTo(unsigned int idx) {
+    PRECONDITION(dp_supplier, "no supplier");
+    static_cast<ContainedType *>(dp_supplier.get())->moveTo(idx);
+  }
   ROMol *operator[](unsigned int idx) {
     PRECONDITION(dp_supplier, "no supplier");
     return static_cast<ContainedType *>(dp_supplier.get())
@@ -231,7 +235,7 @@ class RDKIT_FILEPARSERS_EXPORT SmilesMolSupplier : public MolSupplier {
    * file parser above
    * - As an when new molecules are read using "next" their
    *    positions in the file are noted.
-   *  - A call to the "length" will autamatically parse the entire
+   *  - A call to the "length" will automatically parse the entire
    *    file and cache all the mol block positions
    *  - [] operator is used to access a molecule at "idx", calling
    *    next following this will result in the next molecule after
@@ -298,6 +302,10 @@ class RDKIT_FILEPARSERS_EXPORT SmilesMolSupplier : public MolSupplier {
     params.parseParameters.sanitize = sanitize;
     static_cast<ContainedType *>(dp_supplier.get())->setData(text, params);
   }
+  void moveTo(unsigned int idx) {
+    PRECONDITION(dp_supplier, "no supplier");
+    static_cast<ContainedType *>(dp_supplier.get())->moveTo(idx);
+  }
   ROMol *operator[](unsigned int idx) {
     PRECONDITION(dp_supplier, "no supplier");
     return static_cast<ContainedType *>(dp_supplier.get())
@@ -326,7 +334,7 @@ class RDKIT_FILEPARSERS_EXPORT TDTMolSupplier : public MolSupplier {
    * file parser above
    * - As an when new molecules are read using "next" their
    *    positions in the file are noted.
-   *  - A call to the "length" will autamatically parse the entire
+   *  - A call to the "length" will automatically parse the entire
    *    file and cache all the mol block positions
    *  - [] operator is used to access a molecule at "idx", calling
    *    next following this will result in the next molecule after
@@ -378,6 +386,10 @@ class RDKIT_FILEPARSERS_EXPORT TDTMolSupplier : public MolSupplier {
     params.parseParameters.sanitize = sanitize;
     static_cast<ContainedType *>(dp_supplier.get())->setData(text, params);
   }
+  void moveTo(unsigned int idx) {
+    PRECONDITION(dp_supplier, "no supplier");
+    static_cast<ContainedType *>(dp_supplier.get())->moveTo(idx);
+  }
   ROMol *operator[](unsigned int idx) {
     PRECONDITION(dp_supplier, "no supplier");
     return static_cast<ContainedType *>(dp_supplier.get())
@@ -399,7 +411,7 @@ class RDKIT_FILEPARSERS_EXPORT TDTMolSupplier : public MolSupplier {
   }
 };
 
-//! Deprectead, will be removed in 2024.09 release
+//! Deprecated, will be removed in 2024.09 release
 class RDKIT_FILEPARSERS_EXPORT PDBMolSupplier : public MolSupplier {
  public:
   explicit PDBMolSupplier(std::istream *inStream, bool takeOwnership = true,
@@ -461,6 +473,10 @@ class RDKIT_FILEPARSERS_EXPORT MaeMolSupplier : public MolSupplier {
     params.sanitize = sanitize;
     params.removeHs = removeHs;
     dp_supplier.reset(new ContainedType(fname, params));
+  }
+  void moveTo(unsigned int idx) {
+    PRECONDITION(dp_supplier, "no supplier");
+    static_cast<ContainedType *>(dp_supplier.get())->moveTo(idx);
   }
   RWMol *operator[](unsigned int idx) {
     PRECONDITION(dp_supplier, "no supplier");


### PR DESCRIPTION
#7168 seems to be missing the `moveTo()` methods, which might break builds. This adds them back. Also fixes a couple of typos.


<!-- readthedocs-preview rdkit start -->
----
📚 Documentation preview 📚: https://rdkit--7222.org.readthedocs.build/en/7222/

<!-- readthedocs-preview rdkit end -->