### PR TITLE
Switch from awful macros to Better Enums for enum reflection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,6 +164,18 @@ if(NOT Catch2_FOUND)
   FetchContent_MakeAvailable(Catch2)
 endif()
 
+#include better-enums
+find_package(better_enums 0 QUIET)
+if(NOT better_enums)
+  Include(FetchContent)
+
+  FetchContent_Declare(
+    better_enums
+    GIT_REPOSITORY https://github.com/aantron/better-enums.git
+    GIT_TAG        0.11.3 # or a later release
+  )
+endif()
+
 if(RDK_INSTALL_INTREE)
   set(RDKit_BinDir "${CMAKE_SOURCE_DIR}/bin")
   set(RDKit_LibDir "${CMAKE_SOURCE_DIR}/lib")

--- a/Code/GraphMol/CIPLabeler/catch_tests.cpp
+++ b/Code/GraphMol/CIPLabeler/catch_tests.cpp
@@ -843,7 +843,8 @@ TEST_CASE("upsertTest", "[basic]") {
     auto smilesWriteParams = SmilesWriteParams();
     smilesWriteParams.canonical = true;
     auto smilesOut =
-        MolToCXSmiles(*m, smilesWriteParams, flags, RestoreBondDirOptionClear);
+        MolToCXSmiles(*m, smilesWriteParams, flags,
+                      RestoreBondDirOption::RestoreBondDirOptionClear);
     CHECK(smilesOut != "");
   }
 }

--- a/Code/GraphMol/FileParsers/testAtropisomers.cpp
+++ b/Code/GraphMol/FileParsers/testAtropisomers.cpp
@@ -137,8 +137,8 @@ class MolAtropTest {
             //| SmilesWrite::CXSmilesFields::CX_ALL
             ;
 
-        std::string smilesOut =
-            MolToCXSmiles(*mol, ps, flags, RestoreBondDirOptionTrue);
+        std::string smilesOut = MolToCXSmiles(
+            *mol, ps, flags, RestoreBondDirOption::RestoreBondDirOptionTrue);
 
         generateNewExpectedFilesIfSoSpecified(fName + ".NEW.cxsmi", smilesOut);
 

--- a/Code/GraphMol/MarvinParse/testMrvToMol.cpp
+++ b/Code/GraphMol/MarvinParse/testMrvToMol.cpp
@@ -728,9 +728,9 @@ class MrvTests {
                              SmilesWrite::CXSmilesFields::CX_SGROUPS |
                              SmilesWrite::CXSmilesFields::CX_POLYMER;
 
-        auto restoreDir = RestoreBondDirOptionTrue;
+        auto restoreDir = RestoreBondDirOption::RestoreBondDirOptionTrue;
         if (!molFileTest->reapplyMolBlockWedging) {
-          restoreDir = RestoreBondDirOptionClear;
+          restoreDir = RestoreBondDirOption::RestoreBondDirOptionClear;
         }
 
         std::string smilesOut = MolToCXSmiles(*mol, ps, flags, restoreDir);

--- a/Code/GraphMol/MolDraw2D/MolDraw2DUtils.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DUtils.cpp
@@ -26,6 +26,7 @@
 #include <boost/lexical_cast.hpp>
 #include <boost/property_tree/ptree.hpp>
 #include <boost/property_tree/json_parser.hpp>
+#include <boost/algorithm/string.hpp>
 #include <RDGeneral/BoostEndInclude.h>
 #include <limits>
 #include <cmath>
@@ -129,40 +130,64 @@ void get_rgba(const boost::property_tree::ptree &node, DrawColour &colour) {
   }
 }
 
-void get_colour_option(boost::property_tree::ptree *pt, const char *pnm,
+void get_colour_option(const boost::property_tree::ptree &pt, const char *pnm,
                        DrawColour &colour) {
   PRECONDITION(pnm && strlen(pnm), "bad property name");
-  if (pt->find(pnm) == pt->not_found()) {
+  if (pt.find(pnm) == pt.not_found()) {
     return;
   }
 
-  const auto &node = pt->get_child(pnm);
+  const auto &node = pt.get_child(pnm);
   get_rgba(node, colour);
 }
 
-void get_colour_palette_option(boost::property_tree::ptree *pt, const char *pnm,
-                               ColourPalette &palette) {
+void get_colour_palette_option(const boost::property_tree::ptree &pt,
+                               const char *pnm, ColourPalette &palette) {
   PRECONDITION(pnm && strlen(pnm), "bad property name");
-  if (pt->find(pnm) == pt->not_found()) {
+  static const std::map<std::string, void (*)(ColourPalette &)>
+      PRESET_PALETTE_MAP{
+          {"default", assignDefaultPalette},
+          {"avalon", assignAvalonPalette},
+          {"cdk", assignCDKPalette},
+          {"darkmode", assignDarkModePalette},
+          {"bw", assignBWPalette},
+      };
+  auto atomColourPaletteIt = pt.find(pnm);
+  if (atomColourPaletteIt == pt.not_found()) {
     return;
   }
-
-  for (const auto &atomicNumNodeIt : pt->get_child(pnm)) {
-    int atomicNum = boost::lexical_cast<int>(atomicNumNodeIt.first);
-    DrawColour colour;
-    get_rgba(atomicNumNodeIt.second, colour);
-    palette[atomicNum] = colour;
+  // Does the "atomColourPalette" key correspond to a terminal value?
+  if (atomColourPaletteIt->second.empty()) {
+    const auto &v = atomColourPaletteIt->second.data();
+    if (v.empty()) {
+      return;
+    }
+    auto paletteName = boost::lexical_cast<std::string>(v);
+    boost::algorithm::to_lower(paletteName);
+    auto preSetPaletteIt = PRESET_PALETTE_MAP.find(paletteName);
+    if (preSetPaletteIt == PRESET_PALETTE_MAP.end()) {
+      return;
+    }
+    // Populate the palette calling the corresponding function
+    preSetPaletteIt->second(palette);
+  } else {
+    for (const auto &atomicNumNode : atomColourPaletteIt->second) {
+      int atomicNum = boost::lexical_cast<int>(atomicNumNode.first);
+      DrawColour colour;
+      get_rgba(atomicNumNode.second, colour);
+      palette[atomicNum] = colour;
+    }
   }
 }
 
-void get_highlight_style_option(boost::property_tree::ptree *pt,
+void get_highlight_style_option(const boost::property_tree::ptree &pt,
                                 const char *pnm,
                                 MultiColourHighlightStyle &mchs) {
   PRECONDITION(pnm && strlen(pnm), "bad property name");
-  if (pt->find(pnm) == pt->not_found()) {
+  if (pt.find(pnm) == pt.not_found()) {
     return;
   }
-  const auto &node = pt->get_child(pnm);
+  const auto &node = pt.get_child(pnm);
   auto styleStr = node.get_value<std::string>();
   if (styleStr == "Lasso") {
     mchs = MultiColourHighlightStyle::LASSO;
@@ -232,22 +257,22 @@ void updateMolDrawOptionsFromJSON(MolDrawOptions &opts,
   PT_OPT_GET(drawMolsSameScale);
   PT_OPT_GET(useComplexQueryAtomSymbols);
 
-  get_colour_option(&pt, "highlightColour", opts.highlightColour);
-  get_colour_option(&pt, "backgroundColour", opts.backgroundColour);
-  get_colour_option(&pt, "queryColour", opts.queryColour);
-  get_colour_option(&pt, "legendColour", opts.legendColour);
-  get_colour_option(&pt, "symbolColour", opts.symbolColour);
-  get_colour_option(&pt, "annotationColour", opts.annotationColour);
-  get_colour_option(&pt, "variableAttachmentColour",
+  get_colour_option(pt, "highlightColour", opts.highlightColour);
+  get_colour_option(pt, "backgroundColour", opts.backgroundColour);
+  get_colour_option(pt, "queryColour", opts.queryColour);
+  get_colour_option(pt, "legendColour", opts.legendColour);
+  get_colour_option(pt, "symbolColour", opts.symbolColour);
+  get_colour_option(pt, "annotationColour", opts.annotationColour);
+  get_colour_option(pt, "variableAttachmentColour",
                     opts.variableAttachmentColour);
-  get_colour_palette_option(&pt, "atomColourPalette", opts.atomColourPalette);
+  get_colour_palette_option(pt, "atomColourPalette", opts.atomColourPalette);
   if (pt.find("atomLabels") != pt.not_found()) {
     for (const auto &item : pt.get_child("atomLabels")) {
       opts.atomLabels[boost::lexical_cast<int>(item.first)] =
           item.second.get_value<std::string>();
     }
   }
-  get_highlight_style_option(&pt, "multiColourHighlightStyle",
+  get_highlight_style_option(pt, "multiColourHighlightStyle",
                              opts.multiColourHighlightStyle);
 }
 

--- a/Code/GraphMol/MolHash/hashfunctions.cpp
+++ b/Code/GraphMol/MolHash/hashfunctions.cpp
@@ -29,9 +29,10 @@ namespace {
 
 void addCXExtensions(RDKit::RWMol *mol, std::string &result,
                      unsigned additionalSkips = 0) {
-  unsigned int cxflagsToSkip = additionalSkips | RDKit::SmilesWrite::CX_COORDS;
+  unsigned int cxflagsToSkip =
+      additionalSkips | RDKit::SmilesWrite::CXSmilesFields::CX_COORDS;
   auto cxext = RDKit::SmilesWrite::getCXExtensions(
-      *mol, RDKit::SmilesWrite::CX_ALL ^ cxflagsToSkip);
+      *mol, RDKit::SmilesWrite::CXSmilesFields::CX_ALL ^ cxflagsToSkip);
   if (!cxext.empty()) {
     result += " " + cxext;
   }
@@ -336,7 +337,8 @@ std::string AnonymousGraph(RWMol *mol, bool elem, bool useCXSmiles,
   result = convertToSmilesWithCXFlags(*mol, useCXSmiles);
 
   if (useCXSmiles) {
-    addCXExtensions(mol, result, cxFlagsToSkip | SmilesWrite::CX_RADICALS);
+    addCXExtensions(mol, result,
+                    cxFlagsToSkip | SmilesWrite::CXSmilesFields::CX_RADICALS);
   }
 
   return result;
@@ -373,7 +375,8 @@ std::string MesomerHash(RWMol *mol, bool netq, bool useCXSmiles,
     result += buffer;
   }
   if (useCXSmiles) {
-    addCXExtensions(mol, result, cxFlagsToSkip | SmilesWrite::CX_RADICALS);
+    addCXExtensions(mol, result,
+                    cxFlagsToSkip | SmilesWrite::CXSmilesFields::CX_RADICALS);
   }
   return result;
 }
@@ -674,7 +677,8 @@ std::string TautomerHashv2(RWMol *mol, bool proto, bool useCXSmiles,
   }
   result += buffer;
   if (useCXSmiles) {
-    addCXExtensions(mol, result, cxFlagsToSkip | SmilesWrite::CX_RADICALS);
+    addCXExtensions(mol, result,
+                    cxFlagsToSkip | SmilesWrite::CXSmilesFields::CX_RADICALS);
   }
 
   return result;
@@ -723,7 +727,8 @@ std::string TautomerHash(RWMol *mol, bool proto, bool useCXSmiles,
   }
   result += buffer;
   if (useCXSmiles) {
-    addCXExtensions(mol, result, cxFlagsToSkip | SmilesWrite::CX_RADICALS);
+    addCXExtensions(mol, result,
+                    cxFlagsToSkip | SmilesWrite::CXSmilesFields::CX_RADICALS);
   }
 
   return result;
@@ -836,7 +841,8 @@ std::string ExtendedMurckoScaffold(RWMol *mol, bool useCXSmiles,
   std::string result;
   result = convertToSmilesWithCXFlags(*mol, useCXSmiles);
   if (useCXSmiles) {
-    addCXExtensions(mol, result, cxFlagsToSkip | SmilesWrite::CX_RADICALS);
+    addCXExtensions(mol, result,
+                    cxFlagsToSkip | SmilesWrite::CXSmilesFields::CX_RADICALS);
   }
   return result;
 }
@@ -880,7 +886,8 @@ std::string MurckoScaffoldHash(RWMol *mol, bool useCXSmiles,
   std::string result;
   result = convertToSmilesWithCXFlags(*mol, useCXSmiles);
   if (useCXSmiles) {
-    addCXExtensions(mol, result, cxFlagsToSkip | SmilesWrite::CX_RADICALS);
+    addCXExtensions(mol, result,
+                    cxFlagsToSkip | SmilesWrite::CXSmilesFields::CX_RADICALS);
   }
   return result;
 }

--- a/Code/GraphMol/RGroupDecomposition/GaExample.cpp
+++ b/Code/GraphMol/RGroupDecomposition/GaExample.cpp
@@ -130,7 +130,7 @@ int main(int argc, char *argv[]) {
   }
 
   RGroupDecompositionParameters parameters;
-  parameters.scoreMethod = FingerprintVariance;
+  parameters.scoreMethod = RGroupScore::FingerprintVariance;
   parameters.gaMaximumOperations = vm["maximumOperations"].as<int>();
   parameters.gaNumberOperationsWithoutImprovement =
       vm["numberOperationsWithoutImprovement"].as<int>();
@@ -139,9 +139,9 @@ int main(int argc, char *argv[]) {
   parameters.gaNumberRuns = vm["numberRuns"].as<int>();
   auto strategyString = vm["matchingStrategy"].as<string>();
   if (strategyString == "GA") {
-    parameters.matchingStrategy = GA;
+    parameters.matchingStrategy = RGroupMatching::GA;
   } else if (strategyString == "GreedyChunks") {
-    parameters.matchingStrategy = GreedyChunks;
+    parameters.matchingStrategy = RGroupMatching::GreedyChunks;
   } else {
     cerr << "Unknown matching strategy " << strategyString << endl;
     return 0;

--- a/Code/GraphMol/RGroupDecomposition/RGroupDecomp.cpp
+++ b/Code/GraphMol/RGroupDecomposition/RGroupDecomp.cpp
@@ -361,12 +361,12 @@ int RGroupDecomposition::add(const ROMol &inmol) {
   }
 
   if (tmatches.size() > 1) {
-    if (data->params.matchingStrategy == NoSymmetrization) {
+    if (data->params.matchingStrategy == RGroupMatching::NoSymmetrization) {
       tmatches.resize(1);
     } else if (data->matches.size() == 0) {
       // Greedy strategy just grabs the first match and
       //  takes the best matches from the rest
-      if (data->params.matchingStrategy == Greedy) {
+      if (data->params.matchingStrategy == RGroupMatching::Greedy) {
         tmatches.resize(1);
       }
     }
@@ -572,8 +572,8 @@ int RGroupDecomposition::add(const ROMol &inmol) {
   data->matches.push_back(std::move(potentialMatches));
 
   if (!data->matches.empty()) {
-    if (data->params.matchingStrategy & Greedy ||
-        (data->params.matchingStrategy & GreedyChunks &&
+    if (data->params.matchingStrategy & RGroupMatching::Greedy ||
+        (data->params.matchingStrategy & RGroupMatching::GreedyChunks &&
          data->matches.size() % data->params.chunkSize == 0)) {
       data->process(data->prunePermutations);
     }

--- a/Code/GraphMol/RGroupDecomposition/RGroupDecompParams.h
+++ b/Code/GraphMol/RGroupDecomposition/RGroupDecompParams.h
@@ -14,7 +14,7 @@
 
 #include "../RDKitBase.h"
 #include <GraphMol/Substruct/SubstructMatch.h>
-#include <RDGeneral/WrapBetterEnums.h>
+#include <RDGeneral/ConditionallyUseBetterEnums.h>
 
 namespace RDKit {
 

--- a/Code/GraphMol/RGroupDecomposition/RGroupDecompParams.h
+++ b/Code/GraphMol/RGroupDecomposition/RGroupDecompParams.h
@@ -14,59 +14,52 @@
 
 #include "../RDKitBase.h"
 #include <GraphMol/Substruct/SubstructMatch.h>
+#include <RDGeneral/WrapBetterEnums.h>
 
 namespace RDKit {
 
-#define RGROUPLABELS_ENUM_ITEMS                                         \
-  RGD_ENUM_ITEM(IsotopeLabels, 1 << 0)                                  \
-  RGD_ENUM_ITEM(AtomMapLabels, 1 << 1)                                  \
-  RGD_ENUM_ITEM(AtomIndexLabels, 1 << 2)                                \
-  RGD_ENUM_ITEM(RelabelDuplicateLabels, 1 << 3)                         \
-  RGD_ENUM_ITEM(MDLRGroupLabels, 1 << 4)                                \
-  RGD_ENUM_ITEM(DummyAtomLabels,                                        \
-                1 << 5) /* These are rgroups but will get relabelled */ \
-  RGD_ENUM_ITEM(AutoDetect, 0xFF)
+BETTER_ENUM(RGroupLabels, unsigned int,
+  IsotopeLabels = 0x01,
+  AtomMapLabels = 0x02,
+  AtomIndexLabels = 0x04,
+  RelabelDuplicateLabels = 0x08,
+  MDLRGroupLabels = 0x10,
+  DummyAtomLabels = 0x20,  // These are rgroups but will get relabelled
+  AutoDetect = 0xFF
+);
 
-#define RGROUPMATCHING_ENUM_ITEMS                                          \
-  RGD_ENUM_ITEM(Greedy, 1 << 0)                                            \
-  RGD_ENUM_ITEM(GreedyChunks, 1 << 1)                                      \
-  RGD_ENUM_ITEM(Exhaustive, 1 << 2) /* not really useful for large sets */ \
-  RGD_ENUM_ITEM(NoSymmetrization, 1 << 3)                                  \
-  RGD_ENUM_ITEM(GA, 1 << 4)
+BETTER_ENUM(RGroupMatching, unsigned int,
+  Greedy = 0x01,
+  GreedyChunks = 0x02,
+  Exhaustive = 0x04,  // not really useful for large sets
+  NoSymmetrization = 0x08,
+  GA = 0x10
+);
 
-#define RGROUPLABELLING_ENUM_ITEMS \
-  RGD_ENUM_ITEM(AtomMap, 1 << 0)   \
-  RGD_ENUM_ITEM(Isotope, 1 << 1)   \
-  RGD_ENUM_ITEM(MDLRGroup, 1 << 2)
+BETTER_ENUM(
+  RGroupLabelling, unsigned int,
+  AtomMap = 0x01,
+  Isotope = 0x02,
+  MDLRGroup = 0x04
+);
 
-#define RGROUPCOREALIGNMENT_ENUM_ITEMS \
-  RGD_ENUM_ITEM(NoAlignment, 0)        \
-  RGD_ENUM_ITEM(MCS, 1 << 0)
+BETTER_ENUM(RGroupCoreAlignment, unsigned int,
+  NoAlignment = 0x0,
+  MCS = 0x01
+);
 
-#define RGROUPSCORE_ENUM_ITEMS \
-  RGD_ENUM_ITEM(Match, 1 << 0) \
-  RGD_ENUM_ITEM(FingerprintVariance, 1 << 2)
-
-#define RGD_ENUM_ITEM(k, v) k = v,
-typedef enum { RGROUPLABELS_ENUM_ITEMS } RGroupLabels;
-
-typedef enum { RGROUPMATCHING_ENUM_ITEMS } RGroupMatching;
-
-typedef enum { RGROUPLABELLING_ENUM_ITEMS } RGroupLabelling;
-
-typedef enum { RGROUPCOREALIGNMENT_ENUM_ITEMS } RGroupCoreAlignment;
-
-typedef enum { RGROUPSCORE_ENUM_ITEMS } RGroupScore;
-#undef RGD_ENUM_ITEM
-#define RGD_STD_MAP_ITEM(k) {#k, k},
-#define RGD_ENUM_ITEM(k, v) RGD_STD_MAP_ITEM(k)
+BETTER_ENUM(RGroupScore, unsigned int,
+  Match = 0x1,
+  FingerprintVariance = 0x4
+);
 
 struct RDKIT_RGROUPDECOMPOSITION_EXPORT RGroupDecompositionParameters {
-  unsigned int labels = AutoDetect;
-  unsigned int matchingStrategy = GreedyChunks;
-  unsigned int scoreMethod = Match;
-  unsigned int rgroupLabelling = AtomMap | MDLRGroup;
-  unsigned int alignment = MCS;
+  unsigned int labels = RGroupLabels::AutoDetect;
+  unsigned int matchingStrategy = RGroupMatching::GreedyChunks;
+  unsigned int scoreMethod = RGroupScore::Match;
+  unsigned int rgroupLabelling =
+      RGroupLabelling::AtomMap | RGroupLabelling::MDLRGroup;
+  unsigned int alignment = RGroupCoreAlignment::MCS;
 
   unsigned int chunkSize = 5;
   //! only allow rgroup decomposition at the specified rgroups

--- a/Code/GraphMol/RGroupDecomposition/RGroupGa.cpp
+++ b/Code/GraphMol/RGroupDecomposition/RGroupGa.cpp
@@ -38,12 +38,11 @@ std::string RGroupDecompositionChromosome::info() const {
 
 double RGroupDecompositionChromosome::score() {
   auto &rGroupData = rGroupGa.getRGroupData();
-  RGroupScore scoreMethod =
-      static_cast<RGroupScore>(rGroupData.params.scoreMethod);
+  auto scoreMethod = rGroupData.params.scoreMethod;
   if (operationName != RgroupMutate) {
     decode();
   }
-  if (scoreMethod == FingerprintVariance &&
+  if (scoreMethod == RGroupScore::FingerprintVariance &&
       fingerprintVarianceScoreData.labelsToVarianceData.size() > 0 &&
       operationName == RgroupMutate) {
     fitness = fingerprintVarianceScoreData.fingerprintVarianceGroupScore();

--- a/Code/GraphMol/RGroupDecomposition/RGroupUtils.cpp
+++ b/Code/GraphMol/RGroupDecomposition/RGroupUtils.cpp
@@ -215,30 +215,30 @@ void relabelMappedDummies(ROMol &mol, unsigned int inputLabels,
       continue;
     }
     unsigned int atomMapNum = 0;
-    if (inputLabels & AtomMap) {
+    if (inputLabels & RGroupLabelling::AtomMap) {
       atomMapNum = static_cast<unsigned int>(abs(atom->getAtomMapNum()));
     }
-    if (!atomMapNum && (inputLabels & Isotope)) {
+    if (!atomMapNum && (inputLabels & RGroupLabelling::Isotope)) {
       atomMapNum = atom->getIsotope();
     }
-    if (!atomMapNum && (inputLabels & MDLRGroup)) {
+    if (!atomMapNum && (inputLabels & RGroupLabelling::MDLRGroup)) {
       atom->getPropIfPresent(common_properties::_MolFileRLabel, atomMapNum);
     }
     if (!atomMapNum) {
       continue;
     }
     auto rLabel = "R" + std::to_string(atomMapNum);
-    if (outputLabels & AtomMap) {
+    if (outputLabels & RGroupLabelling::AtomMap) {
       atom->setAtomMapNum(atomMapNum);
     } else {
       atom->setAtomMapNum(0);
     }
-    if (outputLabels & Isotope) {
+    if (outputLabels & RGroupLabelling::Isotope) {
       atom->setIsotope(atomMapNum);
     } else {
       atom->setIsotope(0);
     }
-    if (outputLabels & MDLRGroup) {
+    if (outputLabels & RGroupLabelling::MDLRGroup) {
       atom->setProp(common_properties::_MolFileRLabel, atomMapNum);
       atom->setProp(common_properties::dummyLabel, rLabel);
     } else {

--- a/Code/GraphMol/RGroupDecomposition/RGroupUtils.h
+++ b/Code/GraphMol/RGroupDecomposition/RGroupUtils.h
@@ -105,8 +105,11 @@ RDKIT_RGROUPDECOMPOSITION_EXPORT std::string toJSON(
 /// The inputLabels parameter allows to configure which mappings
 /// are taken into consideration.
 RDKIT_RGROUPDECOMPOSITION_EXPORT void relabelMappedDummies(
-    ROMol &mol, unsigned int inputLabels = AtomMap | Isotope | MDLRGroup,
-    unsigned int outputLabels = MDLRGroup);
+    ROMol &mol,
+    unsigned int inputLabels = RGroupLabelling::AtomMap |
+                               RGroupLabelling::Isotope |
+                               RGroupLabelling::MDLRGroup,
+    unsigned int outputLabels = RGroupLabelling::MDLRGroup);
 
 }  // namespace RDKit
 

--- a/Code/GraphMol/RGroupDecomposition/Wrap/rdRGroupComposition.cpp
+++ b/Code/GraphMol/RGroupDecomposition/Wrap/rdRGroupComposition.cpp
@@ -187,12 +187,6 @@ python::object RGroupDecomp(python::object cores, python::object mols,
   }
 }
 
-void relabelMappedDummiesHelper(ROMol &mol, unsigned int inputLabels,
-                                unsigned int outputLabels) {
-  relabelMappedDummies(mol, static_cast<RGroupLabelling>(inputLabels),
-                       static_cast<RGroupLabelling>(outputLabels));
-}
-
 struct rgroupdecomp_wrapper {
   static void wrap() {
     bool noproxy = true;
@@ -200,39 +194,38 @@ struct rgroupdecomp_wrapper {
 
     std::string docString = "";
     python::enum_<RDKit::RGroupLabels>("RGroupLabels")
-        .value("IsotopeLabels", RDKit::IsotopeLabels)
-        .value("AtomMapLabels", RDKit::AtomMapLabels)
-        .value("AtomIndexLabels", RDKit::AtomIndexLabels)
-        .value("RelabelDuplicateLabels", RDKit::RelabelDuplicateLabels)
-        .value("MDLRGroupLabels", RDKit::MDLRGroupLabels)
-        .value("DummyAtomLabels", RDKit::DummyAtomLabels)
-        .value("AutoDetect", RDKit::AutoDetect)
+        .value("IsotopeLabels", RGroupLabels::IsotopeLabels)
+        .value("AtomMapLabels", RGroupLabels::AtomMapLabels)
+        .value("AtomIndexLabels", RGroupLabels::AtomIndexLabels)
+        .value("RelabelDuplicateLabels", RGroupLabels::RelabelDuplicateLabels)
+        .value("MDLRGroupLabels", RGroupLabels::MDLRGroupLabels)
+        .value("DummyAtomLabels", RGroupLabels::DummyAtomLabels)
+        .value("AutoDetect", RGroupLabels::AutoDetect)
         .export_values();
 
     python::enum_<RDKit::RGroupMatching>("RGroupMatching")
-        .value("Greedy", RDKit::Greedy)
-        .value("GreedyChunks", RDKit::GreedyChunks)
-        .value("Exhaustive", RDKit::Exhaustive)
-        .value("NoSymmetrization", RDKit::NoSymmetrization)
-        .value("GA", RDKit::GA)
+        .value("Greedy", RGroupMatching::Greedy)
+        .value("GreedyChunks", RGroupMatching::GreedyChunks)
+        .value("Exhaustive", RGroupMatching::Exhaustive)
+        .value("NoSymmetrization", RGroupMatching::NoSymmetrization)
+        .value("GA", RGroupMatching::GA)
         .export_values();
 
     python::enum_<RDKit::RGroupLabelling>("RGroupLabelling")
-        .value("AtomMap", RDKit::AtomMap)
-        .value("Isotope", RDKit::Isotope)
-        .value("MDLRGroup", RDKit::MDLRGroup)
+        .value("AtomMap", RGroupLabelling::AtomMap)
+        .value("Isotope", RGroupLabelling::Isotope)
+        .value("MDLRGroup", RGroupLabelling::MDLRGroup)
         .export_values();
 
     python::enum_<RDKit::RGroupCoreAlignment>("RGroupCoreAlignment")
-        // DEPRECATED, remove the folowing line in release 2021.03
-        .value("None", RDKit::NoAlignment)
-        .value("NoAlignment", RDKit::NoAlignment)
-        .value("MCS", RDKit::MCS)
+        .value("None", RGroupCoreAlignment::NoAlignment)
+        .value("NoAlignment", RGroupCoreAlignment::NoAlignment)
+        .value("MCS", RGroupCoreAlignment::MCS)
         .export_values();
 
     python::enum_<RDKit::RGroupScore>("RGroupScore")
-        .value("Match", RDKit::Match)
-        .value("FingerprintVariance", RDKit::FingerprintVariance)
+        .value("Match", RGroupScore::Match)
+        .value("FingerprintVariance", RGroupScore::FingerprintVariance)
         .export_values();
 
     docString =
@@ -435,11 +428,12 @@ struct rgroupdecomp_wrapper {
         "the priority on input is Atom map number > Isotope > MDLRGroup.\n"
         "The inputLabels parameter allows to configure which mappings\n"
         "are taken into consideration.\n";
-    python::def("RelabelMappedDummies", relabelMappedDummiesHelper,
+    python::def("RelabelMappedDummies", relabelMappedDummies,
                 (python::arg("mol"),
-                 python::arg("inputLabels") = static_cast<RGroupLabelling>(
-                     AtomMap | Isotope | MDLRGroup),
-                 python::arg("outputLabels") = MDLRGroup),
+                 python::arg("inputLabels") = RGroupLabelling::AtomMap |
+                                              RGroupLabelling::Isotope |
+                                              RGroupLabelling::MDLRGroup,
+                 python::arg("outputLabels") = RGroupLabelling::MDLRGroup),
                 docString.c_str());
   };
 };

--- a/Code/GraphMol/RGroupDecomposition/catch_rgd.cpp
+++ b/Code/GraphMol/RGroupDecomposition/catch_rgd.cpp
@@ -904,7 +904,7 @@ M  END
     CHECK(
         MolToCXSmiles(*core, p) ==
         "c1cc([4*:2])c([3*:1])cn1 |atomProp:3.dummyLabel.*:3.molAtomMapNumber.2:5.dummyLabel.*:5.molAtomMapNumber.1|");
-    relabelMappedDummies(*core, Isotope);
+    relabelMappedDummies(*core, RGroupLabelling::Isotope);
     CHECK(MolToCXSmiles(*core, p) ==
           "c1cc(*)c(*)cn1 |atomProp:3.dummyLabel.R4:5.dummyLabel.R3|");
   }
@@ -918,21 +918,24 @@ M  END
   SECTION(
       "AtomMap, Isotope and MDLRGroup in, MDLRGroup out - force Isotope priority") {
     ROMol core(*allDifferentCore);
-    relabelMappedDummies(core, Isotope);
+    relabelMappedDummies(core, RGroupLabelling::Isotope);
     CHECK(MolToCXSmiles(core, p) ==
           "c1cc(*)c(*)cn1 |atomProp:3.dummyLabel.R6:5.dummyLabel.R5|");
   }
   SECTION(
       "AtomMap, Isotope and MDLRGroup in, MDLRGroup out - force MDLRGroup priority") {
     ROMol core(*allDifferentCore);
-    relabelMappedDummies(core, MDLRGroup);
+    relabelMappedDummies(core, RGroupLabelling::MDLRGroup);
     CHECK(MolToCXSmiles(core, p) ==
           "c1cc(*)c(*)cn1 |atomProp:3.dummyLabel.R2:5.dummyLabel.R1|");
   }
   SECTION(
       "AtomMap, Isotope and MDLRGroup in, AtomMap out - AtomMap has priority") {
     ROMol core(*allDifferentCore);
-    relabelMappedDummies(core, AtomMap | Isotope | MDLRGroup, AtomMap);
+    relabelMappedDummies(core,
+                         RGroupLabelling::AtomMap | RGroupLabelling::Isotope |
+                             RGroupLabelling::MDLRGroup,
+                         RGroupLabelling::AtomMap);
     CHECK(
         MolToCXSmiles(core, p) ==
         "c1cc([*:4])c([*:3])cn1 |atomProp:3.molAtomMapNumber.4:5.molAtomMapNumber.3|");
@@ -940,13 +943,18 @@ M  END
   SECTION(
       "AtomMap, Isotope and MDLRGroup in, Isotope out - AtomMap has priority") {
     ROMol core(*allDifferentCore);
-    relabelMappedDummies(core, AtomMap | Isotope | MDLRGroup, Isotope);
+    relabelMappedDummies(core,
+                         RGroupLabelling::AtomMap | RGroupLabelling::Isotope |
+                             RGroupLabelling::MDLRGroup,
+                         RGroupLabelling::Isotope);
     CHECK(MolToCXSmiles(core, p) == "c1cc([4*])c([3*])cn1");
   }
   SECTION(
       "AtomMap, Isotope and MDLRGroup in, AtomMap out - Isotope has priority") {
     ROMol core(*allDifferentCore);
-    relabelMappedDummies(core, Isotope | MDLRGroup, AtomMap);
+    relabelMappedDummies(core,
+                         RGroupLabelling::Isotope | RGroupLabelling::MDLRGroup,
+                         RGroupLabelling::AtomMap);
     CHECK(
         MolToCXSmiles(core, p) ==
         "c1cc([*:6])c([*:5])cn1 |atomProp:3.molAtomMapNumber.6:5.molAtomMapNumber.5|");
@@ -954,13 +962,16 @@ M  END
   SECTION(
       "AtomMap, Isotope and MDLRGroup in, Isotope out - Isotope has priority") {
     ROMol core(*allDifferentCore);
-    relabelMappedDummies(core, Isotope | MDLRGroup, Isotope);
+    relabelMappedDummies(core,
+                         RGroupLabelling::Isotope | RGroupLabelling::MDLRGroup,
+                         RGroupLabelling::Isotope);
     CHECK(MolToCXSmiles(core, p) == "c1cc([6*])c([5*])cn1");
   }
   SECTION(
       "AtomMap, Isotope and MDLRGroup in, AtomMap out - MDLRGroup has priority") {
     ROMol core(*allDifferentCore);
-    relabelMappedDummies(core, MDLRGroup, AtomMap);
+    relabelMappedDummies(core, RGroupLabelling::MDLRGroup,
+                         RGroupLabelling::AtomMap);
     CHECK(
         MolToCXSmiles(core, p) ==
         "c1cc([*:2])c([*:1])cn1 |atomProp:3.molAtomMapNumber.2:5.molAtomMapNumber.1|");
@@ -968,7 +979,8 @@ M  END
   SECTION(
       "AtomMap, Isotope and MDLRGroup in, Isotope out - MDLRGroup has priority") {
     ROMol core(*allDifferentCore);
-    relabelMappedDummies(core, MDLRGroup, Isotope);
+    relabelMappedDummies(core, RGroupLabelling::MDLRGroup,
+                         RGroupLabelling::Isotope);
     CHECK(MolToCXSmiles(core, p) == "c1cc([2*])c([1*])cn1");
   }
 }

--- a/Code/GraphMol/RGroupDecomposition/testRGroupDecomp.cpp
+++ b/Code/GraphMol/RGroupDecomposition/testRGroupDecomp.cpp
@@ -110,7 +110,7 @@ void DUMP_RGROUP(RGroupRows::const_iterator &it, std::string &result) {
 const char *symdata[5] = {"c1(Cl)ccccc1", "c1c(Cl)cccc1", "c1cccc(Cl)c1",
                           "c1cc(Cl)ccc1", "c1ccc(Cl)cc1"};
 
-void testSymmetryMatching(RGroupScore scoreMethod = Match) {
+void testSymmetryMatching(RGroupScore scoreMethod = RGroupScore::Match) {
   BOOST_LOG(rdInfoLog)
       << "********************************************************\n";
   BOOST_LOG(rdInfoLog)
@@ -151,7 +151,7 @@ void testGaSymmetryMatching(RGroupScore scoreMethod) {
   UMOLS mols;
   RWMol *core = SmilesToMol("c1ccccc1");
   RGroupDecompositionParameters params;
-  params.matchingStrategy = GA;
+  params.matchingStrategy = RGroupMatching::GA;
   params.scoreMethod = scoreMethod;
   RGroupDecomposition decomp(*core, params);
   for (int i = 0; i < 5; ++i) {
@@ -183,8 +183,8 @@ void testGaBatch() {
   UMOLS mols;
   RWMol *core = SmilesToMol("c1ccccc1");
   RGroupDecompositionParameters params;
-  params.matchingStrategy = GA;
-  params.scoreMethod = FingerprintVariance;
+  params.matchingStrategy = RGroupMatching::GA;
+  params.scoreMethod = RGroupScore::FingerprintVariance;
   params.gaNumberRuns = 3;
   params.gaParallelRuns = true;
 
@@ -232,7 +232,7 @@ void testRGroupOnlyMatching() {
   UMOLS mols;
   RWMol *core = SmilesToMol("c1ccccc1[1*]");
   RGroupDecompositionParameters params;
-  params.labels = IsotopeLabels;
+  params.labels = RGroupLabels::IsotopeLabels;
   params.onlyMatchAtRGroups = true;
 
   RGroupDecomposition decomp(*core, params);
@@ -272,7 +272,7 @@ void testRingMatching() {
   UMOLS mols;
   RWMol *core = SmilesToMol("c1ccc[1*]1");
   RGroupDecompositionParameters params;
-  params.labels = IsotopeLabels;
+  params.labels = RGroupLabels::IsotopeLabels;
 
   auto exceptionThrown = false;
   try {
@@ -354,7 +354,8 @@ void testRingMatching3() {
   RWMol *core = SmartsToMol("*1***[*:1]1");
   // RWMol *core = SmartsToMol("*1****1");
 
-  std::vector<RGroupScore> matchtypes{Match, FingerprintVariance};
+  std::vector<RGroupScore> matchtypes{RGroupScore::Match,
+                                      RGroupScore::FingerprintVariance};
   for (auto match : matchtypes) {
     RGroupDecompositionParameters params;
     // This test is currently failing using the default scoring method (the
@@ -1130,7 +1131,7 @@ Br[*:3]
     // Still three groups added, but bromine and fluorine
     // are not aligned between R1 and R3
     RGroupDecompositionParameters ps;
-    ps.matchingStrategy = RDKit::NoSymmetrization;
+    ps.matchingStrategy = RGroupMatching::NoSymmetrization;
     RGroupDecomposition decomp(*core, ps);
     decomp.add(*m1);
     decomp.add(*m2);
@@ -1334,7 +1335,7 @@ Cn1cnc2cc(Oc3cc(N4CCN(Cc5ccccc5-c5ccc(Cl)cc5)CC4)ccc3C(=O)NS(=O)(=O)c3ccc(NCCCN4
 #else
     ps.timeout = 25.0;
 #endif
-    ps.matchingStrategy = RDKit::NoSymmetrization;
+    ps.matchingStrategy = RGroupMatching::NoSymmetrization;
     std::cerr << "bulk, no symmetry" << std::endl;
     std::vector<ROMOL_SPTR> cores;
     cores.push_back(ROMOL_SPTR(new ROMol(*core)));
@@ -1683,18 +1684,19 @@ $$$$
   RGroupDecompositionParameters params;
 
   // test pre-labelled with MDL R-group labels, autodetect
-  params.labels = AutoDetect;
-  params.alignment = MCS;
+  params.labels = RGroupLabels::AutoDetect;
+  params.alignment = RGroupCoreAlignment::MCS;
   MultiCoreRGD::test(cores, params, expectedLabels, expectedRows,
                      expectedItems);
   // test pre-labelled with MDL R-group labels, no autodetect
-  params.labels = MDLRGroupLabels | RelabelDuplicateLabels;
-  params.alignment = MCS;
+  params.labels =
+      RGroupLabels::MDLRGroupLabels | RGroupLabels::RelabelDuplicateLabels;
+  params.alignment = RGroupCoreAlignment::MCS;
   MultiCoreRGD::test(cores, params, expectedLabels, expectedRows,
                      expectedItems);
   // test pre-labelled with MDL R-group labels, autodetect, no MCS alignment
-  params.labels = AutoDetect;
-  params.alignment = NoAlignment;
+  params.labels = RGroupLabels::AutoDetect;
+  params.alignment = RGroupCoreAlignment::NoAlignment;
   MultiCoreRGD::test(cores, params, expectedLabels, expectedRows,
                      expectedItems);
 
@@ -1708,18 +1710,19 @@ $$$$
     }
   }
   // test pre-labelled with isotopic labels, autodetect
-  params.labels = AutoDetect;
-  params.alignment = MCS;
+  params.labels = RGroupLabels::AutoDetect;
+  params.alignment = RGroupCoreAlignment::MCS;
   MultiCoreRGD::test(cores, params, expectedLabels, expectedRows,
                      expectedItems);
   // test pre-labelled with isotopic labels, no autodetect
-  params.labels = IsotopeLabels | RelabelDuplicateLabels;
-  params.alignment = MCS;
+  params.labels =
+      RGroupLabels::IsotopeLabels | RGroupLabels::RelabelDuplicateLabels;
+  params.alignment = RGroupCoreAlignment::MCS;
   MultiCoreRGD::test(cores, params, expectedLabels, expectedRows,
                      expectedItems);
   // test pre-labelled with isotopic labels, autodetect, no MCS alignment
-  params.labels = AutoDetect;
-  params.alignment = NoAlignment;
+  params.labels = RGroupLabels::AutoDetect;
+  params.alignment = RGroupCoreAlignment::NoAlignment;
   MultiCoreRGD::test(cores, params, expectedLabels, expectedRows,
                      expectedItems);
 
@@ -1733,18 +1736,19 @@ $$$$
     }
   }
   // test pre-labelled with atom map labels, autodetect
-  params.labels = AutoDetect;
-  params.alignment = MCS;
+  params.labels = RGroupLabels::AutoDetect;
+  params.alignment = RGroupCoreAlignment::MCS;
   MultiCoreRGD::test(cores, params, expectedLabels, expectedRows,
                      expectedItems);
   // test pre-labelled with atom map labels, no autodetect
-  params.labels = AtomMapLabels | RelabelDuplicateLabels;
-  params.alignment = MCS;
+  params.labels =
+      RGroupLabels::AtomMapLabels | RGroupLabels::RelabelDuplicateLabels;
+  params.alignment = RGroupCoreAlignment::MCS;
   MultiCoreRGD::test(cores, params, expectedLabels, expectedRows,
                      expectedItems);
   // test pre-labelled with atom map labels, autodetect, no MCS alignment
-  params.labels = AutoDetect;
-  params.alignment = NoAlignment;
+  params.labels = RGroupLabels::AutoDetect;
+  params.alignment = RGroupCoreAlignment::NoAlignment;
   MultiCoreRGD::test(cores, params, expectedLabels, expectedRows,
                      expectedItems);
 
@@ -1764,15 +1768,16 @@ $$$$
                    {"CN[*:1]", "Br[*:1]"},
                    {"CC[*:2]", "F[*:2]"}};
 
-  params.labels = AutoDetect;
-  params.alignment = MCS;
+  params.labels = RGroupLabels::AutoDetect;
+  params.alignment = RGroupCoreAlignment::MCS;
   MultiCoreRGD::test(cores, params, expectedLabels, expectedRows,
                      expectedItems);
   MultiCoreRGD::test(cores, params, expectedLabels, expectedRows,
                      expectedItems);
   // test pre-labelled with dummy atom labels, no autodetect
-  params.labels = DummyAtomLabels | RelabelDuplicateLabels;
-  params.alignment = MCS;
+  params.labels =
+      RGroupLabels::DummyAtomLabels | RGroupLabels::RelabelDuplicateLabels;
+  params.alignment = RGroupCoreAlignment::MCS;
   MultiCoreRGD::test(cores, params, expectedLabels, expectedRows,
                      expectedItems);
 }
@@ -1883,7 +1888,8 @@ void testMultipleCoreRelabellingIssues() {
       "O=C1C([*:2])([*:1])[C@@H]2N1C(C(O)=O)C([*:3])([*:4])S2",
       "O=C1C([*:2])([*:1])[C@@H]2N1C(C(O)=O)C([*:3])([*:4])O2",
       "O=C1C([*:2])([*:1])C([*:6])([*:5])N1"};
-  std::vector<RGroupScore> matchtypes{Match, FingerprintVariance};
+  std::vector<RGroupScore> matchtypes{RGroupScore::Match,
+                                      RGroupScore::FingerprintVariance};
   for (auto match : matchtypes) {
     std::vector<ROMOL_SPTR> cores;
     for (const auto &s : smi) {
@@ -1928,7 +1934,8 @@ void testUnprocessedMapping() {
                                       "C1(O[*:1])CCC(O[*:2])CC1",
                                       "C1([*:1])CCC([*:2])CC1"};
 
-  std::vector<RGroupScore> matchtypes{Match, FingerprintVariance};
+  std::vector<RGroupScore> matchtypes{RGroupScore::Match,
+                                      RGroupScore::FingerprintVariance};
   for (auto match : matchtypes) {
     std::vector<ROMOL_SPTR> cores;
     for (const auto &s : coreSmi) {
@@ -1987,10 +1994,10 @@ M  END
     for (auto mdlRGroupLabels = 0; mdlRGroupLabels < 2; ++mdlRGroupLabels) {
       RGroupDecompositionParameters params;
       if (matchAtRGroup) {
-        params.labels = MDLRGroupLabels;
+        params.labels = RGroupLabels::MDLRGroupLabels;
       }
       if (mdlRGroupLabels) {
-        params.labels = MDLRGroupLabels;
+        params.labels = RGroupLabels::MDLRGroupLabels;
       }
       RGroupDecomposition decomp(*core, params);
       for (const auto &smi : smilesData) {
@@ -2092,7 +2099,7 @@ void testNoAlignmentAndSymmetry() {
   RGroupDecompositionParameters params;
   params.onlyMatchAtRGroups = true;
   params.removeHydrogensPostMatch = true;
-  params.alignment = NoAlignment;
+  params.alignment = RGroupCoreAlignment::NoAlignment;
   RGroupDecomposition decomp(cores, params);
   size_t i = 0;
   for (const auto &smi : smilesData) {
@@ -2269,7 +2276,8 @@ void testUserMatchTypes() {
     }
   };
 
-  std::vector<RGroupScore> matchtype{Match, FingerprintVariance};
+  std::vector<RGroupScore> matchtype{RGroupScore::Match,
+                                     RGroupScore::FingerprintVariance};
   for (auto match : matchtype) {
     auto mol = "C1CCCCC1(N)(O)"_smiles;
     auto core = "C1CCCCC1[*:1]"_smiles;
@@ -2379,7 +2387,7 @@ void testDoNotAddUnnecessaryRLabels() {
     for (unsigned int i = 0; i < 2; ++i) {
       RGroupDecompositionParameters ps;
       if (i) {
-        ps.matchingStrategy = RDKit::NoSymmetrization;
+        ps.matchingStrategy = RGroupMatching::NoSymmetrization;
       }
       RGroupDecomposition decomp(*core, ps);
       TEST_ASSERT(decomp.add(*m1) == 0);
@@ -2877,7 +2885,7 @@ M  END
   std::vector<std::string> smiArray(10, "COc1ccccc1");
   smiArray.push_back("COc1ccncn1");
   RGroupDecompositionParameters params;
-  params.matchingStrategy = GreedyChunks;
+  params.matchingStrategy = RGroupMatching::GreedyChunks;
   RGroupDecomposition decomp(*core, params);
   for (const auto &smiles : smiArray) {
     ROMol *mol = SmilesToMol(smiles);
@@ -2972,7 +2980,7 @@ M  END
 )CTAB"_ctab;
 
   RGroupDecompositionParameters params;
-  params.matchingStrategy = GreedyChunks;
+  params.matchingStrategy = RGroupMatching::GreedyChunks;
   RGroupDecomposition decomp(*core, params);
   decomp.add(*test);
 
@@ -3046,7 +3054,7 @@ M  END
 )CTAB"_ctab;
 
   RGroupDecompositionParameters params;
-  params.matchingStrategy = GreedyChunks;
+  params.matchingStrategy = RGroupMatching::GreedyChunks;
   params.allowMultipleRGroupsOnUnlabelled = true;
   RGroupDecomposition decomp(*core, params);
   auto result = decomp.add(*test);
@@ -3149,8 +3157,8 @@ void testMultipleGroupsToUnlabelledCoreAtom() {
         "COC1CCC(C)(OC)CN1", "COC1CCC(CCC)(C)CN1"};
     RGroupDecompositionParameters params;
     params.allowMultipleRGroupsOnUnlabelled = true;
-    params.matchingStrategy = Exhaustive;
-    params.scoreMethod = FingerprintVariance;
+    params.matchingStrategy = RGroupMatching::Exhaustive;
+    params.scoreMethod = RGroupScore::FingerprintVariance;
     RGroupDecomposition decomp(*core, params);
     for (auto smiles : smilesVec) {
       auto mol = SmilesToMol(smiles);
@@ -3178,7 +3186,7 @@ void testMultipleGroupsToUnlabelledCoreAtom() {
     auto mol = "COC1CCC(C)(C)CN1"_smiles;
     RGroupDecompositionParameters params;
     params.allowMultipleRGroupsOnUnlabelled = true;
-    params.labels = DummyAtomLabels;
+    params.labels = RGroupLabels::DummyAtomLabels;
     RGroupDecomposition decomp(*core, params);
     auto result = decomp.add(*mol);
     TEST_ASSERT(result == 0)
@@ -3191,7 +3199,7 @@ void testMultipleGroupsToUnlabelledCoreAtom() {
     RGroupRows::const_iterator it = rows.begin();
     CHECK_RGROUP(it, expected);
     // Check core with terminal wildcard - dummy atom labels not allowed
-    params.labels = IsotopeLabels;
+    params.labels = RGroupLabels::IsotopeLabels;
     RGroupDecomposition decomp2(*core, params);
     result = decomp2.add(*mol);
     TEST_ASSERT(result == 0)
@@ -3210,8 +3218,8 @@ void testMultipleGroupsToUnlabelledCoreAtom() {
                                        "COC1NCC(C)(C)CN1"};
     RGroupDecompositionParameters params;
     params.allowMultipleRGroupsOnUnlabelled = true;
-    params.matchingStrategy = Exhaustive;
-    params.scoreMethod = FingerprintVariance;
+    params.matchingStrategy = RGroupMatching::Exhaustive;
+    params.scoreMethod = RGroupScore::FingerprintVariance;
     RGroupDecomposition decomp(*core, params);
     for (auto smiles : smilesVec) {
       auto mol = SmilesToMol(smiles);
@@ -3499,7 +3507,7 @@ M  END
 )CTAB"_ctab;
 
   RGroupDecompositionParameters params;
-  params.matchingStrategy = GreedyChunks;
+  params.matchingStrategy = RGroupMatching::GreedyChunks;
   params.allowMultipleRGroupsOnUnlabelled = false;
   params.onlyMatchAtRGroups = true;
   RGroupDecomposition decomp(*core, params);
@@ -3594,7 +3602,7 @@ M  END
   auto mol =
       "Brc1cc(Br)c(Oc2ccc(cc2C#N)S(=O)(=O)Nc3ncc(Br)s3)c(c1)c4ccccc4"_smiles;
   RGroupDecompositionParameters params;
-  params.matchingStrategy = GreedyChunks;
+  params.matchingStrategy = RGroupMatching::GreedyChunks;
   params.allowMultipleRGroupsOnUnlabelled = false;
   params.onlyMatchAtRGroups = false;
   RGroupDecomposition decomp(*core, params);
@@ -3771,7 +3779,7 @@ M  END
 )CTAB"_ctab;
 
   RGroupDecompositionParameters params;
-  params.matchingStrategy = GreedyChunks;
+  params.matchingStrategy = RGroupMatching::GreedyChunks;
   params.allowMultipleRGroupsOnUnlabelled = true;
   params.onlyMatchAtRGroups = false;
   RGroupDecomposition decomp(*core, params);
@@ -3849,7 +3857,7 @@ M  END
   auto mol2 = "CCC1=C(F)C=CC(Cl)=C1"_smiles;
 
   RGroupDecompositionParameters params;
-  params.matchingStrategy = GreedyChunks;
+  params.matchingStrategy = RGroupMatching::GreedyChunks;
   params.allowMultipleRGroupsOnUnlabelled = true;
   params.onlyMatchAtRGroups = false;
   params.doEnumeration = true;
@@ -3884,7 +3892,7 @@ void testTautomerCore() {
   const auto mol2 = "CC1=CNC(=O)C=C1F"_smiles;
 
   RGroupDecompositionParameters params;
-  params.matchingStrategy = GreedyChunks;
+  params.matchingStrategy = RGroupMatching::GreedyChunks;
   params.allowMultipleRGroupsOnUnlabelled = true;
   params.onlyMatchAtRGroups = false;
   params.doTautomers = true;
@@ -3992,7 +4000,7 @@ M  END
 )CTAB"_ctab;
   const auto mol = "C/C=C/C1=CC=CC=C1"_smiles;
   RGroupDecompositionParameters params;
-  params.matchingStrategy = GreedyChunks;
+  params.matchingStrategy = RGroupMatching::GreedyChunks;
   params.allowMultipleRGroupsOnUnlabelled = true;
   params.onlyMatchAtRGroups = false;
   params.doEnumeration = false;
@@ -4098,7 +4106,7 @@ void testNotEnumeratedCore() {
   const auto mol = "C1CCCCC1C"_smiles;
 
   RGroupDecompositionParameters params;
-  params.matchingStrategy = GreedyChunks;
+  params.matchingStrategy = RGroupMatching::GreedyChunks;
   params.allowMultipleRGroupsOnUnlabelled = true;
   params.onlyMatchAtRGroups = false;
   params.doEnumeration = true;
@@ -4125,7 +4133,7 @@ void testRgroupDecompZipping() {
   const auto core = "N1OCC1"_smiles;
   const auto mol = "C1CC2ONC12"_smiles;
   RGroupDecompositionParameters params;
-  params.matchingStrategy = GreedyChunks;
+  params.matchingStrategy = RGroupMatching::GreedyChunks;
   params.allowMultipleRGroupsOnUnlabelled = true;
   params.onlyMatchAtRGroups = false;
   params.doEnumeration = true;
@@ -4158,7 +4166,7 @@ int main() {
   BOOST_LOG(rdInfoLog) << "Testing R-Group Decomposition \n";
 
 #if 1
-  testSymmetryMatching(FingerprintVariance);
+  testSymmetryMatching(RGroupScore::FingerprintVariance);
   testSymmetryMatching();
   testRGroupOnlyMatching();
   testRingMatching();
@@ -4176,8 +4184,8 @@ int main() {
   testSymmetryIssues();
   testMultipleCoreRelabellingIssues();
 
-  testGaSymmetryMatching(FingerprintVariance);
-  testGaSymmetryMatching(Match);
+  testGaSymmetryMatching(RGroupScore::FingerprintVariance);
+  testGaSymmetryMatching(RGroupScore::Match);
   testGaBatch();
 
   testUnprocessedMapping();

--- a/Code/GraphMol/RGroupDecomposition/testRGroupInternals.cpp
+++ b/Code/GraphMol/RGroupDecomposition/testRGroupInternals.cpp
@@ -66,7 +66,7 @@ void testCoresLabelledProperly() {
 
   RGroupDecompositionParameters params;
   params.alignment = RGroupCoreAlignment::NoAlignment;
-  params.scoreMethod = FingerprintVariance;
+  params.scoreMethod = RGroupScore::FingerprintVariance;
   RGroupDecomposition decomposition(cores, params);
 
   auto data = decomposition.data;
@@ -172,7 +172,7 @@ void testGithub3746() {
   RGroupDecompositionParameters params;
   params.onlyMatchAtRGroups = true;
   params.removeHydrogensPostMatch = true;
-  params.matchingStrategy = GA;
+  params.matchingStrategy = RGroupMatching::GA;
   params.removeHydrogensPostMatch = true;
 
   RGroupDecomposition decomposition(cores, params);

--- a/Code/GraphMol/SmilesParse/SmilesWrite.cpp
+++ b/Code/GraphMol/SmilesParse/SmilesWrite.cpp
@@ -767,7 +767,7 @@ std::string MolToSmiles(const ROMol &mol, const SmilesWriteParams &params) {
 
 std::string MolToCXSmiles(const ROMol &romol, const SmilesWriteParams &params,
                           std::uint32_t flags,
-                          RestoreBondDirOption restoreBondDirs) {
+                          unsigned int restoreBondDirs) {
   RWMol trwmol(romol);
 
   bool doingCXSmiles = true;

--- a/Code/GraphMol/SmilesParse/SmilesWrite.cpp
+++ b/Code/GraphMol/SmilesParse/SmilesWrite.cpp
@@ -57,8 +57,8 @@ void updateSmilesWriteParamsFromJSON(SmilesWriteParams &params,
   updateSmilesWriteParamsFromJSON(params, details_json.c_str());
 }
 
-void updateCXSmilesFieldsFromJSON(SmilesWrite::CXSmilesFields &cxSmilesFields,
-                                  RestoreBondDirOption &restoreBondDirs,
+void updateCXSmilesFieldsFromJSON(std::uint32_t &cxSmilesFields,
+                                  unsigned int &restoreBondDirs,
                                   const char *details_json) {
   if (details_json && strlen(details_json)) {
     boost::property_tree::ptree pt;
@@ -86,8 +86,8 @@ void updateCXSmilesFieldsFromJSON(SmilesWrite::CXSmilesFields &cxSmilesFields,
   }
 }
 
-void updateCXSmilesFieldsFromJSON(SmilesWrite::CXSmilesFields &cxSmilesFields,
-                                  RestoreBondDirOption &restoreBondDirs,
+void updateCXSmilesFieldsFromJSON(std::uint32_t &cxSmilesFields,
+                                  unsigned int &restoreBondDirs,
                                   const std::string &details_json) {
   updateCXSmilesFieldsFromJSON(cxSmilesFields, restoreBondDirs,
                                details_json.c_str());

--- a/Code/GraphMol/SmilesParse/SmilesWrite.h
+++ b/Code/GraphMol/SmilesParse/SmilesWrite.h
@@ -260,7 +260,7 @@ BETTER_ENUM(RestoreBondDirOption, unsigned int,
 RDKIT_SMILESPARSE_EXPORT std::string MolToCXSmiles(
     const ROMol &mol, const SmilesWriteParams &ps,
     std::uint32_t flags = SmilesWrite::CXSmilesFields::CX_ALL,
-    RDKit::RestoreBondDirOption restoreBondDirs =
+    unsigned int restoreBondDirs =
         RestoreBondDirOption::RestoreBondDirOptionClear);
 
 //! \brief returns canonical CXSMILES for a molecule

--- a/Code/GraphMol/SmilesParse/SmilesWrite.h
+++ b/Code/GraphMol/SmilesParse/SmilesWrite.h
@@ -16,6 +16,7 @@
 #include <memory>
 #include <cstdint>
 #include <limits>
+#include <RDGeneral/WrapBetterEnums.h>
 
 namespace RDKit {
 class Atom;
@@ -45,32 +46,23 @@ struct RDKIT_SMILESPARSE_EXPORT SmilesWriteParams {
 
 namespace SmilesWrite {
 
-#define CXSMILESFIELDS_ENUM_ITEMS                        \
-  CXSMILESFIELDS_ENUM_ITEM(CX_NONE, 0)                   \
-  CXSMILESFIELDS_ENUM_ITEM(CX_ATOM_LABELS, 1 << 0)       \
-  CXSMILESFIELDS_ENUM_ITEM(CX_MOLFILE_VALUES, 1 << 1)    \
-  CXSMILESFIELDS_ENUM_ITEM(CX_COORDS, 1 << 2)            \
-  CXSMILESFIELDS_ENUM_ITEM(CX_RADICALS, 1 << 3)          \
-  CXSMILESFIELDS_ENUM_ITEM(CX_ATOM_PROPS, 1 << 4)        \
-  CXSMILESFIELDS_ENUM_ITEM(CX_LINKNODES, 1 << 5)         \
-  CXSMILESFIELDS_ENUM_ITEM(CX_ENHANCEDSTEREO, 1 << 6)    \
-  CXSMILESFIELDS_ENUM_ITEM(CX_SGROUPS, 1 << 7)           \
-  CXSMILESFIELDS_ENUM_ITEM(CX_POLYMER, 1 << 8)           \
-  CXSMILESFIELDS_ENUM_ITEM(CX_BOND_CFG, 1 << 9)          \
-  CXSMILESFIELDS_ENUM_ITEM(CX_BOND_ATROPISOMER, 1 << 10) \
-  CXSMILESFIELDS_ENUM_ITEM(CX_COORDINATE_BONDS, 1 << 11) \
-  CXSMILESFIELDS_ENUM_ITEM(CX_ALL, 0x7fffffff)           \
-  CXSMILESFIELDS_ENUM_ITEM(CX_ALL_BUT_COORDS, CX_ALL ^ CX_COORDS)
-
-#define CXSMILESFIELDS_ENUM_ITEM(k, v) k = (v),
-enum CXSmilesFields : uint32_t { CXSMILESFIELDS_ENUM_ITEMS };
-#undef CXSMILESFIELDS_ENUM_ITEM
-#define CXSMILESFIELDS_STD_MAP_ITEM(k) {#k, SmilesWrite::CXSmilesFields::k},
-#define CXSMILESFIELDS_ENUM_ITEM(k, v) CXSMILESFIELDS_STD_MAP_ITEM(k)
-#define CXSMILESFIELDS_ITEMS_MAP                       \
-  std::map<std::string, SmilesWrite::CXSmilesFields> { \
-    CXSMILESFIELDS_ENUM_ITEMS                          \
-  }
+BETTER_ENUM(CXSmilesFields, uint32_t,
+  CX_NONE = 0,
+  CX_ATOM_LABELS = 1 << 0,
+  CX_MOLFILE_VALUES = 1 << 1,
+  CX_COORDS = 1 << 2,
+  CX_RADICALS = 1 << 3,
+  CX_ATOM_PROPS = 1 << 4,
+  CX_LINKNODES = 1 << 5,
+  CX_ENHANCEDSTEREO = 1 << 6,
+  CX_SGROUPS = 1 << 7,
+  CX_POLYMER = 1 << 8,
+  CX_BOND_CFG = 1 << 9,
+  CX_BOND_ATROPISOMER = 1 << 10,
+  CX_COORDINATE_BONDS = 1 << 11,
+  CX_ALL = 0x7fffffff,
+  CX_ALL_BUT_COORDS = CX_ALL ^ CX_COORDS
+);
 
 //! \brief returns the cxsmiles data for a molecule
 RDKIT_SMILESPARSE_EXPORT std::string getCXExtensions(
@@ -259,28 +251,17 @@ inline std::string MolFragmentToSmiles(
                              bondSymbols);
 }
 
-#define RESTOREBONDDIROPTION_ENUM_ITEMS                          \
-  RESTOREBONDDIROPTION_ENUM_ITEM(RestoreBondDirOptionTrue,       \
-                                 0) /*!< DO restore bond dirs */ \
-  RESTOREBONDDIROPTION_ENUM_ITEM(RestoreBondDirOptionClear,      \
-                                 1) /*!< clear all bond dir information */
-
-#define RESTOREBONDDIROPTION_ENUM_ITEM(k, v) k = v,
-enum RestoreBondDirOption { RESTOREBONDDIROPTION_ENUM_ITEMS };
-#undef RESTOREBONDDIROPTION_ENUM_ITEM
-#define RESTOREBONDDIROPTION_STD_MAP_ITEM(k) {#k, k},
-#define RESTOREBONDDIROPTION_ENUM_ITEM(k, v) \
-  RESTOREBONDDIROPTION_STD_MAP_ITEM(k)
-#define RESTOREBONDDIROPTION_ITEMS_MAP          \
-  std::map<std::string, RestoreBondDirOption> { \
-    RESTOREBONDDIROPTION_ENUM_ITEMS             \
-  }
+BETTER_ENUM(RestoreBondDirOption, unsigned int,
+  RestoreBondDirOptionTrue = 0,  //<!DO restore bond dirs
+  RestoreBondDirOptionClear = 1  //<!clear all bond dir information
+);
 
 //! \brief returns canonical CXSMILES for a molecule
 RDKIT_SMILESPARSE_EXPORT std::string MolToCXSmiles(
     const ROMol &mol, const SmilesWriteParams &ps,
     std::uint32_t flags = SmilesWrite::CXSmilesFields::CX_ALL,
-    RestoreBondDirOption restoreBondDirs = RestoreBondDirOptionClear);
+    RDKit::RestoreBondDirOption restoreBondDirs =
+        RestoreBondDirOption::RestoreBondDirOptionClear);
 
 //! \brief returns canonical CXSMILES for a molecule
 /*!
@@ -312,7 +293,8 @@ inline std::string MolToCXSmiles(const ROMol &mol, bool doIsomericSmiles = true,
   ps.allBondsExplicit = allBondsExplicit;
   ps.allHsExplicit = allHsExplicit;
   ps.doRandom = doRandom;
-  return MolToCXSmiles(mol, ps, SmilesWrite::CXSmilesFields::CX_ALL);
+  return MolToCXSmiles(
+      mol, ps, static_cast<std::uint32_t>(SmilesWrite::CXSmilesFields::CX_ALL));
 };
 
 //! \brief returns canonical CXSMILES for part of a molecule
@@ -370,10 +352,10 @@ void updateSmilesWriteParamsFromJSON(SmilesWriteParams &params,
 void updateSmilesWriteParamsFromJSON(SmilesWriteParams &params,
                                      const char *details_json);
 void updateCXSmilesFieldsFromJSON(SmilesWrite::CXSmilesFields &cxSmilesFields,
-                                  RestoreBondDirOption &restoreBondDirs,
+                                  RDKit::RestoreBondDirOption &restoreBondDirs,
                                   const std::string &details_json);
 void updateCXSmilesFieldsFromJSON(SmilesWrite::CXSmilesFields &cxSmilesFields,
-                                  RestoreBondDirOption &restoreBondDirs,
+                                  RDKit::RestoreBondDirOption &restoreBondDirs,
                                   const char *details_json);
 
 }  // namespace RDKit

--- a/Code/GraphMol/SmilesParse/SmilesWrite.h
+++ b/Code/GraphMol/SmilesParse/SmilesWrite.h
@@ -351,11 +351,11 @@ void updateSmilesWriteParamsFromJSON(SmilesWriteParams &params,
                                      const std::string &details_json);
 void updateSmilesWriteParamsFromJSON(SmilesWriteParams &params,
                                      const char *details_json);
-void updateCXSmilesFieldsFromJSON(SmilesWrite::CXSmilesFields &cxSmilesFields,
-                                  RDKit::RestoreBondDirOption &restoreBondDirs,
+void updateCXSmilesFieldsFromJSON(std::uint32_t &cxSmilesFields,
+                                  unsigned int &restoreBondDirs,
                                   const std::string &details_json);
-void updateCXSmilesFieldsFromJSON(SmilesWrite::CXSmilesFields &cxSmilesFields,
-                                  RDKit::RestoreBondDirOption &restoreBondDirs,
+void updateCXSmilesFieldsFromJSON(std::uint32_t &cxSmilesFields,
+                                  unsigned int &restoreBondDirs,
                                   const char *details_json);
 
 }  // namespace RDKit

--- a/Code/GraphMol/SmilesParse/SmilesWrite.h
+++ b/Code/GraphMol/SmilesParse/SmilesWrite.h
@@ -16,7 +16,7 @@
 #include <memory>
 #include <cstdint>
 #include <limits>
-#include <RDGeneral/WrapBetterEnums.h>
+#include <RDGeneral/ConditionallyUseBetterEnums.h>
 
 namespace RDKit {
 class Atom;

--- a/Code/GraphMol/SmilesParse/catch_tests.cpp
+++ b/Code/GraphMol/SmilesParse/catch_tests.cpp
@@ -2069,12 +2069,13 @@ TEST_CASE("wiggly and wedged bonds in CXSMILES") {
     // make sure we end up with the wiggly bond in the output CXSMILES:
     auto cxsmi = MolToCXSmiles(*m, SmilesWriteParams(),
                                SmilesWrite::CXSmilesFields::CX_ALL,
-                               RestoreBondDirOptionTrue);
+                               RestoreBondDirOption::RestoreBondDirOptionTrue);
     CHECK(cxsmi == "CC(O)F |w:1.2|");
     // but we can turn that off
     SmilesWriteParams ps;
-    cxsmi =
-        MolToCXSmiles(*m, ps, SmilesWrite::CX_ALL ^ SmilesWrite::CX_BOND_CFG);
+    cxsmi = MolToCXSmiles(*m, ps,
+                          SmilesWrite::CXSmilesFields::CX_ALL ^
+                              SmilesWrite::CXSmilesFields::CX_BOND_CFG);
     CHECK(cxsmi == "CC(O)F");
   }
 
@@ -2094,7 +2095,7 @@ TEST_CASE("wiggly and wedged bonds in CXSMILES") {
     // make sure we end up with the wiggly bond in the output CXSMILES:
     auto cxsmi = MolToCXSmiles(*m, SmilesWriteParams(),
                                SmilesWrite::CXSmilesFields::CX_ALL,
-                               RestoreBondDirOptionTrue);
+                               RestoreBondDirOption::RestoreBondDirOptionTrue);
     CHECK(cxsmi == "CC(O)F |w:1.2|");
   }
   SECTION("make sure order gets reversed when needed") {
@@ -2150,17 +2151,17 @@ TEST_CASE("wiggly and wedged bonds in CXSMILES") {
     {
       ROMol nm(*m);
       nm.getBondWithIdx(1)->setBondDir(Bond::BondDir::UNKNOWN);
-      auto cxsmi = MolToCXSmiles(nm, SmilesWriteParams(),
-                                 SmilesWrite::CXSmilesFields::CX_ALL,
-                                 RestoreBondDirOptionTrue);
+      auto cxsmi = MolToCXSmiles(
+          nm, SmilesWriteParams(), SmilesWrite::CXSmilesFields::CX_ALL,
+          RestoreBondDirOption::RestoreBondDirOptionTrue);
       CHECK(cxsmi == "CC(O)Cl |w:1.0|");
     }
     {
       ROMol nm(*m);
       nm.getBondWithIdx(1)->setProp(common_properties::_MolFileBondCfg, 2);
-      auto cxsmi = MolToCXSmiles(nm, SmilesWriteParams(),
-                                 SmilesWrite::CXSmilesFields::CX_ALL,
-                                 RestoreBondDirOptionClear);
+      auto cxsmi = MolToCXSmiles(
+          nm, SmilesWriteParams(), SmilesWrite::CXSmilesFields::CX_ALL,
+          RestoreBondDirOption::RestoreBondDirOptionClear);
       CHECK(cxsmi == "CC(O)Cl");
     }
   }
@@ -2198,7 +2199,7 @@ M  END
     m->getBondWithIdx(2)->setBondDir(Bond::BondDir::BEGINDASH);
     cxsmi = MolToCXSmiles(*m, SmilesWriteParams(),
                           SmilesWrite::CXSmilesFields::CX_ALL,
-                          RestoreBondDirOptionTrue);
+                          RestoreBondDirOption::RestoreBondDirOptionTrue);
     CHECK(cxsmi.find("wU:1.0") != std::string::npos);
     cxsmi =
         MolToCXSmiles(*m, ps, SmilesWrite::CXSmilesFields::CX_ALL_BUT_COORDS);
@@ -2206,12 +2207,12 @@ M  END
     m->getBondWithIdx(2)->setBondDir(Bond::BondDir::UNKNOWN);
     cxsmi = MolToCXSmiles(*m, SmilesWriteParams(),
                           SmilesWrite::CXSmilesFields::CX_ALL,
-                          RestoreBondDirOptionTrue);
+                          RestoreBondDirOption::RestoreBondDirOptionTrue);
     CHECK(cxsmi.find("wU:1.0") != std::string::npos);
     // wiggly bonds get written even if we don't output coords:
     cxsmi =
         MolToCXSmiles(*m, ps, SmilesWrite::CXSmilesFields::CX_ALL_BUT_COORDS,
-                      RestoreBondDirOptionClear);
+                      RestoreBondDirOption::RestoreBondDirOptionClear);
     CHECK(cxsmi.find("w:1.0") == std::string::npos);
   }
 

--- a/Code/GraphMol/SmilesParse/cxsmiles_test.cpp
+++ b/Code/GraphMol/SmilesParse/cxsmiles_test.cpp
@@ -674,7 +674,7 @@ class SmilesTest {
       : fileName(fileNameInit),
         expectedResult(expectedResultInit),
         atomCount(atomCountInit),
-        bondCount(bondCountInit) {};
+        bondCount(bondCountInit){};
 
   bool isRxnTest() const { return false; }
 };
@@ -738,7 +738,8 @@ void testOneAtropisomers(const SmilesTest *smilesTest) {
           ;
 
       std::string smilesOut =
-          MolToCXSmiles(*smilesMol, ps, flags, RestoreBondDirOptionTrue);
+          MolToCXSmiles(*smilesMol, ps, flags,
+                        RestoreBondDirOption::RestoreBondDirOptionTrue);
 
       generateNewExpectedFilesIfSoSpecified(fName + ".NEW.cxsmi", smilesOut);
       CHECK(getExpectedValue(expectedFileName) == smilesOut);
@@ -764,7 +765,8 @@ void testOneAtropisomers(const SmilesTest *smilesTest) {
                            SmilesWrite::CXSmilesFields::CX_ENHANCEDSTEREO;
 
       std::string smilesOut =
-          MolToCXSmiles(*smilesMol, ps, flags, RestoreBondDirOptionClear);
+          MolToCXSmiles(*smilesMol, ps, flags,
+                        RestoreBondDirOption::RestoreBondDirOptionClear);
 
       generateNewExpectedFilesIfSoSpecified(fName + ".NEW2.cxsmi", smilesOut);
       CHECK(getExpectedValue(expectedFileName) == smilesOut);
@@ -790,7 +792,8 @@ void testOneAtropisomers(const SmilesTest *smilesTest) {
                            SmilesWrite::CXSmilesFields::CX_ENHANCEDSTEREO;
 
       std::string smilesOut =
-          MolToCXSmiles(*smilesMol, ps, flags, RestoreBondDirOptionClear);
+          MolToCXSmiles(*smilesMol, ps, flags,
+                        RestoreBondDirOption::RestoreBondDirOptionClear);
 
       generateNewExpectedFilesIfSoSpecified(fName + ".NEW3.cxsmi", smilesOut);
       auto expected = getExpectedValue(expectedFileName);
@@ -892,7 +895,8 @@ void testOneAtropisomersCanon(const SmilesTest *smilesTest) {
           ;
 
       std::string smilesOut =
-          MolToCXSmiles(*smilesMol, ps, flags, RestoreBondDirOptionTrue);
+          MolToCXSmiles(*smilesMol, ps, flags,
+                        RestoreBondDirOption::RestoreBondDirOptionTrue);
 
       generateNewExpectedFilesIfSoSpecified(fName + ".kekule_NEW.cxsmi",
                                             smilesOut);
@@ -920,7 +924,8 @@ void testOneAtropisomersCanon(const SmilesTest *smilesTest) {
                            SmilesWrite::CXSmilesFields::CX_ENHANCEDSTEREO;
 
       std::string smilesOut =
-          MolToCXSmiles(*smilesMol, ps, flags, RestoreBondDirOptionClear);
+          MolToCXSmiles(*smilesMol, ps, flags,
+                        RestoreBondDirOption::RestoreBondDirOptionClear);
 
       generateNewExpectedFilesIfSoSpecified(fName + ".arom_NEW.cxsmi",
                                             smilesOut);
@@ -978,7 +983,8 @@ void testOne3dChiral(const SmilesTest *smilesTest) {
           ;
 
       std::string smilesOut =
-          MolToCXSmiles(*smilesMol, ps, flags, RestoreBondDirOptionTrue);
+          MolToCXSmiles(*smilesMol, ps, flags,
+                        RestoreBondDirOption::RestoreBondDirOptionTrue);
 
       generateNewExpectedFilesIfSoSpecified(fName + ".NEW3D.cxsmi", smilesOut);
       CHECK(getExpectedValue(expectedFileName) == smilesOut);
@@ -1006,7 +1012,8 @@ void testOne3dChiral(const SmilesTest *smilesTest) {
                            SmilesWrite::CXSmilesFields::CX_ENHANCEDSTEREO;
 
       std::string smilesOut =
-          MolToCXSmiles(*smilesMol, ps, flags, RestoreBondDirOptionClear);
+          MolToCXSmiles(*smilesMol, ps, flags,
+                        RestoreBondDirOption::RestoreBondDirOptionClear);
 
       generateNewExpectedFilesIfSoSpecified(fName + ".NEW3D2.cxsmi", smilesOut);
       CHECK(getExpectedValue(expectedFileName) == smilesOut);
@@ -1266,10 +1273,10 @@ void testMolCanonicalizationAtrop(std::string fileName1,
 
     // mol1->clearConformers();
 
-    std::string smilesOut1 =
-        MolToCXSmiles(*mol1, ps, flags, RestoreBondDirOptionClear);
-    std::string smilesOut2 =
-        MolToCXSmiles(*mol2, ps, flags, RestoreBondDirOptionClear);
+    std::string smilesOut1 = MolToCXSmiles(
+        *mol1, ps, flags, RestoreBondDirOption::RestoreBondDirOptionClear);
+    std::string smilesOut2 = MolToCXSmiles(
+        *mol2, ps, flags, RestoreBondDirOption::RestoreBondDirOptionClear);
 
     std::vector<std::string> parts = splitOnString(smilesOut1, " |");
     CHECK(parts.size() == 2);

--- a/Code/GraphMol/Wrap/MolOps.cpp
+++ b/Code/GraphMol/Wrap/MolOps.cpp
@@ -189,17 +189,19 @@ ROMol *renumberAtomsHelper(const ROMol &mol, python::object &pyNewOrder) {
 
 namespace {
 std::string getResidue(const ROMol &, const Atom *at) {
-  if (at->getMonomerInfo()->getMonomerType() != AtomMonomerInfo::PDBRESIDUE) {
+  auto monomerInfo = at->getMonomerInfo();
+  if (!monomerInfo || monomerInfo->getMonomerType() != AtomMonomerInfo::PDBRESIDUE) {
     return "";
   }
-  return static_cast<const AtomPDBResidueInfo *>(at->getMonomerInfo())
+  return static_cast<const AtomPDBResidueInfo *>(monomerInfo)
       ->getResidueName();
 }
 std::string getChainId(const ROMol &, const Atom *at) {
-  if (at->getMonomerInfo()->getMonomerType() != AtomMonomerInfo::PDBRESIDUE) {
+auto monomerInfo = at->getMonomerInfo();
+  if (!monomerInfo || monomerInfo->getMonomerType() != AtomMonomerInfo::PDBRESIDUE) {
     return "";
   }
-  return static_cast<const AtomPDBResidueInfo *>(at->getMonomerInfo())
+  return static_cast<const AtomPDBResidueInfo *>(monomerInfo)
       ->getChainId();
 }
 }  // namespace

--- a/Code/GraphMol/Wrap/rdmolfiles.cpp
+++ b/Code/GraphMol/Wrap/rdmolfiles.cpp
@@ -1728,7 +1728,7 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
   python::def(
       "MolToCXSmiles",
       (std::string(*)(const ROMol &, const SmilesWriteParams &, std::uint32_t,
-                      RestoreBondDirOption))RDKit::MolToCXSmiles,
+                      unsigned int))RDKit::MolToCXSmiles,
       (python::arg("mol"), python::arg("params"),
        python::arg("flags") = RDKit::SmilesWrite::CXSmilesFields::CX_ALL,
        python::arg("restoreBondDirs") =

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -8222,7 +8222,16 @@ M  END
                      "[NH2:1]c1ccccc1")
     self.assertEqual(Chem.MolToSmiles(mol, ignoreAtomMapNumbers=False),
                      "c1ccc([NH2:1])cc1")
-    
+
+  def testSplitMolByPDB(self):
+    mol = Chem.MolFromSmiles("C")
+    res2mol = Chem.SplitMolByPDBResidues(mol)
+    self.assertEqual(len(res2mol), 1)
+    self.assertIn("", res2mol)
+    chain2mol = Chem.SplitMolByPDBChainId(mol)
+    self.assertEqual(len(chain2mol), 1)
+    self.assertIn("", chain2mol)
+
 if __name__ == '__main__':
   if "RDTESTCASE" in os.environ:
     suite = unittest.TestSuite()

--- a/Code/JavaWrappers/RGroupDecomposition.i
+++ b/Code/JavaWrappers/RGroupDecomposition.i
@@ -48,5 +48,6 @@ typedef std::vector<std::string> STR_VECT;
   }
 }
 
+%include <RDGeneral/ConditionallyUseBetterEnums.h>
 %include <GraphMol/RGroupDecomposition/RGroupDecompParams.h>
 %include <GraphMol/RGroupDecomposition/RGroupDecomp.h>

--- a/Code/JavaWrappers/SmilesWrite.i
+++ b/Code/JavaWrappers/SmilesWrite.i
@@ -35,4 +35,5 @@
 #include <GraphMol/SmilesParse/SmilesWrite.h>
 %}
 
+%include <RDGeneral/ConditionallyUseBetterEnums.h>
 %include <GraphMol/SmilesParse/SmilesWrite.h>

--- a/Code/MinimalLib/cffi_test.c
+++ b/Code/MinimalLib/cffi_test.c
@@ -2721,6 +2721,50 @@ void test_multi_highlights() {
   free(mpkl);
 }
 
+void test_bw_palette() {
+  printf("--------------------------\n");
+  printf("  bw palette\n");
+  const char *smi = "N";
+  const char *details = "{\"atomColourPalette\":\"bw\"}";
+  char *mpkl;
+  char *svg_with_details;
+  char *svg_without_details;
+  size_t mpkl_size;
+  mpkl = get_mol(smi, &mpkl_size, "");
+  assert(mpkl && mpkl_size);
+  svg_with_details = get_svg(mpkl, mpkl_size, details);
+  assert(strstr(svg_with_details, "#000000"));
+  assert(!strstr(svg_with_details, "#0000FF"));
+  svg_without_details = get_svg(mpkl, mpkl_size, "");
+  assert(!strstr(svg_without_details, "#000000"));
+  assert(strstr(svg_without_details, "#0000FF"));
+  free(svg_with_details);
+  free(svg_without_details);
+  free(mpkl);
+}
+
+void test_custom_palette() {
+  printf("--------------------------\n");
+  printf("  custom palette\n");
+  const char *smi = "N";
+  const char *details = "{\"atomColourPalette\":{\"7\":[1.0,0.0,0.0]}}";
+  char *mpkl;
+  char *svg_with_details;
+  char *svg_without_details;
+  size_t mpkl_size;
+  mpkl = get_mol(smi, &mpkl_size, "");
+  assert(mpkl && mpkl_size);
+  svg_with_details = get_svg(mpkl, mpkl_size, details);
+  assert(strstr(svg_with_details, "#FF0000"));
+  assert(!strstr(svg_with_details, "#0000FF"));
+  svg_without_details = get_svg(mpkl, mpkl_size, "");
+  assert(!strstr(svg_without_details, "#FF0000"));
+  assert(strstr(svg_without_details, "#0000FF"));
+  free(svg_with_details);
+  free(svg_without_details);
+  free(mpkl);
+}
+
 int main() {
   enable_logging();
   char *vers = version();
@@ -2756,5 +2800,7 @@ int main() {
   test_wedged_bond_atropisomer();
   test_get_molblock_use_molblock_wedging();
   test_multi_highlights();
+  test_bw_palette();
+  test_custom_palette();
   return 0;
 }

--- a/Code/MinimalLib/cffiwrapper.cpp
+++ b/Code/MinimalLib/cffiwrapper.cpp
@@ -132,7 +132,8 @@ std::string cxsmiles_helper(const char *pkl, size_t pkl_sz,
   auto mol = mol_from_pkl(pkl, pkl_sz);
   SmilesWrite::CXSmilesFields cxSmilesFields =
       SmilesWrite::CXSmilesFields::CX_ALL;
-  RestoreBondDirOption restoreBondDirs = RestoreBondDirOptionClear;
+  RestoreBondDirOption restoreBondDirs =
+      RestoreBondDirOption::RestoreBondDirOptionClear;
   updateCXSmilesFieldsFromJSON(cxSmilesFields, restoreBondDirs, details_json);
   return MolToCXSmiles(mol, params, cxSmilesFields, restoreBondDirs);
 }

--- a/Code/MinimalLib/cffiwrapper.cpp
+++ b/Code/MinimalLib/cffiwrapper.cpp
@@ -130,9 +130,9 @@ std::string cxsmiles_helper(const char *pkl, size_t pkl_sz,
   }
   auto params = smiles_helper(details_json);
   auto mol = mol_from_pkl(pkl, pkl_sz);
-  SmilesWrite::CXSmilesFields cxSmilesFields =
+  std::uint32_t cxSmilesFields =
       SmilesWrite::CXSmilesFields::CX_ALL;
-  RestoreBondDirOption restoreBondDirs =
+  unsigned int restoreBondDirs =
       RestoreBondDirOption::RestoreBondDirOptionClear;
   updateCXSmilesFieldsFromJSON(cxSmilesFields, restoreBondDirs, details_json);
   return MolToCXSmiles(mol, params, cxSmilesFields, restoreBondDirs);

--- a/Code/MinimalLib/tests/tests.js
+++ b/Code/MinimalLib/tests/tests.js
@@ -3376,6 +3376,32 @@ function test_multi_highlights() {
     mol.delete();
 }
 
+function test_bw_palette() {
+    const mol = RDKitModule.get_mol('N');
+    assert(mol);
+    const details = '{"atomColourPalette":"bw"}';
+    const svgWithDetails = mol.get_svg_with_highlights(details);
+    assert(svgWithDetails.includes('#000000'));
+    assert(!svgWithDetails.includes('#0000FF'));
+    const svgWithoutDetails = mol.get_svg();
+    assert(!svgWithoutDetails.includes('#000000'));
+    assert(svgWithoutDetails.includes('#0000FF'));
+    mol.delete();
+}
+
+function test_custom_palette() {
+    const mol = RDKitModule.get_mol('N');
+    assert(mol);
+    const details = '{"atomColourPalette\":{"7":[1.0,0.0,0.0]}}';
+    const svgWithDetails = mol.get_svg_with_highlights(details);
+    assert(svgWithDetails.includes('#FF0000'));
+    assert(!svgWithDetails.includes('#0000FF'));
+    const svgWithoutDetails = mol.get_svg();
+    assert(!svgWithoutDetails.includes('#FF0000'));
+    assert(svgWithoutDetails.includes('#0000FF'));
+    mol.delete();
+}
+
 initRDKitModule().then(function(instance) {
     var done = {};
     const waitAllTestsFinished = () => {
@@ -3462,6 +3488,9 @@ initRDKitModule().then(function(instance) {
         test_singlecore_rgd();
         test_multicore_rgd();
     }
+    test_bw_palette();
+    test_custom_palette();
+
     waitAllTestsFinished().then(() =>
         console.log("Tests finished successfully")
     );

--- a/Code/RDGeneral/CMakeLists.txt
+++ b/Code/RDGeneral/CMakeLists.txt
@@ -6,9 +6,10 @@ CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/RDConfig.h.cmake
               ${CMAKE_CURRENT_SOURCE_DIR}/RDConfig.h )
 
 FetchContent_MakeAvailable(better_enums)
-if(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/enum.h)
+if(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/BetterEnums.h)
   file(COPY ${better_enums_SOURCE_DIR}/enum.h DESTINATION ${CMAKE_CURRENT_SOURCE_DIR})
-endif(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/enum.h)
+  file(RENAME ${CMAKE_CURRENT_SOURCE_DIR}/enum.h ${CMAKE_CURRENT_SOURCE_DIR}/BetterEnums.h)
+endif(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/BetterEnums.h)
 
 rdkit_library(RDGeneral
               Invariant.cpp types.cpp utils.cpp RDGeneralExceptions.cpp RDLog.cpp
@@ -49,8 +50,8 @@ rdkit_headers(Exceptions.h
               export.h
               test.h
               ConcurrentQueue.h
-              WrapBetterEnums.h
-              enum.h
+              ConditionallyUseBetterEnums.h
+              BetterEnums.h
               DEST RDGeneral)
 
 if (NOT RDK_INSTALL_INTREE)

--- a/Code/RDGeneral/CMakeLists.txt
+++ b/Code/RDGeneral/CMakeLists.txt
@@ -5,6 +5,10 @@ CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/versions.h.cmake
 CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/RDConfig.h.cmake
               ${CMAKE_CURRENT_SOURCE_DIR}/RDConfig.h )
 
+FetchContent_MakeAvailable(better_enums)
+if(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/enum.h)
+  file(COPY ${better_enums_SOURCE_DIR}/enum.h DESTINATION ${CMAKE_CURRENT_SOURCE_DIR})
+endif(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/enum.h)
 
 rdkit_library(RDGeneral
               Invariant.cpp types.cpp utils.cpp RDGeneralExceptions.cpp RDLog.cpp
@@ -45,6 +49,8 @@ rdkit_headers(Exceptions.h
               export.h
               test.h
               ConcurrentQueue.h
+              WrapBetterEnums.h
+              enum.h
               DEST RDGeneral)
 
 if (NOT RDK_INSTALL_INTREE)

--- a/Code/RDGeneral/ConditionallyUseBetterEnums.h
+++ b/Code/RDGeneral/ConditionallyUseBetterEnums.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#ifdef USE_BETTER_ENUMS
-#include "enum.h"
+#if defined(USE_BETTER_ENUMS) && !defined(SWIG)
+#include "BetterEnums.h"
 #else
 #define BETTER_ENUM(Enum, Underlying, ...) enum Enum : Underlying { __VA_ARGS__ }
 #endif

--- a/Code/RDGeneral/WrapBetterEnums.h
+++ b/Code/RDGeneral/WrapBetterEnums.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#ifdef USE_BETTER_ENUMS
+#include "enum.h"
+#else
+#define BETTER_ENUM(Enum, Underlying, ...) enum Enum : Underlying { __VA_ARGS__ }
+#endif

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -10,6 +10,22 @@ GitHub)
 ## Highlights
 
 ## Backwards incompatible changes
+The following enums:
+* RGroupLabels
+* RGroupMatching
+* RGroupLabelling
+* RGroupCoreAlignment
+* RGroupScore
+* RestoreBondDirOption
+* SmilesWrite::CXSmilesFields
+are now Better Enums (https://aantron.github.io/better-enums/index.html)
+as this makes JSON parsing much more elegant and smoother through reflection.
+This may impact you if you are using them from C++, as now your code need
+to refer to enum values with full namespace scoping. i.e.
+RGroupLabels::MDLRGroupLabels as opposed to just MDLRGroupLabels,
+SmilesWrite::CXSmilesFields::CX_ALL as opposed to just SmilesWrite::CX_ALL,
+RestoreBondDirOption::RestoreBondDirOptionTrue as opposed to just
+RestoreBondDirOptionTrue.
 
 ## New Features and Enhancements:
 


### PR DESCRIPTION
## **** WIP - need to fix Windows builds ****

@greglandrum I was just about to add the 3rd instance of awful macros for home-made `enum` reflection when I thought how much you would have suffered, so I thought I'd rather explore Better Enums after being disappointed by magic_enum.

Indeed the experience was totally positive this time, and the code looks much cleaner now.
Please don't be put off by the number of changed file: almost all of the changes are about `enum` member namespace scoping, which I believe is a good thing as it makes source code clearer. However, that introduces a backwards-incompatible change for developers using RDKit from C++, which is why I added a note to Release Notes and scheduled this for `2025_03_1`.