### PR TITLE
Remove misleading walrus operators

### DIFF
--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -7535,19 +7535,19 @@ CAS<~>
     with open(fileNoWedges, 'r') as inF:
       inNoWedges = inF.read()
 
-    m1 = Chem.MolFromMolBlock(inD, sanitize:=False, removeHs:=False, strictParsing:=True)
+    m1 = Chem.MolFromMolBlock(inD, sanitize=False, removeHs=False, strictParsing=True)
     self.assertTrue(m1 is not None)
     self.assertTrue(m1.GetNumAtoms() == 16)
     smi = Chem.MolToCXSmiles(m1)
     self.assertTrue(smi == inWedges)
 
-    m1 = Chem.MolFromMolFile(fileN, sanitize:=False, removeHs:=False, strictParsing:=True)
+    m1 = Chem.MolFromMolFile(fileN, sanitize=False, removeHs=False, strictParsing=True)
     self.assertTrue(m1 is not None)
     self.assertTrue(m1.GetNumAtoms() == 16)
     smi = Chem.MolToCXSmiles(m1)
     self.assertTrue(smi == inWedges)
 
-    m1 = Chem.MolFromMolBlock(inD, sanitize:=False, removeHs:=False, strictParsing:=True)
+    m1 = Chem.MolFromMolBlock(inD, sanitize=False, removeHs=False, strictParsing=True)
     Chem.RemoveNonExplicit3DChirality(m1)
 
     self.assertTrue(m1 is not None)
@@ -7555,7 +7555,7 @@ CAS<~>
     smi = Chem.MolToCXSmiles(m1)
     self.assertTrue(smi == inNoWedges)
 
-    m1 = Chem.MolFromMolFile(fileN, sanitize:=False, removeHs:=False, strictParsing:=True)
+    m1 = Chem.MolFromMolFile(fileN, sanitize=False, removeHs=False, strictParsing=True)
     Chem.RemoveNonExplicit3DChirality(m1)
 
     self.assertTrue(m1 is not None)
@@ -7580,7 +7580,7 @@ CAS<~>
       inNoWedges = inF.read()
 
 
-    m1 = Chem.MolFromMrvBlock(inD, sanitize:=False, removeHs:=False)
+    m1 = Chem.MolFromMrvBlock(inD, sanitize=False, removeHs=False)
 
     self.assertTrue(m1 is not None)
     self.assertTrue(m1.GetNumAtoms() == 16)
@@ -7588,14 +7588,14 @@ CAS<~>
     sys.stdout.flush()
     self.assertTrue(smi == inWedges)
 
-    m1 = Chem.MolFromMrvFile(fileN, sanitize:=False, removeHs:=False)
+    m1 = Chem.MolFromMrvFile(fileN, sanitize=False, removeHs=False)
 
     self.assertTrue(m1 is not None)
     self.assertTrue(m1.GetNumAtoms() == 16)
     smi = Chem.MolToCXSmiles(m1)
     self.assertTrue(smi == inWedges)
 
-    m1 = Chem.MolFromMrvBlock(inD, sanitize:=False, removeHs:=False)
+    m1 = Chem.MolFromMrvBlock(inD, sanitize=False, removeHs=False)
     Chem.RemoveNonExplicit3DChirality(m1)
 
     self.assertTrue(m1 is not None)
@@ -7603,7 +7603,7 @@ CAS<~>
     smi = Chem.MolToCXSmiles(m1)
     self.assertTrue(smi == inNoWedges)
 
-    m1 = Chem.MolFromMrvFile(fileN, sanitize:=False, removeHs:=False)
+    m1 = Chem.MolFromMrvFile(fileN, sanitize=False, removeHs=False)
     Chem.RemoveNonExplicit3DChirality(m1)
 
     self.assertTrue(m1 is not None)


### PR DESCRIPTION
#6903 added some instances of keyword arguments in Python function calls that are specified like `sanitize:=False`. I've never seen this done before and it looks like a mistake to me. It seems that these walrus expression assignments actually translate into positional arguments and (what looks like) keyword parameter names have no effect, e.g:

```
>>> def myfunc(arg1, arg2, arg3):
...     print(f"arg1: {arg1} arg2: {arg2} arg3: {arg3}")
...
>>> myfunc(arg3=3, arg1=1, arg2=2)
arg1: 1 arg2: 2 arg3: 3
>>> myfunc(arg3:=3, arg1:=1, arg2:=2)
arg1: 3 arg2: 1 arg3: 2
```

This was not obvious to me, and feels like a potential source of future bugs. Additionally, it breaks Python 3.7 compatibility (not sure if this is officially supported anymore, but it's the only instance of Python 3.8+ syntax that I'm aware of in RDKit).

This PR removes the colon characters to change the function calls to use regular keyword arguments.
