### PR TITLE
Fix 4.3.0--4.4.0 sql upgrade script

### DIFF
--- a/Code/PgSQL/rdkit/update_sql/rdkit--4.3.0--4.4.0.sql.in
+++ b/Code/PgSQL/rdkit/update_sql/rdkit--4.3.0--4.4.0.sql.in
@@ -9,6 +9,7 @@ CREATE OR REPLACE FUNCTION gbfp_sortsupport(internal)
     LANGUAGE C STRICT;
 
 DROP OPERATOR CLASS IF EXISTS gist_mol_ops USING gist;
+DROP OPERATOR FAMILY IF EXISTS gist_mol_ops USING gist;
 
 CREATE OPERATOR CLASS gist_mol_ops
 DEFAULT FOR TYPE mol USING gist
@@ -29,6 +30,7 @@ AS
 STORAGE         bytea;
 
 DROP OPERATOR CLASS IF EXISTS gist_qmol_ops USING gist;
+DROP OPERATOR FAMILY IF EXISTS gist_qmol_ops USING gist;
 
 CREATE OPERATOR CLASS gist_qmol_ops
 DEFAULT FOR TYPE qmol USING gist
@@ -49,6 +51,7 @@ AS
 STORAGE         bytea;
 
 DROP OPERATOR CLASS IF EXISTS gist_bfp_ops USING gist;
+DROP OPERATOR FAMILY IF EXISTS gist_bfp_ops USING gist;
 
 CREATE OPERATOR CLASS gist_bfp_ops
 DEFAULT FOR TYPE bfp USING gist


### PR DESCRIPTION
Duplicate of https://github.com/rdkit/rdkit/pull/7713, which I accidentally closed.
Below is a copy+paste of that PR

---

Updates the script to drop the operator family so the subsequent creation attempt can pass.


#### What does this implement/fix? Explain your changes.
I noticed the provided PostgreSQL cartridge upgrade path from 4.3.0 to higher versions does not appear to work.

Example upgrade attempt on on PostgreSQL 15.8, rdkit version 3.8 (Release_2020_03_2) upgrading to rdkit 4.5.0 (Release_2024_03_5).

```
psql (15.8)
Type "help" for help.

postgres=# \dx
                          List of installed extensions
  Name   | Version |   Schema   |                  Description                  
---------+---------+------------+-----------------------------------------------
 plpgsql | 1.0     | pg_catalog | PL/pgSQL procedural language
 rdkit   | 3.8     | public     | Cheminformatics functionality for PostgreSQL.
(2 rows)

postgres=# ALTER EXTENSION rdkit UPDATE TO "4.5.0";
ERROR:  duplicate key value violates unique constraint "pg_amop_fam_strat_index"
DETAIL:  Key (amopfamily, amoplefttype, amoprighttype, amopstrategy)=(16650, 16388, 16388, 3) already exists.
```

I was able to solve the problem by dropping the operator family as well in https://github.com/rdkit/rdkit/blob/master/Code/PgSQL/rdkit/update_sql/rdkit--4.3.0--4.4.0.sql.in, which I've committed as part of this PR.

With the patch:
```
test1=# \dx
                          List of installed extensions
  Name   | Version |   Schema   |                  Description                  
---------+---------+------------+-----------------------------------------------
 plpgsql | 1.0     | pg_catalog | PL/pgSQL procedural language
 rdkit   | 3.8     | public     | Cheminformatics functionality for PostgreSQL.
(2 rows)

test1=# ALTER EXTENSION rdkit UPDATE TO "4.5.0";
ALTER EXTENSION
test1=# \dx
                          List of installed extensions
  Name   | Version |   Schema   |                  Description                  
---------+---------+------------+-----------------------------------------------
 plpgsql | 1.0     | pg_catalog | PL/pgSQL procedural language
 rdkit   | 4.5.0   | public     | Cheminformatics functionality for PostgreSQL.
(2 rows)
```

Hope this is helpful.