### PR TITLE
auto-close stale issues and PRs

### DIFF
--- a/.github/workflows/close_stale_issues.yml
+++ b/.github/workflows/close_stale_issues.yml
@@ -1,0 +1,25 @@
+name: Close inactive issues
+on:
+  schedule:
+    - cron: "30 1 * * *"
+
+jobs:
+  close-issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v5
+        with:
+          days-before-issue-stale: 90
+          days-before-issue-close: 14
+          stale-issue-label: "stale"
+          stale-issue-message: "This issue was marked as stale because it has been open for 90 days with no activity."
+          close-issue-message: "This issue was closed because it has been inactive for 14 days since being marked as stale."
+          days-before-pr-stale: 60
+          days-before-pr-close: 14
+          stale-pr-label: "stale"
+          stale-pr-message: "This PR was marked as stale because it has been open for 60 days with no activity."
+          close-pr-message: "This PR was closed because it has been inactive for 14 days since being marked as stale."
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This adds a github action to mark issues/PRs as stale after 90/60 days of inactivity and then close them 14 days after being marked stale if they are still inactive.

I will do a discussions post after this is merged to explain what is going on.
