### PR TITLE
Restore the ability to build RDKit_minimal.js after #7700

### DIFF
--- a/Code/MinimalLib/CMakeLists.txt
+++ b/Code/MinimalLib/CMakeLists.txt
@@ -4,7 +4,7 @@ include_directories(${RDKit_ExternalDir}/rapidjson-1.1.0/include)
 if(RDK_BUILD_MINIMAL_LIB)
     set(MINIMAL_LIB_LIBRARIES "MolInterchange_static;Abbreviations_static;"
         "CIPLabeler_static;MolDraw2D_static;Depictor_static;"
-        "SubstructMatch_static;FileParsers_static;"
+        "Descriptors_static;SubstructMatch_static;FileParsers_static;"
         "SmilesParse_static;GraphMol_static;RDGeometryLib_static;"
         "RDGeneral_static;RGroupDecomposition_static")
     if(RDK_BUILD_INCHI_SUPPORT)


### PR DESCRIPTION
I have just realized that after #7700 the attempt to build `RDKit_minimal.js` fails due to missing symbols:
```
[100%] Linking CXX executable RDKit_minimal.js
wasm-ld: error: CMakeFiles/RDKit_minimal.dir/minilib.cpp.o: undefined symbol: RDKit::Descriptors::Properties::Properties()
wasm-ld: error: CMakeFiles/RDKit_minimal.dir/minilib.cpp.o: undefined symbol: RDKit::Descriptors::Properties::getPropertyNames() const
wasm-ld: error: CMakeFiles/RDKit_minimal.dir/minilib.cpp.o: undefined symbol: RDKit::Descriptors::Properties::computeProperties(RDKit::ROMol const&, bool) const
```
This small PR restores the ability to build `RDKit_minimal.js`.