### PR TITLE
Speed up cleanMolStereo

### DIFF
--- a/Code/GraphMol/FindStereo.cpp
+++ b/Code/GraphMol/FindStereo.cpp
@@ -585,8 +585,8 @@ void initBondInfo(ROMol &mol, bool flagPossible, bool cleanIt,
       if (currentStereo != Bond::BondStereo::STEREOATROPCW &&
           currentStereo != Bond::BondStereo::STEREOATROPCCW) {
         if (cleanIt) {
-      bond->setStereo(Bond::BondStereo::STEREONONE);
-    }
+          bond->setStereo(Bond::BondStereo::STEREONONE);
+        }
       } else {
         knownBonds.set(bidx);
         if (currentStereo == Bond::BondStereo::STEREOATROPCW) {
@@ -919,9 +919,9 @@ void cleanMolStereo(ROMol &mol, const boost::dynamic_bitset<> &fixedAtoms,
                     const boost::dynamic_bitset<> &knownAtoms,
                     const boost::dynamic_bitset<> &fixedBonds,
                     const boost::dynamic_bitset<> &knownBonds) {
-  for (auto i = 0u; i < mol.getNumAtoms(); ++i) {
+  for (auto atom : mol.atoms()) {
+    const auto i = atom->getIdx();
     if (!fixedAtoms[i] && knownAtoms[i]) {
-      auto atom = mol.getAtomWithIdx(i);
       switch (atom->getChiralTag()) {
         case Atom::ChiralType::CHI_TETRAHEDRAL_CCW:
         case Atom::ChiralType::CHI_TETRAHEDRAL_CW:
@@ -938,8 +938,7 @@ void cleanMolStereo(ROMol &mol, const boost::dynamic_bitset<> &fixedAtoms,
         case Atom::ChiralType::CHI_SQUAREPLANAR:
         case Atom::ChiralType::CHI_TRIGONALBIPYRAMIDAL:
         case Atom::ChiralType::CHI_OCTAHEDRAL:
-          mol.getAtomWithIdx(i)->setProp(common_properties::_chiralPermutation,
-                                         0);
+          atom->setProp(common_properties::_chiralPermutation, 0);
           break;
         default:
           break;
@@ -948,8 +947,8 @@ void cleanMolStereo(ROMol &mol, const boost::dynamic_bitset<> &fixedAtoms,
   }
 
   bool removedStereo = false;
-  for (auto i = 0u; i < mol.getNumBonds(); ++i) {
-    auto bond = mol.getBondWithIdx(i);
+  for (auto bond : mol.bonds()) {
+    const auto i = bond->getIdx();
     if (!fixedBonds[i] && knownBonds[i]) {
       bond->setStereo(Bond::BondStereo::STEREONONE);
       bond->setBondDir(Bond::BondDir::NONE);


### PR DESCRIPTION
This simple patch speeds up reading large files when using the new stereo perception.

As an example, I have used protein [1AON](https://www.rcsb.org/structure/1AON) (~59k atoms, ~59k bonds), converted into SD format.

With current RDKit code:
```python3
In [2]: def read_sd():
   ...:     m = Chem.MolFromMolFile('1AON.sd')
   ...: 

In [3]: Chem.SetUseLegacyStereoPerception(False)

In [4]: %time read_sd()
CPU times: user 52.3 s, sys: 238 ms, total: 52.5 s
Wall time: 52.3 s
```

After this patch:
```python3
In [1]: def read_sd():
   ...:     m = Chem.MolFromMolFile('1AON.sd')
   ...: 

In [2]: Chem.SetUseLegacyStereoPerception(False)

In [3]: %time read_sd()
CPU times: user 5.12 s, sys: 106 ms, total: 5.23 s
Wall time: 5.27 s
```

If I'm understanding correctly what's going on, most of the slowdown is due to `auto bond = mol.getBondWithIdx(i);`. On one side, we are doing it for every `i`, even if we don't use `bond` later on. But, on top of that, boost graphmol seems to store bonds as a linked list, so iterating through it to find element `i` we need to iterate over all bonds until we reach it. For small mols, this takes a negligible amount of time, but for big mols like this one, it may end up taking a relevant amount of time. Changing the way we handle this to iterate over elements allows us to iterate only once, and `i` can easily be found by just pulling the idx.

Sadly, this has only an effect on the new stereo perception...
```python3
In [1]: Chem.SetUseLegacyStereoPerception(True)

In [2]: def read_sd():
   ...:     m = Chem.MolFromMolFile('1AON.sd')
   ...: 

In [3]: %time read_sd()
CPU times: user 2min 56s, sys: 671 ms, total: 2min 57s
Wall time: 2min 56s
```