### PR TITLE
Rascal exactConnectionsMatch bug

### DIFF
--- a/Code/GraphMol/RascalMCES/RascalMCES.cpp
+++ b/Code/GraphMol/RascalMCES/RascalMCES.cpp
@@ -255,14 +255,26 @@ void getBondLabels(const ROMol &mol, const RascalOptions &opts,
   getAtomLabels(mol, opts, atomLabels);
   bondLabels = std::vector<std::string>(mol.getNumBonds());
   for (const auto &b : mol.bonds()) {
-    if (b->getBeginAtom()->getAtomicNum() < b->getEndAtom()->getAtomicNum()) {
-      bondLabels[b->getIdx()] = atomLabels[b->getBeginAtomIdx()] +
-                                std::to_string(b->getBondType()) +
-                                atomLabels[b->getEndAtomIdx()];
+    if (b->getBeginAtom()->getAtomicNum() == b->getEndAtom()->getAtomicNum()) {
+      if (b->getEndAtom()->getDegree() < b->getBeginAtom()->getDegree()) {
+        bondLabels[b->getIdx()] = atomLabels[b->getEndAtomIdx()] +
+                                  std::to_string(b->getBondType()) +
+                                  atomLabels[b->getBeginAtomIdx()];
+      } else {
+        bondLabels[b->getIdx()] = atomLabels[b->getBeginAtomIdx()] +
+                                  std::to_string(b->getBondType()) +
+                                  atomLabels[b->getEndAtomIdx()];
+      }
     } else {
-      bondLabels[b->getIdx()] = atomLabels[b->getEndAtomIdx()] +
-                                std::to_string(b->getBondType()) +
-                                atomLabels[b->getBeginAtomIdx()];
+      if (b->getBeginAtom()->getAtomicNum() < b->getEndAtom()->getAtomicNum()) {
+        bondLabels[b->getIdx()] = atomLabels[b->getBeginAtomIdx()] +
+                                  std::to_string(b->getBondType()) +
+                                  atomLabels[b->getEndAtomIdx()];
+      } else {
+        bondLabels[b->getIdx()] = atomLabels[b->getEndAtomIdx()] +
+                                  std::to_string(b->getBondType()) +
+                                  atomLabels[b->getBeginAtomIdx()];
+      }
     }
   }
 }

--- a/Code/GraphMol/SmilesParse/SmilesWrite.h
+++ b/Code/GraphMol/SmilesParse/SmilesWrite.h
@@ -103,7 +103,7 @@ RDKIT_SMILESPARSE_EXPORT std::string MolToSmiles(
 RDKIT_SMILESPARSE_EXPORT std::string MolToSmiles(
     const ROMol &mol, const SmilesWriteParams &params);
 
-//! \brief returns canonical SMILES for a molecule
+//! \brief returns SMILES for a molecule, canonical by default
 /*!
   \param mol : the molecule in question.
   \param doIsomericSmiles : include stereochemistry and isotope information
@@ -119,6 +119,8 @@ RDKIT_SMILESPARSE_EXPORT std::string MolToSmiles(
   \param allBondsExplicit : if true, symbols will be included for all bonds.
   \param allHsExplicit : if true, hydrogen counts will be provided for every
   atom.
+  \param doRandom : if true, the first atom in the SMILES string will be
+  selected at random and the SMILES string will not be canonical
  */
 inline std::string MolToSmiles(const ROMol &mol, bool doIsomericSmiles = true,
                                bool doKekule = false, int rootedAtAtom = -1,


### PR DESCRIPTION
#### Reference Issue
No issue.

#### What does this implement/fix? Explain your changes.
Further testing of the new exactConnectionsMatch option for RASCAL revealed that the MCES sometimes gave incomplete results with different atom orders of the same molecule.

#### Any other comments?
I have also updated the docstring for the C++ MolToSmiles function as it was incomplete.
