### PR TITLE
Fixes #7318

### DIFF
--- a/Code/GraphMol/Atom.cpp
+++ b/Code/GraphMol/Atom.cpp
@@ -877,17 +877,16 @@ std::string getSupplementalSmilesLabel(const Atom *atom) {
   return label;
 }
 
-unsigned int numPiElectrons(const Atom *atom) {
-  PRECONDITION(atom, "no atom");
+unsigned int numPiElectrons(const Atom &atom) {
   unsigned int res = 0;
-  if (atom->getIsAromatic()) {
+  if (atom.getIsAromatic()) {
     res = 1;
-  } else if (atom->getHybridization() != Atom::SP3) {
-    auto val = static_cast<unsigned int>(atom->getExplicitValence());
-    unsigned int physical_bonds = atom->getNumExplicitHs();
-    const auto &mol = atom->getOwningMol();
-    for (const auto bond : mol.atomBonds(atom)) {
-      if (bond->getValenceContrib(atom) != 0.0) {
+  } else if (atom.getHybridization() != Atom::SP3) {
+    auto val = static_cast<unsigned int>(atom.getExplicitValence());
+    unsigned int physical_bonds = atom.getNumExplicitHs();
+    const auto &mol = atom.getOwningMol();
+    for (const auto bond : mol.atomBonds(&atom)) {
+      if (bond->getValenceContrib(&atom) != 0.0) {
         ++physical_bonds;
       }
     }

--- a/Code/GraphMol/Atom.cpp
+++ b/Code/GraphMol/Atom.cpp
@@ -877,6 +877,27 @@ std::string getSupplementalSmilesLabel(const Atom *atom) {
   return label;
 }
 
+unsigned int numPiElectrons(const Atom *atom) {
+  PRECONDITION(atom, "no atom");
+  unsigned int res = 0;
+  if (atom->getIsAromatic()) {
+    res = 1;
+  } else if (atom->getHybridization() != Atom::SP3) {
+    auto val = static_cast<unsigned int>(atom->getExplicitValence());
+    unsigned int physical_bonds = atom->getNumExplicitHs();
+    const auto &mol = atom->getOwningMol();
+    for (const auto bond : mol.atomBonds(atom)) {
+      if (bond->getValenceContrib(atom) != 0.0) {
+        ++physical_bonds;
+      }
+    }
+    CHECK_INVARIANT(val >= physical_bonds,
+                    "explicit valence exceeds atom degree");
+    res = val - physical_bonds;
+  }
+  return res;
+}
+
 }  // namespace RDKit
 
 namespace {

--- a/Code/GraphMol/Atom.h
+++ b/Code/GraphMol/Atom.h
@@ -455,17 +455,16 @@ RDKIT_GRAPHMOL_EXPORT std::string getAtomValue(const Atom *atom);
 RDKIT_GRAPHMOL_EXPORT void setSupplementalSmilesLabel(Atom *atom,
                                                       const std::string &label);
 RDKIT_GRAPHMOL_EXPORT std::string getSupplementalSmilesLabel(const Atom *atom);
+
+//! returns true if the atom is to the left of C
+RDKIT_GRAPHMOL_EXPORT bool isEarlyAtom(int atomicNum);
+//! returns true if the atom is aromatic or has an aromatic bond
+RDKIT_GRAPHMOL_EXPORT bool isAromaticAtom(const Atom &atom);
+//! returns the number of pi electrons on the atom
+RDKIT_GRAPHMOL_EXPORT unsigned int numPiElectrons(const Atom *atom);
 };  // namespace RDKit
 
 //! allows Atom objects to be dumped to streams
 RDKIT_GRAPHMOL_EXPORT std::ostream &operator<<(std::ostream &target,
                                                const RDKit::Atom &at);
-
-namespace RDKit {
-//! returns true if the atom is to the left of C
-RDKIT_GRAPHMOL_EXPORT bool isEarlyAtom(int atomicNum);
-//! returns true if the atom is aromatic or has an aromatic bond
-RDKIT_GRAPHMOL_EXPORT bool isAromaticAtom(const Atom &atom);
-
-}  // namespace RDKit
 #endif

--- a/Code/GraphMol/Atom.h
+++ b/Code/GraphMol/Atom.h
@@ -461,7 +461,7 @@ RDKIT_GRAPHMOL_EXPORT bool isEarlyAtom(int atomicNum);
 //! returns true if the atom is aromatic or has an aromatic bond
 RDKIT_GRAPHMOL_EXPORT bool isAromaticAtom(const Atom &atom);
 //! returns the number of pi electrons on the atom
-RDKIT_GRAPHMOL_EXPORT unsigned int numPiElectrons(const Atom *atom);
+RDKIT_GRAPHMOL_EXPORT unsigned int numPiElectrons(const Atom &atom);
 };  // namespace RDKit
 
 //! allows Atom objects to be dumped to streams

--- a/Code/GraphMol/ConjugHybrid.cpp
+++ b/Code/GraphMol/ConjugHybrid.cpp
@@ -76,9 +76,9 @@ int numBondsPlusLonePairs(Atom *at) {
   int deg = at->getTotalDegree();
 
   auto &mol = at->getOwningMol();
-  for (const auto &nbri : boost::make_iterator_range(mol.getAtomBonds(at))) {
-    auto bond = mol[nbri];
-    if (bond->getBondType() == Bond::ZERO) {
+  for (const auto bond : mol.atomBonds(at)) {
+    if (bond->getBondType() == Bond::ZERO ||
+        (isDative(*bond) && at->getIdx() != bond->getEndAtomIdx())) {
       --deg;
     }
   }

--- a/Code/GraphMol/Descriptors/Wrap/rdMolDescriptors.cpp
+++ b/Code/GraphMol/Descriptors/Wrap/rdMolDescriptors.cpp
@@ -1021,11 +1021,6 @@ BOOST_PYTHON_MODULE(rdMolDescriptors) {
        python::arg("includeChirality") = false),
       docString.c_str(),
       python::return_value_policy<python::manage_new_object>());
-
-  docString = "Returns the number of electrons an atom is using for pi bonding";
-  python::def("GetNumPiElectrons", RDKit::AtomPairs::numPiElectrons,
-              (python::arg("atom")), docString.c_str());
-
   docString = "Returns a Morgan fingerprint for a molecule";
   python::def(
       "GetMorganFingerprint", GetMorganFingerprint,

--- a/Code/GraphMol/Descriptors/Wrap/rdMolDescriptors.cpp
+++ b/Code/GraphMol/Descriptors/Wrap/rdMolDescriptors.cpp
@@ -1022,6 +1022,10 @@ BOOST_PYTHON_MODULE(rdMolDescriptors) {
       docString.c_str(),
       python::return_value_policy<python::manage_new_object>());
 
+  docString = "Returns the number of electrons an atom is using for pi bonding";
+  python::def("GetNumPiElectrons", RDKit::AtomPairs::numPiElectrons,
+              (python::arg("atom")), docString.c_str());
+
   docString = "Returns a Morgan fingerprint for a molecule";
   python::def(
       "GetMorganFingerprint", GetMorganFingerprint,

--- a/Code/GraphMol/Fingerprints/FingerprintUtil.cpp
+++ b/Code/GraphMol/Fingerprints/FingerprintUtil.cpp
@@ -39,27 +39,6 @@
 
 namespace RDKit {
 namespace AtomPairs {
-unsigned int numPiElectrons(const Atom *atom) {
-  PRECONDITION(atom, "no atom");
-  unsigned int res = 0;
-  if (atom->getIsAromatic()) {
-    res = 1;
-  } else if (atom->getHybridization() != Atom::SP3) {
-    auto val = static_cast<unsigned int>(atom->getExplicitValence());
-    unsigned int physical_bonds = atom->getNumExplicitHs();
-    const auto &mol = atom->getOwningMol();
-    for (const auto &bndi :
-         boost::make_iterator_range(mol.getAtomBonds(atom))) {
-      if (mol[bndi]->getValenceContrib(atom) != 0.0) {
-        ++physical_bonds;
-      }
-    }
-    CHECK_INVARIANT(val >= physical_bonds,
-                    "explicit valence exceeds atom degree");
-    res = val - physical_bonds;
-  }
-  return res;
-}
 
 std::uint32_t getAtomCode(const Atom *atom, unsigned int branchSubtract,
                           bool includeChirality) {

--- a/Code/GraphMol/Fingerprints/FingerprintUtil.cpp
+++ b/Code/GraphMol/Fingerprints/FingerprintUtil.cpp
@@ -51,7 +51,7 @@ std::uint32_t getAtomCode(const Atom *atom, unsigned int branchSubtract,
   }
 
   code = numBranches % maxNumBranches;
-  unsigned int nPi = numPiElectrons(atom) % maxNumPi;
+  unsigned int nPi = numPiElectrons(*atom) % maxNumPi;
   code |= nPi << numBranchBits;
 
   unsigned int typeIdx = 0;

--- a/Code/GraphMol/Fingerprints/FingerprintUtil.h
+++ b/Code/GraphMol/Fingerprints/FingerprintUtil.h
@@ -80,8 +80,6 @@ RDKIT_FINGERPRINTS_EXPORT std::uint64_t getTopologicalTorsionCode(
 RDKIT_FINGERPRINTS_EXPORT std::uint32_t getTopologicalTorsionHash(
     const std::vector<std::uint32_t> &pathCodes);
 
-RDKIT_FINGERPRINTS_EXPORT unsigned int numPiElectrons(const Atom *atom);
-
 }  // namespace AtomPairs
 
 namespace MorganFingerprints {

--- a/Code/GraphMol/Fingerprints/FingerprintUtil.h
+++ b/Code/GraphMol/Fingerprints/FingerprintUtil.h
@@ -79,6 +79,9 @@ RDKIT_FINGERPRINTS_EXPORT std::uint64_t getTopologicalTorsionCode(
 
 RDKIT_FINGERPRINTS_EXPORT std::uint32_t getTopologicalTorsionHash(
     const std::vector<std::uint32_t> &pathCodes);
+
+RDKIT_FINGERPRINTS_EXPORT unsigned int numPiElectrons(const Atom *atom);
+
 }  // namespace AtomPairs
 
 namespace MorganFingerprints {

--- a/Code/GraphMol/Fingerprints/catch_tests.cpp
+++ b/Code/GraphMol/Fingerprints/catch_tests.cpp
@@ -788,9 +788,9 @@ TEST_CASE(
     CHECK(atom->getHybridization() == Atom::SP2);
 
     if (atom->getAtomicNum() == 8) {
-      CHECK(RDKit::AtomPair::numPiElectrons(atom) == 0);
+      CHECK(numPiElectrons(atom) == 0);
     } else {
-      CHECK(RDKit::AtomPair::numPiElectrons(atom) == 1);
+      CHECK(numPiElectrons(atom) == 1);
     }
   }
 }

--- a/Code/GraphMol/Fingerprints/catch_tests.cpp
+++ b/Code/GraphMol/Fingerprints/catch_tests.cpp
@@ -788,9 +788,9 @@ TEST_CASE(
     CHECK(atom->getHybridization() == Atom::SP2);
 
     if (atom->getAtomicNum() == 8) {
-      CHECK(numPiElectrons(atom) == 0);
+      CHECK(numPiElectrons(*atom) == 0);
     } else {
-      CHECK(numPiElectrons(atom) == 1);
+      CHECK(numPiElectrons(*atom) == 1);
     }
   }
 }

--- a/Code/GraphMol/Fingerprints/catch_tests.cpp
+++ b/Code/GraphMol/Fingerprints/catch_tests.cpp
@@ -771,3 +771,26 @@ TEST_CASE("topological torsions shorted paths") {
     CHECK(fp->getNumOnBits() == 1);
   }
 }
+
+TEST_CASE(
+    "GitHub #7318: Utils.AtomPairs.NumPiElectrons fails on atoms with dative bonds",
+    "[bug]") {
+  auto mol =
+      "O=C1[O-]->[Cr+3]23(<-[O-]C(=O)C4=CC=CC=N->24)(<-[O-]C(=O)C2=CC=CC=N->32)<-N2=CC=CC=C12"_smiles;
+  REQUIRE(mol);
+
+  for (auto bond_idx : {2, 3, 12, 21, 28, 31}) {
+    INFO("bond = " << bond_idx);
+    auto bond = mol->getBondWithIdx(bond_idx);
+    REQUIRE(bond->getBondType() == Bond::DATIVE);
+
+    const auto atom = bond->getBeginAtom();
+    CHECK(atom->getHybridization() == Atom::SP2);
+
+    if (atom->getAtomicNum() == 8) {
+      CHECK(RDKit::AtomPair::numPiElectrons(atom) == 0);
+    } else {
+      CHECK(RDKit::AtomPair::numPiElectrons(atom) == 1);
+    }
+  }
+}

--- a/Code/GraphMol/MolDraw2D/catch_tests.cpp
+++ b/Code/GraphMol/MolDraw2D/catch_tests.cpp
@@ -773,10 +773,10 @@ TEST_CASE("dative bonds", "[drawing][organometallics]") {
     std::regex d1(
         "<path class='bond-0 atom-0 atom-1' d='M (\\d+\\.\\d+),(\\d+\\.\\d+) L (\\d+\\.\\d+),(\\d+\\.\\d+)' style='fill:none;fill-rule:evenodd;stroke:#0000FF");
     auto dat1 = *std::sregex_iterator(text.begin(), text.end(), d1);
-    CHECK_THAT(stod(dat1[1]), Catch::Matchers::WithinAbs(122.3, 0.1));
-    CHECK_THAT(stod(dat1[2]), Catch::Matchers::WithinAbs(88.5, 0.1));
-    CHECK_THAT(stod(dat1[3]), Catch::Matchers::WithinAbs(85.7, 0.1));
-    CHECK_THAT(stod(dat1[4]), Catch::Matchers::WithinAbs(88.5, 0.1));
+    CHECK_THAT(stod(dat1[1]), Catch::Matchers::WithinAbs(78.2, 0.1));
+    CHECK_THAT(stod(dat1[2]), Catch::Matchers::WithinAbs(88.0, 0.1));
+    CHECK_THAT(stod(dat1[3]), Catch::Matchers::WithinAbs(113.4, 0.1));
+    CHECK_THAT(stod(dat1[4]), Catch::Matchers::WithinAbs(88.0, 0.1));
   }
   SECTION("more complex") {
     auto m1 = "N->1[C@@H]2CCCC[C@H]2N->[Pt]11OC(=O)C(=O)O1"_smiles;

--- a/Code/GraphMol/MolDraw2D/catch_tests.cpp
+++ b/Code/GraphMol/MolDraw2D/catch_tests.cpp
@@ -62,7 +62,7 @@ const std::map<std::string, std::hash_result_t> SVG_HASHES = {
     {"contourMol_3.svg", 936771429U},
     {"contourMol_4.svg", 3302971362U},
     {"contourMol_5.svg", 2230414999U},
-    {"testDativeBonds_1.svg", 2877255976U},
+    {"testDativeBonds_1.svg", 3550231997U},
     {"testDativeBonds_2.svg", 2510476717U},
     {"testDativeBonds_3.svg", 1742381275U},
     {"testDativeBonds_2a.svg", 3936523099U},

--- a/Code/GraphMol/Wrap/Atom.cpp
+++ b/Code/GraphMol/Wrap/Atom.cpp
@@ -523,6 +523,9 @@ These cannot currently be constructed directly from Python\n";
         ">>> Chem.SetSupplementalSmilesLabel(m.GetAtomWithIdx(0), '<xxx>')\n"
         ">>> Chem.MolToSmiles(m)\n"
         "'C<xxx>'\n");
+    python::def(
+        "GetNumPiElectrons", numPiElectrons, (python::arg("atom")),
+        "Returns the number of electrons an atom is using for pi bonding");
   }
 };
 }  // namespace RDKit

--- a/Code/GraphMol/catch_graphmol.cpp
+++ b/Code/GraphMol/catch_graphmol.cpp
@@ -4085,3 +4085,30 @@ M  END
                         {46, 39});
   }
 }
+
+TEST_CASE("Hybridization of dative bonded atoms") {
+  const std::vector<Atom::HybridizationType> ref_hybridizations = {
+      Atom::HybridizationType::SP3, Atom::HybridizationType::SP3,
+      Atom::HybridizationType::SP2, Atom::HybridizationType::SP2,
+      Atom::HybridizationType::SP2, Atom::HybridizationType::SP3D2};
+
+  SECTION("Base mol") {
+    auto m = "CCC(=O)O"_smiles;
+    REQUIRE(m);
+
+    for (unsigned int i = 0; i < m->getNumAtoms(); ++i) {
+      CHECK(m->getAtomWithIdx(i)->getHybridization() == ref_hybridizations[i]);
+    }
+  }
+  SECTION("Dative bonded") {
+    auto m = "CCC(=O)O->[Cu]"_smiles;
+    REQUIRE(m);
+
+    auto dBond = m->getBondWithIdx(4);
+    REQUIRE(dBond->getBondType() == Bond::BondType::DATIVE);
+
+    for (unsigned int i = 0; i < m->getNumAtoms(); ++i) {
+      CHECK(m->getAtomWithIdx(i)->getHybridization() == ref_hybridizations[i]);
+    }
+  }
+}

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -20,7 +20,8 @@ GitHub)
 ## Code removed in this release:
 
 ## Deprecated code (to be removed in a future release):
-
+- AtomPairs.Utils.NumPiElectrons is deprecated in favor of rdMolDescriptors.GetNumPiElectrons.
+AtomPairs.Utils.NumPiElectrons failed if the atom had outgoing dative bonds (see Issue #7318).
 
 # Release_2024.03.1
 (Changes relative to Release_2023.09.1)

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -20,7 +20,7 @@ GitHub)
 ## Code removed in this release:
 
 ## Deprecated code (to be removed in a future release):
-- AtomPairs.Utils.NumPiElectrons is deprecated in favor of rdMolDescriptors.GetNumPiElectrons.
+- AtomPairs.Utils.NumPiElectrons is deprecated in favor of Chem.GetNumPiElectrons.
 AtomPairs.Utils.NumPiElectrons failed if the atom had outgoing dative bonds (see Issue #7318).
 
 # Release_2024.03.1

--- a/rdkit/Chem/AtomPairs/UnitTestDescriptors.py
+++ b/rdkit/Chem/AtomPairs/UnitTestDescriptors.py
@@ -16,7 +16,6 @@ import pickle
 import unittest
 
 from rdkit import Chem, RDConfig
-from rdkit.Chem import rdMolDescriptors as rdMD
 from rdkit.Chem.AtomPairs import Pairs, Sheridan, Torsions, Utils
 
 
@@ -68,36 +67,36 @@ class TestCase(unittest.TestCase):
 
   def testGithub334(self):
     m1 = Chem.MolFromSmiles('N#C')
-    self.assertEqual(rdMD.GetNumPiElectrons(m1.GetAtomWithIdx(0)), 2)
-    self.assertEqual(rdMD.GetNumPiElectrons(m1.GetAtomWithIdx(1)), 2)
+    self.assertEqual(Chem.GetNumPiElectrons(m1.GetAtomWithIdx(0)), 2)
+    self.assertEqual(Chem.GetNumPiElectrons(m1.GetAtomWithIdx(1)), 2)
 
     m1 = Chem.MolFromSmiles('N#[CH]')
-    self.assertEqual(rdMD.GetNumPiElectrons(m1.GetAtomWithIdx(0)), 2)
-    self.assertEqual(rdMD.GetNumPiElectrons(m1.GetAtomWithIdx(1)), 2)
+    self.assertEqual(Chem.GetNumPiElectrons(m1.GetAtomWithIdx(0)), 2)
+    self.assertEqual(Chem.GetNumPiElectrons(m1.GetAtomWithIdx(1)), 2)
 
     m = Chem.MolFromSmiles('C=C')
-    self.assertEqual(rdMD.GetNumPiElectrons(m.GetAtomWithIdx(0)), 1)
+    self.assertEqual(Chem.GetNumPiElectrons(m.GetAtomWithIdx(0)), 1)
 
     m = Chem.MolFromSmiles('C#CC')
-    self.assertEqual(rdMD.GetNumPiElectrons(m.GetAtomWithIdx(0)), 2)
-    self.assertEqual(rdMD.GetNumPiElectrons(m.GetAtomWithIdx(1)), 2)
+    self.assertEqual(Chem.GetNumPiElectrons(m.GetAtomWithIdx(0)), 2)
+    self.assertEqual(Chem.GetNumPiElectrons(m.GetAtomWithIdx(1)), 2)
 
     m = Chem.MolFromSmiles('O=C=CC')
-    self.assertEqual(rdMD.GetNumPiElectrons(m.GetAtomWithIdx(0)), 1)
-    self.assertEqual(rdMD.GetNumPiElectrons(m.GetAtomWithIdx(1)), 2)
-    self.assertEqual(rdMD.GetNumPiElectrons(m.GetAtomWithIdx(2)), 1)
-    self.assertEqual(rdMD.GetNumPiElectrons(m.GetAtomWithIdx(3)), 0)
+    self.assertEqual(Chem.GetNumPiElectrons(m.GetAtomWithIdx(0)), 1)
+    self.assertEqual(Chem.GetNumPiElectrons(m.GetAtomWithIdx(1)), 2)
+    self.assertEqual(Chem.GetNumPiElectrons(m.GetAtomWithIdx(2)), 1)
+    self.assertEqual(Chem.GetNumPiElectrons(m.GetAtomWithIdx(3)), 0)
 
     m = Chem.MolFromSmiles('c1ccccc1')
-    self.assertEqual(rdMD.GetNumPiElectrons(m.GetAtomWithIdx(0)), 1)
+    self.assertEqual(Chem.GetNumPiElectrons(m.GetAtomWithIdx(0)), 1)
 
     # FIX: this behaves oddly in these cases:
 
     m = Chem.MolFromSmiles('S(=O)(=O)')
-    self.assertEqual(rdMD.GetNumPiElectrons(m.GetAtomWithIdx(0)), 2)
+    self.assertEqual(Chem.GetNumPiElectrons(m.GetAtomWithIdx(0)), 2)
 
     m = Chem.MolFromSmiles('S(=O)(=O)(O)O')
-    self.assertEqual(rdMD.GetNumPiElectrons(m.GetAtomWithIdx(0)), 0)
+    self.assertEqual(Chem.GetNumPiElectrons(m.GetAtomWithIdx(0)), 0)
 
 
 def debugFingerprint(mol, fpCalc, fpExpected):  # pragma: nocover

--- a/rdkit/Chem/AtomPairs/UnitTestDescriptors.py
+++ b/rdkit/Chem/AtomPairs/UnitTestDescriptors.py
@@ -16,6 +16,7 @@ import pickle
 import unittest
 
 from rdkit import Chem, RDConfig
+from rdkit.Chem import rdMolDescriptors as rdMD
 from rdkit.Chem.AtomPairs import Pairs, Sheridan, Torsions, Utils
 
 
@@ -67,12 +68,36 @@ class TestCase(unittest.TestCase):
 
   def testGithub334(self):
     m1 = Chem.MolFromSmiles('N#C')
-    self.assertEqual(Utils.NumPiElectrons(m1.GetAtomWithIdx(0)), 2)
-    self.assertEqual(Utils.NumPiElectrons(m1.GetAtomWithIdx(1)), 2)
+    self.assertEqual(rdMD.GetNumPiElectrons(m1.GetAtomWithIdx(0)), 2)
+    self.assertEqual(rdMD.GetNumPiElectrons(m1.GetAtomWithIdx(1)), 2)
 
     m1 = Chem.MolFromSmiles('N#[CH]')
-    self.assertEqual(Utils.NumPiElectrons(m1.GetAtomWithIdx(0)), 2)
-    self.assertEqual(Utils.NumPiElectrons(m1.GetAtomWithIdx(1)), 2)
+    self.assertEqual(rdMD.GetNumPiElectrons(m1.GetAtomWithIdx(0)), 2)
+    self.assertEqual(rdMD.GetNumPiElectrons(m1.GetAtomWithIdx(1)), 2)
+
+    m = Chem.MolFromSmiles('C=C')
+    self.assertEqual(rdMD.GetNumPiElectrons(m.GetAtomWithIdx(0)), 1)
+
+    m = Chem.MolFromSmiles('C#CC')
+    self.assertEqual(rdMD.GetNumPiElectrons(m.GetAtomWithIdx(0)), 2)
+    self.assertEqual(rdMD.GetNumPiElectrons(m.GetAtomWithIdx(1)), 2)
+
+    m = Chem.MolFromSmiles('O=C=CC')
+    self.assertEqual(rdMD.GetNumPiElectrons(m.GetAtomWithIdx(0)), 1)
+    self.assertEqual(rdMD.GetNumPiElectrons(m.GetAtomWithIdx(1)), 2)
+    self.assertEqual(rdMD.GetNumPiElectrons(m.GetAtomWithIdx(2)), 1)
+    self.assertEqual(rdMD.GetNumPiElectrons(m.GetAtomWithIdx(3)), 0)
+
+    m = Chem.MolFromSmiles('c1ccccc1')
+    self.assertEqual(rdMD.GetNumPiElectrons(m.GetAtomWithIdx(0)), 1)
+
+    # FIX: this behaves oddly in these cases:
+
+    m = Chem.MolFromSmiles('S(=O)(=O)')
+    self.assertEqual(rdMD.GetNumPiElectrons(m.GetAtomWithIdx(0)), 2)
+
+    m = Chem.MolFromSmiles('S(=O)(=O)(O)O')
+    self.assertEqual(rdMD.GetNumPiElectrons(m.GetAtomWithIdx(0)), 0)
 
 
 def debugFingerprint(mol, fpCalc, fpExpected):  # pragma: nocover

--- a/rdkit/Chem/AtomPairs/Utils.py
+++ b/rdkit/Chem/AtomPairs/Utils.py
@@ -9,6 +9,7 @@
 #
 
 import math
+import warnings
 
 from rdkit import Chem
 from rdkit.Chem import rdMolDescriptors
@@ -106,45 +107,12 @@ GetAtomCode = rdMolDescriptors.GetAtomPairAtomCode
 
 
 def NumPiElectrons(atom):
-  """ Returns the number of electrons an atom is using for pi bonding
+  """ DEPRECATED: please use rdMolDescriptors.GetNumPiElectrons instead.
+  """
 
-    >>> m = Chem.MolFromSmiles('C=C')
-    >>> NumPiElectrons(m.GetAtomWithIdx(0))
-    1
-
-    >>> m = Chem.MolFromSmiles('C#CC')
-    >>> NumPiElectrons(m.GetAtomWithIdx(0))
-    2
-    >>> NumPiElectrons(m.GetAtomWithIdx(1))
-    2
-
-    >>> m = Chem.MolFromSmiles('O=C=CC')
-    >>> NumPiElectrons(m.GetAtomWithIdx(0))
-    1
-    >>> NumPiElectrons(m.GetAtomWithIdx(1))
-    2
-    >>> NumPiElectrons(m.GetAtomWithIdx(2))
-    1
-    >>> NumPiElectrons(m.GetAtomWithIdx(3))
-    0
-
-    >>> m = Chem.MolFromSmiles('c1ccccc1')
-    >>> NumPiElectrons(m.GetAtomWithIdx(0))
-    1
-
-    FIX: this behaves oddly in these cases:
-
-    >>> m = Chem.MolFromSmiles('S(=O)(=O)')
-    >>> NumPiElectrons(m.GetAtomWithIdx(0))
-    2
-
-    >>> m = Chem.MolFromSmiles('S(=O)(=O)(O)O')
-    >>> NumPiElectrons(m.GetAtomWithIdx(0))
-    0
-
-    In the second case, the S atom is tagged as sp3 hybridized.
-
-    """
+  warnings.warn(
+    "The Chem.AtomPairs.Utils.NumPiElectrons is deprecated; please use rdMolDescriptors.GetNumPiElectrons instead.",
+    DeprecationWarning, stacklevel=2)
 
   res = 0
   if atom.GetIsAromatic():


### PR DESCRIPTION
Fixes #7318

Fortunately, we have a good replacement for `Chem.AtomPairs.Utils.NumPiElectrons` we just need to expose and wrap `RDKit::AtomPair::numPiElectrons`.

The small change in `Code/GraphMol/ConjugHybrid.cpp` also fixes the wrong hybridization I mentioned in the issue too.

