### PR TITLE
Expose replaceAtomWithQueryAtom to Python

### DIFF
--- a/Code/GraphMol/QueryOps.h
+++ b/Code/GraphMol/QueryOps.h
@@ -598,7 +598,8 @@ RDKIT_GRAPHMOL_EXPORT ATOM_OR_QUERY *makeMHAtomQuery();
 // CXSMILES
 const std::vector<std::string> complexQueries = {"A", "AH", "Q", "QH",
                                                  "X", "XH", "M", "MH"};
-RDKIT_GRAPHMOL_EXPORT void convertComplexNameToQuery(Atom *query, std::string_view symb);
+RDKIT_GRAPHMOL_EXPORT void convertComplexNameToQuery(Atom *query,
+                                                     std::string_view symb);
 
 //! returns a Query for matching atoms that have ring bonds
 template <class T>
@@ -1099,6 +1100,8 @@ inline bool isAtomDummy(const Atom *a) {
 namespace QueryOps {
 RDKIT_GRAPHMOL_EXPORT void completeMolQueries(
     RWMol *mol, unsigned int magicVal = 0xDEADBEEF);
+// Replaces the given atom in the molecule with a QueryAtom that is otherwise
+// a copy of the given atom.  Returns a pointer to that atom.
 RDKIT_GRAPHMOL_EXPORT Atom *replaceAtomWithQueryAtom(RWMol *mol, Atom *atom);
 
 RDKIT_GRAPHMOL_EXPORT void finalizeQueryFromDescription(

--- a/Code/GraphMol/QueryOps.h
+++ b/Code/GraphMol/QueryOps.h
@@ -1102,6 +1102,7 @@ RDKIT_GRAPHMOL_EXPORT void completeMolQueries(
     RWMol *mol, unsigned int magicVal = 0xDEADBEEF);
 // Replaces the given atom in the molecule with a QueryAtom that is otherwise
 // a copy of the given atom.  Returns a pointer to that atom.
+// if the atom already has a query, nothing will be changed
 RDKIT_GRAPHMOL_EXPORT Atom *replaceAtomWithQueryAtom(RWMol *mol, Atom *atom);
 
 RDKIT_GRAPHMOL_EXPORT void finalizeQueryFromDescription(

--- a/Code/GraphMol/Wrap/Queries.cpp
+++ b/Code/GraphMol/Wrap/Queries.cpp
@@ -145,10 +145,10 @@ Ret *PropQueryWithTol(const std::string &propname, const ExplicitBitVect &v,
 }
 
 namespace {
-  Atom *replaceAtomWithQueryAtomHelper(ROMol &mol, Atom &atom) {
-    return QueryOps::replaceAtomWithQueryAtom(static_cast<RWMol *>(&mol), &atom);
-  }
+Atom *replaceAtomWithQueryAtomHelper(ROMol &mol, Atom &atom) {
+  return QueryOps::replaceAtomWithQueryAtom(static_cast<RWMol *>(&mol), &atom);
 }
+}  // namespace
 
 struct queries_wrapper {
   static void wrap() {
@@ -321,10 +321,12 @@ struct queries_wrapper {
 
     std::string docString = R"DOC(Changes the given atom in the molecule to
 a query atom and returns the atom which can then be modified, for example
-with additional query contstraints added.)DOC";
-    python::def("ReplaceAtomWithQueryAtom", replaceAtomWithQueryAtomHelper,
-                (python::arg("mol"), python::arg("atom")), docString.c_str(),
-                python::return_value_policy<python::reference_existing_object>());
+with additional query constraints added.  The new atom is otherwise a copy
+of the old.)DOC";
+    python::def(
+        "ReplaceAtomWithQueryAtom", replaceAtomWithQueryAtomHelper,
+        (python::arg("mol"), python::arg("atom")), docString.c_str(),
+        python::return_value_policy<python::reference_existing_object>());
   };
 };
 }  // namespace RDKit

--- a/Code/GraphMol/Wrap/Queries.cpp
+++ b/Code/GraphMol/Wrap/Queries.cpp
@@ -144,6 +144,12 @@ Ret *PropQueryWithTol(const std::string &propname, const ExplicitBitVect &v,
   return res;
 }
 
+namespace {
+  Atom *replaceAtomWithQueryAtomHelper(ROMol &mol, Atom &atom) {
+    return QueryOps::replaceAtomWithQueryAtom(static_cast<RWMol *>(&mol), &atom);
+  }
+}
+
 struct queries_wrapper {
   static void wrap() {
 #define QADEF1(_funcname_)                                                     \
@@ -210,13 +216,13 @@ struct queries_wrapper {
 
     python::def("HasPropQueryAtom", HasPropQueryAtom,
                 (python::arg("propname"), python::arg("negate") = false),
-                "Returns a QueryAtom that matches when the propery 'propname' "
+                "Returns a QueryAtom that matches when the property 'propname' "
                 "exists in the atom.",
                 python::return_value_policy<python::manage_new_object>());
 
     python::def("HasPropQueryBond", HasPropQueryBond,
                 (python::arg("propname"), python::arg("negate") = false),
-                "Returns a QueryBond that matches when the propery 'propname' "
+                "Returns a QueryBond that matches when the property 'propname' "
                 "exists in the bond.",
                 python::return_value_policy<python::manage_new_object>());
 
@@ -224,7 +230,7 @@ struct queries_wrapper {
                 PropQueryWithTol<Atom, QueryAtom, int>,
                 (python::arg("propname"), python::arg("val"),
                  python::arg("negate") = false, python::arg("tolerance") = 0),
-                "Returns a QueryAtom that matches when the propery 'propname' "
+                "Returns a QueryAtom that matches when the property 'propname' "
                 "has the specified int value.",
                 python::return_value_policy<python::manage_new_object>());
 
@@ -232,7 +238,7 @@ struct queries_wrapper {
                 PropQuery<Atom, QueryAtom, bool>,
                 (python::arg("propname"), python::arg("val"),
                  python::arg("negate") = false),
-                "Returns a QueryAtom that matches when the propery 'propname' "
+                "Returns a QueryAtom that matches when the property 'propname' "
                 "has the specified boolean"
                 " value.",
                 python::return_value_policy<python::manage_new_object>());
@@ -241,7 +247,7 @@ struct queries_wrapper {
                 PropQuery<Atom, QueryAtom, std::string>,
                 (python::arg("propname"), python::arg("val"),
                  python::arg("negate") = false),
-                "Returns a QueryAtom that matches when the propery 'propname' "
+                "Returns a QueryAtom that matches when the property 'propname' "
                 "has the specified string "
                 "value.",
                 python::return_value_policy<python::manage_new_object>());
@@ -250,7 +256,7 @@ struct queries_wrapper {
                 PropQueryWithTol<Atom, QueryAtom, double>,
                 (python::arg("propname"), python::arg("val"),
                  python::arg("negate") = false, python::arg("tolerance") = 0.0),
-                "Returns a QueryAtom that matches when the propery 'propname' "
+                "Returns a QueryAtom that matches when the property 'propname' "
                 "has the specified "
                 "value +- tolerance",
                 python::return_value_policy<python::manage_new_object>());
@@ -259,7 +265,7 @@ struct queries_wrapper {
                 PropQueryWithTol<Atom, QueryAtom>,
                 (python::arg("propname"), python::arg("val"),
                  python::arg("negate") = false, python::arg("tolerance") = 0),
-                "Returns a QueryAtom that matches when the propery 'propname' "
+                "Returns a QueryAtom that matches when the property 'propname' "
                 "has the specified explicit bit vector"
                 " value.  The Tolerance is the allowed Tanimoto difference",
                 python::return_value_policy<python::manage_new_object>());
@@ -268,13 +274,13 @@ struct queries_wrapper {
     //  Bond Queries
     python::def("HasPropQueryBond", HasPropQueryBond,
                 (python::arg("propname"), python::arg("negate") = false),
-                "Returns a QueryBond that matches when the propery 'propname' "
+                "Returns a QueryBond that matches when the property 'propname' "
                 "exists in the bond.",
                 python::return_value_policy<python::manage_new_object>());
 
     python::def("HasPropQueryBond", HasPropQueryBond,
                 (python::arg("propname"), python::arg("negate") = false),
-                "Returns a QueryBond that matches when the propery 'propname' "
+                "Returns a QueryBond that matches when the property 'propname' "
                 "exists in the bond.",
                 python::return_value_policy<python::manage_new_object>());
 
@@ -282,7 +288,7 @@ struct queries_wrapper {
                 PropQueryWithTol<Bond, QueryBond, int>,
                 (python::arg("propname"), python::arg("val"),
                  python::arg("negate") = false, python::arg("tolerance") = 0),
-                "Returns a QueryBond that matches when the propery 'propname' "
+                "Returns a QueryBond that matches when the property 'propname' "
                 "has the specified int value.",
                 python::return_value_policy<python::manage_new_object>());
 
@@ -290,7 +296,7 @@ struct queries_wrapper {
                 PropQuery<Bond, QueryBond, bool>,
                 (python::arg("propname"), python::arg("val"),
                  python::arg("negate") = false),
-                "Returns a QueryBond that matches when the propery 'propname' "
+                "Returns a QueryBond that matches when the property 'propname' "
                 "has the specified boolean"
                 " value.",
                 python::return_value_policy<python::manage_new_object>());
@@ -299,7 +305,7 @@ struct queries_wrapper {
                 PropQuery<Bond, QueryBond, std::string>,
                 (python::arg("propname"), python::arg("val"),
                  python::arg("negate") = false),
-                "Returns a QueryBond that matches when the propery 'propname' "
+                "Returns a QueryBond that matches when the property 'propname' "
                 "has the specified string "
                 "value.",
                 python::return_value_policy<python::manage_new_object>());
@@ -308,10 +314,17 @@ struct queries_wrapper {
                 PropQueryWithTol<Bond, QueryBond, double>,
                 (python::arg("propname"), python::arg("val"),
                  python::arg("negate") = false, python::arg("tolerance") = 0.0),
-                "Returns a QueryBond that matches when the propery 'propname' "
+                "Returns a QueryBond that matches when the property 'propname' "
                 "has the specified "
                 "value +- tolerance",
                 python::return_value_policy<python::manage_new_object>());
+
+    std::string docString = R"DOC(Changes the given atom in the molecule to
+a query atom and returns the atom which can then be modified, for example
+with additional query contstraints added.)DOC";
+    python::def("ReplaceAtomWithQueryAtom", replaceAtomWithQueryAtomHelper,
+                (python::arg("mol"), python::arg("atom")), docString.c_str(),
+                python::return_value_policy<python::reference_existing_object>());
   };
 };
 }  // namespace RDKit

--- a/Code/GraphMol/Wrap/Queries.cpp
+++ b/Code/GraphMol/Wrap/Queries.cpp
@@ -322,7 +322,8 @@ struct queries_wrapper {
     std::string docString = R"DOC(Changes the given atom in the molecule to
 a query atom and returns the atom which can then be modified, for example
 with additional query constraints added.  The new atom is otherwise a copy
-of the old.)DOC";
+of the old.
+If the atom already has a query, nothing will be changed.)DOC";
     python::def(
         "ReplaceAtomWithQueryAtom", replaceAtomWithQueryAtomHelper,
         (python::arg("mol"), python::arg("atom")), docString.c_str(),

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -3933,7 +3933,7 @@ CAS<~>
     matches = mol.GetSubstructMatches(qmol)
     self.assertEqual(((1,),), matches)
 
-def testGithubIssue579(self):
+  def testGithubIssue579(self):
     fileN = os.path.join(RDConfig.RDBaseDir, 'Code', 'GraphMol', 'FileParsers', 'test_data',
                          'NCI_aids_few.sdf.gz')
     inf = gzip.open(fileN)

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -3920,7 +3920,20 @@ CAS<~>
     self.assertEqual(ap.GetAtomWithIdx(0).GetPropsAsDict()["foo"], "bar")
     self.assertEqual(ap.GetAtomWithIdx(1).GetPropsAsDict()["foo"], "bar")
 
-  def testGithubIssue579(self):
+  def testReplaceAtomWithQueryAtom(self):
+    mol = Chem.MolFromSmiles("CC(C)C")
+    qmol = Chem.MolFromSmiles("C")
+    matches = mol.GetSubstructMatches(qmol)
+    self.assertEqual(((0,), (1,), (2,), (3,)), matches)
+
+    atom = qmol.GetAtomWithIdx(0)
+    natom = rdqueries.ReplaceAtomWithQueryAtom(qmol, atom)
+    qa = rdqueries.ExplicitDegreeEqualsQueryAtom(3)
+    natom.ExpandQuery(qa, Chem.CompositeQueryType.COMPOSITE_AND)
+    matches = mol.GetSubstructMatches(qmol)
+    self.assertEqual(((1,),), matches)
+
+def testGithubIssue579(self):
     fileN = os.path.join(RDConfig.RDBaseDir, 'Code', 'GraphMol', 'FileParsers', 'test_data',
                          'NCI_aids_few.sdf.gz')
     inf = gzip.open(fileN)


### PR DESCRIPTION
#### Reference Issue
No issue

#### What does this implement/fix? Explain your changes.
Exposes the QueryOps::replaceAtomWithQueryAtom to Python.  At present it's available in C++ and Java/C# but not Python.

#### Any other comments?
As usual, the Boost::Python has been done by analogy and clueless experimentation.  One day, perhaps I'll understand what I'm doing.

At the same time, fixes a recurring typo on docstrings.
