### PR TITLE
add useChirality flag to SaltRemover

### DIFF
--- a/rdkit/Chem/SaltRemover.py
+++ b/rdkit/Chem/SaltRemover.py
@@ -83,12 +83,13 @@ def _getSmartsSaltsFromFile(filename):
 class SaltRemover(object):
   defnFilename = os.path.join(RDConfig.RDDataDir, 'Salts.txt')
 
-  def __init__(self, defnFilename=None, defnData=None, defnFormat=InputFormat.SMARTS):
+  def __init__(self, defnFilename=None, defnData=None, defnFormat=InputFormat.SMARTS, useChirality=False):
     if defnFilename:
       self.defnFilename = defnFilename
     self.defnData = defnData
     self.salts = None
     self.defnFormat = defnFormat
+    self.useChirality = useChirality
     self._initPatterns()
 
   def _initPatterns(self):
@@ -261,13 +262,13 @@ class SaltRemover(object):
         return m
       res = m
 
-      t = Chem.DeleteSubstructs(res, salt, True)
+      t = Chem.DeleteSubstructs(res, salt, True, useChirality=self.useChirality)
       if not t or (notEverything and t.GetNumAtoms() == 0):
         return res
       res = t
       while res.GetNumAtoms() and nAts > res.GetNumAtoms():
         nAts = res.GetNumAtoms()
-        t = Chem.DeleteSubstructs(res, salt, True)
+        t = Chem.DeleteSubstructs(res, salt, True, useChirality=self.useChirality)
         if notEverything and t.GetNumAtoms() == 0:
           break
         res = t


### PR DESCRIPTION
#### Reference Issue
Implements #7750


#### What does this implement/fix? Explain your changes.
Adds 'useChirality flag to the SaltRemover class configuration options.

The standard behaviour of SaltRemover is to ignore chirality when stripping species from the parent mol, but to store the removed species as they are defined in the 'defnData'. Setting useChirality to True will allow species to be stripped 

Example:
defnData contains maleaic acid and fumaric acid:
OC(=O)\C=C/C(O)=O
OC(=O)/C=C/C(O)=O

With useChirality = False (default behaviour):
For either of OC(=O)C=CC(O)=O, OC(=O)\C=C/C(O)=O, OC(=O)/C=C/C(O)=O
- StripMolWithDeleted removes the species, but returns OC(=O)\C=C/C(O)=O in the deleted species list (stripper ignores stereo in defnData, but returns first occurence of the defnData SMILE in deleted list)

With useChirality = True:
- For OC(=O)C=CC(O)=O, no species are removed
- For OC(=O)\C=C/C(O)=O, OC(=O)\C=C/C(O)=O is removed and stored in deleted species list
- For OC(=O)/C=C/C(O)=O, OC(=O)/C=C/C(O)=O is removed and stored in deleted species list

#### Any other comments?
Note that order can matter in the case that defnData includes both the chiral and non-chiral species.
If defnData is in the following order:
OC(=O)\C=C/C(O)=O
OC(=O)/C=C/C(O)=O
C(=O)C=CC(O)=O

This works as above.

However, if we add the non-chiral SMILE first:
C(=O)C=CC(O)=O
OC(=O)\C=C/C(O)=O
OC(=O)/C=C/C(O)=O

The following happens when useChirality is set to True:
- For OC(=O)C=CC(O)=O, C(=O)C=CC(O)=O is removed
- For OC(=O)\C=C/C(O)=O, OC(=O)\C=C/C(O)=O is removed and stored in deleted species list as C(=O)C=CC(O)=O
- For OC(=O)/C=C/C(O)=O, OC(=O)/C=C/C(O)=O is removed and stored in deleted species list as C(=O)C=CC(O)=O