### PR TITLE
Sort CIP entries in place using a lightweight wrapper, only sort tied entries

### DIFF
--- a/Code/GraphMol/Chirality.cpp
+++ b/Code/GraphMol/Chirality.cpp
@@ -1091,7 +1091,9 @@ void buildCIPInvariants(const ROMol &mol, DOUBLE_VECT &res) {
 //! Lightweight sortable wrapper that references a CIP entry and keeps track of
 //! the current rank.
 struct SortableCIPReference {
-  SortableCIPReference(CIP_ENTRY* cipRef, const int atomIdx): cip(cipRef), atomIdx(atomIdx) {}
+  SortableCIPReference(CIP_ENTRY* cipRef, const int atomIdx): cip(cipRef), atomIdx(atomIdx) {
+    CHECK_INVARIANT(cip != nullptr, "null CIP entry");
+  }
   SortableCIPReference(SortableCIPReference && other) noexcept {
     cip = other.cip;
     atomIdx = other.atomIdx;
@@ -1099,6 +1101,9 @@ struct SortableCIPReference {
     currRank = other.currRank;
   }
   SortableCIPReference & operator=(SortableCIPReference && other) noexcept {
+    if (this == &other) {
+      return *this;
+    }
     cip = other.cip;
     atomIdx = other.atomIdx;
     other.cip = nullptr;
@@ -1107,16 +1112,20 @@ struct SortableCIPReference {
   }
 
   bool operator==( const SortableCIPReference & rhs ) const {
+    PRECONDITION(cip != nullptr, "null CIP entry");
+    PRECONDITION(rhs.cip != nullptr, "null CIP entry");
     return *cip == *rhs.cip;
   }
 
   bool operator<( const SortableCIPReference & rhs ) const {
+    PRECONDITION(cip != nullptr, "null CIP entry");
+    PRECONDITION(rhs.cip != nullptr, "null CIP entry");
     return *cip < *rhs.cip;
   }
 
 
 
-  CIP_ENTRY* cip;
+  CIP_ENTRY* cip = nullptr;
   int atomIdx = -1;
   int currRank = -1;
 };

--- a/Code/GraphMol/Chirality.cpp
+++ b/Code/GraphMol/Chirality.cpp
@@ -17,7 +17,6 @@
 #include <GraphMol/Atropisomers.h>
 #include <RDGeneral/Invariant.h>
 #include <RDGeneral/RDLog.h>
-#include <RDGeneral/Ranking.h>
 #include <RDGeneral/types.h>
 #include <RDGeneral/utils.h>
 
@@ -1089,6 +1088,88 @@ void buildCIPInvariants(const ROMol &mol, DOUBLE_VECT &res) {
   }
 }
 
+//! Lightweight sortable wrapper that references a CIP entry and keeps track of
+//! the current rank.
+struct SortableCIPReference {
+  SortableCIPReference(CIP_ENTRY* cipRef, const int atomIdx): cip(cipRef), atomIdx(atomIdx) {}
+  SortableCIPReference(SortableCIPReference && other) noexcept {
+    cip = other.cip;
+    atomIdx = other.atomIdx;
+    other.cip = nullptr;
+    currRank = other.currRank;
+  }
+  SortableCIPReference & operator=(SortableCIPReference && other) noexcept {
+    cip = other.cip;
+    atomIdx = other.atomIdx;
+    other.cip = nullptr;
+    currRank = other.currRank;
+    return *this;
+  }
+
+  bool operator==( const SortableCIPReference & rhs ) const {
+    return *cip == *rhs.cip;
+  }
+
+  bool operator<( const SortableCIPReference & rhs ) const {
+    return *cip < *rhs.cip;
+  }
+
+
+
+  CIP_ENTRY* cip;
+  int atomIdx = -1;
+  int currRank = -1;
+};
+
+//! Iterate over sorted entries, track tied regions and assign ranks.
+//! \param sortedEntries CIP entries
+//! \param res Pairs of start, end index of tied atoms
+//! \param numIndependentEntries The number of unique ranks.
+void findSegmentsToResort(std::vector<SortableCIPReference>& sortedEntries,
+                          std::vector<std::pair<int, int>>& res,
+                          unsigned int& numIndependentEntries) {
+  res.clear();
+  numIndependentEntries = rdcast<unsigned int>(sortedEntries.size());
+  SortableCIPReference * current = &sortedEntries.front();
+  int runningRank = 0;
+  current->currRank = runningRank;
+  bool inEqualSection = false;
+
+  for (size_t i = 1; i < sortedEntries.size(); i++) {
+    SortableCIPReference & entry = sortedEntries[i];
+    if (*current == entry) {
+      entry.currRank = runningRank;
+      numIndependentEntries--;
+      // Case where we need to open a section
+      if (!inEqualSection) {
+        inEqualSection = true;
+        auto& [firstIndex, _] = res.emplace_back();
+        // Go back to the first in this section, we only catch at first + 1
+        firstIndex = i - 1;
+      } else {
+        // Case where we are already in a section, nullop
+      }
+    } else {
+      // Case where we're closing an open section.
+      runningRank++;
+      entry.currRank = runningRank;
+      current = &entry;
+
+      if (inEqualSection) {
+        auto& [_, finalIndex] = res.back();
+        finalIndex = i;
+        inEqualSection = false;
+      }
+    }
+
+  }
+  // Handle currently open.
+  if (inEqualSection) {
+    auto& [_, finalIndex] = res.back();
+    finalIndex = sortedEntries.size() - 1;
+  }
+}
+
 struct PrecomputedBondFeatures {
   //! Pairs of {atom index, counts}, strided by 8 for each atom.
   std::vector<std::pair<std::uint8_t,int>> countsAndNeighborIndices;
@@ -1151,6 +1232,14 @@ PrecomputedBondFeatures computeBondFeatures(const ROMol& mol) {
   return features;
 }
 
+void recomputeRanks(const std::vector<SortableCIPReference>& sortedEntries,
+                    std::vector<unsigned int>& ranks) {
+  for (size_t rank = 0; rank < ranks.size(); ++rank) {
+    const auto& cipEntry = sortedEntries[rank];
+    ranks[cipEntry.atomIdx] = cipEntry.currRank;
+  }
+}
+
 void iterateCIPRanks(const ROMol &mol, const DOUBLE_VECT &invars,
                      UINT_VECT &ranks, bool seedWithInvars) {
   PRECONDITION(invars.size() == mol.getNumAtoms(), "bad invars size");
@@ -1161,6 +1250,12 @@ void iterateCIPRanks(const ROMol &mol, const DOUBLE_VECT &invars,
   for (auto &vec : cipEntries) {
     vec.reserve(16);
   }
+
+  std::vector<SortableCIPReference> sortableEntries;
+  sortableEntries.reserve(numAtoms);
+  for (size_t i = 0; i < cipEntries.size(); i++) {
+    sortableEntries.emplace_back(&cipEntries[i], i);
+  }
 #ifdef VERBOSE_CANON
   BOOST_LOG(rdDebugLog) << "invariants:" << std::endl;
   for (unsigned int i = 0; i < numAtoms; i++) {
@@ -1168,8 +1263,15 @@ void iterateCIPRanks(const ROMol &mol, const DOUBLE_VECT &invars,
   }
 #endif
 
-  // rank those:
-  Rankers::rankVect(invars, ranks);
+  for (unsigned int i = 0; i < numAtoms; i++) {
+    cipEntries[i].push_back(static_cast<int>(invars[i]));
+  }
+  unsigned int numRanks;
+  std::sort(sortableEntries.begin(), sortableEntries.end());
+  std::vector<std::pair<int, int>> needsSorting;
+  findSegmentsToResort(sortableEntries, needsSorting, numRanks);
+  recomputeRanks(sortableEntries, ranks);
+
 #ifdef VERBOSE_CANON
   BOOST_LOG(rdDebugLog) << "initial ranks:" << std::endl;
   for (unsigned int i = 0; i < numAtoms; ++i) {
@@ -1181,9 +1283,9 @@ void iterateCIPRanks(const ROMol &mol, const DOUBLE_VECT &invars,
   //  use invariants here, those lead to incorrect answers
   for (unsigned int i = 0; i < numAtoms; i++) {
     if (seedWithInvars) {
-      cipEntries[i].push_back(static_cast<int>(invars[i]));
+      cipEntries[i][0] = static_cast<int>(invars[i]);
     } else {
-      cipEntries[i].push_back(mol[i]->getAtomicNum());
+      cipEntries[i][0] = mol[i]->getAtomicNum();
       cipEntries[i].push_back(static_cast<int>(ranks[i]));
     }
   }
@@ -1201,11 +1303,10 @@ void iterateCIPRanks(const ROMol &mol, const DOUBLE_VECT &invars,
   unsigned int maxIts = numAtoms / 2 + 1;
   unsigned int numIts = 0;
   int lastNumRanks = -1;
-  unsigned int numRanks = *std::max_element(ranks.begin(), ranks.end()) + 1;
 
   PrecomputedBondFeatures bondFeatures = computeBondFeatures(mol);
 
-  while (numRanks < numAtoms && numIts < maxIts &&
+  while (!needsSorting.empty() && numIts < maxIts &&
          (lastNumRanks < 0 ||
           static_cast<unsigned int>(lastNumRanks) < numRanks)) {
     unsigned int longestEntry = 0;
@@ -1261,8 +1362,15 @@ void iterateCIPRanks(const ROMol &mol, const DOUBLE_VECT &invars,
     //
     lastNumRanks = numRanks;
 
-    Rankers::rankVect(cipEntries, ranks);
-    numRanks = *std::max_element(ranks.begin(), ranks.end()) + 1;
+
+    // Loop through previously tied atom sections and re-sort.
+    for (const auto & [firstIdx, lastIdx] : needsSorting) {
+      std::sort(sortableEntries.begin() + firstIdx, sortableEntries.begin() + lastIdx + 1);
+    }
+    findSegmentsToResort(sortableEntries, needsSorting, numRanks);
+    // Map out of order rankings back to the absolute rankings vector.
+    recomputeRanks(sortableEntries, ranks);
+
 
     // now truncate each vector and stick the rank at the end
     if (static_cast<unsigned int>(lastNumRanks) != numRanks) {


### PR DESCRIPTION

#### Reference Issue
PR 2/3 targeting #7888


#### What does this implement/fix? Explain your changes.
At each iteration, the full array of CIP entries is sorted, but in the algorithm, any pair of atoms that previously was not tied is guaranteed to be in the same relative order. So this is actually a problem of re-sorting subsections of the atoms that were tied, rather than re-sorting the full array. This is important since vector comparisons are a large chunk of the runtime.

This PR does the following:
* Sorts CIP entries in place, using a lightweight reference struct so the data itself doesn't need to be moved. 
* replaces the previous generic vector ranking with an implementation that yields pairs of start/end indices that actually need sorting. 
* Iterates over those regions to sort
#### Any other comments?

