### PR TITLE
Allow reapplyMolBlockWedging() to restore the original wedging regardless the bond type

### DIFF
--- a/Code/GraphMol/Chirality.h
+++ b/Code/GraphMol/Chirality.h
@@ -317,6 +317,7 @@ RDKIT_GRAPHMOL_EXPORT bool shouldBeACrossedBond(const Bond *bond);
 //! Clears existing bond wedging and forces use of atom wedging from MolBlock.
 /*!
  \param mol: molecule to have its wedges altered
+ \param allBondTypes: reapply the wedging also on bonds other than single and aromatic ones
  */
 RDKIT_GRAPHMOL_EXPORT void reapplyMolBlockWedging(ROMol &mol, bool allBondTypes=true);
 //! Remove MolBlock bond wedging information from molecule.

--- a/Code/GraphMol/Chirality.h
+++ b/Code/GraphMol/Chirality.h
@@ -318,7 +318,7 @@ RDKIT_GRAPHMOL_EXPORT bool shouldBeACrossedBond(const Bond *bond);
 /*!
  \param mol: molecule to have its wedges altered
  */
-RDKIT_GRAPHMOL_EXPORT void reapplyMolBlockWedging(ROMol &mol);
+RDKIT_GRAPHMOL_EXPORT void reapplyMolBlockWedging(ROMol &mol, bool allBondTypes=false);
 //! Remove MolBlock bond wedging information from molecule.
 /*!
  \param mol: molecule to modify

--- a/Code/GraphMol/Chirality.h
+++ b/Code/GraphMol/Chirality.h
@@ -318,7 +318,7 @@ RDKIT_GRAPHMOL_EXPORT bool shouldBeACrossedBond(const Bond *bond);
 /*!
  \param mol: molecule to have its wedges altered
  */
-RDKIT_GRAPHMOL_EXPORT void reapplyMolBlockWedging(ROMol &mol, bool allBondTypes=false);
+RDKIT_GRAPHMOL_EXPORT void reapplyMolBlockWedging(ROMol &mol, bool allBondTypes=true);
 //! Remove MolBlock bond wedging information from molecule.
 /*!
  \param mol: molecule to modify

--- a/Code/GraphMol/FileParsers/file_parsers_catch.cpp
+++ b/Code/GraphMol/FileParsers/file_parsers_catch.cpp
@@ -5074,6 +5074,37 @@ M  END
     Chirality::reapplyMolBlockWedging(*m);
     CHECK(m->getBondWithIdx(2)->getBondDir() == Bond::BondDir::NONE);
   }
+  SECTION("Reapply the original wedging, regardless the bond type of wedged bonds") {
+    auto m = R"CTAB(
+  Mrv2311 04232413302D          
+
+  0  0  0     0  0            999 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 5 4 0 0 0
+M  V30 BEGIN ATOM
+M  V30 1 S -11.583 11.3533 0 0
+M  V30 2 C -12.9167 10.5833 0 0
+M  V30 3 O -11.583 12.8933 0 0
+M  V30 4 C -10.2493 10.5833 0 0
+M  V30 5 C -10.2493 9.0433 0 0
+M  V30 END ATOM
+M  V30 BEGIN BOND
+M  V30 1 1 4 5
+M  V30 2 1 2 1
+M  V30 3 1 1 4
+M  V30 4 2 1 3 CFG=1
+M  V30 END BOND
+M  V30 END CTAB
+M  END
+)CTAB"_ctab;
+
+    REQUIRE(m);
+    CHECK(m->getBondWithIdx(3)->getBondType() == Bond::BondType::DOUBLE);
+    Chirality::reapplyMolBlockWedging(*m);
+    CHECK(m->getBondWithIdx(3)->getBondDir() == Bond::BondDir::NONE);
+    Chirality::reapplyMolBlockWedging(*m, true);
+    CHECK(m->getBondWithIdx(3)->getBondDir() == Bond::BondDir::BEGINWEDGE);
+  }
   SECTION("GitHub5448") {
     {
       auto m = R"CTAB(

--- a/Code/GraphMol/FileParsers/file_parsers_catch.cpp
+++ b/Code/GraphMol/FileParsers/file_parsers_catch.cpp
@@ -5101,9 +5101,9 @@ M  END
     REQUIRE(m);
     CHECK(m->getBondWithIdx(3)->getBondType() == Bond::BondType::DOUBLE);
     Chirality::reapplyMolBlockWedging(*m);
-    CHECK(m->getBondWithIdx(3)->getBondDir() == Bond::BondDir::NONE);
-    Chirality::reapplyMolBlockWedging(*m, true);
     CHECK(m->getBondWithIdx(3)->getBondDir() == Bond::BondDir::BEGINWEDGE);
+    Chirality::reapplyMolBlockWedging(*m, false);
+    CHECK(m->getBondWithIdx(3)->getBondDir() == Bond::BondDir::NONE);
   }
   SECTION("GitHub5448") {
     {

--- a/Code/GraphMol/WedgeBonds.cpp
+++ b/Code/GraphMol/WedgeBonds.cpp
@@ -540,7 +540,7 @@ void wedgeBond(Bond *bond, unsigned int fromAtomIdx, const Conformer *conf) {
   }
 }
 
-void reapplyMolBlockWedging(ROMol &mol) {
+void reapplyMolBlockWedging(ROMol &mol, bool allBondTypes) {
   MolOps::clearDirFlags(mol, true);
   for (auto b : mol.bonds()) {
     int explicit_unknown_stereo = -1;
@@ -552,7 +552,7 @@ void reapplyMolBlockWedging(ROMol &mol) {
     int bond_dir = -1;
     if (b->getPropIfPresent<int>(common_properties::_MolFileBondStereo,
                                  bond_dir)) {
-      if (canHaveDirection(*b)) {
+      if (allBondTypes || canHaveDirection(*b)) {
         if (bond_dir == 1) {
           b->setBondDir(Bond::BEGINWEDGE);
         } else if (bond_dir == 6) {
@@ -573,7 +573,7 @@ void reapplyMolBlockWedging(ROMol &mol) {
     b->getPropIfPresent<int>(common_properties::_MolFileBondCfg, cfg);
     switch (cfg) {
       case 1:
-        if (canHaveDirection(*b)) {
+        if (allBondTypes || canHaveDirection(*b)) {
           b->setBondDir(Bond::BEGINWEDGE);
         }
         break;
@@ -586,7 +586,7 @@ void reapplyMolBlockWedging(ROMol &mol) {
         }
         break;
       case 3:
-        if (canHaveDirection(*b)) {
+        if (allBondTypes || canHaveDirection(*b)) {
           b->setBondDir(Bond::BEGINDASH);
         }
         break;

--- a/Code/GraphMol/Wrap/MolOps.cpp
+++ b/Code/GraphMol/Wrap/MolOps.cpp
@@ -2467,6 +2467,8 @@ ARGUMENTS:\n\
           ARGUMENTS:\n\
         \n\
             - molecule: the molecule to update\n\
+            - allBondTypes: reapply the wedging also on bonds other\n\
+              than single and aromatic ones\n\
         \n\
         \n";
     python::def("ReapplyMolBlockWedging", reapplyWedging,

--- a/Code/GraphMol/Wrap/MolOps.cpp
+++ b/Code/GraphMol/Wrap/MolOps.cpp
@@ -388,9 +388,9 @@ void addRecursiveQuery(ROMol &mol, const ROMol &query, unsigned int atomIdx,
   }
 }
 
-void reapplyWedging(ROMol &mol) {
+void reapplyWedging(ROMol &mol, bool allBondTypes) {
   auto &wmol = static_cast<RWMol &>(mol);
-  RDKit::Chirality::reapplyMolBlockWedging(wmol);
+  RDKit::Chirality::reapplyMolBlockWedging(wmol, allBondTypes);
 }
 
 MolOps::SanitizeFlags sanitizeMol(ROMol &mol, boost::uint64_t sanitizeOps,
@@ -2469,7 +2469,8 @@ ARGUMENTS:\n\
             - molecule: the molecule to update\n\
         \n\
         \n";
-    python::def("ReapplyMolBlockWedging", reapplyWedging, (python::arg("mol")),
+    python::def("ReapplyMolBlockWedging", reapplyWedging,
+                (python::arg("mol"), python::arg("allBondTypes") = false),
                 docString.c_str());
 
     docString =

--- a/Code/GraphMol/Wrap/MolOps.cpp
+++ b/Code/GraphMol/Wrap/MolOps.cpp
@@ -2470,7 +2470,7 @@ ARGUMENTS:\n\
         \n\
         \n";
     python::def("ReapplyMolBlockWedging", reapplyWedging,
-                (python::arg("mol"), python::arg("allBondTypes") = false),
+                (python::arg("mol"), python::arg("allBondTypes") = true),
                 docString.c_str());
 
     docString =

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -7705,9 +7705,9 @@ M  END
 ''')
     self.assertEqual(m.GetBondWithIdx(3).GetBondType(), Chem.BondType.DOUBLE)
     Chem.ReapplyMolBlockWedging(m)
-    self.assertEqual(m.GetBondWithIdx(3).GetBondDir(), Chem.BondDir.NONE)
-    Chem.ReapplyMolBlockWedging(m, True)
     self.assertEqual(m.GetBondWithIdx(3).GetBondDir(), Chem.BondDir.BEGINWEDGE)
+    Chem.ReapplyMolBlockWedging(m, False)
+    self.assertEqual(m.GetBondWithIdx(3).GetBondDir(), Chem.BondDir.NONE)
 
   def testAtropisomerWedging(self):
     m =Chem.MolFromSmiles('CC1=C(N2C=CC=C2[C@H](C)Cl)C(C)CCC1 |(2.679,0.4142,;1.3509,1.181,;0.0229,0.4141,;0.0229,-1.1195,;1.2645,-2.0302,;0.7901,-3.4813,;-0.7446,-3.4813,;-1.219,-2.0302,;-2.679,-1.5609,;-3.0039,-0.0556,;-3.8202,-2.595,;-1.3054,1.1809,;-2.6335,0.4141,;-1.3054,2.7145,;0.0229,3.4813,;1.3509,2.7146,),wD:2.11,wU:8.10,&1:8|')

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -7680,6 +7680,35 @@ CAS<~>
 
     self.assertTrue(mBlock == isReapplied)
 
+  def testReapplyMolBlockWedgingAllBondTypes(self):
+    m = Chem.MolFromMolBlock('''
+  Mrv2311 04232413302D          
+
+  0  0  0     0  0            999 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 5 4 0 0 0
+M  V30 BEGIN ATOM
+M  V30 1 S -11.583 11.3533 0 0
+M  V30 2 C -12.9167 10.5833 0 0
+M  V30 3 O -11.583 12.8933 0 0
+M  V30 4 C -10.2493 10.5833 0 0
+M  V30 5 C -10.2493 9.0433 0 0
+M  V30 END ATOM
+M  V30 BEGIN BOND
+M  V30 1 1 4 5
+M  V30 2 1 2 1
+M  V30 3 1 1 4
+M  V30 4 2 1 3 CFG=1
+M  V30 END BOND
+M  V30 END CTAB
+M  END
+''')
+    self.assertEqual(m.GetBondWithIdx(3).GetBondType(), Chem.BondType.DOUBLE)
+    Chem.ReapplyMolBlockWedging(m)
+    self.assertEqual(m.GetBondWithIdx(3).GetBondDir(), Chem.BondDir.NONE)
+    Chem.ReapplyMolBlockWedging(m, True)
+    self.assertEqual(m.GetBondWithIdx(3).GetBondDir(), Chem.BondDir.BEGINWEDGE)
+
   def testAtropisomerWedging(self):
     m =Chem.MolFromSmiles('CC1=C(N2C=CC=C2[C@H](C)Cl)C(C)CCC1 |(2.679,0.4142,;1.3509,1.181,;0.0229,0.4141,;0.0229,-1.1195,;1.2645,-2.0302,;0.7901,-3.4813,;-0.7446,-3.4813,;-1.219,-2.0302,;-2.679,-1.5609,;-3.0039,-0.0556,;-3.8202,-2.595,;-1.3054,1.1809,;-2.6335,0.4141,;-1.3054,2.7145,;0.0229,3.4813,;1.3509,2.7146,),wD:2.11,wU:8.10,&1:8|')
     self.assertTrue(m is  not None)


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
This PR adds a default argument to `Chirality::reapplyMolBlockWedging()` so that it may be optionally possible to restore the original wedging also for bonds with type different from single or aromatic (e.g., double bonds with up/down orientation).

#### Any other comments?
A change was introduced with #6903 limiting `Chirality::reapplyMolBlockWedging()` to only reapply wedged bonds to single and aromatic bonds. Without the changes proposed with this PR, validating the original mol file and identifying cases where wedging is assigned to other bond types would be quite impractical and it would basically require duplicating what `Chirality::reapplyMolBlockWedging()` already does.