### PR TITLE
Fixes #7153

### DIFF
--- a/Code/GraphMol/FileParsers/MaeWriter.cpp
+++ b/Code/GraphMol/FileParsers/MaeWriter.cpp
@@ -13,6 +13,7 @@
 #include <fstream>
 #include <functional>
 #include <memory>
+#include <regex>
 #include <sstream>
 #include <string>
 #include <vector>
@@ -36,6 +37,8 @@ using namespace RDKit::FileParsers::schrodinger;
 namespace RDKit {
 
 namespace {
+
+static const std::regex MMCT_PROP_REGEX("[birs]_[^_ ]+_.+");
 
 template <typename T>
 std::shared_ptr<mae::IndexedProperty<T>> getIndexedProperty(
@@ -149,27 +152,43 @@ void copyProperties(
 
     switch (prop.val.getTag()) {
       case RDTypeTag::BoolTag: {
-        auto propName = std::string("b_rdk_") + prop.key;
+        auto propName = prop.key;
+        if (!std::regex_match(prop.key, MMCT_PROP_REGEX)) {
+          propName.insert(0, "b_rdk_");
+        }
+
         boolSetter(propName, idx, rdvalue_cast<bool>(prop.val));
         break;
       }
 
       case RDTypeTag::IntTag:
       case RDTypeTag::UnsignedIntTag: {
-        auto propName = std::string("i_rdk_") + prop.key;
+        auto propName = prop.key;
+        if (!std::regex_match(prop.key, MMCT_PROP_REGEX)) {
+          propName.insert(0, "i_rdk_");
+        }
+
         intSetter(propName, idx, rdvalue_cast<int>(prop.val));
         break;
       }
 
       case RDTypeTag::DoubleTag:
       case RDTypeTag::FloatTag: {
-        auto propName = std::string("r_rdk_") + prop.key;
+        auto propName = prop.key;
+        if (!std::regex_match(prop.key, MMCT_PROP_REGEX)) {
+          propName.insert(0, "r_rdk_");
+        }
+
         realSetter(propName, idx, rdvalue_cast<double>(prop.val));
         break;
       }
 
       case RDTypeTag::StringTag: {
-        auto propName = std::string("s_rdk_") + prop.key;
+        auto propName = prop.key;
+        if (!std::regex_match(prop.key, MMCT_PROP_REGEX)) {
+          propName.insert(0, "s_rdk_");
+        }
+
         stringSetter(propName, idx, rdvalue_cast<std::string>(prop.val));
         break;
       }

--- a/Code/GraphMol/FileParsers/MaeWriter.cpp
+++ b/Code/GraphMol/FileParsers/MaeWriter.cpp
@@ -22,6 +22,7 @@
 #include <maeparser/Writer.hpp>
 
 #include <GraphMol/Depictor/RDDepictor.h>
+#include <GraphMol/FileParsers/MaestroProperties.h>
 #include <GraphMol/MolOps.h>
 #include <GraphMol/MonomerInfo.h>
 #include <GraphMol/RDKitBase.h>
@@ -30,20 +31,11 @@
 #include <RDGeneral/RDLog.h>
 
 using namespace schrodinger;
+using namespace RDKit::FileParsers::schrodinger;
 
 namespace RDKit {
 
 namespace {
-const std::string MAE_BOND_DATIVE_MARK = "b_sPrivate_dative_bond";
-const std::string MAE_BOND_PARITY = "i_sd_original_parity";
-const std::string MAE_STEREO_STATUS = "i_m_ct_stereo_status";
-const std::string PDB_ATOM_NAME = "s_m_pdb_atom_name";
-const std::string PDB_RESIDUE_NAME = "s_m_pdb_residue_name";
-const std::string PDB_CHAIN_NAME = "s_m_chain_name";
-const std::string PDB_INSERTION_CODE = "s_m_insertion_code";
-const std::string PDB_RESIDUE_NUMBER = "i_m_residue_number";
-const std::string PDB_OCCUPANCY = "r_m_pdb_occupancy";
-const std::string PDB_TFACTOR = "r_m_pdb_tfactor";
 
 template <typename T>
 std::shared_ptr<mae::IndexedProperty<T>> getIndexedProperty(

--- a/Code/GraphMol/FileParsers/MaestroProperties.h
+++ b/Code/GraphMol/FileParsers/MaestroProperties.h
@@ -1,0 +1,32 @@
+//
+//  Copyright (C) 2024 Schrödinger, LLC
+//
+//   @@ All Rights Reserved @@
+//  This file is part of the RDKit.
+//  The contents are covered by the terms of the BSD license
+//  which is included in the file license.txt, found at the root
+//  of the RDKit source tree.
+//
+#include <string>
+
+namespace RDKit {
+namespace FileParsers {
+namespace schrodinger {
+
+static const std::string MAE_ATOM_TYPE = "i_m_mmod_type";
+static const std::string MAE_BOND_DATIVE_MARK = "b_sPrivate_dative_bond";
+static const std::string MAE_BOND_PARITY = "i_sd_original_parity";
+static const std::string MAE_ENHANCED_STEREO_STATUS =
+    "i_m_ct_enhanced_stereo_status";
+static const std::string MAE_STEREO_STATUS = "i_m_ct_stereo_status";
+static const std::string PDB_ATOM_NAME = "s_m_pdb_atom_name";
+static const std::string PDB_CHAIN_NAME = "s_m_chain_name";
+static const std::string PDB_INSERTION_CODE = "s_m_insertion_code";
+static const std::string PDB_OCCUPANCY = "r_m_pdb_occupancy";
+static const std::string PDB_RESIDUE_NAME = "s_m_pdb_residue_name";
+static const std::string PDB_RESIDUE_NUMBER = "i_m_residue_number";
+static const std::string PDB_TFACTOR = "r_m_pdb_tfactor";
+
+}  // namespace schrodinger
+}  // namespace FileParsers
+}  // namespace RDKit


### PR DESCRIPTION
This fixes #7153 by ignoring the `i_m_ct_stereo_status` and `i_m_ct_enhanced_stereo_status` on ingestion (both properties are meaningless to the RDKit).

It also prevents `MaeWriter` from prefixing properties that already match the Maestro property format with `[birs]_rdkit_`, which would prevent Maestro from reading (and in some cases, understanding) these properties.

Finally, it also refactors some knowm Maestro properties into a separate header, so that the definitions can be shared by `MaeMolSupplier` and `MaeWriter`.
