### PR TITLE
Fixes #7434

### DIFF
--- a/Code/GraphMol/Chirality.cpp
+++ b/Code/GraphMol/Chirality.cpp
@@ -1599,9 +1599,13 @@ std::pair<bool, bool> isAtomPotentialChiralCenter(
           // three-coordinate N additional requirements:
           //   in a ring of size 3  (from InChI)
           // OR
-          /// is a bridgehead atom (RDKit extension)
-          if (mol.getRingInfo()->isAtomInRingOfSize(atom->getIdx(), 3) ||
-              queryIsAtomBridgehead(atom)) {
+          //   is a bridgehead atom (RDKit extension)
+          // Also: cannot be SP2 hybridized or have a conjugated bond
+          //   (this was Github #7434)
+          if (atom->getHybridization() == Atom::HybridizationType::SP3 &&
+              !MolOps::atomHasConjugatedBond(atom) &&
+              (mol.getRingInfo()->isAtomInRingOfSize(atom->getIdx(), 3) ||
+               queryIsAtomBridgehead(atom))) {
             legalCenter = true;
           }
         } else if (atom->getAtomicNum() == 15 || atom->getAtomicNum() == 33) {

--- a/Code/GraphMol/FindStereo.cpp
+++ b/Code/GraphMol/FindStereo.cpp
@@ -98,8 +98,12 @@ bool isAtomPotentialTetrahedralCenter(const Atom *atom) {
           //   in a ring of size 3  (from InChI)
           // OR
           /// is a bridgehead atom (RDKit extension)
-          if (mol.getRingInfo()->isAtomInRingOfSize(atom->getIdx(), 3) ||
-              queryIsAtomBridgehead(atom)) {
+          // Also: cannot be SP2 hybridized or have a conjugated bond
+          //   (this was Github #7434)
+          if (atom->getHybridization() == Atom::HybridizationType::SP3 &&
+              !MolOps::atomHasConjugatedBond(atom) &&
+              (mol.getRingInfo()->isAtomInRingOfSize(atom->getIdx(), 3) ||
+               queryIsAtomBridgehead(atom))) {
             legalCenter = true;
           }
         }

--- a/Code/GraphMol/catch_chirality.cpp
+++ b/Code/GraphMol/catch_chirality.cpp
@@ -5680,3 +5680,55 @@ M  END
     }
   }
 }
+
+TEST_CASE(
+    "github #7434: planar amide nitrogen incorrectly flagged as _ChiralityPossible") {
+  SECTION("as reported") {
+    auto m1 = "O=C1CCCCC[C@@H]2CN1CCO2"_smiles;
+    REQUIRE(m1);
+    // new stereo
+    CHECK(Chirality::detail::isAtomPotentialTetrahedralCenter(
+        m1->getAtomWithIdx(7)));
+    CHECK(!Chirality::detail::isAtomPotentialTetrahedralCenter(
+        m1->getAtomWithIdx(9)));
+
+    // force old stereo
+    UseLegacyStereoPerceptionFixture resetStereoPerception{true};
+    bool cleanIt = true;
+    bool flagPossible = true;
+    auto si = Chirality::findPotentialStereo(*m1, cleanIt, flagPossible);
+    CHECK(si.size() == 1);
+  }
+  SECTION("details") {
+    auto m1 = "C1CCCCC[C@@H]2CN1CCO2"_smiles;
+    REQUIRE(m1);
+    CHECK(Chirality::detail::isAtomPotentialTetrahedralCenter(
+        m1->getAtomWithIdx(6)));
+    CHECK(Chirality::detail::isAtomPotentialTetrahedralCenter(
+        m1->getAtomWithIdx(8)));
+
+    // force old stereo
+    UseLegacyStereoPerceptionFixture resetStereoPerception{true};
+    bool cleanIt = true;
+    bool flagPossible = true;
+    {
+      auto si = Chirality::findPotentialStereo(*m1, cleanIt, flagPossible);
+      CHECK(si.size() == 2);
+    }
+    m1->getAtomWithIdx(8)->setHybridization(Atom::HybridizationType::SP2);
+    CHECK(!Chirality::detail::isAtomPotentialTetrahedralCenter(
+        m1->getAtomWithIdx(8)));
+    {
+      auto si = Chirality::findPotentialStereo(*m1, cleanIt, flagPossible);
+      CHECK(si.size() == 1);
+    }
+    m1->getAtomWithIdx(8)->setHybridization(Atom::HybridizationType::SP3);
+    m1->getBondBetweenAtoms(0, 8)->setIsConjugated(true);
+    CHECK(!Chirality::detail::isAtomPotentialTetrahedralCenter(
+        m1->getAtomWithIdx(8)));
+    {
+      auto si = Chirality::findPotentialStereo(*m1, cleanIt, flagPossible);
+      CHECK(si.size() == 1);
+    }
+  }
+}

--- a/Docs/Book/RDKit_Book.rst
+++ b/Docs/Book/RDKit_Book.rst
@@ -630,8 +630,9 @@ The following atom types are potential tetrahedral stereogenic atoms:
   - atoms with degree 4
   - atoms with degree 3 and one implicit H
   - P or As with degree 3 or 4
-  - N with degree 3 which is in a ring of size 3 or which is shared between at
-    least 3 rings (this last condition is an extension to the InChI rules) 
+  - An SP3 hybridized N with degree 3 that is not involved in any conjugated
+    bonds and that is in a ring of size 3 or that is shared between at least 3
+    rings (this last condition is an extension to the InChI rules).
   - S or Se with degree 3 and a total valence of 4 or a total valence of 3 and a
     net charge of +1.
 


### PR DESCRIPTION
Adds two conditions in order to allow three-coordinate N to be considered as stereogenic:
1. Must be sp3 hybridized
2. Cannot be involved in a conjugated bond