### PR TITLE
Postpone clearing computed properties until after all Hs removed

### DIFF
--- a/Code/GraphMol/AddHs.cpp
+++ b/Code/GraphMol/AddHs.cpp
@@ -780,8 +780,9 @@ void molRemoveH(RWMol &mol, unsigned int idx, bool updateExplicitCount) {
       }
     }
   }
-
-  mol.removeAtom(atom);
+  // computed properties will be cleared after all hydrogens are removed
+  bool clearProps = false;
+  mol.removeAtom(atom, clearProps);
 }
 
 bool shouldRemoveH(const RWMol &mol, const Atom *atom,
@@ -1002,6 +1003,7 @@ void removeHs(RWMol &mol, const RemoveHsParameters &ps, bool sanitize) {
       molRemoveH(mol, idx, ps.updateExplicitCount);
     }
   }
+  mol.clearComputedProps(true);
   //
   //  If we didn't only remove implicit Hs, which are guaranteed to
   //  be the highest numbered atoms, we may have altered atom indices.

--- a/Code/GraphMol/RWMol.cpp
+++ b/Code/GraphMol/RWMol.cpp
@@ -350,7 +350,7 @@ void RWMol::setActiveAtom(unsigned int idx) {
 
 void RWMol::removeAtom(unsigned int idx) { removeAtom(getAtomWithIdx(idx)); }
 
-void RWMol::removeAtom(Atom *atom) {
+void RWMol::removeAtom(Atom *atom, bool clearProps) {
   PRECONDITION(atom, "NULL atom provided");
   PRECONDITION(static_cast<RWMol *>(&atom->getOwningMol()) == this,
                "atom not owned by this molecule");
@@ -489,7 +489,9 @@ void RWMol::removeAtom(Atom *atom) {
 
   // clear computed properties and reset our ring info structure
   // they are pretty likely to be wrong now:
-  clearComputedProps(true);
+  if (clearProps) {
+    clearComputedProps(true);
+  }
 
   atom->setOwningMol(nullptr);
 
@@ -500,6 +502,8 @@ void RWMol::removeAtom(Atom *atom) {
   boost::remove_vertex(vd, d_graph);
   delete atom;
 }
+
+void RWMol::removeAtom(Atom *atom) { removeAtom(atom, true); }
 
 unsigned int RWMol::addBond(unsigned int atomIdx1, unsigned int atomIdx2,
                             Bond::BondType bondType) {

--- a/Code/GraphMol/RWMol.h
+++ b/Code/GraphMol/RWMol.h
@@ -113,6 +113,8 @@ class RDKIT_GRAPHMOL_EXPORT RWMol : public ROMol {
   void removeAtom(unsigned int idx);
   //! \overload
   void removeAtom(Atom *atom);
+  //! \overload
+  void removeAtom(Atom *atom, bool clearProps);
 
   //! @}
 


### PR DESCRIPTION
This is a follow up to https://github.com/rdkit/rdkit/pull/7188 -- it looks like there is still quite a bit of time spent on calling clearComputedProps:
<img width="733" alt="Screen Shot 2024-03-12 at 12 18 51 PM" src="https://github.com/rdkit/rdkit/assets/39069546/d6153636-e9ca-4a08-8e4d-008471796cc6">

These changes improve the runtime of my example from ~9s to ~5.6s. I added an overload to removeAtom because I was having linking issues when trying to make clearProps a default argument, and wanted to make sure this would be a reasonable change before looking further into it.