### PR TITLE
Switch imp to importlib in nbtests

### DIFF
--- a/rdkit/Chem/nbtests/github4823.ipynb
+++ b/rdkit/Chem/nbtests/github4823.ipynb
@@ -142,8 +142,8 @@
    ],
    "source": [
     "# NBVAL_IGNORE_OUTPUT\n",
-    "import imp\n",
-    "imp.reload(PandasTools)"
+    "import importlib\n",
+    "importlib.reload(PandasTools)"
    ]
   },
   {


### PR DESCRIPTION
Imp has been deprecated since Python 3.4 and Importlib is replacing it. In Python 3.12 the module has been removed.

This should build on any version of Python >= 3.4