### PR TITLE
fix a lifetime bug in the fingerprint generator

### DIFF
--- a/Code/GraphMol/Fingerprints/Wrap/FingerprintGeneratorWrapper.cpp
+++ b/Code/GraphMol/Fingerprints/Wrap/FingerprintGeneratorWrapper.cpp
@@ -657,7 +657,8 @@ void wrapGenerator(const std::string &nm) {
            "generator\n\n"
            "  RETURNS: an information string\n\n")
       .def("GetOptions", getOptions<T>,
-           python::return_value_policy<python::reference_existing_object>(),
+           python::return_internal_reference<
+               1, python::with_custodian_and_ward_postcall<0, 1>>(),
            python::args("self"), "return the fingerprint options object");
 }
 

--- a/Code/GraphMol/Fingerprints/Wrap/testGenerators.py
+++ b/Code/GraphMol/Fingerprints/Wrap/testGenerators.py
@@ -343,44 +343,53 @@ class TestCase(unittest.TestCase):
     self.assertEqual(len(nz), 1)
 
   def testMorganGeneratorMultiMol(self):
-    smis = ['CC1CCC1','CCC1CCC1','CCCC1CCC1','CC1CC(O)C1','CC1CC(OC)C1',]
+    smis = [
+      'CC1CCC1',
+      'CCC1CCC1',
+      'CCCC1CCC1',
+      'CC1CC(O)C1',
+      'CC1CC(OC)C1',
+    ]
     for i in range(4):
       smis = smis + smis
     ms = [Chem.MolFromSmiles(smi) for smi in smis]
     g = rdFingerprintGenerator.GetMorganGenerator()
     ofps = tuple([g.GetFingerprint(m) for m in ms])
-    tfps = g.GetFingerprints(ms,numThreads=1)
-    for ofp,tfp in zip(ofps,tfps):
-      self.assertEqual(ofp,tfp)
-    tfps = g.GetFingerprints(ms,numThreads=4)
-    for ofp,tfp in zip(ofps,tfps):
-      self.assertEqual(ofp,tfp)
-    
+    tfps = g.GetFingerprints(ms, numThreads=1)
+    for ofp, tfp in zip(ofps, tfps):
+      self.assertEqual(ofp, tfp)
+    tfps = g.GetFingerprints(ms, numThreads=4)
+    for ofp, tfp in zip(ofps, tfps):
+      self.assertEqual(ofp, tfp)
+
     ofps = tuple([g.GetCountFingerprint(m) for m in ms])
-    tfps = g.GetCountFingerprints(ms,numThreads=1)
-    for ofp,tfp in zip(ofps,tfps):
-      self.assertEqual(ofp,tfp)
-    tfps = g.GetCountFingerprints(ms,numThreads=4)
-    for ofp,tfp in zip(ofps,tfps):
-      self.assertEqual(ofp,tfp)
+    tfps = g.GetCountFingerprints(ms, numThreads=1)
+    for ofp, tfp in zip(ofps, tfps):
+      self.assertEqual(ofp, tfp)
+    tfps = g.GetCountFingerprints(ms, numThreads=4)
+    for ofp, tfp in zip(ofps, tfps):
+      self.assertEqual(ofp, tfp)
 
     ofps = tuple([g.GetSparseFingerprint(m) for m in ms])
-    tfps = g.GetSparseFingerprints(ms,numThreads=1)
-    for ofp,tfp in zip(ofps,tfps):
-      self.assertEqual(ofp,tfp)
-    tfps = g.GetSparseFingerprints(ms,numThreads=4)
-    for ofp,tfp in zip(ofps,tfps):
-      self.assertEqual(ofp,tfp)
+    tfps = g.GetSparseFingerprints(ms, numThreads=1)
+    for ofp, tfp in zip(ofps, tfps):
+      self.assertEqual(ofp, tfp)
+    tfps = g.GetSparseFingerprints(ms, numThreads=4)
+    for ofp, tfp in zip(ofps, tfps):
+      self.assertEqual(ofp, tfp)
 
     ofps = tuple([g.GetSparseCountFingerprint(m) for m in ms])
-    tfps = g.GetSparseCountFingerprints(ms,numThreads=1)
-    for ofp,tfp in zip(ofps,tfps):
-      self.assertEqual(ofp,tfp)
-    tfps = g.GetSparseCountFingerprints(ms,numThreads=4)
-    for ofp,tfp in zip(ofps,tfps):
-      self.assertEqual(ofp,tfp)
+    tfps = g.GetSparseCountFingerprints(ms, numThreads=1)
+    for ofp, tfp in zip(ofps, tfps):
+      self.assertEqual(ofp, tfp)
+    tfps = g.GetSparseCountFingerprints(ms, numThreads=4)
+    for ofp, tfp in zip(ofps, tfps):
+      self.assertEqual(ofp, tfp)
 
-
+  def testFingerprintGeneratorOptionsLifetime(self):
+    # this should not result in a seg fault
+    import inspect
+    inspect.getmembers(rdFingerprintGenerator.GetRDKitFPGenerator().GetOptions())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
FingerprintGenerator.GetOptions() wasn't keeping the underlying generator alive.
The fix is simple.

reported by Andrew Dalke