### PR TITLE
Include header for boost::numeric_cast

### DIFF
--- a/Code/RDGeneral/RDValue-taggedunion.h
+++ b/Code/RDGeneral/RDValue-taggedunion.h
@@ -44,6 +44,7 @@
 #include <any>
 #include <boost/utility.hpp>
 #include <boost/lexical_cast.hpp>
+#include <boost/numeric/conversion/cast.hpp>
 #include <boost/type_traits/is_floating_point.hpp>
 #include <RDGeneral/BoostEndInclude.h>
 #include "LocaleSwitcher.h"


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! 
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.

Build was failing with Boost 1.85.0:
```
/tmp/rdkit-20240425-44167-eojptu/rdkit-Release_2024_03_1/Code/RDGeneral/RDValue-taggedunion.h:420:19: error: no member named 'numeric_cast' in namespace 'boost'
    return boost::numeric_cast<float>(v.value.d);
           ~~~~~~~^
```

Probably an indirect include in Boost library was removed.

#### Any other comments?

Seen when updating Boost in Homebrew - https://github.com/Homebrew/homebrew-core/pull/169237