### PR TITLE
Add callbacks to the multithreaded mol suppliers

### DIFF
--- a/Code/GraphMol/FileParsers/CMakeLists.txt
+++ b/Code/GraphMol/FileParsers/CMakeLists.txt
@@ -96,3 +96,7 @@ rdkit_catch_test(v2MolSuppliers v2_suppliers_catch.cpp
 rdkit_catch_test(v2FileParsersCatchTest v2_file_parsers_catch.cpp
     LINK_LIBRARIES FileParsers)
 
+rdkit_catch_test(multithreadedSupplierCatchTest multithreaded_supplier_catch.cpp
+    LINK_LIBRARIES FileParsers)
+
+

--- a/Code/GraphMol/FileParsers/MultithreadedMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/MultithreadedMolSupplier.cpp
@@ -18,8 +18,6 @@ MultithreadedMolSupplier::~MultithreadedMolSupplier() {
   endThreads();
   // destroy all objects in the input queue
   d_inputQueue->clear();
-  // delete the pointer to the input queue
-  delete d_inputQueue;
   if (df_started) {
     std::tuple<RWMol *, std::string, unsigned int> r;
     while (d_outputQueue->pop(r)) {
@@ -29,8 +27,6 @@ MultithreadedMolSupplier::~MultithreadedMolSupplier() {
   }
   // destroy all objects in the output queue
   d_outputQueue->clear();
-  // delete the pointer to the output queue
-  delete d_outputQueue;
 }
 
 void MultithreadedMolSupplier::reader() {
@@ -73,8 +69,8 @@ void MultithreadedMolSupplier::writer() {
 
 std::unique_ptr<RWMol> MultithreadedMolSupplier::next() {
   if (!df_started) {
-    startThreads();
     df_started = true;
+    startThreads();
   }
   std::tuple<RWMol *, std::string, unsigned int> r;
   if (d_outputQueue->pop(r)) {

--- a/Code/GraphMol/FileParsers/MultithreadedMolSupplier.h
+++ b/Code/GraphMol/FileParsers/MultithreadedMolSupplier.h
@@ -134,10 +134,12 @@ class RDKIT_FILEPARSERS_EXPORT MultithreadedMolSupplier : public MolSupplier {
   std::string d_lastItemText;  //!< stores last extracted record
   const unsigned int d_numReaderThread = 1;  //!< number of reader thread
 
-  ConcurrentQueue<std::tuple<std::string, unsigned int, unsigned int>>
-      *d_inputQueue;  //!< concurrent input queue
-  ConcurrentQueue<std::tuple<RWMol *, std::string, unsigned int>>
-      *d_outputQueue;  //!< concurrent output queue
+  std::unique_ptr<
+      ConcurrentQueue<std::tuple<std::string, unsigned int, unsigned int>>>
+      d_inputQueue;  //!< concurrent input queue
+  std::unique_ptr<
+      ConcurrentQueue<std::tuple<RWMol *, std::string, unsigned int>>>
+      d_outputQueue;  //!< concurrent output queue
   Parameters d_params;
   std::function<void(RWMol &, const MultithreadedMolSupplier &)> nextCallback =
       nullptr;

--- a/Code/GraphMol/FileParsers/MultithreadedMolSupplier.h
+++ b/Code/GraphMol/FileParsers/MultithreadedMolSupplier.h
@@ -92,6 +92,7 @@ class RDKIT_FILEPARSERS_EXPORT MultithreadedMolSupplier : public MolSupplier {
   std::thread d_readerThread;                    //!< single reader thread
 
  protected:
+  std::atomic<bool> df_started = false;
   std::atomic<unsigned int> d_lastRecordId =
       0;                       //!< stores last extracted record id
   std::string d_lastItemText;  //!< stores last extracted record

--- a/Code/GraphMol/FileParsers/MultithreadedMolSupplier.h
+++ b/Code/GraphMol/FileParsers/MultithreadedMolSupplier.h
@@ -60,14 +60,35 @@ class RDKIT_FILEPARSERS_EXPORT MultithreadedMolSupplier : public MolSupplier {
   //! returns the text block for the last extracted item
   std::string getLastItemText() const;
 
+  //! sets the callback to be applied to molecules before they are returned by
+  ///! the next() function
+  /*!
+    \param cb: a function that takes a reference to an RWMol and a const
+    reference to the MultithreadedMolSupplier. This can modify the molecule in
+    place
+
+   */
   template <typename T>
   void setNextCallback(T cb) {
     nextCallback = cb;
   }
+  //! sets the callback to be applied to molecules after they are processed, but
+  ///! before they are written to the output queue
+  /*!
+    \param cb: a function that takes a reference to an RWMol, a const reference
+    to the string record, and an unsigned int record id. This can modify the
+    molecule in place
+  */
   template <typename T>
   void setWriteCallback(T cb) {
     writeCallback = cb;
   }
+  //! sets the callback to be applied to input text records before they are
+  ///! added to the input queue
+  /*!
+    \param cb: a function that takes a const reference to the string record and
+    an unsigned int record id and returns the modified string record
+  */
   template <typename T>
   void setReadCallback(T cb) {
     readCallback = cb;

--- a/Code/GraphMol/FileParsers/MultithreadedSDMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/MultithreadedSDMolSupplier.cpp
@@ -21,7 +21,6 @@ MultithreadedSDMolSupplier::MultithreadedSDMolSupplier(
   dp_inStream = openAndCheckStream(fileName);
   initFromSettings(true, params, parseParams);
   POSTCONDITION(dp_inStream, "bad instream");
-  // startThreads();
 }
 
 MultithreadedSDMolSupplier::MultithreadedSDMolSupplier(
@@ -31,13 +30,11 @@ MultithreadedSDMolSupplier::MultithreadedSDMolSupplier(
   dp_inStream = inStream;
   initFromSettings(takeOwnership, params, parseParams);
   POSTCONDITION(dp_inStream, "bad instream");
-  // startThreads();
 }
 
 MultithreadedSDMolSupplier::MultithreadedSDMolSupplier() {
   dp_inStream = nullptr;
   initFromSettings(false, d_params, d_parseParams);
-  // startThreads();
 }
 
 void MultithreadedSDMolSupplier::initFromSettings(
@@ -47,12 +44,12 @@ void MultithreadedSDMolSupplier::initFromSettings(
   d_params = params;
   d_parseParams = parseParams;
   d_params.numWriterThreads = getNumThreadsToUse(params.numWriterThreads);
-  d_inputQueue =
+  d_inputQueue.reset(
       new ConcurrentQueue<std::tuple<std::string, unsigned int, unsigned int>>(
-          d_params.sizeInputQueue);
-  d_outputQueue =
+          d_params.sizeInputQueue));
+  d_outputQueue.reset(
       new ConcurrentQueue<std::tuple<RWMol *, std::string, unsigned int>>(
-          d_params.sizeOutputQueue);
+          d_params.sizeOutputQueue));
 
   df_end = false;
   d_line = 0;

--- a/Code/GraphMol/FileParsers/MultithreadedSDMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/MultithreadedSDMolSupplier.cpp
@@ -21,7 +21,7 @@ MultithreadedSDMolSupplier::MultithreadedSDMolSupplier(
   dp_inStream = openAndCheckStream(fileName);
   initFromSettings(true, params, parseParams);
   POSTCONDITION(dp_inStream, "bad instream");
-  startThreads();
+  // startThreads();
 }
 
 MultithreadedSDMolSupplier::MultithreadedSDMolSupplier(
@@ -31,13 +31,13 @@ MultithreadedSDMolSupplier::MultithreadedSDMolSupplier(
   dp_inStream = inStream;
   initFromSettings(takeOwnership, params, parseParams);
   POSTCONDITION(dp_inStream, "bad instream");
-  startThreads();
+  // startThreads();
 }
 
 MultithreadedSDMolSupplier::MultithreadedSDMolSupplier() {
   dp_inStream = nullptr;
   initFromSettings(false, d_params, d_parseParams);
-  startThreads();
+  // startThreads();
 }
 
 void MultithreadedSDMolSupplier::initFromSettings(

--- a/Code/GraphMol/FileParsers/MultithreadedSmilesMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/MultithreadedSmilesMolSupplier.cpp
@@ -54,12 +54,12 @@ void MultithreadedSmilesMolSupplier::initFromSettings(
   d_params = params;
   d_parseParams = parseParams;
   d_params.numWriterThreads = getNumThreadsToUse(d_params.numWriterThreads);
-  d_inputQueue =
+  d_inputQueue.reset(
       new ConcurrentQueue<std::tuple<std::string, unsigned int, unsigned int>>(
-          d_params.sizeInputQueue);
-  d_outputQueue =
+          d_params.sizeInputQueue));
+  d_outputQueue.reset(
       new ConcurrentQueue<std::tuple<RWMol *, std::string, unsigned int>>(
-          d_params.sizeOutputQueue);
+          d_params.sizeOutputQueue));
   df_end = false;
   d_line = -1;
 }

--- a/Code/GraphMol/FileParsers/MultithreadedSmilesMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/MultithreadedSmilesMolSupplier.cpp
@@ -21,7 +21,6 @@ MultithreadedSmilesMolSupplier::MultithreadedSmilesMolSupplier(
   CHECK_INVARIANT(!(dp_inStream->eof()), "early EOF");
   // set df_takeOwnership = true
   initFromSettings(true, params, parseParams);
-  startThreads();
   POSTCONDITION(dp_inStream, "bad instream");
 }
 
@@ -32,14 +31,12 @@ MultithreadedSmilesMolSupplier::MultithreadedSmilesMolSupplier(
   CHECK_INVARIANT(!(inStream->eof()), "early EOF");
   dp_inStream = inStream;
   initFromSettings(takeOwnership, params, parseParams);
-  startThreads();
   POSTCONDITION(dp_inStream, "bad instream");
 }
 
 MultithreadedSmilesMolSupplier::MultithreadedSmilesMolSupplier() {
   dp_inStream = nullptr;
   initFromSettings(true, d_params, d_parseParams);
-  startThreads();
 }
 
 MultithreadedSmilesMolSupplier::~MultithreadedSmilesMolSupplier() {

--- a/Code/GraphMol/FileParsers/multithreaded_supplier_catch.cpp
+++ b/Code/GraphMol/FileParsers/multithreaded_supplier_catch.cpp
@@ -1,0 +1,152 @@
+//
+//  Copyright (c) 2024 Greg Landrum
+//  All rights reserved.
+//
+//  This file is part of the RDKit.
+//  The contents are covered by the terms of the BSD license
+//  which is included in the file license.txt, found at the root
+//  of the RDKit source tree.
+//
+#include "RDGeneral/test.h"
+#include <string>
+#include <catch2/catch_all.hpp>
+#include <RDGeneral/Invariant.h>
+#include <GraphMol/RDKitBase.h>
+#include <GraphMol/MolOps.h>
+#include <GraphMol/FileParsers/MultithreadedMolSupplier.h>
+#include <GraphMol/FileParsers/MultithreadedSDMolSupplier.h>
+#include <GraphMol/FileParsers/MultithreadedSmilesMolSupplier.h>
+
+using namespace RDKit;
+
+TEST_CASE("multithreaded supplier destruction without reading") {
+  v2::FileParsers::MultithreadedMolSupplier::Parameters params;
+  params.numWriterThreads = 4;
+  std::string rdbase = getenv("RDBASE");
+  std::string sdpath = rdbase + "/Data/NCI/first_200.props.sdf";
+  auto sdsuppl = v2::FileParsers::MultithreadedSDMolSupplier(sdpath, params);
+}
+
+TEST_CASE("callbacks SDF") {
+  v2::FileParsers::MultithreadedMolSupplier::Parameters params;
+  params.numWriterThreads = 4;
+  std::string rdbase = getenv("RDBASE");
+  std::string sdpath = rdbase + "/Data/NCI/first_200.props.sdf";
+  auto sdsuppl = v2::FileParsers::MultithreadedSDMolSupplier(sdpath, params);
+  // std::string smiPath = rdbase + "/Data/NCI/first_5K.smi";
+  // auto smisuppl =
+  //     v2::FileParsers::MultithreadedSmilesMolSupplier(smiPath, params);
+  // {
+  //   std::string smiPath = rdbase + "/Data/NCI/first_5K.smi";
+  //   auto suppl =
+  //       v2::FileParsers::MultithreadedSmilesMolSupplier(smiPath, params);
+  // }
+  SECTION("nextCallback") {
+    std::map<unsigned int, unsigned int> callbackNats;
+    auto callback =
+        [&](RWMol &mol,
+            const v2::FileParsers::MultithreadedMolSupplier &suppl) {
+          callbackNats[suppl.getLastRecordId()] = mol.getNumAtoms();
+        };
+    auto &suppl = sdsuppl;
+    suppl.setNextCallback(callback);
+    unsigned int nMols = 0;
+    while (!suppl.atEnd()) {
+      auto mol = suppl.next();
+      if (!mol) {
+        continue;
+      }
+      auto nats = mol->getNumAtoms();
+      CHECK(callbackNats[suppl.getLastRecordId()] == nats);
+      ++nMols;
+    }
+    CHECK(nMols == callbackNats.size());
+  }
+  SECTION("writeCallback") {
+    auto callback = [](RWMol &mol, const std::string &, unsigned int recordId) {
+      MolOps::addHs(mol);
+      mol.setProp("recordId", recordId);
+    };
+    auto &suppl = sdsuppl;
+    suppl.setWriteCallback(callback);
+    while (!suppl.atEnd()) {
+      auto mol = suppl.next();
+      if (!mol) {
+        continue;
+      }
+
+      CHECK(!MolOps::needsHs(*mol));
+      CHECK(mol->hasProp("recordId"));
+      CHECK(mol->getProp<unsigned int>("recordId") == suppl.getLastRecordId());
+    }
+  }
+  SECTION("readCallback") {
+    auto callback = [](const std::string &sdf, unsigned int recordId) {
+      auto res = sdf;
+      auto pos = sdf.find("$$$$");
+      if (pos == std::string::npos) {
+        return res;
+      }
+      res.replace(pos, 4,
+                  std::string(">  <recordId>\n") + std::to_string(recordId) +
+                      "\n\n$$$$");
+      return res;
+    };
+    auto &suppl = sdsuppl;
+
+    suppl.setReadCallback(callback);
+    while (!suppl.atEnd()) {
+      auto mol = suppl.next();
+      if (!mol) {
+        continue;
+      }
+      CHECK(mol->hasProp("recordId"));
+      CHECK(mol->getProp<unsigned int>("recordId") == suppl.getLastRecordId());
+    }
+  }
+}
+
+TEST_CASE("callbacks smiles") {
+  v2::FileParsers::MultithreadedMolSupplier::Parameters params;
+  params.numWriterThreads = 4;
+  std::string rdbase = getenv("RDBASE");
+  std::string smiPath = rdbase + "/Data/NCI/first_5K.smi";
+  auto suppl = v2::FileParsers::MultithreadedSmilesMolSupplier(smiPath, params);
+  SECTION("nextCallback") {
+    std::map<unsigned int, unsigned int> callbackNats;
+    auto callback =
+        [&](RWMol &mol,
+            const v2::FileParsers::MultithreadedMolSupplier &suppl) {
+          callbackNats[suppl.getLastRecordId()] = mol.getNumAtoms();
+        };
+    suppl.setNextCallback(callback);
+    unsigned int nMols = 0;
+    while (!suppl.atEnd()) {
+      auto mol = suppl.next();
+      if (!mol) {
+        continue;
+      }
+      auto nats = mol->getNumAtoms();
+      CHECK(callbackNats[suppl.getLastRecordId()] == nats);
+      ++nMols;
+    }
+    CHECK(nMols == callbackNats.size());
+  }
+  SECTION("writeCallback") {
+    auto callback = [](RWMol &mol, const std::string &, unsigned int recordId) {
+      MolOps::addHs(mol);
+      mol.setProp("recordId", recordId);
+    };
+    suppl.setWriteCallback(callback);
+    while (!suppl.atEnd()) {
+      auto mol = suppl.next();
+      if (!mol) {
+        continue;
+      }
+
+      CHECK(!MolOps::needsHs(*mol));
+      CHECK(mol->hasProp("recordId"));
+      CHECK(mol->getProp<unsigned int>("recordId") == suppl.getLastRecordId());
+    }
+  }
+}


### PR DESCRIPTION
The main thing here is to add three potential callbacks to the multithreaded mol suppliers:
```
//! sets the callback to be applied to molecules before they are returned by
  ///! the next() function
  /*!
    \param cb: a function that takes a reference to an RWMol and a const
    reference to the MultithreadedMolSupplier. This can modify the molecule in
    place

   */
  template <typename T>
  void setNextCallback(T cb) {
    nextCallback = cb;
  }
  //! sets the callback to be applied to molecules after they are processed, but
  ///! before they are written to the output queue
  /*!
    \param cb: a function that takes a reference to an RWMol, a const reference
    to the string record, and an unsigned int record id. This can modify the
    molecule in place
  */
  template <typename T>
  void setWriteCallback(T cb) {
    writeCallback = cb;
  }
  //! sets the callback to be applied to input text records before they are
  ///! added to the input queue
  /*!
    \param cb: a function that takes a const reference to the string record and
    an unsigned int record id and returns the modified string record
  */
  template <typename T>
  void setReadCallback(T cb) {
    readCallback = cb;
  }
```

The read and write callbacks allow us to easily take advantage of the multithreaded queue that the suppliers use to do additional work with the molecules. The most useful is probably the write callback since that gets the constructed molecule before it is returned. You could imagine using this to do standardization, generate conformers, etc.

There's no Python wrapper for these since calling into Python code from multiple threads is somewhere in between not possible and a terrible idea (maybe this starts to change with 3.13, but we can worry about that later). I have a PR coming soon that provides some convenience functions to allow some of this to be used from Python

Also in this PR:
1. Fixes a bug which caused hangs if multithreaded suppliers were constructed and then destroyed without being used
2. Some minor code cleanup and modernization