### PR TITLE
Make ctest run installed tests if RDK_INSTALL_PYTHON_TESTS

### DIFF
--- a/rdkit/CMakeLists.txt
+++ b/rdkit/CMakeLists.txt
@@ -13,6 +13,13 @@ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/RDPaths.py
   DESTINATION ${RDKit_PythonDir}
   COMPONENT python)
 
-add_pythonpytest(pythonSourceTests ${CMAKE_CURRENT_SOURCE_DIR} )
+if(NOT RDK_INSTALL_INTREE AND RDK_INSTALL_PYTHON_TESTS)
+  set(RDKit_PythonSourceTestsDir ${RDKit_PythonDir})
+else()
+  set(RDKit_PythonSourceTestsDir ${CMAKE_CURRENT_SOURCE_DIR})
+endif()
+
+add_pythonpytest(pythonSourceTests ${RDKit_PythonSourceTestsDir} )
+
 
 add_subdirectory(Chem)


### PR DESCRIPTION
To run the tests for a non-dev install (i.e. with `RDK_INSTALL_INTREE=OFF`) I previously used to do something like this: 

```shell
cmake -D RDK_INSTALL_INTREE=OFF -D CMAKE_INSTALL_PREFIX=$INSTALL_PREFIX [etc...]
make install
export RDBASE=$SRC_DIR
export PYTHONPATH=$INSTALL_PREFIX/lib/python3.10/site-packages
ctest --output-on-failure
```

This runs the tests out of the source directory, but all the RDKit Python imports and libraries are loaded from the installation. However, since the switch to using pytest test discovery in #5916, I see the following error for `pythonSourceTests`:

```
230/230 Test #230: pythonSourceTests ......................***Failed    0.88 sec
ImportError while loading conftest '$SRC_DIR/rdkit/conftest.py'.
__init__.py:6: in <module>
    from . import rdBase
E   ImportError: cannot import name 'rdBase' from 'rdkit' ($SRC_DIR/rdkit/__init__.py)
```

It looks like the problem comes from the use of `conftest.py`, which pytest imports as a module and therefore the top-level RDKit `__init__.py` in the source directory (not the installation) is also implicitly executed. And because `INTREE=OFF` there is no actual install there so it fails to find `rdBase` with the relative import.

I think the problem is pretty much inherent to storing all the test files inline with the source files - I guess it could be solved by moving the test files to their own separate `tests` directory hierarchy (or by finding a way to avoid using `conftest.py`). But keeping the current setup, the best solution I could think of is to also install all the test files (with `RDK_INSTALL_PYTHON_TESTS=ON`) and run the Python tests out of the installation rather than the source directory.

This can be done manually, but it's annoying that ctest reports a test failure for `pythonSourceTests`. So this PR just changes the behavior of ctest to run `pythonSourceTests` in the installation directory rather than the source directory, specifically for the case where `RDK_INSTALL_INTREE=OFF` and `RDK_INSTALL_PYTHON_TESTS=ON`.