### PR TITLE
Add support for building the CFFI lib without InChI

### DIFF
--- a/Code/MinimalLib/CMakeLists.txt
+++ b/Code/MinimalLib/CMakeLists.txt
@@ -3,10 +3,14 @@ include_directories(${RDKit_ExternalDir}/rapidjson-1.1.0/include)
 
 if(RDK_BUILD_MINIMAL_LIB)
     set(MINIMAL_LIB_LIBRARIES "MolInterchange_static;Abbreviations_static;"
-        "CIPLabeler_static;MolDraw2D_static;Depictor_static;RDInchiLib_static;"
+        "CIPLabeler_static;MolDraw2D_static;Depictor_static;"
         "SubstructMatch_static;FileParsers_static;"
         "SmilesParse_static;GraphMol_static;RDGeometryLib_static;"
         "RDGeneral_static;RGroupDecomposition_static")
+    if(RDK_BUILD_INCHI_SUPPORT)
+        add_definitions(-DRDK_BUILD_INCHI_SUPPORT)
+        set(MINIMAL_LIB_LIBRARIES "${MINIMAL_LIB_LIBRARIES};RDInchiLib_static")
+    endif()
     if(RDK_BUILD_MINIMAL_LIB_RXN)
         add_definitions(-DRDK_BUILD_MINIMAL_LIB_RXN)
         set(MINIMAL_LIB_LIBRARIES "${MINIMAL_LIB_LIBRARIES};ChemReactions_static")
@@ -44,8 +48,12 @@ if(RDK_BUILD_CFFI_LIB)
         ForceField Alignment
         MolInterchange Abbreviations CIPLabeler 
         MolDraw2D Depictor 
-        RDInchiLib SubstructMatch FileParsers 
+        SubstructMatch FileParsers 
         SmilesParse GraphMol RDGeometryLib RDGeneral RGroupDecomposition)
+    if(RDK_BUILD_INCHI_SUPPORT)
+        add_definitions(-DRDK_BUILD_INCHI_SUPPORT)
+        list(APPEND LIBS_TO_USE RDInchiLib)
+    endif()
     if(RDK_URF_LIBS)
         list(APPEND LIBS_TO_USE RingDecomposerLib)
     endif()

--- a/Code/MinimalLib/cffi_test.c
+++ b/Code/MinimalLib/cffi_test.c
@@ -364,6 +364,7 @@ M  END",
   free(molblock);
   molblock = NULL;
 
+#ifdef RDK_BUILD_INCHI_SUPPORT
   //---------
   // InChI
   char *inchi = get_inchi(pkl, pkl_size, NULL);
@@ -385,6 +386,7 @@ M  END",
   assert(!strcmp(inchi, "InChI=1/C6H6O/c7-6-4-2-1-3-5-6/h1-5,7H"));
   free(inchi);
   free(molblock);
+#endif
 
   //---------
   // queries

--- a/Code/MinimalLib/cffiwrapper.cpp
+++ b/Code/MinimalLib/cffiwrapper.cpp
@@ -48,7 +48,9 @@
 #include <boost/property_tree/json_parser.hpp>
 #include <RDGeneral/BoostEndInclude.h>
 
+#ifdef RDK_BUILD_INCHI_SUPPORT
 #include <INCHI-API/inchi.h>
+#endif
 
 #include <rapidjson/document.h>
 #include <rapidjson/stringbuffer.h>
@@ -227,6 +229,7 @@ extern "C" char *get_rxn_svg(const char *pkl, size_t pkl_sz,
   return str_to_c(MinimalLib::rxn_to_svg(rxn, width, height, details_json));
 }
 
+#ifdef RDK_BUILD_INCHI_SUPPORT
 extern "C" char *get_inchi(const char *pkl, size_t pkl_sz,
                            const char *details_json) {
   if (!pkl || !pkl_sz) {
@@ -254,6 +257,7 @@ extern "C" char *get_inchikey_for_inchi(const char *inchi) {
   }
   return str_to_c(InchiToInchiKey(inchi));
 }
+#endif
 
 extern "C" char *get_mol(const char *input, size_t *pkl_sz,
                          const char *details_json) {

--- a/Code/MinimalLib/cffiwrapper.h
+++ b/Code/MinimalLib/cffiwrapper.h
@@ -39,11 +39,13 @@ RDKIT_RDKITCFFI_EXPORT char *get_cxsmarts(const char *pkl, size_t pkl_sz,
                                           const char *details_json);
 RDKIT_RDKITCFFI_EXPORT char *get_json(const char *pkl, size_t pkl_sz,
                                       const char *details_json);
+#ifdef RDK_BUILD_INCHI_SUPPORT
 RDKIT_RDKITCFFI_EXPORT char *get_inchi(const char *pkl, size_t pkl_sz,
                                        const char *details_json);
 RDKIT_RDKITCFFI_EXPORT char *get_inchi_for_molblock(const char *ctab,
                                                     const char *details_json);
 RDKIT_RDKITCFFI_EXPORT char *get_inchikey_for_inchi(const char *inchi);
+#endif
 RDKIT_RDKITCFFI_EXPORT char *get_rxn(const char *input, size_t *mol_sz,
                                      const char *details_json);
 RDKIT_RDKITCFFI_EXPORT char **get_mol_frags(const char *pkl, size_t pkl_sz,

--- a/Code/MinimalLib/common.h
+++ b/Code/MinimalLib/common.h
@@ -1000,6 +1000,7 @@ std::string get_mol_frags_mappings(
   return buffer.GetString();
 }
 
+#ifdef RDK_BUILD_INCHI_SUPPORT
 std::string parse_inchi_options(const char *details_json) {
   std::string options;
   if (details_json && strlen(details_json)) {
@@ -1011,6 +1012,7 @@ std::string parse_inchi_options(const char *details_json) {
   }
   return options;
 }
+#endif
 
 struct LogHandle {
  public:

--- a/Code/MinimalLib/jswrapper.cpp
+++ b/Code/MinimalLib/jswrapper.cpp
@@ -372,11 +372,13 @@ EMSCRIPTEN_BINDINGS(RDKit_minimal) {
                 select_overload<std::string(const std::string &) const>(
                     &JSMol::get_v3Kmolblock))
       .function("get_as_uint8array", &get_as_uint8array)
+#ifdef RDK_BUILD_INCHI_SUPPORT
       .function("get_inchi",
                 select_overload<std::string(const std::string &) const>(
                     &JSMol::get_inchi))
       .function("get_inchi",
                 select_overload<std::string() const>(&JSMol::get_inchi))
+#endif
       .function("get_json", &JSMol::get_json)
       .function("get_svg",
                 select_overload<std::string() const>(&JSMol::get_svg))
@@ -645,7 +647,9 @@ EMSCRIPTEN_BINDINGS(RDKit_minimal) {
   function("prefer_coordgen", &prefer_coordgen);
   function("use_legacy_stereo_perception", &use_legacy_stereo_perception);
   function("allow_non_tetrahedral_chirality", &allow_non_tetrahedral_chirality);
+#ifdef RDK_BUILD_INCHI_SUPPORT
   function("get_inchikey_for_inchi", &get_inchikey_for_inchi);
+#endif
   function("get_mol", &get_mol, allow_raw_pointers());
   function("get_mol", &get_mol_no_details, allow_raw_pointers());
   function("get_mol_from_uint8array", &get_mol_from_uint8array,

--- a/Code/MinimalLib/minilib.cpp
+++ b/Code/MinimalLib/minilib.cpp
@@ -40,7 +40,9 @@
 #include <DataStructs/BitOps.h>
 #include <DataStructs/ExplicitBitVect.h>
 
+#ifdef RDK_BUILD_INCHI_SUPPORT
 #include <INCHI-API/inchi.h>
+#endif
 
 #include <rapidjson/document.h>
 #include <rapidjson/stringbuffer.h>
@@ -139,11 +141,13 @@ std::string JSMol::get_svg_with_highlights(const std::string &details) const {
   return MinimalLib::mol_to_svg(*d_mol, w, h, details);
 }
 
+#ifdef RDK_BUILD_INCHI_SUPPORT
 std::string JSMol::get_inchi(const std::string &options) const {
   assert(d_mol);
   ExtraInchiReturnValues rv;
   return MolToInchi(*d_mol, rv, !options.empty() ? options.c_str() : nullptr);
 }
+#endif
 std::string JSMol::get_molblock(const std::string &details) const {
   assert(d_mol);
   return MinimalLib::molblock_helper(*d_mol, details.c_str(), false);
@@ -856,9 +860,11 @@ unsigned int JSSubstructLibrary::count_matches(const JSMol &q,
 }
 #endif
 
+#ifdef RDK_BUILD_INCHI_SUPPORT
 std::string get_inchikey_for_inchi(const std::string &input) {
   return InchiToInchiKey(input);
 }
+#endif
 
 JSMol *get_mol_copy(const JSMol &other) {
   return new JSMol(new RWMol(*other.d_mol));

--- a/Code/MinimalLib/minilib.h
+++ b/Code/MinimalLib/minilib.h
@@ -37,8 +37,10 @@ class JSMol {
   std::string get_v3Kmolblock(const std::string &details) const;
   std::string get_v3Kmolblock() const { return get_v3Kmolblock("{}"); }
   std::string get_pickle() const;
+#ifdef RDK_BUILD_INCHI_SUPPORT
   std::string get_inchi(const std::string &options) const;
   std::string get_inchi() const { return get_inchi(""); }
+#endif
   std::string get_json() const;
   std::string get_svg(int width, int height) const;
   std::string get_svg() const {
@@ -272,7 +274,9 @@ class JSSubstructLibrary {
 };
 #endif
 
+#ifdef RDK_BUILD_INCHI_SUPPORT
 std::string get_inchikey_for_inchi(const std::string &input);
+#endif
 JSMol *get_mol(const std::string &input, const std::string &details_json);
 JSMol *get_mol_from_pickle(const std::string &pkl);
 JSMol *get_mol_copy(const JSMol &other);


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

Hi, thanks for RDKit! This PR allows the CFFI lib to build successfully with `-DRDK_BUILD_INCHI_SUPPORT=OFF`. It currently fails with:

```text
ld: library 'RDInchiLib_static' not found
```

#### Any other comments?

This produces a smaller shared library (7.9 MB instead of 9 MB on Mac arm64) with simpler licensing for users who don't need InChI support.