### PR TITLE
[CI]: temporarily be explicit about using the macos-12 image

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,7 +37,7 @@ jobs:
   pool:
     vmImage: macos-12
   variables:
-    compiler: clangxx_osx-64
+    compiler: clangxx_osx-64=18.1
     compiler_version: 12.0
     boost_version: 1.82.0
     number_of_cores: sysctl -n hw.ncpu

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,7 +35,7 @@ jobs:
 - job: macOS_x64
   timeoutInMinutes: 120
   pool:
-    vmImage: macos-latest
+    vmImage: macos-12
   variables:
     compiler: clangxx_osx-64
     compiler_version: 12.0
@@ -106,7 +106,7 @@ jobs:
 - job: macOS_x64_java
   timeoutInMinutes: 90
   pool:
-    vmImage: macos-latest
+    vmImage: macos-12
   variables:
     compiler: clangxx_osx-64
     compiler_version: 15.0


### PR DESCRIPTION
The Mac CI images no longer include conda by default: 
https://github.com/actions/runner-images/issues/9262 

We need to update the mac build scripts to install miniforge ourselves at some point, but before starting that dance, I wanted to get the CI builds working quickly.