### PR TITLE
Add atom map number to complex query atom symbol.

### DIFF
--- a/Code/GraphMol/MolDraw2D/DrawMol.cpp
+++ b/Code/GraphMol/MolDraw2D/DrawMol.cpp
@@ -1375,6 +1375,11 @@ std::string DrawMol::getAtomSymbol(const Atom &atom,
     }
   } else if (isComplexQuery(&atom)) {
     symbol = "?";
+    if (atom.hasProp("molAtomMapNumber")) {
+      std::string map_num = "";
+      atom.getProp("molAtomMapNumber", map_num);
+      symbol += ":" + map_num;
+    }
   } else if (drawOptions_.atomLabelDeuteriumTritium &&
              atom.getAtomicNum() == 1 && (iso == 2 || iso == 3)) {
     symbol = ((iso == 2) ? "D" : "T");

--- a/Code/GraphMol/MolDraw2D/DrawMol.cpp
+++ b/Code/GraphMol/MolDraw2D/DrawMol.cpp
@@ -1375,10 +1375,9 @@ std::string DrawMol::getAtomSymbol(const Atom &atom,
     }
   } else if (isComplexQuery(&atom)) {
     symbol = "?";
-    if (atom.hasProp("molAtomMapNumber")) {
-      std::string map_num = "";
-      atom.getProp("molAtomMapNumber", map_num);
-      symbol += ":" + map_num;
+    std::string mapNum;
+    if (atom.getPropIfPresent("molAtomMapNumber", mapNum)) {
+      symbol += ":" + mapNum;
     }
   } else if (drawOptions_.atomLabelDeuteriumTritium &&
              atom.getAtomicNum() == 1 && (iso == 2 || iso == 3)) {
@@ -1389,10 +1388,9 @@ std::string DrawMol::getAtomSymbol(const Atom &atom,
     std::vector<std::string> preText, postText;
 
     // first thing after the symbol is the atom map
-    if (atom.hasProp("molAtomMapNumber")) {
-      std::string map_num = "";
-      atom.getProp("molAtomMapNumber", map_num);
-      postText.push_back(std::string(":") + map_num);
+    std::string mapNum;
+    if (atom.getPropIfPresent("molAtomMapNumber", mapNum)) {
+      postText.push_back(std::string(":") + mapNum);
     }
 
     if (0 != atom.getFormalCharge()) {


### PR DESCRIPTION
#### Reference Issue
Fixes #7570

#### What does this implement/fix? Explain your changes.
The drawing code displays a complex query atom as a "?", but without the map number which means a reaction drawing isn't a true reflection of the reaction, for example.
In the 'Getting Started' guide, for instance, the reaction
`rxn = rdChemReactions.ReactionFromSmarts('[C:1](=[O:2])-[OD1].[N!H0:3]>>[C:1](=[O:2])[N:3]')`
is drawn as
<img width="669" alt="image" src="https://github.com/rdkit/rdkit/assets/9198870/41f4f54b-fc67-4fa6-a420-fce2c8864f8c">

This adds the map number, so that one gets
<img width="532" alt="image" src="https://github.com/rdkit/rdkit/assets/9198870/80e1e588-18aa-4026-8dae-37edafb4219b">

#### Any other comments?
The 2nd image is the no-freetype version, hence the slightly flakey character positioning.  It was easier for the test case.
