### PR TITLE
Avoid inconsistency between V2K and V3K MDL output wrt isotopic labelling of R groups

### DIFF
--- a/Code/GraphMol/FileParsers/MolFileWriter.cpp
+++ b/Code/GraphMol/FileParsers/MolFileWriter.cpp
@@ -139,6 +139,11 @@ int getQueryBondSymbol(const Bond *bond) {
   }
   return res;
 }
+
+bool isAtomRGroup(const Atom &atom) {
+  return atom.getAtomicNum() == 0 &&
+         atom.hasProp(common_properties::_MolFileRLabel);
+}
 }  // namespace
 
 const std::string GetMolFileChargeInfo(const RWMol &mol) {
@@ -177,7 +182,7 @@ const std::string GetMolFileChargeInfo(const RWMol &mol) {
         nRads = 0;
       }
     }
-    if (!atom->hasQuery()) {
+    if (!isAtomRGroup(*atom)) {
       int isotope = atom->getIsotope();
       if (isotope != 0) {
         ++nMassDiffs;
@@ -805,7 +810,7 @@ const std::string GetV3000MolFileAtomLine(
   if (chg != 0) {
     ss << " CHG=" << chg;
   }
-  if (isotope != 0) {
+  if (isotope != 0 && !isAtomRGroup(*atom)) {
     // the documentation for V3000 CTABs says that this should contain the
     // "absolute atomic weight" (whatever that means).
     // Online examples seem to have integer (isotope) values and Marvin won't

--- a/Code/GraphMol/FileParsers/testMolWriter.cpp
+++ b/Code/GraphMol/FileParsers/testMolWriter.cpp
@@ -1557,6 +1557,50 @@ void testMolFileWriterDativeBonds() {
   }
 }
 
+void testRGPMolFileWriterV2KV3K() {
+  BOOST_LOG(rdInfoLog)
+      << "testing that R groups do not lead either to M  ISO or MASS records"
+      << std::endl;
+  {
+    auto m = R"CTAB(
+
+     RDKit          2D
+  4  3  0  0  0  0  0  0  0  0999 V2000
+    0.0000    2.4750    0.0000 R#  0  0  0  0  0  0  0  0  0  0  0  0
+    0.7145    2.0625    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    1.4289    2.4750    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0
+    0.7145    1.2375    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+  1  2  1  0
+  2  3  2  0
+  2  4  1  0
+M  RGP  1   1   2
+M  END)CTAB"_ctab;
+    auto mbV2K = MolToMolBlock(*m);
+    TEST_ASSERT(mbV2K.find("M  ISO") == std::string::npos);
+    TEST_ASSERT(mbV2K.find("M  RGP") != std::string::npos);
+    auto mbV3K = MolToV3KMolBlock(*m);
+    TEST_ASSERT(mbV3K.find("MASS") == std::string::npos);
+    TEST_ASSERT(mbV3K.find("RGROUPS") != std::string::npos);
+  }
+  {
+    auto m = R"CTAB(
+  MJ201100                      
+
+  3  2  0  0  0  0  0  0  0  0999 V2000
+   -1.5623    1.6625    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -2.2767    1.2500    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -1.5623    2.4875    0.0000 A   0  0  0  0  0  0  0  0  0  0  0  0
+  2  1  1  0  0  0  0
+  1  3  1  0  0  0  0
+M  ISO  1   3   3
+M  END)CTAB"_ctab;
+    auto mbV2K = MolToMolBlock(*m);
+    TEST_ASSERT(mbV2K.find("M  ISO") != std::string::npos);
+    auto mbV3K = MolToV3KMolBlock(*m);
+    TEST_ASSERT(mbV3K.find("MASS") != std::string::npos);
+  }
+}
+
 int main() {
   RDLog::InitLogs();
 
@@ -1709,5 +1753,9 @@ int main() {
 
   BOOST_LOG(rdInfoLog) << "-----------------------------------------\n";
   testMolFileWriterDativeBonds();
+  BOOST_LOG(rdInfoLog) << "-----------------------------------------\n\n";
+
+  BOOST_LOG(rdInfoLog) << "-----------------------------------------\n";
+  testRGPMolFileWriterV2KV3K();
   BOOST_LOG(rdInfoLog) << "-----------------------------------------\n\n";
 }


### PR DESCRIPTION
This was originally reported by @MariaDolotova.
While the V2000 MDL writer has logic to prevent writing the isotopic label associated to an R-group as a separate `M  ISO` record, the V3000 MDL writer lacks such logic, and hence the R-group atom has a `MASS` record. This is undesired and inconsistent with the V2000 behavior.
This PR corrects that.
Additionally, the decision whether the isotopic label should be written to the MDL output for an atom with atomic number 0 is made based on the presence of the `common_properties::_MolFileRLabel` rather than on the presence of an atom query as previously happened for V2000, which seems a preferrable choice to me as it is less restrictive.