### PR TITLE
Fixes #7556

### DIFF
--- a/Code/GraphMol/CMakeLists.txt
+++ b/Code/GraphMol/CMakeLists.txt
@@ -196,3 +196,7 @@ rdkit_catch_test(pickleTestsCatch catch_pickles.cpp
 
 rdkit_catch_test(tableTestsCatch catch_periodictable.cpp
         LINK_LIBRARIES GraphMol)
+
+rdkit_catch_test(molopsTestsCatch catch_molops.cpp
+        LINK_LIBRARIES SmilesParse GraphMol)
+

--- a/Code/GraphMol/ConjugHybrid.cpp
+++ b/Code/GraphMol/ConjugHybrid.cpp
@@ -21,6 +21,17 @@ namespace RDKit {
 namespace {
 bool isAtomConjugCand(const Atom *at) {
   PRECONDITION(at, "bad atom");
+  std::cerr << "  iacc: " << at->getIdx() << std::endl;
+  // return false for neutral atoms where the current valence exceeds the
+  // minimal valence for the atom. logic: if we're hypervalent we aren't
+  // conjugated
+  const auto &vals =
+      PeriodicTable::getTable()->getValenceList(at->getAtomicNum());
+  if (!at->getFormalCharge() && vals.front() >= 0 &&
+      at->getTotalValence() > static_cast<unsigned int>(vals.front())) {
+    std::cerr << "  no 1" << std::endl;
+    return false;
+  }
   // the second check here is for Issue211, where the c-P bonds in
   // Pc1ccccc1 were being marked as conjugated.  This caused the P atom
   // itself to be SP2 hybridized.  This is wrong.  For now we'll do a quick
@@ -28,13 +39,15 @@ bool isAtomConjugCand(const Atom *at) {
   // the first row of the periodic table.  (Conjugation in aromatic rings
   // has already been attended to, so this is safe.)
   int nouter = PeriodicTable::getTable()->getNouterElecs(at->getAtomicNum());
-  return ((at->getAtomicNum() <= 10) || (nouter != 5 && nouter != 6) ||
-          (nouter == 6 && at->getTotalDegree() < 2u)) &&
-         (MolOps::countAtomElec(at) > 0);
+  auto res = (at->getAtomicNum() <= 10) || (nouter != 5 && nouter != 6) ||
+             (nouter == 6 && at->getTotalDegree() < 2u);
+  std::cerr << "  no2 " << res << std::endl;
+  return res;
 }
 
 void markConjAtomBonds(Atom *at) {
   PRECONDITION(at, "bad atom");
+  std::cerr << "macb: " << at->getIdx() << std::endl;
   if (!isAtomConjugCand(at)) {
     return;
   }
@@ -47,14 +60,12 @@ void markConjAtomBonds(Atom *at) {
     return;
   }
 
-  for (const auto &nbri : boost::make_iterator_range(mol.getAtomBonds(at))) {
-    auto bnd1 = mol[nbri];
+  for (const auto bnd1 : mol.atomBonds(at)) {
     if (bnd1->getValenceContrib(at) < 1.5) {
       continue;
     }
 
-    for (const auto &nbrj : boost::make_iterator_range(mol.getAtomBonds(at))) {
-      auto bnd2 = mol[nbrj];
+    for (const auto bnd2 : mol.atomBonds(at)) {
       if (bnd1 == bnd2) {
         continue;
       }
@@ -64,6 +75,7 @@ void markConjAtomBonds(Atom *at) {
         continue;
       }
       if (isAtomConjugCand(at2)) {
+        std::cerr << "   MARK MARK MARK" << std::endl;
         bnd1->setIsConjugated(true);
         bnd2->setIsConjugated(true);
       }

--- a/Code/GraphMol/ConjugHybrid.cpp
+++ b/Code/GraphMol/ConjugHybrid.cpp
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2001-2021 Greg Landrum and Rational Discovery LLC
+//  Copyright (C) 2001-2024 Greg Landrum and other RDKit contributors
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -117,8 +117,7 @@ bool atomHasConjugatedBond(const Atom *at) {
   PRECONDITION(at, "bad atom");
 
   auto &mol = at->getOwningMol();
-  for (const auto &nbri : boost::make_iterator_range(mol.getAtomBonds(at))) {
-    auto bnd = mol[nbri];
+  for (const auto bnd : mol.atomBonds(at)) {
     if (bnd->getIsConjugated()) {
       return true;
     }

--- a/Code/GraphMol/catch_molops.cpp
+++ b/Code/GraphMol/catch_molops.cpp
@@ -1,0 +1,30 @@
+//
+//  Copyright (C) 2024 Greg Landrum and other RDKit contributors
+//
+//   @@ All Rights Reserved @@
+//  This file is part of the RDKit.
+//  The contents are covered by the terms of the BSD license
+//  which is included in the file license.txt, found at the root
+//  of the RDKit source tree.
+//
+
+#include <catch2/catch_all.hpp>
+
+#include <GraphMol/RDKitBase.h>
+#include <GraphMol/MolOps.h>
+#include <GraphMol/test_fixtures.h>
+
+#include <GraphMol/SmilesParse/SmilesParse.h>
+#include <GraphMol/SmilesParse/SmilesWrite.h>
+
+using namespace RDKit;
+
+TEST_CASE("github #7556: chiral sulfur in conjugated rings") {
+  SECTION("as reported") {
+    auto m = "CC1=CC(Cl)=CC2=C1N=[S@](C)N=C2N"_smiles;
+    REQUIRE(m);
+    CHECK(!m->getBondBetweenAtoms(8, 9)->getIsConjugated());
+    CHECK(!m->getBondBetweenAtoms(9, 11)->getIsConjugated());
+    REQUIRE(m->getAtomWithIdx(9)->getChiralTag() != Atom::CHI_UNSPECIFIED);
+  }
+}


### PR DESCRIPTION
This adds an additional condition for an atom to be a candidate for conjugation: it cannot be hypervalent (as determined by it having a non-default valence).