### PR TITLE
Fix issue in #7720

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -303,12 +303,12 @@ if(RDK_BUILD_PYTHON_WRAPPERS)
   )
 
   if(WIN32 OR "${Py_ENABLE_SHARED}" STREQUAL "1")
-    target_link_libraries(rdkit_py_base INTERFACE ${Python3_LIBRARY} )
+    target_link_libraries(rdkit_py_base INTERFACE ${Python3_LIBRARIES} )
   endif()
 
-   
+
   find_package(Boost ${RDK_BOOST_VERSION} COMPONENTS "python${Python3_VERSION_MAJOR}${Python3_VERSION_MINOR}" "numpy${Python3_VERSION_MAJOR}${Python3_VERSION_MINOR}" REQUIRED CONFIG)
-  
+
   target_link_libraries(rdkit_py_base INTERFACE "Boost::python${Python3_VERSION_MAJOR}${Python3_VERSION_MINOR}" "Boost::numpy${Python3_VERSION_MAJOR}${Python3_VERSION_MINOR}")
 
   if(RDK_INSTALL_INTREE)


### PR DESCRIPTION
It seems that the newest versions of CMake may have problems with the `Python3_LIBRARY` variable (we've seen some on Mac with CMake 3.27.1) that was introduced in #7720 (before we used `Python3_LIBRARIES`).

The CMake documentation for `FindPython3` mentions `Python3_LIBRARY` as an "Artifact" (I'm not sure what that is), but it seems that the correct "result" variable is `Python3_LIBRARIES`.

