### PR TITLE
Fixes #7873

### DIFF
--- a/Code/GraphMol/Atom.cpp
+++ b/Code/GraphMol/Atom.cpp
@@ -624,6 +624,11 @@ int Atom::calcImplicitValence(bool strict) {
   return d_implicitValence;
 }
 
+void Atom::setMonomerInfo(AtomMonomerInfo *info) {
+  delete dp_monomerInfo;
+  dp_monomerInfo = info;
+}
+  
 void Atom::setIsotope(unsigned int what) { d_isotope = what; }
 
 double Atom::getMass() const {

--- a/Code/GraphMol/Atom.h
+++ b/Code/GraphMol/Atom.h
@@ -385,10 +385,7 @@ class RDKIT_GRAPHMOL_EXPORT Atom : public RDProps {
   AtomMonomerInfo *getMonomerInfo() { return dp_monomerInfo; }
   const AtomMonomerInfo *getMonomerInfo() const { return dp_monomerInfo; }
   //! takes ownership of the pointer
-  void setMonomerInfo(AtomMonomerInfo *info) {
-    delete dp_monomerInfo;
-    dp_monomerInfo = info;
-  }
+  void setMonomerInfo(AtomMonomerInfo *info);
 
   //! Set the atom map Number of the atom
   void setAtomMapNum(int mapno, bool strict = true) {

--- a/Code/GraphMol/Atom.h
+++ b/Code/GraphMol/Atom.h
@@ -385,7 +385,10 @@ class RDKIT_GRAPHMOL_EXPORT Atom : public RDProps {
   AtomMonomerInfo *getMonomerInfo() { return dp_monomerInfo; }
   const AtomMonomerInfo *getMonomerInfo() const { return dp_monomerInfo; }
   //! takes ownership of the pointer
-  void setMonomerInfo(AtomMonomerInfo *info) { dp_monomerInfo = info; }
+  void setMonomerInfo(AtomMonomerInfo *info) {
+    delete dp_monomerInfo;
+    dp_monomerInfo = info;
+  }
 
   //! Set the atom map Number of the atom
   void setAtomMapNum(int mapno, bool strict = true) {

--- a/Code/GraphMol/Wrap/Atom.cpp
+++ b/Code/GraphMol/Wrap/Atom.cpp
@@ -104,7 +104,11 @@ std::string AtomGetSmarts(const Atom *atom, bool doKekule, bool allHsExplicit,
 }
 
 void SetAtomMonomerInfo(Atom *atom, const AtomMonomerInfo *info) {
-  atom->setMonomerInfo(info->copy());
+  if(!info) {
+    atom->setMonomerInfo(nullptr);
+  } else {
+    atom->setMonomerInfo(info->copy());
+  }
 }
 
 AtomMonomerInfo *AtomGetMonomerInfo(Atom *atom) {
@@ -112,6 +116,12 @@ AtomMonomerInfo *AtomGetMonomerInfo(Atom *atom) {
 }
 
 void AtomSetPDBResidueInfo(Atom *atom, const AtomMonomerInfo *info) {
+  if(!info) {
+    // This clears out the monomer info
+    atom->setMonomerInfo(nullptr);
+    return;
+  }
+  
   if (info->getMonomerType() != AtomMonomerInfo::PDBRESIDUE) {
     throw_value_error("MonomerInfo is not a PDB Residue");
   }

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -8222,6 +8222,10 @@ M  END
                      "[NH2:1]c1ccccc1")
     self.assertEqual(Chem.MolToSmiles(mol, ignoreAtomMapNumbers=False),
                      "c1ccc([NH2:1])cc1")
+
+  def github7873(self):
+    # this segfaults
+    Chem.MolFromSmiles("C").GetAtomWithIdx(0).SetPDBResidueInfo(None)
     
 if __name__ == '__main__':
   if "RDTESTCASE" in os.environ:


### PR DESCRIPTION
This fixes two issues, one when calling setMonomorInfo with a nullptr would leak an existing residue, second, the python API would try to dereference a nullptr causing a segmentation fault.

Both are resolved. 