### PR TITLE
Fixes #7378, raw docstring to escape null chars

### DIFF
--- a/rdkit/Chem/Draw/__init__.py
+++ b/rdkit/Chem/Draw/__init__.py
@@ -675,7 +675,7 @@ def _MolsNestedToLinear(molsMatrix, legendsMatrix=None, highlightAtomListsMatrix
 def MolsMatrixToGridImage(molsMatrix, subImgSize=(200, 200), legendsMatrix=None,
                           highlightAtomListsMatrix=None, highlightBondListsMatrix=None,
                           useSVG=False, returnPNG=False, **kwargs):
-  """Creates a mol grid image from a nested data structure (where each data substructure represents a row),
+  r"""Creates a mol grid image from a nested data structure (where each data substructure represents a row),
   padding rows as needed so all rows are the length of the longest row
           ARGUMENTS:
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! 
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->
Fixes #7378, by setting the docstring to be `r`aw, which escapes the escapes.


#### What does this implement/fix? Explain your changes.
The `\x00` characters in the un-raw docstring originally get interpreted as null bytes, while the docstring means for this to be an example. By making the docstring raw, this keeps the desired formatting and does not insert null (or other control) bytes into the file.


#### Any other comments?

