### PR TITLE
Fixes #7327

### DIFF
--- a/Code/GraphMol/ChemTransforms/catch_tests.cpp
+++ b/Code/GraphMol/ChemTransforms/catch_tests.cpp
@@ -556,19 +556,15 @@ TEST_CASE("Molzip with 2D coordinates", "[molzip]") {
 }
 
 TEST_CASE("Molzip with split rings from rgroup", "[molzip]") {
-  std::vector<std::string> frags = {"[*:1]CC[*:2]",
-                                    "[*:1]NN[*:2]",
-				    "[*:1]NN[*:2]"
-  };
+  std::vector<std::string> frags = {"[*:1]CC[*:2]", "[*:1]NN[*:2]",
+                                    "[*:1]NN[*:2]"};
   std::vector<ROMOL_SPTR> mols;
-  for (auto smi: frags) {
+  for (auto smi : frags) {
     mols.push_back(ROMOL_SPTR(SmilesToMol(smi)));
   }
   const auto zippedMol = molzip(mols);
   CHECK(MolToSmiles(*zippedMol) == "C1CNN1");
 }
-  
-
 
 TEST_CASE("Github #6034: FragmentOnBonds may create unexpected radicals") {
   auto m = "C[C@H](Cl)c1ccccc1"_smiles;
@@ -595,4 +591,21 @@ TEST_CASE("Github #6034: FragmentOnBonds may create unexpected radicals") {
       CHECK(at->getTotalValence() == 4);
     }
   }
+}
+
+TEST_CASE(
+    "GitHub #7327: SaltRemover may clear computed properties even if no atoms are removed",
+    "[bug]") {
+  auto m = "C=CC=O"_smiles;
+  REQUIRE(m);
+  REQUIRE(m->getRingInfo()->isSymmSssr());
+
+  auto q = "[O,N]"_smarts;
+  REQUIRE(q);
+
+  bool onlyFrags = true;
+  std::unique_ptr<ROMol> m2{deleteSubstructs(*m, *q, onlyFrags)};
+  REQUIRE(m2);
+  CHECK(m2->getNumAtoms() == m->getNumAtoms());  // No atoms removed
+  CHECK(m2->getRingInfo()->isSymmSssr());
 }

--- a/rdkit/Chem/UnitTestSaltRemover.py
+++ b/rdkit/Chem/UnitTestSaltRemover.py
@@ -76,6 +76,22 @@ class TestCase(unittest.TestCase):
     res = saltstrip.StripMol(m, sanitize=False)
     self.assertEqual(Chem.MolToSmiles(res), 'CN1=CC=CC=C1')
 
+  def test_github_7327(self):
+    m = Chem.MolFromSmiles('C=CC=O')
+    assert m
+
+    saltstrip = SaltRemover()
+    m = saltstrip.StripMol(m)
+
+    # No atoms removed
+    assert m.GetNumAtoms() == 4
+
+    # Rotatable bond definition from mmpdb
+    q = Chem.MolFromSmarts('[!$([NH]!@C(=O))&!D1&!$(*#*)]-&!@[!$([NH]!@C(=O))&!D1&!$(*#*)]')
+    assert q
+
+    assert m.GetSubstructMatches(q) == ((1, 2), )
+
 
 if __name__ == '__main__':  # pragma: nocover
   unittest.main()


### PR DESCRIPTION
Fixes #7327

The fix is easy: the computed props are cleared in the call to `commitBatchEdit()`, so we just need to return before the batch edits if there's no atoms to delete.