### PR TITLE
Torsion energy calculations are sometimes nan

### DIFF
--- a/Code/ForceField/MMFF/TorsionAngle.cpp
+++ b/Code/ForceField/MMFF/TorsionAngle.cpp
@@ -26,7 +26,12 @@ double calcTorsionCosPhi(const RDGeom::Point3D &iPoint,
   RDGeom::Point3D r4 = lPoint - kPoint;
   RDGeom::Point3D t1 = r1.crossProduct(r2);
   RDGeom::Point3D t2 = r3.crossProduct(r4);
-  double cosPhi = t1.dotProduct(t2) / (t1.length() * t2.length());
+  auto t1_len = t1.length();
+  auto t2_len = t2.length();
+  if (isDoubleZero(t1_len)|| isDoubleZero(t2_len)) {
+    return 0.0;
+  }
+  double cosPhi = t1.dotProduct(t2) / (t1_len * t2_len);
   clipToOne(cosPhi);
 
   return cosPhi;


### PR DESCRIPTION
#### Reference Issue
Fixes #7671


#### What does this implement/fix? Explain your changes.
`calcTorsionCosPhi` was returning `nan` when two adjacent bonds in a torsion are parallel. For example, atoms 37, 38, 39, 42 here:
<img width="292" alt="image" src="https://github.com/user-attachments/assets/6e6c31b2-07b4-45a4-a2b7-b6fecfa16da0">

This change makes the return 0.0 instead so that the minimization doesn't fail. I'm not sure if that is the right thing to do or not.

#### Any other comments?
I also spent some RDKit UGM hackathon time looking into #7781 and #7726 because they had the same error message. I didn't have time to actually fix them, but I believe they are due to the entire gradient being set to 0 causing the linearSearch to return early.