### PR TITLE
Don't register FilterMatcherBase twice

### DIFF
--- a/Code/GraphMol/FilterCatalog/Wrap/FilterCatalog.cpp
+++ b/Code/GraphMol/FilterCatalog/Wrap/FilterCatalog.cpp
@@ -348,7 +348,7 @@ struct filtercat_wrapper {
         .def("GetName", &FilterMatcherBase::getName, python::args("self"))
         .def("__str__", &FilterMatcherBase::getName, python::args("self"));
 
-    python::register_ptr_to_python<boost::shared_ptr<FilterMatcherBase>>();
+    //python::register_ptr_to_python<boost::shared_ptr<FilterMatcherBase>>();
 
     python::class_<SmartsMatcher,
                    python::bases<FilterMatcherBase>>(

--- a/Code/GraphMol/FilterCatalog/Wrap/FilterCatalog.cpp
+++ b/Code/GraphMol/FilterCatalog/Wrap/FilterCatalog.cpp
@@ -348,8 +348,6 @@ struct filtercat_wrapper {
         .def("GetName", &FilterMatcherBase::getName, python::args("self"))
         .def("__str__", &FilterMatcherBase::getName, python::args("self"));
 
-    //python::register_ptr_to_python<boost::shared_ptr<FilterMatcherBase>>();
-
     python::class_<SmartsMatcher,
                    python::bases<FilterMatcherBase>>(
         "SmartsMatcher", SmartsMatcherDoc,


### PR DESCRIPTION
Fixes #7585 

Missed for years, this prevents the warning the FilterMatcherBase is already registered.