### PR TITLE
Fix parsing RBCNT from mol files, and add exporting it

### DIFF
--- a/Code/GraphMol/FileParsers/MolFileParser.cpp
+++ b/Code/GraphMol/FileParsers/MolFileParser.cpp
@@ -2324,8 +2324,15 @@ void ParseV3000AtomProps(RWMol *mol, Atom *&atom, typename T::iterator &token,
         if (!atom->hasQuery()) {
           atom = QueryOps::replaceAtomWithQueryAtom(mol, atom);
         }
+        atom->setProp(common_properties::molRingBondCount, rbcount);
         if (rbcount == -1) {
           rbcount = 0;
+        } else if (rbcount == -2) {
+          // Ring bonds can only be counted during post processing
+          mol->setProp(common_properties::_NeedsQueryScan, 1);
+          rbcount = 0xDEADBEEF;
+        } else if (rbcount > 4) {
+          rbcount = 4;
         }
         atom->expandQuery(makeAtomRingBondCountQuery(rbcount));
       }

--- a/Code/GraphMol/FileParsers/MolFileWriter.cpp
+++ b/Code/GraphMol/FileParsers/MolFileWriter.cpp
@@ -861,6 +861,10 @@ const std::string GetV3000MolFileAtomLine(
         iprop) {
       ss << " SUBST=" << iprop;
     }
+    if (atom->getPropIfPresent(common_properties::molRingBondCount, iprop) &&
+        iprop) {
+      ss << " RBCNT=" << iprop;
+    }
   }
   {
     std::string sprop;

--- a/Code/GraphMol/FileParsers/file_parsers_catch.cpp
+++ b/Code/GraphMol/FileParsers/file_parsers_catch.cpp
@@ -2256,6 +2256,37 @@ M  END
     CHECK(molb.find("SUBST=-2") != std::string::npos);
     CHECK(molb.find("SUBST=-1") != std::string::npos);
   }
+  SECTION("RBCNT") {
+    auto mol = R"CTAB(test
+  Mrv2007 03132018122D
+
+  0  0  0     0  0            999 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 4 3 0 0 0
+M  V30 BEGIN ATOM
+M  V30 1 C -16.6248 7.1666 0 0 RBCNT=3
+M  V30 2 C -15.2911 7.9366 0 0 RBCNT=-2
+M  V30 3 N -13.9574 7.1666 0 0 RBCNT=-1
+M  V30 4 C -17.9585 7.9366 0 0 RBCNT=4
+M  V30 END ATOM
+M  V30 BEGIN BOND
+M  V30 1 1 1 2
+M  V30 2 1 2 3
+M  V30 3 1 1 4
+M  V30 END BOND
+M  V30 END CTAB
+M  END
+)CTAB"_ctab;
+    REQUIRE(mol);
+
+    auto smarts = MolToSmarts(*mol);
+    CHECK(smarts == "[#6&x3](-[#6&x0]-[#7&x0])-[#6&x4]");
+
+    auto molb = MolToV3KMolBlock(*mol);
+    CHECK(molb.find("RBCNT=3") != std::string::npos);
+    CHECK(molb.find("RBCNT=-2") != std::string::npos);
+    CHECK(molb.find("RBCNT=-1") != std::string::npos);
+  }
   SECTION("bond props") {
     auto mol = R"CTAB(bogus example
   Mrv2007 03132017102D

--- a/Code/RDGeneral/types.cpp
+++ b/Code/RDGeneral/types.cpp
@@ -120,7 +120,7 @@ const std::string smilesSymbol = "smilesSymbol";
 const std::string atomLabel = "atomLabel";
 const std::string OxidationNumber = "OxidationNumber";
 const std::string internalRgroupSmiles = "internalRgroupSmiles";
-
+const std::string molRingBondCount = "molRingBondCount";
 const std::string molSubstCount = "molSubstCount";
 const std::string molAttachPoint = "molAttchpt";
 const std::string molAttachOrder = "molAttchord";

--- a/Code/RDGeneral/types.h
+++ b/Code/RDGeneral/types.h
@@ -169,6 +169,7 @@ RDKIT_RDGENERAL_EXPORT extern const std::string molStereoCare;      // int
 RDKIT_RDGENERAL_EXPORT extern const std::string molRxnComponent;    // int
 RDKIT_RDGENERAL_EXPORT extern const std::string molRxnRole;         // int
 RDKIT_RDGENERAL_EXPORT extern const std::string molTotValence;      // int
+RDKIT_RDGENERAL_EXPORT extern const std::string molRingBondCount;   // int
 RDKIT_RDGENERAL_EXPORT extern const std::string molSubstCount;      // int
 RDKIT_RDGENERAL_EXPORT extern const std::string molAttachPoint;     // int
 RDKIT_RDGENERAL_EXPORT extern const std::string molAttachOrder;     // int


### PR DESCRIPTION
This fixes parsing the RBCNT field in mol file atom lines, and adds exporting it.

The existing implementation didn't handle the special "-2" value, and also didn't cap the possible values at 4, as mentioned in the documentation.