### PR TITLE
Simple speed up for CIPLabeler

### DIFF
--- a/Code/GraphMol/CIPLabeler/Digraph.cpp
+++ b/Code/GraphMol/CIPLabeler/Digraph.cpp
@@ -11,7 +11,6 @@
 
 #include <list>
 #include <sstream>
-#include <deque>
 
 #include "Digraph.h"
 #include "CIPMol.h"
@@ -75,12 +74,10 @@ int Digraph::getNumNodes() const { return d_nodes.size(); }
 
 std::vector<Node *> Digraph::getNodes(Atom *atom) const {
   std::vector<Node *> result;
-  std::deque<Node*> queue = {getCurrentRoot()};
+  std::vector<Node*> queue = {getCurrentRoot()};
 
-  while (!queue.empty()) {
-    auto node = queue.front();
-    queue.pop_front();
-
+  for (size_t i=0; i<queue.size(); ++i) {
+    auto node = queue[i];
     if (atom == node->getAtom()) {
       result.push_back(node);
     }

--- a/Code/GraphMol/CIPLabeler/Digraph.cpp
+++ b/Code/GraphMol/CIPLabeler/Digraph.cpp
@@ -11,6 +11,7 @@
 
 #include <list>
 #include <sstream>
+#include <deque>
 
 #include "Digraph.h"
 #include "CIPMol.h"
@@ -74,9 +75,12 @@ int Digraph::getNumNodes() const { return d_nodes.size(); }
 
 std::vector<Node *> Digraph::getNodes(Atom *atom) const {
   std::vector<Node *> result;
-  auto queue = std::list<Node *>({getCurrentRoot()});
+  std::deque<Node*> queue = {getCurrentRoot()};
 
-  for (const auto &node : queue) {
+  while (!queue.empty()) {
+    auto node = queue.front();
+    queue.pop_front();
+
     if (atom == node->getAtom()) {
       result.push_back(node);
     }


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
std::list is almost never the data structure that you want. vector uses fewer allocations, and the data has better locality. This speeds up the CIPLabeler on some protein examples by about 2x (75s to 38s)