### PR TITLE
Make CXSMILES writer use the default conformer ID

### DIFF
--- a/Code/GraphMol/MolDraw2D/Wrap/testMolDraw2D.py
+++ b/Code/GraphMol/MolDraw2D/Wrap/testMolDraw2D.py
@@ -831,6 +831,7 @@ M  END''')
         text = d2d.GetDrawingText()
         self.assertTrue("#7F7F7F" not in text)
 
+    @unittest.skipUnless(hasattr(Draw, 'MolDraw2DCairo'), 'Cairo support not enabled')
     def testGithub7409(self):
         m = Chem.MolFromSmiles('CC |(-0.75,0,;0.75,0,)|')
         m.GetConformer().SetId(5)

--- a/Code/GraphMol/MolDraw2D/Wrap/testMolDraw2D.py
+++ b/Code/GraphMol/MolDraw2D/Wrap/testMolDraw2D.py
@@ -831,6 +831,13 @@ M  END''')
         text = d2d.GetDrawingText()
         self.assertTrue("#7F7F7F" not in text)
 
+    def testGithub7409(self):
+        m = Chem.MolFromSmiles('CC |(-0.75,0,;0.75,0,)|')
+        m.GetConformer().SetId(5)
+        d2d = rdMolDraw2D.MolDraw2DCairo(200, 200)
+        # it's enough to check that this doesn't throw an exception
+        d2d.DrawMolecule(m)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Code/GraphMol/MolDraw2D/catch_tests.cpp
+++ b/Code/GraphMol/MolDraw2D/catch_tests.cpp
@@ -9506,3 +9506,18 @@ M  END)CTAB"_ctab;
     outs.close();
   }
 }
+
+#ifdef RDK_BUILD_CAIRO_SUPPORT
+TEST_CASE(
+    "github #7409: drawing mol with a non zero confID results in bad confID error") {
+  SECTION("basics") {
+    auto m = "CC |(-0.75,0,;0.75,0,)|"_smiles;
+    REQUIRE(m);
+    CHECK(m->getNumConformers() == 1);
+    m->getConformer().setId(5);
+    MolDraw2DCairo drawer(350, 300);
+    // it's enough to test that this doesn't throw
+    drawer.drawMolecule(*m);
+  }
+}
+#endif

--- a/Code/GraphMol/SmilesParse/CXSmilesOps.cpp
+++ b/Code/GraphMol/SmilesParse/CXSmilesOps.cpp
@@ -2082,7 +2082,7 @@ std::string get_bond_config_block(
         int dirCode;
         bool reverse;
         Chirality::GetMolFileBondStereoInfo(
-            bond, wedgeBonds, &mol.getConformer(0), dirCode, reverse);
+            bond, wedgeBonds, &mol.getConformer(), dirCode, reverse);
         switch (dirCode) {
           case 1:
             bd = Bond::BondDir::BEGINWEDGE;

--- a/Code/GraphMol/SmilesParse/cxsmiles_test.cpp
+++ b/Code/GraphMol/SmilesParse/cxsmiles_test.cpp
@@ -1468,3 +1468,13 @@ TEST_CASE("write attachment points") {
   m->getAtomWithIdx(5)->setProp(common_properties::_fromAttachPoint, 2);
   CHECK(MolToCXSmiles(*m) == "*N[C@@H](C)C(*)=O |$_AP1;;;;;_AP2;$|");
 }
+
+TEST_CASE("github #7414: CXSmiles writer does not use default conformer ID") {
+  SECTION("basics") {
+    auto m = "CC |(-0.75,0,;0.75,0,)|"_smiles;
+    REQUIRE(m);
+    CHECK(m->getNumConformers() == 1);
+    m->getConformer().setId(5);
+    CHECK(MolToCXSmiles(*m) == "CC |(-0.75,0,;0.75,0,)|");
+  }
+}


### PR DESCRIPTION
Two bugs with a one character change! ;-)

Fixes #7409
Fixes #7414
