### PR TITLE
Fixes #7685

### DIFF
--- a/Code/GraphMol/Substruct/SubstructMatch.cpp
+++ b/Code/GraphMol/Substruct/SubstructMatch.cpp
@@ -175,7 +175,7 @@ void ResSubstructMatchHelper_(const ResSubstructMatchHelperArgs_ &args,
                               std::set<MatchVectType> *matches, unsigned int bi,
                               unsigned int ei);
 
-typedef std::list<
+typedef std::vector<
     std::pair<MolGraph::vertex_descriptor, MolGraph::vertex_descriptor>>
     ssPairType;
 
@@ -388,7 +388,7 @@ class AtomLabelFunctor {
  public:
   AtomLabelFunctor(const ROMol &query, const ROMol &mol,
                    const SubstructMatchParameters &ps)
-      : d_query(query), d_mol(mol), d_params(ps) {};
+      : d_query(query), d_mol(mol), d_params(ps){};
   bool operator()(unsigned int i, unsigned int j) const {
     bool res = false;
     if (d_params.useChirality) {
@@ -415,7 +415,7 @@ class BondLabelFunctor {
  public:
   BondLabelFunctor(const ROMol &query, const ROMol &mol,
                    const SubstructMatchParameters &ps)
-      : d_query(query), d_mol(mol), d_params(ps) {};
+      : d_query(query), d_mol(mol), d_params(ps){};
   bool operator()(MolGraph::edge_descriptor i,
                   MolGraph::edge_descriptor j) const {
     if (d_params.useChirality) {
@@ -503,7 +503,7 @@ std::vector<MatchVectType> SubstructMatch(
   detail::BondLabelFunctor bondLabeler(query, mol, params);
   MolMatchFinalCheckFunctor matchChecker(query, mol, params);
 
-  std::list<detail::ssPairType> pms;
+  std::vector<detail::ssPairType> pms;
 #if 0
   bool found=boost::ullmann_all(query.getTopology(),mol.getTopology(),
 				atomLabeler,bondLabeler,pms);
@@ -629,7 +629,7 @@ unsigned int RecursiveMatcher(const ROMol &mol, const ROMol &query,
 
   matches.clear();
   matches.resize(0);
-  std::list<detail::ssPairType> pms;
+  std::vector<detail::ssPairType> pms;
 #if 0
       bool found=boost::ullmann_all(query.getTopology(),mol.getTopology(),
 				    atomLabeler,bondLabeler,pms);

--- a/Code/GraphMol/Substruct/SubstructMatch.cpp
+++ b/Code/GraphMol/Substruct/SubstructMatch.cpp
@@ -201,9 +201,6 @@ bool MolMatchFinalCheckFunctor::operator()(const std::uint32_t q_c[],
   if (d_params.extraFinalCheck || d_params.useGenericMatchers) {
     // EFF: we can no-doubt do better than this
     std::vector<unsigned int> aids(m_c, m_c + d_query.getNumAtoms());
-    for (unsigned int i = 0; i < d_query.getNumAtoms(); ++i) {
-      aids[i] = m_c[i];
-    }
     if (d_params.useGenericMatchers &&
         !GenericGroups::genericAtomMatcher(d_mol, d_query, aids)) {
       return false;
@@ -388,7 +385,7 @@ class AtomLabelFunctor {
  public:
   AtomLabelFunctor(const ROMol &query, const ROMol &mol,
                    const SubstructMatchParameters &ps)
-      : d_query(query), d_mol(mol), d_params(ps){};
+      : d_query(query), d_mol(mol), d_params(ps) {};
   bool operator()(unsigned int i, unsigned int j) const {
     bool res = false;
     if (d_params.useChirality) {
@@ -415,7 +412,7 @@ class BondLabelFunctor {
  public:
   BondLabelFunctor(const ROMol &query, const ROMol &mol,
                    const SubstructMatchParameters &ps)
-      : d_query(query), d_mol(mol), d_params(ps){};
+      : d_query(query), d_mol(mol), d_params(ps) {};
   bool operator()(MolGraph::edge_descriptor i,
                   MolGraph::edge_descriptor j) const {
     if (d_params.useChirality) {

--- a/Code/GraphMol/Substruct/vf2.hpp
+++ b/Code/GraphMol/Substruct/vf2.hpp
@@ -555,8 +555,9 @@ class VF2SubState {
       GetCoreSet(c1, c2);
       if (MatchChecks(c1, c2)) {
         typename DoubleBackInsertionSequence::value_type newSeq;
+        newSeq.reserve(core_len);
         for (unsigned int i = 0; i < core_len; ++i) {
-          newSeq.push_back(std::pair<int, int>(c1[i], c2[i]));
+          newSeq.emplace_back(c1[i], c2[i]);
         }
         res.push_back(newSeq);
         return lim && res.size() >= lim;
@@ -638,10 +639,11 @@ bool vf2(const Graph &g1, const Graph &g2, VertexLabeling &vertex_labeling,
   int n = 0;
 
   F.clear();
-  F.resize(0);
   if (match(&n, ni1, ni2, s0)) {
-    for (unsigned int i = 0; i < num_vertices(g1); i++) {
-      F.push_back(std::pair<int, int>(ni1[i], ni2[i]));
+    auto sz = num_vertices(g1);
+    F.reserve(sz);
+    for (unsigned int i = 0; i < sz; ++i) {
+      F.emplace_back(ni1[i], ni2[i]);
     }
   }
   delete[] ni1;


### PR DESCRIPTION
The cause of the issue seems to be the bad performance of `std::list` in some C++ implementations (probably older ones). For large number of matches, like in the example issue description, this difference may become very large, making the call intractable.

This fixes the issue by replacing `std::list` with `std::vector`. I have benchmarked the change on 3 different platforms using the example script in the issue (maxMatches=1000000).

```
2019 Intel Mac on macOS 14.6.1 / xcode 16: 0.06 minutes
Intel i7-10870H / Ubuntu 22.04 / gcc 12.3.0: 0.35 minutes
Intel w5-2465X / Rocky8 container / gcc 11.3.0: ... never finishes running (I interrupted the run after several minutes).
```

After this patch:

```
2019 Intel Mac on macOS 14.6.1 / xcode 16: 0.03 minutes
Intel i7-10870H / Ubuntu 22.04 / gcc 12.3.0: 0.28 minutes
Intel w5-2465X / Rocky8 container / gcc 11.3.0: 0.20 minutes
```