### PR TITLE
warn when findMesoCenters() is called and legacy stereo is being used

### DIFF
--- a/Code/GraphMol/Chirality.cpp
+++ b/Code/GraphMol/Chirality.cpp
@@ -3777,6 +3777,12 @@ void simplifyEnhancedStereo(ROMol &mol, bool removeAffectedStereoGroups) {
 
 std::vector<std::pair<unsigned int, unsigned int>> findMesoCenters(
     const ROMol &mol, bool includeIsotopes, bool includeAtomMaps) {
+  if (getUseLegacyStereoPerception()) {
+    BOOST_LOG(rdWarningLog)
+        << "WARNING: findMesoCenters is not supported when legacy stereo perception is enabled."
+        << std::endl;
+    return {};
+  }
   std::vector<std::pair<unsigned int, unsigned int>> res;
   boost::dynamic_bitset<> specifiedChiralAts(mol.getNumAtoms());
   std::vector<unsigned int> ringStereoAts(mol.getNumAtoms(), mol.getNumAtoms());

--- a/Code/GraphMol/Chirality.h
+++ b/Code/GraphMol/Chirality.h
@@ -402,6 +402,9 @@ RDKIT_GRAPHMOL_EXPORT void simplifyEnhancedStereo(
 /*!
  \param mol: molecule to work with
 
+ **NOTE**: this function does nothing when the legacy stereo perception code is
+ being used.
+
 */
 RDKIT_GRAPHMOL_EXPORT std::vector<std::pair<unsigned int, unsigned int>>
 findMesoCenters(const ROMol &mol, bool includeIsotopes = true,

--- a/Code/GraphMol/Wrap/MolOps.cpp
+++ b/Code/GraphMol/Wrap/MolOps.cpp
@@ -2256,6 +2256,10 @@ RETURNS:
       calculation.
     - includeAtomMaps: (optional) toggles whether or not atom maps should be included in the
       calculation.
+
+  **NOTE**: this function does nothing when the legacy stereo perception code is
+    being used.
+
     )DOC";
     python::def("FindMesoCenters", findMesoHelper,
                 (python::arg("mol"), python::arg("includeIsotopes") = true,


### PR DESCRIPTION
The function `findMesoCenters()` does not work when legacy stereo chemistry is being used, so mention that in the docs and raise a warning about it.