### PR TITLE
fix(rdmolfiles): fix parameters and docstrings

### DIFF
--- a/Code/GraphMol/Wrap/rdmolfiles.cpp
+++ b/Code/GraphMol/Wrap/rdmolfiles.cpp
@@ -782,7 +782,7 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
       "Construct a molecule from a TPL block.\n\n\
   ARGUMENTS:\n\
 \n\
-    - fileName: name of the file to read\n\
+    - tplBlock: string containing the TPL block\n\
 \n\
     - sanitize: (optional) toggles sanitization of the molecule.\n\
       Defaults to True.\n\
@@ -908,7 +908,7 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
       "Construct a molecule from an XYZ file.\n\n\
   ARGUMENTS:\n\
 \n\
-    - xyzname: name of the file to read\n\
+    - xyzFileName: name of the file to read\n\
 \n\
   RETURNS:\n\
 \n\
@@ -929,7 +929,7 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
     a Mol object, None on failure.\n\
 \n";
   python::def("MolFromXYZBlock", RDKit::MolFromXYZBlock,
-              (python::arg("xyzFileName")), docString.c_str(),
+              (python::arg("xyzBlock")), docString.c_str(),
               python::return_value_policy<python::manage_new_object>());
 
   docString =
@@ -952,7 +952,7 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
   NOTE: this functionality should be considered beta.\n\
 \n";
   python::def("MolFromRDKitSVG", RDKit::MolFromSVG,
-              (python::arg("molBlock"), python::arg("sanitize") = true,
+              (python::arg("svg"), python::arg("sanitize") = true,
                python::arg("removeHs") = true),
               docString.c_str(),
               python::return_value_policy<python::manage_new_object>());
@@ -966,7 +966,7 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
 \n\
   ARGUMENTS:\n                                  \
 \n\
-    - fileName: name of the file to read\n\
+    - mol2FileName: name of the file to read\n\
 \n\
     - sanitize: (optional) toggles sanitization of the molecule.\n\
       Defaults to true.\n\
@@ -984,11 +984,12 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
     a Mol object, None on failure.\n\
 \n";
   python::def("MolFromMol2File", RDKit::MolFromMol2File,
-              (python::arg("molFileName"), python::arg("sanitize") = true,
+              (python::arg("mol2FileName"), python::arg("sanitize") = true,
                python::arg("removeHs") = true,
                python::arg("cleanupSubstructures") = true),
               docString.c_str(),
               python::return_value_policy<python::manage_new_object>());
+
   docString =
       "Construct a molecule from a Tripos Mol2 block.\n\n\
   NOTE:\n\
@@ -1016,7 +1017,7 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
     a Mol object, None on failure.\n\
 \n";
   python::def("MolFromMol2Block", RDKit::MolFromMol2Block,
-              (python::arg("molBlock"), python::arg("sanitize") = true,
+              (python::arg("mol2Block"), python::arg("sanitize") = true,
                python::arg("removeHs") = true,
                python::arg("cleanupSubstructures") = true),
               docString.c_str(),
@@ -1026,7 +1027,7 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
       "Construct a molecule from a Mol file.\n\n\
   ARGUMENTS:\n\
 \n\
-    - fileName: name of the file to read\n\
+    - molFileName: name of the file to read\n\
 \n\
     - sanitize: (optional) toggles sanitization of the molecule.\n\
       Defaults to true.\n\
@@ -1318,7 +1319,7 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
   docString =
       "Writes a Marvin (MRV) file for a molecule\n\
    ARGUMENTS:\n\
- \n\
+\n\
      - mol: the molecule\n\
      - filename: the file to write to\n\
      - includeStereo: (optional) toggles inclusion of stereochemical\n\
@@ -1326,11 +1327,7 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
      - confId: (optional) selects which conformation to output (-1 = default)\n\
      - kekulize: (optional) triggers kekulization of the molecule before it's written.\n\
      - prettyPrint: (optional) makes the output more human readable.\n\
- \n\
-   RETURNS:\n\
- \n\
-     a string\n\
- \n";
+\n";
   python::def(
       "MolToMrvFile",
       (void (*)(const ROMol &, const std::string &, bool, int, bool,
@@ -1348,10 +1345,6 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
     - filename: the file to write to\n\
     - params: marvin write params\n\
     - confId: (optional) selects which conformation to output (-1 = default)\n\
-\n\
-  RETURNS:\n\
-\n\
-    a string\n\
 \n";
   python::def("MolToMrvFile",
               (void (*)(const ROMol &, const std::string &,
@@ -1455,18 +1448,19 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
       .def_readwrite(
           "mergeHs", &RDKit::SmartsParserParams::mergeHs,
           "toggles merging H atoms in the SMARTS into neighboring atoms");
+
   docString =
       "Construct a molecule from a SMILES string.\n\n\
      ARGUMENTS:\n\
-   \n\
+\n\
        - SMILES: the smiles string\n\
-   \n\
+\n\
        - params: used to provide optional parameters for the SMILES parsing\n\
-   \n\
+\n\
      RETURNS:\n\
-   \n\
+\n\
        a Mol object, None on failure.\n\
-   \n";
+\n";
   python::def("MolFromSmiles", MolFromSmilesHelper,
               (python::arg("SMILES"), python::arg("params")), docString.c_str(),
               python::return_value_policy<python::manage_new_object>());
@@ -1491,9 +1485,9 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
    in the input SMILES. The set of substitutions is repeatedly looped through until \n\
    the string no longer changes. It is the responsibility of the caller to make sure \n\
    that substitutions results in legal and sensible SMILES. \n\
- \n\
+\n\
    Examples of replacements: \n\
- \n\
+\n\
      CC{Q}C with {'{Q}':'OCCO'} -> CCOCCOC  \n\n\
      C{A}C{Q}C with {'{Q}':'OCCO', '{A}':'C1(CC1)'} -> CC1(CC1)COCCOC  \n\n\
      C{A}C{Q}C with {'{Q}':'{X}CC{X}', '{A}':'C1CC1', '{X}':'N'} -> CC1CC1CNCCNC  \n\n\
@@ -1503,10 +1497,12 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
                python::arg("replacements") = python::dict()),
               docString.c_str(),
               python::return_value_policy<python::manage_new_object>());
+
   docString = "Construct an atom from a SMILES string";
   python::def("AtomFromSmiles", SmilesToAtom, python::arg("SMILES"),
               docString.c_str(),
               python::return_value_policy<python::manage_new_object>());
+
   docString = "Construct a bond from a SMILES string";
   python::def("BondFromSmiles", SmilesToBond, python::arg("SMILES"),
               docString.c_str(),
@@ -1534,10 +1530,12 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
                python::arg("replacements") = python::dict()),
               docString.c_str(),
               python::return_value_policy<python::manage_new_object>());
+
   docString = "Construct an atom from a SMARTS string";
   python::def("AtomFromSmarts", SmartsToAtom, python::arg("SMARTS"),
               docString.c_str(),
               python::return_value_policy<python::manage_new_object>());
+
   docString = "Construct a bond from a SMARTS string";
   python::def("BondFromSmarts", SmartsToBond, python::arg("SMILES"),
               docString.c_str(),
@@ -1546,15 +1544,15 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
   docString =
       "Construct a molecule from a SMARTS string.\n\n\
      ARGUMENTS:\n\
-   \n\
+\n\
        - SMARTS: the smarts string\n\
-   \n\
+\n\
        - params: used to provide optional parameters for the SMARTS parsing\n\
-   \n\
+\n\
      RETURNS:\n\
-   \n\
+\n\
        a Mol object, None on failure.\n\
-   \n";
+\n";
   python::def("MolFromSmarts", MolFromSmartsHelper,
               (python::arg("SMARTS"), python::arg("params")), docString.c_str(),
               python::return_value_policy<python::manage_new_object>());
@@ -1789,6 +1787,7 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
                python::arg("atomsToUse"), python::arg("bondsToUse") = 0,
                python::arg("atomSymbols") = 0, python::arg("bondSymbols") = 0),
               docString.c_str());
+
   docString =
       "Returns the CXSMILES string for a fragment of a molecule\n\
   ARGUMENTS:\n\
@@ -1847,6 +1846,7 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
               (python::arg("mol"), python::arg("isomericSmiles") = true,
                python::arg("rootedAtAtom") = -1),
               docString.c_str());
+
   docString =
       "Returns a SMARTS string for a molecule\n\
   ARGUMENTS:\n\
@@ -1882,6 +1882,7 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
       (python::arg("mol"), python::arg("atomsToUse"),
        python::arg("bondsToUse") = 0, python::arg("isomericSmarts") = true),
       docString.c_str());
+
   docString =
       "Returns a SMARTS string for a molecule\n\
   ARGUMENTS:\n\
@@ -1962,7 +1963,7 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
       "Construct a molecule from a PDB file.\n\n\
   ARGUMENTS:\n\
 \n\
-    - fileName: name of the file to read\n\
+    - pdbFileName: name of the file to read\n\
 \n\
     - sanitize: (optional) toggles sanitization of the molecule.\n\
       Defaults to true.\n\
@@ -1980,7 +1981,7 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
     a Mol object, None on failure.\n\
 \n";
   python::def("MolFromPDBFile", RDKit::MolFromPDBFile,
-              (python::arg("molFileName"), python::arg("sanitize") = true,
+              (python::arg("pdbFileName"), python::arg("sanitize") = true,
                python::arg("removeHs") = true, python::arg("flavor") = 0,
                python::arg("proximityBonding") = true),
               docString.c_str(),
@@ -2036,6 +2037,7 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
               (python::arg("mol"), python::arg("confId") = -1,
                python::arg("flavor") = 0),
               docString.c_str());
+
   docString =
       "Writes a PDB file for a molecule\n\
   ARGUMENTS:\n\
@@ -2050,10 +2052,6 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
             - flavor & 8 : Don't use multiple CONECTs to encode bond order \n\
             - flavor & 16 : Write MASTER record \n\
             - flavor & 32 : Write TER record \n\
-\n\
-  RETURNS:\n\
-\n\
-    a string\n\
 \n";
   python::def("MolToPDBFile", RDKit::MolToPDBFile,
               (python::arg("mol"), python::arg("filename"),
@@ -2090,6 +2088,7 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
                python::arg("flavor") = 0),
               docString.c_str(),
               python::return_value_policy<python::manage_new_object>());
+
   docString =
       "Returns the sequence string for a molecule\n\
   ARGUMENTS:\n\
@@ -2134,6 +2133,7 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
                python::arg("flavor") = 0),
               docString.c_str(),
               python::return_value_policy<python::manage_new_object>());
+
   docString =
       "Returns the FASTA string for a molecule\n\
   ARGUMENTS:\n\
@@ -2166,6 +2166,7 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
               (python::arg("text"), python::arg("sanitize") = true),
               docString.c_str(),
               python::return_value_policy<python::manage_new_object>());
+
   docString =
       "Returns the HELM string for a molecule\n\
   ARGUMENTS:\n\
@@ -2293,6 +2294,7 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
        python::arg("allBondsExplicit") = false,
        python::arg("allHsExplicit") = false),
       "returns a list of SMILES generated using the randomSmiles algorithm");
+
 #ifdef RDK_USE_BOOST_IOSTREAMS
   docString =
       R"DOC(Construct a molecule from metadata in a PNG string.
@@ -2353,6 +2355,7 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
        - filename: the cdxml filename
 
        - sanitize: if True, sanitize the molecules [default True]
+
        - removeHs: if True, convert explicit Hs into implicit Hs. [default True]
 
      RETURNS:
@@ -2372,11 +2375,11 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
 
      ARGUMENTS:
 
-       - filename: the cdxml string
+       - cdxml: the cdxml string
 
        - sanitize: if True, sanitize the molecules [default True]
-       - removeHs: if True, convert explicit Hs into implicit Hs. [default True]
 
+       - removeHs: if True, convert explicit Hs into implicit Hs. [default True]
 
      RETURNS:
        an iterator of parsed Mol objects.)DOC";


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! 
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.

Some of parameters and docstrings in `rdkit.Chem.rdmolfiles` are incorrect e.g. <https://www.rdkit.org/docs/source/rdkit.Chem.rdmolfiles.html#rdkit.Chem.rdmolfiles.MolFromTPLBlock>.

#### Any other comments?

