### PR TITLE
Fix `Chem.Randomize.py`

### DIFF
--- a/rdkit/Chem/Randomize.py
+++ b/rdkit/Chem/Randomize.py
@@ -20,6 +20,11 @@ def _shuffle(indices):
 
 def RandomizeMolBlock(molblock):
     mol = Chem.MolFromMolBlock(molblock, sanitize=False, removeHs=False)
+
+    return Chem.MolToMolBlock(RandomizeMol(mol))
+
+
+def RandomizeMol(mol):
     atom_indices = [atom.GetIdx() for atom in mol.GetAtoms()]
     atom_indices_randomized = _shuffle(atom_indices)
     if len(atom_indices) > 1:
@@ -27,11 +32,4 @@ def RandomizeMolBlock(molblock):
         while atom_indices_randomized == atom_indices:
             atom_indices_randomized = _shuffle(atom_indices)
 
-    return Chem.MolToMolBlock(Chem.RenumberAtoms(mol, atom_indices_randomized))
-
-
-def RandomizeMol(mol):
-    molblock = Chem.MolToMolBlock(mol)
-    molblock_randomized = RandomizeMolBlock(molblock)
-
-    return Chem.MolFromMolBlock(molblock_randomized)
+    return Chem.RenumberAtoms(mol, atom_indices_randomized)

--- a/rdkit/Chem/Randomize.py
+++ b/rdkit/Chem/Randomize.py
@@ -12,13 +12,13 @@ import random
 from rdkit import Chem
 
 
-def _shuffle(indices: list[int]) -> list[int]:
+def _shuffle(indices):
     # Shuffle without in-place mutation.
     # See https://docs.python.org/3/library/random.html#random.shuffle.
     return random.sample(indices, len(indices))
 
 
-def RandomizeMolBlock(molblock: str) -> str:
+def RandomizeMolBlock(molblock):
     mol = Chem.MolFromMolBlock(molblock, sanitize=False, removeHs=False)
     atom_indices = [atom.GetIdx() for atom in mol.GetAtoms()]
     atom_indices_randomized = _shuffle(atom_indices)
@@ -30,7 +30,7 @@ def RandomizeMolBlock(molblock: str) -> str:
     return Chem.MolToMolBlock(Chem.RenumberAtoms(mol, atom_indices_randomized))
 
 
-def RandomizeMol(mol: Chem.Mol) -> Chem.Mol:
+def RandomizeMol(mol):
     molblock = Chem.MolToMolBlock(mol)
     molblock_randomized = RandomizeMolBlock(molblock)
 

--- a/rdkit/Chem/Randomize.py
+++ b/rdkit/Chem/Randomize.py
@@ -23,7 +23,7 @@ def RandomizeMolBlock(molblock):
     atom_indices = [atom.GetIdx() for atom in mol.GetAtoms()]
     atom_indices_randomized = _shuffle(atom_indices)
     if len(atom_indices) > 1:
-        # Enforce randomization.
+        # Enforce different permutation of atom indices.
         while atom_indices_randomized == atom_indices:
             atom_indices_randomized = _shuffle(atom_indices)
 

--- a/rdkit/Chem/UnitTestRandomize.py
+++ b/rdkit/Chem/UnitTestRandomize.py
@@ -1,5 +1,6 @@
 import unittest
 import random
+import textwrap
 from rdkit import Chem
 from rdkit.Chem import Randomize
 
@@ -28,6 +29,37 @@ class TestCase(unittest.TestCase):
                     _get_bond_indices(mol_randomized),
                     msg=f"Failed to randomize charged mol {smi}",
                 )
+
+    def test_RandomizeMolBlock(self):
+        molblock = textwrap.dedent(
+            """
+                 RDKit          2D
+
+              6  6  0  0  0  0  0  0  0  0999 V2000
+                1.5000    0.0000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+                0.7500   -1.2990    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+               -0.7500   -1.2990    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+               -1.5000    0.0000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+               -0.7500    1.2990    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+                0.7500    1.2990    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+              1  2  2  0
+              2  3  1  0
+              3  4  2  0
+              4  5  1  0
+              5  6  2  0
+              6  1  1  0
+            M  END
+            """
+        )
+        molblock_randomized = Randomize.RandomizeMolBlock(molblock)
+        mol = Chem.MolFromMolBlock(molblock)
+        mol_randomized = Chem.MolFromMolBlock(molblock_randomized)
+
+        self.assertNotEqual(
+            _get_bond_indices(mol),
+            _get_bond_indices(mol_randomized),
+            msg="Failed to randomize molblock",
+        )
 
     def test_smiles_canonicalization(self):
         smiles = ["CON", "c1ccccn1", "C/C=C/F"]

--- a/rdkit/Chem/UnitTestRandomize.py
+++ b/rdkit/Chem/UnitTestRandomize.py
@@ -1,0 +1,48 @@
+import pytest
+from contextlib import contextmanager
+from rdkit import Chem
+from rdkit.Chem import Randomize
+from rdkit import RDRandom as random
+
+
+def _get_bond_indices(mol: Chem.Mol) -> list[tuple[int, int]]:
+    return [(bond.GetBeginAtomIdx(), bond.GetEndAtomIdx()) for bond in mol.GetBonds()]
+
+
+@contextmanager
+def set_random_seed():
+    random.seed(42)
+    yield
+
+
+@set_random_seed()
+@pytest.mark.parametrize(
+    "smiles",
+    [
+        "CC(=O)[O-]",
+        "[NH3+]CC(=O)[O-]",
+        "[O-][O-]",
+        "[O-]C[O-]",
+    ],
+)
+def test_RandomizeMol(smiles):
+    for _ in range(5):
+        mol = Chem.MolFromSmiles(smiles)
+        mol_randomized = Randomize.RandomizeMol(mol)
+
+        assert _get_bond_indices(mol) != _get_bond_indices(mol_randomized)
+
+
+@set_random_seed()
+@pytest.mark.parametrize(
+    "smiles",
+    ["CON", "c1ccccn1", "C/C=C/F"],
+)
+def test_smiles_canonicalization(smiles):
+    mol = Chem.MolFromSmiles(smiles)
+    canonical_reference_smiles = Chem.MolToSmiles(mol, False)
+    for _ in range(5):
+        mol_randomized = Randomize.RandomizeMol(mol)
+        canonical_smiles = Chem.MolToSmiles(mol_randomized, False)
+
+        assert canonical_reference_smiles == canonical_smiles

--- a/rdkit/Chem/UnitTestRandomize.py
+++ b/rdkit/Chem/UnitTestRandomize.py
@@ -5,7 +5,7 @@ from rdkit.Chem import Randomize
 from rdkit import RDRandom as random
 
 
-def _get_bond_indices(mol: Chem.Mol) -> list[tuple[int, int]]:
+def _get_bond_indices(mol):
     return [(bond.GetBeginAtomIdx(), bond.GetEndAtomIdx()) for bond in mol.GetBonds()]
 
 


### PR DESCRIPTION
We're implementing shuffle / invariance tests for the InChI (https://github.com/IUPAC-InChI/InChI/issues/7).
I was planning on using `RandomizeMolBlock` when I came across #1376.

The current PR is an attempt to bring #1376 over the finish line.
I refactored `RandomizeMolBlock` according to @greglandrum's [suggestion](https://github.com/rdkit/rdkit/pull/1376#pullrequestreview-36938717).

Two things weren't clear two me.
1. The docstring / attribution at the top of `Randomize.py` seems outdated . Should it be updated, and if so, how?
2. Does `test_smiles_canonicalization` belong to the tests? I moved it over from the `if __name__ == '__main__'` block in `Randomize.py`. However, essentially, it doesn't test the randomization. Should I remove the test or move it somewhere else? If so, where?
