### PR TITLE
Prevent SIGSEGV in SplitMolByPDBResidues

### DIFF
--- a/Code/GraphMol/Wrap/MolOps.cpp
+++ b/Code/GraphMol/Wrap/MolOps.cpp
@@ -189,17 +189,19 @@ ROMol *renumberAtomsHelper(const ROMol &mol, python::object &pyNewOrder) {
 
 namespace {
 std::string getResidue(const ROMol &, const Atom *at) {
-  if (at->getMonomerInfo()->getMonomerType() != AtomMonomerInfo::PDBRESIDUE) {
+  auto monomerInfo = at->getMonomerInfo();
+  if (!monomerInfo || monomerInfo->getMonomerType() != AtomMonomerInfo::PDBRESIDUE) {
     return "";
   }
-  return static_cast<const AtomPDBResidueInfo *>(at->getMonomerInfo())
+  return static_cast<const AtomPDBResidueInfo *>(monomerInfo)
       ->getResidueName();
 }
 std::string getChainId(const ROMol &, const Atom *at) {
-  if (at->getMonomerInfo()->getMonomerType() != AtomMonomerInfo::PDBRESIDUE) {
+auto monomerInfo = at->getMonomerInfo();
+  if (!monomerInfo || monomerInfo->getMonomerType() != AtomMonomerInfo::PDBRESIDUE) {
     return "";
   }
-  return static_cast<const AtomPDBResidueInfo *>(at->getMonomerInfo())
+  return static_cast<const AtomPDBResidueInfo *>(monomerInfo)
       ->getChainId();
 }
 }  // namespace

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -8222,7 +8222,18 @@ M  END
                      "[NH2:1]c1ccccc1")
     self.assertEqual(Chem.MolToSmiles(mol, ignoreAtomMapNumbers=False),
                      "c1ccc([NH2:1])cc1")
-    
+
+  def testSplitMolByPDB(self):
+    mol = Chem.MolFromSmiles("C")
+    res2mol = Chem.SplitMolByPDBResidues(mol)
+    self.assertEqual(len(res2mol), 1)
+    self.assertIn("", res2mol)
+    assert len(res2mol) == 1
+    chain2mol = Chem.SplitMolByPDBChainId(mol)
+    self.assertEqual(len(chain2mol), 1)
+    self.assertIn("", chain2mol)
+    assert len(res2mol) == 1
+
 if __name__ == '__main__':
   if "RDTESTCASE" in os.environ:
     suite = unittest.TestSuite()

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -8228,11 +8228,9 @@ M  END
     res2mol = Chem.SplitMolByPDBResidues(mol)
     self.assertEqual(len(res2mol), 1)
     self.assertIn("", res2mol)
-    assert len(res2mol) == 1
     chain2mol = Chem.SplitMolByPDBChainId(mol)
     self.assertEqual(len(chain2mol), 1)
     self.assertIn("", chain2mol)
-    assert len(res2mol) == 1
 
 if __name__ == '__main__':
   if "RDTESTCASE" in os.environ:


### PR DESCRIPTION
#### Reference Issue
Fixes #5599 

#### What does this implement/fix? Explain your changes.
The `SplitMolByPDB*` functions dereference an `Atom`'s `MonomerInfo*` that may be null if the molecule was not loaded from a PDB. This leads to a `SEGFAULT` in Python.

This change adds a check for non-null `MonomerInfo*` before dereferencing it to avoid this crash.

#### Any other comments?

Added a basic unit test that calls these functions as in #5599