### PR TITLE
Fixes #7256

### DIFF
--- a/Code/GraphMol/FileParsers/MolFileParser.cpp
+++ b/Code/GraphMol/FileParsers/MolFileParser.cpp
@@ -422,6 +422,10 @@ void ParseRadicalLine(RWMol *mol, const std::string &text, bool firstCall,
       spos += 4;
 
       switch (rad) {
+        case 0:
+          // This shouldn't be required, but let's make sure.
+          mol->getAtomWithIdx(aid - 1)->setNumRadicalElectrons(0);
+          break;
         case 1:
           mol->getAtomWithIdx(aid - 1)->setNumRadicalElectrons(2);
           break;

--- a/Code/GraphMol/FileParsers/file_parsers_catch.cpp
+++ b/Code/GraphMol/FileParsers/file_parsers_catch.cpp
@@ -7025,3 +7025,22 @@ TEST_CASE("FragmentSgroupTest", "[bug][reader]") {
     }
   };
 }
+
+TEST_CASE(
+    "GitHub Issue #7256: RDKit fails to parse \"M RAD\" lines with were radical is 0",
+    "[bug]") {
+  const auto mb = R"CTAB(
+     RDKit          2D
+
+  1  0  0  0  0  0  0  0  0  0999 V2000
+    0.0000    0.0000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+M  RAD  1   1   0
+M  END
+)CTAB";
+
+  std::unique_ptr<RWMol> mol(MolBlockToMol(mb));
+  REQUIRE(mol);
+  REQUIRE(mol->getNumAtoms() == 1);
+  const auto at = mol->getAtomWithIdx(0);
+  CHECK(at->getNumRadicalElectrons() == 0);
+}


### PR DESCRIPTION
Fixes #7256

A simple fix to prevent the parser from throwing when it find M RAD 0. We shouldn't need to `setNumRadicalElectrons(0)`, since there's nothing that would change it in the atom or bond block, but just in case.