### PR TITLE
Update ring fusion cache when needed

### DIFF
--- a/Code/GraphMol/RingInfo.cpp
+++ b/Code/GraphMol/RingInfo.cpp
@@ -195,25 +195,22 @@ unsigned int RingInfo::addRing(const INT_VECT &atomIndices,
 }
 
 bool RingInfo::isRingFused(unsigned int ringIdx) {
-  PRECONDITION(ringIdx < d_bondRings.size(), "ringIdx out of bounds");
-  if (d_fusedRings.empty()) {
-    initFusedRings();
-  }
-  return d_fusedRings.at(ringIdx).any();
+  initFusedRings();
+  PRECONDITION(ringIdx < d_fusedRings.size(), "ringIdx out of bounds");
+  return d_fusedRings[ringIdx].any();
 }
 
 bool RingInfo::areRingsFused(unsigned int ring1Idx, unsigned int ring2Idx) {
-  PRECONDITION(ring1Idx < d_bondRings.size(), "ring1Idx out of bounds");
-  PRECONDITION(ring2Idx < d_bondRings.size(), "ring2Idx out of bounds");
-  if (d_fusedRings.empty()) {
-    initFusedRings();
-  }
-  return d_fusedRings.at(ring1Idx).test(ring2Idx);
+  initFusedRings();
+  PRECONDITION(ring1Idx < d_fusedRings.size(), "ring1Idx out of bounds");
+  PRECONDITION(ring2Idx < d_fusedRings.size(), "ring2Idx out of bounds");
+  return d_fusedRings[ring1Idx].test(ring2Idx);
 }
 
 unsigned int RingInfo::numFusedBonds(unsigned int ringIdx) {
   PRECONDITION(ringIdx < d_bondRings.size(), "ringIdx out of bounds");
-  if (d_numFusedBonds.empty()) {
+  if (d_numFusedBonds.size() != d_bondRings.size()) {
+    d_numFusedBonds.clear();
     d_numFusedBonds.resize(d_bondRings.size(), 0);
     for (unsigned int ri = 0; ri < d_bondRings.size(); ++ri) {
       d_numFusedBonds[ri] += std::count_if(
@@ -225,12 +222,14 @@ unsigned int RingInfo::numFusedBonds(unsigned int ringIdx) {
 }
 
 unsigned int RingInfo::numFusedRingNeighbors(unsigned int ringIdx) {
+  initFusedRings();
   PRECONDITION(ringIdx < d_fusedRings.size(), "ringIdx out of bounds");
   return d_fusedRings[ringIdx].count();
 }
 
 std::vector<unsigned int> RingInfo::fusedRingNeighbors(unsigned int ringIdx) {
-  PRECONDITION(ringIdx < d_bondRings.size(), "ringIdx out of bounds");
+  initFusedRings();
+  PRECONDITION(ringIdx < d_fusedRings.size(), "ringIdx out of bounds");
   std::vector<unsigned int> res;
   res.reserve(d_fusedRings[ringIdx].count());
   for (unsigned int i = 0; i < d_fusedRings[ringIdx].size(); ++i) {
@@ -242,6 +241,10 @@ std::vector<unsigned int> RingInfo::fusedRingNeighbors(unsigned int ringIdx) {
 }
 
 void RingInfo::initFusedRings() {
+  if (d_fusedRings.size() == d_bondRings.size()) {
+    return;
+  }
+  d_fusedRings.clear();
   if (d_bondRings.empty()) {
     return;
   }


### PR DESCRIPTION
Prompted by @sroughley reporting a failure in his KNIME testing pipeline involving `RingInfo::isFusedRings()`, I reviewed that code and, though I did not manage to reproduce a segfault (`RingInfo::isFusedRings()` uses `std::vector::at()` to access vector elements, so it should never segfault for going out of bounds), I assembled a couple of test cases where the current code would certain yield wrong results.
Here's a PR to fix that.