### PR TITLE
Fix aliasing bug in MultithreadedSDMolSupplier and move GeneralFileReader to v2 API

### DIFF
--- a/Code/GraphMol/FileParsers/GeneralFileReader.h
+++ b/Code/GraphMol/FileParsers/GeneralFileReader.h
@@ -23,6 +23,7 @@
 #include "MultithreadedSmilesMolSupplier.h"
 
 namespace RDKit {
+namespace FileParsers = v2::FileParsers;
 namespace GeneralMolSupplier {
 struct SupplierOptions {
   bool takeOwnership = true;
@@ -39,7 +40,7 @@ struct SupplierOptions {
   int confId2D = -1;
   int confId3D = 0;
 
-  unsigned int numWriterThreads = 0;
+  int numWriterThreads = 0;
 };
 //! current supported file formats
 const std::vector<std::string> supportedFileFormats{
@@ -51,8 +52,8 @@ const std::vector<std::string> supportedCompressionFormats{"gz"};
 //! returns true on success, otherwise false
 //! Note: Error handeling is done in the getSupplier method
 
-void determineFormat(const std::string path, std::string& fileFormat,
-                     std::string& compressionFormat) {
+void determineFormat(const std::string path, std::string &fileFormat,
+                     std::string &compressionFormat) {
   //! filename without compression format
   std::string basename;
   //! Special case maegz.
@@ -78,7 +79,7 @@ void determineFormat(const std::string path, std::string& fileFormat,
     basename = path;
     compressionFormat = "";
   }
-  for (auto const& suffix : supportedFileFormats) {
+  for (auto const &suffix : supportedFileFormats) {
     if (boost::algorithm::iends_with(basename, "." + suffix)) {
       fileFormat = suffix;
       return;
@@ -95,14 +96,14 @@ void determineFormat(const std::string path, std::string& fileFormat,
       - the caller owns the memory and therefore the pointer must be deleted
 */
 
-std::unique_ptr<MolSupplier> getSupplier(const std::string& path,
-                                         const struct SupplierOptions& opt) {
+std::unique_ptr<FileParsers::MolSupplier> getSupplier(
+    const std::string &path, const struct SupplierOptions &opt) {
   std::string fileFormat = "";
   std::string compressionFormat = "";
   //! get the file and compression format form the path
   determineFormat(path, fileFormat, compressionFormat);
 
-  std::istream* strm;
+  std::istream *strm;
   if (compressionFormat.empty()) {
     strm = new std::ifstream(path.c_str(), std::ios::in | std::ios::binary);
   } else {
@@ -114,53 +115,70 @@ std::unique_ptr<MolSupplier> getSupplier(const std::string& path,
 #endif
   }
 
+  FileParsers::MultithreadedMolSupplier::Parameters params;
+  params.numWriterThreads = getNumThreadsToUse(opt.numWriterThreads);
   //! Dispatch to the appropriate supplier
   if (fileFormat == "sdf") {
+    FileParsers::MolFileParserParams parseParams;
+    parseParams.sanitize = opt.sanitize;
+    parseParams.removeHs = opt.removeHs;
+    parseParams.strictParsing = opt.strictParsing;
 #ifdef RDK_BUILD_THREADSAFE_SSS
-    if (opt.numWriterThreads > 0) {
-      MultithreadedSDMolSupplier* sdsup = new MultithreadedSDMolSupplier(
-          strm, true, opt.sanitize, opt.removeHs, opt.strictParsing,
-          opt.numWriterThreads);
-      std::unique_ptr<MolSupplier> p(sdsup);
+    if (opt.numWriterThreads > 1) {
+      auto sdsup = new FileParsers::MultithreadedSDMolSupplier(
+          strm, true, params, parseParams);
+      std::unique_ptr<FileParsers::MolSupplier> p(sdsup);
       return p;
     }
 #endif
-    ForwardSDMolSupplier* sdsup = new ForwardSDMolSupplier(
-        strm, true, opt.sanitize, opt.removeHs, opt.strictParsing);
-    std::unique_ptr<MolSupplier> p(sdsup);
+    FileParsers::ForwardSDMolSupplier *sdsup =
+        new FileParsers::ForwardSDMolSupplier(strm, true, parseParams);
+    std::unique_ptr<FileParsers::MolSupplier> p(sdsup);
     return p;
   }
 
   else if (fileFormat == "smi" || fileFormat == "csv" || fileFormat == "txt" ||
            fileFormat == "tsv") {
+    FileParsers::SmilesMolSupplierParams parseParams;
+    parseParams.delimiter = opt.delimiter;
+    parseParams.smilesColumn = opt.smilesColumn;
+    parseParams.nameColumn = opt.nameColumn;
+    parseParams.titleLine = opt.titleLine;
+    parseParams.parseParameters.sanitize = opt.sanitize;
 #ifdef RDK_BUILD_THREADSAFE_SSS
     if (opt.numWriterThreads > 0) {
-      MultithreadedSmilesMolSupplier* smsup =
-          new MultithreadedSmilesMolSupplier(
-              strm, true, opt.delimiter, opt.smilesColumn, opt.nameColumn,
-              opt.titleLine, opt.sanitize, opt.numWriterThreads);
-      std::unique_ptr<MolSupplier> p(smsup);
+      FileParsers::MultithreadedSmilesMolSupplier *smsup =
+          new FileParsers::MultithreadedSmilesMolSupplier(strm, true, params,
+                                                          parseParams);
+      std::unique_ptr<FileParsers::MolSupplier> p(smsup);
       return p;
     }
 #endif
-    SmilesMolSupplier* smsup =
-        new SmilesMolSupplier(strm, true, opt.delimiter, opt.smilesColumn,
-                              opt.nameColumn, opt.titleLine, opt.sanitize);
-    std::unique_ptr<MolSupplier> p(smsup);
+    FileParsers::SmilesMolSupplier *smsup =
+        new FileParsers::SmilesMolSupplier(strm, true, parseParams);
+    std::unique_ptr<FileParsers::MolSupplier> p(smsup);
     return p;
   }
 #ifdef RDK_BUILD_MAEPARSER_SUPPORT
   else if (fileFormat == "mae") {
-    MaeMolSupplier* maesup =
-        new MaeMolSupplier(strm, true, opt.sanitize, opt.removeHs);
-    std::unique_ptr<MolSupplier> p(maesup);
+    FileParsers::MaeMolSupplierParams parseParams;
+    parseParams.sanitize = opt.sanitize;
+    parseParams.removeHs = opt.removeHs;
+    FileParsers::MaeMolSupplier *maesup =
+        new FileParsers::MaeMolSupplier(strm, true, parseParams);
+    std::unique_ptr<FileParsers::MolSupplier> p(maesup);
     return p;
   }
 #endif
   else if (fileFormat == "tdt") {
-    TDTMolSupplier* tdtsup = new TDTMolSupplier(
-        strm, true, opt.nameRecord, opt.confId2D, opt.confId3D, opt.sanitize);
-    std::unique_ptr<MolSupplier> p(tdtsup);
+    FileParsers::TDTMolSupplierParams parseParams;
+    parseParams.nameRecord = opt.nameRecord;
+    parseParams.confId2D = opt.confId2D;
+    parseParams.confId3D = opt.confId3D;
+    parseParams.parseParameters.sanitize = opt.sanitize;
+    FileParsers::TDTMolSupplier *tdtsup =
+        new FileParsers::TDTMolSupplier(strm, true, parseParams);
+    std::unique_ptr<FileParsers::MolSupplier> p(tdtsup);
     return p;
   }
   throw BadFileException("Unsupported file format: " + fileFormat);

--- a/Code/GraphMol/FileParsers/MultithreadedSDMolSupplier.h
+++ b/Code/GraphMol/FileParsers/MultithreadedSDMolSupplier.h
@@ -51,7 +51,6 @@ class RDKIT_FILEPARSERS_EXPORT MultithreadedSDMolSupplier
   void initFromSettings(bool takeOwnership, const Parameters &params,
                         const MolFileParserParams &parseParams);
 
-  Parameters d_params;
   bool df_end = false;  //!< have we reached the end of the file?
   int d_line = 0;       //!< line number we are currently on
   bool df_processPropertyLists = true;

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -14,6 +14,7 @@ GitHub)
 - The SimilarityMap functions GetSimilarityMapFromWeights(), GetSimilarityMapForFingerprint(), and GetSimilarityMapForModel() all now require an rdMolDraw2D drawing object to be passed in.
 - A bug fix in v2 of the tautomer and protomer hashes can lead to different results for these hashes. One less bond is now included in the tautomeric zone for systems like enamines/imines, so the v2 tautomer hash of the molecules CN=CC and CNC=C is now [C]:[C]:[N]-[CH3]_4_0 instead of [C]:[C]:[N]:[C]_7_0
 - The way valences are checked and implicit valences are calculated has been changed. The results should generally be the same as before, but some previously allowed valence states have been removed. These include: five-valent [C+], valence state 6 for the elements Al and Si, and valence state 7 for the elements P, As, Sb, and Bi.
+- The GeneralMolSupplier has been moved to use the v2 API. The only change that should be necessary to end-user code is that the resulting supplier now returns std::unique_ptr<ROMol> instead of ROMol *.
 
 ## New Features and Enhancements:
 


### PR DESCRIPTION
Two small things:
1. The `MultithreadedSDMolSupplier` had its own copy of `d_params` which, of course, would not be used when calling base-class methods.
2. Move the `GeneralFileReader` to the v2 API

I think it's safe to move the file reader to the new API and not keep a v1 version around since I doubt that anyone is actually using this code. We've never really talked about it or made use of that. This will, hopefully, change with the next release.... but the reason for that will come in a future PR.
