### PR TITLE
Restore "oops, exponential is a pain" code snippet in the RGD algorithm

### DIFF
--- a/Code/GraphMol/RGroupDecomposition/RGroupDecomp.cpp
+++ b/Code/GraphMol/RGroupDecomposition/RGroupDecomp.cpp
@@ -388,11 +388,14 @@ int RGroupDecomposition::add(const ROMol &inmol) {
   // Exhaustive - saves all matches and optimizes later exhaustive
   //               May never finish due to combinatorial complexity
   // Greedy - matches to *FIRST* available match
-  // GreedyChunks - default - process every N chunks
+  // GreedyChunks - default - process every N chunks, unless
+  // MAX_PERMUTATIONS is exceeded, in which case it falls back to
+  // Greedy
 
   //  Should probably scan all mols first to find match with
   //  smallest number of matches...
   std::vector<RGroupMatch> potentialMatches;
+  constexpr size_t MAX_PERMUTATIONS = 100000;
 
   std::unique_ptr<ROMol> tMol;
   for (const auto &tmatche : tmatches) {
@@ -559,8 +562,10 @@ int RGroupDecomposition::add(const ROMol &inmol) {
       size_t sz = matche->size();
       N *= sz;
     }
-    // oops, exponential is a pain
-    if (N * potentialMatches.size() > 100000) {
+    // Highly symmetric cores can lead to a very large number of
+    // permutations to test. Fall back to Greedy when the number
+    // is too high.
+    if (N * potentialMatches.size() > MAX_PERMUTATIONS) {
       data->process(data->prunePermutations);
     }
   }

--- a/Code/GraphMol/RGroupDecomposition/RGroupDecomp.cpp
+++ b/Code/GraphMol/RGroupDecomposition/RGroupDecomp.cpp
@@ -552,11 +552,18 @@ int RGroupDecomposition::add(const ROMol &inmol) {
     return -2;
   }
 
-  // in case the value ends up being changed in a future version of the code:
-  if (data->prunePermutations) {
-    data->permutationProduct = 1;
+  if (data->params.matchingStrategy != GA) {
+    size_t N = 1;
+    for (auto matche = data->matches.begin() + data->previousMatchSize;
+         matche != data->matches.end(); ++matche) {
+      size_t sz = matche->size();
+      N *= sz;
+    }
+    // oops, exponential is a pain
+    if (N * potentialMatches.size() > 100000) {
+      data->process(data->prunePermutations);
+    }
   }
-
   data->matches.push_back(std::move(potentialMatches));
 
   if (!data->matches.empty()) {

--- a/Code/GraphMol/RGroupDecomposition/RGroupDecomp.cpp
+++ b/Code/GraphMol/RGroupDecomposition/RGroupDecomp.cpp
@@ -390,7 +390,7 @@ int RGroupDecomposition::add(const ROMol &inmol) {
   // Greedy - matches to *FIRST* available match
   // GreedyChunks - default - process every N chunks, unless
   // MAX_PERMUTATIONS is exceeded, in which case it falls back to
-  // Greedy
+  // Greedy for the current chunk
 
   //  Should probably scan all mols first to find match with
   //  smallest number of matches...
@@ -563,8 +563,8 @@ int RGroupDecomposition::add(const ROMol &inmol) {
       N *= sz;
     }
     // Highly symmetric cores can lead to a very large number of
-    // permutations to test. Fall back to Greedy when the number
-    // is too high.
+    // permutations to test. Fall back to Greedy for the current chunk
+    // when the number is too high.
     if (N * potentialMatches.size() > MAX_PERMUTATIONS) {
       data->process(data->prunePermutations);
     }

--- a/Code/GraphMol/RGroupDecomposition/RGroupDecompData.h
+++ b/Code/GraphMol/RGroupDecomposition/RGroupDecompData.h
@@ -26,9 +26,6 @@ struct RGroupDecompData {
   std::map<int, RCore> cores;
   std::map<std::string, int> newCores;  // new "cores" found along the way
   int newCoreLabel = EMPTY_CORE_LABEL;
-  // this caches the running product of permutations
-  // across calls to process()
-  size_t permutationProduct = 1;
   // this caches the size of the previous matches vector
   // such that the size of the current chunk can be inferred
   size_t previousMatchSize = 0;


### PR DESCRIPTION
Restores a RGD code snippet that was intentionally removed in #7186 because 1. it is unclear 2. it is not tested 3. It introduced an undocumented change in the documented `GreedyChunks` behavior based on an arbitrary threshold. Discussed in #7896.