### PR TITLE
Lock the clang version for the MacOS CI builds

### DIFF
--- a/.azure-pipelines/mac_build.yml
+++ b/.azure-pipelines/mac_build.yml
@@ -20,7 +20,7 @@ steps:
     conda config --set solver libmamba
     conda config --set channel_priority strict
     conda config --add channels conda-forge
-    conda create --name rdkit_build $(python) $(compiler) libcxx cmake \
+    conda create --name rdkit_build $(python) $(compiler)=$(compiler_version) libcxx cmake \
         libboost=$(boost_version) libboost-devel=$(boost_version) \
         libboost-python=$(boost_version) libboost-python-devel=$(boost_version) \
         qt \

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -38,7 +38,7 @@ jobs:
     vmImage: macos-latest
   variables:
     compiler: clangxx_osx-64
-    compiler_version: 12.0
+    compiler_version: 16.0
     boost_version: 1.82.0
     number_of_cores: sysctl -n hw.ncpu
     python: python=3.11


### PR DESCRIPTION
The CI machines are now using clang18, which is currently causing problems