### PR TITLE
Restore mol writing functions in the RDKFuncs module

### DIFF
--- a/Code/JavaWrappers/MolWriters.i
+++ b/Code/JavaWrappers/MolWriters.i
@@ -32,9 +32,11 @@
 */
 
 %{
+#include <GraphMol/FileParsers/FileWriters.h>
 #include <GraphMol/FileParsers/MolWriters.h>
 %}
 
+%include <GraphMol/FileParsers/FileWriters.h>
 %include <GraphMol/FileParsers/MolWriters.h>
 
 

--- a/Code/JavaWrappers/gmwrapper/src-test/org/RDKit/BasicMoleculeTests.java
+++ b/Code/JavaWrappers/gmwrapper/src-test/org/RDKit/BasicMoleculeTests.java
@@ -49,6 +49,8 @@ public class BasicMoleculeTests extends GraphMolTest {
 	@Test public void testSmilesWrite() {
 		String smi = mol1.MolToSmiles();
 		assertEquals(smi,smi,"c1ccccc1");
+		String smiRDKFuncs = RDKFuncs.MolToSmiles(mol1);
+		assertEquals(smiRDKFuncs,smiRDKFuncs,smi);
 	}
 	@Test public void testAtoms() {
 		assertEquals( mol1.getAtomWithIdx(0).getAtomicNum(),6);

--- a/Code/JavaWrappers/gmwrapper/src-test/org/RDKit/Chemv2Tests.java
+++ b/Code/JavaWrappers/gmwrapper/src-test/org/RDKit/Chemv2Tests.java
@@ -152,6 +152,7 @@ public class Chemv2Tests extends GraphMolTest {
 
         // System.out.print(template.MolToMolBlock());
         // System.out.print(m.MolToMolBlock());
+        assertEquals(template.MolToMolBlock(), RDKFuncs.MolToMolBlock(template));
         Conformer c1 = template.getConformer();
         Conformer c2 = m.getConformer();
         assertEquals(c1.getAtomPos(0).getX(), c2.getAtomPos(6).getX(), defaultDoubleTol);


### PR DESCRIPTION
As part of #7077 mol writers were moved to `Code/GraphMol/FileParsers/FileWriters.h`, but since `Code/JavaWrappers/MolWriters.i` was not updated accordingly, symbols which used to be available in the `RDKFuncs` module are now missing.
This went unnoticed as there were no unit tests in RDKit for those `RDKFuncs` free functions, since the same functions are available as `ROMol` methods.
However, as there may be Java or C# code using those free functions, I think it would be good to restore them; for example, this was noticed by @manuelschwarze while running KNIME tests on 2024.03.3.
This PR restores the missing symbols and adds a couple of tests to avoid similar regressions in the future.