### PR TITLE
Speed up GetPropsAsDict(), especially on Mac

### DIFF
--- a/Code/GraphMol/Wrap/props.hpp
+++ b/Code/GraphMol/Wrap/props.hpp
@@ -97,15 +97,23 @@ boost::python::dict GetPropsAsDict(const T &obj, bool includePrivate,
           dict[rdvalue.key] = from_rdvalue<double>(rdvalue.val);
           break;
         case RDTypeTag::StringTag:
-          if (autoConvertStrings) {
-            // Auto convert strings to ints and double if possible
-            if (AddToDict<int>(obj, dict, rdvalue.key)) {
-              break;
-            } else if (AddToDict<double>(obj, dict, rdvalue.key)) {
-              break;
+          {
+            auto value = from_rdvalue<std::string>(rdvalue.val);
+            if (autoConvertStrings) {
+              // Auto convert strings to ints and double if possible
+              int ivalue;
+              if (boost::conversion::try_lexical_convert(value, ivalue)) {
+                dict[rdvalue.key] = ivalue;
+                break;
+              }
+              double dvalue;
+              if (boost::conversion::try_lexical_convert(value, dvalue)) {
+                dict[rdvalue.key] = dvalue;
+                break;
+              }
             }
+            dict[rdvalue.key] = value;
           }
-          dict[rdvalue.key] = from_rdvalue<std::string>(rdvalue.val);
           break;
         case RDTypeTag::FloatTag:
           dict[rdvalue.key] = from_rdvalue<float>(rdvalue.val);


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
Speed up GetPropsAsDict(), especially on mac

I noticed that we have some workflows for which
GetPropsAsDict() is a bottleneck. This function _should be_ pretty
fast, but exception stack unwinding is pretty slow, especially
on Mac. I'd expect conversion to int or double to _often_ fail
for properties with "string" type tag.

I ran this script on my M3 macbook pro:

```
from rdkit import Chem
import time

m = Chem.MolFromSmiles('c1ccccc1')
for i in range(100):
    m.SetProp(f'foo{i}', f'{i % 5} sdf')
m.SetProp('foo', 'bar')
m.SetIntProp('foo1', 1)
m.SetIntProp('foo1', 123)

start = time.perf_counter()
try:
    for i in range (3000):
        m.GetPropsAsDict()
finally:
    duration = time.perf_counter() - start
    print(f'Ran {i} iterations in {duration:.2f} seconds')
```

**Before this change: 100s**
**After this change:  0.12s**

So, a 1000x speedup! That won't translate to a 1000x speedup
in the workflows I was looking up, but it definitely will change
the rate-limiting step.

On my Linux machine, the same script takes 3s.
