### PR TITLE
fixes #7295

### DIFF
--- a/Code/GraphMol/SmilesParse/SmilesWrite.cpp
+++ b/Code/GraphMol/SmilesParse/SmilesWrite.cpp
@@ -371,7 +371,6 @@ std::string FragmentSmilesConstruct(
   if (params.canonical && params.doIsomericSmiles) {
     Canon::canonicalizeEnhancedStereo(mol, &ranks);
   }
-
   Canon::canonicalizeFragment(mol, atomIdx, colors, ranks, molStack,
                               bondsInPlay, bondSymbols, params.doIsomericSmiles,
                               params.doRandom);
@@ -521,11 +520,10 @@ std::string MolToSmiles(const ROMol &mol, const SmilesWriteParams &params,
     // but that should not be:
     if (params.doIsomericSmiles) {
       tmol->setProp(common_properties::_doIsoSmiles, 1);
-      if (!mol.hasProp(common_properties::_StereochemDone)) {
+      if (!tmol->hasProp(common_properties::_StereochemDone)) {
         MolOps::assignStereochemistry(*tmol, true);
       }
     }
-
     if (!doingCXSmiles) {
       // remove any stereo groups that may be present. Otherwise they will be
       // used in the canonicalization

--- a/Code/GraphMol/SmilesParse/catch_tests.cpp
+++ b/Code/GraphMol/SmilesParse/catch_tests.cpp
@@ -2791,3 +2791,19 @@ TEST_CASE("leaks on unclosed rings") {
     REQUIRE(!m);
   }
 }
+
+TEST_CASE("Github #7295") {
+  SECTION("basics") {
+    auto m = "C[C@@H]1CC[C@@H](C(=O)O)CC1.Cl"_smiles;
+    REQUIRE(m);
+    auto smi1 = MolToSmiles(*m);
+    m->clearComputedProps();
+    auto smi2 = MolToSmiles(*m);
+    CHECK(smi1 == smi2);
+    auto m2(*m);
+    bool cleanIt=true;
+    MolOps::assignStereochemistry(m2, cleanIt);
+    auto smi3 = MolToSmiles(m2);
+    CHECK(smi1 == smi3);
+  }
+}


### PR DESCRIPTION
Very small change to fix a canonical SMILES bug in molecules which have ring stereo and multiple fragments.

With this change in place, all of the differences in canonical SMILES generated with 2024.03.1 relative to 2023.09.6 are expected. 