### PR TITLE
fixStructureCheckerBuildError - fix location of MolFileSterechem.h

### DIFF
--- a/Code/GraphMol/StructChecker/StripSmallFragments.cpp
+++ b/Code/GraphMol/StructChecker/StripSmallFragments.cpp
@@ -13,7 +13,7 @@
 #include "../Descriptors/MolDescriptors.h"
 #include "StripSmallFragments.h"
 #include "../SmilesParse/SmilesWrite.h"
-#include "../MolFileStereochem.h"
+#include "../FileParsers/MolFileStereochem.h"
 
 // define snprintf for msvc
 #if _MSC_VER


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! 
-->
#### Reference Issue
fixStructureCheckerBuildError - building Structure Checker fails


#### What does this implement/fix? Explain your changes.
the location is/was incorrectly specificed in .../Code/GraphMol/StructChecker/StripSmallFragments.cpp

#### Any other comments?

