### PR TITLE
Fix duplicate 'self' argument

### DIFF
--- a/rdkit/Chem/Descriptors.py
+++ b/rdkit/Chem/Descriptors.py
@@ -266,7 +266,7 @@ class PropertyFunctor(rdMolDescriptors.PythonPropertyFunctor):
     """
 
   def __init__(self, name, version):
-    rdMolDescriptors.PythonPropertyFunctor.__init__(self, self, name, version)
+    rdMolDescriptors.PythonPropertyFunctor.__init__(self, name, version)
 
   def __call__(self, mol):
     raise NotImplementedError("Please implement the __call__ method")


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

`mypy` brought this error up:

```
.../site-packages/rdkit-stubs/Chem/rdMolDescriptors.pyi:247: error: Duplicate argument "self" in function definition
```

For me it only broke type checking, but I assume, that it also would give an exception, when `PropertyFunctor` is used.
