### PR TITLE
remove a bunch of std::endls

### DIFF
--- a/Code/GraphMol/FileParsers/MolFileWriter.cpp
+++ b/Code/GraphMol/FileParsers/MolFileWriter.cpp
@@ -157,7 +157,7 @@ const std::string GetMolFileChargeInfo(const RWMol &mol) {
       chgss << boost::format(" %3d %3d") % (atom->getIdx() + 1) %
                    atom->getFormalCharge();
       if (nChgs == 8) {
-        res << boost::format("M  CHG%3d") % nChgs << chgss.str() << std::endl;
+        res << boost::format("M  CHG%3d") % nChgs << chgss.str() << "\n";
         chgss.str("");
         nChgs = 0;
       }
@@ -172,7 +172,7 @@ const std::string GetMolFileChargeInfo(const RWMol &mol) {
       }
       radss << boost::format(" %3d %3d") % (atom->getIdx() + 1) % nRadEs;
       if (nRads == 8) {
-        res << boost::format("M  RAD%3d") % nRads << radss.str() << std::endl;
+        res << boost::format("M  RAD%3d") % nRads << radss.str() << "\n";
         radss.str("");
         nRads = 0;
       }
@@ -185,7 +185,7 @@ const std::string GetMolFileChargeInfo(const RWMol &mol) {
                           isotope;
         if (nMassDiffs == 8) {
           res << boost::format("M  ISO%3d") % nMassDiffs << massdiffss.str()
-              << std::endl;
+              << "\n";
           massdiffss.str("");
           nMassDiffs = 0;
         }
@@ -193,14 +193,13 @@ const std::string GetMolFileChargeInfo(const RWMol &mol) {
     }
   }
   if (nChgs) {
-    res << boost::format("M  CHG%3d") % nChgs << chgss.str() << std::endl;
+    res << boost::format("M  CHG%3d") % nChgs << chgss.str() << "\n";
   }
   if (nRads) {
-    res << boost::format("M  RAD%3d") % nRads << radss.str() << std::endl;
+    res << boost::format("M  RAD%3d") % nRads << radss.str() << "\n";
   }
   if (nMassDiffs) {
-    res << boost::format("M  ISO%3d") % nMassDiffs << massdiffss.str()
-        << std::endl;
+    res << boost::format("M  ISO%3d") % nMassDiffs << massdiffss.str() << "\n";
   }
   return res.str();
 }
@@ -243,15 +242,14 @@ const std::string GetMolFileQueryInfo(
         hasComplexQuery(atom)) {
       std::string sma =
           SmartsWrite::GetAtomSmarts(static_cast<const QueryAtom *>(atom));
-      ss << "V  " << std::setw(3) << atom->getIdx() + 1 << " " << sma
-         << std::endl;
+      ss << "V  " << std::setw(3) << atom->getIdx() + 1 << " " << sma << "\n";
       wrote_query = true;
     }
     std::string molFileValue;
     if (!wrote_query &&
         atom->getPropIfPresent(common_properties::molFileValue, molFileValue)) {
       ss << "V  " << std::setw(3) << atom->getIdx() + 1 << " " << molFileValue
-         << std::endl;
+         << "\n";
     }
   }
   for (const auto atom : mol.atoms()) {
@@ -289,7 +287,7 @@ const std::string GetMolFileRGroupInfo(const RWMol &mol) {
   }
   std::stringstream ss2;
   if (nEntries) {
-    ss2 << "M  RGP" << std::setw(3) << nEntries << ss.str() << std::endl;
+    ss2 << "M  RGP" << std::setw(3) << nEntries << ss.str() << "\n";
   }
   return ss2.str();
 }
@@ -332,7 +330,7 @@ const std::string GetMolFileZBOInfo(const RWMol &mol) {
       ss << " " << std::setw(3) << (*bondIt)->getIdx() + 1 << " "
          << std::setw(3) << 0;
       if (nEntries == 8) {
-        res << "M  ZBO" << std::setw(3) << nEntries << ss.str() << std::endl;
+        res << "M  ZBO" << std::setw(3) << nEntries << ss.str() << "\n";
         nEntries = 0;
         ss.str("");
       }
@@ -341,7 +339,7 @@ const std::string GetMolFileZBOInfo(const RWMol &mol) {
     }
   }
   if (nEntries) {
-    res << "M  ZBO" << std::setw(3) << nEntries << ss.str() << std::endl;
+    res << "M  ZBO" << std::setw(3) << nEntries << ss.str() << "\n";
   }
   if (atomsAffected.count()) {
     std::stringstream hydss;
@@ -357,7 +355,7 @@ const std::string GetMolFileZBOInfo(const RWMol &mol) {
       hydss << boost::format(" %3d %3d") % (atom->getIdx() + 1) %
                    atom->getTotalNumHs();
       if (nhyd == 8) {
-        res << boost::format("M  HYD%3d") % nhyd << hydss.str() << std::endl;
+        res << boost::format("M  HYD%3d") % nhyd << hydss.str() << "\n";
         hydss.str("");
         nhyd = 0;
       }
@@ -366,17 +364,17 @@ const std::string GetMolFileZBOInfo(const RWMol &mol) {
         zchss << boost::format(" %3d %3d") % (atom->getIdx() + 1) %
                      atom->getFormalCharge();
         if (nzch == 8) {
-          res << boost::format("M  ZCH%3d") % nzch << zchss.str() << std::endl;
+          res << boost::format("M  ZCH%3d") % nzch << zchss.str() << "\n";
           zchss.str("");
           nzch = 0;
         }
       }
     }
     if (nhyd) {
-      res << boost::format("M  HYD%3d") % nhyd << hydss.str() << std::endl;
+      res << boost::format("M  HYD%3d") % nhyd << hydss.str() << "\n";
     }
     if (nzch) {
-      res << boost::format("M  ZCH%3d") % nzch << zchss.str() << std::endl;
+      res << boost::format("M  ZCH%3d") % nzch << zchss.str() << "\n";
     }
   }
   return res.str();

--- a/Code/GraphMol/FileParsers/MolSGroupWriting.cpp
+++ b/Code/GraphMol/FileParsers/MolSGroupWriting.cpp
@@ -30,15 +30,13 @@ std::string BuildV2000STYLines(const ROMol &mol) {
          << FormatV2000StringField(sg->getProp<std::string>("TYPE"), 3, true,
                                    true);
     if (++count == 8) {
-      ret << "M  STY" << FormatV2000NumEntriesField(8) << temp.str()
-          << std::endl;
+      ret << "M  STY" << FormatV2000NumEntriesField(8) << temp.str() << "\n";
       temp.str("");
       count = 0;
     }
   }
   if (count) {
-    ret << "M  STY" << FormatV2000NumEntriesField(count) << temp.str()
-        << std::endl;
+    ret << "M  STY" << FormatV2000NumEntriesField(count) << temp.str() << "\n";
   }
 
   return ret.str();
@@ -62,7 +60,7 @@ std::string BuildV2000StringPropLines(const unsigned int entriesPerLine,
            << FormatV2000StringField(propValue, fieldWitdh, true, true);
       if (++count == entriesPerLine) {
         ret << "M  " << propCode << FormatV2000NumEntriesField(entriesPerLine)
-            << temp.str() << std::endl;
+            << temp.str() << "\n";
         temp.str("");
         count = 0;
       }
@@ -70,7 +68,7 @@ std::string BuildV2000StringPropLines(const unsigned int entriesPerLine,
   }
   if (count) {
     ret << "M  " << propCode << FormatV2000NumEntriesField(count) << temp.str()
-        << std::endl;
+        << "\n";
   }
 
   return ret.str();
@@ -89,16 +87,14 @@ std::string BuildV2000SLBLines(const ROMol &mol) {
       temp << FormatV2000IntField(1 + (sg - sgroups.begin()))
            << FormatV2000IntField(id);
       if (++count == 8) {
-        ret << "M  SLB" << FormatV2000NumEntriesField(8) << temp.str()
-            << std::endl;
+        ret << "M  SLB" << FormatV2000NumEntriesField(8) << temp.str() << "\n";
         temp.str("");
         count = 0;
       }
     }
   }
   if (count) {
-    ret << "M  SLB" << FormatV2000NumEntriesField(count) << temp.str()
-        << std::endl;
+    ret << "M  SLB" << FormatV2000NumEntriesField(count) << temp.str() << "\n";
   }
 
   return ret.str();
@@ -117,7 +113,7 @@ std::string BuildV2000SDSLines(const ROMol &mol) {
       temp << FormatV2000IntField(1 + (sg - sgroups.begin()));
       if (++count == 15) {
         ret << "M  SDS EXP" << FormatV2000NumEntriesField(15) << temp.str()
-            << std::endl;
+            << "\n";
         temp.str("");
         count = 0;
       }
@@ -125,7 +121,7 @@ std::string BuildV2000SDSLines(const ROMol &mol) {
   }
   if (count) {
     ret << "M  SDS EXP" << FormatV2000NumEntriesField(count) << temp.str()
-        << std::endl;
+        << "\n";
   }
 
   return ret.str();
@@ -144,16 +140,14 @@ std::string BuildV2000SPLLines(const ROMol &mol) {
       temp << FormatV2000IntField(1 + (sg - sgroups.begin()))
            << FormatV2000IntField(parentIdx);
       if (++count == 8) {
-        ret << "M  SPL" << FormatV2000NumEntriesField(8) << temp.str()
-            << std::endl;
+        ret << "M  SPL" << FormatV2000NumEntriesField(8) << temp.str() << "\n";
         temp.str("");
         count = 0;
       }
     }
   }
   if (count) {
-    ret << "M  SPL" << FormatV2000NumEntriesField(count) << temp.str()
-        << std::endl;
+    ret << "M  SPL" << FormatV2000NumEntriesField(count) << temp.str() << "\n";
   }
 
   return ret.str();
@@ -172,16 +166,14 @@ std::string BuildV2000SNCLines(const ROMol &mol) {
       temp << FormatV2000IntField(1 + (sg - sgroups.begin()))
            << FormatV2000IntField(compno);
       if (++count == 8) {
-        ret << "M  SNC" << FormatV2000NumEntriesField(8) << temp.str()
-            << std::endl;
+        ret << "M  SNC" << FormatV2000NumEntriesField(8) << temp.str() << "\n";
         temp.str("");
         count = 0;
       }
     }
   }
   if (count) {
-    ret << "M  SNC" << FormatV2000NumEntriesField(count) << temp.str()
-        << std::endl;
+    ret << "M  SNC" << FormatV2000NumEntriesField(count) << temp.str() << "\n";
   }
 
   return ret.str();
@@ -208,16 +200,14 @@ std::string BuildV2000SBTLines(const ROMol &mol) {
         throw SubstanceGroupException(errout.str());
       }
       if (++count == 8) {
-        ret << "M  SBT" << FormatV2000NumEntriesField(8) << temp.str()
-            << std::endl;
+        ret << "M  SBT" << FormatV2000NumEntriesField(8) << temp.str() << "\n";
         temp.str("");
         count = 0;
       }
     }
   }
   if (count) {
-    ret << "M  SBT" << FormatV2000NumEntriesField(count) << temp.str()
-        << std::endl;
+    ret << "M  SBT" << FormatV2000NumEntriesField(count) << temp.str() << "\n";
   }
 
   return ret.str();
@@ -236,15 +226,14 @@ std::string BuildV2000IdxVectorDataLines(const unsigned int entriesPerLine,
     temp << FormatV2000IntField(1 + idx);
     if (++count == entriesPerLine) {
       ret << "M  " << code << FormatV2000IntField(sGroupId)
-          << FormatV2000NumEntriesField(entriesPerLine) << temp.str()
-          << std::endl;
+          << FormatV2000NumEntriesField(entriesPerLine) << temp.str() << "\n";
       temp.str("");
       count = 0;
     }
   }
   if (count) {
     ret << "M  " << code << FormatV2000IntField(sGroupId)
-        << FormatV2000NumEntriesField(count) << temp.str() << std::endl;
+        << FormatV2000NumEntriesField(count) << temp.str() << "\n";
   }
   return ret.str();
 }
@@ -257,7 +246,7 @@ std::string BuildV2000SMTLine(const int idx, const SubstanceGroup &sgroup) {
        sgroup.getPropIfPresent("MULT", smtValue)) ||
       sgroup.getPropIfPresent("LABEL", smtValue)) {
     ret << "M  SMT" << FormatV2000IntField(idx)
-        << FormatV2000StringField(smtValue, 69, false, true) << std::endl;
+        << FormatV2000StringField(smtValue, 69, false, true) << "\n";
   }
   return ret.str();
 }
@@ -275,7 +264,7 @@ std::string BuildV2000SDILine(const int idx, const SubstanceGroup &sgroup) {
       ret << FormatV2000DoubleField(bracket.at(iPoint).x);
       ret << FormatV2000DoubleField(bracket.at(iPoint).y);
     }
-    ret << std::endl;
+    ret << "\n";
   }
 
   return ret.str();
@@ -291,7 +280,7 @@ std::string BuildV2000SBVLine(const int idx, const SubstanceGroup &sgroup) {
       ret << FormatV2000DoubleField(cstate.vector.x);
       ret << FormatV2000DoubleField(cstate.vector.y);
     }
-    ret << std::endl;
+    ret << "\n";
   }
 
   return ret.str();
@@ -322,7 +311,7 @@ std::string BuildV2000SDTLine(const int idx, const SubstanceGroup &sgroup) {
       ret << FormatV2000StringField(sdtValue, 15, true, false);
     }
 
-    ret << std::endl;
+    ret << "\n";
   }
   return ret.str();
 }
@@ -334,7 +323,7 @@ std::string BuildV2000SDDLine(const int idx, const SubstanceGroup &sgroup) {
   if (sgroup.getPropIfPresent("FIELDDISP", sddValue)) {
     ret << "M  SDD" << FormatV2000IntField(idx);
     ret << FormatV2000StringField(sddValue, 69, false, true);
-    ret << std::endl;
+    ret << "\n";
   }
 
   return ret.str();
@@ -358,11 +347,11 @@ std::string BuildV2000SCDSEDLines(const int idx, const SubstanceGroup &sgroup) {
       for (; length > end; start += 69, end += 69) {
         std::string dataChunk = data.substr(start, end);
         ret << "M  SCD" << FormatV2000IntField(idx)
-            << FormatV2000StringField(dataChunk, 69, true, true) << std::endl;
+            << FormatV2000StringField(dataChunk, 69, true, true) << "\n";
       }
       std::string dataChunk = data.substr(start, end);
       ret << "M  SED" << FormatV2000IntField(idx)
-          << FormatV2000StringField(dataChunk, 69, false, true) << std::endl;
+          << FormatV2000StringField(dataChunk, 69, false, true) << "\n";
     }
   }
 
@@ -387,14 +376,14 @@ std::string BuildV2000SAPLines(const int idx, const SubstanceGroup &sgroup) {
     temp << FormatV2000StringField(sap.id, 2, false, true);
     if (++count == entriesPerLine) {
       ret << "M  SAP" << FormatV2000IntField(idx)
-          << FormatV2000IntField(entriesPerLine) << temp.str() << std::endl;
+          << FormatV2000IntField(entriesPerLine) << temp.str() << "\n";
       temp.str("");
       count = 0;
     }
   }
   if (count) {
     ret << "M  SAP" << FormatV2000IntField(idx)
-        << FormatV2000NumEntriesField(count) << temp.str() << std::endl;
+        << FormatV2000NumEntriesField(count) << temp.str() << "\n";
   }
   return ret.str();
 }
@@ -406,7 +395,7 @@ std::string BuildV2000SCLLine(const int idx, const SubstanceGroup &sgroup) {
   if (sgroup.getPropIfPresent("CLASS", sclValue)) {
     ret << "M  SCL" << FormatV2000IntField(idx);
     ret << FormatV2000StringField(sclValue, 69, false, true);
-    ret << std::endl;
+    ret << "\n";
   }
 
   return ret.str();

--- a/Code/GraphMol/FileParsers/TplFileWriter.cpp
+++ b/Code/GraphMol/FileParsers/TplFileWriter.cpp
@@ -48,7 +48,7 @@ void writeAtom(const ROMol &mol, unsigned int atomId,
   dest << " "
        << "U";
 
-  dest << std::endl;
+  dest << "\n";
 }
 
 void writeBond(const ROMol &mol, unsigned int bondId,
@@ -97,7 +97,7 @@ void writeBond(const ROMol &mol, unsigned int bondId,
        << " "
        << "0";
 
-  dest << std::endl;
+  dest << "\n";
 }
 }  // namespace TPLWriter
 
@@ -110,8 +110,10 @@ std::string MolToTPLText(const ROMol &mol, const std::string &partialChargeProp,
   }
   std::ostringstream res;
   std::string tempStr;
-  res << "BioCAD format, all rights reserved" << std::endl;
-  res << "Output from RDKit" << std::endl;
+  res << "BioCAD format, all rights reserved"
+      << "\n";
+  res << "Output from RDKit"
+      << "\n";
   if (!mol.hasProp(common_properties::_Name)) {
     BOOST_LOG(rdWarningLog)
         << "Molecule has no name; arbitrary name assigned.\n";
@@ -119,9 +121,10 @@ std::string MolToTPLText(const ROMol &mol, const std::string &partialChargeProp,
   } else {
     mol.getProp(common_properties::_Name, tempStr);
   }
-  res << "NAME " << tempStr << std::endl;
-  res << "PROP 7 1" << std::endl;
-  res << mol.getNumAtoms() << " " << mol.getNumBonds() << std::endl;
+  res << "NAME " << tempStr << "\n";
+  res << "PROP 7 1"
+      << "\n";
+  res << mol.getNumAtoms() << " " << mol.getNumBonds() << "\n";
 
   auto confIt = mol.beginConformers();
   // write the atoms:
@@ -135,7 +138,7 @@ std::string MolToTPLText(const ROMol &mol, const std::string &partialChargeProp,
   }
 
   // write the additional conformations:
-  res << "CONFS " << mol.getNumConformers() - 1 << std::endl;
+  res << "CONFS " << mol.getNumConformers() - 1 << "\n";
   if (!writeFirstConfTwice) {
     ++confIt;
   }
@@ -145,16 +148,16 @@ std::string MolToTPLText(const ROMol &mol, const std::string &partialChargeProp,
 
     tmpStrm << "conformer_" << (*confIt)->getId();
     confName = tmpStrm.str();
-    res << "NAME " << confName << std::endl;
+    res << "NAME " << confName << "\n";
 
     for (unsigned int i = 0; i < mol.getNumAtoms(); ++i) {
       const RDGeom::Point3D &pos = (*confIt)->getAtomPos(i);
       res << " " << 100. * pos.x << " " << 100. * pos.y << " " << 100. * pos.z
-          << std::endl;
+          << "\n";
     }
     ++confIt;
     if (confIt != mol.endConformers()) {
-      res << std::endl;
+      res << "\n";
     }
   }
 

--- a/Code/GraphMol/MolDraw2D/DrawTextFTSVG.cpp
+++ b/Code/GraphMol/MolDraw2D/DrawTextFTSVG.cpp
@@ -39,7 +39,8 @@ double DrawTextFTSVG::extractOutline() {
   }
 
   double adv = DrawTextFT::extractOutline();
-  oss_ << "' fill='" << col << "'/>" << std::endl;
+  oss_ << "' fill='" << col << "'/>"
+       << "\n";
 
   return adv;
 }
@@ -49,7 +50,7 @@ int DrawTextFTSVG::MoveToFunctionImpl(const FT_Vector *to) {
   double dx, dy;
   fontPosToDrawPos(to->x, to->y, dx, dy);
   oss_ << "M " << MolDraw2D_detail::formatDouble(dx) << ' '
-       << MolDraw2D_detail::formatDouble(dy) << std::endl;
+       << MolDraw2D_detail::formatDouble(dy) << "\n";
 
   return 0;
 }
@@ -59,7 +60,7 @@ int DrawTextFTSVG::LineToFunctionImpl(const FT_Vector *to) {
   double dx, dy;
   fontPosToDrawPos(to->x, to->y, dx, dy);
   oss_ << "L " << MolDraw2D_detail::formatDouble(dx) << ' '
-       << MolDraw2D_detail::formatDouble(dy) << std::endl;
+       << MolDraw2D_detail::formatDouble(dy) << "\n";
 
   return 0;
 }
@@ -76,7 +77,7 @@ int DrawTextFTSVG::ConicToFunctionImpl(const FT_Vector *control,
   oss_ << "Q " << MolDraw2D_detail::formatDouble(controlX) << ' '
        << MolDraw2D_detail::formatDouble(controlY) << ", "
        << MolDraw2D_detail::formatDouble(dx) << ' '
-       << MolDraw2D_detail::formatDouble(dy) << std::endl;
+       << MolDraw2D_detail::formatDouble(dy) << "\n";
 
   return 0;
 }
@@ -98,7 +99,7 @@ int DrawTextFTSVG::CubicToFunctionImpl(const FT_Vector *controlOne,
        << MolDraw2D_detail::formatDouble(controlTwoX) << ' '
        << MolDraw2D_detail::formatDouble(controlTwoY) << ", "
        << MolDraw2D_detail::formatDouble(dx) << ' '
-       << MolDraw2D_detail::formatDouble(dy) << std::endl;
+       << MolDraw2D_detail::formatDouble(dy) << "\n";
 
   return 0;
 }

--- a/Code/GraphMol/MolDraw2D/DrawTextSVG.cpp
+++ b/Code/GraphMol/MolDraw2D/DrawTextSVG.cpp
@@ -64,7 +64,8 @@ void DrawTextSVG::drawChar(char c, const Point2D &cds) {
        << "fill:" << col << "'";
   oss_ << " >";
   oss_ << cs;
-  oss_ << "</text>" << std::endl;
+  oss_ << "</text>"
+       << "\n";
 }
 
 // ****************************************************************************

--- a/Code/GraphMol/MolDraw2D/MolDraw2DSVG.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DSVG.cpp
@@ -335,11 +335,13 @@ void MolDraw2DSVG::clearDrawing() {
 static const char *RDKIT_SVG_VERSION = "0.9";
 void MolDraw2DSVG::addMoleculeMetadata(const ROMol &mol, int confId) const {
   PRECONDITION(d_os, "no output stream");
-  d_os << "<metadata>" << std::endl;
+  d_os << "<metadata>"
+       << "\n";
   d_os << "<rdkit:mol"
        << " xmlns:rdkit = \"http://www.rdkit.org/xml\""
        << " version=\"" << RDKIT_SVG_VERSION << "\""
-       << ">" << std::endl;
+       << ">"
+       << "\n";
   for (const auto atom : mol.atoms()) {
     d_os << "<rdkit:atom idx=\"" << atom->getIdx() + 1 << "\"";
     bool doKekule = false, allHsExplicit = true, isomericSmiles = true;
@@ -366,7 +368,8 @@ void MolDraw2DSVG::addMoleculeMetadata(const ROMol &mol, int confId) const {
 
     outputMetaData(atom, d_os);
 
-    d_os << " />" << std::endl;
+    d_os << " />"
+         << "\n";
   }
   for (const auto bond : mol.bonds()) {
     d_os << "<rdkit:bond idx=\"" << bond->getIdx() + 1 << "\"";
@@ -379,9 +382,11 @@ void MolDraw2DSVG::addMoleculeMetadata(const ROMol &mol, int confId) const {
 
     outputMetaData(bond, d_os);
 
-    d_os << " />" << std::endl;
+    d_os << " />"
+         << "\n";
   }
-  d_os << "</rdkit:mol></metadata>" << std::endl;
+  d_os << "</rdkit:mol></metadata>"
+       << "\n";
 }
 
 // ****************************************************************************


### PR DESCRIPTION
Nothing fancy here, this just replaces a number of occurances of `std::endl` with `"\n"`

There are a number of places suggesting that `std::endl` should be avoided when the explicit flush that it does isn't actually needed; here's one of them: https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rio-endl

I initially implemented this as a global change, but it caused problems with a number of tests and logging (see below), and we aren't logging in performance-critical code, so I went back to mainly changing the places we write files

On the problems with logging in the tests: the problems came up in tests where the logs are captured in other streams (like stringstreams). These are not automatically flushed (unlike `std::cerr` and `std::cout`), so I would have had to rewrite a bunch of tests. That seemed too heavyweight at the moment... we can decide to do that in the future if we want it.