### PR TITLE
Fix a bug in findMesoCenters()

### DIFF
--- a/Code/GraphMol/catch_chirality.cpp
+++ b/Code/GraphMol/catch_chirality.cpp
@@ -5966,3 +5966,39 @@ TEST_CASE(
     }
   }
 }
+
+TEST_CASE("findMesoCenters bug") {
+  UseLegacyStereoPerceptionFixture reset_stereo_perception(false);
+
+  SECTION("as reported") {
+    std::vector<std::pair<std::string,
+                          std::vector<std::pair<unsigned int, unsigned int>>>>
+        cases{
+            {"Cl[CH](C)[C@H](C)C[C@H](C)[CH](C)Cl", {{3, 6}}},
+            {"Cl[CH](C)[C@H](C)C[C@@H](C)[CH](C)Cl", {}},
+            {"Cl[C@H](C)[CH](C)C[CH](C)[C@H](C)Cl", {{1, 8}}},
+            {"Cl[C@H](C)[CH](C)C[CH](C)[C@@H](C)Cl", {}},
+            {"Cl[C@H](C)[C@H](C)C[C@H](C)[C@@H](C)Cl", {}},
+            {"Cl[C@H](C)[C@H](C)C[C@@H](C)[C@@H](C)Cl", {}},
+            {"Cl[C@H](C)[C@H](C)C[C@H](C)[C@H](C)Cl", {{1, 8}, {3, 6}}},
+
+        };
+    for (auto &[smi, expected] : cases) {
+      INFO(smi);
+      auto m = v2::SmilesParse::MolFromSmiles(smi);
+      REQUIRE(m);
+      auto res = Chirality::findMesoCenters(*m);
+      CHECK(res.size() == expected.size());
+      CHECK(res == expected);
+      for (auto [a1, a2] : res) {
+        unsigned int oa = m->getNumAtoms() + 1;
+        CHECK(m->getAtomWithIdx(a1)->getPropIfPresent(
+            common_properties::_mesoOtherAtom, oa));
+        CHECK(oa == a2);
+        CHECK(m->getAtomWithIdx(a2)->getPropIfPresent(
+            common_properties::_mesoOtherAtom, oa));
+        CHECK(oa == a1);
+      }
+    }
+  }
+}

--- a/Code/GraphMol/catch_chirality.cpp
+++ b/Code/GraphMol/catch_chirality.cpp
@@ -5981,6 +5981,14 @@ TEST_CASE("findMesoCenters bug") {
             {"Cl[C@H](C)[C@H](C)C[C@H](C)[C@@H](C)Cl", {}},
             {"Cl[C@H](C)[C@H](C)C[C@@H](C)[C@@H](C)Cl", {}},
             {"Cl[C@H](C)[C@H](C)C[C@H](C)[C@H](C)Cl", {{1, 8}, {3, 6}}},
+            {"Cl[C@H](C)CC[C@H](C)CC[C@H](C)CC[C@@H](C)Cl",
+             {}},  //< as reported
+            {"Cl[C@H](C)CC[C@H](C)CC[C@H](C)CC[C@H](C)Cl", {{1, 13}, {5, 9}}},
+            // larger examples, propagating outwards
+            {"Cl[C@H](C)[C@@H](Cl)[C@H](C)C[C@H](C)[C@H](Cl)[C@H](Cl)C", {}},
+            {"Cl[C@H](C)[C@@H](Cl)[C@H](C)C[C@H](C)[C@@H](Cl)[C@H](Cl)C", {}},
+            {"Cl[C@H](C)[C@@H](Cl)[C@H](C)C[C@H](C)[C@@H](Cl)[C@@H](Cl)C",
+             {{1, 12}, {3, 10}, {5, 8}}},
 
         };
     for (auto &[smi, expected] : cases) {


### PR DESCRIPTION
In the version of the code on master, there are two pairs of meso centers - (1,8) and (3,6) - reported for this molecule
`Cl[C@H](C)[C@H](C)C[C@H](C)[C@@H](C)Cl`:
![image](https://github.com/user-attachments/assets/d25d81bb-8448-416b-b887-5b4e245a9382)
The molecule itself is actually not meso.

This change fixes the problem by ensuring that each of the pairs of meso atoms found for a molecule can stand on their own : the pairs are still recognized as meso when the chirality on the other meso atoms is removed.


This was reported by @tadhurst-cdd 
