### PR TITLE
Fix year typo in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,7 +136,7 @@ set(RDK_PYTHON_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/rdkit")
 
 #-------
 # Config variables:
-set(RDKit_Year "2023")
+set(RDKit_Year "2025")
 set(RDKit_Month "03")
 set(RDKit_Revision "1")
 set(RDKit_RevisionModifier "pre")


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

Fixes a typo in CMakeLists.txt introduced during the preparation for the next release cycle
