### PR TITLE
Fixes #7509

### DIFF
--- a/Code/GraphMol/catch_chirality.cpp
+++ b/Code/GraphMol/catch_chirality.cpp
@@ -5790,3 +5790,39 @@ TEST_CASE("github #7438: expose code for simplified stereo labels") {
     }
   }
 }
+
+TEST_CASE(
+    "GitHub #7509: atomChiralTypeFromBondDirPseudo3D fails for poorly scaled molecular coordinates") {
+  auto m = R"CTAB(
+     RDKit          2D
+
+  5  4  0  0  0  0  0  0  0  0999 V2000
+   -2.0785    0.0000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -0.7794    0.7500    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    0.5196   -0.0000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    1.8187    0.7500    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    0.5196   -1.5000    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0
+  1  2  1  0
+  2  3  1  0
+  3  4  1  1
+  3  5  1  0
+M  END
+)CTAB"_ctab;
+  REQUIRE(m);
+
+  auto at = m->getAtomWithIdx(2);
+  REQUIRE(at->getChiralTag() == Atom::ChiralType::CHI_TETRAHEDRAL_CW);
+
+  auto &pos = m->getConformer().getPositions();
+  std::for_each(pos.begin(), pos.end(),
+                [](RDGeom::Point3D &pos) { pos *= 6.0; });
+
+  // Reset chirality and the original bond direction
+  // (it was stripper after parsing m for the first time)
+  at->setChiralTag(Atom::ChiralType::CHI_UNSPECIFIED);
+  m->getBondBetweenAtoms(2, 3)->setBondDir(Bond::BondDir::BEGINWEDGE);
+
+  MolOps::assignChiralTypesFromBondDirs(*m);
+
+  CHECK(at->getChiralTag() == Atom::ChiralType::CHI_TETRAHEDRAL_CW);
+}

--- a/rdkit/Chem/UnitTestInchi.py
+++ b/rdkit/Chem/UnitTestInchi.py
@@ -37,14 +37,12 @@ import re
 import unittest
 
 from rdkit import RDConfig, RDLogger
-from rdkit.Chem import (INCHI_AVAILABLE, ForwardSDMolSupplier, MolFromMolBlock,
-                        MolFromSmiles, MolToMolBlock, MolToSmiles, SanitizeMol,
-                        rdDepictor)
+from rdkit.Chem import (INCHI_AVAILABLE, ForwardSDMolSupplier, MolFromMolBlock, MolFromSmiles,
+                        MolToMolBlock, MolToSmiles, SanitizeMol, rdDepictor)
 
 if INCHI_AVAILABLE:
-  from rdkit.Chem import (InchiReadWriteError, InchiToInchiKey,
-                          MolBlockToInchi, MolFromInchi, MolToInchi,
-                          MolToInchiKey)
+  from rdkit.Chem import (InchiReadWriteError, InchiToInchiKey, MolBlockToInchi, MolFromInchi,
+                          MolToInchi, MolToInchiKey)
 
 COLOR_RED = '\033[31m'
 COLOR_GREEN = '\033[32m'
@@ -167,9 +165,9 @@ class TestCase(unittest.TestCase):
 
       fmt = "\n{0}InChI write Summary: {1} identical, {2} suffix variance, {3} reasonable{4}"
       print(fmt.format(COLOR_GREEN, same, diff, reasonable, COLOR_RESET))
-      self.assertEqual(same, 1160)
+      self.assertEqual(same, 1162)
       self.assertEqual(diff, 0)
-      self.assertEqual(reasonable, 21)
+      self.assertEqual(reasonable, 19)
 
   def test1InchiReadPubChem(self):
     for f in self.dataset.values():


### PR DESCRIPTION
Fixes #7509

The issue is caused by the scale of the coordinates: when bond lengths become large enough, the pseudo 3d offset used in `atomChiralTypeFromBondDirPseudo3D()` becomes irrelevant in the volume calculation, leading to this issue.

The fix is to scale the offset based on the bond length. This patch assumes that, while the scale of the coordinates is weird, at least all bonds are not distorted (i.e. they are all scaled the same), so that we can use the length of the reference bond as representative of the bond lengths in the mol (which seems reasonable, since before we assumed all bond lengths were "normal").

