### PR TITLE
Fix issues arising from useMolBlockWedging and the new atropisomer kekulization code

### DIFF
--- a/Code/GraphMol/MolDraw2D/DrawMol.cpp
+++ b/Code/GraphMol/MolDraw2D/DrawMol.cpp
@@ -171,14 +171,6 @@ void DrawMol::finishCreateDrawObjects() {
 // ****************************************************************************
 void DrawMol::initDrawMolecule(const ROMol &mol) {
   drawMol_.reset(new RWMol(mol));
-  if (!isReactionMol_) {
-    if (drawOptions_.prepareMolsBeforeDrawing) {
-      MolDraw2DUtils::prepareMolForDrawing(*drawMol_);
-    } else if (!mol.getNumConformers()) {
-      const bool canonOrient = true;
-      RDDepict::compute2DCoords(*drawMol_, nullptr, canonOrient);
-    }
-  }
   if (drawOptions_.centreMoleculesBeforeDrawing) {
     if (drawMol_->getNumConformers()) {
       centerMolForDrawing(*drawMol_, confId_);
@@ -189,6 +181,14 @@ void DrawMol::initDrawMolecule(const ROMol &mol) {
   }
   if (drawOptions_.useMolBlockWedging) {
     Chirality::reapplyMolBlockWedging(*drawMol_);
+  }
+  if (!isReactionMol_) {
+    if (drawOptions_.prepareMolsBeforeDrawing) {
+      MolDraw2DUtils::prepareMolForDrawing(*drawMol_);
+    } else if (!mol.getNumConformers()) {
+      const bool canonOrient = true;
+      RDDepict::compute2DCoords(*drawMol_, nullptr, canonOrient);
+    }
   }
   if (drawOptions_.simplifiedStereoGroupLabel &&
       !mol.hasProp(common_properties::molNote)) {

--- a/Code/GraphMol/MolDraw2D/catch_tests.cpp
+++ b/Code/GraphMol/MolDraw2D/catch_tests.cpp
@@ -336,6 +336,7 @@ const std::map<std::string, std::hash_result_t> SVG_HASHES = {
     {"testWedgeNonSingleBonds-6.svg", 238313010U},
     {"testWedgeNonSingleBonds-7.svg", 3641456570U},
     {"testWedgeNonSingleBonds-8.svg", 3209701539U},
+    {"testWedgingShouldBeOnSingleBond.svg", 1002741488U},
 };
 
 // These PNG hashes aren't completely reliable due to floating point cruft,
@@ -9688,5 +9689,73 @@ TEST_CASE("wedge non-single bonds") {
       outs.close();
       check_file_hash("testWedgeNonSingleBonds-8.svg");
     }
+  }
+  SECTION(
+      "basics 3: make sure reapplyMolBlockWedging is called before prepareMolForDrawing") {
+    auto m = R"CTAB(
+  Mrv2311 05242408162D          
+
+  0  0  0     0  0            999 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 14 15 0 0 0
+M  V30 BEGIN ATOM
+M  V30 1 C 2.0006 -1.54 0 0
+M  V30 2 N 2.0006 -3.08 0 0
+M  V30 3 C 0.6669 -3.85 0 0
+M  V30 4 C -0.6668 -3.08 0 0
+M  V30 5 C -0.6668 -1.54 0 0
+M  V30 6 C -2.0006 -0.77 0 0
+M  V30 7 C 0.6669 -0.77 0 0
+M  V30 8 C 0.6669 0.77 0 0
+M  V30 9 C -0.6668 1.54 0 0
+M  V30 10 C -2.0006 0.77 0 0
+M  V30 11 C -0.6668 3.08 0 0
+M  V30 12 C 0.6669 3.85 0 0
+M  V30 13 C 2.0006 3.08 0 0
+M  V30 14 C 2.0006 1.54 0 0
+M  V30 END ATOM
+M  V30 BEGIN BOND
+M  V30 1 1 1 2
+M  V30 2 2 2 3
+M  V30 3 1 3 4
+M  V30 4 2 4 5
+M  V30 5 1 5 6
+M  V30 6 1 7 5 CFG=3
+M  V30 7 2 7 1
+M  V30 8 1 7 8
+M  V30 9 2 8 9
+M  V30 10 1 9 10
+M  V30 11 1 9 11
+M  V30 12 2 11 12
+M  V30 13 1 12 13
+M  V30 14 2 13 14
+M  V30 15 1 8 14
+M  V30 END BOND
+M  V30 END CTAB
+M  END
+)CTAB"_ctab;
+    REQUIRE(m);
+    int panelHeight = -1;
+    int panelWidth = -1;
+    bool noFreeType = true;
+    MolDraw2DSVG drawer(350, 300, panelWidth, panelHeight, noFreeType);
+    drawer.drawOptions().useMolBlockWedging = true;
+    drawer.drawMolecule(*m);
+    drawer.finishDrawing();
+    auto text = drawer.getDrawingText();
+    std::ofstream outs("testWedgingShouldBeOnSingleBond.svg");
+    outs << text;
+    outs.close();
+    check_file_hash("testWedgingShouldBeOnSingleBond.svg");
+    std::regex regex1(
+        "<path class='bond-5 atom-6 atom-4'.*style='fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1\\.0px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />");
+    std::regex regex2(
+        "<path class='bond-5 atom-6 atom-4'.*style='fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2\\.0px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />");
+    size_t nRegex1Matches = std::distance(
+        std::sregex_token_iterator(text.begin(), text.end(), regex1),
+        std::sregex_token_iterator());
+    CHECK(nRegex1Matches > 6);  // check the bond is hashed
+    auto dat2 = *std::sregex_iterator(text.begin(), text.end(), regex2);
+    CHECK(dat2.empty());  // check the bond is single
   }
 }

--- a/Code/MinimalLib/cffi_test.c
+++ b/Code/MinimalLib/cffi_test.c
@@ -2461,6 +2461,136 @@ M  END\n\
   free(mpkl);
 }
 
+void test_wedged_bond_atropisomer() {
+  printf("--------------------------\n");
+  printf("  test_wedged_bond_atropisomer\n");
+  const char *atropisomer =
+      "\n\
+  Mrv2311 05242408162D          \n\
+\n\
+  0  0  0     0  0            999 V3000\n\
+M  V30 BEGIN CTAB\n\
+M  V30 COUNTS 14 15 0 0 0\n\
+M  V30 BEGIN ATOM\n\
+M  V30 1 C 2.0006 -1.54 0 0\n\
+M  V30 2 N 2.0006 -3.08 0 0\n\
+M  V30 3 C 0.6669 -3.85 0 0\n\
+M  V30 4 C -0.6668 -3.08 0 0\n\
+M  V30 5 C -0.6668 -1.54 0 0\n\
+M  V30 6 C -2.0006 -0.77 0 0\n\
+M  V30 7 C 0.6669 -0.77 0 0\n\
+M  V30 8 C 0.6669 0.77 0 0\n\
+M  V30 9 C -0.6668 1.54 0 0\n\
+M  V30 10 C -2.0006 0.77 0 0\n\
+M  V30 11 C -0.6668 3.08 0 0\n\
+M  V30 12 C 0.6669 3.85 0 0\n\
+M  V30 13 C 2.0006 3.08 0 0\n\
+M  V30 14 C 2.0006 1.54 0 0\n\
+M  V30 END ATOM\n\
+M  V30 BEGIN BOND\n\
+M  V30 1 1 1 2\n\
+M  V30 2 2 2 3\n\
+M  V30 3 1 3 4\n\
+M  V30 4 2 4 5\n\
+M  V30 5 1 5 6\n\
+M  V30 6 1 7 5 CFG=3\n\
+M  V30 7 2 7 1\n\
+M  V30 8 1 7 8\n\
+M  V30 9 2 8 9\n\
+M  V30 10 1 9 10\n\
+M  V30 11 1 9 11\n\
+M  V30 12 2 11 12\n\
+M  V30 13 1 12 13\n\
+M  V30 14 2 13 14\n\
+M  V30 15 1 8 14\n\
+M  V30 END BOND\n\
+M  V30 END CTAB\n\
+M  END\n";
+  char *mpkl;
+  size_t mpkl_size;
+  char *svg;
+  mpkl = get_mol(atropisomer, &mpkl_size, "");
+  assert(mpkl);
+  svg = get_svg(mpkl, mpkl_size,
+                "{\"useMolBlockWedging\":true,\"noFreetype\":true}");
+  assert(svg);
+  char *line = strtok(svg, "\n");
+  char *str = NULL;
+  int n_matches = 0;
+  while (line) {
+    str = strstr(line, "<path class='bond-5 atom-6 atom-4'");
+    if (str) {
+      ++n_matches;
+      assert(strstr(
+          str,
+          "style='fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.0px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />"));
+      assert(!strstr(
+          str,
+          "style='fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2.0px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />"));
+    }
+    line = strtok(NULL, "\n");
+  }
+  assert(n_matches > 6);
+  free(svg);
+  free(mpkl);
+}
+
+void test_get_molblock_use_molblock_wedging() {
+  printf("--------------------------\n");
+  printf("  test_get_molblock_use_molblock_wedging\n");
+  const char *mb =
+      "\n\
+     RDKit          2D\n\
+\n\
+  9 10  0  0  1  0  0  0  0  0999 V2000\n\
+    1.4885   -4.5513    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0\n\
+    2.0405   -3.9382    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n\
+    2.8610   -4.0244    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n\
+    3.1965   -3.2707    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n\
+    3.0250   -2.4637    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n\
+    2.2045   -2.3775    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n\
+    1.7920   -1.6630    0.0000 N   0  0  0  0  0  0  0  0  0  0  0  0\n\
+    1.8690   -3.1311    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n\
+    2.5834   -2.7186    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n\
+  2  1  1  1\n\
+  2  3  1  0\n\
+  4  3  1  0\n\
+  4  5  1  0\n\
+  6  5  1  0\n\
+  6  7  1  1\n\
+  6  8  1  0\n\
+  8  9  1  1\n\
+  8  2  1  0\n\
+  4  9  1  1\n\
+M  END\n\
+";
+  char *mpkl;
+  char *mpkl_copy;
+  size_t mpkl_size;
+  const char *mb_rdkit_wedging;
+  const char *mb_rdkit_wedging_post_orig;
+  const char *mb_orig_wedging;
+  mpkl = get_mol(mb, &mpkl_size, "");
+  assert(mpkl && mpkl_size);
+  mpkl_copy = malloc(mpkl_size);
+  assert(mpkl_copy);
+  memcpy(mpkl_copy, mpkl, mpkl_size);
+  mb_rdkit_wedging = get_molblock(mpkl, mpkl_size, NULL);
+  assert(strcmp(mb, mb_rdkit_wedging));
+  mb_orig_wedging =
+      get_molblock(mpkl, mpkl_size, "{\"useMolBlockWedging\":true}");
+  assert(!memcmp(mpkl, mpkl_copy, mpkl_size));
+  assert(!strcmp(mb, mb_orig_wedging));
+  mb_rdkit_wedging_post_orig = get_molblock(mpkl, mpkl_size, NULL);
+  assert(strcmp(mb, mb_rdkit_wedging_post_orig));
+  assert(!strcmp(mb_rdkit_wedging, mb_rdkit_wedging_post_orig));
+  free(mb_rdkit_wedging);
+  free(mb_rdkit_wedging_post_orig);
+  free(mb_orig_wedging);
+  free(mpkl);
+  free(mpkl_copy);
+}
+
 int main() {
   enable_logging();
   char *vers = version();
@@ -2491,5 +2621,7 @@ int main() {
   test_relabel_mapped_dummies();
   test_assign_cip_labels();
   test_smiles_smarts_params();
+  test_wedged_bond_atropisomer();
+  test_get_molblock_use_molblock_wedging();
   return 0;
 }

--- a/Code/MinimalLib/common_defs.h
+++ b/Code/MinimalLib/common_defs.h
@@ -7,7 +7,10 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
+#include <GraphMol/MolDraw2D/MolDraw2D.h>
 #include <GraphMol/MolDraw2D/MolDraw2DHelpers.h>
+#include <GraphMol/MolDraw2D/MolDraw2DUtils.h>
+#include <GraphMol/Chirality.h>
 #include <string>
 #include <vector>
 
@@ -27,6 +30,7 @@ struct DrawingDetails {
   bool wedgeBonds = true;
   bool forceCoords = false;
   bool wavyBonds = false;
+  bool useMolBlockWedging = false;
   std::string legend;
   std::vector<int> atomIds;
   std::vector<int> bondIds;
@@ -67,6 +71,92 @@ extern std::string process_rxn_details(const std::string &details,
                         std::vector<int> &atomIds, std::vector<int> &bondIds,
                         bool &kekulize, bool &highlightByReactant,
                         std::vector<DrawColour> &highlightColorsReactants);
+
+class DrawerFromDetails {
+ public:
+  virtual ~DrawerFromDetails() {}
+  std::string draw_mol(const ROMol &mol) {
+    MolDrawingDetails molDrawingDetails;
+    molDrawingDetails.width = d_width;
+    molDrawingDetails.height = d_height;
+    if (!d_details.empty()) {
+      auto problems = process_mol_details(d_details, molDrawingDetails);
+      if (!problems.empty()) {
+        return problems;
+      }
+    }
+    initDrawer(molDrawingDetails);
+    const ROMol *molPtr = &mol;
+    std::unique_ptr<ROMol> origWedgingMol;
+    if (molDrawingDetails.useMolBlockWedging) {
+      origWedgingMol.reset(new ROMol(mol));
+      Chirality::reapplyMolBlockWedging(*origWedgingMol);
+      molPtr = origWedgingMol.get();
+    }
+    if (molDrawingDetails.useMolBlockWedging) {
+      drawer().drawOptions().useMolBlockWedging = false;
+    }
+    drawer().setOffset(molDrawingDetails.offsetx, molDrawingDetails.offsety);
+
+    MolDraw2DUtils::prepareAndDrawMolecule(
+        drawer(), *molPtr, molDrawingDetails.legend, &molDrawingDetails.atomIds,
+        &molDrawingDetails.bondIds,
+        molDrawingDetails.atomMap.empty() ? nullptr
+                                          : &molDrawingDetails.atomMap,
+        molDrawingDetails.bondMap.empty() ? nullptr
+                                          : &molDrawingDetails.bondMap,
+        molDrawingDetails.radiiMap.empty() ? nullptr
+                                           : &molDrawingDetails.radiiMap,
+        -1, molDrawingDetails.kekulize, molDrawingDetails.addChiralHs,
+        molDrawingDetails.wedgeBonds, molDrawingDetails.forceCoords,
+        molDrawingDetails.wavyBonds);
+
+    return finalizeDrawing();
+  }
+  std::string draw_rxn(const ChemicalReaction &rxn) {
+    RxnDrawingDetails rxnDrawingDetails;
+    rxnDrawingDetails.width = d_width;
+    rxnDrawingDetails.height = d_height;
+    if (!d_details.empty()) {
+      auto problems = process_rxn_details(d_details, rxnDrawingDetails);
+      if (!problems.empty()) {
+        return problems;
+      }
+    }
+    initDrawer(rxnDrawingDetails);
+    if (!rxnDrawingDetails.kekulize) {
+      drawer().drawOptions().prepareMolsBeforeDrawing = false;
+    }
+    drawer().drawReaction(
+        rxn, rxnDrawingDetails.highlightByReactant,
+        !rxnDrawingDetails.highlightByReactant ||
+                rxnDrawingDetails.highlightColorsReactants.empty()
+            ? nullptr
+            : &rxnDrawingDetails.highlightColorsReactants);
+    return finalizeDrawing();
+  }
+
+ protected:
+  void init(int w = -1, int h = -1,
+            const std::string &details = std::string()) {
+    d_width = w;
+    d_height = h;
+    d_details = details;
+  }
+  void updateDrawerParamsFromJSON() {
+    if (!d_details.empty()) {
+      MolDraw2DUtils::updateDrawerParamsFromJSON(drawer(), d_details);
+    }
+  }
+
+ private:
+  virtual MolDraw2D &drawer() const = 0;
+  virtual void initDrawer(const DrawingDetails &drawingDetails) = 0;
+  virtual std::string finalizeDrawing() = 0;
+  int d_width;
+  int d_height;
+  std::string d_details;
+};
 
 }  // namespace MinimalLib
 }  // namespace RDKit

--- a/Code/MinimalLib/jswrapper.cpp
+++ b/Code/MinimalLib/jswrapper.cpp
@@ -30,7 +30,7 @@ class JSDrawerFromDetails : public MinimalLib::DrawerFromDetails {
 
  private:
   MolDraw2DJS &drawer() const {
-    CHECK_INVARIANT(d_drawer, "d_drawer must not be null");
+    PRECONDITION(d_drawer, "d_drawer must not be null");
     return *d_drawer;
   };
   void initDrawer(const MinimalLib::DrawingDetails &drawingDetails) {

--- a/Code/MinimalLib/jswrapper.cpp
+++ b/Code/MinimalLib/jswrapper.cpp
@@ -20,6 +20,31 @@
 using namespace RDKit;
 
 namespace {
+class JSDrawerFromDetails : public MinimalLib::DrawerFromDetails {
+ public:
+  JSDrawerFromDetails(const emscripten::val &ctx, int w = -1, int h = -1,
+                      const std::string &details = std::string()) {
+    init(w, h, details);
+    d_ctx = ctx;
+  }
+
+ private:
+  MolDraw2DJS &drawer() const {
+    CHECK_INVARIANT(d_drawer, "d_drawer must not be null");
+    return *d_drawer;
+  };
+  void initDrawer(const MinimalLib::DrawingDetails &drawingDetails) {
+    d_drawer.reset(new MolDraw2DJS(drawingDetails.width, drawingDetails.height,
+                                   d_ctx, drawingDetails.panelWidth,
+                                   drawingDetails.panelHeight,
+                                   drawingDetails.noFreetype));
+    updateDrawerParamsFromJSON();
+  }
+  std::string finalizeDrawing() { return ""; }
+  std::unique_ptr<MolDraw2DJS> d_drawer;
+  emscripten::val d_ctx;
+};
+
 std::string draw_to_canvas_with_offset(JSMol &self, emscripten::val canvas,
                                        int offsetx, int offsety, int width,
                                        int height) {
@@ -51,36 +76,10 @@ std::string draw_to_canvas_with_highlights(JSMol &self, emscripten::val canvas,
   }
 
   auto ctx = canvas.call<emscripten::val>("getContext", std::string("2d"));
-  MinimalLib::MolDrawingDetails molDrawingDetails;
-  molDrawingDetails.width = canvas["width"].as<int>();
-  molDrawingDetails.height = canvas["height"].as<int>();
-  if (!details.empty()) {
-    auto problems = MinimalLib::process_mol_details(details, molDrawingDetails);
-    if (!problems.empty()) {
-      return problems;
-    }
-  }
-
-  std::unique_ptr<MolDraw2DJS> d2d(new MolDraw2DJS(
-      molDrawingDetails.width, molDrawingDetails.height, ctx,
-      molDrawingDetails.panelWidth, molDrawingDetails.panelHeight,
-      molDrawingDetails.noFreetype));
-  if (!details.empty()) {
-    MolDraw2DUtils::updateDrawerParamsFromJSON(*d2d, details);
-  }
-  d2d->setOffset(molDrawingDetails.offsetx, molDrawingDetails.offsety);
-
-  MolDraw2DUtils::prepareAndDrawMolecule(
-      *d2d, *self.d_mol, molDrawingDetails.legend, &molDrawingDetails.atomIds,
-      &molDrawingDetails.bondIds,
-      molDrawingDetails.atomMap.empty() ? nullptr : &molDrawingDetails.atomMap,
-      molDrawingDetails.bondMap.empty() ? nullptr : &molDrawingDetails.bondMap,
-      molDrawingDetails.radiiMap.empty() ? nullptr
-                                         : &molDrawingDetails.radiiMap,
-      -1, molDrawingDetails.kekulize, molDrawingDetails.addChiralHs,
-      molDrawingDetails.wedgeBonds, molDrawingDetails.forceCoords,
-      molDrawingDetails.wavyBonds);
-  return "";
+  int width = canvas["width"].as<int>();
+  int height = canvas["height"].as<int>();
+  JSDrawerFromDetails jsDrawer(ctx, width, height, details);
+  return jsDrawer.draw_mol(*self.d_mol);
 }
 
 #ifdef RDK_BUILD_MINIMAL_LIB_RXN
@@ -118,28 +117,8 @@ std::string draw_rxn_to_canvas_with_highlights(JSReaction &self,
   auto ctx = canvas.call<emscripten::val>("getContext", std::string("2d"));
   int w = canvas["width"].as<int>();
   int h = canvas["height"].as<int>();
-  MinimalLib::RxnDrawingDetails rxnDrawingDetails;
-  if (!details.empty()) {
-    auto problems = MinimalLib::process_rxn_details(details, rxnDrawingDetails);
-    if (!problems.empty()) {
-      return problems;
-    }
-  }
-
-  std::unique_ptr<MolDraw2DJS> d2d(new MolDraw2DJS(w, h, ctx));
-  if (!details.empty()) {
-    MolDraw2DUtils::updateDrawerParamsFromJSON(*d2d, details);
-  }
-  d2d->setOffset(rxnDrawingDetails.offsetx, rxnDrawingDetails.offsety);
-  if (!rxnDrawingDetails.kekulize) {
-    d2d->drawOptions().prepareMolsBeforeDrawing = false;
-  }
-  d2d->drawReaction(*self.d_rxn, rxnDrawingDetails.highlightByReactant,
-                    !rxnDrawingDetails.highlightByReactant ||
-                            rxnDrawingDetails.highlightColorsReactants.empty()
-                        ? nullptr
-                        : &rxnDrawingDetails.highlightColorsReactants);
-  return "";
+  JSDrawerFromDetails jsDrawer(ctx, w, h, details);
+  return jsDrawer.draw_rxn(*self.d_rxn);
 }
 #endif
 
@@ -393,8 +372,11 @@ EMSCRIPTEN_BINDINGS(RDKit_minimal) {
                 select_overload<std::string(const std::string &) const>(
                     &JSMol::get_v3Kmolblock))
       .function("get_as_uint8array", &get_as_uint8array)
-      .function("get_inchi", select_overload<std::string(const std::string&) const>(&JSMol::get_inchi))
-      .function("get_inchi", select_overload<std::string() const>(&JSMol::get_inchi))
+      .function("get_inchi",
+                select_overload<std::string(const std::string &) const>(
+                    &JSMol::get_inchi))
+      .function("get_inchi",
+                select_overload<std::string() const>(&JSMol::get_inchi))
       .function("get_json", &JSMol::get_json)
       .function("get_svg",
                 select_overload<std::string() const>(&JSMol::get_svg))


### PR DESCRIPTION
The current `master` depiction code has a few issues connected with usage of the `useMolBlockWedging` drawing option to depict the wedging as originally specified in the molblock (as opposed to calling `Chirality::reapplyMolBlockWedging` in advance).
The first issue affects all RDKit layers: since the code in `Code/GraphMol/MolDraw2D/DrawMol.cpp` calls `MolDraw2DUtils::prepareMolForDrawing` _before_ `Chirality::reapplyMolBlockWedging`, the kekulization code does not have a chance to try and place double bonds on non-wedged bonds, and hence results in unnecessary double bond wedging.
Here's a reproducible on current `master`:

```
from rdkit import Chem
from rdkit.Chem.Draw import rdMolDraw2D
from IPython.display import SVG

mb = """
  Mrv2311 05242408162D          

  0  0  0     0  0            999 V3000
M  V30 BEGIN CTAB
M  V30 COUNTS 14 15 0 0 0
M  V30 BEGIN ATOM
M  V30 1 C 2.0006 -1.54 0 0
M  V30 2 N 2.0006 -3.08 0 0
M  V30 3 C 0.6669 -3.85 0 0
M  V30 4 C -0.6668 -3.08 0 0
M  V30 5 C -0.6668 -1.54 0 0
M  V30 6 C -2.0006 -0.77 0 0
M  V30 7 C 0.6669 -0.77 0 0
M  V30 8 C 0.6669 0.77 0 0
M  V30 9 C -0.6668 1.54 0 0
M  V30 10 C -2.0006 0.77 0 0
M  V30 11 C -0.6668 3.08 0 0
M  V30 12 C 0.6669 3.85 0 0
M  V30 13 C 2.0006 3.08 0 0
M  V30 14 C 2.0006 1.54 0 0
M  V30 END ATOM
M  V30 BEGIN BOND
M  V30 1 1 1 2
M  V30 2 2 2 3
M  V30 3 1 3 4
M  V30 4 2 4 5
M  V30 5 1 5 6
M  V30 6 1 7 5 CFG=3
M  V30 7 2 7 1
M  V30 8 1 7 8
M  V30 9 2 8 9
M  V30 10 1 9 10
M  V30 11 1 9 11
M  V30 12 2 11 12
M  V30 13 1 12 13
M  V30 14 2 13 14
M  V30 15 1 8 14
M  V30 END BOND
M  V30 END CTAB
M  END
"""
mol = Chem.MolFromMolBlock(mb)
drawer = rdMolDraw2D.MolDraw2DSVG(300, 300)
drawer.drawOptions().useMolBlockWedging = True
drawer.DrawMolecule(mol)
drawer.FinishDrawing()
SVG(drawer.GetDrawingText())
```
![image](https://github.com/rdkit/rdkit/assets/5244385/366f70fa-d146-40cc-962a-5043f4037509)

This PR corrects that by calling `Chirality::reapplyMolBlockWedging` _before_ `MolDraw2DUtils::prepareMolForDrawing` , which results in a better location of the double bond on a non-wedged bond:
![image](https://github.com/rdkit/rdkit/assets/5244385/5810c895-4aca-43b2-b657-2ed1952156c3)

This fix was not sufficient for MinimalLib, because MInimalLib drawing options also support kekulization and addition of chiral Hs by calling `prepareAndDrawMolecule` ahead of the depiction, and then setting the `prepareMoleculeBeforeDrawing` drawing option to `false` to avoid overriding the user choices. However, this causes again `reappplyMolBlockWedging` to be called _after_ the molecule has been kekulized, thus causing suboptimal co-location of the double bond on the wedged bond.
This PR corrects also the MinimalLib depictions by calling `reapplyMolBlockWedging` before `prepareAndDrawMolecule`.

While applying this change I realized that the MinimalLib `canvas` and `SVG` drawing code were sharing a significant amount of duplicated code, so I consolidated it into an abstract class with two derived classes for `canvas` and `SVG` depictions, respectively.

Finally, I fixed a long-standing MinimalLib bug where calling `get_molblock()` with the `useMolBlockWedging` would alter wedging in the passed molecule (which is supposed to be `const`) rather than applying only to the molblock output; now `reapplyMolBlockWedging` is called on a copy such that the passed molecule is not changed.

I added unit tests for all of the above.