### PR TITLE
HasPropWithValueQueryBase needs a virtual destructor

### DIFF
--- a/Code/GraphMol/QueryOps.h
+++ b/Code/GraphMol/QueryOps.h
@@ -865,6 +865,8 @@ Queries::EqualityQuery<int, const Target *, true> *makeHasPropQuery(
 // ! Query whether an atom has a property with a value
 class HasPropWithValueQueryBase {
   public:
+  HasPropWithValueQueryBase() = default;
+  virtual ~HasPropWithValueQueryBase() = default;
   virtual Dict::Pair getPair() const = 0;
   virtual double getTolerance() const = 0;
 };


### PR DESCRIPTION
Since #7692, including `GraphMol/QueryOps.h` in a .cpp file results in a build error:

```

In file included from /tmp/rdkit-install/include/rdkit/GraphMol/QueryAtom.h:17,
                 from /tmp/test/rdkit.cpp:15:
/tmp/rdkit-install/include/rdkit/GraphMol/QueryOps.h:866:7: error: ‘class RDKit::HasPropWithValueQueryBase’ has virtual functions and accessible non-virtual destructor [-Werror=non-virtual-dtor]
  866 | class HasPropWithValueQueryBase {
      |       ^~~~~~~~~~~~~~~~~~~~~~~~~
cc1plus: all warnings being treated as errors

```

This PR gives `HasPropWithValueQueryBase()` a default constructor and a virtual destructor, which fixes the build issue.