### PR TITLE
Fix some mem errors in 2024.09.1

### DIFF
--- a/Code/GraphMol/CIPLabeler/catch_tests.cpp
+++ b/Code/GraphMol/CIPLabeler/catch_tests.cpp
@@ -825,12 +825,12 @@ TEST_CASE("AssignMandP", "[accurateCIP]") {
 
 TEST_CASE("upsertTest", "[basic]") {
   SECTION("upsertTest1") {
-    auto ps = SmilesParserParams();
+    auto ps = v2::SmilesParse::SmilesParserParams();
     ps.allowCXSMILES = true;
     ps.sanitize = true;
     ps.removeHs = false;
 
-    auto m = SmilesToMol(
+    auto m = v2::SmilesParse::MolFromSmiles(
         "CC1=C(C2=C(F)C=C(C(N)=O)C3=C2C2=C(C[C@@H](C(C)(C)O)CC2)N3)C=CC=C1N1C(=O)C2=C(C(F)=CC=C2)N(C)C1=O |(-0.0582,-1.2887,-0.4699;-0.138,-0.6553,-1.1342;-0.9031,-0.4893,-1.4844;-1.6332,-0.9186,-1.2186;-1.8741,-1.6494,-1.6034;-1.4248,-1.9619,-2.2208;-2.581,-2.0639,-1.3539;-3.069,-1.7619,-0.7143;-3.8054,-2.1982,-0.4602;-4.0043,-2.9212,-0.8738;-4.2532,-1.9338,0.1012;-2.8218,-1.0304,-0.3345;-2.1142,-0.6018,-0.5711;-2.0583,0.1027,-0.0552;-2.7239,0.0857,0.4696;-2.9136,0.6925,1.1267;-2.4007,1.4836,0.9934;-2.4335,2.0277,1.7578;-1.9128,2.8014,1.6418;-3.3209,2.2556,1.9643;-2.112,1.5747,2.4382;-1.4992,1.2797,0.7621;-1.4396,0.7778,-0.0395;-3.1799,-0.5981,0.3004;-0.9727,0.1003,-2.1031;-0.2773,0.5242,-2.3716;0.4878,0.3584,-2.0214;0.5573,-0.2316,-1.4028;1.3588,-0.3932,-1.0482;1.5905,0.0773,-0.3585;1.2002,0.6554,-0.0665;2.3933,-0.1194,0.0095;2.9068,-0.6967,-0.3594;3.6768,-0.8489,0.0041;4.2097,-1.3952,-0.3066;3.9217,-0.4363,0.7167;3.4017,0.1354,1.0788;2.6386,0.2956,0.7262;2.6425,-1.1179,-1.0794;3.1982,-1.7169,-1.457;1.8575,-1.0047,-1.4246;1.6168,-1.4364,-2.0026),wU:27.30|",
         ps);
 
@@ -867,7 +867,7 @@ TEST_CASE("atropisomers", "[basic]") {
       auto fName =
           rdbase + "/Code/GraphMol/FileParsers/test_data/atropisomers/" + file;
 
-      auto molsdf = MolFileToMol(fName, true, true, true);
+      std::unique_ptr<RWMol> molsdf(MolFileToMol(fName, true, true, true));
       REQUIRE(molsdf);
       CIPLabeler::assignCIPLabels(*molsdf, 100000);
 
@@ -897,12 +897,12 @@ TEST_CASE("atropisomers", "[basic]") {
           RDKit::SmilesWrite::CXSmilesFields::CX_ATOM_PROPS |
           RDKit::SmilesWrite::CXSmilesFields::CX_BOND_CFG |
           RDKit::SmilesWrite::CXSmilesFields::CX_BOND_ATROPISOMER;
-      SmilesParserParams pp;
+      v2::SmilesParse::SmilesParserParams pp;
       pp.allowCXSMILES = true;
       pp.sanitize = true;
 
       auto smi = MolToCXSmiles(*molsdf, wp, flags);
-      auto newMol = SmilesToMol(smi, pp);
+      auto newMol = v2::SmilesParse::MolFromSmiles(smi, pp);
       CIPLabeler::assignCIPLabels(*newMol, 100000);
 
       std::map<std::pair<unsigned int, unsigned int>, std::string> newCIPVals;

--- a/Code/GraphMol/ChemTransforms/MolFragmenter.cpp
+++ b/Code/GraphMol/ChemTransforms/MolFragmenter.cpp
@@ -1110,11 +1110,11 @@ std::unique_ptr<ROMol> molzip(std::vector<ROMOL_SPTR> &decomposition,
 
   auto combinedMol = decomposition[0];
   if (!mols.empty()) {
-    combinedMol.reset(
-        std::accumulate(mols.begin(), mols.end(), decomposition[0].get(),
-                        [](const auto *combined, const auto &mol) {
-                          return combineMols(*combined, *mol);
-                        }));
+    combinedMol = std::accumulate(
+        mols.begin(), mols.end(), decomposition[0],
+        [](const auto &combined, const auto &mol) {
+          return boost::shared_ptr<ROMol>(combineMols(*combined, *mol));
+        });
   }
   const static ROMol b;
   std::optional attachmentMappingOption = std::map<int, int>();

--- a/Code/GraphMol/DetermineBonds/catch_tests.cpp
+++ b/Code/GraphMol/DetermineBonds/catch_tests.cpp
@@ -416,12 +416,14 @@ TEST_CASE(
     "github #7299: DetermineBondOrders() does not assign single bonds correctly") {
   SECTION("as reported") {
     RWMol m;
-    m.addAtom(new Atom(6));
-    m.addAtom(new Atom(8));
-    m.addAtom(new Atom(8));
-    m.addAtom(new Atom(8));
-    m.addAtom(new Atom(1));
-    m.addAtom(new Atom(1));
+    bool updateLabel = true;
+    bool takeOwnership = true;
+    m.addAtom(new Atom(6), updateLabel, takeOwnership);
+    m.addAtom(new Atom(8), updateLabel, takeOwnership);
+    m.addAtom(new Atom(8), updateLabel, takeOwnership);
+    m.addAtom(new Atom(8), updateLabel, takeOwnership);
+    m.addAtom(new Atom(1), updateLabel, takeOwnership);
+    m.addAtom(new Atom(1), updateLabel, takeOwnership);
     m.addBond(0, 1, Bond::UNSPECIFIED);
     m.addBond(0, 2, Bond::UNSPECIFIED);
     m.addBond(0, 3, Bond::UNSPECIFIED);

--- a/Code/GraphMol/FileParsers/PDBParser.cpp
+++ b/Code/GraphMol/FileParsers/PDBParser.cpp
@@ -546,8 +546,9 @@ void BasicPDBCleanup(RWMol &mol) {
   }
 }
 
-void parsePdbBlock(RWMol *&mol, const char *str, bool sanitize, bool removeHs,
-                   unsigned int flavor, bool proximityBonding) {
+std::unique_ptr<RWMol> parsePdbBlock(const char *str, bool sanitize,
+                                     bool removeHs, unsigned int flavor,
+                                     bool proximityBonding) {
   PRECONDITION(str, "bad char ptr");
   std::map<int, Atom *> amap;
   std::map<Bond *, int> bmap;
@@ -555,6 +556,8 @@ void parsePdbBlock(RWMol *&mol, const char *str, bool sanitize, bool removeHs,
   bool multi_conformer = false;
   int conformer_atmidx = 0;
   Conformer *conf = nullptr;
+
+  std::unique_ptr<RWMol> mol;
 
   while (*str) {
     unsigned int len;
@@ -584,46 +587,46 @@ void parsePdbBlock(RWMol *&mol, const char *str, bool sanitize, bool removeHs,
         str[4] == ' ' && str[5] == ' ') {
       if (!multi_conformer) {
         if (!mol) {
-          mol = new RWMol();
+          mol.reset(new RWMol());
         }
-        PDBAtomLine(mol, str, len, flavor, amap);
+        PDBAtomLine(mol.get(), str, len, flavor, amap);
       } else {
-        PDBConformerLine(mol, str, len, conf, conformer_atmidx);
+        PDBConformerLine(mol.get(), str, len, conf, conformer_atmidx);
       }
       // HETATM records
     } else if (str[0] == 'H' && str[1] == 'E' && str[2] == 'T' &&
                str[3] == 'A' && str[4] == 'T' && str[5] == 'M') {
       if (!multi_conformer) {
         if (!mol) {
-          mol = new RWMol();
+          mol.reset(new RWMol());
         }
-        PDBAtomLine(mol, str, len, flavor, amap);
+        PDBAtomLine(mol.get(), str, len, flavor, amap);
       } else {
-        PDBConformerLine(mol, str, len, conf, conformer_atmidx);
+        PDBConformerLine(mol.get(), str, len, conf, conformer_atmidx);
       }
       // CONECT records
     } else if (str[0] == 'C' && str[1] == 'O' && str[2] == 'N' &&
                str[3] == 'E' && str[4] == 'C' && str[5] == 'T') {
       if (mol && !multi_conformer) {
-        PDBBondLine(mol, str, len, amap, bmap);
+        PDBBondLine(mol.get(), str, len, amap, bmap);
       }
       // COMPND records
     } else if (str[0] == 'C' && str[1] == 'O' && str[2] == 'M' &&
                str[3] == 'P' && str[4] == 'N' && str[5] == 'D') {
       if (!mol) {
-        mol = new RWMol();
+        mol.reset(new RWMol());
       }
       if (len > 10 &&
           (str[9] == ' ' || !strncmp(str + 9, "2 MOLECULE: ", 12))) {
-        PDBTitleLine(mol, str, len);
+        PDBTitleLine(mol.get(), str, len);
       }
       // HEADER records
     } else if (str[0] == 'H' && str[1] == 'E' && str[2] == 'A' &&
                str[3] == 'D' && str[4] == 'E' && str[5] == 'R') {
       if (!mol) {
-        mol = new RWMol();
+        mol.reset(new RWMol());
       }
-      PDBTitleLine(mol, str, len < 50 ? len : 50);
+      PDBTitleLine(mol.get(), str, len < 50 ? len : 50);
       // ENDMDL records
     } else if (str[0] == 'E' && str[1] == 'N' && str[2] == 'D' &&
                str[3] == 'M' && str[4] == 'D' && str[5] == 'L') {
@@ -638,15 +641,15 @@ void parsePdbBlock(RWMol *&mol, const char *str, bool sanitize, bool removeHs,
   }
 
   if (!mol) {
-    return;
+    return mol;
   }
 
   if (proximityBonding) {
-    ConnectTheDots(mol, ctdIGNORE_H_H_CONTACTS);
+    ConnectTheDots(mol.get(), ctdIGNORE_H_H_CONTACTS);
   }
   // flavor & 8 doesn't encode double bonds
   if (proximityBonding || flavor & 8) {
-    StandardPDBResidueBondOrders(mol);
+    StandardPDBResidueBondOrders(mol.get());
   }
 
   BasicPDBCleanup(*mol);
@@ -664,7 +667,9 @@ void parsePdbBlock(RWMol *&mol, const char *str, bool sanitize, bool removeHs,
 
   /* Set tetrahedral chirality from 3D co-ordinates */
   MolOps::assignChiralTypesFrom3D(*mol);
-  StandardPDBResidueChirality(mol);
+  StandardPDBResidueChirality(mol.get());
+
+  return mol;
 }
 }  // namespace
 
@@ -673,10 +678,8 @@ namespace FileParsers {
 
 std::unique_ptr<RWMol> MolFromPDBBlock(const std::string &str,
                                        const PDBParserParams &params) {
-  RWMol *res = nullptr;
-  parsePdbBlock(res, str.c_str(), params.sanitize, params.removeHs,
-                params.flavor, params.proximityBonding);
-  return std::unique_ptr<RWMol>(res);
+  return parsePdbBlock(str.c_str(), params.sanitize, params.removeHs,
+                       params.flavor, params.proximityBonding);
 }
 
 std::unique_ptr<RWMol> MolFromPDBDataStream(std::istream &inStream,

--- a/Code/GraphMol/FileParsers/file_parsers_catch.cpp
+++ b/Code/GraphMol/FileParsers/file_parsers_catch.cpp
@@ -7156,7 +7156,7 @@ class FragTest {
         expectedResult(expectedResultInit),
         reapplyMolBlockWedging(reapplyMolBlockWedgingInit),
         origSgroupCount(origSgroupCountInit),
-        newSgroupCount(newSgroupCountInit) {};
+        newSgroupCount(newSgroupCountInit){};
 };
 
 void testFragmentation(const FragTest &fragTest) {
@@ -7394,7 +7394,7 @@ TEST_CASE("MolToV2KMolBlock") {
     };
     for (const auto &smi : smileses) {
       INFO(smi);
-      auto m = SmilesToMol(smi);
+      auto m = v2::SmilesParse::MolFromSmiles(smi);
       REQUIRE(m);
       CHECK_THROWS_AS(MolToV2KMolBlock(*m), ValueErrorException);
     }

--- a/Code/GraphMol/FileParsers/molfile_stereo_catch.cpp
+++ b/Code/GraphMol/FileParsers/molfile_stereo_catch.cpp
@@ -635,7 +635,7 @@ M  V30 END CTAB
 M  END
 )CTAB";
 
-    auto m = MolBlockToMol(molblock, true, false, false);
+    std::unique_ptr<RWMol> m(MolBlockToMol(molblock, true, false, false));
 
     REQUIRE(m);
     CHECK(m->getBondWithIdx(1)->getStereo() == Bond::BondStereo::STEREONONE);

--- a/Code/GraphMol/FileParsers/testMolWriter.cpp
+++ b/Code/GraphMol/FileParsers/testMolWriter.cpp
@@ -1096,13 +1096,13 @@ void testV3000DoublePrecision() {
   rdbase += "/Code/GraphMol/FileParsers/test_data/";
   {
     std::string fName = rdbase + "precision.v3k.mol";
-    RWMol *mol = MolFileToMol(fName);
+    std::unique_ptr<RWMol> mol(MolFileToMol(fName));
     TEST_ASSERT(mol);
     size_t numAtoms = mol->getNumAtoms();
     TEST_ASSERT(numAtoms == 7);
     MolWriterParams params{true, true, true, 15};
     std::string molBlock = MolToMolBlock(*mol, params, -1);
-    RWMol *readMol = MolBlockToMol(molBlock);
+    std::unique_ptr<RWMol> readMol(MolBlockToMol(molBlock));
     TEST_ASSERT(numAtoms == readMol->getNumAtoms());
     const Conformer &conformer = mol->getConformer();
     const Conformer &readConformer = readMol->getConformer();

--- a/Code/GraphMol/FileParsers/v2_suppliers_catch.cpp
+++ b/Code/GraphMol/FileParsers/v2_suppliers_catch.cpp
@@ -115,7 +115,7 @@ TEST_CASE("MaeMolSupplier") {
     fName += "/Code/GraphMol/FileParsers/test_data/props_test.mae";
 
     MaeMolSupplier maesup(fName);
-    auto nmol = maesup.next();
+    std::unique_ptr<ROMol> nmol(maesup.next());
     TEST_ASSERT(nmol);
   }
 }

--- a/Code/GraphMol/Fingerprints/catch_tests.cpp
+++ b/Code/GraphMol/Fingerprints/catch_tests.cpp
@@ -798,7 +798,8 @@ TEST_CASE(
 TEST_CASE("github #7533: IndexError while computing fingerprint") {
   auto mol = "CC1C(B(C)C)S1(C)(C)=O"_smiles;
   REQUIRE(mol);
-  auto fp = MorganFingerprints::getFingerprint(*mol, 2);
+  std::unique_ptr<SparseIntVect<std::uint32_t>> fp(
+      MorganFingerprints::getFingerprint(*mol, 2));
   REQUIRE(fp);
   CHECK(fp->getLength() == std::numeric_limits<unsigned>::max());
 }

--- a/Code/GraphMol/MolEnumerator/enumerator_catch.cpp
+++ b/Code/GraphMol/MolEnumerator/enumerator_catch.cpp
@@ -1708,10 +1708,12 @@ M  END)CTAB"};
   };
 
   for (auto &[sru_label, expected_repetitions] : test_info) {
-    std::vector test_mols{
-        SmilesToMol(boost::str(boost::format(smiles_template) % sru_label)),
-        MolBlockToMol(
-            boost::str(boost::format(molblock_template) % sru_label))};
+    std::shared_ptr<RWMol> molFromSmi(
+        SmilesToMol(boost::str(boost::format(smiles_template) % sru_label)));
+    std::shared_ptr<RWMol> molFromMolBlock(MolBlockToMol(
+        boost::str(boost::format(molblock_template) % sru_label)));
+
+    std::vector test_mols{molFromSmi, molFromMolBlock};
 
     REQUIRE(test_mols[0]);
     REQUIRE(test_mols[1]);

--- a/Code/GraphMol/MolInterchange/Parser.cpp
+++ b/Code/GraphMol/MolInterchange/Parser.cpp
@@ -58,7 +58,7 @@ namespace MolInterchange {
 
 namespace {
 struct DefaultValueCache {
-  DefaultValueCache(const rj::Value &defs) : rjDefaults(defs) {};
+  DefaultValueCache(const rj::Value &defs) : rjDefaults(defs){};
   const rj::Value &rjDefaults;
   mutable std::map<const char *, int> intMap;
   mutable std::map<const char *, bool> boolMap;
@@ -970,10 +970,13 @@ std::vector<boost::shared_ptr<ROMol>> DocToMols(
     }
     for (const auto &molval : doc["molecules"].GetArray()) {
       auto *mol = new RWMol();
+
+      // Add the mol to res, so that it is managed in case processMol throws
+      res.emplace_back(static_cast<ROMol *>(mol));
+
       processMol(mol, molval, atomDefaults, bondDefaults, params);
       mol->updatePropertyCache(params.strictValenceCheck);
       mol->setProp(common_properties::_StereochemDone, 1);
-      res.emplace_back(static_cast<ROMol *>(mol));
     }
   }
 

--- a/Code/GraphMol/MolInterchange/Parser.cpp
+++ b/Code/GraphMol/MolInterchange/Parser.cpp
@@ -58,7 +58,7 @@ namespace MolInterchange {
 
 namespace {
 struct DefaultValueCache {
-  DefaultValueCache(const rj::Value &defs) : rjDefaults(defs){};
+  DefaultValueCache(const rj::Value &defs) : rjDefaults(defs) {};
   const rj::Value &rjDefaults;
   mutable std::map<const char *, int> intMap;
   mutable std::map<const char *, bool> boolMap;
@@ -969,14 +969,11 @@ std::vector<boost::shared_ptr<ROMol>> DocToMols(
       throw FileParseException("Bad Format: molecules is not an array");
     }
     for (const auto &molval : doc["molecules"].GetArray()) {
-      auto *mol = new RWMol();
-
-      // Add the mol to res, so that it is managed in case processMol throws
-      res.emplace_back(static_cast<ROMol *>(mol));
-
-      processMol(mol, molval, atomDefaults, bondDefaults, params);
+      std::unique_ptr<RWMol> mol(new RWMol());
+      processMol(mol.get(), molval, atomDefaults, bondDefaults, params);
       mol->updatePropertyCache(params.strictValenceCheck);
       mol->setProp(common_properties::_StereochemDone, 1);
+      res.emplace_back(static_cast<ROMol *>(mol.release()));
     }
   }
 

--- a/Code/GraphMol/catch_graphmol.cpp
+++ b/Code/GraphMol/catch_graphmol.cpp
@@ -3519,7 +3519,8 @@ $$$$
   bool strict_valences = false;
 
   SECTION("replace with a double bond") {
-    m->replaceBond(1, new Bond(Bond::BondType::DOUBLE));
+    auto b = Bond(Bond::BondType::DOUBLE);
+    m->replaceBond(1, &b);
     m->updatePropertyCache(strict_valences);
     CHECK(begin_atom->getNumExplicitHs() == 0);
     CHECK(begin_atom->getTotalValence() == 4);
@@ -3527,7 +3528,8 @@ $$$$
     CHECK(end_atom->getTotalValence() == 4);
   }
   SECTION("replace with a triple bond") {
-    m->replaceBond(1, new Bond(Bond::BondType::TRIPLE));
+    auto b = Bond(Bond::BondType::TRIPLE);
+    m->replaceBond(1, &b);
     m->updatePropertyCache(strict_valences);
     CHECK(begin_atom->getNumExplicitHs() == 0);
     CHECK(begin_atom->getTotalValence() == 5);  // Yeah, this is expected
@@ -3535,7 +3537,8 @@ $$$$
     CHECK(end_atom->getTotalValence() == 4);
   }
   SECTION("replace with a dative bond") {
-    m->replaceBond(1, new Bond(Bond::BondType::DATIVE));
+    auto b = Bond(Bond::BondType::DATIVE);
+    m->replaceBond(1, &b);
     m->updatePropertyCache(strict_valences);
     CHECK(begin_atom->getNumExplicitHs() == 1);
     CHECK(begin_atom->getTotalValence() == 4);

--- a/Code/GraphMol/test1.cpp
+++ b/Code/GraphMol/test1.cpp
@@ -1581,7 +1581,8 @@ void testHasValenceViolation() {
   auto to_mol = [](const auto &smiles) {
     int debugParse = 0;
     bool sanitize = false;
-    auto mol = RDKit::SmilesToMol(smiles, debugParse, sanitize);
+    std::unique_ptr<RWMol> mol(
+        RDKit::SmilesToMol(smiles, debugParse, sanitize));
     TEST_ASSERT(mol != nullptr);
     mol->updatePropertyCache(false);
     return mol;
@@ -1659,7 +1660,7 @@ void testHasValenceViolation() {
            "[!#6&!#7&!#8](-[#6])=[#6]",  // disallowed list
            "[#6&R](-[#6])=[#6]",         // advanced query features
        }) {
-    auto mol = RDKit::SmartsToMol(smarts);
+    auto mol = v2::SmilesParse::MolFromSmarts(smarts);
     for (auto atom : mol->atoms()) {
       TEST_ASSERT(!atom->hasValenceViolation());
     }
@@ -1684,7 +1685,7 @@ void testGithub6370() {
                  radicalType)
                     .str();
         }
-        RWMol *m = SmilesToMol(smi);
+        auto m = v2::SmilesParse::MolFromSmiles(smi);
         TEST_ASSERT(
             static_cast<int>(m->getAtomWithIdx(0)->getNumRadicalElectrons()) ==
             valence - explicitHCount);
@@ -1713,7 +1714,7 @@ void testGithub6370() {
   // where m = 1, ..., 7 denotes the radical type
   for (int radicalType = 1; radicalType <= 7; radicalType++) {
     std::string smi = (boost::format("[NH4+] |^%d:0|") % radicalType).str();
-    RWMol *m = SmilesToMol(smi);
+    auto m = v2::SmilesParse::MolFromSmiles(smi);
     TEST_ASSERT(
         static_cast<int>(m->getAtomWithIdx(0)->getNumRadicalElectrons()) == 0);
   }

--- a/External/INCHI-API/inchi.cpp
+++ b/External/INCHI-API/inchi.cpp
@@ -157,12 +157,12 @@ bool assignBondDirs(RWMol &mol, INT_PAIR_VECT &zBondPairs,
                 // not assigned, then add to queue
                 queue.push(std::make_pair(otherBond->getIdx(), _dir));
               }  // end if otherBond's bond direction check
-            }    // end if there is a match
-          }      // end loop over pairs in _rules
-        }        // end for _ to go thru rule sets
-      }          // end if this bond is assigned
-    }            // end if queue is empty
-  }              // end while on pending set and queue
+            }  // end if there is a match
+          }  // end loop over pairs in _rules
+        }  // end for _ to go thru rule sets
+      }  // end if this bond is assigned
+    }  // end if queue is empty
+  }  // end while on pending set and queue
   return true;
 }
 
@@ -1246,32 +1246,17 @@ void cleanUp(RWMol &mol) {
         break;
 
     }  // end the switch block
-  }    // end the for loop that iterates over atoms
+  }  // end the for loop that iterates over atoms
 }  // end cleanUp
-
-class ManagedCharArray {
- public:
-  ManagedCharArray() = delete;
-  ManagedCharArray(const std::string &str) : m_data(new char[str.size() + 1]) {
-    strcpy(m_data, str.c_str());
-  }
-  ~ManagedCharArray() { delete[] m_data; }
-  char *get() { return m_data; }
-
- private:
-  char *m_data = nullptr;
-};
-
 }  // namespace
 
 RWMol *InchiToMol(const std::string &inchi, ExtraInchiReturnValues &rv,
                   bool sanitize, bool removeHs) {
   // input
-  ManagedCharArray _inchi(inchi);
+  std::vector<char> _inchi(inchi.begin(), inchi.end());
   char options[1] = "";
-
   inchi_InputINCHI inchiInput;
-  inchiInput.szInChI = _inchi.get();
+  inchiInput.szInChI = _inchi.data();
   inchiInput.szOptions = options;
 
   // creating RWMol for return
@@ -1643,7 +1628,7 @@ RWMol *InchiToMol(const std::string &inchi, ExtraInchiReturnValues &rv,
                   << "Unrecognized stereo0D type (" << (int)stereo0DPtr->type
                   << ") is ignored!" << std::endl;
           }  // end switch stereotype
-        }    // end for loop over all stereo0D entries
+        }  // end for loop over all stereo0D entries
         // set the bond directions
         if (!assignBondDirs(*m, zBondPairs, eBondPairs)) {
           BOOST_LOG(rdWarningLog)
@@ -1651,7 +1636,7 @@ RWMol *InchiToMol(const std::string &inchi, ExtraInchiReturnValues &rv,
           ;
         }
       }  // end if (if stereo0D presents)
-    }    // end if (if return code is success)
+    }  // end if (if return code is success)
 
     // clean up
     FreeStructFromINCHI(&inchiOutput);

--- a/External/INCHI-API/inchi.cpp
+++ b/External/INCHI-API/inchi.cpp
@@ -1253,7 +1253,11 @@ void cleanUp(RWMol &mol) {
 RWMol *InchiToMol(const std::string &inchi, ExtraInchiReturnValues &rv,
                   bool sanitize, bool removeHs) {
   // input
-  std::vector<char> _inchi(inchi.begin(), inchi.end());
+  std::vector<char> _inchi;
+  _inchi.reserve(inchi.size() + 1);
+  std::copy(inchi.begin(), inchi.end(), std::back_inserter(_inchi));
+  _inchi.push_back('\0');
+
   char options[1] = "";
   inchi_InputINCHI inchiInput;
   inchiInput.szInChI = _inchi.data();

--- a/External/INCHI-API/inchi.cpp
+++ b/External/INCHI-API/inchi.cpp
@@ -157,12 +157,12 @@ bool assignBondDirs(RWMol &mol, INT_PAIR_VECT &zBondPairs,
                 // not assigned, then add to queue
                 queue.push(std::make_pair(otherBond->getIdx(), _dir));
               }  // end if otherBond's bond direction check
-            }  // end if there is a match
-          }  // end loop over pairs in _rules
-        }  // end for _ to go thru rule sets
-      }  // end if this bond is assigned
-    }  // end if queue is empty
-  }  // end while on pending set and queue
+            }    // end if there is a match
+          }      // end loop over pairs in _rules
+        }        // end for _ to go thru rule sets
+      }          // end if this bond is assigned
+    }            // end if queue is empty
+  }              // end while on pending set and queue
   return true;
 }
 
@@ -1246,18 +1246,32 @@ void cleanUp(RWMol &mol) {
         break;
 
     }  // end the switch block
-  }  // end the for loop that iterates over atoms
+  }    // end the for loop that iterates over atoms
 }  // end cleanUp
+
+class ManagedCharArray {
+ public:
+  ManagedCharArray() = delete;
+  ManagedCharArray(const std::string &str) : m_data(new char[str.size() + 1]) {
+    strcpy(m_data, str.c_str());
+  }
+  ~ManagedCharArray() { delete[] m_data; }
+  char *get() { return m_data; }
+
+ private:
+  char *m_data = nullptr;
+};
+
 }  // namespace
 
 RWMol *InchiToMol(const std::string &inchi, ExtraInchiReturnValues &rv,
                   bool sanitize, bool removeHs) {
   // input
-  char *_inchi = new char[inchi.size() + 1];
+  ManagedCharArray _inchi(inchi);
   char options[1] = "";
-  strcpy(_inchi, inchi.c_str());
+
   inchi_InputINCHI inchiInput;
-  inchiInput.szInChI = _inchi;
+  inchiInput.szInChI = _inchi.get();
   inchiInput.szOptions = options;
 
   // creating RWMol for return
@@ -1629,7 +1643,7 @@ RWMol *InchiToMol(const std::string &inchi, ExtraInchiReturnValues &rv,
                   << "Unrecognized stereo0D type (" << (int)stereo0DPtr->type
                   << ") is ignored!" << std::endl;
           }  // end switch stereotype
-        }  // end for loop over all stereo0D entries
+        }    // end for loop over all stereo0D entries
         // set the bond directions
         if (!assignBondDirs(*m, zBondPairs, eBondPairs)) {
           BOOST_LOG(rdWarningLog)
@@ -1637,10 +1651,9 @@ RWMol *InchiToMol(const std::string &inchi, ExtraInchiReturnValues &rv,
           ;
         }
       }  // end if (if stereo0D presents)
-    }  // end if (if return code is success)
+    }    // end if (if return code is success)
 
     // clean up
-    delete[] _inchi;
     FreeStructFromINCHI(&inchiOutput);
   }
 


### PR DESCRIPTION
I hadn't done a mem tests run in a while.

Most of these are pointers leaking from tests, but there's also a couple of real things there, like the PDB parsing thing or the `combineMol()` one.

Besides these, there's also https://github.com/rdkit/rdkit/issues/7865, and some more leaks I hit in Inchi, but those can't be fixed here (I'm also not sure I build against the last release).