### PR TITLE
Support writing CX extensions in reactions

### DIFF
--- a/Code/GraphMol/ChemReactions/ReactionWriter.cpp
+++ b/Code/GraphMol/ChemReactions/ReactionWriter.cpp
@@ -129,9 +129,6 @@ std::string chemicalReactionToRxnToString(
   res += ">";
   res +=
       chemicalReactionTemplatesToString(rxn, RDKit::Product, toSmiles, params);
-  res += ">";
-  res += chemicalReactionTemplatesToString(rxn, RDKit::Product, toSmiles,
-                                           canonical);
 
   if (params.includeCX) {
     // I think this will work? combine reactants, agents and products into a

--- a/Code/GraphMol/ChemReactions/catch_tests.cpp
+++ b/Code/GraphMol/ChemReactions/catch_tests.cpp
@@ -1102,8 +1102,9 @@ TEST_CASE("CXSMILES for reactions", "[cxsmiles]") {
         common_properties::atomLabel, alabel));
     CHECK(alabel == "_AP1");
 
-    bool includeCX = true;
-    auto roundtrip = v2::ReactionParser::ReactionFromSmarts(ChemicalReactionToRxnSmarts(*rxn, includeCX));
+    SmilesWriteParams ps;
+    ps.includeCX = true;
+    auto roundtrip = v2::ReactionParser::ReactionFromSmarts(ChemicalReactionToRxnSmarts(*rxn, ps));
     REQUIRE(roundtrip);
     CHECK(roundtrip->getReactants().size() == 2);
     CHECK(roundtrip->getReactants()[0]->getAtomWithIdx(3)->getPropIfPresent(
@@ -1127,8 +1128,9 @@ TEST_CASE("CXSMILES for reactions", "[cxsmiles]") {
         common_properties::atomLabel, alabel));
     CHECK(alabel == "_AP1");
 
-    bool includeCX = true;
-    auto roundtrip = v2::ReactionParser::ReactionFromSmarts(ChemicalReactionToRxnSmarts(*rxn, includeCX));
+    SmilesWriteParams ps;
+    ps.includeCX = true;
+    auto roundtrip = v2::ReactionParser::ReactionFromSmarts(ChemicalReactionToRxnSmarts(*rxn, ps));
     REQUIRE(roundtrip);
     CHECK(roundtrip->getReactants().size() == 2);
     CHECK(roundtrip->getReactants()[0]->getAtomWithIdx(3)->getPropIfPresent(
@@ -1152,8 +1154,9 @@ TEST_CASE("CXSMILES for reactions", "[cxsmiles]") {
         common_properties::atomLabel, alabel));
     CHECK(alabel == "_AP1");
 
-    bool includeCX = true;
-    auto roundtrip = v2::ReactionParser::ReactionFromSmarts(ChemicalReactionToRxnSmarts(*rxn, includeCX));
+    SmilesWriteParams ps;
+    ps.includeCX = true;
+    auto roundtrip = v2::ReactionParser::ReactionFromSmarts(ChemicalReactionToRxnSmarts(*rxn, ps));
     REQUIRE(roundtrip);
     CHECK(roundtrip->getReactants().size() == 2);
     CHECK(roundtrip->getReactants()[0]->getAtomWithIdx(3)->getPropIfPresent(
@@ -1198,8 +1201,9 @@ TEST_CASE("CXSMILES for reactions", "[cxsmiles]") {
     CHECK(getSubstanceGroups(*rxn->getReactants()[0]).size() == 2);
     CHECK(getSubstanceGroups(*rxn->getProducts()[0]).size() == 2);
 
-    bool includeCX = true;
-    auto roundtrip = v2::ReactionParser::ReactionFromSmarts(ChemicalReactionToRxnSmarts(*rxn, includeCX));
+    SmilesWriteParams ps;
+    ps.includeCX = true;
+    auto roundtrip = v2::ReactionParser::ReactionFromSmarts(ChemicalReactionToRxnSmarts(*rxn, ps));
     REQUIRE(roundtrip);
     CHECK(getSubstanceGroups(*roundtrip->getReactants()[0]).size() == 2);
     CHECK(getSubstanceGroups(*roundtrip->getProducts()[0]).size() == 2);
@@ -1262,8 +1266,9 @@ TEST_CASE("CXSMILES for reactions", "[cxsmiles]") {
     CHECK(rxn->getProducts()[0]->getBondWithIdx(1)->getStereo() ==
           Bond::BondStereo::STEREOCIS);
 
-    bool includeCX = true;
-    auto roundtrip = v2::ReactionParser::ReactionFromSmarts(ChemicalReactionToRxnSmarts(*rxn, includeCX));
+    SmilesWriteParams ps;
+    ps.includeCX = true;
+    auto roundtrip = v2::ReactionParser::ReactionFromSmarts(ChemicalReactionToRxnSmarts(*rxn, ps));
     REQUIRE(roundtrip);
     CHECK(roundtrip->getReactants().size() == 1);
     CHECK(roundtrip->getProducts().size() == 1);
@@ -1285,8 +1290,9 @@ TEST_CASE("CXSMILES for reactions", "[cxsmiles]") {
         "_MolFileBondCfg", bondcfg));
     CHECK(bondcfg == 2);
 
-    bool includeCX = true;
-    auto roundtrip = v2::ReactionParser::ReactionFromSmarts(ChemicalReactionToRxnSmarts(*rxn, includeCX));
+    SmilesWriteParams ps;
+    ps.includeCX = true;
+    auto roundtrip = v2::ReactionParser::ReactionFromSmarts(ChemicalReactionToRxnSmarts(*rxn, ps));
     REQUIRE(roundtrip);
     CHECK(roundtrip->getReactants().size() == 1);
     CHECK(roundtrip->getProducts().size() == 1);

--- a/Code/GraphMol/ChemReactions/catch_tests.cpp
+++ b/Code/GraphMol/ChemReactions/catch_tests.cpp
@@ -1101,6 +1101,17 @@ TEST_CASE("CXSMILES for reactions", "[cxsmiles]") {
     CHECK(rxn->getReactants()[1]->getAtomWithIdx(2)->getPropIfPresent(
         common_properties::atomLabel, alabel));
     CHECK(alabel == "_AP1");
+
+    bool includeCX = true;
+    auto roundtrip = v2::ReactionParser::ReactionFromSmarts(ChemicalReactionToRxnSmarts(*rxn, includeCX));
+    REQUIRE(roundtrip);
+    CHECK(roundtrip->getReactants().size() == 2);
+    CHECK(roundtrip->getReactants()[0]->getAtomWithIdx(3)->getPropIfPresent(
+        common_properties::atomLabel, alabel));
+    CHECK(alabel == "_AP1");
+    CHECK(roundtrip->getReactants()[1]->getAtomWithIdx(2)->getPropIfPresent(
+        common_properties::atomLabel, alabel));
+    CHECK(alabel == "_AP1");
   }
   SECTION("basics with agents") {
     // clang-format off
@@ -1115,6 +1126,17 @@ TEST_CASE("CXSMILES for reactions", "[cxsmiles]") {
     CHECK(rxn->getReactants()[1]->getAtomWithIdx(2)->getPropIfPresent(
         common_properties::atomLabel, alabel));
     CHECK(alabel == "_AP1");
+
+    bool includeCX = true;
+    auto roundtrip = v2::ReactionParser::ReactionFromSmarts(ChemicalReactionToRxnSmarts(*rxn, includeCX));
+    REQUIRE(roundtrip);
+    CHECK(roundtrip->getReactants().size() == 2);
+    CHECK(roundtrip->getReactants()[0]->getAtomWithIdx(3)->getPropIfPresent(
+        common_properties::atomLabel, alabel));
+    CHECK(alabel == "_AP1");
+    CHECK(roundtrip->getReactants()[1]->getAtomWithIdx(2)->getPropIfPresent(
+        common_properties::atomLabel, alabel));
+    CHECK(alabel == "_AP1");
   }
   SECTION("missing products") {
     // clang-format off
@@ -1127,6 +1149,17 @@ TEST_CASE("CXSMILES for reactions", "[cxsmiles]") {
         common_properties::atomLabel, alabel));
     CHECK(alabel == "_AP1");
     CHECK(rxn->getReactants()[1]->getAtomWithIdx(2)->getPropIfPresent(
+        common_properties::atomLabel, alabel));
+    CHECK(alabel == "_AP1");
+
+    bool includeCX = true;
+    auto roundtrip = v2::ReactionParser::ReactionFromSmarts(ChemicalReactionToRxnSmarts(*rxn, includeCX));
+    REQUIRE(roundtrip);
+    CHECK(roundtrip->getReactants().size() == 2);
+    CHECK(roundtrip->getReactants()[0]->getAtomWithIdx(3)->getPropIfPresent(
+        common_properties::atomLabel, alabel));
+    CHECK(alabel == "_AP1");
+    CHECK(roundtrip->getReactants()[1]->getAtomWithIdx(2)->getPropIfPresent(
         common_properties::atomLabel, alabel));
     CHECK(alabel == "_AP1");
   }
@@ -1164,6 +1197,12 @@ TEST_CASE("CXSMILES for reactions", "[cxsmiles]") {
     REQUIRE(rxn);
     CHECK(getSubstanceGroups(*rxn->getReactants()[0]).size() == 2);
     CHECK(getSubstanceGroups(*rxn->getProducts()[0]).size() == 2);
+
+    bool includeCX = true;
+    auto roundtrip = v2::ReactionParser::ReactionFromSmarts(ChemicalReactionToRxnSmarts(*rxn, includeCX));
+    REQUIRE(roundtrip);
+    CHECK(getSubstanceGroups(*roundtrip->getReactants()[0]).size() == 2);
+    CHECK(getSubstanceGroups(*roundtrip->getProducts()[0]).size() == 2);
   }
   SECTION("link nodes") {
     // clang-format off
@@ -1222,6 +1261,16 @@ TEST_CASE("CXSMILES for reactions", "[cxsmiles]") {
           Bond::BondStereo::STEREOCIS);
     CHECK(rxn->getProducts()[0]->getBondWithIdx(1)->getStereo() ==
           Bond::BondStereo::STEREOCIS);
+
+    bool includeCX = true;
+    auto roundtrip = v2::ReactionParser::ReactionFromSmarts(ChemicalReactionToRxnSmarts(*rxn, includeCX));
+    REQUIRE(roundtrip);
+    CHECK(roundtrip->getReactants().size() == 1);
+    CHECK(roundtrip->getProducts().size() == 1);
+    CHECK(roundtrip->getReactants()[0]->getBondWithIdx(1)->getStereo() ==
+          Bond::BondStereo::STEREOCIS);
+    CHECK(roundtrip->getProducts()[0]->getBondWithIdx(1)->getStereo() ==
+          Bond::BondStereo::STEREOCIS);
   }
   SECTION("wedged bonds") {
     auto rxn = "CC(O)(F)Cl>>CC(N)(F)Cl |w:1.0,6.5|"_rxnsmiles;
@@ -1233,6 +1282,19 @@ TEST_CASE("CXSMILES for reactions", "[cxsmiles]") {
         "_MolFileBondCfg", bondcfg));
     CHECK(bondcfg == 2);
     CHECK(rxn->getProducts()[0]->getBondWithIdx(1)->getPropIfPresent(
+        "_MolFileBondCfg", bondcfg));
+    CHECK(bondcfg == 2);
+
+    bool includeCX = true;
+    auto roundtrip = v2::ReactionParser::ReactionFromSmarts(ChemicalReactionToRxnSmarts(*rxn, includeCX));
+    REQUIRE(roundtrip);
+    CHECK(roundtrip->getReactants().size() == 1);
+    CHECK(roundtrip->getProducts().size() == 1);
+    bondcfg = 0;
+    CHECK(roundtrip->getReactants()[0]->getBondWithIdx(0)->getPropIfPresent(
+        "_MolFileBondCfg", bondcfg));
+    CHECK(bondcfg == 2);
+    CHECK(roundtrip->getProducts()[0]->getBondWithIdx(1)->getPropIfPresent(
         "_MolFileBondCfg", bondcfg));
     CHECK(bondcfg == 2);
   }

--- a/Code/GraphMol/ChemReactions/testing.py
+++ b/Code/GraphMol/ChemReactions/testing.py
@@ -1,0 +1,36 @@
+from rdkit import Chem
+
+from rdkit.Chem import rdChemReactions
+
+smarts = "[CH3:1][CH:2]([CH3:3])[*:4].[OH:5][CH2:6][*:7]>O=C=O>[CH3:1][CH:2]([CH3:3])[CH2:6][OH:5] |$;;;_AP1;;;_AP1;;;;;;;;$|"
+smarts = "[OH:5][CH2:6][*:7].[CH3:1][CH:2]([CH3:3])[*:4]>O=C=O>[CH3:1][CH:2]([CH3:3])[CH2:6][OH:5] |$;;;_AP1;;;_AP1;;;;;;;;$|"
+smarts = "[Na].[Cl]>>[Na+].[Cl-]"
+smarts = "[CH3:1][CH:2]([CH3:3])[*:4].[Fe:8][OH:5][CH2:6][*:7]>>[Fe:8][OH:5][CH2:6][CH2:1][CH:2]([CH3:3])[*:4] |$;;;_AP1;;;;_AP1;;;;;;;_AP1$,C:5.3,9.6,SgD:6:foo:bar::::,SgD:10:bar:baz::::|"
+# [C&H3:1][C&H1:2]([C&H3:3])[*:4].[O&H1:5][C&H2:6][*:7]>O=C=O>[C&H3:1][C&H1:2]([C&H3:3])[C&H2:6][O&H1|$;;;_AP1;;;_AP1;;;;;;;;$|
+# smarts = "CO.OC1CCC(F)C1>>COC1CC(O)CC1F |LN:3:1.3.4.8,13:2.5.12.15|"
+
+smarts = "[CH3:6][O:5][CH:3](-*)[O:2]-*>>[CH3:6][NH:5][CH:3](-*)[O:2]-* |$;;;star_e;;star_e;;;;star_e;;star_e$,SgD:1,0:foo:bar::::,SgD:7,6:foo:baz::::,Sg:n:4,2,1,0::ht,Sg:n:10,8,7,6::ht,SgH:2:0,3:1|"
+# smarts = "[C&H3:6][O:5][C&H1:3](-*)[O:2]-*>>[C&H3:6][N&H1:5             |$;;;star_e;;star_e;;;;star_e;;star_e$,SgD:1,0:foo:bar::::,SgD:7,6:foo:baz::::,Sg:n:4,2,1,0::ht,Sg:n:10,8,7,6::ht:::,SgH:3:1.1|"
+rxn = rdChemReactions.ReactionFromSmarts(smarts)
+
+for m in rxn.GetReactants():
+    print("Reactant:")
+    for at in m.GetAtoms():
+        print("\t", at.GetPropsAsDict())
+    print()
+
+for m in rxn.GetAgents():
+    print("Agent:")
+    for at in m.GetAtoms():
+        print("\t", at.GetPropsAsDict())
+    print()
+
+for m in rxn.GetProducts():
+    print("Product:")
+    for at in m.GetAtoms():
+        print("\t", at.GetPropsAsDict())
+    print()
+
+# print(rdChemReactions.ReactionToSmarts(rxn))
+# print(rdChemReactions.ReactionToSmarts(rxn, includeCX=True))
+print(rdChemReactions.ReactionToSmarts(rxn, includeCX=True))

--- a/Code/GraphMol/SmilesParse/SmilesWrite.h
+++ b/Code/GraphMol/SmilesParse/SmilesWrite.h
@@ -41,6 +41,7 @@ struct RDKIT_SMILESPARSE_EXPORT SmilesWriteParams {
                bonds will be written as single bonds*/
   bool ignoreAtomMapNumbers = false; /**< If true, ignores any atom map numbers
                                         when canonicalizing the molecule */
+  bool includeCX = false; /**< include CXSMILES extensions in reactions */
 };
 
 namespace SmilesWrite {


### PR DESCRIPTION
We are hoping to get support for writing CX extensions when writing to reaction SMILES/SMARTS. This is just a draft, I wanted to see if we think this would work. At the very least it would be nice to be able to read/write atom labels and stereo information.

Currently, there are a few things that aren’t supported
* Link nodes
* Coordinate bonds
* Writing to CX smiles (worried about atom/fragment reordering?)

I’m also a little confused about the substance group writing — it seems like the atoms are correct, however there are some extra commas and colons written compared to the input. RDKit seems to parse this correctly but I'm not sure if this is expected/a problem? For example:

```
Input SMARTS: [CH3:6][O:5][CH:3](-*)[O:2]-*>>[CH3:6][NH:5][CH:3](-*)[O:2]-* |$;;;star_e;;star_e;;;;star_e;;star_e$,SgD:1,0:foo:bar::::,SgD:7,6:foo:baz::::,Sg:n:4,2,1,0::ht,Sg:n:10,8,7,6::ht,SgH:2:0,3:1|

Roundtrip output SMARTS: [C&H3:6][O:5][C&H1:3](-*)[O:2]-*>>[C&H3:6][N&H1:5][C&H1:3](-*)[O:2]-* |$;;;star_e;;star_e;;;;star_e;;star_e$,SgD:1,0:foo:bar::::,,SgD:7,6:foo:baz::::,,,Sg:n:4,2,1,0::ht:::,,Sg:n:10,8,7,6::ht:::,SgH:3:1.1|
```

If this seems like a reasonable approach, I can try to extend this to work for SMILES as well.
