### PR TITLE
... and more mem errors fixed

### DIFF
--- a/Code/GraphMol/CIPLabeler/catch_tests.cpp
+++ b/Code/GraphMol/CIPLabeler/catch_tests.cpp
@@ -944,22 +944,20 @@ TEST_CASE("atropisomers", "[basic]") {
   }
 }
 
-std::string cipLabels(std::string molBlock) {
-  RDKit::ROMol *mol = nullptr;
+std::string cipLabels(const std::string &molBlock) {
+  std::unique_ptr<RDKit::ROMol> mol;
   std::string result = "";
   try {
     // try parsing the mol block with sanitize ob
     try {
-      mol = MolBlockToMol(molBlock, true, false);
+      mol.reset(MolBlockToMol(molBlock, true, false));
     } catch (...) {
-      delete mol;
-      mol = nullptr;
     }
 
     // if parsing with Sanitize on did NOT work, try it without
 
-    if (mol == NULL) {
-      mol = MolBlockToMol(molBlock, false, false);
+    if (mol == nullptr) {
+      mol.reset(MolBlockToMol(molBlock, false, false));
       mol->updatePropertyCache(false);
     }
 
@@ -991,12 +989,8 @@ std::string cipLabels(std::string molBlock) {
              boost::algorithm::join(bondsArray, ", ");
     return result;
   } catch (const CIPLabeler::MaxIterationsExceeded &e) {
-    delete mol;
-    mol = nullptr;
     return "";
   } catch (const std::exception &e) {
-    delete mol;
-    mol = nullptr;
     return e.what();
   }
 }

--- a/Code/GraphMol/Fingerprints/Wrap/FingerprintGeneratorWrapper.cpp
+++ b/Code/GraphMol/Fingerprints/Wrap/FingerprintGeneratorWrapper.cpp
@@ -36,18 +36,18 @@ namespace np = boost::python::numpy;
 namespace RDKit {
 namespace FingerprintWrapper {
 
-void convertPyArguments(python::object py_fromAtoms,
-                        python::object py_ignoreAtoms,
-                        python::object py_atomInvs, python::object py_bondInvs,
-                        std::vector<std::uint32_t> *&fromAtoms,
-                        std::vector<std::uint32_t> *&ignoreAtoms,
-                        std::vector<std::uint32_t> *&customAtomInvariants,
-                        std::vector<std::uint32_t> *&customBondInvariants) {
+void convertPyArguments(
+    python::object py_fromAtoms, python::object py_ignoreAtoms,
+    python::object py_atomInvs, python::object py_bondInvs,
+    std::unique_ptr<std::vector<std::uint32_t>> &fromAtoms,
+    std::unique_ptr<std::vector<std::uint32_t>> &ignoreAtoms,
+    std::unique_ptr<std::vector<std::uint32_t>> &customAtomInvariants,
+    std::unique_ptr<std::vector<std::uint32_t>> &customBondInvariants) {
   if (!py_fromAtoms.is_none()) {
     unsigned int len =
         python::extract<unsigned int>(py_fromAtoms.attr("__len__")());
     if (len) {
-      fromAtoms = new std::vector<std::uint32_t>();
+      fromAtoms.reset(new std::vector<std::uint32_t>());
       fromAtoms->reserve(len);
       for (unsigned int i = 0; i < len; ++i) {
         fromAtoms->push_back(python::extract<std::uint32_t>(py_fromAtoms[i]));
@@ -59,7 +59,7 @@ void convertPyArguments(python::object py_fromAtoms,
     unsigned int len =
         python::extract<unsigned int>(py_ignoreAtoms.attr("__len__")());
     if (len) {
-      ignoreAtoms = new std::vector<std::uint32_t>();
+      ignoreAtoms.reset(new std::vector<std::uint32_t>());
       ignoreAtoms->reserve(len);
       for (unsigned int i = 0; i < len; ++i) {
         ignoreAtoms->push_back(
@@ -72,7 +72,7 @@ void convertPyArguments(python::object py_fromAtoms,
     unsigned int len =
         python::extract<unsigned int>(py_atomInvs.attr("__len__")());
     if (len) {
-      customAtomInvariants = new std::vector<std::uint32_t>();
+      customAtomInvariants.reset(new std::vector<std::uint32_t>());
       customAtomInvariants->reserve(len);
       for (unsigned int i = 0; i < len; ++i) {
         customAtomInvariants->push_back(
@@ -85,7 +85,7 @@ void convertPyArguments(python::object py_fromAtoms,
     unsigned int len =
         python::extract<unsigned int>(py_bondInvs.attr("__len__")());
     if (len) {
-      customBondInvariants = new std::vector<std::uint32_t>();
+      customBondInvariants.reset(new std::vector<std::uint32_t>());
       customBondInvariants->reserve(len);
       for (unsigned int i = 0; i < len; ++i) {
         customBondInvariants->push_back(
@@ -103,10 +103,10 @@ SparseIntVect<OutputType> *getSparseCountFingerprint(
     python::object py_fromAtoms, python::object py_ignoreAtoms,
     const int confId, python::object py_atomInvs, python::object py_bondInvs,
     python::object py_additionalOutput) {
-  std::vector<std::uint32_t> *fromAtoms = nullptr;
-  std::vector<std::uint32_t> *ignoreAtoms = nullptr;
-  std::vector<std::uint32_t> *customAtomInvariants = nullptr;
-  std::vector<std::uint32_t> *customBondInvariants = nullptr;
+  std::unique_ptr<std::vector<std::uint32_t>> fromAtoms;
+  std::unique_ptr<std::vector<std::uint32_t>> ignoreAtoms;
+  std::unique_ptr<std::vector<std::uint32_t>> customAtomInvariants;
+  std::unique_ptr<std::vector<std::uint32_t>> customBondInvariants;
 
   convertPyArguments(py_fromAtoms, py_ignoreAtoms, py_atomInvs, py_bondInvs,
                      fromAtoms, ignoreAtoms, customAtomInvariants,
@@ -116,13 +116,10 @@ SparseIntVect<OutputType> *getSparseCountFingerprint(
     additionalOutput = python::extract<AdditionalOutput *>(py_additionalOutput);
   }
 
-  FingerprintFuncArguments args(fromAtoms, ignoreAtoms, confId,
-                                additionalOutput, customAtomInvariants,
-                                customBondInvariants);
+  FingerprintFuncArguments args(fromAtoms.get(), ignoreAtoms.get(), confId,
+                                additionalOutput, customAtomInvariants.get(),
+                                customBondInvariants.get());
   auto result = fpGen->getSparseCountFingerprint(mol, args);
-
-  delete fromAtoms;
-  delete ignoreAtoms;
 
   return result.release();
 }
@@ -133,10 +130,10 @@ SparseBitVect *getSparseFingerprint(
     python::object py_fromAtoms, python::object py_ignoreAtoms,
     const int confId, python::object py_atomInvs, python::object py_bondInvs,
     python::object py_additionalOutput) {
-  std::vector<std::uint32_t> *fromAtoms = nullptr;
-  std::vector<std::uint32_t> *ignoreAtoms = nullptr;
-  std::vector<std::uint32_t> *customAtomInvariants = nullptr;
-  std::vector<std::uint32_t> *customBondInvariants = nullptr;
+  std::unique_ptr<std::vector<std::uint32_t>> fromAtoms;
+  std::unique_ptr<std::vector<std::uint32_t>> ignoreAtoms;
+  std::unique_ptr<std::vector<std::uint32_t>> customAtomInvariants;
+  std::unique_ptr<std::vector<std::uint32_t>> customBondInvariants;
   convertPyArguments(py_fromAtoms, py_ignoreAtoms, py_atomInvs, py_bondInvs,
                      fromAtoms, ignoreAtoms, customAtomInvariants,
                      customBondInvariants);
@@ -145,13 +142,10 @@ SparseBitVect *getSparseFingerprint(
     additionalOutput = python::extract<AdditionalOutput *>(py_additionalOutput);
   }
 
-  FingerprintFuncArguments args(fromAtoms, ignoreAtoms, confId,
-                                additionalOutput, customAtomInvariants,
-                                customBondInvariants);
+  FingerprintFuncArguments args(fromAtoms.get(), ignoreAtoms.get(), confId,
+                                additionalOutput, customAtomInvariants.get(),
+                                customBondInvariants.get());
   auto result = fpGen->getSparseFingerprint(mol, args);
-
-  delete fromAtoms;
-  delete ignoreAtoms;
 
   return result.release();
 }
@@ -162,10 +156,10 @@ SparseIntVect<std::uint32_t> *getCountFingerprint(
     python::object py_fromAtoms, python::object py_ignoreAtoms,
     const int confId, python::object py_atomInvs, python::object py_bondInvs,
     python::object py_additionalOutput) {
-  std::vector<std::uint32_t> *fromAtoms = nullptr;
-  std::vector<std::uint32_t> *ignoreAtoms = nullptr;
-  std::vector<std::uint32_t> *customAtomInvariants = nullptr;
-  std::vector<std::uint32_t> *customBondInvariants = nullptr;
+  std::unique_ptr<std::vector<std::uint32_t>> fromAtoms;
+  std::unique_ptr<std::vector<std::uint32_t>> ignoreAtoms;
+  std::unique_ptr<std::vector<std::uint32_t>> customAtomInvariants;
+  std::unique_ptr<std::vector<std::uint32_t>> customBondInvariants;
   convertPyArguments(py_fromAtoms, py_ignoreAtoms, py_atomInvs, py_bondInvs,
                      fromAtoms, ignoreAtoms, customAtomInvariants,
                      customBondInvariants);
@@ -174,13 +168,10 @@ SparseIntVect<std::uint32_t> *getCountFingerprint(
     additionalOutput = python::extract<AdditionalOutput *>(py_additionalOutput);
   }
 
-  FingerprintFuncArguments args(fromAtoms, ignoreAtoms, confId,
-                                additionalOutput, customAtomInvariants,
-                                customBondInvariants);
+  FingerprintFuncArguments args(fromAtoms.get(), ignoreAtoms.get(), confId,
+                                additionalOutput, customAtomInvariants.get(),
+                                customBondInvariants.get());
   auto result = fpGen->getCountFingerprint(mol, args);
-
-  delete fromAtoms;
-  delete ignoreAtoms;
 
   return result.release();
 }
@@ -192,10 +183,10 @@ ExplicitBitVect *getFingerprint(const FingerprintGenerator<OutputType> *fpGen,
                                 python::object py_atomInvs,
                                 python::object py_bondInvs,
                                 python::object py_additionalOutput) {
-  std::vector<std::uint32_t> *fromAtoms = nullptr;
-  std::vector<std::uint32_t> *ignoreAtoms = nullptr;
-  std::vector<std::uint32_t> *customAtomInvariants = nullptr;
-  std::vector<std::uint32_t> *customBondInvariants = nullptr;
+  std::unique_ptr<std::vector<std::uint32_t>> fromAtoms;
+  std::unique_ptr<std::vector<std::uint32_t>> ignoreAtoms;
+  std::unique_ptr<std::vector<std::uint32_t>> customAtomInvariants;
+  std::unique_ptr<std::vector<std::uint32_t>> customBondInvariants;
   convertPyArguments(py_fromAtoms, py_ignoreAtoms, py_atomInvs, py_bondInvs,
                      fromAtoms, ignoreAtoms, customAtomInvariants,
                      customBondInvariants);
@@ -204,13 +195,10 @@ ExplicitBitVect *getFingerprint(const FingerprintGenerator<OutputType> *fpGen,
     additionalOutput = python::extract<AdditionalOutput *>(py_additionalOutput);
   }
 
-  FingerprintFuncArguments args(fromAtoms, ignoreAtoms, confId,
-                                additionalOutput, customAtomInvariants,
-                                customBondInvariants);
+  FingerprintFuncArguments args(fromAtoms.get(), ignoreAtoms.get(), confId,
+                                additionalOutput, customAtomInvariants.get(),
+                                customBondInvariants.get());
   auto result = fpGen->getFingerprint(mol, args);
-
-  delete fromAtoms;
-  delete ignoreAtoms;
 
   return result.release();
 }

--- a/Code/GraphMol/Wrap/PDBWriter.cpp
+++ b/Code/GraphMol/Wrap/PDBWriter.cpp
@@ -25,7 +25,6 @@ namespace RDKit {
 using boost_adaptbx::python::streambuf;
 namespace {
 PDBWriter *getPDBWriter(python::object &fileobj, unsigned int flavor = 0) {
-  // FIX: minor leak here
   auto *sb = new streambuf(fileobj, 't');
   auto *ost = new streambuf::ostream(sb);
   return new PDBWriter(ost, true, flavor);

--- a/Code/GraphMol/Wrap/PDBWriter.cpp
+++ b/Code/GraphMol/Wrap/PDBWriter.cpp
@@ -27,7 +27,7 @@ namespace {
 PDBWriter *getPDBWriter(python::object &fileobj, unsigned int flavor = 0) {
   // FIX: minor leak here
   auto *sb = new streambuf(fileobj, 't');
-  auto *ost = new streambuf::ostream(*sb);
+  auto *ost = new streambuf::ostream(sb);
   return new PDBWriter(ost, true, flavor);
 }
 }  // namespace

--- a/Code/GraphMol/Wrap/SDWriter.cpp
+++ b/Code/GraphMol/Wrap/SDWriter.cpp
@@ -27,7 +27,7 @@ namespace RDKit {
 SDWriter *getSDWriter(python::object &fileobj) {
   // FIX: minor leak here
   auto *sb = new streambuf(fileobj, 't');
-  auto *ost = new streambuf::ostream(*sb);
+  auto *ost = new streambuf::ostream(sb);
   return new SDWriter(ost, true);
 }
 

--- a/Code/GraphMol/Wrap/SDWriter.cpp
+++ b/Code/GraphMol/Wrap/SDWriter.cpp
@@ -25,7 +25,6 @@ using boost_adaptbx::python::streambuf;
 
 namespace RDKit {
 SDWriter *getSDWriter(python::object &fileobj) {
-  // FIX: minor leak here
   auto *sb = new streambuf(fileobj, 't');
   auto *ost = new streambuf::ostream(sb);
   return new SDWriter(ost, true);

--- a/Code/GraphMol/Wrap/SmilesWriter.cpp
+++ b/Code/GraphMol/Wrap/SmilesWriter.cpp
@@ -29,7 +29,6 @@ SmilesWriter *getSmilesWriter(python::object &fileobj,
                               bool includeHeader = true,
                               bool isomericSmiles = true,
                               bool kekuleSmiles = false) {
-  // FIX: minor leak here
   auto *sb = new streambuf(fileobj, 't');
   auto *ost = new streambuf::ostream(sb);
   return new SmilesWriter(ost, delimiter, nameHeader, includeHeader, true,

--- a/Code/GraphMol/Wrap/SmilesWriter.cpp
+++ b/Code/GraphMol/Wrap/SmilesWriter.cpp
@@ -31,7 +31,7 @@ SmilesWriter *getSmilesWriter(python::object &fileobj,
                               bool kekuleSmiles = false) {
   // FIX: minor leak here
   auto *sb = new streambuf(fileobj, 't');
-  auto *ost = new streambuf::ostream(*sb);
+  auto *ost = new streambuf::ostream(sb);
   return new SmilesWriter(ost, delimiter, nameHeader, includeHeader, true,
                           isomericSmiles, kekuleSmiles);
 }

--- a/Code/GraphMol/Wrap/TDTWriter.cpp
+++ b/Code/GraphMol/Wrap/TDTWriter.cpp
@@ -27,7 +27,7 @@ using boost_adaptbx::python::streambuf;
 TDTWriter *getTDTWriter(python::object &fileobj) {
   // FIX: minor leak here
   auto *sb = new streambuf(fileobj, 't');
-  auto *ost = new streambuf::ostream(*sb);
+  auto *ost = new streambuf::ostream(sb);
   return new TDTWriter(ost, true);
 }
 

--- a/Code/GraphMol/Wrap/TDTWriter.cpp
+++ b/Code/GraphMol/Wrap/TDTWriter.cpp
@@ -25,7 +25,6 @@ namespace python = boost::python;
 namespace RDKit {
 using boost_adaptbx::python::streambuf;
 TDTWriter *getTDTWriter(python::object &fileobj) {
-  // FIX: minor leak here
   auto *sb = new streambuf(fileobj, 't');
   auto *ost = new streambuf::ostream(sb);
   return new TDTWriter(ost, true);

--- a/Code/RDBoost/python_streambuf.h
+++ b/Code/RDBoost/python_streambuf.h
@@ -529,11 +529,20 @@ class streambuf : public std::basic_streambuf<char> {
       exceptions(std::ios_base::badbit);
     }
 
+    // overload that takes ownership of the streambuf ptr
+    ostream(streambuf *buf) : std::ostream(buf), m_buf(buf) {
+      exceptions(std::ios_base::badbit);
+    }
+
     ~ostream() override {
       if (this->good()) {
         this->flush();
       }
+      delete m_buf;
     }
+
+   private:
+    streambuf *m_buf = nullptr;
   };
 };
 


### PR DESCRIPTION
This is round 3.

- The change in `Code/RDBoost/python_streambuf.h` that takes ownership of the pointer allows fixing the leaking `streambuf`s in `getTDTWriter()`, `getSmilesWriter()`, `getSDWriter()` and `getPDBWriter()`.

- The changes in `Code/GraphMol/Fingerprints/Wrap/FingerprintGeneratorWrapper.cpp` are due to the `std::vector<std::uint32_t> *`s leaking in `getFingerprint()`.  `customAtomInvariants` and `customBondInvariants` are never cleaned up, but `fromAtoms` and `ignoreAtoms` would also leak if something goes wrong in `getFingerprint()` and an exception is thrown.

- In `Code/GraphMol/Wrap/MolOps.cpp`, there's two fixes: `sb` and `istr` leaking if `parseQueryDefFile()` throws, and `atomCountsV` in `wrapLayeredFingerprint()` also leaking if we either hit the `throw_value_error()` or `LayeredFingerprintMol()` throws.

- Finally, in `Code/ML/Cluster/Murtagh/Clustering.cpp`, `PyArray_SimpleNewFromData()` does not take ownership of the `ia`, `ib` or `crit` arrays it is called on. So, to allow Python to manage the lifetime of these arrays, we use `PyCapsule_New()` to encapsulate them and associate a destructor function to them, and then attach the capsules to the array, so that the lifetime of the encapsulated C array is dependent on the PyArray.