### PR TITLE
Make _NonExplicit3DChirality a public property

### DIFF
--- a/Code/GraphMol/Chirality.cpp
+++ b/Code/GraphMol/Chirality.cpp
@@ -450,9 +450,6 @@ const Atom *findHighestCIPNeighbor(const Atom *atom, const Atom *skipAtom) {
 
 namespace Chirality {
 
-const std::string _NonExplicit3DChirality =
-    "_NonExplicit3DChirality";  // set if the molecule has explicit 3D
-                                // stereochemistry
 std::optional<Atom::ChiralType> atomChiralTypeFromBondDirPseudo3D(
     const ROMol &mol, const Bond *bond, const Conformer *conf,
     double pseudo3DOffset = 0.1, double volumeTolerance = 0.01) {
@@ -2664,8 +2661,8 @@ void GetMolFileBondStereoInfo(
 
 void removeNonExplicit3DChirality(ROMol &mol) {
   for (auto atom : mol.atoms()) {
-    if (atom->hasProp(Chirality::_NonExplicit3DChirality)) {
-      atom->clearProp(Chirality::_NonExplicit3DChirality);
+    if (atom->hasProp(common_properties::_NonExplicit3DChirality)) {
+      atom->clearProp(common_properties::_NonExplicit3DChirality);
       atom->setChiralTag(Atom::CHI_UNSPECIFIED);
     }
   }
@@ -3302,7 +3299,7 @@ void assignChiralTypesFrom3D(ROMol &mol, int confId, bool replaceExistingTags) {
     if (allowNontetrahedralStereo &&
         assignNontetrahedralChiralTypeFrom3D(mol, conf, atom)) {
       if (explicitAtoms[atom->getIdx()] == 0) {
-        atom->setProp(Chirality::_NonExplicit3DChirality, 1);
+        atom->setProp(common_properties::_NonExplicit3DChirality, 1);
       }
       continue;
     }
@@ -3356,7 +3353,7 @@ void assignChiralTypesFrom3D(ROMol &mol, int confId, bool replaceExistingTags) {
     }
 
     if (chiralitySet && explicitAtoms[atom->getIdx()] == 0) {
-      atom->setProp<int>(Chirality::_NonExplicit3DChirality, 1);
+      atom->setProp<int>(common_properties::_NonExplicit3DChirality, 1);
     }
   }
 }

--- a/Code/RDGeneral/types.cpp
+++ b/Code/RDGeneral/types.cpp
@@ -49,6 +49,7 @@ const std::string _MolFileBondCfg = "_MolFileBondCfg";
 
 const std::string _Name = "_Name";
 const std::string _NeedsQueryScan = "_NeedsQueryScan";
+const std::string _NonExplicit3DChirality = "_NonExplicit3DChirality";
 const std::string _QueryFormalCharge = "_QueryFormalCharge";
 const std::string _QueryHCount = "_QueryHCount";
 const std::string _QueryIsotope = "_QueryIsotope";

--- a/Code/RDGeneral/types.h
+++ b/Code/RDGeneral/types.h
@@ -191,6 +191,10 @@ RDKIT_RDGENERAL_EXPORT extern const std::string
     _MolFileBondCfg;  // unsigned int
 RDKIT_RDGENERAL_EXPORT extern const std::string
     MRV_SMA;  // smarts string from Marvin
+
+// flag indicating that the chirality wasn't specified in the input,
+// but was calculated from 3D coordinates in the input
+RDKIT_RDGENERAL_EXPORT extern const std::string _NonExplicit3DChirality;  // int
 RDKIT_RDGENERAL_EXPORT extern const std::string dummyLabel;  // atom string
 
 RDKIT_RDGENERAL_EXPORT extern const std::string


### PR DESCRIPTION
`_NonExplicit3DChirality` was introduced in the atropoisomers patch (#6903), but it is not exposed through any header nor Python wrapped. This moves it to `common_properties` so that it is exported through the public header and wrapped.