### PR TITLE
Suppress large amounts of 'macro redefined' warnings in clang/emcc builds

### DIFF
--- a/Code/GraphMol/CIPLabeler/CIPLabeler.h
+++ b/Code/GraphMol/CIPLabeler/CIPLabeler.h
@@ -10,7 +10,9 @@
 //
 #pragma once
 
+#include <RDGeneral/BoostStartInclude.h>
 #include <boost/dynamic_bitset.hpp>
+#include <RDGeneral/BoostEndInclude.h>
 
 #include <RDGeneral/export.h>
 

--- a/Code/GraphMol/CIPLabeler/Digraph.h
+++ b/Code/GraphMol/CIPLabeler/Digraph.h
@@ -20,7 +20,9 @@
 #include <list>
 #include <vector>
 
+#include <RDGeneral/BoostStartInclude.h>
 #include <boost/rational.hpp>
+#include <RDGeneral/BoostEndInclude.h>
 
 #include "TooManyNodesException.h"
 

--- a/Code/GraphMol/CIPLabeler/Mancude.h
+++ b/Code/GraphMol/CIPLabeler/Mancude.h
@@ -21,7 +21,9 @@
 
 #include <vector>
 
+#include <RDGeneral/BoostStartInclude.h>
 #include <boost/rational.hpp>
+#include <RDGeneral/BoostEndInclude.h>
 
 namespace RDKit {
 

--- a/Code/GraphMol/FileParsers/MolSGroupWriting.cpp
+++ b/Code/GraphMol/FileParsers/MolSGroupWriting.cpp
@@ -8,7 +8,9 @@
 //  of the RDKit source tree.
 //
 
+#include <RDGeneral/BoostStartInclude.h>
 #include <boost/algorithm/string/join.hpp>
+#include <RDGeneral/BoostEndInclude.h>
 
 #include "FileParsers.h"
 #include "MolSGroupWriting.h"

--- a/Code/GraphMol/FileParsers/MolSGroupWriting.h
+++ b/Code/GraphMol/FileParsers/MolSGroupWriting.h
@@ -10,8 +10,10 @@
 
 #pragma once
 
+#include <RDGeneral/BoostStartInclude.h>
 #include <boost/algorithm/string/trim.hpp>
 #include <boost/format.hpp>
+#include <RDGeneral/BoostEndInclude.h>
 #include <GraphMol/SubstanceGroup.h>
 
 namespace RDKit {

--- a/Code/GraphMol/FileParsers/SDWriter.cpp
+++ b/Code/GraphMol/FileParsers/SDWriter.cpp
@@ -13,7 +13,9 @@
 #include <sstream>
 #include <string>
 
+#include <RDGeneral/BoostStartInclude.h>
 #include <boost/any.hpp>
+#include <RDGeneral/BoostEndInclude.h>
 
 #include <RDGeneral/BadFileException.h>
 #include <RDGeneral/FileParseException.h>

--- a/Code/GraphMol/FileParsers/TDTWriter.cpp
+++ b/Code/GraphMol/FileParsers/TDTWriter.cpp
@@ -14,7 +14,9 @@
 #include <sstream>
 #include <string>
 
+#include <RDGeneral/BoostStartInclude.h>
 #include <boost/algorithm/string.hpp>
+#include <RDGeneral/BoostEndInclude.h>
 
 #include <GraphMol/SmilesParse/SmilesWrite.h>
 #include <RDGeneral/BadFileException.h>

--- a/Code/GraphMol/FileParsers/XYZFileParser.cpp
+++ b/Code/GraphMol/FileParsers/XYZFileParser.cpp
@@ -8,7 +8,9 @@
 //  of the RDKit source tree.
 //
 
+#include <RDGeneral/BoostStartInclude.h>
 #include <boost/lexical_cast.hpp>
+#include <RDGeneral/BoostEndInclude.h>
 
 #include "FileParsers.h"
 #include "FileParserUtils.h"

--- a/Code/GraphMol/MolDraw2D/AtomSymbol.cpp
+++ b/Code/GraphMol/MolDraw2D/AtomSymbol.cpp
@@ -10,8 +10,10 @@
 // Original author: David Cosgrove (CozChemIx Limited)
 //
 
+#include <RDGeneral/BoostStartInclude.h>
 #include <boost/format.hpp>
 #include <boost/algorithm/string.hpp>
+#include <RDGeneral/BoostEndInclude.h>
 
 #include <GraphMol/MolDraw2D/AtomSymbol.h>
 #include <GraphMol/MolDraw2D/DrawText.h>

--- a/Code/GraphMol/MolDraw2D/DrawTextJS.cpp
+++ b/Code/GraphMol/MolDraw2D/DrawTextJS.cpp
@@ -12,7 +12,9 @@
 // to draw text onto a picture.
 #ifdef __EMSCRIPTEN__
 #include <sstream>
+#include <RDGeneral/BoostStartInclude.h>
 #include <boost/algorithm/string.hpp>
+#include <RDGeneral/BoostEndInclude.h>
 
 #include <GraphMol/MolDraw2D/DrawTextJS.h>
 #include <GraphMol/MolDraw2D/MolDraw2DJS.h>

--- a/Code/GraphMol/MolDraw2D/DrawTextSVG.cpp
+++ b/Code/GraphMol/MolDraw2D/DrawTextSVG.cpp
@@ -13,8 +13,10 @@
 // to draw text onto a picture.
 
 #include <sstream>
+#include <RDGeneral/BoostStartInclude.h>
 #include <boost/algorithm/string.hpp>
 #include <boost/format.hpp>
+#include <RDGeneral/BoostEndInclude.h>
 
 #include <GraphMol/MolDraw2D/MolDraw2DDetails.h>
 #include <GraphMol/MolDraw2D/DrawTextSVG.h>

--- a/Code/GraphMol/PartialCharges/GasteigerParams.cpp
+++ b/Code/GraphMol/PartialCharges/GasteigerParams.cpp
@@ -8,15 +8,14 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
-#include <boost/tokenizer.hpp>
-typedef boost::tokenizer<boost::char_separator<char>> tokenizer;
-#include "GasteigerParams.h"
-
 #include <RDGeneral/BoostStartInclude.h>
 #include <boost/flyweight.hpp>
 #include <boost/flyweight/key_value.hpp>
 #include <boost/flyweight/no_tracking.hpp>
+#include <boost/tokenizer.hpp>
+typedef boost::tokenizer<boost::char_separator<char>> tokenizer;
 #include <RDGeneral/BoostEndInclude.h>
+#include "GasteigerParams.h"
 
 #include <sstream>
 #include <locale>

--- a/Code/GraphMol/RWMol.cpp
+++ b/Code/GraphMol/RWMol.cpp
@@ -8,7 +8,9 @@
 //  of the RDKit source tree.
 //
 
+#include <RDGeneral/BoostStartInclude.h>
 #include <boost/tokenizer.hpp>
+#include <RDGeneral/BoostEndInclude.h>
 
 // our stuff
 #include <RDGeneral/Invariant.h>

--- a/Code/GraphMol/RascalMCES/PartitionSet.h
+++ b/Code/GraphMol/RascalMCES/PartitionSet.h
@@ -14,7 +14,9 @@
 #include <map>
 #include <vector>
 
+#include <RDGeneral/BoostStartInclude.h>
 #include <boost/dynamic_bitset.hpp>
+#include <RDGeneral/BoostEndInclude.h>
 
 namespace RDKit {
 

--- a/Code/GraphMol/RascalMCES/RascalMCES.cpp
+++ b/Code/GraphMol/RascalMCES/RascalMCES.cpp
@@ -23,8 +23,10 @@
 #include <unordered_set>
 #include <vector>
 
+#include <RDGeneral/BoostStartInclude.h>
 #include <boost/dynamic_bitset.hpp>
 #include <boost/algorithm/string.hpp>
+#include <RDGeneral/BoostEndInclude.h>
 
 #include <GraphMol/ROMol.h>
 #include <GraphMol/MolOps.h>

--- a/Code/GraphMol/RascalMCES/RascalResult.cpp
+++ b/Code/GraphMol/RascalMCES/RascalResult.cpp
@@ -11,8 +11,10 @@
 #include <regex>
 #include <set>
 
+#include <RDGeneral/BoostStartInclude.h>
 #include <boost/dynamic_bitset.hpp>
 #include <boost/algorithm/string.hpp>
+#include <RDGeneral/BoostEndInclude.h>
 
 #include <GraphMol/MolOps.h>
 #include <GraphMol/QueryAtom.h>

--- a/Code/GraphMol/StereoGroup.cpp
+++ b/Code/GraphMol/StereoGroup.cpp
@@ -2,7 +2,9 @@
 #include <utility>
 #include <vector>
 
+#include <RDGeneral/BoostStartInclude.h>
 #include <boost/dynamic_bitset.hpp>
+#include <RDGeneral/BoostEndInclude.h>
 
 #include "StereoGroup.h"
 #include "Atom.h"

--- a/Code/RDGeneral/RDExportMacros.h
+++ b/Code/RDGeneral/RDExportMacros.h
@@ -16,7 +16,18 @@
 #pragma warning(disable : 4275)
 #endif
 
+#ifdef BOOST_NO_CXX98_FUNCTION_BASE
+#undef BOOST_NO_CXX98_FUNCTION_BASE
+#ifndef _SHOULD_DEFINE_BOOST_NO_CXX98_FUNCTION_BASE
+#define _SHOULD_DEFINE_BOOST_NO_CXX98_FUNCTION_BASE 1
+#endif
+#endif
 #include <boost/config.hpp>
+#ifdef _SHOULD_DEFINE_BOOST_NO_CXX98_FUNCTION_BASE
+#ifndef BOOST_NO_CXX98_FUNCTION_BASE
+#define BOOST_NO_CXX98_FUNCTION_BASE 1
+#endif
+#endif
 
 // RDKit export macro definitions
 #ifdef RDKIT_DYN_LINK

--- a/External/GA/util/Util.cpp
+++ b/External/GA/util/Util.cpp
@@ -11,7 +11,9 @@
 #include <string>
 #include <cstdlib>
 
+#include <RDGeneral/BoostStartInclude.h>
 #include <boost/algorithm/string.hpp>
+#include <RDGeneral/BoostEndInclude.h>
 
 #include "Util.h"
 


### PR DESCRIPTION
In `CMakeLists.txt` we define `BOOST_NO_CXX98_FUNCTION_BASE` for `clang` versions >= 15:
```
if (CMAKE_COMPILER_IS_CLANG OR CMAKE_COMPILER_IS_EMCC)
  if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 15)
    target_compile_definitions(rdkit_base INTERFACE -DBOOST_SYSTEM_NO_DEPRECATED -DBOOST_NO_CXX98_FUNCTION_BASE -D_HAS_AUTO_PTR_ETC=0)
    target_compile_options(rdkit_base INTERFACE -Wno-deprecated-builtins -Wno-deprecated-non-prototype -Wno-unused-parameter)
  endif()
endif()
```
to avoid usage of the unary function which is deprecated in C++11 and later.
However, recent versions of Boost already do this check and define `BOOST_NO_CXX98_FUNCTION_BASE` accordingly, without checking if `BOOST_NO_CXX98_FUNCTION_BASE` had already been defined previously:
```
#if _LIBCPP_VERSION >= 15000
//
// Unary function is now deprecated in C++11 and later:
//
#if __cplusplus >= 201103L
#define BOOST_NO_CXX98_FUNCTION_BASE
#endif
#endif
```
This causes a huge amount of verbose warnings such as
```
In file included from /scratch/toscopa1/src/rdkit/External/CoordGen/maeparser/Writer.cpp:3:
In file included from /scratch/toscopa1/.conda/envs/pyds_v1.4L/include/boost/algorithm/string/predicate.hpp:15:
In file included from /scratch/toscopa1/.conda/envs/pyds_v1.4L/include/boost/algorithm/string/config.hpp:14:
In file included from /scratch/toscopa1/.conda/envs/pyds_v1.4L/include/boost/config.hpp:48:
/scratch/toscopa1/.conda/envs/pyds_v1.4L/include/boost/config/stdlib/libcpp.hpp:176:9: warning: 'BOOST_NO_CXX98_FUNCTION_BASE' macro redefined [-Wmacro-redefined]
  176 | #define BOOST_NO_CXX98_FUNCTION_BASE
      |         ^
<command line>:3:9: note: previous definition is here
    3 | #define BOOST_NO_CXX98_FUNCTION_BASE 1
      |         ^

```
which completely swamp the build console and shadow any other more useful warnings.

This PR adds a guard around
```
#include <boost/config.hpp>
```
which is the trigger for such warnings, and adds a number of missing
```
#include <RDGeneral/BoostStartInclude.h>
[...]
#include <RDGeneral/BoostEndInclude.h>
```
guards to suppress these annoying warnings.