### PR TITLE
Catch exceptions in MultithreadedMolSupplier callbacks

### DIFF
--- a/Code/GraphMol/FileParsers/MultithreadedMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/MultithreadedMolSupplier.cpp
@@ -9,6 +9,9 @@
 //  of the RDKit source tree.
 //
 #include "MultithreadedMolSupplier.h"
+
+#include <RDGeneral/RDLog.h>
+
 namespace RDKit {
 
 namespace v2 {
@@ -34,7 +37,12 @@ void MultithreadedMolSupplier::reader() {
   unsigned int lineNum, index;
   while (extractNextRecord(record, lineNum, index)) {
     if (readCallback) {
-      record = readCallback(record, index);
+      try {
+        record = readCallback(record, index);
+      } catch (std::exception &e) {
+        BOOST_LOG(rdErrorLog)
+            << "Read callback exception: " << e.what() << std::endl;
+      }
     }
     auto r = std::make_tuple(record, lineNum, index);
     d_inputQueue->push(r);
@@ -78,7 +86,11 @@ std::unique_ptr<RWMol> MultithreadedMolSupplier::next() {
     d_lastRecordId = std::get<2>(r);
     std::unique_ptr<RWMol> res{std::get<0>(r)};
     if (res && nextCallback) {
-      nextCallback(*res, *this);
+      try {
+        nextCallback(*res, *this);
+      } catch (...) {
+        // Ignore exception and proceed with mol as is.
+      }
     }
     return res;
   }

--- a/Code/GraphMol/FileParsers/multithreaded_supplier_catch.cpp
+++ b/Code/GraphMol/FileParsers/multithreaded_supplier_catch.cpp
@@ -65,8 +65,8 @@ TEST_CASE("callbacks SDF") {
   SECTION("nextCallbackException") {
     std::map<unsigned int, unsigned int> callbackNats;
     auto callback =
-        [&](RWMol &mol,
-            const v2::FileParsers::MultithreadedMolSupplier &suppl) {
+        [&](RWMol &,
+            const v2::FileParsers::MultithreadedMolSupplier &) {
           throw std::runtime_error(
               "This is not the callback you are looking for");
         };
@@ -101,7 +101,7 @@ TEST_CASE("callbacks SDF") {
     }
   }
   SECTION("writeCallbackException") {
-    auto callback = [](RWMol &mol, const std::string &, unsigned int recordId) {
+    auto callback = [](RWMol &, const std::string &, unsigned int) {
       throw std::runtime_error("You cannot pass!");
     };
     auto &suppl = sdsuppl;
@@ -139,9 +139,8 @@ TEST_CASE("callbacks SDF") {
     }
   }
   SECTION("readCallbackException") {
-    auto callback = [](const std::string &sdf, unsigned int recordId) {
+    auto callback = [](const std::string &, unsigned int) -> std::string {
       throw std::runtime_error("I'm Sorry Dave. I'm afraid I can't do that.");
-      return std::string(sdf);
     };
     auto &suppl = sdsuppl;
 


### PR DESCRIPTION
### Reference Issue

This is a followup to #7763 as discussed with Greg during the UGM hackathon.

#### What does this implement/fix? Explain your changes.

* In next(), simply ignore any exceptions from nextCallback.
* In reader(), if readCallback throws, log a warning and proceed using the unmodified record.
* (writer() was already handling exceptions from writeCallback.)

#### Any other comments?

The multithreadedSupplierCatchTest sometimes hangs, and getting a stack trace, I see something involving com.apple.rosetta.exceptionserver ; I'm using an Intel build on an M1 Mac. Google suggest this may have something to do with System Integrity Protection (SIP) on the Mac. I suspect and hope that this is only be a problem for Intel builds on the Mac. I should note that I see the same random hangs with a build before applying my changes! (I was at commit 4c37b03071181007316c306d874f75aa9f5cb7cf ).

#### Questions

* Should we also catch exceptions not derived from std::exception in reader()? We wouldn't have a "what" for those.
* Refactoring idea: would make sense to define a couple of structs for the queue types so that we can use descriptive names to access the data members, instead of having to use std::get<0> et al.?