### PR TITLE
fixes bug with overly large count_bounds

### DIFF
--- a/Code/GraphMol/Fingerprints/FingerprintGenerator.cpp
+++ b/Code/GraphMol/Fingerprints/FingerprintGenerator.cpp
@@ -400,6 +400,14 @@ FingerprintGenerator<OutputType>::getFingerprint(
     const ROMol &mol, FingerprintFuncArguments &args) const {
   std::uint32_t effectiveSize = dp_fingerprintArguments->d_fpSize;
   if (dp_fingerprintArguments->df_countSimulation) {
+    if (dp_fingerprintArguments->d_countBounds.empty()) {
+      throw ValueErrorException("Count bounds are empty");
+    }
+
+    if (dp_fingerprintArguments->d_countBounds.size() >= effectiveSize) {
+      throw ValueErrorException("Count bounds size is >= fingerprint size");
+    }
+
     // effective size needs to be smaller than result size to compensate for
     // count simulation
     effectiveSize /= dp_fingerprintArguments->d_countBounds.size();

--- a/Code/GraphMol/Fingerprints/fpgen_catch_tests.cpp
+++ b/Code/GraphMol/Fingerprints/fpgen_catch_tests.cpp
@@ -337,3 +337,35 @@ TEST_CASE("multithreaded fp generation") {
 #endif
   }
 }
+
+TEST_CASE("countBounds edge cases") {
+  auto mol = "CC"_smiles;
+  REQUIRE(mol);
+  SECTION("just zeros") {
+    std::unique_ptr<FingerprintGenerator<std::uint64_t>> fpGenerator(
+        MorganFingerprint::getMorganGenerator<std::uint64_t>(2));
+    REQUIRE(fpGenerator);
+    fpGenerator->getOptions()->df_countSimulation = true;
+    fpGenerator->getOptions()->d_countBounds = {0, 0, 0, 0};
+    std::unique_ptr<ExplicitBitVect> fp(fpGenerator->getFingerprint(*mol));
+    REQUIRE(fp);
+    CHECK(fp->getNumBits() == 2048);
+  }
+  SECTION("empty bounds") {
+    std::unique_ptr<FingerprintGenerator<std::uint64_t>> fpGenerator(
+        MorganFingerprint::getMorganGenerator<std::uint64_t>(2));
+    REQUIRE(fpGenerator);
+    fpGenerator->getOptions()->df_countSimulation = true;
+    fpGenerator->getOptions()->d_countBounds.clear();
+    REQUIRE_THROWS_AS(fpGenerator->getFingerprint(*mol), ValueErrorException);
+  }
+  SECTION("really big") {
+    std::unique_ptr<FingerprintGenerator<std::uint64_t>> fpGenerator(
+        MorganFingerprint::getMorganGenerator<std::uint64_t>(2));
+    REQUIRE(fpGenerator);
+    fpGenerator->getOptions()->df_countSimulation = true;
+    fpGenerator->getOptions()->d_countBounds =
+        std::vector<unsigned int>((1 << 11) + 1, 0);
+    REQUIRE_THROWS_AS(fpGenerator->getFingerprint(*mol), ValueErrorException);
+  }
+}


### PR DESCRIPTION
bug found by Andrew Dalke

This prevents the problem by raising a ValueError if the number of count bounds exceeds the number of bits in the FP.
