### PR TITLE
Fix #7485 and #7530

### DIFF
--- a/Code/GraphMol/MolInterchange/CMakeLists.txt
+++ b/Code/GraphMol/MolInterchange/CMakeLists.txt
@@ -6,8 +6,16 @@ if(NOT EXISTS "${CMAKE_SOURCE_DIR}/External/rapidjson-1.1.0")
     execute_process(COMMAND ${CMAKE_COMMAND} -E tar zxf
       ${CMAKE_SOURCE_DIR}/External/rapidjson-1.1.0.tar.gz
       WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/External)
+    # comment out a line which causes a compilation error on some platforms
+    # (based on the change which has already been applied to the RapidJSON master branch, see
+    # https://github.com/Tencent/rapidjson/blob/ab1842a2dae061284c0a62dca1cc6d5e7e37e346/include/rapidjson/document.h#L414)
+    file(READ ${CMAKE_SOURCE_DIR}/External/rapidjson-1.1.0/include/rapidjson/document.h RAPIDJSON_DOCUMENT_H)
+    string(REGEX REPLACE
+           "( *)(GenericStringRef& operator=\\(const GenericStringRef& rhs\\) { s = rhs\\.s. length = rhs\\.length. })" "\\1//\\2"
+           RAPIDJSON_DOCUMENT_H "${RAPIDJSON_DOCUMENT_H}")
+    file(WRITE ${CMAKE_SOURCE_DIR}/External/rapidjson-1.1.0/include/rapidjson/document.h "${RAPIDJSON_DOCUMENT_H}")
 else()
-  message("-- Found RapidJSON source in ${CMAKE_SOURCE_DIR}/External")
+    message("-- Found RapidJSON source in ${CMAKE_SOURCE_DIR}/External")
 endif()
 
 include_directories(${CMAKE_SOURCE_DIR}/External/rapidjson-1.1.0/include)

--- a/Code/MinimalLib/docker/Dockerfile
+++ b/Code/MinimalLib/docker/Dockerfile
@@ -26,7 +26,7 @@ ARG BOOST_MAJOR_VERSION="1"
 ARG BOOST_MINOR_VERSION="84"
 ARG BOOST_PATCH_VERSION="0"
 
-FROM debian:buster as build-stage
+FROM debian:bookworm as build-stage
 ARG RDKIT_GIT_URL
 ARG RDKIT_BRANCH
 ARG EMSDK_VERSION
@@ -36,16 +36,15 @@ ARG BOOST_PATCH_VERSION
 
 LABEL maintainer="Greg Landrum <greg.landrum@t5informatics.com>"
 
-RUN echo "deb http://deb.debian.org/debian buster-backports main" >> /etc/apt/sources.list.d/backports.list
-
 RUN apt-get update && apt-get upgrade -y && apt install -y \
   curl \
   wget \
-  cmake/buster-backports \
+  cmake \
   python3 \
   g++ \
   libeigen3-dev \
   git \
+  xz-utils \
   nodejs
 
 ENV LANG C
@@ -97,6 +96,12 @@ RUN emcmake cmake -DBoost_INCLUDE_DIR=/opt/boost/include -DRDK_BUILD_FREETYPE_SU
 # "patch" to make the InChI code work with emscripten:
 RUN cp /src/rdkit/External/INCHI-API/src/INCHI_BASE/src/util.c /src/rdkit/External/INCHI-API/src/INCHI_BASE/src/util.c.bak && \
   sed 's/&& defined(__APPLE__)//' /src/rdkit/External/INCHI-API/src/INCHI_BASE/src/util.c.bak > /src/rdkit/External/INCHI-API/src/INCHI_BASE/src/util.c
+
+# comment out a line which causes a compilation error on some platforms
+# (based on the change which has already been applied to the RapidJSON master branch, see
+# https://github.com/Tencent/rapidjson/blob/ab1842a2dae061284c0a62dca1cc6d5e7e37e346/include/rapidjson/document.h#L414)
+RUN sed -i 's|^\( *\)\(GenericStringRef\& operator=(const GenericStringRef\& rhs) { s = rhs.s; length = rhs.length; } *\)$|\1//\2|' \
+  /src/rdkit/External/rapidjson-1.1.0/include/rapidjson/document.h
 
 # build and "install"
 RUN make -j2 RDKit_minimal && \


### PR DESCRIPTION
- patch RapidJSON 1.1.0 release backporting a fix from the master branch to avoid a compilation error on newer compilers (fix #7485)
- update MinimalLib Dockerfile to Debian Bookworm and patch RapidJSON in case someone wants to build an older release (fix #7530)
