### PR TITLE
Modernise ExplicitBitVect.

### DIFF
--- a/Code/DataStructs/BitOps.cpp
+++ b/Code/DataStructs/BitOps.cpp
@@ -238,7 +238,7 @@ bool EBVToBitmap(const ExplicitBitVect &bv, const unsigned char *&fp,
   if (!canUseBitmapHack) {
     return false;
   }
-  const auto *p1 = (const bitset_impl *)(const void *)bv.dp_bits;
+  const auto *p1 = (const bitset_impl *)(const void *)bv.dp_bits.get();
   // Run-time sanity check (just in case)
   if (p1->m_num_bits != bv.dp_bits->size()) {
     return false;

--- a/Code/DataStructs/ExplicitBitVect.h
+++ b/Code/DataStructs/ExplicitBitVect.h
@@ -37,6 +37,7 @@ class RDKIT_DATASTRUCTS_EXPORT ExplicitBitVect : public BitVect {
   //! initialize with a particular size and all bits set
   ExplicitBitVect(unsigned int size, bool bitsSet);
   ExplicitBitVect(const ExplicitBitVect &other);
+  ExplicitBitVect(ExplicitBitVect &&other) noexcept;
   //! construct from a string pickle
   ExplicitBitVect(const std::string &pkl);
   //! construct from a text pickle
@@ -51,6 +52,7 @@ class RDKIT_DATASTRUCTS_EXPORT ExplicitBitVect : public BitVect {
   ~ExplicitBitVect() override;
 
   ExplicitBitVect &operator=(const ExplicitBitVect &other);
+  ExplicitBitVect &operator=(ExplicitBitVect &&other) noexcept;
   bool operator[](const unsigned int which) const override;
   bool setBit(const unsigned int which) override;
   bool unsetBit(const unsigned int which) override;
@@ -78,7 +80,8 @@ class RDKIT_DATASTRUCTS_EXPORT ExplicitBitVect : public BitVect {
   void clearBits() override { dp_bits->reset(); }
   std::string toString() const override;
 
-  boost::dynamic_bitset<> *dp_bits{nullptr};  //!< our raw storage
+  std::unique_ptr<boost::dynamic_bitset<>> dp_bits{
+      nullptr};  //!< our raw storage
 
   bool operator==(const ExplicitBitVect &o) const {
     return *dp_bits == *o.dp_bits;


### PR DESCRIPTION
#### Reference Issue
No issue


#### What does this implement/fix? Explain your changes.
Holds the bitset in a unique_ptr rather than a raw pointer.
Adds move c'tor and move operator=.
Some minor tidying.

#### Any other comments?
Technically, this is a breaking change because someone could be uncouth enough to be using dp_bits directly, since it's public.  Maybe it should be made private?
