### PR TITLE
Another 2x performance improvement in CIP labelling

### DIFF
--- a/Code/GraphMol/CIPLabeler/CIPMol.h
+++ b/Code/GraphMol/CIPLabeler/CIPMol.h
@@ -95,8 +95,7 @@ class CIPMol {
 
  private:
   ROMol &d_mol;
-  std::unique_ptr<RWMol> dp_kekulized_mol = nullptr;
-
+  std::vector<RDKit::Bond::BondType> d_kekulized_bonds;
   std::vector<boost::rational<int>> d_atomnums;
 };
 


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
For example, PDB ID 2ZP8 goes from 133s (after #7826) to 53s (this plus #7826) on my M3 laptop.

Boost graph edges (our bonds) cannot be accessed by index, they must be searched for - linearly. This protein only has 27,000 bonds (after addition of explicit hydrogens), but that's still a enough to make `getBondWithIdx()` a rate-limiting step.

For comparison, the sdgr suite does CIP labelling on 2ZP8 in 0.7s, so we're nowhere near the floor (I also don't think that 0.7 is the floor). I'm just proposing some easy fixes while I try to understand this code and figure out a plan.


