### PR TITLE
ConfGen: fix a logic error in one of the chiral volume tests

### DIFF
--- a/Code/GraphMol/DistGeomHelpers/Embedder.cpp
+++ b/Code/GraphMol/DistGeomHelpers/Embedder.cpp
@@ -545,7 +545,7 @@ bool checkChiralCenters(const RDGeom::PointPtrVect *positions,
     double lb = chiralSet->getLowerVolumeBound();
     double ub = chiralSet->getUpperVolumeBound();
     if ((lb > 0 && vol < lb && ((lb - vol) / lb > .2 || vol * lb < 0)) ||
-        (ub < 0 && vol > ub && ((vol - ub) / ub > .2 || vol * ub < 0))) {
+        (ub < 0 && vol > ub && ((vol - ub) / ub < -.2 || vol * ub < 0))) {
 #ifdef DEBUG_EMBEDDING
       std::cerr << " fail! (" << chiralSet->d_idx0 << ") iter: "
                 << " " << vol << " " << lb << "-" << ub << std::endl;

--- a/Code/GraphMol/DistGeomHelpers/catch_tests.cpp
+++ b/Code/GraphMol/DistGeomHelpers/catch_tests.cpp
@@ -651,7 +651,8 @@ M  END
   auto cid = DGeomHelpers::EmbedMolecule(*mol, ps);
   CHECK(cid < 0);
   CHECK(ps.failures[DGeomHelpers::EmbedFailureCauses::INITIAL_COORDS] > 5);
-  CHECK(ps.failures[DGeomHelpers::EmbedFailureCauses::FINAL_CHIRAL_BOUNDS] > 5);
+  CHECK(ps.failures[DGeomHelpers::EmbedFailureCauses::FINAL_CHIRAL_BOUNDS] >=
+        5);
 }
 
 #ifdef RDK_TEST_MULTITHREADED

--- a/Code/GraphMol/DistGeomHelpers/catch_tests.cpp
+++ b/Code/GraphMol/DistGeomHelpers/catch_tests.cpp
@@ -878,6 +878,7 @@ TEST_CASE("atropisomers bulk") {
         auto chiralVol = v3.crossProduct(v4).dotProduct(v2);
         INFO(cid << MolToV3KMolBlock(*mol, true, cid));
         CHECK(chiralVol * vol > 0);
+        CHECK(fabs(chiralVol) > 0.5);
       }
     }  // now swap the stereo and see if it still works
     mol->getBondWithIdx(bondIdx)->setStereo(
@@ -900,6 +901,7 @@ TEST_CASE("atropisomers bulk") {
         auto chiralVol = v3.crossProduct(v4).dotProduct(v2);
         INFO(cid << MolToV3KMolBlock(*mol, true, cid));
         CHECK(chiralVol * vol < 0);
+        CHECK(fabs(chiralVol) > 0.5);
       }
     }
   }


### PR DESCRIPTION
The error here was leading to structures with a chiral volume that had the correct sign but which was too small.

@nmaeder pointed out the example that led to this fix
