### PR TITLE
Fixes #7246

### DIFF
--- a/Code/GraphMol/FileParsers/MolSGroupParsing.cpp
+++ b/Code/GraphMol/FileParsers/MolSGroupParsing.cpp
@@ -1044,7 +1044,10 @@ std::string ParseV3000StringPropLabel(std::stringstream &stream) {
   std::string strValue;
 
   auto nextChar = stream.peek();
-  if (nextChar == '"') {
+  if (nextChar == ' ') {
+    // empty value, we peeked at the next field's separator
+    return strValue;
+  } else if (nextChar == '"') {
     // skip the opening quote:
     stream.get();
 


### PR DESCRIPTION
Fixes #7246

Easy fix: when parsing the value, if the first thing we see is a space, then assume that the field is empty, since values containing spaces should be double quoted.