### PR TITLE
refactor MolStandardize::PipelineOptions::allowEmptyMolecules

### DIFF
--- a/Code/GraphMol/MolStandardize/Validate.cpp
+++ b/Code/GraphMol/MolStandardize/Validate.cpp
@@ -53,7 +53,7 @@ std::vector<ValidationErrorInfo> RDKitValidation::validate(
 
   unsigned int na = mol.getNumAtoms();
 
-  if (!na) {
+  if (!na && !allowEmptyMolecules) {
     errors.emplace_back("ERROR: [NoAtomValidation] Molecule has no atoms");
   }
 

--- a/Code/GraphMol/MolStandardize/Validate.h
+++ b/Code/GraphMol/MolStandardize/Validate.h
@@ -80,12 +80,17 @@ class RDKIT_MOLSTANDARDIZE_EXPORT CompositeValidation
 */
 class RDKIT_MOLSTANDARDIZE_EXPORT RDKitValidation : public ValidationMethod {
  public:
+  RDKitValidation(bool allowEmptyMolecules = false)
+      : allowEmptyMolecules(allowEmptyMolecules){};
+
   std::vector<ValidationErrorInfo> validate(
       const ROMol &mol, bool reportAllFailures) const override;
 
   std::shared_ptr<ValidationMethod> copy() const override {
     return std::make_shared<RDKitValidation>(*this);
   }
+
+  bool allowEmptyMolecules;
 };
 
 //////////////////////////////

--- a/Code/GraphMol/MolStandardize/Wrap/Validate.cpp
+++ b/Code/GraphMol/MolStandardize/Wrap/Validate.cpp
@@ -109,7 +109,10 @@ struct validate_wrapper {
 
     python::class_<MolStandardize::RDKitValidation,
                    python::bases<MolStandardize::ValidationMethod>,
-                   boost::noncopyable>("RDKitValidation");
+                   boost::noncopyable>("RDKitValidation")
+        .def(python::init<bool>(python::arg("allowEmptyMolecules") = false))
+        .def_readwrite("allowEmptyMolecules",
+                       &MolStandardize::RDKitValidation::allowEmptyMolecules);
 
     python::class_<MolStandardize::NoAtomValidation,
                    python::bases<MolStandardize::ValidationMethod>,

--- a/Code/GraphMol/MolStandardize/Wrap/testMolStandardize.py
+++ b/Code/GraphMol/MolStandardize/Wrap/testMolStandardize.py
@@ -272,6 +272,14 @@ class TestCase(unittest.TestCase):
     self.assertEqual(
       """INFO: [ValenceValidation] Explicit valence for atom # 1 O, 3, is greater than permitted""",
       msg[0])
+    mol = Chem.MolFromSmiles("")
+    msg = vm.validate(mol)
+    self.assertEqual(len(msg), 1)
+    self.assertEqual("ERROR: [NoAtomValidation] Molecule has no atoms", msg[0])
+    vm.allowEmptyMolecules = True
+    msg = vm.validate(mol)
+    self.assertEqual(len(msg), 0)
+
 
     vm2 = rdMolStandardize.MolVSValidation([rdMolStandardize.FragmentValidation()])
     # with no argument it also works

--- a/Code/GraphMol/MolStandardize/testValidate.cpp
+++ b/Code/GraphMol/MolStandardize/testValidate.cpp
@@ -75,6 +75,13 @@ void testRDKitValidation() {
     msgs2.push_back(msg);
   }
   TEST_ASSERT(msgs2 == ans2);
+
+  // testing configurable behavior for molecule with no atoms
+  bool allowEmptyMolecules = true;
+  RDKitValidation vm2(allowEmptyMolecules);
+  vector<ValidationErrorInfo> errout5 = vm2.validate(*m2, true);
+  TEST_ASSERT(errout5.empty());
+
   BOOST_LOG(rdInfoLog) << "Finished" << std::endl;
 }
 


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
This PR implements an alternative cleanup of the `MolStandardize::Pipeline` workflow in relation to the handling of molecule with no atoms, keeping the `allowEmptyMolecules` option, but moving the conditional logic into `RDKitValidation`.

#### Any other comments?
