### PR TITLE
Remove MolStandardize::PipelineOptions::allowEmptyMolecules

### DIFF
--- a/Code/GraphMol/MolStandardize/Pipeline.cpp
+++ b/Code/GraphMol/MolStandardize/Pipeline.cpp
@@ -46,40 +46,36 @@ PipelineResult Pipeline::run(const std::string &molblock) const {
 
   RWMOL_SPTR_PAIR output;
 
-  if (mol->getNumAtoms() == 0 && options.allowEmptyMolecules) {
-    output = {mol, mol};
-  } else {
-    // we try sanitization and validation on a copy, because we want to preserve
-    // the original input molecule for later
-    RWMOL_SPTR molCopy{new RWMol(*mol)};
-    for (const auto &[stage, operation] : validationSteps) {
-      result.stage = stage;
-      molCopy = operation(molCopy, result, options);
-      if (!molCopy || ((result.status & PIPELINE_ERROR) != NO_EVENT &&
-                       !options.reportAllFailures)) {
-        return result;
-      }
+  // we try sanitization and validation on a copy, because we want to preserve
+  // the original input molecule for later
+  RWMOL_SPTR molCopy{new RWMol(*mol)};
+  for (const auto &[stage, operation] : validationSteps) {
+    result.stage = stage;
+    molCopy = operation(molCopy, result, options);
+    if (!molCopy || ((result.status & PIPELINE_ERROR) != NO_EVENT &&
+                      !options.reportAllFailures)) {
+      return result;
     }
+  }
 
-    for (const auto &[stage, operation] : standardizationSteps) {
-      result.stage = stage;
-      mol = operation(mol, result, options);
-      if (!mol || ((result.status & PIPELINE_ERROR) != NO_EVENT &&
-                   !options.reportAllFailures)) {
-        return result;
-      }
+  for (const auto &[stage, operation] : standardizationSteps) {
+    result.stage = stage;
+    mol = operation(mol, result, options);
+    if (!mol || ((result.status & PIPELINE_ERROR) != NO_EVENT &&
+                  !options.reportAllFailures)) {
+      return result;
     }
-    if (makeParent) {
-      result.stage = static_cast<uint32_t>(PipelineStage::MAKE_PARENT);
-      output = makeParent(mol, result, options);
-      if (!output.first || !output.second ||
-          ((result.status & PIPELINE_ERROR) != NO_EVENT &&
-           !options.reportAllFailures)) {
-        return result;
-      }
-    } else {
-      output = {mol, mol};
+  }
+  if (makeParent) {
+    result.stage = static_cast<uint32_t>(PipelineStage::MAKE_PARENT);
+    output = makeParent(mol, result, options);
+    if (!output.first || !output.second ||
+        ((result.status & PIPELINE_ERROR) != NO_EVENT &&
+          !options.reportAllFailures)) {
+      return result;
     }
+  } else {
+    output = {mol, mol};
   }
 
   // serialize as MolBlocks

--- a/Code/GraphMol/MolStandardize/Pipeline.h
+++ b/Code/GraphMol/MolStandardize/Pipeline.h
@@ -26,7 +26,6 @@ struct RDKIT_MOLSTANDARDIZE_EXPORT PipelineOptions {
 
   // validation
   bool reportAllFailures{true};
-  bool allowEmptyMolecules{false};
   bool allowEnhancedStereo{false};
   bool allowAromaticBondType{false};
   bool allowDativeBondType{false};

--- a/Code/GraphMol/MolStandardize/Wrap/Pipeline.cpp
+++ b/Code/GraphMol/MolStandardize/Wrap/Pipeline.cpp
@@ -31,8 +31,6 @@ void wrap_pipeline() {
                      &MolStandardize::PipelineOptions::strictParsing)
       .def_readwrite("reportAllFailures",
                      &MolStandardize::PipelineOptions::reportAllFailures)
-      .def_readwrite("allowEmptyMolecules",
-                     &MolStandardize::PipelineOptions::allowEmptyMolecules)
       .def_readwrite("allowEnhancedStereo",
                      &MolStandardize::PipelineOptions::allowEnhancedStereo)
       .def_readwrite("allowAromaticBondType",

--- a/Code/GraphMol/MolStandardize/Wrap/testMolStandardize.py
+++ b/Code/GraphMol/MolStandardize/Wrap/testMolStandardize.py
@@ -1753,25 +1753,6 @@ M  END
     outputSmiles = Chem.MolToSmiles(outputMol)
     self.assertEqual(outputSmiles, "C[S+](C)[O-]")
 
-  def test26PipelineAllowEmptyMoleculesOption(self):
-    options = rdMolStandardize.PipelineOptions()
-    options.allowEmptyMolecules = True
-    pipeline = rdMolStandardize.Pipeline(options)
-
-    # no atoms
-    molblock = '''
-          10052313452D          
-
-  0  0  0     0  0            999 V3000
-M  V30 BEGIN CTAB
-M  V30 COUNTS 0 0 0 0 0
-M  V30 END CTAB
-M  END
-'''
-    result = pipeline.run(molblock)
-    self.assertEqual(result.stage, rdMolStandardize.PipelineStage.COMPLETED)
-    self.assertEqual(result.status, rdMolStandardize.PipelineStatus.NO_EVENT)
-
 
 if __name__ == "__main__":
   unittest.main()

--- a/Code/GraphMol/MolStandardize/testPipeline.cpp
+++ b/Code/GraphMol/MolStandardize/testPipeline.cpp
@@ -621,34 +621,6 @@ M  END
   }
 }
 
-TEST_CASE("VALIDATION_WITH_ALLOW_EMPTY_MOLS_OPTION") {
-  MolStandardize::PipelineOptions options;
-  options.allowEmptyMolecules = true;
-  MolStandardize::Pipeline pipeline(options);
-
-  SECTION("no atoms produces no error") {
-    const char *molblock = R"(
-          10052313452D          
-
-  0  0  0     0  0            999 V3000
-M  V30 BEGIN CTAB
-M  V30 COUNTS 0 0 0 0 0
-M  V30 END CTAB
-M  END
-)";
-
-    MolStandardize::PipelineResult result = pipeline.run(molblock);
-
-    for (auto &info : result.log) {
-      std::cerr << info.status << " " << info.detail << std::endl;
-    }
-
-    REQUIRE(static_cast<MolStandardize::PipelineStage>(result.stage) ==
-            MolStandardize::PipelineStage::COMPLETED);
-    REQUIRE(result.status == MolStandardize::PipelineStatus::NO_EVENT);
-  }
-}
-
 TEST_CASE("VALIDATION_WITH_DISALLOWED_LONG_BONDS_IN_RINGS") {
   MolStandardize::PipelineOptions options;
   options.bondLengthLimit = 10.;  // adapted to test structure


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
This is a small follow-up  to #7582, consisting in the removal of the `allowEmptyMolecules` pipeline option and consequent streamlining of the pipeline execution flow.

