### PR TITLE
Don't do the fancy merging of solid wedges and bond lines for triple …

### DIFF
--- a/Code/GraphMol/MolDraw2D/DrawMol.cpp
+++ b/Code/GraphMol/MolDraw2D/DrawMol.cpp
@@ -3236,7 +3236,7 @@ void DrawMol::findOtherBondVecs(const Atom *atom, const Atom *otherAtom,
     // Don't do anything if the wedge is to a triple bond.  It gets
     // really messed up especially if the two bonds aren't exactly
     // co-linear which happens sometimes in a cluttered layout (Github 7620).
-    if (bond->getBondType() != 3) {
+    if (bond->getBondType() != Bond::BondType::TRIPLE) {
       Point2D const &at1_cds = atCds_[atom->getIdx()];
       Point2D const &at2_cds = atCds_[thirdAtom->getIdx()];
       otherBondVecs.push_back(at1_cds.directionVector(at2_cds));
@@ -3257,7 +3257,7 @@ void DrawMol::adjustBondsOnSolidWedgeEnds() {
                                                  thirdAtom->getIdx());
       // Don't do anything if it's a triple bond.  Moving the central
       // line to the wedge corner is clearly wrong.
-      if (bond1->getBondType() == 3) {
+      if (bond1->getBondType() == Bond::BondType::TRIPLE) {
         continue;
       }
       // If the bonds are co-linear, don't do anything (Github7036)

--- a/Code/GraphMol/MolDraw2D/DrawMol.cpp
+++ b/Code/GraphMol/MolDraw2D/DrawMol.cpp
@@ -3231,9 +3231,16 @@ void DrawMol::findOtherBondVecs(const Atom *atom, const Atom *otherAtom,
   }
   for (unsigned int i = 1; i < atom->getDegree(); ++i) {
     auto thirdAtom = otherNeighbor(atom, otherAtom, i - 1, *drawMol_);
-    Point2D const &at1_cds = atCds_[atom->getIdx()];
-    Point2D const &at2_cds = atCds_[thirdAtom->getIdx()];
-    otherBondVecs.push_back(at1_cds.directionVector(at2_cds));
+    auto bond =
+        drawMol_->getBondBetweenAtoms(atom->getIdx(), thirdAtom->getIdx());
+    // Don't do anything if the wedge is to a triple bond.  It gets
+    // really messed up especially if the two bonds aren't exactly
+    // co-linear which happens sometimes in a cluttered layout (Github 7620).
+    if (bond->getBondType() != 3) {
+      Point2D const &at1_cds = atCds_[atom->getIdx()];
+      Point2D const &at2_cds = atCds_[thirdAtom->getIdx()];
+      otherBondVecs.push_back(at1_cds.directionVector(at2_cds));
+    }
   }
 }
 
@@ -3248,7 +3255,12 @@ void DrawMol::adjustBondsOnSolidWedgeEnds() {
           otherNeighbor(bond->getEndAtom(), bond->getBeginAtom(), 0, *drawMol_);
       auto bond1 = drawMol_->getBondBetweenAtoms(bond->getEndAtomIdx(),
                                                  thirdAtom->getIdx());
-      // If the bonds a co-linear, don't do anything (Github7036)
+      // Don't do anything if it's a triple bond.  Moving the central
+      // line to the wedge corner is clearly wrong.
+      if (bond1->getBondType() == 3) {
+        continue;
+      }
+      // If the bonds are co-linear, don't do anything (Github7036)
       auto b1 = atCds_[bond->getEndAtomIdx()].directionVector(
           atCds_[bond->getBeginAtomIdx()]);
       auto b2 = atCds_[bond1->getEndAtomIdx()].directionVector(


### PR DESCRIPTION
…bonds.
#### Reference Issue
Fixes #7620 


#### What does this implement/fix? Explain your changes.
The problem was due to the merging of bond lines incident on the wedge.  It turned out that it was related to #7036 and also manifested itself in that test code when RDDepict::preferCoordGen as true.  I have altered that test instead so there is no explicit test for the fix of #7620.  The fix is to not do the merging at all for triple bonds.  The #7036 fix just skipped it for co-linear bonds.  In the molecule in #7620, the bonds weren't exactly co-linear due to clutter in the layout so the underlying problem re-emerged.

#### Any other comments?
Many of the tests in catch_tests.cpp are affected by changing the global RDDepict::preferCoordGen, depending on the order the tests are run by the test runner.  There is probably something to be said for always putting it back as it was at the outset of each test.  That feels like it should be a separate PR, however.
