### PR TITLE
Fix #7221

### DIFF
--- a/Scripts/gen_rdkit_stubs/__init__.py
+++ b/Scripts/gen_rdkit_stubs/__init__.py
@@ -542,7 +542,7 @@ class ProcessDocLines:
                     self.top_signature = src_line
                 if overload_prefix:
                     src_line = overload_prefix + src_line
-        return src_line
+        return src_line.replace("\\", "\\\\")
 
     def process_doc_lines(self, doc_lines):
         """Process the raw docstring lines.


### PR DESCRIPTION
Simple PR to make sure backslashes in docstrings are escaped before they are fed to `pybind11-stubgen`