### PR TITLE
Fix an out of bounds access in ForwardMolSupplier

### DIFF
--- a/Code/GraphMol/FileParsers/ForwardSDMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/ForwardSDMolSupplier.cpp
@@ -72,11 +72,11 @@ void ForwardSDMolSupplier::readMolProps(ROMol &mol) {
   std::string_view tempStr = inl;
 
   // FIX: report files missing the $$$$ marker
-  while (!dp_inStream->eof() && !dp_inStream->fail() &&
-         (tempStr[0] != '$' || tempStr.substr(0, 4) != "$$$$")) {
+  while (!dp_inStream->eof() && !dp_inStream->fail() && 
+         (tempStr.empty() || tempStr.at(0) != '$' || tempStr.substr(0, 4) != "$$$$")) {
     tempStr = FileParserUtils::strip(tempStr);
     if (!tempStr.empty()) {
-      if (tempStr[0] == '>') {  // data header line: start of a data item
+      if (tempStr.at(0) == '>') {  // data header line: start of a data item
         // ignore all other crap and seek for for a data label enclosed
         // by '<' and '>'
         // FIX: "CTfile.pdf" (page 51) says that the data header line does not
@@ -116,17 +116,19 @@ void ForwardSDMolSupplier::readMolProps(ROMol &mol) {
           std::string prop = "";
           auto stmp = FileParserUtils::strip(tempStr);
           int nplines = 0;  // number of lines for this property
-          while (!stmp.empty() || (!tempStr.empty() && (tempStr[0] == ' ' ||
-							tempStr[0] == '\t'))) {
+          while (!stmp.empty() || (!tempStr.empty() && (tempStr.at(0) == ' ' ||
+							tempStr.at(0) == '\t'))) {
             nplines++;
             if (nplines > 1) {
               prop += "\n";
             }
             // take off \r if it's still in the property:
-            if (tempStr.back() == '\r') {
-              tempStr = tempStr.substr(0, tempStr.size() - 1);
-            }
-            prop += tempStr;
+	    if (!tempStr.empty()) {
+	      if (tempStr.back() == '\r') {
+		tempStr = tempStr.substr(0, tempStr.size() - 1);
+	      }
+	      prop += tempStr;
+	    }
             d_line++;
             // erase inl in case the file does not end with a carriage
             // return (we will end up in an infinite loop if we don't do
@@ -134,7 +136,11 @@ void ForwardSDMolSupplier::readMolProps(ROMol &mol) {
             inl.erase();
             std::getline(*dp_inStream, inl);
             tempStr = inl;
-            stmp = FileParserUtils::strip(tempStr);
+	    if (tempStr.empty()) {
+	      stmp = tempStr;
+	    } else {
+	      stmp = FileParserUtils::strip(tempStr);
+	    }
           }
           mol.setProp(dlabel, prop);
           if (df_processPropertyLists) {
@@ -215,7 +221,7 @@ std::unique_ptr<RWMol> ForwardSDMolSupplier::_next() {
       std::getline(*dp_inStream, tempStr);
       ++d_line;
       while (!dp_inStream->eof() && !dp_inStream->fail() &&
-             (tempStr[0] != '$' || tempStr.substr(0, 4) != "$$$$")) {
+             (tempStr.at(0) != '$' || tempStr.substr(0, 4) != "$$$$")) {
         std::getline(*dp_inStream, tempStr);
         ++d_line;
       }
@@ -236,7 +242,7 @@ std::unique_ptr<RWMol> ForwardSDMolSupplier::_next() {
     d_line++;
     std::getline(*dp_inStream, tempStr);
     while (!dp_inStream->eof() && !dp_inStream->fail() &&
-           (tempStr[0] != '$' || tempStr.substr(0, 4) != "$$$$")) {
+           (tempStr.at(0) != '$' || tempStr.substr(0, 4) != "$$$$")) {
       d_line++;
       std::getline(*dp_inStream, tempStr);
     }
@@ -258,7 +264,7 @@ std::unique_ptr<RWMol> ForwardSDMolSupplier::_next() {
       df_eofHitOnRead = true;
     }
     while (!dp_inStream->eof() && !dp_inStream->fail() &&
-           (tempStr[0] != '$' || tempStr.substr(0, 4) != "$$$$")) {
+           (tempStr.at(0) != '$' || tempStr.substr(0, 4) != "$$$$")) {
       d_line++;
       std::getline(*dp_inStream, tempStr);
     }
@@ -280,7 +286,7 @@ std::unique_ptr<RWMol> ForwardSDMolSupplier::_next() {
       df_eofHitOnRead = true;
     }
     while (!dp_inStream->eof() && !dp_inStream->fail() &&
-           (tempStr[0] != '$' || tempStr.substr(0, 4) != "$$$$")) {
+           (tempStr.at(0) != '$' || tempStr.substr(0, 4) != "$$$$")) {
       d_line++;
       std::getline(*dp_inStream, tempStr);
     }

--- a/Code/GraphMol/FileParsers/ForwardSDMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/ForwardSDMolSupplier.cpp
@@ -116,8 +116,8 @@ void ForwardSDMolSupplier::readMolProps(ROMol &mol) {
           std::string prop = "";
           auto stmp = FileParserUtils::strip(tempStr);
           int nplines = 0;  // number of lines for this property
-          while (stmp.length() != 0 || tempStr[0] == ' ' ||
-                 tempStr[0] == '\t') {
+          while (stmp.length() != 0 || (tempStr.length() && (tempStr[0] == ' ' ||
+							     tempStr[0] == '\t'))) {
             nplines++;
             if (nplines > 1) {
               prop += "\n";

--- a/Code/GraphMol/FileParsers/ForwardSDMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/ForwardSDMolSupplier.cpp
@@ -242,7 +242,7 @@ std::unique_ptr<RWMol> ForwardSDMolSupplier::_next() {
     d_line++;
     std::getline(*dp_inStream, tempStr);
     while (!dp_inStream->eof() && !dp_inStream->fail() &&
-           (tempStr.at(0) != '$' || tempStr.substr(0, 4) != "$$$$")) {
+           (tempStr.empty() || tempStr.at(0) != '$' || tempStr.substr(0, 4) != "$$$$")) {
       d_line++;
       std::getline(*dp_inStream, tempStr);
     }
@@ -264,7 +264,7 @@ std::unique_ptr<RWMol> ForwardSDMolSupplier::_next() {
       df_eofHitOnRead = true;
     }
     while (!dp_inStream->eof() && !dp_inStream->fail() &&
-           (tempStr.at(0) != '$' || tempStr.substr(0, 4) != "$$$$")) {
+           (tempStr.empty() || tempStr.at(0) != '$' || tempStr.substr(0, 4) != "$$$$")) {
       d_line++;
       std::getline(*dp_inStream, tempStr);
     }
@@ -286,7 +286,7 @@ std::unique_ptr<RWMol> ForwardSDMolSupplier::_next() {
       df_eofHitOnRead = true;
     }
     while (!dp_inStream->eof() && !dp_inStream->fail() &&
-           (tempStr.at(0) != '$' || tempStr.substr(0, 4) != "$$$$")) {
+           (tempStr.empty() || tempStr.at(0) != '$' || tempStr.substr(0, 4) != "$$$$")) {
       d_line++;
       std::getline(*dp_inStream, tempStr);
     }

--- a/Code/GraphMol/FileParsers/ForwardSDMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/ForwardSDMolSupplier.cpp
@@ -116,8 +116,8 @@ void ForwardSDMolSupplier::readMolProps(ROMol &mol) {
           std::string prop = "";
           auto stmp = FileParserUtils::strip(tempStr);
           int nplines = 0;  // number of lines for this property
-          while (stmp.length() != 0 || (tempStr.length() && (tempStr[0] == ' ' ||
-							     tempStr[0] == '\t'))) {
+          while (!stmp.empty() || (!tempStr.empty() && (tempStr[0] == ' ' ||
+							tempStr[0] == '\t'))) {
             nplines++;
             if (nplines > 1) {
               prop += "\n";


### PR DESCRIPTION
An update to the osx toolchain on conga hit this long standing bug,