### PR TITLE
Fix performance issue in PR 7327

### DIFF
--- a/Code/GraphMol/ChemTransforms/ChemTransforms.cpp
+++ b/Code/GraphMol/ChemTransforms/ChemTransforms.cpp
@@ -119,13 +119,13 @@ ROMol *deleteSubstructs(const ROMol &mol, const ROMol &query, bool onlyFrags,
   // all matches on the molecule - list of list of atom ids
   VECT_INT_VECT matches;
   matches.reserve(fgpMatches.size());
-  for (auto mati : fgpMatches) {
+  for (const auto& mati : fgpMatches) {
     INT_VECT match;  // each match onto the molecule - list of atoms ids
     match.reserve(mati.size());
-    for (auto mi : mati) {
+    for (const auto&  mi : mati) {
       match.push_back(mi.second);
     }
-    matches.push_back(match);
+    matches.push_back(std::move(match));
   }
 
   // now loop over the list of matches and check if we can delete any of them
@@ -133,9 +133,9 @@ ROMol *deleteSubstructs(const ROMol &mol, const ROMol &query, bool onlyFrags,
   if (onlyFrags) {
     VECT_INT_VECT frags;
     MolOps::getMolFrags(*res, frags);
-    for (auto fi : frags) {
+    for (auto& fi : frags) {
       std::sort(fi.begin(), fi.end());
-      for (auto mxi : matches) {
+      for (auto& mxi : matches) {
         std::sort(mxi.begin(), mxi.end());
         if (fi == mxi) {
           INT_VECT tmp;
@@ -149,7 +149,7 @@ ROMol *deleteSubstructs(const ROMol &mol, const ROMol &query, bool onlyFrags,
     // in this case we want to delete any matches we find
     // simply loop over the matches and collect the atoms that need to
     // be removed
-    for (auto mxi : matches) {
+    for (const auto& mxi : matches) {
       INT_VECT tmp;
       Union(mxi, delList, tmp);
       delList = tmp;

--- a/Code/GraphMol/RWMol.cpp
+++ b/Code/GraphMol/RWMol.cpp
@@ -642,8 +642,12 @@ void RWMol::beginBatchEdit() {
 }
 
 void RWMol::commitBatchEdit() {
-  if ((!dp_delBonds || dp_delBonds->none()) &&
-      (!dp_delAtoms || dp_delAtoms->none())) {
+  if (!(dp_delBonds || dp_delAtoms)) {
+    return;
+  } else if (dp_delBonds->none() && dp_delAtoms->none()) {
+    // no need to reset, since nothing is removed
+    dp_delBonds.reset();
+    dp_delAtoms.reset();
     return;
   }
 

--- a/Code/GraphMol/RWMol.cpp
+++ b/Code/GraphMol/RWMol.cpp
@@ -645,7 +645,8 @@ void RWMol::commitBatchEdit() {
   if (!(dp_delBonds || dp_delAtoms)) {
     return;
   } else if (dp_delBonds->none() && dp_delAtoms->none()) {
-    // no need to reset, since nothing is removed
+    // no need to reset ring info & calculated properties,
+    // since nothing gets removed
     dp_delBonds.reset();
     dp_delAtoms.reset();
     return;

--- a/Code/GraphMol/RWMol.cpp
+++ b/Code/GraphMol/RWMol.cpp
@@ -570,7 +570,7 @@ void RWMol::removeBond(unsigned int aid1, unsigned int aid2) {
   auto endAtm = bnd->getEndAtom();
   std::vector<std::vector<Atom *>> bond_atoms = {{beginAtm, endAtm},
                                                  {endAtm, beginAtm}};
-  for (auto atoms : bond_atoms) {
+  for (const auto &atoms : bond_atoms) {
     for (auto obnd : this->atomBonds(atoms[0])) {
       if (obnd == bnd) {
         continue;
@@ -642,7 +642,8 @@ void RWMol::beginBatchEdit() {
 }
 
 void RWMol::commitBatchEdit() {
-  if (!(dp_delBonds || dp_delAtoms)) {
+  if ((!dp_delBonds || dp_delBonds->none()) &&
+      (!dp_delAtoms || dp_delAtoms->none())) {
     return;
   }
 
@@ -659,7 +660,7 @@ void RWMol::commitBatchEdit() {
 }
 
 void RWMol::batchRemoveBonds() {
-  if (!dp_delBonds) {
+  if (!dp_delBonds || dp_delBonds->none()) {
     return;
   }
 
@@ -695,7 +696,7 @@ void RWMol::batchRemoveBonds() {
     auto endAtm = bnd->getEndAtom();
     std::vector<std::vector<Atom *>> bond_atoms = {{beginAtm, endAtm},
                                                    {endAtm, beginAtm}};
-    for (auto atoms : bond_atoms) {
+    for (const auto &atoms : bond_atoms) {
       for (auto obnd : atomBonds(atoms[0])) {
         if (obnd == bnd) {
           continue;
@@ -739,7 +740,7 @@ void RWMol::batchRemoveBonds() {
 }
 
 void RWMol::batchRemoveAtoms() {
-  if (!dp_delAtoms) {
+  if (!dp_delAtoms || dp_delAtoms->none()) {
     return;
   }
   std::vector<Atom *> oldIndices(getNumAtoms());


### PR DESCRIPTION
I came back to #7327, and noticed that there's a performance in the PR that slipped through the review: the `for` loop I added don't use references! This means making copies of vectors, which may become slow. I updated them, and a couple more I noticed in RWMol, to use references.

I also noticed Dan's comment in the PR, and added checks to `commitBatchEdit()`, `batchRemoveBonds()` and `batchRemoveAtoms()` to exit early if nothing is going to be removed.