### PR TITLE
[IterateCIPRanks] Precompute neighbor indices and counts, sort them together for each atom

### DIFF
--- a/Code/GraphMol/Chirality.cpp
+++ b/Code/GraphMol/Chirality.cpp
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2004-2021 Greg Landrum and other RDKit contributors
+//  Copyright (C) 2004-2024 Greg Landrum and other RDKit contributors
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.

--- a/Code/GraphMol/Chirality.cpp
+++ b/Code/GraphMol/Chirality.cpp
@@ -1225,8 +1225,8 @@ void iterateCIPRanks(const ROMol &mol, const DOUBLE_VECT &invars,
       // to our cipEntry in reverse rank order, where N is the weight.
       if (numNeighbors > 1) {  // compare vs 1 for performance.
         std::sort(sortBegin, sortEnd,
-                  [&ranks](const std::pair<int, int>& countAndIdx1,
-                           const std::pair<int, int>& countAndIdx2) {
+                  [&ranks](const std::pair<std::uint8_t, int>& countAndIdx1,
+                           const std::pair<std::uint8_t, int>& countAndIdx2) {
                     return ranks[countAndIdx1.second] > ranks[countAndIdx2.second];
                   });
       }


### PR DESCRIPTION
#### Reference Issue
Partial implementation of #7888


#### What does this implement/fix? Explain your changes.

Pulled neighbor assignment and counts out of the iteration loop. The idx and count are paired for sorting. Each atom is strided up to 8 bond partners, but only the actual number of partners is 

#### Any other comments?
The bulk of the diff is extracting the counting functionality from the core loop verbatim.

Perf implications are discussed in the issue - but the reported values are for this combined with two followup PRs
