### PR TITLE
Fixes #7731

### DIFF
--- a/Code/RDBoost/Wrap/RDBase.cpp
+++ b/Code/RDBoost/Wrap/RDBase.cpp
@@ -81,7 +81,7 @@ struct PyLogStream : std::ostream, std::streambuf {
 #if PY_VERSION_HEX < 0x30d0000
     if (!_Py_IsFinalizing()) {
 #else
-    if (Py_IsFinalizing()) {
+    if (!Py_IsFinalizing()) {
 #endif
       Py_XDECREF(logfn);
     }

--- a/Code/RDBoost/Wrap/RDBase.cpp
+++ b/Code/RDBoost/Wrap/RDBase.cpp
@@ -78,7 +78,11 @@ struct PyLogStream : std::ostream, std::streambuf {
   }
 
   ~PyLogStream() {
+#if PY_VERSION_HEX < 0x30d0000
     if (!_Py_IsFinalizing()) {
+#else
+    if (Py_IsFinalizing()) {
+#endif
       Py_XDECREF(logfn);
     }
   }


### PR DESCRIPTION
Simple matter to switch to `Py_IsFinalizing()` for python v3.13+