### PR TITLE
Optionally limit the MolStandardize::Uncharger to only alter the protonation state

### DIFF
--- a/Code/GraphMol/MolStandardize/Charge.h
+++ b/Code/GraphMol/MolStandardize/Charge.h
@@ -137,6 +137,11 @@ class RDKIT_MOLSTANDARDIZE_EXPORT Uncharger {
     df_canonicalOrdering = canonicalOrdering;
     df_force = force;
   }
+  Uncharger(bool canonicalOrdering, bool force, bool protonationOnly) : Uncharger() {
+    df_canonicalOrdering = canonicalOrdering;
+    df_force = force;
+    df_protonationOnly = protonationOnly;
+  }
   Uncharger(const Uncharger &) = default;
   ~Uncharger() = default;
   
@@ -144,8 +149,11 @@ class RDKIT_MOLSTANDARDIZE_EXPORT Uncharger {
   void unchargeInPlace(RWMol &mol);
 
  private:
+  bool removePosIfPossible(Atom *atom);
+  bool removeNegIfPossible(Atom *atom);
   bool df_canonicalOrdering = true;
   bool df_force = false;
+  bool df_protonationOnly = false;
   std::shared_ptr<ROMol> pos_h;
   std::shared_ptr<ROMol> pos_noh;
   std::shared_ptr<ROMol> neg;

--- a/Code/GraphMol/MolStandardize/Wrap/Charge.cpp
+++ b/Code/GraphMol/MolStandardize/Wrap/Charge.cpp
@@ -86,9 +86,10 @@ struct charge_wrapper {
                 "and a list of charge corrections",
                 python::return_value_policy<python::manage_new_object>());
     python::class_<MolStandardize::Uncharger, boost::noncopyable>(
-        "Uncharger", python::init<bool, bool>((python::arg("self"),
+        "Uncharger", python::init<bool, bool, bool>((python::arg("self"),
                                          python::arg("canonicalOrder") = true,
-                                         python::arg("force") = false)))
+                                         python::arg("force") = false,
+                                         python::arg("protonationOnly") = false)))
         .def("uncharge", &MolStandardize::Uncharger::uncharge,
              (python::arg("self"), python::arg("mol")), "",
              python::return_value_policy<python::manage_new_object>())

--- a/Code/GraphMol/MolStandardize/testCharge.cpp
+++ b/Code/GraphMol/MolStandardize/testCharge.cpp
@@ -261,6 +261,52 @@ void testChargedAromatics() {
   BOOST_LOG(rdDebugLog) << "Finished" << std::endl;
 }
 
+void testUnchargerProtonationOnly() {
+  BOOST_LOG(rdDebugLog)
+      << "-----------------------\n Testing removal of formal charges limited to "
+         "changing the protonation state (no redox via addition/removal of H-)"
+      << std::endl;
+  {
+    // simple test verifying that for protic compounds the behavior
+    // should be the same as usual
+    auto m1 = "C[N+](C)(C)CC[O-]"_smiles;
+    TEST_ASSERT(m1);
+    // with force=false the zwitterion should stay unmodified
+    MolStandardize::Uncharger uncharger1(false, false, true);
+    std::unique_ptr<ROMol> res1(uncharger1.uncharge(*m1));
+    TEST_ASSERT(res1.get());
+    TEST_ASSERT(MolToSmiles(*res1) == "C[N+](C)(C)CC[O-]");
+    // with force=true the oxygen should be neutralized
+    MolStandardize::Uncharger uncharger2(false, true, true);
+    std::unique_ptr<ROMol> res2(uncharger2.uncharge(*m1));
+    TEST_ASSERT(res2.get());
+    TEST_ASSERT(MolToSmiles(*res2) == "C[N+](C)(C)CCO");
+  }
+  {
+    auto tropylium = "[cH+]1cccccc1"_smiles;
+    TEST_ASSERT(tropylium);
+    // try uncharging as much as possible, but only allow
+    // protonating/deprotonating.
+    MolStandardize::Uncharger uncharger(false, true, true);
+    // tropylium should stay unmodified
+    std::unique_ptr<ROMol> res(uncharger.uncharge(*tropylium));
+    TEST_ASSERT(res.get());
+    TEST_ASSERT(MolToSmiles(*res) == "c1ccc[cH+]cc1");
+  }
+  {
+    auto boronhydride = "[BH4-]"_smiles;
+    TEST_ASSERT(boronhydride);
+    // try uncharging as much as possible, but only allow
+    // protonating/deprotonating.
+    MolStandardize::Uncharger uncharger(false, true, true);
+    // boronhydride should stay unmodified
+    std::unique_ptr<ROMol> res(uncharger.uncharge(*boronhydride));
+    TEST_ASSERT(res.get());
+    TEST_ASSERT(MolToSmiles(*res) == "[BH4-]");
+  }
+  BOOST_LOG(rdDebugLog) << "Finished" << std::endl;
+}
+
 void testInorganicAcids() {
   BOOST_LOG(rdDebugLog) << "-----------------------\n Testing inorganic acids"
                         << std::endl;
@@ -390,6 +436,7 @@ int main() {
   testGithub2144();
   testGithub2346();
   testChargedAromatics();
+  testUnchargerProtonationOnly();
   testInorganicAcids();
   testReionizerParams();
   return 0;


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
This PR extends the `MolStandardize::Uncharger` class to optionally limit the removal of formal charges to changes in the compound's protonation state (no H- would be added/removed).

