### PR TITLE
Do not apply the normalization of conjugated cations to the oxime oxygen

### DIFF
--- a/Code/GraphMol/MolStandardize/TransformCatalog/normalizations.in
+++ b/Code/GraphMol/MolStandardize/TransformCatalog/normalizations.in
@@ -52,11 +52,11 @@ std::vector<std::pair<std::string, std::string>> defaultNormalizations = {
     // Conjugated cation rules taken from Francis Atkinson's standardiser. Those
     // that can reduce aromaticity aren't included
     {"Normalize 1,3 conjugated cation",
-     "[N,O;+0!H0:1]-[A:2]=[N!$(*~[N,O,P,S;-1]),O;+1H0:3]>>[*+1:1]=[*:2]-[*+0:3]"},
+     "[N,O!$(*N);+0!H0:1]-[A:2]=[N!$(*~[N,O,P,S;-1]),O;+1H0:3]>>[*+1:1]=[*:2]-[*+0:3]"},
     {"Normalize 1,3 conjugated cation",
      "[n;+0!H0:1]:[c:2]=[N!$(*~[N,O,P,S;-1]),O;+1H0:3]>>[*+1:1]:[*:2]-[*+0:3]"},
     {"Normalize 1,5 conjugated cation",
-     "[N,O;+0!H0:1]-[A:2]=[A:3]-[A:4]=[N!$(*~[N,O,P,S;-1]),O;+1H0:5]>>[*+1:1]=[*:2]-[*:"
+     "[N,O!$(*N);+0!H0:1]-[A:2]=[A:3]-[A:4]=[N!$(*~[N,O,P,S;-1]),O;+1H0:5]>>[*+1:1]=[*:2]-[*:"
      "3]=[*:4]-[*+0:5]"},
     {"Normalize 1,5 conjugated cation",
      "[n;+0!H0:1]:[a:2]:[a:3]:[c:4]=[N!$(*~[N,O,P,S;-1]),O;+1H0:5]>>[n+1:1]:[*:2]:[*:3]:"

--- a/Code/GraphMol/MolStandardize/testNormalize.cpp
+++ b/Code/GraphMol/MolStandardize/testNormalize.cpp
@@ -70,6 +70,8 @@ void test1() {
 
   // Test normalization of 1,3-conjugated cations
   TEST_ASSERT(normalize("C[N+](C)=CN") == "CN(C)C=[NH2+]");
+  // verify it doesn't apply to oximes
+  TEST_ASSERT(normalize("C[N+](C)=NO") == "C[N+](C)=NO");
   // verify it doesn't affect diazo groups
   TEST_ASSERT(normalize("[N-]=[N+]=CN") == "[N-]=[N+]=CN");
   // but still applies if the adjacent heteroatom is neutral
@@ -77,6 +79,8 @@ void test1() {
 
   // Test normalization of 1,5-conjugated cations
   TEST_ASSERT(normalize("C[N+](C)=CC=CN") == "CN(C)C=CC=[NH2+]");
+  // verify it doesn't apply to oximes
+  TEST_ASSERT(normalize("C[N+](C)=CC=NO") == "C[N+](C)=CC=NO");
   // verify it doesn't affect diazo groups
   TEST_ASSERT(normalize("[N-]=[N+]=CC=CN") == "[N-]=[N+]=CC=CN");
   // but still applies if the adjacent heteroatom is neutral


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
This PR further constraints the normalization of 1,3- and 1,5- aliphatic conjugated cations. The motivating case was about preventing the transformation of oxime groups into nitroso compounds.

