### PR TITLE
Convert reaction fingerprinter to use FingerprintGenerators

### DIFF
--- a/Code/GraphMol/ChemReactions/ReactionFingerprints.cpp
+++ b/Code/GraphMol/ChemReactions/ReactionFingerprints.cpp
@@ -1,5 +1,6 @@
 //
-//  Copyright (c) 2014, Novartis Institutes for BioMedical Research Inc.
+//  Copyright (c) 2014-2024, Novartis Institutes for BioMedical Research Inc.
+//  and other RDKit contributors
 //  All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -35,11 +36,13 @@
 #include <DataStructs/ExplicitBitVect.h>
 #include <DataStructs/BitOps.h>
 #include <GraphMol/ChemReactions/Reaction.h>
-#include <GraphMol/Fingerprints/Fingerprints.h>
-#include <GraphMol/Fingerprints/AtomPairs.h>
 #include "GraphMol/ChemReactions/ReactionFingerprints.h"
 #include <GraphMol/Fingerprints/MACCS.h>
-#include <GraphMol/Fingerprints/MorganFingerprints.h>
+#include <GraphMol/Fingerprints/Fingerprints.h>
+#include <GraphMol/Fingerprints/AtomPairGenerator.h>
+#include <GraphMol/Fingerprints/TopologicalTorsionGenerator.h>
+#include <GraphMol/Fingerprints/MorganGenerator.h>
+#include <GraphMol/Fingerprints/RDKitFPGenerator.h>
 #include <DataStructs/SparseIntVect.h>
 #include <GraphMol/ChemReactions/ReactionUtils.h>
 
@@ -48,32 +51,35 @@ namespace {
 RDKit::SparseIntVect<std::uint32_t> *generateFingerprint(
     RDKit::ROMol &mol, unsigned int fpSize, RDKit::FingerprintType t) {
   mol.updatePropertyCache(false);
-  RDKit::SparseIntVect<std::uint32_t> *res;
+  RDKit::SparseIntVect<std::uint32_t> *res = nullptr;
   switch (t) {
-    case RDKit::AtomPairFP: {
-      RDKit::SparseIntVect<std::int32_t> *tmp1 =
-          RDKit::AtomPairs::getHashedAtomPairFingerprint(mol, fpSize);
-      res = new RDKit::SparseIntVect<std::uint32_t>(fpSize);
-      for (auto val : tmp1->getNonzeroElements()) {
-        res->setVal(static_cast<std::uint32_t>(val.first), val.second);
-      }
-      delete tmp1;
+    case RDKit::FingerprintType::AtomPairFP: {
+      RDKit::AtomPair::AtomPairArguments args;
+      args.d_fpSize = fpSize;
+      std::unique_ptr<RDKit::FingerprintGenerator<std::uint32_t>> fpg{
+          RDKit::AtomPair::getAtomPairGenerator<std::uint32_t>(args)};
+      res = fpg->getCountFingerprint(mol);
     } break;
-    case RDKit::TopologicalTorsion: {
-      RDKit::SparseIntVect<boost::int64_t> *tmp2 =
-          RDKit::AtomPairs::getHashedTopologicalTorsionFingerprint(mol, fpSize);
-      res = new RDKit::SparseIntVect<std::uint32_t>(fpSize);
-      for (auto val : tmp2->getNonzeroElements()) {
-        res->setVal(static_cast<std::uint32_t>(val.first), val.second);
-      }
-      delete tmp2;
+    case RDKit::FingerprintType::TopologicalTorsionFP: {
+      RDKit::TopologicalTorsion::TopologicalTorsionArguments args;
+      args.d_fpSize = fpSize;
+      std::unique_ptr<RDKit::FingerprintGenerator<std::uint64_t>> fpg{
+          RDKit::TopologicalTorsion::getTopologicalTorsionGenerator<
+              std::uint64_t>(args)};
+
+      res = fpg->getCountFingerprint(mol);
     } break;
-    case RDKit::MorganFP: {
+    case RDKit::FingerprintType::MorganFP: {
       if (!mol.getRingInfo()->isInitialized()) {
         mol.updatePropertyCache();
         RDKit::MolOps::findSSSR(mol);
       }
-      res = RDKit::MorganFingerprints::getHashedFingerprint(mol, 2, fpSize);
+      RDKit::MorganFingerprint::MorganArguments args;
+      args.d_radius = 2;
+      args.d_fpSize = fpSize;
+      std::unique_ptr<RDKit::FingerprintGenerator<std::uint32_t>> fpg{
+          RDKit::MorganFingerprint::getMorganGenerator<std::uint32_t>(args)};
+      res = fpg->getCountFingerprint(mol);
     } break;
     default:
       std::stringstream err;
@@ -89,25 +95,43 @@ ExplicitBitVect *generateFingerprintAsBitVect(RDKit::ROMol &mol,
   mol.updatePropertyCache(false);
   ExplicitBitVect *res;
   switch (t) {
-    case RDKit::AtomPairFP:
-      res =
-          RDKit::AtomPairs::getHashedAtomPairFingerprintAsBitVect(mol, fpSize);
-      break;
-    case RDKit::RDKitFP:
-      res = RDKit::RDKFingerprintMol(mol, 1, 7, fpSize);
-      break;
-    case RDKit::TopologicalTorsion:
-      res = RDKit::AtomPairs::getHashedTopologicalTorsionFingerprintAsBitVect(
-          mol, fpSize);
-      break;
-    case RDKit::MorganFP: {
+    case RDKit::FingerprintType::AtomPairFP: {
+      RDKit::AtomPair::AtomPairArguments args;
+      args.d_fpSize = fpSize;
+      std::unique_ptr<RDKit::FingerprintGenerator<std::uint32_t>> fpg{
+          RDKit::AtomPair::getAtomPairGenerator<std::uint32_t>(args)};
+      res = fpg->getFingerprint(mol);
+    } break;
+    case RDKit::FingerprintType::RDKitFP: {
+      RDKit::RDKitFP::RDKitFPArguments args;
+      args.d_fpSize = fpSize;
+      args.d_minPath = 1;
+      args.d_maxPath = 7;
+      std::unique_ptr<RDKit::FingerprintGenerator<std::uint32_t>> fpg{
+          RDKit::RDKitFP::getRDKitFPGenerator<std::uint32_t>(args)};
+      res = fpg->getFingerprint(mol);
+    } break;
+    case RDKit::FingerprintType::TopologicalTorsionFP: {
+      RDKit::TopologicalTorsion::TopologicalTorsionArguments args;
+      args.d_fpSize = fpSize;
+      std::unique_ptr<RDKit::FingerprintGenerator<std::uint64_t>> fpg{
+          RDKit::TopologicalTorsion::getTopologicalTorsionGenerator<
+              std::uint64_t>(args)};
+      res = fpg->getFingerprint(mol);
+    } break;
+    case RDKit::FingerprintType::MorganFP: {
       if (!mol.getRingInfo()->isInitialized()) {
         mol.updatePropertyCache();
         RDKit::MolOps::findSSSR(mol);
       }
-      res = RDKit::MorganFingerprints::getFingerprintAsBitVect(mol, 2, fpSize);
+      RDKit::MorganFingerprint::MorganArguments args;
+      args.d_radius = 2;
+      args.d_fpSize = fpSize;
+      std::unique_ptr<RDKit::FingerprintGenerator<std::uint32_t>> fpg{
+          RDKit::MorganFingerprint::getMorganGenerator<std::uint32_t>(args)};
+      res = fpg->getFingerprint(mol);
     } break;
-    case RDKit::PatternFP:
+    case RDKit::FingerprintType::PatternFP:
       res = RDKit::PatternFingerprintMol(mol, fpSize);
       break;
     default:
@@ -121,10 +145,10 @@ ExplicitBitVect *generateFingerprintAsBitVect(RDKit::ROMol &mol,
 
 namespace RDKit {
 
-const ReactionFingerprintParams DefaultStructuralFPParams(true, 0.2, 1, 1, 4096,
-                                                          PatternFP);
-const ReactionFingerprintParams DefaultDifferenceFPParams(true, 0.0, 10, 1,
-                                                          2048, AtomPairFP);
+const ReactionFingerprintParams DefaultStructuralFPParams(
+    true, 0.2, 1, 1, 4096, FingerprintType::PatternFP);
+const ReactionFingerprintParams DefaultDifferenceFPParams(
+    true, 0.0, 10, 1, 2048, FingerprintType::AtomPairFP);
 
 SparseIntVect<std::uint32_t> *generateFingerprintChemReactionAsCountVect(
     const ChemicalReaction &rxn, unsigned int fpSize, FingerprintType t,
@@ -197,7 +221,8 @@ ExplicitBitVect *StructuralFingerprintChemReaction(
 SparseIntVect<std::uint32_t> *DifferenceFingerprintChemReaction(
     const ChemicalReaction &rxn, const ReactionFingerprintParams &params) {
   PRECONDITION(params.fpSize != 0, "fpSize==0");
-  PRECONDITION(params.fpType > 0 && params.fpType < 4,
+  PRECONDITION(static_cast<int>(params.fpType) > 0 &&
+                   static_cast<int>(params.fpType) < 4,
                "Fingerprinttype not supported");
 
   SparseIntVect<std::uint32_t> *reactantFP =

--- a/Code/GraphMol/ChemReactions/ReactionFingerprints.cpp
+++ b/Code/GraphMol/ChemReactions/ReactionFingerprints.cpp
@@ -93,7 +93,7 @@ ExplicitBitVect *generateFingerprintAsBitVect(RDKit::ROMol &mol,
                                               unsigned int fpSize,
                                               RDKit::FingerprintType t) {
   mol.updatePropertyCache(false);
-  ExplicitBitVect *res;
+  ExplicitBitVect *res = nullptr;
   switch (t) {
     case RDKit::FingerprintType::AtomPairFP: {
       RDKit::AtomPair::AtomPairArguments args;

--- a/Code/GraphMol/ChemReactions/ReactionFingerprints.h
+++ b/Code/GraphMol/ChemReactions/ReactionFingerprints.h
@@ -40,9 +40,9 @@ namespace RDKit {
 
 class ChemicalReaction;
 
-enum FingerprintType {
+enum class FingerprintType {
   AtomPairFP = 1,
-  TopologicalTorsion,
+  TopologicalTorsionFP,
   MorganFP,
   RDKitFP,
   PatternFP
@@ -90,7 +90,7 @@ struct RDKIT_CHEMREACTIONS_EXPORT ReactionFingerprintParams {
   unsigned int nonAgentWeight{10};
   int agentWeight{1};
   unsigned int fpSize{2048};
-  FingerprintType fpType{AtomPairFP};
+  FingerprintType fpType{FingerprintType::AtomPairFP};
 };
 
 RDKIT_CHEMREACTIONS_EXPORT extern const ReactionFingerprintParams

--- a/Code/GraphMol/ChemReactions/Wrap/rdChemReactions.cpp
+++ b/Code/GraphMol/ChemReactions/Wrap/rdChemReactions.cpp
@@ -534,11 +534,11 @@ BOOST_PYTHON_MODULE(rdChemReactions) {
       &rdChemicalReactionExceptionTranslator);
 
   python::enum_<RDKit::FingerprintType>("FingerprintType")
-      .value("AtomPairFP", RDKit::AtomPairFP)
-      .value("TopologicalTorsion", RDKit::TopologicalTorsion)
-      .value("MorganFP", RDKit::MorganFP)
-      .value("RDKitFP", RDKit::RDKitFP)
-      .value("PatternFP", RDKit::PatternFP);
+      .value("AtomPairFP", RDKit::FingerprintType::AtomPairFP)
+      .value("TopologicalTorsion", RDKit::FingerprintType::TopologicalTorsionFP)
+      .value("MorganFP", RDKit::FingerprintType::MorganFP)
+      .value("RDKitFP", RDKit::FingerprintType::RDKitFP)
+      .value("PatternFP", RDKit::FingerprintType::PatternFP);
   std::string docStringReactionFPParams =
       "A class for storing parameters to manipulate the calculation of "
       "fingerprints of chemical reactions.";

--- a/Code/GraphMol/ChemReactions/catch_tests.cpp
+++ b/Code/GraphMol/ChemReactions/catch_tests.cpp
@@ -25,6 +25,7 @@
 #include <GraphMol/ChemReactions/ReactionUtils.h>
 #include <GraphMol/ChemReactions/ReactionPickler.h>
 #include <GraphMol/ChemReactions/SanitizeRxn.h>
+#include <GraphMol/ChemReactions/ReactionFingerprints.h>
 #include <GraphMol/FileParsers/PNGParser.h>
 #include <GraphMol/FileParsers/FileParserUtils.h>
 
@@ -2089,5 +2090,24 @@ M  END)CTAB"_ctab;
     CHECK(ps[1][0]->getStereoGroups().size() == 2);
     CHECK(ps[0][0]->getStereoGroups()[0].getGroupType() ==
           StereoGroupType::STEREO_AND);
+  }
+}
+
+TEST_CASE("Structural fingerprints values") {
+  SECTION("basics") {
+    auto rxn1 = "c1ccccc1>CC(=O)O.[Na+]>c1ccncc1"_rxnsmarts;
+    REQUIRE(rxn1);
+    auto rxn2 = "c1ncccc1>[Na+]>c1ncncc1"_rxnsmarts;
+    REQUIRE(rxn2);
+
+    ReactionFingerprintParams params;
+    params.fpType = FingerprintType::TopologicalTorsionFP;
+    params.fpSize = 4096;
+
+    std::unique_ptr<ExplicitBitVect> fp1{
+        StructuralFingerprintChemReaction(*rxn1, params)};
+    std::unique_ptr<ExplicitBitVect> fp2{
+        StructuralFingerprintChemReaction(*rxn2, params)};
+    CHECK(TanimotoSimilarity(*fp1, *fp2) == 0.4);
   }
 }

--- a/Code/GraphMol/ChemReactions/testReactionFingerprints.cpp
+++ b/Code/GraphMol/ChemReactions/testReactionFingerprints.cpp
@@ -61,7 +61,7 @@ void testStructuralFingerprintsReaction() {
     TEST_ASSERT(rxn);
     TEST_ASSERT(rxnq);
     ReactionFingerprintParams params;
-    params.fpType = PatternFP;
+    params.fpType = FingerprintType::PatternFP;
     params.fpSize = 4096;
 
     ExplicitBitVect *rxnFP = StructuralFingerprintChemReaction(*rxn, params);
@@ -102,7 +102,7 @@ void testStructuralFingerprintsReaction() {
     TEST_ASSERT(rxnq);
 
     ReactionFingerprintParams params;
-    params.fpType = PatternFP;
+    params.fpType = FingerprintType::PatternFP;
     params.fpSize = 4096;
 
     ExplicitBitVect *rxnFP = StructuralFingerprintChemReaction(*rxn, params);
@@ -147,7 +147,7 @@ void testStructuralFingerprintsReaction() {
     TEST_ASSERT(rxnq2);
 
     ReactionFingerprintParams params;
-    params.fpType = PatternFP;
+    params.fpType = FingerprintType::PatternFP;
     params.fpSize = 4096;
     ExplicitBitVect *rxnFP = StructuralFingerprintChemReaction(*rxn, params);
     ExplicitBitVect *rxnqFP = StructuralFingerprintChemReaction(*rxnq, params);
@@ -199,7 +199,7 @@ void testStructuralFingerprintsReaction() {
     TEST_ASSERT(rxnq2);
 
     ReactionFingerprintParams params;
-    params.fpType = PatternFP;
+    params.fpType = FingerprintType::PatternFP;
     params.fpSize = 4096;
 
     ExplicitBitVect *rxnFP = StructuralFingerprintChemReaction(*rxn, params);
@@ -249,7 +249,7 @@ void testStructuralFingerprintsReaction() {
     TEST_ASSERT(rxnq2);
 
     ReactionFingerprintParams params;
-    params.fpType = PatternFP;
+    params.fpType = FingerprintType::PatternFP;
     params.fpSize = 4096;
 
     ExplicitBitVect *rxnFP = StructuralFingerprintChemReaction(*rxn, params);
@@ -307,7 +307,7 @@ void testStructuralFingerprintsReaction() {
     TEST_ASSERT(rxnq2);
 
     ReactionFingerprintParams params;
-    params.fpType = PatternFP;
+    params.fpType = FingerprintType::PatternFP;
     params.fpSize = 4096;
 
     ExplicitBitVect *rxnFP = StructuralFingerprintChemReaction(*rxn, params);
@@ -344,7 +344,7 @@ void testStructuralFingerprintsReaction() {
     TEST_ASSERT(rxnq2);
 
     ReactionFingerprintParams params;
-    params.fpType = MorganFP;
+    params.fpType = FingerprintType::MorganFP;
     params.fpSize = 4096;
 
     ExplicitBitVect *rxnFP = StructuralFingerprintChemReaction(*rxn, params);
@@ -411,7 +411,7 @@ void testStructuralFingerprintsReaction() {
     TEST_ASSERT(rxnq2);
 
     ReactionFingerprintParams params;
-    params.fpType = TopologicalTorsion;
+    params.fpType = FingerprintType::TopologicalTorsionFP;
     params.fpSize = 4096;
 
     ExplicitBitVect *rxnFP = StructuralFingerprintChemReaction(*rxn, params);
@@ -445,7 +445,7 @@ void testStructuralFingerprintsReaction() {
     TEST_ASSERT(rxnq2);
 
     ReactionFingerprintParams params;
-    params.fpType = RDKitFP;
+    params.fpType = FingerprintType::RDKitFP;
     params.fpSize = 4096;
 
     ExplicitBitVect *rxnFP = StructuralFingerprintChemReaction(*rxn, params);
@@ -479,7 +479,7 @@ void testStructuralFingerprintsReaction() {
     TEST_ASSERT(rxnq2);
 
     ReactionFingerprintParams params;
-    params.fpType = RDKitFP;
+    params.fpType = FingerprintType::RDKitFP;
     params.fpSize = 4096;
 
     ExplicitBitVect *rxnFP = StructuralFingerprintChemReaction(*rxn, params);
@@ -653,7 +653,7 @@ void testDifferenceFingerprintsReaction() {
     TEST_ASSERT(rxn2);
 
     ReactionFingerprintParams params;
-    params.fpType = MorganFP;
+    params.fpType = FingerprintType::MorganFP;
 
     SparseIntVect<std::uint32_t> *rxn1FP =
         DifferenceFingerprintChemReaction(*rxn1, params);
@@ -680,7 +680,7 @@ void testDifferenceFingerprintsReaction() {
     TEST_ASSERT(rxn2);
 
     ReactionFingerprintParams params;
-    params.fpType = TopologicalTorsion;
+    params.fpType = FingerprintType::TopologicalTorsionFP;
 
     SparseIntVect<std::uint32_t> *rxn1FP =
         DifferenceFingerprintChemReaction(*rxn1, params);

--- a/Code/GraphMol/Fingerprints/AtomPairGenerator.cpp
+++ b/Code/GraphMol/Fingerprints/AtomPairGenerator.cpp
@@ -208,27 +208,44 @@ std::string AtomPairEnvGenerator<OutputType>::infoString() const {
 
 template <typename OutputType>
 FingerprintGenerator<OutputType> *getAtomPairGenerator(
+    const AtomPairArguments &args,
+    AtomInvariantsGenerator *atomInvariantsGenerator,
+    const bool ownsAtomInvGen) {
+  AtomEnvironmentGenerator<OutputType> *atomPairEnvGenerator =
+      new AtomPair::AtomPairEnvGenerator<OutputType>();
+  bool ownsAtomInvGenerator = ownsAtomInvGen;
+  if (!atomInvariantsGenerator) {
+    atomInvariantsGenerator =
+        new AtomPairAtomInvGenerator(args.df_includeChirality);
+    ownsAtomInvGenerator = true;
+  }
+
+  return new FingerprintGenerator<OutputType>(
+      atomPairEnvGenerator, new AtomPairArguments(args),
+      atomInvariantsGenerator, nullptr, ownsAtomInvGenerator, false);
+}
+
+template <typename OutputType>
+FingerprintGenerator<OutputType> *getAtomPairGenerator(
     const unsigned int minDistance, const unsigned int maxDistance,
     const bool includeChirality, const bool use2D,
     AtomInvariantsGenerator *atomInvariantsGenerator,
     const bool useCountSimulation, const std::uint32_t fpSize,
     const std::vector<std::uint32_t> countBounds, const bool ownsAtomInvGen) {
-  AtomEnvironmentGenerator<OutputType> *atomPairEnvGenerator =
-      new AtomPair::AtomPairEnvGenerator<OutputType>();
-  FingerprintArguments *atomPairArguments = new AtomPair::AtomPairArguments(
-      useCountSimulation, includeChirality, use2D, minDistance, maxDistance,
-      countBounds, fpSize);
+  AtomPair::AtomPairArguments arguments(useCountSimulation, includeChirality,
+                                        use2D, minDistance, maxDistance,
+                                        countBounds, fpSize);
 
-  bool ownsAtomInvGenerator = ownsAtomInvGen;
-  if (!atomInvariantsGenerator) {
-    atomInvariantsGenerator = new AtomPairAtomInvGenerator(includeChirality);
-    ownsAtomInvGenerator = true;
-  }
-
-  return new FingerprintGenerator<OutputType>(
-      atomPairEnvGenerator, atomPairArguments, atomInvariantsGenerator, nullptr,
-      ownsAtomInvGenerator, false);
+  return getAtomPairGenerator<OutputType>(arguments, atomInvariantsGenerator,
+                                          ownsAtomInvGen);
 }
+
+template RDKIT_FINGERPRINTS_EXPORT FingerprintGenerator<std::uint32_t> *
+getAtomPairGenerator(const AtomPairArguments &, AtomInvariantsGenerator *,
+                     const bool);
+template RDKIT_FINGERPRINTS_EXPORT FingerprintGenerator<std::uint64_t> *
+getAtomPairGenerator(const AtomPairArguments &, AtomInvariantsGenerator *,
+                     const bool);
 
 template RDKIT_FINGERPRINTS_EXPORT FingerprintGenerator<std::uint32_t> *
 getAtomPairGenerator(const unsigned int minDistance,

--- a/Code/GraphMol/Fingerprints/AtomPairGenerator.h
+++ b/Code/GraphMol/Fingerprints/AtomPairGenerator.h
@@ -50,9 +50,9 @@ class RDKIT_FINGERPRINTS_EXPORT AtomPairAtomInvGenerator
 class RDKIT_FINGERPRINTS_EXPORT AtomPairArguments
     : public FingerprintArguments {
  public:
-  bool df_use2D;
-  unsigned int d_minDistance;
-  unsigned int d_maxDistance;
+  bool df_use2D = true;
+  unsigned int d_minDistance = 1;
+  unsigned int d_maxDistance = maxPathLen - 1;
 
   std::string infoString() const override;
 
@@ -183,6 +183,12 @@ getAtomPairGenerator(
     const std::vector<std::uint32_t> countBounds = {1, 2, 4, 8},
     const bool ownsAtomInvGen = false);
 
+//! overload
+template <typename OutputType>
+FingerprintGenerator<OutputType> *getAtomPairGenerator(
+    const AtomPairArguments &args,
+    AtomInvariantsGenerator *atomInvariantsGenerator = nullptr,
+    const bool ownsAtomInvGen = false);
 }  // namespace AtomPair
 }  // namespace RDKit
 

--- a/Code/GraphMol/Fingerprints/FingerprintGenerator.h
+++ b/Code/GraphMol/Fingerprints/FingerprintGenerator.h
@@ -76,19 +76,18 @@ struct RDKIT_FINGERPRINTS_EXPORT AdditionalOutput {
   hold fingerprint type specific arguments
 
  */
-class RDKIT_FINGERPRINTS_EXPORT FingerprintArguments
-    : private boost::noncopyable {
+class RDKIT_FINGERPRINTS_EXPORT FingerprintArguments {
  public:
   FingerprintArguments(bool countSimulation,
                        const std::vector<std::uint32_t> countBounds,
                        std::uint32_t fpSize,
                        std::uint32_t numBitsPerFeature = 1,
                        bool includeChirality = false);
-  bool df_countSimulation;
-  bool df_includeChirality;
+  bool df_countSimulation = false;
+  bool df_includeChirality = false;
   std::vector<std::uint32_t> d_countBounds;
-  std::uint32_t d_fpSize;
-  std::uint32_t d_numBitsPerFeature;
+  std::uint32_t d_fpSize = 2048;
+  std::uint32_t d_numBitsPerFeature = 1;
 
   /**
    \brief method that returns information string about the fingerprint specific
@@ -107,6 +106,7 @@ class RDKIT_FINGERPRINTS_EXPORT FingerprintArguments
   std::string commonArgumentsString() const;
 
   virtual ~FingerprintArguments() {}
+  FingerprintArguments() = default;
 };
 
 /*!

--- a/Code/GraphMol/Fingerprints/MorganGenerator.cpp
+++ b/Code/GraphMol/Fingerprints/MorganGenerator.cpp
@@ -379,18 +379,12 @@ std::string MorganEnvGenerator<OutputType>::infoString() const {
 
 template <typename OutputType>
 FingerprintGenerator<OutputType> *getMorganGenerator(
-    unsigned int radius, bool countSimulation, bool includeChirality,
-    bool useBondTypes, bool onlyNonzeroInvariants,
-    bool includeRedundantEnvironments,
+    const MorganArguments &args,
     AtomInvariantsGenerator *atomInvariantsGenerator,
-    BondInvariantsGenerator *bondInvariantsGenerator, std::uint32_t fpSize,
-    std::vector<std::uint32_t> countBounds, bool ownsAtomInvGen,
+    BondInvariantsGenerator *bondInvariantsGenerator, bool ownsAtomInvGen,
     bool ownsBondInvGen) {
   AtomEnvironmentGenerator<OutputType> *morganEnvGenerator =
       new MorganEnvGenerator<OutputType>();
-  FingerprintArguments *morganArguments = new MorganArguments(
-      radius, countSimulation, includeChirality, onlyNonzeroInvariants,
-      countBounds, fpSize, includeRedundantEnvironments);
 
   bool ownsAtomInvGenerator = ownsAtomInvGen;
   if (!atomInvariantsGenerator) {
@@ -400,15 +394,37 @@ FingerprintGenerator<OutputType> *getMorganGenerator(
 
   bool ownsBondInvGenerator = ownsBondInvGen;
   if (!bondInvariantsGenerator) {
-    bondInvariantsGenerator =
-        new MorganBondInvGenerator(useBondTypes, includeChirality);
+    bondInvariantsGenerator = new MorganBondInvGenerator(
+        args.df_useBondTypes, args.df_includeChirality);
     ownsBondInvGenerator = true;
   }
 
   return new FingerprintGenerator<OutputType>(
-      morganEnvGenerator, morganArguments, atomInvariantsGenerator,
+      morganEnvGenerator, new MorganArguments(args), atomInvariantsGenerator,
       bondInvariantsGenerator, ownsAtomInvGenerator, ownsBondInvGenerator);
 }
+
+template <typename OutputType>
+FingerprintGenerator<OutputType> *getMorganGenerator(
+    unsigned int radius, bool countSimulation, bool includeChirality,
+    bool useBondTypes, bool onlyNonzeroInvariants,
+    bool includeRedundantEnvironments,
+    AtomInvariantsGenerator *atomInvariantsGenerator,
+    BondInvariantsGenerator *bondInvariantsGenerator, std::uint32_t fpSize,
+    std::vector<std::uint32_t> countBounds, bool ownsAtomInvGen,
+    bool ownsBondInvGen) {
+  MorganArguments arguments(radius, countSimulation, includeChirality,
+                            onlyNonzeroInvariants, countBounds, fpSize,
+                            includeRedundantEnvironments, useBondTypes);
+
+  return getMorganGenerator<OutputType>(arguments, atomInvariantsGenerator,
+                                        bondInvariantsGenerator, ownsAtomInvGen,
+                                        ownsBondInvGen);
+}
+
+template RDKIT_FINGERPRINTS_EXPORT FingerprintGenerator<std::uint32_t> *
+getMorganGenerator(const MorganArguments &, AtomInvariantsGenerator *,
+                   BondInvariantsGenerator *, bool, bool);
 
 template RDKIT_FINGERPRINTS_EXPORT FingerprintGenerator<std::uint32_t> *
 getMorganGenerator(unsigned int radius, bool countSimulation,

--- a/Code/GraphMol/Fingerprints/MorganGenerator.h
+++ b/Code/GraphMol/Fingerprints/MorganGenerator.h
@@ -109,6 +109,7 @@ class RDKIT_FINGERPRINTS_EXPORT MorganArguments : public FingerprintArguments {
   bool df_onlyNonzeroInvariants = false;
   unsigned int d_radius = 3;
   bool df_includeRedundantEnvironments = false;
+  bool df_useBondTypes = true;
 
   std::string infoString() const override;
 
@@ -128,18 +129,22 @@ class RDKIT_FINGERPRINTS_EXPORT MorganArguments : public FingerprintArguments {
    versions
    \param includeRedundantEnvironments if set redundant environments will be
    included in the fingerprint
+   \param useBondTypes if set bond types will be included in the fingerprint
   */
   MorganArguments(unsigned int radius, bool countSimulation = false,
                   bool includeChirality = false,
                   bool onlyNonzeroInvariants = false,
                   std::vector<std::uint32_t> countBounds = {1, 2, 4, 8},
                   std::uint32_t fpSize = 2048,
-                  bool includeRedundantEnvironments = false)
+                  bool includeRedundantEnvironments = false,
+                  bool useBondTypes = true)
       : FingerprintArguments(countSimulation, countBounds, fpSize, 1,
                              includeChirality),
         df_onlyNonzeroInvariants(onlyNonzeroInvariants),
         d_radius(radius),
-        df_includeRedundantEnvironments(includeRedundantEnvironments) {};
+        df_includeRedundantEnvironments(includeRedundantEnvironments),
+        df_useBondTypes(useBondTypes) {};
+  MorganArguments() = default;
 };
 
 /**
@@ -254,6 +259,13 @@ RDKIT_FINGERPRINTS_EXPORT FingerprintGenerator<OutputType> *getMorganGenerator(
     BondInvariantsGenerator *bondInvariantsGenerator = nullptr,
     std::uint32_t fpSize = 2048,
     std::vector<std::uint32_t> countBounds = {1, 2, 4, 8},
+    bool ownsAtomInvGen = false, bool ownsBondInvGen = false);
+//! \overload
+template <typename OutputType>
+RDKIT_FINGERPRINTS_EXPORT FingerprintGenerator<OutputType> *getMorganGenerator(
+    const MorganArguments &args,
+    AtomInvariantsGenerator *atomInvariantsGenerator = nullptr,
+    BondInvariantsGenerator *bondInvariantsGenerator = nullptr,
     bool ownsAtomInvGen = false, bool ownsBondInvGen = false);
 
 /**

--- a/Code/GraphMol/Fingerprints/MorganGenerator.h
+++ b/Code/GraphMol/Fingerprints/MorganGenerator.h
@@ -131,7 +131,7 @@ class RDKIT_FINGERPRINTS_EXPORT MorganArguments : public FingerprintArguments {
    included in the fingerprint
    \param useBondTypes if set bond types will be included in the fingerprint
   */
-  MorganArguments(unsigned int radius, bool countSimulation = false,
+  MorganArguments(unsigned int radius = 3, bool countSimulation = false,
                   bool includeChirality = false,
                   bool onlyNonzeroInvariants = false,
                   std::vector<std::uint32_t> countBounds = {1, 2, 4, 8},
@@ -144,7 +144,6 @@ class RDKIT_FINGERPRINTS_EXPORT MorganArguments : public FingerprintArguments {
         d_radius(radius),
         df_includeRedundantEnvironments(includeRedundantEnvironments),
         df_useBondTypes(useBondTypes) {};
-  MorganArguments() = default;
 };
 
 /**

--- a/Code/GraphMol/Fingerprints/RDKitFPGenerator.cpp
+++ b/Code/GraphMol/Fingerprints/RDKitFPGenerator.cpp
@@ -194,25 +194,32 @@ RDKitFPEnvGenerator<OutputType>::getEnvironments(
 
 template <typename OutputType>
 FingerprintGenerator<OutputType> *getRDKitFPGenerator(
-    unsigned int minPath, unsigned int maxPath, bool useHs, bool branchedPaths,
-    bool useBondOrder, AtomInvariantsGenerator *atomInvariantsGenerator,
-    bool countSimulation, const std::vector<std::uint32_t> countBounds,
-    std::uint32_t fpSize, std::uint32_t numBitsPerFeature,
-    bool ownsAtomInvGen) {
+    const RDKitFPArguments &args,
+    AtomInvariantsGenerator *atomInvariantsGenerator, bool ownsAtomInvGen) {
   auto *envGenerator = new RDKitFPEnvGenerator<OutputType>();
-  auto *arguments = new RDKitFPArguments(
-      minPath, maxPath, useHs, branchedPaths, useBondOrder, countSimulation,
-      countBounds, fpSize, numBitsPerFeature);
-
   bool ownsAtomInvGenerator = ownsAtomInvGen;
   if (!atomInvariantsGenerator) {
     atomInvariantsGenerator = new RDKitFPAtomInvGenerator();
     ownsAtomInvGenerator = true;
   }
 
-  return new FingerprintGenerator<OutputType>(envGenerator, arguments,
-                                              atomInvariantsGenerator, nullptr,
-                                              ownsAtomInvGenerator, false);
+  return new FingerprintGenerator<OutputType>(
+      envGenerator, new RDKitFPArguments(args), atomInvariantsGenerator,
+      nullptr, ownsAtomInvGenerator, false);
+}
+
+template <typename OutputType>
+FingerprintGenerator<OutputType> *getRDKitFPGenerator(
+    unsigned int minPath, unsigned int maxPath, bool useHs, bool branchedPaths,
+    bool useBondOrder, AtomInvariantsGenerator *atomInvariantsGenerator,
+    bool countSimulation, const std::vector<std::uint32_t> countBounds,
+    std::uint32_t fpSize, std::uint32_t numBitsPerFeature,
+    bool ownsAtomInvGen) {
+  RDKitFPArguments arguments(minPath, maxPath, useHs, branchedPaths,
+                             useBondOrder, countSimulation, countBounds, fpSize,
+                             numBitsPerFeature);
+  return getRDKitFPGenerator<OutputType>(arguments, atomInvariantsGenerator,
+                                         ownsAtomInvGen);
 }
 
 template RDKIT_FINGERPRINTS_EXPORT FingerprintGenerator<std::uint32_t> *
@@ -232,6 +239,15 @@ getRDKitFPGenerator(unsigned int minPath, unsigned int maxPath, bool useHs,
                     const std::vector<std::uint32_t> countBounds,
                     std::uint32_t fpSize, std::uint32_t numBitsPerFeature,
                     bool ownsAtomInvGen);
+
+template RDKIT_FINGERPRINTS_EXPORT FingerprintGenerator<std::uint32_t> *
+getRDKitFPGenerator(const RDKitFPArguments &args,
+                    AtomInvariantsGenerator *atomInvariantsGenerator = nullptr,
+                    bool ownsAtomInvGen = false);
+template RDKIT_FINGERPRINTS_EXPORT FingerprintGenerator<std::uint64_t> *
+getRDKitFPGenerator(const RDKitFPArguments &args,
+                    AtomInvariantsGenerator *atomInvariantsGenerator = nullptr,
+                    bool ownsAtomInvGen = false);
 
 }  // namespace RDKitFP
 

--- a/Code/GraphMol/Fingerprints/RDKitFPGenerator.cpp
+++ b/Code/GraphMol/Fingerprints/RDKitFPGenerator.cpp
@@ -241,13 +241,9 @@ getRDKitFPGenerator(unsigned int minPath, unsigned int maxPath, bool useHs,
                     bool ownsAtomInvGen);
 
 template RDKIT_FINGERPRINTS_EXPORT FingerprintGenerator<std::uint32_t> *
-getRDKitFPGenerator(const RDKitFPArguments &args,
-                    AtomInvariantsGenerator *atomInvariantsGenerator = nullptr,
-                    bool ownsAtomInvGen = false);
+getRDKitFPGenerator(const RDKitFPArguments &, AtomInvariantsGenerator *, bool);
 template RDKIT_FINGERPRINTS_EXPORT FingerprintGenerator<std::uint64_t> *
-getRDKitFPGenerator(const RDKitFPArguments &args,
-                    AtomInvariantsGenerator *atomInvariantsGenerator = nullptr,
-                    bool ownsAtomInvGen = false);
+getRDKitFPGenerator(const RDKitFPArguments &, AtomInvariantsGenerator *, bool);
 
 }  // namespace RDKitFP
 

--- a/Code/GraphMol/Fingerprints/RDKitFPGenerator.h
+++ b/Code/GraphMol/Fingerprints/RDKitFPGenerator.h
@@ -47,11 +47,12 @@ class RDKIT_FINGERPRINTS_EXPORT RDKitFPArguments : public FingerprintArguments {
    path/subgraph found
 
    */
-  RDKitFPArguments(unsigned int minPath, unsigned int maxPath, bool useHs,
-                   bool branchedPaths, bool useBondOrder, bool countSimulation,
-                   const std::vector<std::uint32_t> countBounds,
-                   std::uint32_t fpSize, std::uint32_t numBitsPerFeature);
-  RDKitFPArguments() = default;
+  RDKitFPArguments(unsigned int minPath = 1, unsigned int maxPath = 7,
+                   bool useHs = true, bool branchedPaths = true,
+                   bool useBondOrder = true, bool countSimulation = false,
+                   const std::vector<std::uint32_t> countBounds = {1, 2, 4, 8},
+                   std::uint32_t fpSize = 2048,
+                   std::uint32_t numBitsPerFeature = 2);
 };
 
 class RDKIT_FINGERPRINTS_EXPORT RDKitFPAtomInvGenerator

--- a/Code/GraphMol/Fingerprints/RDKitFPGenerator.h
+++ b/Code/GraphMol/Fingerprints/RDKitFPGenerator.h
@@ -19,11 +19,11 @@ namespace RDKitFP {
 
 class RDKIT_FINGERPRINTS_EXPORT RDKitFPArguments : public FingerprintArguments {
  public:
-  unsigned int d_minPath;
-  unsigned int d_maxPath;
-  bool df_useHs;
-  bool df_branchedPaths;
-  bool df_useBondOrder;
+  unsigned int d_minPath = 1;
+  unsigned int d_maxPath = 7;
+  bool df_useHs = true;
+  bool df_branchedPaths = true;
+  bool df_useBondOrder = true;
 
   std::string infoString() const override;
 

--- a/Code/GraphMol/Fingerprints/RDKitFPGenerator.h
+++ b/Code/GraphMol/Fingerprints/RDKitFPGenerator.h
@@ -51,6 +51,7 @@ class RDKIT_FINGERPRINTS_EXPORT RDKitFPArguments : public FingerprintArguments {
                    bool branchedPaths, bool useBondOrder, bool countSimulation,
                    const std::vector<std::uint32_t> countBounds,
                    std::uint32_t fpSize, std::uint32_t numBitsPerFeature);
+  RDKitFPArguments() = default;
 };
 
 class RDKIT_FINGERPRINTS_EXPORT RDKitFPAtomInvGenerator
@@ -156,6 +157,12 @@ RDKIT_FINGERPRINTS_EXPORT FingerprintGenerator<OutputType> *getRDKitFPGenerator(
     bool countSimulation = false,
     const std::vector<std::uint32_t> countBounds = {1, 2, 4, 8},
     std::uint32_t fpSize = 2048, std::uint32_t numBitsPerFeature = 2,
+    bool ownsAtomInvGen = false);
+// \overload
+template <typename OutputType>
+RDKIT_FINGERPRINTS_EXPORT FingerprintGenerator<OutputType> *getRDKitFPGenerator(
+    const RDKitFPArguments &args,
+    AtomInvariantsGenerator *atomInvariantsGenerator = nullptr,
     bool ownsAtomInvGen = false);
 
 }  // namespace RDKitFP

--- a/Code/GraphMol/Fingerprints/TopologicalTorsionGenerator.cpp
+++ b/Code/GraphMol/Fingerprints/TopologicalTorsionGenerator.cpp
@@ -179,25 +179,32 @@ std::string TopologicalTorsionEnvGenerator<OutputType>::infoString() const {
 
 template <typename OutputType>
 FingerprintGenerator<OutputType> *getTopologicalTorsionGenerator(
-    bool includeChirality, uint32_t torsionAtomCount,
-    AtomInvariantsGenerator *atomInvariantsGenerator, bool countSimulation,
-    std::uint32_t fpSize, std::vector<std::uint32_t> countBounds,
-    bool ownsAtomInvGen) {
+    const TopologicalTorsionArguments &args,
+    AtomInvariantsGenerator *atomInvariantsGenerator,
+    const bool ownsAtomInvGen) {
   auto *envGenerator = new TopologicalTorsionEnvGenerator<OutputType>();
-
-  auto *arguments = new TopologicalTorsionArguments(
-      includeChirality, torsionAtomCount, countSimulation, countBounds, fpSize);
 
   bool ownsAtomInvGenerator = ownsAtomInvGen;
   if (!atomInvariantsGenerator) {
     atomInvariantsGenerator =
-        new AtomPair::AtomPairAtomInvGenerator(includeChirality, true);
+        new AtomPair::AtomPairAtomInvGenerator(args.df_includeChirality, true);
     ownsAtomInvGenerator = true;
   }
 
-  return new FingerprintGenerator<OutputType>(envGenerator, arguments,
-                                              atomInvariantsGenerator, nullptr,
-                                              ownsAtomInvGenerator, false);
+  return new FingerprintGenerator<OutputType>(
+      envGenerator, new TopologicalTorsionArguments(args),
+      atomInvariantsGenerator, nullptr, ownsAtomInvGenerator, false);
+};
+template <typename OutputType>
+FingerprintGenerator<OutputType> *getTopologicalTorsionGenerator(
+    bool includeChirality, uint32_t torsionAtomCount,
+    AtomInvariantsGenerator *atomInvariantsGenerator, bool countSimulation,
+    std::uint32_t fpSize, std::vector<std::uint32_t> countBounds,
+    bool ownsAtomInvGen) {
+  TopologicalTorsionArguments arguments(includeChirality, torsionAtomCount,
+                                        countSimulation, countBounds, fpSize);
+  return getTopologicalTorsionGenerator<OutputType>(
+      arguments, atomInvariantsGenerator, ownsAtomInvGen);
 };
 
 // Topological torsion fingerprint does not support 32 bit output yet
@@ -208,6 +215,9 @@ getTopologicalTorsionGenerator(bool includeChirality, uint32_t torsionAtomCount,
                                bool countSimulation, std::uint32_t fpSize,
                                std::vector<std::uint32_t> countBounds,
                                bool ownsAtomInvGen);
+template RDKIT_FINGERPRINTS_EXPORT FingerprintGenerator<std::uint64_t> *
+getTopologicalTorsionGenerator(const TopologicalTorsionArguments &,
+                               AtomInvariantsGenerator *, const bool);
 
 }  // namespace TopologicalTorsion
 }  // namespace RDKit

--- a/Code/GraphMol/Fingerprints/TopologicalTorsionGenerator.h
+++ b/Code/GraphMol/Fingerprints/TopologicalTorsionGenerator.h
@@ -43,6 +43,7 @@ class RDKIT_FINGERPRINTS_EXPORT TopologicalTorsionArguments
                               const bool countSimulation,
                               const std::vector<std::uint32_t> countBounds,
                               const std::uint32_t fpSize);
+  TopologicalTorsionArguments() = default;
 };
 
 template <typename OutputType>
@@ -123,6 +124,12 @@ getTopologicalTorsionGenerator(
     bool countSimulation = true, std::uint32_t fpSize = 2048,
     std::vector<std::uint32_t> countBounds = {1, 2, 4, 8},
     bool ownsAtomInvGen = false);
+//! overload
+template <typename OutputType>
+FingerprintGenerator<OutputType> *getTopologicalTorsionGenerator(
+    const TopologicalTorsionArguments &args,
+    AtomInvariantsGenerator *atomInvariantsGenerator = nullptr,
+    const bool ownsAtomInvGen = false);
 }  // namespace TopologicalTorsion
 }  // namespace RDKit
 

--- a/Code/GraphMol/Fingerprints/TopologicalTorsionGenerator.h
+++ b/Code/GraphMol/Fingerprints/TopologicalTorsionGenerator.h
@@ -38,12 +38,11 @@ class RDKIT_FINGERPRINTS_EXPORT TopologicalTorsionArguments
    \param fpSize size of the generated fingerprint, does not affect the sparse
    versions
    */
-  TopologicalTorsionArguments(const bool includeChirality,
-                              const uint32_t torsionAtomCount,
-                              const bool countSimulation,
-                              const std::vector<std::uint32_t> countBounds,
-                              const std::uint32_t fpSize);
-  TopologicalTorsionArguments() = default;
+  TopologicalTorsionArguments(
+      const bool includeChirality = false, const uint32_t torsionAtomCount = 4,
+      const bool countSimulation = true,
+      const std::vector<std::uint32_t> countBounds = {1, 2, 4, 8},
+      const std::uint32_t fpSize = 2048);
 };
 
 template <typename OutputType>


### PR DESCRIPTION
This fixes #7521 

There are also a general improvement to the FingerprintGenertors themselves here: adding a ctor that allows them to be constructed from the corresponding `FingerprintArguments` subclasses.
