### PR TITLE
Add option for RASCAL to restrict atom matching to atoms of same degree

### DIFF
--- a/Code/GraphMol/RascalMCES/RascalMCES.cpp
+++ b/Code/GraphMol/RascalMCES/RascalMCES.cpp
@@ -19,7 +19,6 @@
 #include <iostream>
 #include <map>
 #include <regex>
-#include <set>
 #include <stdexcept>
 #include <unordered_set>
 #include <vector>
@@ -117,11 +116,14 @@ void sortedDegreeSeqs(
 }
 
 // Make labels for the atoms - by default the atomic symbol.
-void getAtomLabels(const ROMol &mol, const RascalOptions & /* opts */,
+void getAtomLabels(const ROMol &mol, const RascalOptions &opts,
                    std::vector<std::string> &atomLabels) {
   atomLabels.resize(mol.getNumAtoms());
   for (const auto &a : mol.atoms()) {
     std::string label = a->getSymbol();
+    if (opts.exactConnectionsMatch) {
+      label += "X" + std::to_string(a->getDegree());
+    }
     atomLabels[a->getIdx()] = label;
   }
 }
@@ -1063,7 +1065,7 @@ std::vector<RascalResult> findMCES(RascalStartPoint &starter,
                      starter.d_adjMatrix2, c, starter.d_vtxPairs, timedOut,
                      starter.d_swapped, starter.d_tier1Sim, starter.d_tier2Sim,
                      opts.ringMatchesRingOnly, opts.singleLargestFrag,
-                     opts.maxFragSeparation));
+                     opts.maxFragSeparation, opts.exactConnectionsMatch));
   }
   std::sort(results.begin(), results.end(), details::resultCompare);
   return results;

--- a/Code/GraphMol/RascalMCES/RascalOptions.h
+++ b/Code/GraphMol/RascalMCES/RascalOptions.h
@@ -23,6 +23,10 @@ struct RDKIT_RASCALMCES_EXPORT RascalOptions {
       true;  // if true, partial aromatic rings won't be returned
   bool ringMatchesRingOnly =
       false;  // if true, ring bonds won't match non-ring bonds
+  bool exactConnectionsMatch =
+      false; /* if true, atoms will only match atoms if they have the same
+                number of explicit connections.  E.g. the central atom of
+                C(C)(C) won't match either atom in CC */
   bool singleLargestFrag =
       false; /* if true, only return a single fragment for the MCES. Default
                 is to produce multiple matching fragments if necessary. */

--- a/Code/GraphMol/RascalMCES/RascalResult.cpp
+++ b/Code/GraphMol/RascalMCES/RascalResult.cpp
@@ -34,12 +34,14 @@ RascalResult::RascalResult(const RDKit::ROMol &mol1, const RDKit::ROMol &mol2,
                            const std::vector<std::pair<int, int>> &vtx_pairs,
                            bool timedOut, bool swapped, double tier1Sim,
                            double tier2Sim, bool ringMatchesRingOnly,
-                           bool singleLargestFrag, int maxFragSep)
+                           bool singleLargestFrag, int maxFragSep,
+                           bool exactConnectionsMatch)
     : d_timedOut(timedOut),
       d_tier1Sim(tier1Sim),
       d_tier2Sim(tier2Sim),
       d_ringMatchesRingOnly(ringMatchesRingOnly),
-      d_maxFragSep(maxFragSep) {
+      d_maxFragSep(maxFragSep),
+      d_exactConnectionsMatch(exactConnectionsMatch) {
   const std::vector<std::vector<int>> *mol1AdjMatrix;
   if (swapped) {
     d_mol1.reset(new RDKit::ROMol(mol2));
@@ -226,6 +228,10 @@ std::string RascalResult::createSmartsString() const {
         mol1Rings->numAtomRings(mol1Atom->getIdx()) &&
         mol2Rings->numAtomRings(mol2Atom->getIdx())) {
       a.expandQuery(RDKit::makeAtomInRingQuery(), Queries::COMPOSITE_AND, true);
+    }
+    if (d_exactConnectionsMatch) {
+      a.expandQuery(RDKit::makeAtomExplicitDegreeQuery(mol1Atom->getDegree()),
+                    Queries::COMPOSITE_AND, true);
     }
     auto ai = smartsMol.addAtom(&a);
     atomMap.insert(std::make_pair(am.first, ai));

--- a/Code/GraphMol/RascalMCES/RascalResult.h
+++ b/Code/GraphMol/RascalMCES/RascalResult.h
@@ -33,8 +33,8 @@ class RDKIT_RASCALMCES_EXPORT RascalResult {
                const std::vector<unsigned int> &clique,
                const std::vector<std::pair<int, int>> &vtx_pairs, bool timedOut,
                bool swapped, double tier1Sim, double tier2Sim,
-               bool ringMatchesRingOnly, bool singleLargestFrag,
-               int minFragSep);
+               bool ringMatchesRingOnly, bool singleLargestFrag, int minFragSep,
+               bool exactConnectionsMatch = false);
   // For when the tier[12]Sim didn't hit the threshold, but it
   // might be of interest what the estimates of similarity were.
   RascalResult(double tier1Sim, double tier2Sim);
@@ -111,6 +111,7 @@ class RDKIT_RASCALMCES_EXPORT RascalResult {
   double d_tier2Sim;
   bool d_ringMatchesRingOnly{false};
   int d_maxFragSep{-1};
+  bool d_exactConnectionsMatch{false};
 
   // These are used for sorting the results.
   mutable int d_numFrags{-1};

--- a/Code/GraphMol/RascalMCES/Wrap/rdRascalMCES.cpp
+++ b/Code/GraphMol/RascalMCES/Wrap/rdRascalMCES.cpp
@@ -177,6 +177,12 @@ BOOST_PYTHON_MODULE(rdRascalMCES) {
                      &RDKit::RascalMCES::RascalOptions::ringMatchesRingOnly,
                      "If True (default), ring bonds won't match ring bonds.")
       .def_readwrite(
+          "exactConnectionsMatch",
+          &RDKit::RascalMCES::RascalOptions::exactConnectionsMatch,
+          "If True (default is False), atoms will only match atoms if they have the same\n"
+          " number of explicit connections.  E.g. the central atom of\n"
+          " C(C)(C) won't match either atom in CC")
+      .def_readwrite(
           "minFragSize", &RDKit::RascalMCES::RascalOptions::minFragSize,
           "Imposes a minimum on the number of atoms in a fragment that may be part of the MCES.  Default -1 means no minimum.")
       .def_readwrite(

--- a/Code/GraphMol/RascalMCES/Wrap/testRascalMCES.py
+++ b/Code/GraphMol/RascalMCES/Wrap/testRascalMCES.py
@@ -165,15 +165,19 @@ class TestCase(unittest.TestCase):
 
   def testExactConnectionsMatch(self):
     opts = rdRascalMCES.RascalOptions()
-    mol1 = Chem.MolFromSmiles('c1ccccc1C(C)C')
-    mol2 = Chem.MolFromSmiles('c1ccccc1CCC')
+    opts.similarityThreshold = 0.5
+    opts.allBestMCESs = True
+    mol1 = Chem.MolFromSmiles('c1ccccc1C1CCC(C(C)C)C1')
+    mol2 = Chem.MolFromSmiles('c1ccccc1C(C)C')
     results = rdRascalMCES.FindMCES(mol1, mol2, opts)
-    self.assertEqual(results[0].numFragments, 2)
+    self.assertEqual(results[0].numFragments, 1)
+    self.assertEqual(results[0].smartsString, 'c1:c:c:c:c:c:1-C(-C)-C')
 
     opts.exactConnectionsMatch = True
     results = rdRascalMCES.FindMCES(mol1, mol2, opts)
-    self.assertEqual(results[0].numFragments, 1)
-
+    self.assertEqual(results[0].numFragments, 2)
+    self.assertEqual(results[0].smartsString,
+                     '[#6&a&D2]1:[#6&a&D2]:[#6&a&D2]:[#6&a&D2]:[#6&a&D2]:[#6&a&D3]:1.[#6&A&D3](-[#6&A&D1])-[#6&A&D1]')
 
 
 if __name__ == "__main__":

--- a/Code/GraphMol/RascalMCES/Wrap/testRascalMCES.py
+++ b/Code/GraphMol/RascalMCES/Wrap/testRascalMCES.py
@@ -163,6 +163,18 @@ class TestCase(unittest.TestCase):
     results = rdRascalMCES.FindMCES(too_long_1, too_long_2, opts)
     self.assertEqual(len(results[0].bondMatches()), 26)
 
+  def testExactConnectionsMatch(self):
+    opts = rdRascalMCES.RascalOptions()
+    mol1 = Chem.MolFromSmiles('c1ccccc1C(C)C')
+    mol2 = Chem.MolFromSmiles('c1ccccc1CCC')
+    results = rdRascalMCES.FindMCES(mol1, mol2, opts)
+    self.assertEqual(results[0].numFragments, 2)
+
+    opts.exactConnectionsMatch = True
+    results = rdRascalMCES.FindMCES(mol1, mol2, opts)
+    self.assertEqual(results[0].numFragments, 1)
+
+
 
 if __name__ == "__main__":
   unittest.main()

--- a/Code/GraphMol/RascalMCES/mces_catch.cpp
+++ b/Code/GraphMol/RascalMCES/mces_catch.cpp
@@ -1207,3 +1207,24 @@ TEST_CASE("Trim small frags") {
   REQUIRE(res.front().getNumFrags() == 2);
   REQUIRE(res.front().getSmarts() == "CCCC(=O)-NCCC-[#6].Cc1:c:c:c:c:c:1");
 }
+
+TEST_CASE("Exact Connection Matches", "[basics]") {
+  {
+    auto m1 = "c1ccccc1CC(=O)C(N)N"_smiles;
+    REQUIRE(m1);
+    auto m2 = "c1ccccc1CC(=O)C2NCC(CN2)C(=O)C(N)N"_smiles;
+    REQUIRE(m2);
+
+    RascalOptions opts;
+    opts.similarityThreshold = 0.5;
+    auto res1 = rascalMCES(*m1, *m2, opts);
+    CHECK(res1.front().getNumFrags() == 1);
+    CHECK(res1.front().getSmarts() == "c1:c:c:c:c:c:1-CC(=O)-C(-N)-N");
+    opts.exactConnectionsMatch = true;
+    auto res2 = rascalMCES(*m1, *m2, opts);
+    CHECK(res2.front().getNumFrags() == 2);
+    CHECK(res2.front().getSmarts() ==
+          "[#6&a&D2]1:[#6&a&D2]:[#6&a&D2]:[#6&a&D2]:[#6&a&D2]:[#6&a&D3]:1"
+          "-[#6&A&D2]-[#6&A&D3]=[#8&A&D1].[#6&A&D3](-[#7&A&D1])-[#7&A&D1]");
+  }
+}


### PR DESCRIPTION
#### Reference Issue
No issue

#### What does this implement/fix? Explain your changes.
Consider the pair of molecules
![image](https://github.com/rdkit/rdkit/assets/9198870/0f3e8130-9b47-49c1-a38f-7aabf6ba150b)
The default RASCAL options give rise to 2 distinct MCESs, with the 2 different amide moieties matching, as in:
![image](https://github.com/rdkit/rdkit/assets/9198870/4f0005c7-f8f0-4491-a9f6-d7290600a9fd)
They don't both match at the same time, obviously.
Sometimes, for example when looking for pairs of molecules that differ only by a linking group, that's a bit too permissive.  This option only allows atoms to match if they have the same degree (i.e. same number of explicit connections).  In this case the SMARTS returned is
```
[#6&a&D2]1:[#6&a&D2]:[#6&a&D2]:[#6&a&D2]:[#6&a&D2]:[#6&a&D3]:1.[#6&A&D3](=[#8&A&D1])-[#6&A&D3](-[#7&A&D1])-[#7&A&D1]
```
which gives the single match:
![image](https://github.com/rdkit/rdkit/assets/9198870/0c0848e0-9dc6-46b7-8718-858104e183e4)


#### Any other comments?

