### PR TITLE
fix one case of undesired 1-3 charge recombination

### DIFF
--- a/Code/GraphMol/MolStandardize/TransformCatalog/normalizations.in
+++ b/Code/GraphMol/MolStandardize/TransformCatalog/normalizations.in
@@ -39,7 +39,7 @@ std::vector<std::pair<std::string, std::string>> defaultNormalizations = {
     {"Recombine 1,3-separated charges",
      "[n,o,p,s;-1:1]:[a:2]=[N,O,P,S;+1:3]>>[*-0:1]:[*:2]-[*+0:3]"},
     {"Recombine 1,3-separated charges",
-     "[N,O,P,S;-1:1]-[a:2]:[n,o,p,s;+1:3]>>[*-0:1]=[*:2]:[*+0:3]"},
+     "[N,O,P,S;-1:1]-[a+0:2]:[n,o,p,s;+1:3]>>[*-0:1]=[*:2]:[*+0:3]"},
     {"Recombine 1,5-separated charges",
      "[N,P,As,Sb,O,S,Se,Te;-1:1]-[A+0:2]=[A:3]-[A:4]=[N,P,As,Sb,O,S,Se,Te;+1:5]"
      ">>[*-0:1]=[*:2]-[*:3]=[*:4]-[*+0:5]"},

--- a/Code/GraphMol/MolStandardize/testNormalize.cpp
+++ b/Code/GraphMol/MolStandardize/testNormalize.cpp
@@ -55,6 +55,10 @@ void test1() {
     normalize("CC12CCCCC1(Cl)[N+]([O-])=[N+]2[O-]")
     == "CC12CCCCC1(Cl)[N+]([O-])=[N+]2[O-]");
 
+  // Test a case where 1,3-separated charges should not be recombined.
+  TEST_ASSERT(
+    normalize("[O-][n+]1cccc[n+]1[O-]") == "[O-][n+]1cccc[n+]1[O-]");
+
   // Test 1,5-separated charges are recombined.
   TEST_ASSERT(normalize(R"(C[N+](C)=C\C=C\[O-])") == "CN(C)C=CC=O");
 


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
This PR fixes one of the "1-3 charge recombination" normalization transformations to prevent the undesired application on two adjacent N-oxide groups.

#### Any other comments?
A similar constraint I think is already in place for the aliphatic case, and this is basically the same, but applying to aromatic rings. 
