### PR TITLE
fix RDKitEquals strategy of gmol_consistent and greaction_consistent

### DIFF
--- a/Code/PgSQL/rdkit/rdkit_gist.c
+++ b/Code/PgSQL/rdkit/rdkit_gist.c
@@ -517,7 +517,7 @@ Datum gmol_consistent(PG_FUNCTION_ARGS) {
       if (!ISALLTRUE(key)) {
         /*
         ** verify the necessary condition that key should contain the query
-        ** (on leaf nodes, couldn't it also verify that query contains key?)
+        ** (on leaf nodes, check that key and query match)
         */
         if (siglen != SIGLEN(query)) {
           elog(ERROR, "All fingerprints should be the same length");
@@ -526,7 +526,11 @@ Datum gmol_consistent(PG_FUNCTION_ARGS) {
         uint8 *k = (uint8 *)VARDATA(key);
         uint8 *q = (uint8 *)VARDATA(query);
 
-        res = bitstringContains(siglen, k, q);
+        if (GIST_LEAF(entry)) {
+          res = (memcmp(k, q, siglen) == 0);
+        } else {
+          res = bitstringContains(siglen, k, q);
+        }
       }
       break;
     default:
@@ -800,13 +804,11 @@ Datum greaction_consistent(PG_FUNCTION_ARGS) {
         uint8 *k = (uint8 *)VARDATA(key);
         uint8 *q = (uint8 *)VARDATA(query);
 
-        res = bitstringContains(siglen, k, q)
-              /*
-              ** the original implementation also required the query to
-              ** contain the key, but (I think) this is only true on the
-              ** leaves (FIXME?)
-              */
-              && bitstringContains(siglen, q, k);
+        if (GIST_LEAF(entry)) {
+          res = (memcmp(k, q, siglen) == 0);
+        } else {
+          res = bitstringContains(siglen, k, q);
+        }
       }
       break;
     default:


### PR DESCRIPTION
#### Reference Issue
Fixes #7493 

#### What does this implement/fix? Explain your changes.
This PR includes @ergo70's fix for the RDKitEquals strategy of gmol_consistent and applies the same changes to greaction_consistent.

#### Any other comments?
@ergo70: sorry I couldn't find your branch `ergo70-issue_7493` in github (was it deleted?) and I was for this reason unable to include your original commit objects. 

