### PR TITLE
Install the atropisomer header

### DIFF
--- a/Code/GraphMol/CMakeLists.txt
+++ b/Code/GraphMol/CMakeLists.txt
@@ -22,6 +22,7 @@ endif ()
 rdkit_headers(Atom.h
         atomic_data.h
         AtomIterators.h
+        Atropisomers.h
         Bond.h
         BondIterators.h
         Canon.h


### PR DESCRIPTION
The atropisomer header is missing is not being installed in the 2024.03.3 release.