### PR TITLE
Use Boost_INCLUDE_DIRS instead of Boost_INCLUDE_DIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -457,7 +457,7 @@ endif()
 target_include_directories(rdkit_base INTERFACE
                            $<BUILD_INTERFACE:${RDKit_CodeDir}>
                            $<INSTALL_INTERFACE:${RDKit_HdrDir}>
-                           ${Boost_INCLUDE_DIR}
+                           ${Boost_INCLUDE_DIRS}
                            )
 target_link_libraries(rdkit_base INTERFACE ${BOOST_LIBRARIES})
 


### PR DESCRIPTION
#### Reference Issue

Fixes #7776

#### What does this implement/fix? Explain your changes.

`Boost_INCLUDE_DIR` is not always set ([more info](https://discourse.cmake.org/t/findboost-difference-between-boost-include-dir-and-boost-include-dirs/855/2)).

