### PR TITLE
Expose preset color palettes to MinimalLib through JSON

### DIFF
--- a/Code/GraphMol/MolDraw2D/MolDraw2DUtils.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DUtils.cpp
@@ -26,6 +26,7 @@
 #include <boost/lexical_cast.hpp>
 #include <boost/property_tree/ptree.hpp>
 #include <boost/property_tree/json_parser.hpp>
+#include <boost/algorithm/string.hpp>
 #include <RDGeneral/BoostEndInclude.h>
 #include <limits>
 #include <cmath>
@@ -129,40 +130,64 @@ void get_rgba(const boost::property_tree::ptree &node, DrawColour &colour) {
   }
 }
 
-void get_colour_option(boost::property_tree::ptree *pt, const char *pnm,
+void get_colour_option(const boost::property_tree::ptree &pt, const char *pnm,
                        DrawColour &colour) {
   PRECONDITION(pnm && strlen(pnm), "bad property name");
-  if (pt->find(pnm) == pt->not_found()) {
+  if (pt.find(pnm) == pt.not_found()) {
     return;
   }
 
-  const auto &node = pt->get_child(pnm);
+  const auto &node = pt.get_child(pnm);
   get_rgba(node, colour);
 }
 
-void get_colour_palette_option(boost::property_tree::ptree *pt, const char *pnm,
-                               ColourPalette &palette) {
+void get_colour_palette_option(const boost::property_tree::ptree &pt,
+                               const char *pnm, ColourPalette &palette) {
   PRECONDITION(pnm && strlen(pnm), "bad property name");
-  if (pt->find(pnm) == pt->not_found()) {
+  static const std::map<std::string, void (*)(ColourPalette &)>
+      PRESET_PALETTE_MAP{
+          {"default", assignDefaultPalette},
+          {"avalon", assignAvalonPalette},
+          {"cdk", assignCDKPalette},
+          {"darkmode", assignDarkModePalette},
+          {"bw", assignBWPalette},
+      };
+  auto atomColourPaletteIt = pt.find(pnm);
+  if (atomColourPaletteIt == pt.not_found()) {
     return;
   }
-
-  for (const auto &atomicNumNodeIt : pt->get_child(pnm)) {
-    int atomicNum = boost::lexical_cast<int>(atomicNumNodeIt.first);
-    DrawColour colour;
-    get_rgba(atomicNumNodeIt.second, colour);
-    palette[atomicNum] = colour;
+  // Does the "atomColourPalette" key correspond to a terminal value?
+  if (atomColourPaletteIt->second.empty()) {
+    const auto &v = atomColourPaletteIt->second.data();
+    if (v.empty()) {
+      return;
+    }
+    auto paletteName = boost::lexical_cast<std::string>(v);
+    boost::algorithm::to_lower(paletteName);
+    auto preSetPaletteIt = PRESET_PALETTE_MAP.find(paletteName);
+    if (preSetPaletteIt == PRESET_PALETTE_MAP.end()) {
+      return;
+    }
+    // Populate the palette calling the corresponding function
+    preSetPaletteIt->second(palette);
+  } else {
+    for (const auto &atomicNumNode : atomColourPaletteIt->second) {
+      int atomicNum = boost::lexical_cast<int>(atomicNumNode.first);
+      DrawColour colour;
+      get_rgba(atomicNumNode.second, colour);
+      palette[atomicNum] = colour;
+    }
   }
 }
 
-void get_highlight_style_option(boost::property_tree::ptree *pt,
+void get_highlight_style_option(const boost::property_tree::ptree &pt,
                                 const char *pnm,
                                 MultiColourHighlightStyle &mchs) {
   PRECONDITION(pnm && strlen(pnm), "bad property name");
-  if (pt->find(pnm) == pt->not_found()) {
+  if (pt.find(pnm) == pt.not_found()) {
     return;
   }
-  const auto &node = pt->get_child(pnm);
+  const auto &node = pt.get_child(pnm);
   auto styleStr = node.get_value<std::string>();
   if (styleStr == "Lasso") {
     mchs = MultiColourHighlightStyle::LASSO;
@@ -232,22 +257,22 @@ void updateMolDrawOptionsFromJSON(MolDrawOptions &opts,
   PT_OPT_GET(drawMolsSameScale);
   PT_OPT_GET(useComplexQueryAtomSymbols);
 
-  get_colour_option(&pt, "highlightColour", opts.highlightColour);
-  get_colour_option(&pt, "backgroundColour", opts.backgroundColour);
-  get_colour_option(&pt, "queryColour", opts.queryColour);
-  get_colour_option(&pt, "legendColour", opts.legendColour);
-  get_colour_option(&pt, "symbolColour", opts.symbolColour);
-  get_colour_option(&pt, "annotationColour", opts.annotationColour);
-  get_colour_option(&pt, "variableAttachmentColour",
+  get_colour_option(pt, "highlightColour", opts.highlightColour);
+  get_colour_option(pt, "backgroundColour", opts.backgroundColour);
+  get_colour_option(pt, "queryColour", opts.queryColour);
+  get_colour_option(pt, "legendColour", opts.legendColour);
+  get_colour_option(pt, "symbolColour", opts.symbolColour);
+  get_colour_option(pt, "annotationColour", opts.annotationColour);
+  get_colour_option(pt, "variableAttachmentColour",
                     opts.variableAttachmentColour);
-  get_colour_palette_option(&pt, "atomColourPalette", opts.atomColourPalette);
+  get_colour_palette_option(pt, "atomColourPalette", opts.atomColourPalette);
   if (pt.find("atomLabels") != pt.not_found()) {
     for (const auto &item : pt.get_child("atomLabels")) {
       opts.atomLabels[boost::lexical_cast<int>(item.first)] =
           item.second.get_value<std::string>();
     }
   }
-  get_highlight_style_option(&pt, "multiColourHighlightStyle",
+  get_highlight_style_option(pt, "multiColourHighlightStyle",
                              opts.multiColourHighlightStyle);
 }
 

--- a/Code/MinimalLib/cffi_test.c
+++ b/Code/MinimalLib/cffi_test.c
@@ -2721,6 +2721,50 @@ void test_multi_highlights() {
   free(mpkl);
 }
 
+void test_bw_palette() {
+  printf("--------------------------\n");
+  printf("  bw palette\n");
+  const char *smi = "N";
+  const char *details = "{\"atomColourPalette\":\"bw\"}";
+  char *mpkl;
+  char *svg_with_details;
+  char *svg_without_details;
+  size_t mpkl_size;
+  mpkl = get_mol(smi, &mpkl_size, "");
+  assert(mpkl && mpkl_size);
+  svg_with_details = get_svg(mpkl, mpkl_size, details);
+  assert(strstr(svg_with_details, "#000000"));
+  assert(!strstr(svg_with_details, "#0000FF"));
+  svg_without_details = get_svg(mpkl, mpkl_size, "");
+  assert(!strstr(svg_without_details, "#000000"));
+  assert(strstr(svg_without_details, "#0000FF"));
+  free(svg_with_details);
+  free(svg_without_details);
+  free(mpkl);
+}
+
+void test_custom_palette() {
+  printf("--------------------------\n");
+  printf("  custom palette\n");
+  const char *smi = "N";
+  const char *details = "{\"atomColourPalette\":{\"7\":[1.0,0.0,0.0]}}";
+  char *mpkl;
+  char *svg_with_details;
+  char *svg_without_details;
+  size_t mpkl_size;
+  mpkl = get_mol(smi, &mpkl_size, "");
+  assert(mpkl && mpkl_size);
+  svg_with_details = get_svg(mpkl, mpkl_size, details);
+  assert(strstr(svg_with_details, "#FF0000"));
+  assert(!strstr(svg_with_details, "#0000FF"));
+  svg_without_details = get_svg(mpkl, mpkl_size, "");
+  assert(!strstr(svg_without_details, "#FF0000"));
+  assert(strstr(svg_without_details, "#0000FF"));
+  free(svg_with_details);
+  free(svg_without_details);
+  free(mpkl);
+}
+
 int main() {
   enable_logging();
   char *vers = version();
@@ -2756,5 +2800,7 @@ int main() {
   test_wedged_bond_atropisomer();
   test_get_molblock_use_molblock_wedging();
   test_multi_highlights();
+  test_bw_palette();
+  test_custom_palette();
   return 0;
 }

--- a/Code/MinimalLib/tests/tests.js
+++ b/Code/MinimalLib/tests/tests.js
@@ -3376,6 +3376,32 @@ function test_multi_highlights() {
     mol.delete();
 }
 
+function test_bw_palette() {
+    const mol = RDKitModule.get_mol('N');
+    assert(mol);
+    const details = '{"atomColourPalette":"bw"}';
+    const svgWithDetails = mol.get_svg_with_highlights(details);
+    assert(svgWithDetails.includes('#000000'));
+    assert(!svgWithDetails.includes('#0000FF'));
+    const svgWithoutDetails = mol.get_svg();
+    assert(!svgWithoutDetails.includes('#000000'));
+    assert(svgWithoutDetails.includes('#0000FF'));
+    mol.delete();
+}
+
+function test_custom_palette() {
+    const mol = RDKitModule.get_mol('N');
+    assert(mol);
+    const details = '{"atomColourPalette\":{"7":[1.0,0.0,0.0]}}';
+    const svgWithDetails = mol.get_svg_with_highlights(details);
+    assert(svgWithDetails.includes('#FF0000'));
+    assert(!svgWithDetails.includes('#0000FF'));
+    const svgWithoutDetails = mol.get_svg();
+    assert(!svgWithoutDetails.includes('#FF0000'));
+    assert(svgWithoutDetails.includes('#0000FF'));
+    mol.delete();
+}
+
 initRDKitModule().then(function(instance) {
     var done = {};
     const waitAllTestsFinished = () => {
@@ -3462,6 +3488,9 @@ initRDKitModule().then(function(instance) {
         test_singlecore_rgd();
         test_multicore_rgd();
     }
+    test_bw_palette();
+    test_custom_palette();
+
     waitAllTestsFinished().then(() =>
         console.log("Tests finished successfully")
     );


### PR DESCRIPTION
Small PR to expose preset color palettes to MinimalLib via JSON.
Custom palette could already be loaded via a JSON object as follows:
```
{
    "atomColourPalette": {
        "7", [1.0, 0.0, 0.0]
    }
}
```
Now in addition to the JSON object mapping atomic numbers to RGB(A) tuples, it is also possible to associate the `atomColourPalette` key to a string value chosen among `default, avalon, cdk, darkmode, bw` (all case-insensitive), e.g.:
```
{
    "atomColourPalette": "bw"
}
```
