### PR TITLE
Adds the ranks of the neighboring atoms when running CIP labeling

### DIFF
--- a/Code/GraphMol/CIPLabeler/catch_tests.cpp
+++ b/Code/GraphMol/CIPLabeler/catch_tests.cpp
@@ -948,20 +948,22 @@ TEST_CASE("atropisomers", "[basic]") {
 TEST_CASE("neighbor_annotations", "[basic]") {
   SECTION("chirality") {
     auto mol = R"(C1C[C@H](C)C(=O)C[C@H]1O)"_smiles;
-    CIPLabeler::assignCIPLabels(*mol, 10);
+    CIPLabeler::assignCIPLabels(*mol, 100);
     auto a = mol->getAtomWithIdx(2);
     auto ranked_neighbors = a->getProp<std::vector<int>>("_CIPNeighborRanks");
-    CHECK(ranked_neighbors == std::vector{1, 2, 3});
+    CHECK(ranked_neighbors == std::vector{4, 1, 3});
   }
 
   SECTION("bond_stereo") {
-    auto mol = R"([H]/C=C(N)/C)"_smiles;
-    auto b = mol->getBondWithIdx(1);
-    auto& stereo_atoms = b->getStereoAtoms();
-    CHECK(stereo_atoms[1] == 4);
-    CIPLabeler::assignCIPLabels(*mol, 10);
+    auto mol = R"(C/C=C(C)/N)"_smiles;
+    mol->getBondWithIdx(1)->setStereoAtoms(0, 3);
+    auto& stereo_atoms1 = mol->getBondWithIdx(1)->getStereoAtoms();
+    CHECK(stereo_atoms1[0] == 0);
+    CHECK(stereo_atoms1[1] == 3);
+    CIPLabeler::assignCIPLabels(*mol, 100);
     // did the stereoatom switch to the highest CIP ranked neighbor?
-    stereo_atoms = b->getStereoAtoms();
-    CHECK(stereo_atoms[1] == 3);
+    auto& stereo_atoms2 = mol->getBondWithIdx(1)->getStereoAtoms();
+    CHECK(stereo_atoms2[0] == 0);
+    CHECK(stereo_atoms2[1] == 4);
   }
 }

--- a/Code/GraphMol/CIPLabeler/catch_tests.cpp
+++ b/Code/GraphMol/CIPLabeler/catch_tests.cpp
@@ -943,3 +943,25 @@ TEST_CASE("atropisomers", "[basic]") {
     }
   }
 }
+
+// Do we annotate/label the molecule with the ranks of their neighbors?
+TEST_CASE("neighbor_annotations", "[basic]") {
+  SECTION("chirality") {
+    auto mol = R"(C1C[C@H](C)C(=O)C[C@H]1O)"_smiles;
+    CIPLabeler::assignCIPLabels(*mol, 10);
+    auto a = mol->getAtomWithIdx(2);
+    auto ranked_neighbors = a->getProp<std::vector<int>>("_CIPNeighborRanks");
+    CHECK(ranked_neighbors == std::vector{1, 2, 3});
+  }
+
+  SECTION("bond_stereo") {
+    auto mol = R"([H]/C=C(N)/C)"_smiles;
+    auto b = mol->getBondWithIdx(1);
+    auto& stereo_atoms = b->getStereoAtoms();
+    CHECK(stereo_atoms[1] == 4);
+    CIPLabeler::assignCIPLabels(*mol, 10);
+    // did the stereoatom switch to the highest CIP ranked neighbor?
+    stereo_atoms = b->getStereoAtoms();
+    CHECK(stereo_atoms[1] == 3);
+  }
+}

--- a/Code/GraphMol/CIPLabeler/configs/Sp2Bond.cpp
+++ b/Code/GraphMol/CIPLabeler/configs/Sp2Bond.cpp
@@ -128,6 +128,7 @@ Descriptor Sp2Bond::label(Node *root1, Digraph &digraph, const Rules &comp) {
     // other nodes.
     std::vector<Atom*> updated_carriers = {edges1[0]->getEnd()->getAtom(),
                                            edges2[0]->getEnd()->getAtom()};
+    setCarriers(std::move(updated_carriers));
   }
 
   if (config == Bond::STEREOCIS) {

--- a/Code/GraphMol/CIPLabeler/configs/Sp2Bond.cpp
+++ b/Code/GraphMol/CIPLabeler/configs/Sp2Bond.cpp
@@ -122,6 +122,14 @@ Descriptor Sp2Bond::label(Node *root1, Digraph &digraph, const Rules &comp) {
     }
   }
 
+  {
+    // At this point, edges1 and edges2 are sorted by priority starting from
+    // this node. Record that now! - they may be resorted after processing
+    // other nodes.
+    std::vector<Atom*> updated_carriers = {edges1[0]->getEnd()->getAtom(),
+                                           edges2[0]->getEnd()->getAtom()};
+  }
+
   if (config == Bond::STEREOCIS) {
     if (priority1.isPseudoAsymetric() != priority2.isPseudoAsymetric()) {
       return Descriptor::seqCis;

--- a/Code/GraphMol/CIPLabeler/configs/Tetrahedral.cpp
+++ b/Code/GraphMol/CIPLabeler/configs/Tetrahedral.cpp
@@ -151,6 +151,21 @@ Descriptor Tetrahedral::label(Node *node, const Rules &comp) const {
     throw std::runtime_error("Could not calculate parity! Carrier mismatch");
   }
 
+  {
+    // At this point, the edges are sorted by priority starting from
+    // this node. Record that now! - they may be resorted after processing
+    // other nodes.
+    auto a = node->getAtom();
+    std::vector<int> ranks;
+    ranks.reserve(4);
+    for (auto e: edges) {
+      if (e && e->getBond()) {
+        ranks.push_back(e->getBond()->getOtherAtom(a)->getIdx());
+      }
+    }
+    a->setProp("_CIPNeighborRanks", ranks, true);
+  }
+
   auto config = focus->getChiralTag();
   if (parity == 1) {
     if (config == Atom::CHI_TETRAHEDRAL_CCW) {


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
I think this could be an optional additional annotation. I would
find this useful for replacing some schrödinger code that uses
the ranks. (I'd ultimately like to update that code to use
parity, but that's a much bigger project).
    
I was also hoping to do some performance work in the CIPLabeler,
and having this as a debug/validation tool would be nice.

#### Any other comments?
This does not impact the performance of the CIPLabeler.

My main worry here is that properties are a sticky part of API, and it's
hard to remove property generation once you add it.

