### PR TITLE
determinBonds: remove call to debugMol that logs to std::cerr

### DIFF
--- a/Code/GraphMol/DetermineBonds/DetermineBonds.cpp
+++ b/Code/GraphMol/DetermineBonds/DetermineBonds.cpp
@@ -347,7 +347,6 @@ void addBondOrdering(RWMol &mol,
   }
 
   if (MolOps::getFormalCharge(mol) != charge) {
-    mol.debugMol(std::cerr);
     std::stringstream ss;
     ss << "Final molecular charge (" << charge << ") does not match input ("
        << MolOps::getFormalCharge(mol)


### PR DESCRIPTION
Simple fix, removes a call to debugMol that we missed earlier.