### PR TITLE
Fixes #7929

### DIFF
--- a/Code/GraphMol/Chirality.cpp
+++ b/Code/GraphMol/Chirality.cpp
@@ -2376,10 +2376,7 @@ void legacyStereoPerception(ROMol &mol, bool cleanIt,
   bool hasStereoBonds = false;
   for (auto bond : mol.bonds()) {
     if (cleanIt) {
-      if (bond->hasProp(common_properties::_CIPCode)) {
-        bond->clearProp(common_properties::_CIPCode);
-      }
-
+      bond->clearProp(common_properties::_CIPCode);
       // enforce no stereo on small rings
       if ((bond->getBondType() == Bond::DOUBLE ||
            bond->getBondType() == Bond::AROMATIC) &&

--- a/Code/GraphMol/Chirality.cpp
+++ b/Code/GraphMol/Chirality.cpp
@@ -2376,6 +2376,10 @@ void legacyStereoPerception(ROMol &mol, bool cleanIt,
   bool hasStereoBonds = false;
   for (auto bond : mol.bonds()) {
     if (cleanIt) {
+      if (bond->hasProp(common_properties::_CIPCode)) {
+        bond->clearProp(common_properties::_CIPCode);
+      }
+
       // enforce no stereo on small rings
       if ((bond->getBondType() == Bond::DOUBLE ||
            bond->getBondType() == Bond::AROMATIC) &&
@@ -2605,6 +2609,7 @@ void stereoPerception(ROMol &mol, bool cleanIt,
       atom->clearProp(common_properties::_ChiralityPossible);
     }
     for (auto bond : mol.bonds()) {
+      bond->clearProp(common_properties::_CIPCode);
       if (bond->getBondDir() == Bond::BondDir::EITHERDOUBLE) {
         bond->setStereo(Bond::BondStereo::STEREOANY);
         bond->getStereoAtoms().clear();

--- a/Code/GraphMol/catch_chirality.cpp
+++ b/Code/GraphMol/catch_chirality.cpp
@@ -5966,3 +5966,35 @@ TEST_CASE(
     }
   }
 }
+
+TEST_CASE(
+    "GitHub Issue #7929: AssignStereochemistry(cleanIt=True) does not clean _CIPCode property on bonds") {
+  UseLegacyStereoPerceptionFixture reset_stereo_perception(true);
+
+  auto m = "CC"_smiles;
+  REQUIRE(m);
+
+  m->getAtomWithIdx(0)->setProp(common_properties::_CIPCode, "X");
+  m->getBondWithIdx(0)->setProp(common_properties::_CIPCode, "X");
+
+  bool clean = true;
+  bool flag = true;
+  bool force = true;
+
+  SECTION("legacy stereo perception") {
+    Chirality::setUseLegacyStereoPerception(true);
+
+    RDKit::MolOps::assignStereochemistry(*m, clean, force, flag);
+
+    CHECK(m->getAtomWithIdx(0)->hasProp(common_properties::_CIPCode) == false);
+    CHECK(m->getBondWithIdx(0)->hasProp(common_properties::_CIPCode) == false);
+  }
+  SECTION("new stereo perception") {
+    Chirality::setUseLegacyStereoPerception(false);
+
+    RDKit::MolOps::assignStereochemistry(*m, clean, force, flag);
+
+    CHECK(m->getAtomWithIdx(0)->hasProp(common_properties::_CIPCode) == false);
+    CHECK(m->getBondWithIdx(0)->hasProp(common_properties::_CIPCode) == false);
+  }
+}


### PR DESCRIPTION
Fixes #7929

Just clean the `_CIPCode` property when we use `cleanIt=true`.