### PR TITLE
Fixes #7526

### DIFF
--- a/rdkit/Chem/__init__.py
+++ b/rdkit/Chem/__init__.py
@@ -100,8 +100,8 @@ class _GetBondsIterator(_GetRDKitObjIterator):
     return self._mol.GetBondWithIdx(i)
 
 
-rdchem.Mol.GetAtoms = lambda m: _GetAtomsIterator(m)
-rdchem.Mol.GetBonds = lambda m: _GetBondsIterator(m)
+rdchem.Mol.GetAtoms = lambda self: _GetAtomsIterator(self)
+rdchem.Mol.GetBonds = lambda self: _GetBondsIterator(self)
 
 
 def QuickSmartsMatch(smi, sma, unique=True, display=False):


### PR DESCRIPTION
Small PR which renames the `m` parameter to `self` in the `GetAtoms` and `GetBonds` lambdas to address #7526.