### PR TITLE
MaeWriter: handle the R group label property and update the Maestro property prefixing

### DIFF
--- a/Code/GraphMol/FileParsers/MaeMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/MaeMolSupplier.cpp
@@ -207,10 +207,15 @@ void parseStereoBondLabel(RWMol &mol, const std::string &stereo_prop) {
 }
 
 std::string strip_prefix_from_mae_property(const std::string &propName) {
-  const char &first = propName[0];
-  if ((first == 'b' || first == 'i' || first == 'r' || first == 's') &&
-      (strncmp(&propName.c_str()[1], "_rdk_", 5) == 0)) {
-    return propName.substr(6);
+  const char *propNamePtr = propName.c_str();
+  if (*propNamePtr == 'b' || *propNamePtr == 'i' || *propNamePtr == 'r' ||
+      *propNamePtr == 's') {
+    ++propNamePtr;
+    if (strncmp(propNamePtr, "_rdk_", 5) == 0) {
+      return propName.substr(6);
+    } else if (strncmp(propNamePtr, "_rdkit_", 7) == 0) {
+      return propName.substr(8);
+    }
   }
   return propName;
 }
@@ -317,6 +322,10 @@ void set_atom_properties(Atom &atom, const mae::IndexedBlock &atom_block,
     if (prop.first == mae::ATOM_FORMAL_CHARGE) {
       // Formal charge has a specific setter
       atom.setFormalCharge(prop.second->at(i));
+    } else if (prop.first == MAE_RGROUP_LABEL) {
+      // Schrodinger adopted RDKit's Group label property,
+      // but with a "i_sd_" prefix instead of the usual "i_rdkit_"
+      atom.setProp(common_properties::_MolFileRLabel, prop.second->at(i));
     } else {
       auto propName = strip_prefix_from_mae_property(prop.first);
       atom.setProp(propName, prop.second->at(i));

--- a/Code/GraphMol/FileParsers/MaeWriter.cpp
+++ b/Code/GraphMol/FileParsers/MaeWriter.cpp
@@ -154,7 +154,7 @@ void copyProperties(
       case RDTypeTag::BoolTag: {
         auto propName = prop.key;
         if (!std::regex_match(prop.key, MMCT_PROP_REGEX)) {
-          propName.insert(0, "b_rdk_");
+          propName.insert(0, "b_rdkit_");
         }
 
         boolSetter(propName, idx, rdvalue_cast<bool>(prop.val));
@@ -164,8 +164,10 @@ void copyProperties(
       case RDTypeTag::IntTag:
       case RDTypeTag::UnsignedIntTag: {
         auto propName = prop.key;
-        if (!std::regex_match(prop.key, MMCT_PROP_REGEX)) {
-          propName.insert(0, "i_rdk_");
+        if (prop.key == common_properties::_MolFileRLabel) {
+          propName = MAE_RGROUP_LABEL;
+        } else if (!std::regex_match(prop.key, MMCT_PROP_REGEX)) {
+          propName.insert(0, "i_rdkit_");
         }
 
         intSetter(propName, idx, rdvalue_cast<int>(prop.val));
@@ -176,7 +178,7 @@ void copyProperties(
       case RDTypeTag::FloatTag: {
         auto propName = prop.key;
         if (!std::regex_match(prop.key, MMCT_PROP_REGEX)) {
-          propName.insert(0, "r_rdk_");
+          propName.insert(0, "r_rdkit_");
         }
 
         realSetter(propName, idx, rdvalue_cast<double>(prop.val));
@@ -186,7 +188,7 @@ void copyProperties(
       case RDTypeTag::StringTag: {
         auto propName = prop.key;
         if (!std::regex_match(prop.key, MMCT_PROP_REGEX)) {
-          propName.insert(0, "s_rdk_");
+          propName.insert(0, "s_rdkit_");
         }
 
         stringSetter(propName, idx, rdvalue_cast<std::string>(prop.val));

--- a/Code/GraphMol/FileParsers/MaestroProperties.h
+++ b/Code/GraphMol/FileParsers/MaestroProperties.h
@@ -18,6 +18,7 @@ static const std::string MAE_BOND_DATIVE_MARK = "b_sPrivate_dative_bond";
 static const std::string MAE_BOND_PARITY = "i_sd_original_parity";
 static const std::string MAE_ENHANCED_STEREO_STATUS =
     "i_m_ct_enhanced_stereo_status";
+static const std::string MAE_RGROUP_LABEL = "i_sd__MolFileRLabel";
 static const std::string MAE_STEREO_STATUS = "i_m_ct_stereo_status";
 static const std::string PDB_ATOM_NAME = "s_m_pdb_atom_name";
 static const std::string PDB_CHAIN_NAME = "s_m_chain_name";

--- a/Code/GraphMol/FileParsers/file_parsers_catch.cpp
+++ b/Code/GraphMol/FileParsers/file_parsers_catch.cpp
@@ -6003,7 +6003,7 @@ $$$$
 }
 
 TEST_CASE("MaeWriter basic testing", "[mae][MaeWriter][writer]") {
-  auto mol = "C1CCCCC1"_smiles;
+  auto mol = "C1CCC(*)CC1"_smiles;
   REQUIRE(mol);
 
   auto add_some_props = [](RDProps &obj, const std::string &prefix) {
@@ -6016,6 +6016,8 @@ TEST_CASE("MaeWriter basic testing", "[mae][MaeWriter][writer]") {
   add_some_props(*mol, "mol");
   add_some_props(*mol->getAtomWithIdx(0), "atom");
   add_some_props(*mol->getBondWithIdx(0), "bond");
+
+  setAtomRLabel(mol->getAtomWithIdx(4), 3);
 
   SECTION("Check output") {
     mol->setProp(common_properties::_Name, "test mol 1");
@@ -6035,10 +6037,10 @@ TEST_CASE("MaeWriter basic testing", "[mae][MaeWriter][writer]") {
     auto ctBlockStart = mae.find("f_m_ct");
     REQUIRE(ctBlockStart != std::string::npos);
 
-    auto atomBlockStart = mae.find("m_atom[6]");
+    auto atomBlockStart = mae.find("m_atom[7]");
     REQUIRE(atomBlockStart != std::string::npos);
 
-    auto bondBlockStart = mae.find("m_bond[6]");
+    auto bondBlockStart = mae.find("m_bond[7]");
     REQUIRE(bondBlockStart != std::string::npos);
 
     std::string ctBlock(&mae[ctBlockStart], atomBlockStart - ctBlockStart);
@@ -6049,10 +6051,10 @@ TEST_CASE("MaeWriter basic testing", "[mae][MaeWriter][writer]") {
     // Check mol properties
     CHECK(ctBlock.find("s_m_title") != std::string::npos);
 
-    CHECK(ctBlock.find("b_rdk_mol_bool_prop") != std::string::npos);
-    CHECK(ctBlock.find("i_rdk_mol_int_prop") != std::string::npos);
-    CHECK(ctBlock.find("r_rdk_mol_real_prop") != std::string::npos);
-    CHECK(ctBlock.find("s_rdk_mol_string_prop") != std::string::npos);
+    CHECK(ctBlock.find("b_rdkit_mol_bool_prop") != std::string::npos);
+    CHECK(ctBlock.find("i_rdkit_mol_int_prop") != std::string::npos);
+    CHECK(ctBlock.find("r_rdkit_mol_real_prop") != std::string::npos);
+    CHECK(ctBlock.find("s_rdkit_mol_string_prop") != std::string::npos);
 
     // Check Atom properties
     CHECK(atomBlock.find("r_m_x_coord") != std::string::npos);
@@ -6061,20 +6063,20 @@ TEST_CASE("MaeWriter basic testing", "[mae][MaeWriter][writer]") {
     CHECK(atomBlock.find("i_m_atomic_number") != std::string::npos);
     CHECK(atomBlock.find("i_m_formal_charge") != std::string::npos);
 
-    CHECK(atomBlock.find("b_rdk_atom_bool_prop") != std::string::npos);
-    CHECK(atomBlock.find("i_rdk_atom_int_prop") != std::string::npos);
-    CHECK(atomBlock.find("r_rdk_atom_real_prop") != std::string::npos);
-    CHECK(atomBlock.find("s_rdk_atom_string_prop") != std::string::npos);
+    CHECK(atomBlock.find("b_rdkit_atom_bool_prop") != std::string::npos);
+    CHECK(atomBlock.find("i_rdkit_atom_int_prop") != std::string::npos);
+    CHECK(atomBlock.find("r_rdkit_atom_real_prop") != std::string::npos);
+    CHECK(atomBlock.find("s_rdkit_atom_string_prop") != std::string::npos);
 
     // Check Bond properties
     CHECK(bondBlock.find("i_m_from") != std::string::npos);
     CHECK(bondBlock.find("i_m_to") != std::string::npos);
     CHECK(bondBlock.find("i_m_order") != std::string::npos);
 
-    CHECK(bondBlock.find("b_rdk_bond_bool_prop") != std::string::npos);
-    CHECK(bondBlock.find("i_rdk_bond_int_prop") != std::string::npos);
-    CHECK(bondBlock.find("r_rdk_bond_real_prop") != std::string::npos);
-    CHECK(bondBlock.find("s_rdk_bond_string_prop") != std::string::npos);
+    CHECK(bondBlock.find("b_rdkit_bond_bool_prop") != std::string::npos);
+    CHECK(bondBlock.find("i_rdkit_bond_int_prop") != std::string::npos);
+    CHECK(bondBlock.find("r_rdkit_bond_real_prop") != std::string::npos);
+    CHECK(bondBlock.find("s_rdkit_bond_string_prop") != std::string::npos);
   }
 
   SECTION("Check bond ends indices order") {
@@ -6088,7 +6090,7 @@ TEST_CASE("MaeWriter basic testing", "[mae][MaeWriter][writer]") {
 
     std::string line;
     while (std::getline(*oss, line) &&
-           line.find("m_bond[6]") == std::string::npos) {
+           line.find("m_bond[7]") == std::string::npos) {
       // Discard data until we reach the bond block
     }
 
@@ -6167,10 +6169,10 @@ TEST_CASE("MaeWriter basic testing", "[mae][MaeWriter][writer]") {
     auto ctBlockStart = mae.find("f_m_ct");
     REQUIRE(ctBlockStart != std::string::npos);
 
-    auto atomBlockStart = mae.find("m_atom[6]");
+    auto atomBlockStart = mae.find("m_atom[7]");
     REQUIRE(atomBlockStart != std::string::npos);
 
-    auto bondBlockStart = mae.find("m_bond[6]");
+    auto bondBlockStart = mae.find("m_bond[7]");
     REQUIRE(bondBlockStart != std::string::npos);
 
     std::string ctBlock(&mae[ctBlockStart], atomBlockStart - ctBlockStart);
@@ -6181,11 +6183,11 @@ TEST_CASE("MaeWriter basic testing", "[mae][MaeWriter][writer]") {
     // Check mol properties
     CHECK(ctBlock.find("s_m_title") != std::string::npos);
 
-    CHECK(ctBlock.find("b_rdk_mol_bool_prop") != std::string::npos);
+    CHECK(ctBlock.find("b_rdkit_mol_bool_prop") != std::string::npos);
 
-    CHECK(ctBlock.find("i_rdk_mol_int_prop") == std::string::npos);
-    CHECK(ctBlock.find("r_rdk_mol_real_prop") == std::string::npos);
-    CHECK(ctBlock.find("s_rdk_mol_string_prop") == std::string::npos);
+    CHECK(ctBlock.find("i_rdkit_mol_int_prop") == std::string::npos);
+    CHECK(ctBlock.find("r_rdkit_mol_real_prop") == std::string::npos);
+    CHECK(ctBlock.find("s_rdkit_mol_string_prop") == std::string::npos);
 
     // Check Atom properties
     CHECK(atomBlock.find("r_m_x_coord") != std::string::npos);
@@ -6194,25 +6196,25 @@ TEST_CASE("MaeWriter basic testing", "[mae][MaeWriter][writer]") {
     CHECK(atomBlock.find("i_m_atomic_number") != std::string::npos);
     CHECK(atomBlock.find("i_m_formal_charge") != std::string::npos);
 
-    CHECK(atomBlock.find("i_rdk_atom_int_prop") != std::string::npos);
+    CHECK(atomBlock.find("i_rdkit_atom_int_prop") != std::string::npos);
 
-    CHECK(atomBlock.find("b_rdk_atom_bool_prop") == std::string::npos);
-    CHECK(atomBlock.find("r_rdk_atom_real_prop") == std::string::npos);
-    CHECK(atomBlock.find("s_rdk_atom_string_prop") == std::string::npos);
+    CHECK(atomBlock.find("b_rdkit_atom_bool_prop") == std::string::npos);
+    CHECK(atomBlock.find("r_rdkit_atom_real_prop") == std::string::npos);
+    CHECK(atomBlock.find("s_rdkit_atom_string_prop") == std::string::npos);
 
     // Check Bond properties
     CHECK(bondBlock.find("i_m_from") != std::string::npos);
     CHECK(bondBlock.find("i_m_to") != std::string::npos);
     CHECK(bondBlock.find("i_m_order") != std::string::npos);
 
-    CHECK(bondBlock.find("r_rdk_bond_real_prop") != std::string::npos);
+    CHECK(bondBlock.find("r_rdkit_bond_real_prop") != std::string::npos);
 
-    CHECK(bondBlock.find("b_rdk_bond_bool_prop") == std::string::npos);
-    CHECK(bondBlock.find("i_rdk_bond_int_prop") == std::string::npos);
-    CHECK(bondBlock.find("s_rdk_bond_string_prop") == std::string::npos);
+    CHECK(bondBlock.find("b_rdkit_bond_bool_prop") == std::string::npos);
+    CHECK(bondBlock.find("i_rdkit_bond_int_prop") == std::string::npos);
+    CHECK(bondBlock.find("s_rdkit_bond_string_prop") == std::string::npos);
 
-    // The "i_rdk_atom_int_prop" prop should only be set on the first atom,
-    // and unset on the other five
+    // The "i_rdkit_atom_int_prop" prop should only be set on the first atom,
+    // and unset on the other six
     auto count_occurrences = [&atomBlock](const char *needle) {
       size_t pos = 0;
       unsigned counter = 0;
@@ -6224,7 +6226,7 @@ TEST_CASE("MaeWriter basic testing", "[mae][MaeWriter][writer]") {
     };
 
     CHECK(count_occurrences(" 42") == 1);
-    CHECK(count_occurrences(" <>") == 5);
+    CHECK(count_occurrences(" <>") == 6);
   }
 
   SECTION("Check roundtrip") {
@@ -6242,7 +6244,7 @@ TEST_CASE("MaeWriter basic testing", "[mae][MaeWriter][writer]") {
     std::unique_ptr<ROMol> roundtrip_mol(r.next());
     REQUIRE(roundtrip_mol);
 
-    REQUIRE(MolToSmiles(*roundtrip_mol) == "C1CCCCC1");
+    REQUIRE(MolToSmiles(*roundtrip_mol) == "*C1CCCCC1");
 
     {
       INFO("Checking mol properties");
@@ -6646,20 +6648,20 @@ TEST_CASE("MaeWriter should not prefix Maestro-formatted properties") {
   }
 
   // properties that already match the Maestro format should not be prefixed
-  // with "[birs]_rdk_"
-  CHECK(mae_block.find("b_rdk_b_m_subgroup_collapsed") == std::string::npos);
+  // with "[birs]_rdkit_"
+  CHECK(mae_block.find("b_rdkit_b_m_subgroup_collapsed") == std::string::npos);
   CHECK(mae_block.find("b_m_subgroup_collapsed") != std::string::npos);
 
-  CHECK(mae_block.find("b_rdk_b_sd_chiral_flag") == std::string::npos);
+  CHECK(mae_block.find("b_rdkit_b_sd_chiral_flag") == std::string::npos);
   CHECK(mae_block.find("b_sd_chiral_flag") != std::string::npos);
 
-  CHECK(mae_block.find("i_rdk_i_m_Source_File_Index") == std::string::npos);
+  CHECK(mae_block.find("i_rdkit_i_m_Source_File_Index") == std::string::npos);
   CHECK(mae_block.find("i_m_Source_File_Index") != std::string::npos);
 
-  CHECK(mae_block.find("i_rdk_i_m_ct_format") == std::string::npos);
+  CHECK(mae_block.find("i_rdkit_i_m_ct_format") == std::string::npos);
   CHECK(mae_block.find("i_m_ct_format") != std::string::npos);
 
-  CHECK(mae_block.find("s_rdk_s_m_entry_name") == std::string::npos);
+  CHECK(mae_block.find("s_rdkit_s_m_entry_name") == std::string::npos);
   CHECK(mae_block.find("s_m_entry_name") != std::string::npos);
 }
 


### PR DESCRIPTION
Maestro Structures adopted RDKit's property name for R group labels, but instead of prefixing it with the standard `i_rdkit_` prefix that is usually applied to integer properties coming from RDKit properties to adapt them to Maestro's property format, it is prefixed with `i_sd_`. This patch adds a few lines of code to handle this in `MaeWriter` and `MaeMolSupplier`.

Also, this patch updates the prefix that is applied to and expected from Maestro properties: oddly enough, Schrödinger's code applies a `[birs]_rdkit_` prefix to (most; see above) properties coming from RDKit, but `MaeWriter` was using `[birs]_rdk_`. This patch updates `MaeWriter` to also use `[birs]_rdkit_` as prefix. I allowed `MaeMolSupplier` to still accept `[birs]_rdk_` for backwards compatibility with potantially existing data files.