### PR TITLE
Allow the substruct library to be deleted when refcount goes to 0

### DIFF
--- a/Code/GraphMol/SubstructLibrary/Wrap/SubstructLibraryWrap.cpp
+++ b/Code/GraphMol/SubstructLibrary/Wrap/SubstructLibraryWrap.cpp
@@ -743,7 +743,7 @@ struct substructlibrary_wrapper {
         python::init<>(python::args("self")))
         .def(python::init<unsigned int>(python::args("self", "numBits")));
 
-    python::class_<SubstructLibraryWrap>(
+    python::class_<SubstructLibraryWrap, boost::shared_ptr<SubstructLibraryWrap>>(
         "SubstructLibrary", SubstructLibraryDoc,
         python::init<>(python::args("self")))
         .def(python::init<boost::shared_ptr<MolHolderBase>>(

--- a/Code/GraphMol/SubstructLibrary/Wrap/SubstructLibraryWrap.cpp
+++ b/Code/GraphMol/SubstructLibrary/Wrap/SubstructLibraryWrap.cpp
@@ -832,8 +832,7 @@ struct substructlibrary_wrapper {
 
         .def("Serialize", &SubstructLibrary_Serialize, python::args("self"))
         // enable pickle support
-        .def_pickle(substructlibrary_pickle_suite()
-		    );
+        .def_pickle(substructlibrary_pickle_suite());
 
     python::def("SubstructLibraryCanSerialize", SubstructLibraryCanSerialize,
                 "Returns True if the SubstructLibrary is serializable "

--- a/Code/GraphMol/SubstructLibrary/Wrap/SubstructLibraryWrap.cpp
+++ b/Code/GraphMol/SubstructLibrary/Wrap/SubstructLibraryWrap.cpp
@@ -743,8 +743,7 @@ struct substructlibrary_wrapper {
         python::init<>(python::args("self")))
         .def(python::init<unsigned int>(python::args("self", "numBits")));
 
-    python::class_<SubstructLibraryWrap, SubstructLibraryWrap *,
-                   const SubstructLibraryWrap *>(
+    python::class_<SubstructLibraryWrap>(
         "SubstructLibrary", SubstructLibraryDoc,
         python::init<>(python::args("self")))
         .def(python::init<boost::shared_ptr<MolHolderBase>>(
@@ -833,7 +832,8 @@ struct substructlibrary_wrapper {
 
         .def("Serialize", &SubstructLibrary_Serialize, python::args("self"))
         // enable pickle support
-        .def_pickle(substructlibrary_pickle_suite());
+        .def_pickle(substructlibrary_pickle_suite()
+		    );
 
     python::def("SubstructLibraryCanSerialize", SubstructLibraryCanSerialize,
                 "Returns True if the SubstructLibrary is serializable "


### PR DESCRIPTION
Fixes  #7457

Using the equivalent of an infinite number monkeys writing Shakespeare, this patch allows python to free a substructlibrary when the ref count goes to zero.

Why it works, or why it was broken in the first place, I have no idea.