### PR TITLE
Rascal match exact atom type

### DIFF
--- a/Code/GraphMol/RascalMCES/RascalMCES.cpp
+++ b/Code/GraphMol/RascalMCES/RascalMCES.cpp
@@ -125,6 +125,9 @@ void getAtomLabels(const ROMol &mol, const RascalOptions &opts,
     if (opts.exactConnectionsMatch) {
       label += "X" + std::to_string(a->getDegree());
     }
+    if (opts.exactAtomTypeMatch && a->getIsAromatic()) {
+      label = "a" + label;
+    }
     atomLabels[a->getIdx()] = label;
   }
 }

--- a/Code/GraphMol/RascalMCES/RascalMCES.cpp
+++ b/Code/GraphMol/RascalMCES/RascalMCES.cpp
@@ -125,7 +125,7 @@ void getAtomLabels(const ROMol &mol, const RascalOptions &opts,
     if (opts.exactConnectionsMatch) {
       label += "X" + std::to_string(a->getDegree());
     }
-    if (opts.exactAtomTypeMatch && a->getIsAromatic()) {
+    if (!opts.ignoreAtomAromaticity && a->getIsAromatic()) {
       label = "a" + label;
     }
     atomLabels[a->getIdx()] = label;

--- a/Code/GraphMol/RascalMCES/RascalOptions.h
+++ b/Code/GraphMol/RascalMCES/RascalOptions.h
@@ -55,9 +55,9 @@ struct RDKIT_RASCALMCES_EXPORT RascalOptions {
                                        more than 1 class of equivalent atoms.*/
   bool ignoreBondOrders = false; /* If true, will treat all bonds as the same,
                                     irrespective of order. */
-  bool exactAtomTypeMatch = false; /* If true, will treat aromatic and aliphatic
-                                      as different. If false, they are both just
-                                      matched on atomic number. */
+  bool ignoreAtomAromaticity = true; /* If true, atoms are matched just on atomic
+                                        number; if false, will treat aromatic
+                                        and aliphatic as different. */
 };
 }  // namespace RascalMCES
 }  // namespace RDKit

--- a/Code/GraphMol/RascalMCES/RascalOptions.h
+++ b/Code/GraphMol/RascalMCES/RascalOptions.h
@@ -55,6 +55,9 @@ struct RDKIT_RASCALMCES_EXPORT RascalOptions {
                                        more than 1 class of equivalent atoms.*/
   bool ignoreBondOrders = false; /* If true, will treat all bonds as the same,
                                     irrespective of order. */
+  bool exactAtomTypeMatch = false; /* If true, will treat aromatic and aliphatic
+                                      as different. If false, they are both just
+                                      matched on atomic number. */
 };
 }  // namespace RascalMCES
 }  // namespace RDKit

--- a/Code/GraphMol/RascalMCES/Wrap/rdRascalMCES.cpp
+++ b/Code/GraphMol/RascalMCES/Wrap/rdRascalMCES.cpp
@@ -214,8 +214,12 @@ BOOST_PYTHON_MODULE(rdRascalMCES) {
                      "class of equivalent atoms.")
       .def_readwrite("ignoreBondOrders",
                      &RDKit::RascalMCES::RascalOptions::ignoreBondOrders,
-                     "If True, will treat all bonds as the same,\n"
-                     "irrespective of order.  Default=False.");
+                     "If True, will treat all bonds as the same,"
+                     " irrespective of order.  Default=False.")
+      .def_readwrite("exactAtomTypeMatch",
+                     &RDKit::RascalMCES::RascalOptions::exactAtomTypeMatch,
+                     "If True, will treat aromatic and aliphatic atoms"
+                     " as different.  Default=False.");
 
   docString =
       "Find one or more MCESs between the 2 molecules given.  Returns a list of "

--- a/Code/GraphMol/RascalMCES/Wrap/rdRascalMCES.cpp
+++ b/Code/GraphMol/RascalMCES/Wrap/rdRascalMCES.cpp
@@ -216,10 +216,11 @@ BOOST_PYTHON_MODULE(rdRascalMCES) {
                      &RDKit::RascalMCES::RascalOptions::ignoreBondOrders,
                      "If True, will treat all bonds as the same,"
                      " irrespective of order.  Default=False.")
-      .def_readwrite("exactAtomTypeMatch",
-                     &RDKit::RascalMCES::RascalOptions::exactAtomTypeMatch,
-                     "If True, will treat aromatic and aliphatic atoms"
-                     " as different.  Default=False.");
+      .def_readwrite("ignoreAtomAromaticity",
+                     &RDKit::RascalMCES::RascalOptions::ignoreAtomAromaticity,
+                     "If True, matches atoms solely on atomic number."
+                     "  If False, will treat aromatic and aliphatic atoms"
+                     " as different.  Default=True.");
 
   docString =
       "Find one or more MCESs between the 2 molecules given.  Returns a list of "

--- a/Code/GraphMol/RascalMCES/Wrap/testRascalMCES.py
+++ b/Code/GraphMol/RascalMCES/Wrap/testRascalMCES.py
@@ -199,6 +199,17 @@ class TestCase(unittest.TestCase):
     self.assertEqual(results[0].numFragments, 1)
     self.assertEqual(results[0].smartsString, 'C~C~C~C')
     
+
+  def testExactAtomTypeMatch(self):
+    opts = rdRascalMCES.RascalOptions()
+    opts.similarityThreshold = 0.1
+    opts.exactAtomTypeMatch = True
+    mol1 = Chem.MolFromSmiles('c1ccccc1NCC')
+    mol2 = Chem.MolFromSmiles('C1CCCCC1NCC')
+    results = rdRascalMCES.FindMCES(mol1, mol2, opts)
+    self.assertEqual(results[0].numFragments, 1)
+    self.assertEqual(results[0].smartsString, 'NCC')
+
     
 if __name__ == "__main__":
   unittest.main()

--- a/Code/GraphMol/RascalMCES/Wrap/testRascalMCES.py
+++ b/Code/GraphMol/RascalMCES/Wrap/testRascalMCES.py
@@ -203,7 +203,7 @@ class TestCase(unittest.TestCase):
   def testExactAtomTypeMatch(self):
     opts = rdRascalMCES.RascalOptions()
     opts.similarityThreshold = 0.1
-    opts.exactAtomTypeMatch = True
+    opts.ignoreAtomAromaticity = False
     mol1 = Chem.MolFromSmiles('c1ccccc1NCC')
     mol2 = Chem.MolFromSmiles('C1CCCCC1NCC')
     results = rdRascalMCES.FindMCES(mol1, mol2, opts)

--- a/Code/GraphMol/RascalMCES/mces_catch.cpp
+++ b/Code/GraphMol/RascalMCES/mces_catch.cpp
@@ -1290,7 +1290,7 @@ TEST_CASE("Equivalent atoms") {
     opts.similarityThreshold = 0.5;
     opts.equivalentAtoms = "[F,Cl,Br,I]";
     auto res = rascalMCES(*m1, *m2, opts);
-    CHECK(res.size() == 1);
+    REQUIRE(res.size() == 1);
     CHECK(res.front().getAtomMatches().size() == 8);
     CHECK(res.front().getSmarts() ==
           "c1:c:c(-[F,Cl,Br,I]):c:c:c:1-[F,Cl,Br,I]");
@@ -1306,7 +1306,7 @@ TEST_CASE("Equivalent atoms") {
     opts.similarityThreshold = 0.5;
     opts.equivalentAtoms = "[F,Cl,Br,I] [c,n]";
     auto res = rascalMCES(*m1, *m2, opts);
-    CHECK(res.size() == 1);
+    REQUIRE(res.size() == 1);
     CHECK(res.front().getAtomMatches().size() == 7);
     CHECK(res.front().getSmarts() ==
           "[c,n]1:[c,n]:[c,n]:[c,n]:[c,n]:[c,n]:1-[F,Cl,Br,I]");
@@ -1322,7 +1322,7 @@ TEST_CASE("Equivalent atoms") {
     opts.similarityThreshold = 0.5;
     opts.equivalentAtoms = "[*]";
     auto res = rascalMCES(*m1, *m2, opts);
-    CHECK(res.size() == 1);
+    REQUIRE(res.size() == 1);
     CHECK(res.front().getAtomMatches().size() == 6);
     CHECK(res.front().getSmarts() == "[*]1:[*]:[*]:[*]:[*]:[*]:1");
     check_smarts_ok(*m1, *m2, res.front());
@@ -1352,7 +1352,7 @@ TEST_CASE("Equivalent bonds") {
     opts.similarityThreshold = 0.5;
     opts.ignoreBondOrders = true;
     auto res = rascalMCES(*m1, *m2, opts);
-    CHECK(res.size() == 1);
+    REQUIRE(res.size() == 1);
     CHECK(res.front().getAtomMatches().size() == 4);
     CHECK(res.front().getBondMatches().size() == 3);
     CHECK(res.front().getSmarts() == "C~C~C~C");
@@ -1369,7 +1369,7 @@ TEST_CASE("Equivalent bonds") {
     opts.equivalentAtoms = "[#6,#7]";
     opts.ignoreBondOrders = true;
     auto res = rascalMCES(*m1, *m2, opts);
-    CHECK(res.size() == 1);
+    REQUIRE(res.size() == 1);
     CHECK(res.front().getAtomMatches().size() == 9);
     CHECK(res.front().getBondMatches().size() == 9);
     CHECK(res.front().getSmarts() ==

--- a/Code/GraphMol/RascalMCES/mces_catch.cpp
+++ b/Code/GraphMol/RascalMCES/mces_catch.cpp
@@ -1377,3 +1377,38 @@ TEST_CASE("Equivalent bonds") {
     check_smarts_ok(*m1, *m2, res.front());
   }
 }
+
+TEST_CASE("Exact atom type match") {
+  {
+    auto m1 = "c1ccccc1NCC"_smiles;
+    REQUIRE(m1);
+    auto m2 = "C1CCCCC1NCC"_smiles;
+    REQUIRE(m2);
+
+    RascalOptions opts;
+    opts.similarityThreshold = 0.1;
+    opts.exactAtomTypeMatch = false;
+    auto res = rascalMCES(*m1, *m2, opts);
+    REQUIRE(res.size() == 1);
+    CHECK(res.front().getAtomMatches().size() == 4);
+    CHECK(res.front().getBondMatches().size() == 3);
+    CHECK(res.front().getSmarts() == "[#6]-NCC");
+    check_smarts_ok(*m1, *m2, res.front());
+  }
+  {
+    auto m1 = "c1ccccc1NCC"_smiles;
+    REQUIRE(m1);
+    auto m2 = "C1CCCCC1NCC"_smiles;
+    REQUIRE(m2);
+
+    RascalOptions opts;
+    opts.similarityThreshold = 0.1;
+    opts.exactAtomTypeMatch = true;
+    auto res = rascalMCES(*m1, *m2, opts);
+    REQUIRE(res.size() == 1);
+    CHECK(res.front().getAtomMatches().size() == 3);
+    CHECK(res.front().getBondMatches().size() == 2);
+    CHECK(res.front().getSmarts() == "NCC");
+    check_smarts_ok(*m1, *m2, res.front());
+  }
+}

--- a/Code/GraphMol/RascalMCES/mces_catch.cpp
+++ b/Code/GraphMol/RascalMCES/mces_catch.cpp
@@ -1378,7 +1378,7 @@ TEST_CASE("Equivalent bonds") {
   }
 }
 
-TEST_CASE("Exact atom type match") {
+TEST_CASE("Atom aromaticity match") {
   {
     auto m1 = "c1ccccc1NCC"_smiles;
     REQUIRE(m1);
@@ -1387,7 +1387,7 @@ TEST_CASE("Exact atom type match") {
 
     RascalOptions opts;
     opts.similarityThreshold = 0.1;
-    opts.exactAtomTypeMatch = false;
+    opts.ignoreAtomAromaticity = true;
     auto res = rascalMCES(*m1, *m2, opts);
     REQUIRE(res.size() == 1);
     CHECK(res.front().getAtomMatches().size() == 4);
@@ -1403,7 +1403,7 @@ TEST_CASE("Exact atom type match") {
 
     RascalOptions opts;
     opts.similarityThreshold = 0.1;
-    opts.exactAtomTypeMatch = true;
+    opts.ignoreAtomAromaticity = false;
     auto res = rascalMCES(*m1, *m2, opts);
     REQUIRE(res.size() == 1);
     CHECK(res.front().getAtomMatches().size() == 3);


### PR DESCRIPTION

#### Reference Issue
No issue

#### What does this implement/fix? Explain your changes.
The default behaviour in Rascal is to encode bond types as `<atomic number><bond type><atomic number>` where the atomic numbers are for the two atoms involved in the bond.  In the pair of molecules
<img width="353" alt="image" src="https://github.com/user-attachments/assets/00464ed0-b9fb-493d-a00a-08def56b3a97">
<img width="339" alt="image" src="https://github.com/user-attachments/assets/a8652212-0e24-49b1-a8ab-c16ed3a1bcc2">
The MCES returned is [#6]-NCC
where the ring carbon is included in both cases.  You might not want that, so there's a new option in RascalOptions that distinguishes aromatic and aliphatic carbons, such that the MCES becomes NCC.  It is off by default.

The extract from the unit test demonstrates use.
```
    opts = rdRascalMCES.RascalOptions()
    opts.similarityThreshold = 0.1
    opts.exactAtomTypeMatch = True
    mol1 = Chem.MolFromSmiles('c1ccccc1NCC')
    mol2 = Chem.MolFromSmiles('C1CCCCC1NCC')
    results = rdRascalMCES.FindMCES(mol1, mol2, opts)
    self.assertEqual(results[0].numFragments, 1)
    self.assertEqual(results[0].smartsString, 'NCC')
```

#### Any other comments?
I've changed a couple of other tests in mces_catch.cpp so they don't give a misleading seg fault should they fail.  It didn't seem worth a separate PR.
