### PR TITLE
Documentation updates

### DIFF
--- a/Code/GraphMol/MolOps.h
+++ b/Code/GraphMol/MolOps.h
@@ -1063,7 +1063,6 @@ RDKIT_GRAPHMOL_EXPORT void assignChiralTypesFromBondDirs(
 
 //! \deprecated: this function will be removed in a future release. Use
 //! setDoubleBondNeighborDirections() instead
-[[deprecated("please use setDoubleBondNeighborDirections() instead")]]
 RDKIT_GRAPHMOL_EXPORT void detectBondStereochemistry(ROMol &mol,
                                                      int confId = -1);
 //! Sets bond directions based on double bond stereochemistry

--- a/Code/GraphMol/MolOps.h
+++ b/Code/GraphMol/MolOps.h
@@ -583,6 +583,7 @@ Book)
 - \c AROMATICITY_SIMPLE only considers 5- and 6-membered simple rings (it
 does not consider the outer envelope of fused rings)
 - \c AROMATICITY_MDL
+- \c AROMATICIT_MMFF94 the aromaticity model used by the MMFF94 force field
 - \c AROMATICITY_CUSTOM uses a caller-provided function
 */
 typedef enum {
@@ -594,6 +595,7 @@ typedef enum {
   AROMATICITY_CUSTOM = 0xFFFFFFF  ///< use a function
 } AromaticityModel;
 
+//! sets the aromaticity model for a molecule to MMFF94
 RDKIT_GRAPHMOL_EXPORT void setMMFFAromaticity(RWMol &mol);
 
 //! Sets up the aromaticity for a molecule
@@ -702,7 +704,7 @@ RDKIT_GRAPHMOL_EXPORT void adjustHs(RWMol &mol);
 
    <b>Notes:</b>
      - this does not modify query bonds which have bond type queries (like
-   those which come from SMARTS) or rings containing them.
+       those which come from SMARTS) or rings containing them.
      - even if \c markAtomsBonds is \c false the \c BondType for all modified
        aromatic bonds will be changed from \c RDKit::Bond::AROMATIC to \c
        RDKit::Bond::SINGLE or RDKit::Bond::DOUBLE during Kekulization.
@@ -857,6 +859,7 @@ RDKIT_GRAPHMOL_EXPORT int symmetrizeSSSR(ROMol &mol,
   \param force           forces calculation of the matrix, even if already
   computed
   \param propNamePrefix  used to set the cached property name
+  \param bondsToUse      used to limit which bonds are considered
 
   \return the adjacency matrix.
 
@@ -949,6 +952,7 @@ RDKIT_GRAPHMOL_EXPORT double *getDistanceMat(
 RDKIT_GRAPHMOL_EXPORT double *get3DDistanceMat(
     const ROMol &mol, int confId = -1, bool useAtomWts = false,
     bool force = false, const char *propNamePrefix = nullptr);
+
 //! Find the shortest path between two atoms
 /*!
   Uses the Bellman-Ford algorithm
@@ -1006,12 +1010,12 @@ class Hybridizations {
 //! removes bogus chirality markers (e.g. tetrahedral flags on non-sp3 centers):
 RDKIT_GRAPHMOL_EXPORT void cleanupChirality(RWMol &mol);
 
-//! \overload
-RDKIT_GRAPHMOL_EXPORT void cleanupAtropisomers(RWMol &);
 //! removes bogus atropisomeric markers (e.g. those without sp2 begin and end
 //! atoms):
 RDKIT_GRAPHMOL_EXPORT void cleanupAtropisomers(RWMol &mol,
                                                Hybridizations &hybridizations);
+//! \overload
+RDKIT_GRAPHMOL_EXPORT void cleanupAtropisomers(RWMol &);
 
 //! \brief Uses a conformer to assign ChiralTypes to a molecule's atoms
 /*!
@@ -1059,6 +1063,7 @@ RDKIT_GRAPHMOL_EXPORT void assignChiralTypesFromBondDirs(
 
 //! \deprecated: this function will be removed in a future release. Use
 //! setDoubleBondNeighborDirections() instead
+[[deprecated("please use setDoubleBondNeighborDirections() instead")]]
 RDKIT_GRAPHMOL_EXPORT void detectBondStereochemistry(ROMol &mol,
                                                      int confId = -1);
 //! Sets bond directions based on double bond stereochemistry
@@ -1072,6 +1077,7 @@ RDKIT_GRAPHMOL_EXPORT void clearSingleBondDirFlags(ROMol &mol,
 //! removes directions from all bonds. Wiggly bonds and cross bonds will have
 //! the property _UnknownStereo set on them
 RDKIT_GRAPHMOL_EXPORT void clearAllBondDirFlags(ROMol &mol);
+//! removes directions from all bonds. Wiggly bonds and cross bonds will have
 RDKIT_GRAPHMOL_EXPORT void clearDirFlags(ROMol &mol,
                                          bool onlyWedgeFlags = false);
 

--- a/Code/GraphMol/MolOps.h
+++ b/Code/GraphMol/MolOps.h
@@ -1068,15 +1068,16 @@ RDKIT_GRAPHMOL_EXPORT void detectBondStereochemistry(ROMol &mol,
 //! Sets bond directions based on double bond stereochemistry
 RDKIT_GRAPHMOL_EXPORT void setDoubleBondNeighborDirections(
     ROMol &mol, const Conformer *conf = nullptr);
-//! removes directions from single bonds. Wiggly bonds will have the property
-//! _UnknownStereo set on them
+//! removes directions from single bonds. The property _UnknownStereo will be
+//! set on wiggly bonds
 RDKIT_GRAPHMOL_EXPORT void clearSingleBondDirFlags(ROMol &mol,
                                                    bool onlyWedgeFlags = false);
 
-//! removes directions from all bonds. Wiggly bonds and cross bonds will have
-//! the property _UnknownStereo set on them
+//! removes directions from all bonds. The property _UnknownStereo will be set
+//! on wiggly bonds
 RDKIT_GRAPHMOL_EXPORT void clearAllBondDirFlags(ROMol &mol);
-//! removes directions from all bonds. Wiggly bonds and cross bonds will have
+//! removes directions from all bonds. The property _UnknownStereo will be set
+//! on wiggly bonds
 RDKIT_GRAPHMOL_EXPORT void clearDirFlags(ROMol &mol,
                                          bool onlyWedgeFlags = false);
 

--- a/Docs/Book/source/rdkit.Chem.rdShapeAlign.rst
+++ b/Docs/Book/source/rdkit.Chem.rdShapeAlign.rst
@@ -1,0 +1,8 @@
+rdkit.Chem.rdShapeAlign module
+=================================
+
+.. automodule:: rdkit.Chem.rdShapeAlign
+    :members:
+    :undoc-members:
+    :show-inheritance:
+

--- a/Docs/Book/source/rdkit.Chem.rst
+++ b/Docs/Book/source/rdkit.Chem.rst
@@ -108,6 +108,7 @@ Submodules
    rdkit.Chem.rdTautomerQuery
    rdkit.Chem.rdEHTTools
    rdkit.Chem.rdDetermineBonds
+   rdkit.Chem.rdShapeAlign
 
 Module contents
 ---------------

--- a/External/pubchem_shape/PubChemShape.hpp
+++ b/External/pubchem_shape/PubChemShape.hpp
@@ -2,6 +2,7 @@
 #include <map>
 #include <vector>
 
+//! The input for the pubchem shape alignment code
 struct RDKIT_PUBCHEMSHAPE_EXPORT ShapeInput {
   std::vector<float> coord;
   std::vector<double> alpha_vector;
@@ -14,15 +15,52 @@ struct RDKIT_PUBCHEMSHAPE_EXPORT ShapeInput {
   double sof{0.0};
 };
 
+//! Prepare the input for the shape comparison
+/*!
+  \param mol        the molecule to prepare
+  \param confId     (optional) the conformer to use
+  \param useColors  (optional) whether to generate info about colors
+
+  \return a ShapeInput object
+*/
 RDKIT_PUBCHEMSHAPE_EXPORT ShapeInput PrepareConformer(const RDKit::ROMol &mol,
                                                       int confId = -1,
                                                       bool useColors = true);
 
+//! Align a molecule to a reference shape
+/*!
+  \param refShape     the reference shape
+  \param fit          the molecule to align
+  \param matrix       the transformation matrix (populated on return)
+  \param fitConfId    (optional) the conformer to use for the fit molecule
+  \param useColors    (optional) whether or not to use colors in the scoring
+  \param opt_param    (optional) the optimization parameter
+  \param max_preiters (optional) the max number of pre-optimization iterations
+  \param max_postiters(optional) the max number of post-optimization iterations
+
+  \return a pair of the shape Tanimoto value and the color Tanimoto value (zero
+  if useColors is false)
+*/
 RDKIT_PUBCHEMSHAPE_EXPORT std::pair<double, double> AlignMolecule(
     const ShapeInput &refShape, RDKit::ROMol &fit, std::vector<float> &matrix,
     int fitConfId = -1, bool useColors = true, double opt_param = 0.5,
     unsigned int max_preiters = 3u, unsigned int max_postiters = 16u);
 
+//! Align a molecule to a reference molecule
+/*!
+  \param ref          the reference molecule
+  \param fit          the molecule to align
+  \param matrix       the transformation matrix (populated on return)
+  \param refConfId    (optional) the conformer to use for the reference molecule
+  \param fitConfId    (optional) the conformer to use for the fit molecule
+  \param useColors    (optional) whether or not to use colors in the scoring
+  \param opt_param    (optional) the optimization parameter
+  \param max_preiters (optional) the max number of pre-optimization iterations
+  \param max_postiters(optional) the max number of post-optimization iterations
+
+  \return a pair of the shape Tanimoto value and the color Tanimoto value (zero
+  if useColors is false)
+*/
 RDKIT_PUBCHEMSHAPE_EXPORT std::pair<double, double> AlignMolecule(
     const RDKit::ROMol &ref, RDKit::ROMol &fit, std::vector<float> &matrix,
     int refConfId = -1, int fitConfId = -1, bool useColors = true,

--- a/External/pubchem_shape/PubChemShape.hpp
+++ b/External/pubchem_shape/PubChemShape.hpp
@@ -29,14 +29,14 @@ RDKIT_PUBCHEMSHAPE_EXPORT ShapeInput PrepareConformer(const RDKit::ROMol &mol,
 
 //! Align a molecule to a reference shape
 /*!
-  \param refShape     the reference shape
-  \param fit          the molecule to align
-  \param matrix       the transformation matrix (populated on return)
-  \param fitConfId    (optional) the conformer to use for the fit molecule
-  \param useColors    (optional) whether or not to use colors in the scoring
-  \param opt_param    (optional) the optimization parameter
-  \param max_preiters (optional) the max number of pre-optimization iterations
-  \param max_postiters(optional) the max number of post-optimization iterations
+  \param refShape      the reference shape
+  \param fit           the molecule to align
+  \param matrix        the transformation matrix (populated on return)
+  \param fitConfId     (optional) the conformer to use for the fit molecule
+  \param useColors     (optional) whether or not to use colors in the scoring
+  \param opt_param     (optional) the optimization parameter
+  \param max_preiters  (optional) the max number of pre-optimization iterations
+  \param max_postiters (optional) the max number of post-optimization iterations
 
   \return a pair of the shape Tanimoto value and the color Tanimoto value (zero
   if useColors is false)
@@ -48,15 +48,15 @@ RDKIT_PUBCHEMSHAPE_EXPORT std::pair<double, double> AlignMolecule(
 
 //! Align a molecule to a reference molecule
 /*!
-  \param ref          the reference molecule
-  \param fit          the molecule to align
-  \param matrix       the transformation matrix (populated on return)
-  \param refConfId    (optional) the conformer to use for the reference molecule
-  \param fitConfId    (optional) the conformer to use for the fit molecule
-  \param useColors    (optional) whether or not to use colors in the scoring
-  \param opt_param    (optional) the optimization parameter
-  \param max_preiters (optional) the max number of pre-optimization iterations
-  \param max_postiters(optional) the max number of post-optimization iterations
+  \param ref           the reference molecule
+  \param fit           the molecule to align
+  \param matrix        the transformation matrix (populated on return)
+  \param refConfId     (optional) the conformer to use for the reference molecule
+  \param fitConfId     (optional) the conformer to use for the fit molecule
+  \param useColors     (optional) whether or not to use colors in the scoring
+  \param opt_param     (optional) the optimization parameter
+  \param max_preiters  (optional) the max number of pre-optimization iterations
+  \param max_postiters (optional) the max number of post-optimization iterationsa
 
   \return a pair of the shape Tanimoto value and the color Tanimoto value (zero
   if useColors is false)

--- a/External/pubchem_shape/Wrap/cshapealign.cpp
+++ b/External/pubchem_shape/Wrap/cshapealign.cpp
@@ -68,17 +68,76 @@ void wrap_pubchemshape() {
        python::arg("probeConfId") = -1, python::arg("useColors") = true,
        python::arg("opt_param") = 0.5, python::arg("max_preiters") = 3,
        python::arg("max_postiters") = 16),
-      "aligns probe to ref, probe is modified");
-  python::def("AlignMol", &helpers::alignMol2,
-              (python::arg("refShape"), python::arg("probe"),
-               python::arg("probeConfId") = -1, python::arg("useColors") = true,
-               python::arg("opt_param") = 0.5, python::arg("max_preiters") = 3,
-               python::arg("max_postiters") = 16),
-              "aligns probe to reference shape, probe is modified");
-  python::def("PrepareConformer", &helpers::prepConf,
-              (python::arg("mol"), python::arg("confId") = -1,
-               python::arg("useColors") = true),
-              "returns a shape object for a molecule",
+      R"DOC(Aligns a probe molecule to a reference molecule. The probe is modified.
+
+Parameters
+----------
+ref : RDKit.ROMol
+    Reference molecule
+probe : RDKit.ROMol
+    Probe molecule
+refConfId : int, optional
+    Reference conformer ID (default is -1)
+probeConfId : int, optional
+    Probe conformer ID (default is -1)
+useColors : bool, optional
+    Whether or not to use colors in the scoring (default is True)
+optParam : float, optional 
+max_preiters : int, optional
+max_postiters : int, optional
+
+Returns
+-------
+ 2-tuple of doubles
+    The results are (shape_score, color_score)
+    The color_score is zero if useColors is False)DOC");
+
+  python::def(
+      "AlignMol", &helpers::alignMol2,
+      (python::arg("refShape"), python::arg("probe"),
+       python::arg("probeConfId") = -1, python::arg("useColors") = true,
+       python::arg("opt_param") = 0.5, python::arg("max_preiters") = 3,
+       python::arg("max_postiters") = 16),
+      R"DOC(Aligns a probe molecule to a reference shape. The probe is modified.
+
+Parameters
+----------
+refShape : ShapeInput
+    Reference molecule
+probe : RDKit.ROMol
+    Probe molecule
+probeConfId : int, optional
+    Probe conformer ID (default is -1)
+useColors : bool, optional
+    Whether or not to use colors in the scoring (default is True)
+optParam : float, optional 
+max_preiters : int, optional
+max_postiters : int, optional
+
+Returns
+-------
+ 2-tuple of doubles
+    The results are (shape_score, color_score)
+    The color_score is zero if useColors is False)DOC"););
+
+  python::def(
+      "PrepareConformer", &helpers::prepConf,
+      (python::arg("mol"), python::arg("confId") = -1,
+       python::arg("useColors") = true),
+      R"DOC(Generates a ShapeInput object for a molecule
+
+Parameters
+----------
+mol : RDKit.ROMol
+    Reference molecule
+confId : int, optional
+    Conformer ID to use (default is -1)
+useColors : bool, optional
+    Whether or not to assign chemical features (colors) (default is True)
+
+Returns
+-------
+ a ShapeInput for the molecule)DOC"),
               python::return_value_policy<python::manage_new_object>());
   python::class_<ShapeInput, boost::noncopyable>("ShapeInput", python::no_init)
       .def_readwrite("coord", &ShapeInput::coord)

--- a/External/pubchem_shape/Wrap/cshapealign.cpp
+++ b/External/pubchem_shape/Wrap/cshapealign.cpp
@@ -82,9 +82,10 @@ probeConfId : int, optional
     Probe conformer ID (default is -1)
 useColors : bool, optional
     Whether or not to use colors in the scoring (default is True)
-optParam : float, optional 
+optParam : float, optional
 max_preiters : int, optional
 max_postiters : int, optional
+
 
 Returns
 -------
@@ -110,21 +111,21 @@ probeConfId : int, optional
     Probe conformer ID (default is -1)
 useColors : bool, optional
     Whether or not to use colors in the scoring (default is True)
-optParam : float, optional 
+optParam : float, optional
 max_preiters : int, optional
 max_postiters : int, optional
+
 
 Returns
 -------
  2-tuple of doubles
     The results are (shape_score, color_score)
-    The color_score is zero if useColors is False)DOC"););
+    The color_score is zero if useColors is False)DOC");
 
-  python::def(
-      "PrepareConformer", &helpers::prepConf,
-      (python::arg("mol"), python::arg("confId") = -1,
-       python::arg("useColors") = true),
-      R"DOC(Generates a ShapeInput object for a molecule
+  python::def("PrepareConformer", &helpers::prepConf,
+              (python::arg("mol"), python::arg("confId") = -1,
+               python::arg("useColors") = true),
+              R"DOC(Generates a ShapeInput object for a molecule
 
 Parameters
 ----------
@@ -137,7 +138,7 @@ useColors : bool, optional
 
 Returns
 -------
- a ShapeInput for the molecule)DOC"),
+ a ShapeInput for the molecule)DOC",
               python::return_value_policy<python::manage_new_object>());
   python::class_<ShapeInput, boost::noncopyable>("ShapeInput", python::no_init)
       .def_readwrite("coord", &ShapeInput::coord)


### PR DESCRIPTION
First of a series of PRs with improvements to the docs.
There are no actual code changes here.

A note on docstring formatting: when adding new docstrings for the python wrappers, I've started using the numpy/scipy format (https://numpydoc.readthedocs.io/en/latest/format.html) instead of whatever random thing we were doing before.
I'd suggeste that we adopt this format going forward and switch old docstrings over as time allows.