### PR TITLE
Expose three ROMol methods which were not previously exposed to SWIG wrappers

### DIFF
--- a/Code/JavaWrappers/ROMol.i
+++ b/Code/JavaWrappers/ROMol.i
@@ -438,6 +438,18 @@ unsigned int getDefaultPickleProperties();
     RDKit::ClearSingleBondDirFlags(*($self));
   };
 
+  void reapplyMolBlockWedging() {
+    RDKit::Chirality::reapplyMolBlockWedging(*($self));
+  }
+
+  void clearMolBlockWedgingInfo() {
+    RDKit::Chirality::clearMolBlockWedgingInfo(*($self));
+  }
+
+  void invertMolBlockWedgingInfo() {
+    RDKit::Chirality::invertMolBlockWedgingInfo(*($self));
+  }
+
   /* Methods from ConjugHybrid.cpp */
   void setConjugation() {
     RDKit::MolOps::setConjugation(*($self));


### PR DESCRIPTION
@greglandrum As you may remember, this is something that we noticed while updating the KNIME depiction nodes. We worked around the missing methods in the current KNIME nodes by creating an `RWMol` copy of the `ROMol`, which is suboptimal for performance reasons.
This PR obviates the problem.