### PR TITLE
Allow atom map numbers to be ignored when generating canonical SMILES

### DIFF
--- a/Code/GraphMol/SmilesParse/SmilesWrite.h
+++ b/Code/GraphMol/SmilesParse/SmilesWrite.h
@@ -40,7 +40,7 @@ struct RDKIT_SMILESPARSE_EXPORT SmilesWriteParams {
       true; /**< include the RDKit extension for dative bonds. Otherwise dative
                bonds will be written as single bonds*/
   bool ignoreAtomMapNumbers = false; /**< If true, ignores any atom map numbers
-                                        when generating canonical SMILES */
+                                        when canonicalizing the molecule */
 };
 
 namespace SmilesWrite {
@@ -168,7 +168,7 @@ RDKIT_SMILESPARSE_EXPORT std::string MolToSmiles(
   \param doRandom : if true, the first atom in the SMILES string will be
   selected at random and the SMILES string will not be canonical
   \param ignoreAtomMapNumbers : if true, ignores any atom map numbers when
-  generating canonical SMILES
+  canonicalizing the molecule
  */
 inline std::string MolToSmiles(const ROMol &mol, bool doIsomericSmiles = true,
                                bool doKekule = false, int rootedAtAtom = -1,

--- a/Code/GraphMol/SmilesParse/SmilesWrite.h
+++ b/Code/GraphMol/SmilesParse/SmilesWrite.h
@@ -39,6 +39,8 @@ struct RDKIT_SMILESPARSE_EXPORT SmilesWriteParams {
   bool includeDativeBonds =
       true; /**< include the RDKit extension for dative bonds. Otherwise dative
                bonds will be written as single bonds*/
+  bool ignoreAtomMapNumbers = false; /**< If true, ignores any atom map numbers
+                                        when generating canonical SMILES */
 };
 
 namespace SmilesWrite {
@@ -165,13 +167,16 @@ RDKIT_SMILESPARSE_EXPORT std::string MolToSmiles(
   atom.
   \param doRandom : if true, the first atom in the SMILES string will be
   selected at random and the SMILES string will not be canonical
+  \param ignoreAtomMapNumbers : if true, ignores any atom map numbers when
+  generating canonical SMILES
  */
 inline std::string MolToSmiles(const ROMol &mol, bool doIsomericSmiles = true,
                                bool doKekule = false, int rootedAtAtom = -1,
                                bool canonical = true,
                                bool allBondsExplicit = false,
                                bool allHsExplicit = false,
-                               bool doRandom = false) {
+                               bool doRandom = false,
+                               bool ignoreAtomMapNumbers = false) {
   SmilesWriteParams ps;
   ps.doIsomericSmiles = doIsomericSmiles;
   ps.doKekule = doKekule;
@@ -180,6 +185,7 @@ inline std::string MolToSmiles(const ROMol &mol, bool doIsomericSmiles = true,
   ps.allBondsExplicit = allBondsExplicit;
   ps.allHsExplicit = allHsExplicit;
   ps.doRandom = doRandom;
+  ps.ignoreAtomMapNumbers = ignoreAtomMapNumbers;
   return MolToSmiles(mol, ps);
 };
 

--- a/Code/GraphMol/SmilesParse/catch_tests.cpp
+++ b/Code/GraphMol/SmilesParse/catch_tests.cpp
@@ -2880,3 +2880,16 @@ TEST_CASE("Canonicalization of meso structures") {
     }
   }
 }
+
+TEST_CASE("Ignore atom map numbers") {
+  SmilesWriteParams params;
+  auto m1 = "[NH2:1]c1ccccc1"_smiles;
+  CHECK(MolToSmiles(*m1, params) == "c1ccc([NH2:1])cc1");
+  params.ignoreAtomMapNumbers = true;
+  CHECK(MolToSmiles(*m1, params) == "[NH2:1]c1ccccc1");
+  auto m2 = "Nc1ccccc1"_smiles;
+  m1->getAtomWithIdx(0)->setAtomMapNum(0);
+  CHECK(MolToSmiles(*m1, params) == MolToSmiles(*m2, params));
+  CHECK(MolToSmiles(*m1, true, false, -1, true, false, false, false, true) ==
+        MolToSmiles(*m2, true, false, -1, true, false, false, false, true));
+}

--- a/Code/GraphMol/Wrap/rdmolfiles.cpp
+++ b/Code/GraphMol/Wrap/rdmolfiles.cpp
@@ -1582,7 +1582,11 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
                      "resulting SMILES is not canonical")
       .def_readwrite(
           "includeDativeBonds", &RDKit::SmilesWriteParams::includeDativeBonds,
-          "include the RDKit extension for dative bonds. Otherwise dative bonds will be written as single bonds");
+          "include the RDKit extension for dative bonds. Otherwise dative bonds will be written as single bonds")
+      .def_readwrite(
+          "ignoreAtomMapNumbers",
+          &RDKit::SmilesWriteParams::ignoreAtomMapNumbers,
+          "ignore atom map numbers when generating canonical SMILES");
 
   python::def("MolToSmiles",
               (std::string(*)(const ROMol &,
@@ -1609,6 +1613,8 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
       in the output SMILES. Defaults to false.\n\
     - doRandom: (optional) if true, randomize the traversal of the molecule graph,\n\
       so we can generate random smiles. Defaults to false.\n\
+    - ignoreAtomMapNumbers (optional) if true, ignores any atom map numbers when\n"
+      "  generating canonical SMILES \n\
 \n\
   RETURNS:\n\
 \n\
@@ -1616,12 +1622,13 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
 \n";
   python::def(
       "MolToSmiles",
-      (std::string(*)(const ROMol &, bool, bool, int, bool, bool, bool,
+      (std::string(*)(const ROMol &, bool, bool, int, bool, bool, bool, bool,
                       bool))RDKit::MolToSmiles,
       (python::arg("mol"), python::arg("isomericSmiles") = true,
        python::arg("kekuleSmiles") = false, python::arg("rootedAtAtom") = -1,
        python::arg("canonical") = true, python::arg("allBondsExplicit") = false,
-       python::arg("allHsExplicit") = false, python::arg("doRandom") = false),
+       python::arg("allHsExplicit") = false, python::arg("doRandom") = false,
+       python::arg("ignoreAtomMapNumbers") = false),
       docString.c_str());
 
   docString =

--- a/Code/GraphMol/Wrap/rdmolfiles.cpp
+++ b/Code/GraphMol/Wrap/rdmolfiles.cpp
@@ -1586,7 +1586,7 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
       .def_readwrite(
           "ignoreAtomMapNumbers",
           &RDKit::SmilesWriteParams::ignoreAtomMapNumbers,
-          "ignore atom map numbers when generating canonical SMILES");
+          "ignore atom map numbers when canonicalizing the molecule");
 
   python::def("MolToSmiles",
               (std::string(*)(const ROMol &,
@@ -1613,8 +1613,8 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
       in the output SMILES. Defaults to false.\n\
     - doRandom: (optional) if true, randomize the traversal of the molecule graph,\n\
       so we can generate random smiles. Defaults to false.\n\
-    - ignoreAtomMapNumbers (optional) if true, ignores any atom map numbers when\n"
-      "  generating canonical SMILES \n\
+    - ignoreAtomMapNumbers (optional) if true, ignores any atom map numbers when\n\
+      canonicalizing the molecule \n\
 \n\
   RETURNS:\n\
 \n\

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -8213,7 +8213,17 @@ M  END
     centers = Chem.FindMesoCenters(mol, includeIsotopes=False)
     self.assertEqual(centers, ())
 
-
+  def testIgnoreAtomMapNumbers(self):
+    mol = Chem.MolFromSmiles("[NH2:1]c1ccccc1")
+    ps = Chem.SmilesWriteParams()
+    ps.ignoreAtomMapNumbers = True
+    self.assertEqual(Chem.MolToSmiles(mol, ps), "[NH2:1]c1ccccc1")
+    self.assertEqual(Chem.MolToSmiles(mol, ignoreAtomMapNumbers=True),
+                     "[NH2:1]c1ccccc1")
+    self.assertEqual(Chem.MolToSmiles(mol, ignoreAtomMapNumbers=False),
+                     "c1ccc([NH2:1])cc1")
+    
+    
 if __name__ == '__main__':
   if "RDTESTCASE" in os.environ:
     suite = unittest.TestSuite()

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -8223,7 +8223,6 @@ M  END
     self.assertEqual(Chem.MolToSmiles(mol, ignoreAtomMapNumbers=False),
                      "c1ccc([NH2:1])cc1")
     
-    
 if __name__ == '__main__':
   if "RDTESTCASE" in os.environ:
     suite = unittest.TestSuite()


### PR DESCRIPTION
#### Reference Issue
<!-- Example: Fixes #1234 -->
Relevant to #4830.  Requested by [@laurenreid1](https://github.com/laurenreid1)

#### What does this implement/fix? Explain your changes.
When generating canonical SMILES, the atom maps are temporarily removed so that the atom order is the same as if the atom maps weren't present.

#### Any other comments?

