### PR TITLE
Refactor distgeom minimizations

### DIFF
--- a/Code/DistGeom/DistGeomUtils.cpp
+++ b/Code/DistGeom/DistGeomUtils.cpp
@@ -28,7 +28,7 @@
 #include <ForceField/MMFF/Nonbonded.h>
 
 namespace DistGeom {
-const double EIGVAL_TOL = 0.001;
+constexpr double EIGVAL_TOL = 0.001;
 constexpr double KNOWN_DIST_TOL = 0.01;
 constexpr double KNOWN_DIST_FORCE_CONSTANT = 100;
 

--- a/Code/DistGeom/DistGeomUtils.cpp
+++ b/Code/DistGeom/DistGeomUtils.cpp
@@ -30,6 +30,7 @@
 namespace DistGeom {
 const double EIGVAL_TOL = 0.001;
 const double KNOWN_DIST_TOL = 0.01;
+const double KNOWN_DIST_FORCE_CONSTANT = 100;
 
 double pickRandomDistMat(const BoundsMatrix &mmat,
                          RDNumeric::SymmMatrix<double> &distMat, int seed) {
@@ -479,16 +480,14 @@ ForceFields::ForceField *construct3DForceField(
   addExperimentalTorsionTerms(field, etkdgDetails, atomPairs, N);
   addImproperTorsionTerms(field, 10.0, etkdgDetails.improperAtoms,
                           is13Constrained);
-
-  constexpr double knownDistanceConstraintForce = 100.0;
   add12Terms(field, etkdgDetails, atomPairs, positions,
-             knownDistanceConstraintForce, N);
+             KNOWN_DIST_FORCE_CONSTANT, N);
   add13Terms(field, etkdgDetails, atomPairs, positions,
-             knownDistanceConstraintForce, is13Constrained, true, N);
+             KNOWN_DIST_FORCE_CONSTANT, is13Constrained, true, N);
 
   // minimum distance for all other atom pairs that aren't constrained
   addLongRangeDistanceConstraints(field, etkdgDetails, atomPairs, positions,
-                                  knownDistanceConstraintForce, mmat, N);
+                                  KNOWN_DIST_FORCE_CONSTANT, mmat, N);
   return field;
 }  // construct3DForceField
 
@@ -529,15 +528,13 @@ ForceFields::ForceField *constructPlain3DForceField(
 
   // ET torsion constraints
   addExperimentalTorsionTerms(field, etkdgDetails, atomPairs, N);
-
-  constexpr double knownDistanceConstraintForce = 100.0;
   add12Terms(field, etkdgDetails, atomPairs, positions,
-             knownDistanceConstraintForce, N);
+             KNOWN_DIST_FORCE_CONSTANT, N);
   add13Terms(field, etkdgDetails, atomPairs, positions,
-             knownDistanceConstraintForce, is13Constrained, false, N);
+             KNOWN_DIST_FORCE_CONSTANT, is13Constrained, false, N);
   // minimum distance for all other atom pairs that aren't constrained
   addLongRangeDistanceConstraints(field, etkdgDetails, atomPairs, positions,
-                                  knownDistanceConstraintForce, mmat, N);
+                                  KNOWN_DIST_FORCE_CONSTANT, mmat, N);
 
   return field;
 }  // constructPlain3DForceField

--- a/Code/DistGeom/DistGeomUtils.cpp
+++ b/Code/DistGeom/DistGeomUtils.cpp
@@ -29,7 +29,7 @@
 
 namespace DistGeom {
 const double EIGVAL_TOL = 0.001;
-const double MIN_TOLERANCE = 0.01;
+const double KNOWN_DIST_TOL = 0.01;
 
 double pickRandomDistMat(const BoundsMatrix &mmat,
                          RDNumeric::SymmMatrix<double> &distMat, int seed) {
@@ -356,8 +356,8 @@ void add12Terms(ForceFields::ForceField *ff,
       atomPairs[j * numAtoms + i] = 1;
     }
     double d = ((*positions[i]) - (*positions[j])).length();
-    double l = d - MIN_TOLERANCE;
-    double u = d + MIN_TOLERANCE;
+    double l = d - KNOWN_DIST_TOL;
+    double u = d + KNOWN_DIST_TOL;
     auto *contrib = new ForceFields::UFF::DistanceConstraintContrib(
         ff, i, j, l, u, forceConstant);
     ff->contribs().emplace_back(contrib);
@@ -402,8 +402,8 @@ void add13Terms(ForceFields::ForceField *ff,
       ff->contribs().emplace_back(contrib);
     } else if (!is13Constrained[j]) {
       double d = ((*positions[i]) - (*positions[k])).length();
-      double l = d - MIN_TOLERANCE;
-      double u = d + MIN_TOLERANCE;
+      double l = d - KNOWN_DIST_TOL;
+      double u = d + KNOWN_DIST_TOL;
       auto *contrib = new ForceFields::UFF::DistanceConstraintContrib(
           ff, i, k, l, u, forceConstant);
       ff->contribs().emplace_back(contrib);
@@ -445,8 +445,8 @@ void addLongRangeDistanceCosntraints(
             etkdgDetails.constrainedAtoms[j]) {
           // we're constrained, so use very tight bounds
           l = u = ((*positions[i]) - (*positions[j])).length();
-          l -= MIN_TOLERANCE;
-          u += MIN_TOLERANCE;
+          l -= KNOWN_DIST_TOL;
+          u += KNOWN_DIST_TOL;
           fdist = knownDistanceForceConstant;
         }
         auto *contrib = new ForceFields::UFF::DistanceConstraintContrib(

--- a/Code/DistGeom/DistGeomUtils.cpp
+++ b/Code/DistGeom/DistGeomUtils.cpp
@@ -289,7 +289,7 @@ void addImproperTorsionTerms(
   }
 }
 
-void addTorsionTerms(
+void addExperimentalTorsionTerms(
     ForceFields::ForceField *ff,
     const ForceFields::CrystalFF::CrystalFFDetails &etkdgDetails,
     boost::dynamic_bitset<> &atomPairs, unsigned int numRows) {
@@ -337,7 +337,7 @@ void add13Terms(ForceFields::ForceField *ff,
                 RDGeom::Point3DPtrVect &positions, double forceConstant,
                 boost::dynamic_bitset<> &atomPairs,
                 boost::dynamic_bitset<> &is13Constrained,
-                bool addSPLinearityConstraint, unsigned int numRows) {
+                bool useBasicKnowledge, unsigned int numRows) {
   for (const auto &angle : etkdgDetails.angles) {
     unsigned int i = angle[0];
     unsigned int j = angle[1];
@@ -349,7 +349,7 @@ void add13Terms(ForceFields::ForceField *ff,
       atomPairs[k * numRows + i] = 1;
     }
     // check for triple bonds
-    if (addSPLinearityConstraint && angle[3]) {
+    if (useBasicKnowledge && angle[3]) {
       auto *contrib = new ForceFields::UFF::AngleConstraintContrib(
           ff, i, j, k, 179.0, 180.0, 1);
       ff->contribs().emplace_back(contrib);
@@ -364,7 +364,7 @@ void add13Terms(ForceFields::ForceField *ff,
   }
 }
 
-void addMinDistanceCosntraints(
+void addLongRangeDistanceCosntraints(
     ForceFields::ForceField *ff, unsigned int numRows,
     boost::dynamic_bitset<> atomPairs, RDGeom::Point3DPtrVect &positions,
     const ForceFields::CrystalFF::CrystalFFDetails &etkdgDetails,
@@ -413,7 +413,7 @@ ForceFields::ForceField *construct3DForceField(
   boost::dynamic_bitset<> is13Constrained(N);
 
   // torsion constraints
-  addTorsionTerms(field, etkdgDetails, atomPairs, N);
+  addExperimentalTorsionTerms(field, etkdgDetails, atomPairs, N);
   addImproperTorsionTerms(field, 10.0, etkdgDetails, is13Constrained);
 
   constexpr double knownDistanceConstraintForce = 100.0;
@@ -424,8 +424,8 @@ ForceFields::ForceField *construct3DForceField(
   add13Terms(field, etkdgDetails, positions, knownDistanceConstraintForce,
              atomPairs, is13Constrained, true, N);
   // minimum distance for all other atom pairs that aren't constrained
-  addMinDistanceCosntraints(field, N, atomPairs, positions, etkdgDetails, mmat,
-                            knownDistanceConstraintForce);
+  addLongRangeDistanceCosntraints(field, N, atomPairs, positions, etkdgDetails,
+                                  mmat, knownDistanceConstraintForce);
   return field;
 }  // construct3DForceField
 
@@ -465,8 +465,7 @@ ForceFields::ForceField *constructPlain3DForceField(
   boost::dynamic_bitset<> is13Constrained(N);
 
   // torsion constraints
-  // torsion constraints
-  addTorsionTerms(field, etkdgDetails, atomPairs, N);
+  addExperimentalTorsionTerms(field, etkdgDetails, atomPairs, N);
 
   constexpr double knownDistanceConstraintForce = 100.0;
   // 1,2 distance constraints
@@ -476,8 +475,8 @@ ForceFields::ForceField *constructPlain3DForceField(
   add13Terms(field, etkdgDetails, positions, knownDistanceConstraintForce,
              atomPairs, is13Constrained, false, N);
   // minimum distance for all other atom pairs that aren't constrained
-  addMinDistanceCosntraints(field, N, atomPairs, positions, etkdgDetails, mmat,
-                            knownDistanceConstraintForce);
+  addLongRangeDistanceCosntraints(field, N, atomPairs, positions, etkdgDetails,
+                                  mmat, knownDistanceConstraintForce);
 
   return field;
 }  // constructPlain3DForceField

--- a/Code/DistGeom/DistGeomUtils.cpp
+++ b/Code/DistGeom/DistGeomUtils.cpp
@@ -264,7 +264,7 @@ ForceFields::ForceField *constructForceField(
 void addImproperTorsionTerms(
     ForceFields::ForceField *ff, double forceScalingFactor,
     const ForceFields::CrystalFF::CrystalFFDetails &etkdgDetails,
-    std::vector<bool> &is13Constrained) {
+    boost::dynamic_bitset<> &is13Constrained) {
   for (const auto &improperAtom : etkdgDetails.improperAtoms) {
     std::vector<int> n(4);
     for (unsigned int i = 0; i < 3; ++i) {
@@ -312,7 +312,7 @@ void addImproperTorsionTerms(
 void addExperimentalTorsionTerms(
     ForceFields::ForceField *ff,
     const ForceFields::CrystalFF::CrystalFFDetails &etkdgDetails,
-    std::vector<bool> &atomPairs, unsigned int numAtoms) {
+    boost::dynamic_bitset<> &atomPairs, unsigned int numAtoms) {
   for (unsigned int t = 0; t < etkdgDetails.expTorsionAtoms.size(); ++t) {
     int i = etkdgDetails.expTorsionAtoms[t][0];
     int j = etkdgDetails.expTorsionAtoms[t][1];
@@ -345,8 +345,9 @@ void addExperimentalTorsionTerms(
 */
 void add12Terms(ForceFields::ForceField *ff,
                 const ForceFields::CrystalFF::CrystalFFDetails &etkdgDetails,
-                std::vector<bool> &atomPairs, RDGeom::Point3DPtrVect &positions,
-                double forceConstant, unsigned int numAtoms) {
+                boost::dynamic_bitset<> &atomPairs,
+                RDGeom::Point3DPtrVect &positions, double forceConstant,
+                unsigned int numAtoms) {
   for (const auto &bond : etkdgDetails.bonds) {
     unsigned int i = bond.first;
     unsigned int j = bond.second;
@@ -382,8 +383,9 @@ void add12Terms(ForceFields::ForceField *ff,
 */
 void add13Terms(ForceFields::ForceField *ff,
                 const ForceFields::CrystalFF::CrystalFFDetails &etkdgDetails,
-                std::vector<bool> &atomPairs, RDGeom::Point3DPtrVect &positions,
-                double forceConstant, std::vector<bool> &is13Constrained,
+                boost::dynamic_bitset<> &atomPairs,
+                RDGeom::Point3DPtrVect &positions, double forceConstant,
+                boost::dynamic_bitset<> &is13Constrained,
                 bool useBasicKnowledge, unsigned int numAtoms) {
   for (const auto &angle : etkdgDetails.angles) {
     unsigned int i = angle[0];
@@ -427,10 +429,10 @@ void add13Terms(ForceFields::ForceField *ff,
   \param numAtoms number of atoms in molecule
 
 */
-void addLongRangeDistanceCosntraints(
+void addLongRangeDistanceConstraints(
     ForceFields::ForceField *ff,
     const ForceFields::CrystalFF::CrystalFFDetails &etkdgDetails,
-    std::vector<bool> &atomPairs, RDGeom::Point3DPtrVect &positions,
+    boost::dynamic_bitset<> &atomPairs, RDGeom::Point3DPtrVect &positions,
     double knownDistanceForceConstant, const BoundsMatrix &mmat,
     unsigned int numAtoms) {
   double fdist = knownDistanceForceConstant;
@@ -472,8 +474,8 @@ ForceFields::ForceField *construct3DForceField(
   // keep track which atoms are 1,2- or 1,3-restrained
   // don't add 1-3 Distances constraints for angles where the
   // central atom of the angle is the central atom of an improper torsion.
-  std::vector<bool> atomPairs(N * N);
-  std::vector<bool> is13Constrained(N);
+  boost::dynamic_bitset<> atomPairs(N * N);
+  boost::dynamic_bitset<> is13Constrained(N);
 
   // torsion constraints
   addExperimentalTorsionTerms(field, etkdgDetails, atomPairs, N);
@@ -487,7 +489,7 @@ ForceFields::ForceField *construct3DForceField(
   add13Terms(field, etkdgDetails, atomPairs, positions,
              knownDistanceConstraintForce, is13Constrained, true, N);
   // minimum distance for all other atom pairs that aren't constrained
-  addLongRangeDistanceCosntraints(field, etkdgDetails, atomPairs, positions,
+  addLongRangeDistanceConstraints(field, etkdgDetails, atomPairs, positions,
                                   knownDistanceConstraintForce, mmat, N);
   return field;
 }  // construct3DForceField
@@ -524,8 +526,8 @@ ForceFields::ForceField *constructPlain3DForceField(
                             positions.end());
 
   // keep track which atoms are 1,2- or 1,3-restrained
-  std::vector<bool> atomPairs(N * N);
-  std::vector<bool> is13Constrained(N);
+  boost::dynamic_bitset<> atomPairs(N * N);
+  boost::dynamic_bitset<> is13Constrained(N);
 
   // torsion constraints
   addExperimentalTorsionTerms(field, etkdgDetails, atomPairs, N);
@@ -538,7 +540,7 @@ ForceFields::ForceField *constructPlain3DForceField(
   add13Terms(field, etkdgDetails, atomPairs, positions,
              knownDistanceConstraintForce, is13Constrained, false, N);
   // minimum distance for all other atom pairs that aren't constrained
-  addLongRangeDistanceCosntraints(field, etkdgDetails, atomPairs, positions,
+  addLongRangeDistanceConstraints(field, etkdgDetails, atomPairs, positions,
                                   knownDistanceConstraintForce, mmat, N);
 
   return field;
@@ -555,7 +557,7 @@ ForceFields::ForceField *construct3DImproperForceField(
 
   // improper torsions / out-of-plane bend / inversion
   double oobForceScalingFactor = 10.0;
-  std::vector<bool> is13Constrained(N);
+  boost::dynamic_bitset<> is13Constrained(N);
   addImproperTorsionTerms(field, oobForceScalingFactor, etkdgDetails,
                           is13Constrained);
 

--- a/Code/DistGeom/DistGeomUtils.cpp
+++ b/Code/DistGeom/DistGeomUtils.cpp
@@ -279,11 +279,11 @@ void addImproperTorsionTerms(
           break;
       }
 
-      auto contrib = std::make_unique<ForceFields::UFF::InversionContrib>(
+      auto *contrib = new ForceFields::UFF::InversionContrib(
           ff, improperAtom[n[0]], improperAtom[n[1]], improperAtom[n[2]],
           improperAtom[n[3]], improperAtom[4],
           static_cast<bool>(improperAtom[5]), forceScalingFactor);
-      ff->contribs().emplace_back(std::move(contrib));
+      ff->contribs().emplace_back(contrib);
       is13Constrained[improperAtom[n[1]]] = 1;
     }
   }
@@ -303,11 +303,10 @@ void addTorsionTerms(
     } else {
       atomPairs[l * numRows + i] = 1;
     }
-    auto contrib =
-        std::make_unique<ForceFields::CrystalFF::TorsionAngleContribM6>(
-            ff, i, j, k, l, etkdgDetails.expTorsionAngles[t].second,
-            etkdgDetails.expTorsionAngles[t].first);
-    ff->contribs().emplace_back(std::move(contrib));
+    auto *contrib = new ForceFields::CrystalFF::TorsionAngleContribM6(
+        ff, i, j, k, l, etkdgDetails.expTorsionAngles[t].second,
+        etkdgDetails.expTorsionAngles[t].first);
+    ff->contribs().emplace_back(contrib);
   }
 }
 
@@ -327,10 +326,9 @@ void add12Terms(ForceFields::ForceField *ff,
     double d = ((*positions[i]) - (*positions[j])).length();
     double l = d - MIN_TOLERANCE;
     double u = d + MIN_TOLERANCE;
-    auto contrib =
-        std::make_unique<ForceFields::UFF::DistanceConstraintContrib>(
-            ff, i, j, l, u, forceConstant);
-    ff->contribs().emplace_back();
+    auto *contrib = new ForceFields::UFF::DistanceConstraintContrib(
+        ff, i, j, l, u, forceConstant);
+    ff->contribs().emplace_back(contrib);
   }
 }
 
@@ -352,17 +350,16 @@ void add13Terms(ForceFields::ForceField *ff,
     }
     // check for triple bonds
     if (addSPLinearityConstraint && angle[3]) {
-      auto contrib = std::make_unique<ForceFields::UFF::AngleConstraintContrib>(
+      auto *contrib = new ForceFields::UFF::AngleConstraintContrib(
           ff, i, j, k, 179.0, 180.0, 1);
-      ff->contribs().emplace_back(std::move(contrib));
+      ff->contribs().emplace_back(contrib);
     } else if (!is13Constrained.test(j)) {
       double d = ((*positions[i]) - (*positions[k])).length();
       double l = d - MIN_TOLERANCE;
       double u = d + MIN_TOLERANCE;
-      auto contrib =
-          std::make_unique<ForceFields::UFF::DistanceConstraintContrib>(
-              ff, i, k, l, u, forceConstant);
-      ff->contribs().emplace_back(std::move(contrib));
+      auto *contrib = new ForceFields::UFF::DistanceConstraintContrib(
+          ff, i, k, l, u, forceConstant);
+      ff->contribs().emplace_back(contrib);
     }
   }
 }
@@ -388,10 +385,9 @@ void addMinDistanceCosntraints(
           u += MIN_TOLERANCE;
           fdist = forceConstant;
         }
-        auto contrib =
-            std::make_unique<ForceFields::UFF::DistanceConstraintContrib>(
-                ff, i, j, l, u, fdist);
-        ff->contribs().emplace_back(std::move(contrib));
+        auto *contrib = new ForceFields::UFF::DistanceConstraintContrib(
+            ff, i, j, l, u, fdist);
+        ff->contribs().emplace_back(contrib);
       }
     }
   }
@@ -443,10 +439,10 @@ ForceFields::ForceField *construct3DForceField(
   // double dielConst = 1.0;
   boost::uint8_t dielModel = 1;
   for (const auto &charge : CPCI) {
-    auto contrib = std::make_unique<ForceFields::MMFF::EleContrib>(
+    auto *contrib = new ForceFields::MMFF::EleContrib(
         field, charge.first.first, charge.first.second, charge.second,
         dielModel, is1_4);
-    field->contribs().emplace_back(std::move(contrib));
+    field->contribs().emplace_back(contrib);
   }
 
   return field;
@@ -504,13 +500,12 @@ ForceFields::ForceField *construct3DImproperForceField(
   // Check that SP Centers have an angle of 180 degrees.
   for (const auto &angle : etkdgDetails.angles) {
     if (angle[3]) {
-      auto contrib = std::make_unique<ForceFields::UFF::AngleConstraintContrib>(
+      auto *contrib = new ForceFields::UFF::AngleConstraintContrib(
           field, angle[0], angle[1], angle[2], 179.0, 180.0,
           oobForceScalingFactor);
-      field->contribs().emplace_back(std::move(contrib));
+      field->contribs().emplace_back(contrib);
     }
   }
   return field;
-
 }  // construct3DImproperForceField
 }  // namespace DistGeom

--- a/Code/DistGeom/DistGeomUtils.cpp
+++ b/Code/DistGeom/DistGeomUtils.cpp
@@ -256,12 +256,11 @@ ForceFields::ForceField *constructForceField(
 /*!
 
   \param ff                 Force field to add contributions to
-  \param forceScalingFactor Force constant to use for contrib
+  \param forceScalingFactor Force scaling factor to use in inversion contrib
   \param improperAtoms      Indices of atoms to be used in improper torsion
   terms.
-  \param is13Constrained    The bit at every position where the atom with
-  the same index in the molecule is the center of an improper torsion is set to
-  one.
+  \param is13Constrained    bit vector with length of total num atoms of the
+  molecule where index of every central atom of improper torsion is set to one
 
 */
 void addImproperTorsionTerms(ForceFields::ForceField *ff,
@@ -307,8 +306,9 @@ void addImproperTorsionTerms(ForceFields::ForceField *ff,
 
   \param ff           Force field to add contributions to
   \param etkdgDetails Contains information about the ETKDG force field
-  \param atomPairs    bitset for which atom pairs will be set to one for all
-  the 1-4 atom pairs that are part of an experimental torsion contribution
+  \param atomPairs    bit set for every atom pair in the molecule where
+  a bit is set to one when the atom pair are the end atoms of a torsion
+  angle contribution
   \param numAtoms     number of atoms in the molecule
 
  */
@@ -338,8 +338,8 @@ void addExperimentalTorsionTerms(
 
   \param ff Force field to add contributions to
   \param etkdgDetails Contains information about the ETKDG force field
-  \param atomPairs bitset for which atom pairs will be set to one for all the
-  1-4 atom pairs that are part of an experimental torsion contribution
+  \param atomPairs bit set for every atom pair in the molecule where
+  a bit is set to one when the atom pair is a bond that is constrained here
   \param positions       A vector of pointers to 3D Points to write out the
   resulting coordinates
   \param forceConstant force constant with which to constrain bond distances
@@ -371,15 +371,15 @@ void add12Terms(ForceFields::ForceField *ff,
 
   \param ff Force field to add contributions to
   \param etkdgDetails Contains information about the ETKDG force field
-  \param atomPairs bitset for which atom pairs will be set to one for all the
-  1-4 atom pairs that are part of an experimental torsion contribution
-  \param positions       A vector of pointers to 3D Points to write out the
-  resulting coordinates
-  \param forceConstant force constant with which to constrain bond distances
-  \param is13Constrained  The bit at every position where the atom with the
-  same index in the molecule is the center of an improper torsion is set to one.
-  \param useBasicKnowledge whether to use basic knowledge terms
-  \param numAtoms number of atoms in molecule
+  \param atomPairs bit set for every atom pair in the molecule where
+  a bit is set to one when the atom pair is the both end atoms of a 13
+  contribution that is constrained here
+  \param positions A vector of pointers to 3D Points to write out the resulting
+  coordinates \param forceConstant force constant with which to constrain bond
+  distances \param is13Constrained bit vector with length of total num atoms of
+  the molecule where index of every central atom of improper torsion is set to
+  one \param useBasicKnowledge whether to use basic knowledge terms \param
+  numAtoms number of atoms in molecule
 
 */
 void add13Terms(ForceFields::ForceField *ff,
@@ -418,9 +418,10 @@ void add13Terms(ForceFields::ForceField *ff,
 
   \param ff Force field to add contributions to
   \param etkdgDetails Contains information about the ETKDG force field
-  \param atomPairs bitset for which atom pairs will be set to one for all the
-  1-4 atom pairs that are part of an experimental torsion contribution
-  \param positions       A vector of pointers to 3D Points to write out the
+  \param atomPairs bit set for every atom pair in the molecule where
+  a bit is set to one when the two atoms in the pair are distance constrained
+  with respect to each other
+  \param positions A vector of pointers to 3D Points to write out the
   resulting coordinates
   \param knownDistanceForceConstant force constant with which to constrain bond
   distances

--- a/Code/DistGeom/DistGeomUtils.cpp
+++ b/Code/DistGeom/DistGeomUtils.cpp
@@ -252,7 +252,7 @@ ForceFields::ForceField *constructForceField(
   return field;
 }  // constructForceField
 
-//! Add improper torsion contributions to a force field
+//! Add basic knowledge improper torsion contributions to a force field
 /*!
 
   \param ff                 Force field to add contributions to
@@ -471,13 +471,12 @@ ForceFields::ForceField *construct3DForceField(
   field->positions().insert(field->positions().begin(), positions.begin(),
                             positions.end());
 
-  // keep track which atoms are 1,2- or 1,3-restrained
+  // keep track which atoms are 1,2-, 1,3- or 1,4-restrained
+  boost::dynamic_bitset<> atomPairs(N * N);
   // don't add 1-3 Distances constraints for angles where the
   // central atom of the angle is the central atom of an improper torsion.
-  boost::dynamic_bitset<> atomPairs(N * N);
   boost::dynamic_bitset<> is13Constrained(N);
 
-  // ET/K torsion constraints
   addExperimentalTorsionTerms(field, etkdgDetails, atomPairs, N);
   addImproperTorsionTerms(field, 10.0, etkdgDetails.improperAtoms,
                           is13Constrained);
@@ -523,11 +522,12 @@ ForceFields::ForceField *constructPlain3DForceField(
   field->positions().insert(field->positions().begin(), positions.begin(),
                             positions.end());
 
-  // keep track which atoms are 1,2- or 1,3-restrained
+  // keep track which atoms are 1,2-, 1,3- or 1,4-restrained
   boost::dynamic_bitset<> atomPairs(N * N);
+  // don't add 1-3 Distances constraints for angles where the
+  // central atom of the angle is the central atom of an improper torsion.
   boost::dynamic_bitset<> is13Constrained(N);
 
-  // ET torsion constraints
   addExperimentalTorsionTerms(field, etkdgDetails, atomPairs, N);
   add12Terms(field, etkdgDetails, atomPairs, positions,
              KNOWN_DIST_FORCE_CONSTANT, N);

--- a/Code/DistGeom/DistGeomUtils.cpp
+++ b/Code/DistGeom/DistGeomUtils.cpp
@@ -255,17 +255,19 @@ ForceFields::ForceField *constructForceField(
 /*!
 
   \param ff                 Force field to add contributions to
-  \param forceScalingFactor Force Constant to use for contrib
-  \param etkdgDetails       Contains information about the ETKDG force field
-  \param is13Constrained    The bit at every position where the atom with the
-  same index in the molecule is the center of an improper torsion is set to one.
+  \param forceScalingFactor Force constant to use for contrib
+  \param improperAtoms      Indices of atoms to be used in improper torsion
+  terms.
+  \param is13Constrained    The bit at every position where the atom with
+  the same index in the molecule is the center of an improper torsion is set to
+  one.
 
 */
-void addImproperTorsionTerms(
-    ForceFields::ForceField *ff, double forceScalingFactor,
-    const ForceFields::CrystalFF::CrystalFFDetails &etkdgDetails,
-    boost::dynamic_bitset<> &is13Constrained) {
-  for (const auto &improperAtom : etkdgDetails.improperAtoms) {
+void addImproperTorsionTerms(ForceFields::ForceField *ff,
+                             double forceScalingFactor,
+                             const std::vector<std::vector<int>> &improperAtoms,
+                             boost::dynamic_bitset<> &is13Constrained) {
+  for (const auto &improperAtom : improperAtoms) {
     std::vector<int> n(4);
     for (unsigned int i = 0; i < 3; ++i) {
       n[1] = 1;
@@ -302,11 +304,11 @@ void addImproperTorsionTerms(
 //! Add experimental torsion angle contributions to a force field
 /*!
 
-  \param ff Force field to add contributions to
+  \param ff           Force field to add contributions to
   \param etkdgDetails Contains information about the ETKDG force field
-  \param atomPairs bitset for which atom pairs will be set to one for all the
-  1-4 atom pairs that are part of an experimental torsion contribution
-  \param numAtoms number of atoms in the molecule
+  \param atomPairs    bitset for which atom pairs will be set to one for all
+  the 1-4 atom pairs that are part of an experimental torsion contribution
+  \param numAtoms     number of atoms in the molecule
 
  */
 void addExperimentalTorsionTerms(
@@ -479,7 +481,8 @@ ForceFields::ForceField *construct3DForceField(
 
   // torsion constraints
   addExperimentalTorsionTerms(field, etkdgDetails, atomPairs, N);
-  addImproperTorsionTerms(field, 10.0, etkdgDetails, is13Constrained);
+  addImproperTorsionTerms(field, 10.0, etkdgDetails.improperAtoms,
+                          is13Constrained);
 
   constexpr double knownDistanceConstraintForce = 100.0;
   // 1,2 distance constraints
@@ -548,7 +551,10 @@ ForceFields::ForceField *constructPlain3DForceField(
 
 ForceFields::ForceField *construct3DImproperForceField(
     const BoundsMatrix &mmat, RDGeom::Point3DPtrVect &positions,
-    const ForceFields::CrystalFF::CrystalFFDetails &etkdgDetails) {
+    const std::vector<std::vector<int>> &improperAtoms,
+    const std::vector<std::vector<int>> &angles,
+    const std::vector<int> &atomNums) {
+  RDUNUSED_PARAM(atomNums);
   unsigned int N = mmat.numRows();
   CHECK_INVARIANT(N == positions.size(), "");
   auto *field = new ForceFields::ForceField(positions[0]->dimension());
@@ -558,11 +564,11 @@ ForceFields::ForceField *construct3DImproperForceField(
   // improper torsions / out-of-plane bend / inversion
   double oobForceScalingFactor = 10.0;
   boost::dynamic_bitset<> is13Constrained(N);
-  addImproperTorsionTerms(field, oobForceScalingFactor, etkdgDetails,
+  addImproperTorsionTerms(field, oobForceScalingFactor, improperAtoms,
                           is13Constrained);
 
   // Check that SP Centers have an angle of 180 degrees.
-  for (const auto &angle : etkdgDetails.angles) {
+  for (const auto &angle : angles) {
     if (angle[3]) {
       auto *contrib = new ForceFields::UFF::AngleConstraintContrib(
           field, angle[0], angle[1], angle[2], 179.0, 180.0,

--- a/Code/DistGeom/DistGeomUtils.cpp
+++ b/Code/DistGeom/DistGeomUtils.cpp
@@ -359,10 +359,8 @@ void add12Terms(ForceFields::ForceField *ff,
       atomPairs[j * numAtoms + i] = 1;
     }
     double d = ((*positions[i]) - (*positions[j])).length();
-    double l = d - KNOWN_DIST_TOL;
-    double u = d + KNOWN_DIST_TOL;
     auto *contrib = new ForceFields::UFF::DistanceConstraintContrib(
-        ff, i, j, l, u, forceConstant);
+        ff, i, j, d - KNOWN_DIST_TOL, d + KNOWN_DIST_TOL, forceConstant);
     ff->contribs().emplace_back(contrib);
   }
 }
@@ -406,10 +404,8 @@ void add13Terms(ForceFields::ForceField *ff,
       ff->contribs().emplace_back(contrib);
     } else if (!is13Constrained[j]) {
       double d = ((*positions[i]) - (*positions[k])).length();
-      double l = d - KNOWN_DIST_TOL;
-      double u = d + KNOWN_DIST_TOL;
       auto *contrib = new ForceFields::UFF::DistanceConstraintContrib(
-          ff, i, k, l, u, forceConstant);
+          ff, i, k, d - KNOWN_DIST_TOL, d + KNOWN_DIST_TOL, forceConstant);
       ff->contribs().emplace_back(contrib);
     }
   }
@@ -479,18 +475,17 @@ ForceFields::ForceField *construct3DForceField(
   boost::dynamic_bitset<> atomPairs(N * N);
   boost::dynamic_bitset<> is13Constrained(N);
 
-  // torsion constraints
+  // ET/K torsion constraints
   addExperimentalTorsionTerms(field, etkdgDetails, atomPairs, N);
   addImproperTorsionTerms(field, 10.0, etkdgDetails.improperAtoms,
                           is13Constrained);
 
   constexpr double knownDistanceConstraintForce = 100.0;
-  // 1,2 distance constraints
   add12Terms(field, etkdgDetails, atomPairs, positions,
              knownDistanceConstraintForce, N);
-  // 1,3 distance constraints
   add13Terms(field, etkdgDetails, atomPairs, positions,
              knownDistanceConstraintForce, is13Constrained, true, N);
+
   // minimum distance for all other atom pairs that aren't constrained
   addLongRangeDistanceConstraints(field, etkdgDetails, atomPairs, positions,
                                   knownDistanceConstraintForce, mmat, N);
@@ -532,14 +527,12 @@ ForceFields::ForceField *constructPlain3DForceField(
   boost::dynamic_bitset<> atomPairs(N * N);
   boost::dynamic_bitset<> is13Constrained(N);
 
-  // torsion constraints
+  // ET torsion constraints
   addExperimentalTorsionTerms(field, etkdgDetails, atomPairs, N);
 
   constexpr double knownDistanceConstraintForce = 100.0;
-  // 1,2 distance constraints
   add12Terms(field, etkdgDetails, atomPairs, positions,
              knownDistanceConstraintForce, N);
-  // 1,3 distance constraints
   add13Terms(field, etkdgDetails, atomPairs, positions,
              knownDistanceConstraintForce, is13Constrained, false, N);
   // minimum distance for all other atom pairs that aren't constrained

--- a/Code/DistGeom/DistGeomUtils.h
+++ b/Code/DistGeom/DistGeomUtils.h
@@ -15,15 +15,13 @@
 #include <Numerics/SymmMatrix.h>
 #include <map>
 #include <Geometry/point.h>
+#include <GraphMol/ForceFieldHelpers/CrystalFF/TorsionPreferences.h>
 #include "ChiralSet.h"
 #include <RDGeneral/utils.h>
 #include <boost/dynamic_bitset.hpp>
 
 namespace ForceFields {
 class ForceField;
-namespace CrystalFF {
-struct CrystalFFDetails;
-}
 }  // namespace ForceFields
 
 namespace DistGeom {
@@ -180,7 +178,8 @@ RDKIT_DISTGEOMETRY_EXPORT ForceFields::ForceField *constructPlain3DForceField(
   \param improperAtoms   A list of groups of 4 atom indices for inversion terms
   \param angles          List of lists with the three angle indices and whether
   the center atom in the angle is SP hybridized for every angle in the molecule.
-  \param atomNums        A list of atomic numbers for all atoms in the molecule
+  \param atomNums        A list of atomic numbers for all atoms in the molecule,
+  not used anymore!
 
   \return a pointer to a ForceField with improper terms
     <b>NOTE:</b> the caller is responsible for deleting this force field.
@@ -193,6 +192,26 @@ construct3DImproperForceField(
     const std::vector<std::vector<int>> &angles,
     const std::vector<int> &atomNums);
 
+//! Force field with improper terms and SP linearity contributions
+/*!
+
+  \param mmat            Distance bounds matrix
+  \param positions       A vector of pointers to 3D Points to write out the
+  resulting coordinates
+  \param etkdgDetails    Contains information about the ETKDG force field
+
+  \return a pointer to a ForceField with improper terms
+    <b>NOTE:</b> the caller is responsible for deleting this force field.
+
+*/
+//! \overload
+inline ForceFields::ForceField *construct3DImproperForceField(
+    const BoundsMatrix &mmat, RDGeom::Point3DPtrVect &positions,
+    const ForceFields::CrystalFF::CrystalFFDetails &etkdgDetails) {
+  return construct3DImproperForceField(
+      mmat, positions, etkdgDetails.improperAtoms, etkdgDetails.angles,
+      etkdgDetails.atomNums);
+}
 }  // namespace DistGeom
 
 #endif

--- a/Code/DistGeom/DistGeomUtils.h
+++ b/Code/DistGeom/DistGeomUtils.h
@@ -177,7 +177,10 @@ RDKIT_DISTGEOMETRY_EXPORT ForceFields::ForceField *constructPlain3DForceField(
   \param mmat            Distance bounds matrix
   \param positions       A vector of pointers to 3D Points to write out the
   resulting coordinates
-  \param etkdgDetails    Contains information about the ETKDG force field
+  \param improperAtoms   A list of groups of 4 atom indices for inversion terms
+  \param angles          List of lists with the three angle indices and whether
+  the center atom in the angle is SP hybridized for every angle in the molecule.
+  \param atomNums        A list of atomic numbers for all atoms in the molecule
 
   \return a pointer to a ForceField with improper terms
     <b>NOTE:</b> the caller is responsible for deleting this force field.
@@ -186,7 +189,9 @@ RDKIT_DISTGEOMETRY_EXPORT ForceFields::ForceField *constructPlain3DForceField(
 RDKIT_DISTGEOMETRY_EXPORT ForceFields::ForceField *
 construct3DImproperForceField(
     const BoundsMatrix &mmat, RDGeom::Point3DPtrVect &positions,
-    const ForceFields::CrystalFF::CrystalFFDetails &etkdgDetails);
+    const std::vector<std::vector<int>> &improperAtoms,
+    const std::vector<std::vector<int>> &angles,
+    const std::vector<int> &atomNums);
 
 }  // namespace DistGeom
 

--- a/Code/DistGeom/DistGeomUtils.h
+++ b/Code/DistGeom/DistGeomUtils.h
@@ -179,7 +179,7 @@ RDKIT_DISTGEOMETRY_EXPORT ForceFields::ForceField *constructPlain3DForceField(
   \param angles          List of lists with the three angle indices and whether
   the center atom in the angle is SP hybridized for every angle in the molecule.
   \param atomNums        A list of atomic numbers for all atoms in the molecule,
-  not used anymore!
+no longer used.
 
   \return a pointer to a ForceField with improper terms
     <b>NOTE:</b> the caller is responsible for deleting this force field.

--- a/Code/DistGeom/DistGeomUtils.h
+++ b/Code/DistGeom/DistGeomUtils.h
@@ -171,7 +171,7 @@ RDKIT_DISTGEOMETRY_EXPORT ForceFields::ForceField *constructPlain3DForceField(
     const BoundsMatrix &mmat, RDGeom::Point3DPtrVect &positions,
     const ForceFields::CrystalFF::CrystalFFDetails &etkdgDetails);
 
-//! Force field with only improper terms
+//! Force field with improper terms and SP linearity contributions
 /*!
 
   \param mmat            Distance bounds matrix

--- a/Code/DistGeom/DistGeomUtils.h
+++ b/Code/DistGeom/DistGeomUtils.h
@@ -189,9 +189,7 @@ RDKIT_DISTGEOMETRY_EXPORT ForceFields::ForceField *constructPlain3DForceField(
 RDKIT_DISTGEOMETRY_EXPORT ForceFields::ForceField *
 construct3DImproperForceField(
     const BoundsMatrix &mmat, RDGeom::Point3DPtrVect &positions,
-    const std::vector<std::vector<int>> &improperAtoms,
-    const std::vector<std::vector<int>> &angles,
-    const std::vector<int> &atomNums);
+    const ForceFields::CrystalFF::CrystalFFDetails &etkdgDetails);
 
 }  // namespace DistGeom
 

--- a/Code/DistGeom/DistGeomUtils.h
+++ b/Code/DistGeom/DistGeomUtils.h
@@ -177,10 +177,7 @@ RDKIT_DISTGEOMETRY_EXPORT ForceFields::ForceField *constructPlain3DForceField(
   \param mmat            Distance bounds matrix
   \param positions       A vector of pointers to 3D Points to write out the
   resulting coordinates
-  \param improperAtoms   A list of groups of 4 atom indices for inversion terms
-  \param angles          List of lists with the three angle indices and whether
-  the center atom in the angle is SP hybridized for every angle in the molecule.
-  \param atomNums        A list of atomic numbers for all atoms in the molecule
+  \param etkdgDetails    Contains information about the ETKDG force field
 
   \return a pointer to a ForceField with improper terms
     <b>NOTE:</b> the caller is responsible for deleting this force field.

--- a/Code/GraphMol/DistGeomHelpers/Embedder.cpp
+++ b/Code/GraphMol/DistGeomHelpers/Embedder.cpp
@@ -636,8 +636,9 @@ bool minimizeWithExpTorsions(RDGeom::PointPtrVect &positions,
   if (embedParams.useBasicKnowledge) {
     // create a force field with only the impropers
     std::unique_ptr<ForceFields::ForceField> field2(
-        DistGeom::construct3DImproperForceField(*eargs.mmat, positions3D,
-                                                *eargs.etkdgDetails));
+        DistGeom::construct3DImproperForceField(
+            *eargs.mmat, positions3D, eargs.etkdgDetails->improperAtoms,
+            eargs.etkdgDetails->angles, eargs.etkdgDetails->atomNums));
     if (embedParams.useRandomCoords && embedParams.coordMap != nullptr) {
       for (const auto &v : *embedParams.coordMap) {
         field2->fixedPoints().push_back(v.first);

--- a/Code/GraphMol/DistGeomHelpers/Embedder.cpp
+++ b/Code/GraphMol/DistGeomHelpers/Embedder.cpp
@@ -636,9 +636,8 @@ bool minimizeWithExpTorsions(RDGeom::PointPtrVect &positions,
   if (embedParams.useBasicKnowledge) {
     // create a force field with only the impropers
     std::unique_ptr<ForceFields::ForceField> field2(
-        DistGeom::construct3DImproperForceField(
-            *eargs.mmat, positions3D, eargs.etkdgDetails->improperAtoms,
-            eargs.etkdgDetails->angles, eargs.etkdgDetails->atomNums));
+        DistGeom::construct3DImproperForceField(*eargs.mmat, positions3D,
+                                                *eargs.etkdgDetails));
     if (embedParams.useRandomCoords && embedParams.coordMap != nullptr) {
       for (const auto &v : *embedParams.coordMap) {
         field2->fixedPoints().push_back(v.first);


### PR DESCRIPTION
removing some code duplication by extracting duplicate code into functions.
Also exchanging some for loops containing `push_back` with `vector.insert(...)` and removing `push_back(ForceFields::ContribPtr(contrib))` in favor of  `emplace_back(contrib)`

Added an inline overload for construct3DImproperForceField, all calls in Embedder.cpp have been adapted accordingly.

