### PR TITLE
Fix vectToString such that it outputs valid JSON

### DIFF
--- a/Code/RDGeneral/RDValue.h
+++ b/Code/RDGeneral/RDValue.h
@@ -32,7 +32,7 @@
 #ifndef RDKIT_RDVALUE_H
 #define RDKIT_RDVALUE_H
 
-//#define UNSAFE_RDVALUE
+// #define UNSAFE_RDVALUE
 #ifdef UNSAFE_RDVALUE
 #include "RDValue-doublemagic.h"
 #else
@@ -179,7 +179,10 @@ std::string vectToString(RDValue val) {
   sstr.imbue(std::locale("C"));
   sstr << std::setprecision(17);
   sstr << "[";
-  std::copy(tv.begin(), tv.end(), std::ostream_iterator<T>(sstr, ","));
+  if (!tv.empty()) {
+    std::copy(tv.begin(), tv.end() - 1, std::ostream_iterator<T>(sstr, ","));
+    sstr << tv.back();
+  }
   sstr << "]";
   return sstr.str();
 }

--- a/Code/RDGeneral/testDict.cpp
+++ b/Code/RDGeneral/testDict.cpp
@@ -424,7 +424,7 @@ void testVectToString() {
     d.setVal("foo", v);
     std::string sv;
     d.getVal("foo", sv);
-    TEST_ASSERT(sv == "[1,0,]");
+    TEST_ASSERT(sv == "[1,0]");
   }
   {
     Dict d;
@@ -434,9 +434,9 @@ void testVectToString() {
     d.setVal("foo", v);
     std::string sv;
     d.getVal("foo", sv);
-    TEST_ASSERT(sv == "[1,0,]");
+    TEST_ASSERT(sv == "[1,0]");
     sv = d.getVal<std::string>("foo");
-    TEST_ASSERT(sv == "[1,0,]");
+    TEST_ASSERT(sv == "[1,0]");
   }
   {
     Dict d;
@@ -446,9 +446,9 @@ void testVectToString() {
     d.setVal("foo", v);
     std::string sv;
     d.getVal("foo", sv);
-    TEST_ASSERT(sv == "[1.2,0,]");
+    TEST_ASSERT(sv == "[1.2,0]");
     sv = d.getVal<std::string>("foo");
-    TEST_ASSERT(sv == "[1.2,0,]");
+    TEST_ASSERT(sv == "[1.2,0]");
   }
   {
     Dict d;
@@ -458,9 +458,9 @@ void testVectToString() {
     d.setVal("foo", v);
     std::string sv;
     d.getVal("foo", sv);
-    TEST_ASSERT(sv == "[10001,0,]");
+    TEST_ASSERT(sv == "[10001,0]");
     sv = d.getVal<std::string>("foo");
-    TEST_ASSERT(sv == "[10001,0,]");
+    TEST_ASSERT(sv == "[10001,0]");
   }
 
   BOOST_LOG(rdErrorLog) << "\tdone" << std::endl;


### PR DESCRIPTION
This small PR fixes `vectToString` such that it outputs valid JSON (i.e., without a trailing comma) such that it can be directly parsed as a JSON string.
@greglandrum As discussed, I have extracted this change out of #7322.