### PR TITLE
Additional compatibility updates for commutator/negator settings for …

### DIFF
--- a/Code/PgSQL/rdkit/CMakeLists.txt
+++ b/Code/PgSQL/rdkit/CMakeLists.txt
@@ -261,8 +261,6 @@ else()
 endif()
 
 if (${PostgreSQL_VERSION_STRING} VERSION_GREATER_EQUAL 17.0)
-  set(RDKIT_PG_ATEQ_COMMUTATOR "'@='")
-  set(RDKIT_PG_ATEQ_NEGATOR "'@<>'")
   set(RDKIT_PG_ALTER_OPERATOR_ATEQ_MOL "ALTER OPERATOR @= (mol, mol) SET (
     COMMUTATOR = '@=',
     NEGATOR = '@<>'
@@ -271,9 +269,6 @@ if (${PostgreSQL_VERSION_STRING} VERSION_GREATER_EQUAL 17.0)
     COMMUTATOR = '@=',
     NEGATOR = '@<>'
 );")
-else()
-  set(RDKIT_PG_ATEQ_COMMUTATOR "'='")
-  set(RDKIT_PG_ATEQ_NEGATOR "'<>'")
 endif()
 
 configure_file("${PG_CURRENT_SOURCE_DIR}${EXTENSION}.sql.in"

--- a/Code/PgSQL/rdkit/rdkit.control
+++ b/Code/PgSQL/rdkit/rdkit.control
@@ -1,4 +1,4 @@
 comment = 'Cheminformatics functionality for PostgreSQL.'
-default_version = '4.6.0'
+default_version = '4.6.1'
 module_pathname = '$libdir/rdkit'
 relocatable = true

--- a/Code/PgSQL/rdkit/rdkit.sql.in
+++ b/Code/PgSQL/rdkit/rdkit.sql.in
@@ -1370,8 +1370,8 @@ CREATE OPERATOR @= (
     LEFTARG = mol,
     RIGHTARG = mol,
     PROCEDURE = mol_eq,
-    COMMUTATOR = @RDKIT_PG_ATEQ_COMMUTATOR@,
-    NEGATOR = @RDKIT_PG_ATEQ_NEGATOR@,
+    COMMUTATOR = '@=',
+    NEGATOR = '@<>',
     RESTRICT = eqsel,
     JOIN = eqjoinsel
 );
@@ -1691,8 +1691,8 @@ CREATE OPERATOR @= (
     LEFTARG = reaction,
     RIGHTARG = reaction,
     PROCEDURE = reaction_eq,
-    COMMUTATOR = @RDKIT_PG_ATEQ_COMMUTATOR@,
-    NEGATOR = @RDKIT_PG_ATEQ_NEGATOR@,
+    COMMUTATOR = '@=',
+    NEGATOR = '@<>',
     RESTRICT = eqsel,
     JOIN = eqjoinsel
 );

--- a/Code/PgSQL/rdkit/update_sql/rdkit--4.6.0--4.6.1.sql.in
+++ b/Code/PgSQL/rdkit/update_sql/rdkit--4.6.0--4.6.1.sql.in
@@ -1,0 +1,23 @@
+DROP OPERATOR IF EXISTS @= (mol, mol);
+
+CREATE OPERATOR @= (
+    LEFTARG = mol,
+    RIGHTARG = mol,
+    PROCEDURE = mol_eq,
+    COMMUTATOR = '@=',
+    NEGATOR = '@<>',
+    RESTRICT = eqsel,
+    JOIN = eqjoinsel
+);
+
+DROP OPERATOR IF EXISTS @= (reaction, reaction);
+
+CREATE OPERATOR @= (
+    LEFTARG = reaction,
+    RIGHTARG = reaction,
+    PROCEDURE = reaction_eq,
+    COMMUTATOR = '@=',
+    NEGATOR = '@<>',
+    RESTRICT = eqsel,
+    JOIN = eqjoinsel
+);


### PR DESCRIPTION
…operator @=

#### Reference Issue
<!-- Example: Fixes #1234 -->
Follow-up for additional fixes for https://github.com/rdkit/rdkit/issues/7459. 
Also see conversation at the bottom of https://github.com/rdkit/rdkit/pull/7596.

#### What does this implement/fix? Explain your changes.
Allows upgrades from postgres versions <= 16 with existing installs to 17 and bumps cartridge version to 4.6.1.
