### PR TITLE
Fixes #7552

### DIFF
--- a/Code/DistGeom/ChiralSet.h
+++ b/Code/DistGeom/ChiralSet.h
@@ -17,6 +17,11 @@
 
 namespace DistGeom {
 
+enum class ChiralSetStructureFlags : std::uint64_t {
+  IN_FUSED_SMALL_RINGS =
+      1 << 0,  // a chiral center involved in fusing 2 or more small rings
+};
+
 /*! \brief Class used to store a quartet of points and chiral volume bounds on
  *them
  *
@@ -30,17 +35,20 @@ class RDKIT_DISTGEOMETRY_EXPORT ChiralSet {
   unsigned int d_idx4;
   double d_volumeLowerBound;
   double d_volumeUpperBound;
+  std::uint64_t d_structureFlags =
+      0;  // used to track special cases that may make embedding more difficult
 
   ChiralSet(unsigned int pid0, unsigned int pid1, unsigned int pid2,
             unsigned int pid3, unsigned int pid4, double lowerVolBound,
-            double upperVolBound)
+            double upperVolBound, std::uint64_t structureFlags = 0)
       : d_idx0(pid0),
         d_idx1(pid1),
         d_idx2(pid2),
         d_idx3(pid3),
         d_idx4(pid4),
         d_volumeLowerBound(lowerVolBound),
-        d_volumeUpperBound(upperVolBound) {
+        d_volumeUpperBound(upperVolBound),
+        d_structureFlags(structureFlags) {
     CHECK_INVARIANT(lowerVolBound <= upperVolBound, "Inconsistent bounds\n");
     d_volumeLowerBound = lowerVolBound;
     d_volumeUpperBound = upperVolBound;

--- a/Code/GraphMol/DistGeomHelpers/Embedder.cpp
+++ b/Code/GraphMol/DistGeomHelpers/Embedder.cpp
@@ -1046,8 +1046,9 @@ void findChiralSets(const ROMol &mol, DistGeom::VECT_CHIRALSET &chiralCenters,
 
         // set a flag for tetrahedral centers that are in multiple small rings
         auto numSmallRings = 0u;
+        constexpr unsigned int smallRingSize = 5;
         for (const auto sz : mol.getRingInfo()->atomRingSizes(atom->getIdx())) {
-          if (sz < 5) {
+          if (sz < smallRingSize) {
             ++numSmallRings;
           }
         }

--- a/Code/GraphMol/DistGeomHelpers/Embedder.cpp
+++ b/Code/GraphMol/DistGeomHelpers/Embedder.cpp
@@ -1046,7 +1046,7 @@ void findChiralSets(const ROMol &mol, DistGeom::VECT_CHIRALSET &chiralCenters,
 
         // set a flag for tetrahedral centers that are in multiple small rings
         auto numSmallRings = 0u;
-        constexpr unsigned int smallRingSize = 5;
+        constexpr int smallRingSize = 5;
         for (const auto sz : mol.getRingInfo()->atomRingSizes(atom->getIdx())) {
           if (sz < smallRingSize) {
             ++numSmallRings;

--- a/Code/GraphMol/DistGeomHelpers/catch_tests.cpp
+++ b/Code/GraphMol/DistGeomHelpers/catch_tests.cpp
@@ -986,3 +986,33 @@ TEST_CASE("terminal groups in pruning") {
     }
   }
 }
+
+TEST_CASE("github #7552") {
+  DGeomHelpers::EmbedParameters ps = DGeomHelpers::ETKDGv3;
+  ps.randomSeed = 0xf00d;
+  SECTION("as reported") {
+    auto mol = "O=CCC1OC2COC12"_smiles;
+    REQUIRE(mol);
+    MolOps::addHs(*mol);
+    CHECK(DGeomHelpers::EmbedMolecule(*mol, ps) == 0);
+  }
+  SECTION("as reported, bulk") {
+    std::vector<std::string> smileses{
+        "O=CCC1OC2COC12",      "O=C1OC2CCC12C#N",    "CC1C2CC3OC2C13O",
+        "CC12CC1C3(C)OCC23",   "OC1C2COC13COC23",    "OC1C2C3C2N4C3CC14",
+        "CC1OC12C3CC2(O)C3",   "OC1C2CC3C2CCC13",    "CN1CC2(O)C3CC3C12",
+        "C1OC2C3C4C5C4C12N35", "C1OC2CC3OC12C=C3",   "C1C2OC3C1OC23",
+        "CC1(O)CC2CCC12",      "CC12NC(=O)C1C3OC23", "OC1CC2(NCCC12)C#N",
+        "CC12C3C1C(=O)C3C2O",  "C1C=C2C3OC4C3N1C24", "CC12C3C1C4=NC3C2O4",
+        "C1OC23C=CC4C2N4C13",  "OCC12CNC1C(=O)N2",   "CC1C2C3C1C(C#C)n23",
+
+    };
+    for (const auto &smiles : smileses) {
+      INFO(smiles);
+      auto mol = v2::SmilesParse::MolFromSmiles(smileses[0]);
+      REQUIRE(mol);
+      MolOps::addHs(*mol);
+      CHECK(DGeomHelpers::EmbedMolecule(*mol, ps) == 0);
+    }
+  }
+}


### PR DESCRIPTION
This adds code to recognize tetrahedral centers which are involved in more than one ring with < members and be more tolerant when checking their geometries.