### PR TITLE
Allow wedged double and aromatic bonds

### DIFF
--- a/Code/GraphMol/MolDraw2D/DrawMol.cpp
+++ b/Code/GraphMol/MolDraw2D/DrawMol.cpp
@@ -1862,6 +1862,13 @@ void DrawMol::makeDoubleBondLines(
   int at2Idx = bond->getEndAtomIdx();
   adjustBondEndsForLabels(at1Idx, at2Idx, end1, end2);
 
+  bool skipFirstLine = false;
+  if (bond->getBondDir() == Bond::BEGINWEDGE ||
+      bond->getBondDir() == Bond::BEGINDASH) {
+    makeWedgedBond(bond, cols);
+    skipFirstLine = true;
+  }
+
   Point2D l1s, l1f, l2s, l2f, sat1, sat2;
   sat1 = atCds_[at1Idx];
   atCds_[at1Idx] = end1;
@@ -1869,8 +1876,10 @@ void DrawMol::makeDoubleBondLines(
   atCds_[at2Idx] = end2;
   calcDoubleBondLines(doubleBondOffset, *bond, l1s, l1f, l2s, l2f);
   int bondIdx = bond->getIdx();
-  newBondLine(l1s, l1f, cols.first, cols.second, at1Idx, at2Idx, bondIdx,
-              noDash);
+  if (!skipFirstLine) {
+    newBondLine(l1s, l1f, cols.first, cols.second, at1Idx, at2Idx, bondIdx,
+                noDash);
+  }
   if (bond->getBondType() == Bond::AROMATIC) {
     newBondLine(l2s, l2f, cols.first, cols.second, at1Idx, at2Idx, bondIdx,
                 dashes);
@@ -2859,6 +2868,7 @@ void DrawMol::calcDoubleBondLines(double offset, const Bond &bond, Point2D &l1s,
   Atom *at1 = bond.getBeginAtom();
   Atom *at2 = bond.getEndAtom();
   Point2D perp;
+
   if (isLinearAtom(*at1, atCds_) || isLinearAtom(*at2, atCds_) ||
       (at1->getDegree() == 1 && at2->getDegree() == 1)) {
     const Point2D &at1_cds = atCds_[at1->getIdx()];

--- a/Code/GraphMol/MolDraw2D/DrawMol.cpp
+++ b/Code/GraphMol/MolDraw2D/DrawMol.cpp
@@ -1862,11 +1862,11 @@ void DrawMol::makeDoubleBondLines(
   int at2Idx = bond->getEndAtomIdx();
   adjustBondEndsForLabels(at1Idx, at2Idx, end1, end2);
 
-  bool skipFirstLine = false;
+  bool skipOuterLine = false;
   if (bond->getBondDir() == Bond::BEGINWEDGE ||
       bond->getBondDir() == Bond::BEGINDASH) {
     makeWedgedBond(bond, cols);
-    skipFirstLine = true;
+    skipOuterLine = true;
   }
 
   Point2D l1s, l1f, l2s, l2f, sat1, sat2;
@@ -1876,7 +1876,7 @@ void DrawMol::makeDoubleBondLines(
   atCds_[at2Idx] = end2;
   calcDoubleBondLines(doubleBondOffset, *bond, l1s, l1f, l2s, l2f);
   int bondIdx = bond->getIdx();
-  if (!skipFirstLine) {
+  if (!skipOuterLine) {
     newBondLine(l1s, l1f, cols.first, cols.second, at1Idx, at2Idx, bondIdx,
                 noDash);
   }

--- a/Code/GraphMol/MolDraw2D/catch_tests.cpp
+++ b/Code/GraphMol/MolDraw2D/catch_tests.cpp
@@ -9521,3 +9521,133 @@ TEST_CASE(
   }
 }
 #endif
+
+TEST_CASE("wedge non-single bonds") {
+  SECTION("basics 1: aromatic bonds") {
+    auto m =
+        "CC(=O)C1=CC=CC=C1C |wU:1.0, (-0.954,-1.74918,;-0.9532,-0.74918,;-1.8188,-0.24858,;-0.0868,-0.24998,;0.7788,-0.75058,;1.6452,-0.25138,;1.646,0.74862,;0.7804,1.24942,;-0.086,0.75002,;-0.9516,1.25082,)|"_smiles;
+    REQUIRE(m);
+    m->getBondBetweenAtoms(3, 4)->setBondDir(Bond::BondDir::BEGINWEDGE);
+    {
+      MolDraw2DSVG drawer(350, 300);
+      drawer.drawOptions().prepareMolsBeforeDrawing = false;
+      drawer.drawMolecule(*m);
+      drawer.finishDrawing();
+      auto text = drawer.getDrawingText();
+      std::ofstream outs("testWedgeNonSingleBonds-1.svg");
+      outs << text;
+      outs.close();
+      check_file_hash("testWedgeNonSingleBonds-1.svg");
+    }
+
+    m->getBondBetweenAtoms(3, 4)->setBondDir(Bond::BondDir::BEGINDASH);
+    {
+      MolDraw2DSVG drawer(350, 300);
+      drawer.drawOptions().prepareMolsBeforeDrawing = false;
+      drawer.drawMolecule(*m);
+      drawer.finishDrawing();
+      auto text = drawer.getDrawingText();
+      std::ofstream outs("testWedgeNonSingleBonds-2.svg");
+      outs << text;
+      outs.close();
+      check_file_hash("testWedgeNonSingleBonds-2.svg");
+    }
+  }
+  SECTION("basics 2 : aromatic bonds, draw to a heteroatom") {
+    auto m =
+        "CC(=O)C1=NC=CC=C1C |wU:1.0, (-0.954,-1.74918,;-0.9532,-0.74918,;-1.8188,-0.24858,;-0.0868,-0.24998,;0.7788,-0.75058,;1.6452,-0.25138,;1.646,0.74862,;0.7804,1.24942,;-0.086,0.75002,;-0.9516,1.25082,)|"_smiles;
+    REQUIRE(m);
+    m->getBondBetweenAtoms(3, 4)->setBondDir(Bond::BondDir::BEGINWEDGE);
+    {
+      MolDraw2DSVG drawer(350, 300);
+      drawer.drawOptions().prepareMolsBeforeDrawing = false;
+      drawer.drawMolecule(*m);
+      drawer.finishDrawing();
+      auto text = drawer.getDrawingText();
+      std::ofstream outs("testWedgeNonSingleBonds-3.svg");
+      outs << text;
+      outs.close();
+      check_file_hash("testWedgeNonSingleBonds-3.svg");
+    }
+
+    m->getBondBetweenAtoms(3, 4)->setBondDir(Bond::BondDir::BEGINDASH);
+    {
+      MolDraw2DSVG drawer(350, 300);
+      drawer.drawOptions().prepareMolsBeforeDrawing = false;
+      drawer.drawMolecule(*m);
+      drawer.finishDrawing();
+      auto text = drawer.getDrawingText();
+      std::ofstream outs("testWedgeNonSingleBonds-4.svg");
+      outs << text;
+      outs.close();
+      check_file_hash("testWedgeNonSingleBonds-4.svg");
+    }
+  }
+
+  SECTION("basics 3: double bonds") {
+    auto m =
+        "CC(=O)C1=CC=CC=C1C |wU:1.0, (-0.954,-1.74918,;-0.9532,-0.74918,;-1.8188,-0.24858,;-0.0868,-0.24998,;0.7788,-0.75058,;1.6452,-0.25138,;1.646,0.74862,;0.7804,1.24942,;-0.086,0.75002,;-0.9516,1.25082,)|"_smiles;
+    REQUIRE(m);
+    MolOps::Kekulize(*m);
+    CHECK(m->getBondBetweenAtoms(3, 4)->getBondType() ==
+          Bond::BondType::DOUBLE);
+    m->getBondBetweenAtoms(3, 4)->setBondDir(Bond::BondDir::BEGINWEDGE);
+    {
+      MolDraw2DSVG drawer(350, 300);
+      drawer.drawOptions().prepareMolsBeforeDrawing = false;
+      drawer.drawMolecule(*m);
+      drawer.finishDrawing();
+      auto text = drawer.getDrawingText();
+      std::ofstream outs("testWedgeNonSingleBonds-5.svg");
+      outs << text;
+      outs.close();
+      check_file_hash("testWedgeNonSingleBonds-5.svg");
+    }
+
+    m->getBondBetweenAtoms(3, 4)->setBondDir(Bond::BondDir::BEGINDASH);
+    {
+      MolDraw2DSVG drawer(350, 300);
+      drawer.drawOptions().prepareMolsBeforeDrawing = false;
+      drawer.drawMolecule(*m);
+      drawer.finishDrawing();
+      auto text = drawer.getDrawingText();
+      std::ofstream outs("testWedgeNonSingleBonds-6.svg");
+      outs << text;
+      outs.close();
+      check_file_hash("testWedgeNonSingleBonds-6.svg");
+    }
+  }
+  SECTION("basics 3: double bonds, draw to a heteroatom") {
+    auto m =
+        "CC(=O)C1=NC=CC=C1C |wU:1.0, (-0.954,-1.74918,;-0.9532,-0.74918,;-1.8188,-0.24858,;-0.0868,-0.24998,;0.7788,-0.75058,;1.6452,-0.25138,;1.646,0.74862,;0.7804,1.24942,;-0.086,0.75002,;-0.9516,1.25082,)|"_smiles;
+    REQUIRE(m);
+    MolOps::Kekulize(*m);
+    CHECK(m->getBondBetweenAtoms(3, 4)->getBondType() ==
+          Bond::BondType::DOUBLE);
+    m->getBondBetweenAtoms(3, 4)->setBondDir(Bond::BondDir::BEGINWEDGE);
+    {
+      MolDraw2DSVG drawer(350, 300);
+      drawer.drawOptions().prepareMolsBeforeDrawing = false;
+      drawer.drawMolecule(*m);
+      drawer.finishDrawing();
+      auto text = drawer.getDrawingText();
+      std::ofstream outs("testWedgeNonSingleBonds-7.svg");
+      outs << text;
+      outs.close();
+      check_file_hash("testWedgeNonSingleBonds-7.svg");
+    }
+
+    m->getBondBetweenAtoms(3, 4)->setBondDir(Bond::BondDir::BEGINDASH);
+    {
+      MolDraw2DSVG drawer(350, 300);
+      drawer.drawOptions().prepareMolsBeforeDrawing = false;
+      drawer.drawMolecule(*m);
+      drawer.finishDrawing();
+      auto text = drawer.getDrawingText();
+      std::ofstream outs("testWedgeNonSingleBonds-8.svg");
+      outs << text;
+      outs.close();
+      check_file_hash("testWedgeNonSingleBonds-8.svg");
+    }
+  }
+}

--- a/Code/GraphMol/MolDraw2D/catch_tests.cpp
+++ b/Code/GraphMol/MolDraw2D/catch_tests.cpp
@@ -327,7 +327,16 @@ const std::map<std::string, std::hash_result_t> SVG_HASHES = {
     {"AtropCanon1.svg", 1587179714U},
     {"AtropManyChiralsEnhanced.svg", 3871032500U},
     {"testGithub6968.svg", 1554428830U},
-    {"testGithub7036.svg", 2355702607U}};
+    {"testGithub7036.svg", 2355702607U},
+    {"testWedgeNonSingleBonds-1.svg", 865601717U},
+    {"testWedgeNonSingleBonds-2.svg", 2960559495U},
+    {"testWedgeNonSingleBonds-3.svg", 1428196589U},
+    {"testWedgeNonSingleBonds-4.svg", 3897680387U},
+    {"testWedgeNonSingleBonds-5.svg", 2183530217U},
+    {"testWedgeNonSingleBonds-6.svg", 238313010U},
+    {"testWedgeNonSingleBonds-7.svg", 3641456570U},
+    {"testWedgeNonSingleBonds-8.svg", 3209701539U},
+};
 
 // These PNG hashes aren't completely reliable due to floating point cruft,
 // but they can still reduce the number of drawings that need visual
@@ -9523,13 +9532,22 @@ TEST_CASE(
 #endif
 
 TEST_CASE("wedge non-single bonds") {
+  int panelHeight = -1;
+  int panelWidth = -1;
+  bool noFreeType = false;
+  MolDraw2DSVG drawer(350, 300, panelWidth, panelHeight, noFreeType);
+  drawer.drawOptions().prepareMolsBeforeDrawing = false;
+
   SECTION("basics 1: aromatic bonds") {
     auto m =
         "CC(=O)C1=CC=CC=C1C |wU:1.0, (-0.954,-1.74918,;-0.9532,-0.74918,;-1.8188,-0.24858,;-0.0868,-0.24998,;0.7788,-0.75058,;1.6452,-0.25138,;1.646,0.74862,;0.7804,1.24942,;-0.086,0.75002,;-0.9516,1.25082,)|"_smiles;
     REQUIRE(m);
     m->getBondBetweenAtoms(3, 4)->setBondDir(Bond::BondDir::BEGINWEDGE);
     {
-      MolDraw2DSVG drawer(350, 300);
+      int panelHeight = -1;
+      int panelWidth = -1;
+      bool noFreeType = false;
+      MolDraw2DSVG drawer(350, 300, panelWidth, panelHeight, noFreeType);
       drawer.drawOptions().prepareMolsBeforeDrawing = false;
       drawer.drawMolecule(*m);
       drawer.finishDrawing();
@@ -9542,7 +9560,10 @@ TEST_CASE("wedge non-single bonds") {
 
     m->getBondBetweenAtoms(3, 4)->setBondDir(Bond::BondDir::BEGINDASH);
     {
-      MolDraw2DSVG drawer(350, 300);
+      int panelHeight = -1;
+      int panelWidth = -1;
+      bool noFreeType = false;
+      MolDraw2DSVG drawer(350, 300, panelWidth, panelHeight, noFreeType);
       drawer.drawOptions().prepareMolsBeforeDrawing = false;
       drawer.drawMolecule(*m);
       drawer.finishDrawing();
@@ -9559,7 +9580,10 @@ TEST_CASE("wedge non-single bonds") {
     REQUIRE(m);
     m->getBondBetweenAtoms(3, 4)->setBondDir(Bond::BondDir::BEGINWEDGE);
     {
-      MolDraw2DSVG drawer(350, 300);
+      int panelHeight = -1;
+      int panelWidth = -1;
+      bool noFreeType = false;
+      MolDraw2DSVG drawer(350, 300, panelWidth, panelHeight, noFreeType);
       drawer.drawOptions().prepareMolsBeforeDrawing = false;
       drawer.drawMolecule(*m);
       drawer.finishDrawing();
@@ -9572,7 +9596,10 @@ TEST_CASE("wedge non-single bonds") {
 
     m->getBondBetweenAtoms(3, 4)->setBondDir(Bond::BondDir::BEGINDASH);
     {
-      MolDraw2DSVG drawer(350, 300);
+      int panelHeight = -1;
+      int panelWidth = -1;
+      bool noFreeType = false;
+      MolDraw2DSVG drawer(350, 300, panelWidth, panelHeight, noFreeType);
       drawer.drawOptions().prepareMolsBeforeDrawing = false;
       drawer.drawMolecule(*m);
       drawer.finishDrawing();
@@ -9593,7 +9620,10 @@ TEST_CASE("wedge non-single bonds") {
           Bond::BondType::DOUBLE);
     m->getBondBetweenAtoms(3, 4)->setBondDir(Bond::BondDir::BEGINWEDGE);
     {
-      MolDraw2DSVG drawer(350, 300);
+      int panelHeight = -1;
+      int panelWidth = -1;
+      bool noFreeType = false;
+      MolDraw2DSVG drawer(350, 300, panelWidth, panelHeight, noFreeType);
       drawer.drawOptions().prepareMolsBeforeDrawing = false;
       drawer.drawMolecule(*m);
       drawer.finishDrawing();
@@ -9606,7 +9636,10 @@ TEST_CASE("wedge non-single bonds") {
 
     m->getBondBetweenAtoms(3, 4)->setBondDir(Bond::BondDir::BEGINDASH);
     {
-      MolDraw2DSVG drawer(350, 300);
+      int panelHeight = -1;
+      int panelWidth = -1;
+      bool noFreeType = false;
+      MolDraw2DSVG drawer(350, 300, panelWidth, panelHeight, noFreeType);
       drawer.drawOptions().prepareMolsBeforeDrawing = false;
       drawer.drawMolecule(*m);
       drawer.finishDrawing();
@@ -9626,7 +9659,10 @@ TEST_CASE("wedge non-single bonds") {
           Bond::BondType::DOUBLE);
     m->getBondBetweenAtoms(3, 4)->setBondDir(Bond::BondDir::BEGINWEDGE);
     {
-      MolDraw2DSVG drawer(350, 300);
+      int panelHeight = -1;
+      int panelWidth = -1;
+      bool noFreeType = false;
+      MolDraw2DSVG drawer(350, 300, panelWidth, panelHeight, noFreeType);
       drawer.drawOptions().prepareMolsBeforeDrawing = false;
       drawer.drawMolecule(*m);
       drawer.finishDrawing();
@@ -9639,7 +9675,10 @@ TEST_CASE("wedge non-single bonds") {
 
     m->getBondBetweenAtoms(3, 4)->setBondDir(Bond::BondDir::BEGINDASH);
     {
-      MolDraw2DSVG drawer(350, 300);
+      int panelHeight = -1;
+      int panelWidth = -1;
+      bool noFreeType = false;
+      MolDraw2DSVG drawer(350, 300, panelWidth, panelHeight, noFreeType);
       drawer.drawOptions().prepareMolsBeforeDrawing = false;
       drawer.drawMolecule(*m);
       drawer.finishDrawing();


### PR DESCRIPTION
When working with atropisomers, it's more or less inevitable that we're going to have things like this happen and we need to be able to render them.

This uses the following drawing style for these cases (shown here for aromatic bonds):
![image](https://github.com/rdkit/rdkit/assets/540511/14979949-b414-4f3f-ba33-56f76a5ea918)

(yes, the example molecule is a stupid one... the idea is just to show what the drawing style is)
