### PR TITLE
Fix typo (Fingeprint -> Fingerprint)

### DIFF
--- a/Code/GraphMol/Fingerprints/Wrap/FingerprintGeneratorWrapper.cpp
+++ b/Code/GraphMol/Fingerprints/Wrap/FingerprintGeneratorWrapper.cpp
@@ -722,8 +722,8 @@ BOOST_PYTHON_MODULE(rdFingerprintGenerator) {
       .def("SetCountBounds", &setCountBoundsHelper,
            python::args("self", "bounds"), "set the bins for the count bounds");
 
-  wrapGenerator<std::uint32_t>("FingeprintGenerator32");
-  wrapGenerator<std::uint64_t>("FingeprintGenerator64");
+  wrapGenerator<std::uint32_t>("FingerprintGenerator32");
+  wrapGenerator<std::uint64_t>("FingerprintGenerator64");
 
   python::enum_<FPType>("FPType")
       .value("RDKitFP", FPType::RDKitFP)


### PR DESCRIPTION
Given that those classes cannot be instantiated from Python and currently
```
grep -l FingeprintGenerator -r .
```
in the `rdkit` source tree only yields hits in `./Docs/Book` and `./rdkit-stubs` I would not bother deprecating the old name with the typo and just fix it.