### PR TITLE
Only save the most recent CIP rank for sorting

### DIFF
--- a/Code/GraphMol/Chirality.cpp
+++ b/Code/GraphMol/Chirality.cpp
@@ -1295,6 +1295,9 @@ void iterateCIPRanks(const ROMol &mol, const DOUBLE_VECT &invars,
     }
   }
 
+  // Based on above seeding, the rank will be set at index 1 or 2.
+  const int cipRankIndex = seedWithInvars ? 1 : 2;
+
   // Loop until either:
   //   1) all classes are uniquified
   //   2) the number of ranks doesn't change from one iteration to
@@ -1379,9 +1382,8 @@ void iterateCIPRanks(const ROMol &mol, const DOUBLE_VECT &invars,
     // now truncate each vector and stick the rank at the end
     if (static_cast<unsigned int>(lastNumRanks) != numRanks) {
       for (unsigned int i = 0; i < numAtoms; ++i) {
-        cipEntries[i][numIts + 1] = ranks[i];
-        cipEntries[i].erase(cipEntries[i].begin() + numIts + 2,
-                            cipEntries[i].end());
+        cipEntries[i][cipRankIndex] = ranks[i];
+        cipEntries[i].resize(cipRankIndex + 1);
       }
     }
 

--- a/Code/GraphMol/Chirality.cpp
+++ b/Code/GraphMol/Chirality.cpp
@@ -1317,7 +1317,6 @@ void iterateCIPRanks(const ROMol &mol, const DOUBLE_VECT &invars,
   while (!needsSorting.empty() && numIts < maxIts &&
          (lastNumRanks < 0 ||
           static_cast<unsigned int>(lastNumRanks) < numRanks)) {
-    unsigned int longestEntry = 0;
     // ----------------------------------------------------
     //
     // for each atom, get a sorted list of its neighbors' ranks:
@@ -1347,21 +1346,6 @@ void iterateCIPRanks(const ROMol &mol, const DOUBLE_VECT &invars,
       // add a zero for each coordinated H as long as we're not a query atom
       if (!mol[index]->hasQuery()) {
         cipEntry.insert(cipEntry.end(), mol[index]->getTotalNumHs(), 0);
-      }
-
-      if (cipEntry.size() > longestEntry) {
-        longestEntry = rdcast<unsigned int>(cipEntry.size());
-      }
-    }
-    // ----------------------------------------------------
-    //
-    // pad the entries so that we compare rounds to themselves:
-    //
-    for (unsigned int index = 0; index < numAtoms; ++index) {
-      auto sz = rdcast<unsigned int>(cipEntries[index].size());
-      if (sz < longestEntry) {
-        cipEntries[index].insert(cipEntries[index].end(), longestEntry - sz,
-                                 -1);
       }
     }
     // ----------------------------------------------------


### PR DESCRIPTION
#### Reference Issue
Final PR for #7888


#### What does this implement/fix? Explain your changes.

Previous PRs have isolated rank sorting to sections of atoms that were previously tied. Since they were previously tied, the CIP entries of previous iterations are guaranteed to be identical, and no longer need to be stored. 

With this change, each iteration no longer increases the length of vectors that need to be compared. 
#### Any other comments?

