### PR TITLE
Make sure that loggers can be enabled, disabled, captured and tee'd from MinimalLib

### DIFF
--- a/Code/MinimalLib/cffi_test.c
+++ b/Code/MinimalLib/cffi_test.c
@@ -16,7 +16,7 @@
 #define _DEFINED_USE_MATH_DEFINES
 #include <fcntl.h>
 #include <io.h>
-#include <winndows.h>
+#include <windows.h>
 #endif
 #else
 #include <unistd.h>

--- a/Code/MinimalLib/cffi_test.c
+++ b/Code/MinimalLib/cffi_test.c
@@ -2245,11 +2245,13 @@ CapturedStreams *capture_streams(unsigned int buf_size) {
     release_streams(&res);
     return NULL;
   }
-  if (PIPE_FUNC(res->stdout_pipes, buf_size) == -1 || PIPE_FUNC(res->stderr_pipes, buf_size) == -1) {
+  if (PIPE_FUNC(res->stdout_pipes, buf_size) == -1 ||
+      PIPE_FUNC(res->stderr_pipes, buf_size) == -1) {
     release_streams(&res);
     return NULL;
   }
-  if (DUP2_FUNC(res->stdout_pipes[1], FILENO_FUNC(stdout)) == -1 || DUP2_FUNC(res->stderr_pipes[1], FILENO_FUNC(stderr)) == -1) {
+  if (DUP2_FUNC(res->stdout_pipes[1], FILENO_FUNC(stdout)) == -1 ||
+      DUP2_FUNC(res->stderr_pipes[1], FILENO_FUNC(stderr)) == -1) {
     release_streams(&res);
     return NULL;
   }
@@ -2284,7 +2286,8 @@ int can_read(int fd) {
 }
 
 int non_blocking_read(int fd, void *buf, unsigned int buf_size) {
-  // do not attempt to read if the pipe is empty as the read operation will block
+  // do not attempt to read if the pipe is empty as the read operation will
+  // block
   int has_data = can_read(fd);
   if (has_data == -1) {
     return -1;
@@ -2310,7 +2313,8 @@ char *_get_capture_buf(int *pipes, unsigned int buf_size) {
     return NULL;
   }
   memset(buf, 0, buf_size);
-  // do not attempt to read if the pipe is empty as the read operation will block
+  // do not attempt to read if the pipe is empty as the read operation will
+  // block
   if (non_blocking_read(pipes[0], buf, buf_size) == -1) {
     free(buf);
     return NULL;
@@ -2336,9 +2340,11 @@ void test_capture_logs() {
   void *log_handle;
   void *log_handle2;
   const char *PENTAVALENT_CARBON = "CC(C)(C)(C)C";
-  const char *PENTAVALENT_CARBON_VALENCE_ERROR = "Explicit valence for atom # 1 C, 5, is greater than permitted";
+  const char *PENTAVALENT_CARBON_VALENCE_ERROR =
+      "Explicit valence for atom # 1 C, 5, is greater than permitted";
   const char *TETRAVALENT_NITROGEN = "CN(C)(C)C";
-  const char *TETRAVALENT_NITROGEN_VALENCE_ERROR = "Explicit valence for atom # 1 N, 4, is greater than permitted";
+  const char *TETRAVALENT_NITROGEN_VALENCE_ERROR =
+      "Explicit valence for atom # 1 N, 4, is greater than permitted";
   const size_t BUF_SIZE = PIPE_BUF_SIZE;
   CapturedStreams *captured_streams;
   typedef struct {
@@ -2394,7 +2400,9 @@ void test_capture_logs() {
     assert(!mpkl);
     log_buffer = get_stderr_buf(captured_streams, BUF_SIZE);
     assert(log_buffer);
-    assert(tests[i].func == set_log_tee ? !!strstr(log_buffer, TETRAVALENT_NITROGEN_VALENCE_ERROR) : !log_buffer[0]);
+    assert(tests[i].func == set_log_tee
+               ? !!strstr(log_buffer, TETRAVALENT_NITROGEN_VALENCE_ERROR)
+               : !log_buffer[0]);
     free(log_buffer);
     release_streams(&captured_streams);
     log_buffer = get_log_buffer(log_handle);
@@ -2414,7 +2422,9 @@ void test_capture_logs() {
     assert(!mpkl);
     log_buffer = get_stderr_buf(captured_streams, BUF_SIZE);
     assert(log_buffer);
-    assert(tests[i].func == set_log_tee ? !!strstr(log_buffer, PENTAVALENT_CARBON_VALENCE_ERROR) : !log_buffer[0]);
+    assert(tests[i].func == set_log_tee
+               ? !!strstr(log_buffer, PENTAVALENT_CARBON_VALENCE_ERROR)
+               : !log_buffer[0]);
     free(log_buffer);
     release_streams(&captured_streams);
     log_buffer = get_log_buffer(log_handle);

--- a/Code/MinimalLib/cffi_test.c
+++ b/Code/MinimalLib/cffi_test.c
@@ -14,7 +14,13 @@
 #ifndef _USE_MATH_DEFINES
 #define _USE_MATH_DEFINES
 #define _DEFINED_USE_MATH_DEFINES
+#include <fcntl.h>
+#include <io.h>
+#include <winndows.h>
 #endif
+#else
+#include <unistd.h>
+#include <poll.h>
 #endif
 #include <math.h>
 #ifdef _DEFINED_USE_MATH_DEFINES
@@ -2170,6 +2176,156 @@ void test_partial_sanitization() {
   free(mpkl);
 }
 
+#define PIPE_BUF_SIZE 4096
+#define PIPE_FD_SIZE 2
+#ifdef _WIN32
+#define DUP_FUNC _dup
+#define DUP2_FUNC _dup2
+#define PIPE_FUNC(fds, buf_size) _pipe(fds, buf_size, _O_BINARY)
+#define READ_FUNC _read
+#define FILENO_FUNC _fileno
+#define CLOSE_FUNC _close
+#else
+#define DUP_FUNC dup
+#define DUP2_FUNC dup2
+#define PIPE_FUNC(fds, buf_size) pipe(fds)
+#define READ_FUNC read
+#define FILENO_FUNC fileno
+#define CLOSE_FUNC close
+#endif
+
+typedef struct {
+  int orig_stdout;
+  int orig_stderr;
+  int stdout_pipes[PIPE_FD_SIZE];
+  int stderr_pipes[PIPE_FD_SIZE];
+} CapturedStreams;
+
+void release_streams(CapturedStreams **captured_streams) {
+  size_t i;
+  if (!captured_streams || !*captured_streams) {
+    return;
+  }
+  if ((*captured_streams)->orig_stdout != -1) {
+    fflush(stdout);
+    DUP2_FUNC((*captured_streams)->orig_stdout, FILENO_FUNC(stdout));
+  }
+  if ((*captured_streams)->orig_stderr != -1) {
+    fflush(stderr);
+    DUP2_FUNC((*captured_streams)->orig_stderr, FILENO_FUNC(stderr));
+  }
+  for (i = 0; i < PIPE_FD_SIZE; ++i) {
+    if ((*captured_streams)->stdout_pipes[i] != -1) {
+      CLOSE_FUNC((*captured_streams)->stdout_pipes[i]);
+    }
+    if ((*captured_streams)->stderr_pipes[i] != -1) {
+      CLOSE_FUNC((*captured_streams)->stderr_pipes[i]);
+    }
+  }
+  free(*captured_streams);
+  *captured_streams = NULL;
+}
+
+CapturedStreams *capture_streams(unsigned int buf_size) {
+  CapturedStreams *res;
+  res = (CapturedStreams *)malloc(sizeof(CapturedStreams));
+  if (!res) {
+    return NULL;
+  }
+  memset(res, 0, sizeof(CapturedStreams));
+  res->stdout_pipes[0] = -1;
+  res->stdout_pipes[1] = -1;
+  res->stderr_pipes[0] = -1;
+  res->stderr_pipes[1] = -1;
+  fflush(stdout);
+  fflush(stderr);
+  res->orig_stdout = DUP_FUNC(FILENO_FUNC(stdout));
+  res->orig_stderr = DUP_FUNC(FILENO_FUNC(stderr));
+  if (res->orig_stdout == -1 || res->orig_stderr == -1) {
+    release_streams(&res);
+    return NULL;
+  }
+  if (PIPE_FUNC(res->stdout_pipes, buf_size) == -1 || PIPE_FUNC(res->stderr_pipes, buf_size) == -1) {
+    release_streams(&res);
+    return NULL;
+  }
+  if (DUP2_FUNC(res->stdout_pipes[1], FILENO_FUNC(stdout)) == -1 || DUP2_FUNC(res->stderr_pipes[1], FILENO_FUNC(stderr)) == -1) {
+    release_streams(&res);
+    return NULL;
+  }
+  return res;
+}
+
+int can_read(int fd) {
+  int res;
+#ifndef _WIN32
+  struct pollfd pollfd_instance;
+  pollfd_instance.fd = fd;
+  pollfd_instance.events = POLLIN;
+  res = poll(&pollfd_instance, 1, 0);
+  if (res != -1) {
+    res = (pollfd_instance.revents & POLLIN ? 1 : 0);
+  }
+#else
+  HANDLE pipe_handle;
+  DWORD bytes_avail;
+  pipe_handle = (HANDLE)_get_osfhandle(fd);
+  if (pipe_handle == INVALID_HANDLE_VALUE) {
+    return -1;
+  }
+  res = PeekNamedPipe(pipe_handle, NULL, 0, NULL, &bytes_avail, NULL);
+  if (res == 0) {
+    res = -1;
+  } else {
+    res = (bytes_avail > 0 ? 1 : 0);
+  }
+#endif
+  return res;
+}
+
+int non_blocking_read(int fd, void *buf, unsigned int buf_size) {
+  // do not attempt to read if the pipe is empty as the read operation will block
+  int has_data = can_read(fd);
+  if (has_data == -1) {
+    return -1;
+  }
+  int n_read = 0;
+  if (has_data) {
+    n_read = READ_FUNC(fd, buf, buf_size);
+  }
+  return n_read;
+}
+
+char *_get_capture_buf(int *pipes, unsigned int buf_size) {
+  char *buf;
+  if (!pipes || pipes[0] == -1 || pipes[1] == -1) {
+    return NULL;
+  }
+  if (CLOSE_FUNC(pipes[1]) == -1) {
+    return NULL;
+  }
+  pipes[1] = -1;
+  buf = (char *)malloc(buf_size);
+  if (!buf) {
+    return NULL;
+  }
+  memset(buf, 0, buf_size);
+  // do not attempt to read if the pipe is empty as the read operation will block
+  if (non_blocking_read(pipes[0], buf, buf_size) == -1) {
+    free(buf);
+    return NULL;
+  }
+  return buf;
+}
+
+char *get_stdout_buf(CapturedStreams *captured_streams, unsigned int buf_size) {
+  return _get_capture_buf(captured_streams->stdout_pipes, buf_size);
+}
+
+char *get_stderr_buf(CapturedStreams *captured_streams, unsigned int buf_size) {
+  return _get_capture_buf(captured_streams->stderr_pipes, buf_size);
+}
+
 void test_capture_logs() {
   printf("--------------------------\n");
   printf("  test_capture_logs\n");
@@ -2178,41 +2334,112 @@ void test_capture_logs() {
   void *null_handle = NULL;
   size_t mpkl_size;
   void *log_handle;
+  void *log_handle2;
+  const char *PENTAVALENT_CARBON = "CC(C)(C)(C)C";
+  const char *PENTAVALENT_CARBON_VALENCE_ERROR = "Explicit valence for atom # 1 C, 5, is greater than permitted";
+  const char *TETRAVALENT_NITROGEN = "CN(C)(C)C";
+  const char *TETRAVALENT_NITROGEN_VALENCE_ERROR = "Explicit valence for atom # 1 N, 4, is greater than permitted";
+  const size_t BUF_SIZE = PIPE_BUF_SIZE;
+  CapturedStreams *captured_streams;
   typedef struct {
-    const char *type;
     void *(*func)(const char *);
   } capture_test;
-  capture_test tests[] = {{"tee", set_log_tee}, {"capture", set_log_capture}};
+  capture_test tests[] = {{set_log_tee}, {set_log_capture}};
+  assert(disable_logging());
+  assert(!enable_logger("dummy"));
+  assert(enable_logger("rdApp.info"));
+  // Should see no warning on pentavalent carbon below
+  captured_streams = capture_streams(BUF_SIZE);
+  assert(captured_streams);
+  mpkl = get_mol(PENTAVALENT_CARBON, &mpkl_size, "");
+  assert(!mpkl);
+  log_buffer = get_stderr_buf(captured_streams, BUF_SIZE);
+  assert(log_buffer);
+  assert(!log_buffer[0]);
+  free(log_buffer);
+  release_streams(&captured_streams);
+  assert(enable_logger("rdApp.error"));
+  // Should see warning on pentavalent carbon below
+  captured_streams = capture_streams(BUF_SIZE);
+  assert(captured_streams);
+  mpkl = get_mol(PENTAVALENT_CARBON, &mpkl_size, "");
+  assert(!mpkl);
+  log_buffer = get_stderr_buf(captured_streams, BUF_SIZE);
+  assert(log_buffer);
+  assert(strstr(log_buffer, PENTAVALENT_CARBON_VALENCE_ERROR));
+  free(log_buffer);
+  release_streams(&captured_streams);
+  assert(disable_logging());
+  // Should again see no warning on pentavalent carbon below
+  captured_streams = capture_streams(BUF_SIZE);
+  assert(captured_streams);
+  mpkl = get_mol(PENTAVALENT_CARBON, &mpkl_size, "");
+  assert(!mpkl);
+  log_buffer = get_stderr_buf(captured_streams, BUF_SIZE);
+  assert(log_buffer);
+  assert(!log_buffer[0]);
+  free(log_buffer);
+  release_streams(&captured_streams);
   for (size_t i = 0; i < sizeof(tests) / sizeof(capture_test); ++i) {
-    printf("%zu. %s\n", i + 1, tests[i].type);
-    log_handle = tests[i].func("dummy");
-    assert(!log_handle);
+    assert(!get_log_buffer(null_handle));
     log_handle = tests[i].func("rdApp.*");
     assert(log_handle);
-    assert(!get_log_buffer(null_handle));
     log_buffer = get_log_buffer(log_handle);
     assert(log_buffer);
-    assert(!strlen(log_buffer));
+    assert(!log_buffer[0]);
     free(log_buffer);
-    mpkl = get_mol("CN(C)(C)C", &mpkl_size, "");
+    captured_streams = capture_streams(BUF_SIZE);
+    assert(captured_streams);
+    mpkl = get_mol(TETRAVALENT_NITROGEN, &mpkl_size, "");
     assert(!mpkl);
+    log_buffer = get_stderr_buf(captured_streams, BUF_SIZE);
+    assert(log_buffer);
+    assert(tests[i].func == set_log_tee ? !!strstr(log_buffer, TETRAVALENT_NITROGEN_VALENCE_ERROR) : !log_buffer[0]);
+    free(log_buffer);
+    release_streams(&captured_streams);
     log_buffer = get_log_buffer(log_handle);
     assert(log_buffer);
-    assert(strstr(
-        log_buffer,
-        "Explicit valence for atom # 1 N, 4, is greater than permitted"));
+    assert(strstr(log_buffer, TETRAVALENT_NITROGEN_VALENCE_ERROR));
     free(log_buffer);
-    assert(!clear_log_buffer(null_handle));
     assert(clear_log_buffer(log_handle));
     log_buffer = get_log_buffer(log_handle);
     assert(log_buffer);
-    assert(!strlen(log_buffer));
+    assert(!log_buffer[0]);
+    free(log_buffer);
+    log_handle2 = tests[i].func("rdApp.*");
+    assert(!log_handle2);
+    captured_streams = capture_streams(BUF_SIZE);
+    assert(captured_streams);
+    mpkl = get_mol(PENTAVALENT_CARBON, &mpkl_size, "");
+    assert(!mpkl);
+    log_buffer = get_stderr_buf(captured_streams, BUF_SIZE);
+    assert(log_buffer);
+    assert(tests[i].func == set_log_tee ? !!strstr(log_buffer, PENTAVALENT_CARBON_VALENCE_ERROR) : !log_buffer[0]);
+    free(log_buffer);
+    release_streams(&captured_streams);
+    log_buffer = get_log_buffer(log_handle);
+    assert(log_buffer);
+    assert(strstr(log_buffer, PENTAVALENT_CARBON_VALENCE_ERROR));
     free(log_buffer);
     assert(!destroy_log_handle(null_handle));
     assert(!destroy_log_handle(&null_handle));
     assert(destroy_log_handle(&log_handle));
     assert(!log_handle);
+    log_handle2 = tests[i].func("rdApp.*");
+    assert(log_handle2);
+    assert(destroy_log_handle(&log_handle2));
+    assert(!log_handle2);
   }
+  // Should again see no warning on pentavalent carbon below
+  captured_streams = capture_streams(BUF_SIZE);
+  assert(captured_streams);
+  mpkl = get_mol(PENTAVALENT_CARBON, &mpkl_size, "");
+  assert(!mpkl);
+  log_buffer = get_stderr_buf(captured_streams, BUF_SIZE);
+  assert(log_buffer);
+  assert(!log_buffer[0]);
+  free(log_buffer);
+  release_streams(&captured_streams);
 }
 
 void test_relabel_mapped_dummies() {

--- a/Code/MinimalLib/cffiwrapper.cpp
+++ b/Code/MinimalLib/cffiwrapper.cpp
@@ -835,12 +835,16 @@ extern "C" short allow_non_tetrahedral_chirality(short value) {
 std::unique_ptr<MinimalLib::LoggerStateSingletons>
     MinimalLib::LoggerStateSingletons::d_instance;
 
-extern "C" short enable_logging() { return MinimalLib::LogHandle::enableLogging(); }
+extern "C" short enable_logging() {
+  return MinimalLib::LogHandle::enableLogging();
+}
 extern "C" short enable_logger(const char *log_name) {
   return MinimalLib::LogHandle::enableLogging(log_name);
 }
 
-extern "C" short disable_logging() { return MinimalLib::LogHandle::disableLogging(); }
+extern "C" short disable_logging() {
+  return MinimalLib::LogHandle::disableLogging();
+}
 extern "C" short disable_logger(const char *log_name) {
   return MinimalLib::LogHandle::disableLogging(log_name);
 }

--- a/Code/MinimalLib/cffiwrapper.cpp
+++ b/Code/MinimalLib/cffiwrapper.cpp
@@ -832,12 +832,18 @@ extern "C" short allow_non_tetrahedral_chirality(short value) {
   return was;
 }
 
-MinimalLib::LogHandle::LoggingFlag MinimalLib::LogHandle::d_loggingNeedsInit =
-    true;
+std::unique_ptr<MinimalLib::LoggerStateSingletons>
+    MinimalLib::LoggerStateSingletons::d_instance;
 
-extern "C" void enable_logging() { MinimalLib::LogHandle::enableLogging(); }
+extern "C" short enable_logging() { return MinimalLib::LogHandle::enableLogging(); }
+extern "C" short enable_logger(const char *log_name) {
+  return MinimalLib::LogHandle::enableLogging(log_name);
+}
 
-extern "C" void disable_logging() { MinimalLib::LogHandle::disableLogging(); }
+extern "C" short disable_logging() { return MinimalLib::LogHandle::disableLogging(); }
+extern "C" short disable_logger(const char *log_name) {
+  return MinimalLib::LogHandle::disableLogging(log_name);
+}
 
 extern "C" void *set_log_tee(const char *log_name) {
   return MinimalLib::LogHandle::setLogTee(log_name);
@@ -864,7 +870,7 @@ extern "C" char *get_log_buffer(void *log_handle) {
              : nullptr;
 }
 
-extern "C" bool clear_log_buffer(void *log_handle) {
+extern "C" short clear_log_buffer(void *log_handle) {
   if (log_handle) {
     reinterpret_cast<MinimalLib::LogHandle *>(log_handle)->clearBuffer();
     return 1;

--- a/Code/MinimalLib/cffiwrapper.h
+++ b/Code/MinimalLib/cffiwrapper.h
@@ -150,8 +150,10 @@ RDKIT_RDKITCFFI_EXPORT short set_2d_coords_aligned(char **pkl, size_t *pkl_sz,
 RDKIT_RDKITCFFI_EXPORT void free_ptr(char *ptr);
 
 RDKIT_RDKITCFFI_EXPORT char *version();
-RDKIT_RDKITCFFI_EXPORT void enable_logging();
-RDKIT_RDKITCFFI_EXPORT void disable_logging();
+RDKIT_RDKITCFFI_EXPORT short enable_logging();
+RDKIT_RDKITCFFI_EXPORT short enable_logger(const char *log_name);
+RDKIT_RDKITCFFI_EXPORT short disable_logging();
+RDKIT_RDKITCFFI_EXPORT short disable_logger(const char *log_name);
 
 // chirality
 RDKIT_RDKITCFFI_EXPORT short use_legacy_stereo_perception(short value);

--- a/Code/MinimalLib/common.h
+++ b/Code/MinimalLib/common.h
@@ -55,6 +55,10 @@
 #include <boost/property_tree/ptree.hpp>
 #include <boost/property_tree/json_parser.hpp>
 #include <RDGeneral/BoostEndInclude.h>
+#ifdef RDK_BUILD_THREADSAFE_SSS
+#include <mutex>
+#include <atomic>
+#endif
 
 #ifndef _MSC_VER
 // shutoff some warnings from rapidjson
@@ -1090,26 +1094,159 @@ std::string parse_inchi_options(const char *details_json) {
 }
 #endif
 
-struct LogHandle {
+namespace {
+#ifdef RDK_BUILD_THREADSAFE_SSS
+std::mutex &logger_mutex_get() {
+  // create on demand
+  static std::mutex _mutex;
+  return _mutex;
+}
+
+void logger_mutex_create() {
+  std::mutex &mutex = logger_mutex_get();
+  std::lock_guard<std::mutex> test_lock(mutex);
+}
+
+std::mutex &getLoggerMutex() {
+  static std::once_flag flag;
+  std::call_once(flag, logger_mutex_create);
+  return logger_mutex_get();
+}
+#endif
+
+class LoggerState {
  public:
-  LogHandle(const std::string &logName) : d_logName(logName) {
-    d_logNameToLoggers = std::map<std::string, LoggerStateVector>{
-        {"rdApp.debug", {LoggerState(rdDebugLog)}},
-        {"rdApp.info", {LoggerState(rdInfoLog)}},
-        {"rdApp.warning", {LoggerState(rdWarningLog)}},
-        {"rdApp.error", {LoggerState(rdErrorLog)}},
-        {"rdApp.*",
-         {LoggerState(rdDebugLog), LoggerState(rdInfoLog),
-          LoggerState(rdWarningLog), LoggerState(rdErrorLog)}}};
+  // this runs only once under mutex lock
+  LoggerState(const std::string &logName, RDLogger &logger)
+      : d_logName(logName), d_logger(logger), d_lock(false) {
+    CHECK_INVARIANT(d_logger, "d_logger must not be null");
+    // store original logger stream
+    d_prevDest = d_logger->dp_dest;
+    // store whether the logger was originally enabled
+    d_enabled = d_logger->df_enabled;
   }
-  ~LogHandle() { close(); }
-  static void enableLogging() {
-    initLogsIfNeeded();
-    boost::logging::enable_logs("rdApp.*");
+  LoggerState(const LoggerState &) = delete;
+  LoggerState &operator=(const LoggerState &) = delete;
+  ~LoggerState() {}
+  void resetStream() { setStream(d_prevDest); }
+  void setTee(std::ostream &ostream) { d_logger->SetTee(ostream); }
+  void clearTee() { d_logger->ClearTee(); }
+  void setStream(std::ostream *ostream) {
+    if (d_logger->dp_dest) {
+      d_logger->dp_dest->flush();
+    }
+    d_logger->dp_dest = ostream;
   }
-  static void disableLogging() {
-    initLogsIfNeeded();
-    boost::logging::disable_logs("rdApp.*");
+  void setEnabled(bool enabled, bool store = false) {
+    if (store) {
+      d_enabled = enabled;
+    }
+    if (enabled) {
+      boost::logging::enable_logs(d_logName);
+    } else if (!d_lock) {
+      boost::logging::disable_logs(d_logName);
+    }
+  }
+  bool hasLock() { return d_lock; }
+  bool setLock() {
+    if (!d_lock) {
+      d_lock = true;
+      return true;
+    }
+    return false;
+  }
+  void releaseLock() {
+    d_lock = false;
+    setEnabled(d_enabled);
+  }
+
+ private:
+  bool d_enabled = false;
+  std::string d_logName;
+  RDLogger d_logger;
+  std::ostream *d_prevDest;
+#ifdef RDK_BUILD_THREADSAFE_SSS
+  std::atomic<bool> d_lock;
+#else
+  bool d_lock;
+#endif
+};
+
+typedef std::vector<LoggerState *> LoggerStatePtrVector;
+
+class LoggerStateSingletons {
+ public:
+  static LoggerStatePtrVector *get(const std::string &logName) {
+    auto it = instance()->d_map.find(logName);
+    if (it != instance()->d_map.end()) {
+      return &it->second;
+    }
+    return nullptr;
+  }
+  static bool enable(const char *logNameCStr, bool enabled) {
+    std::string inputLogName(logNameCStr ? logNameCStr : defaultLogName());
+    auto loggerStates = get(inputLogName);
+    if (!loggerStates) {
+      return false;
+    }
+#ifdef RDK_BUILD_THREADSAFE_SSS
+    std::lock_guard<std::mutex> lock(getLoggerMutex());
+#endif
+    for (auto &loggerState : *loggerStates) {
+      loggerState->setEnabled(enabled, true);
+    }
+    return true;
+  }
+
+ private:
+  LoggerStateSingletons() {
+    // this runs only once under mutex lock
+    // and initializes LoggerState singletons
+    RDLog::InitLogs();
+    for (auto &[logName, logger] :
+         std::vector<std::pair<std::string, RDLogger>>{
+             {"rdApp.debug", rdDebugLog},
+             {"rdApp.info", rdInfoLog},
+             {"rdApp.warning", rdWarningLog},
+             {"rdApp.error", rdErrorLog},
+         }) {
+      d_singletonLoggerStates.emplace_back(new LoggerState(logName, logger));
+      auto loggerState = d_singletonLoggerStates.back().get();
+      CHECK_INVARIANT(loggerState, "loggerState must not be nullptr");
+      d_map[logName].push_back(loggerState);
+      d_map[defaultLogName()].push_back(loggerState);
+    }
+  }
+  static const char *defaultLogName() {
+    static const char *DEFAULT_LOG_NAME = "rdApp.*";
+    return DEFAULT_LOG_NAME;
+  }
+  static LoggerStateSingletons *instance() {
+    // this is called under mutex lock
+    if (!d_instance) {
+      d_instance.reset(new LoggerStateSingletons());
+    }
+    return d_instance.get();
+  }
+  std::vector<std::unique_ptr<LoggerState>> d_singletonLoggerStates;
+  std::map<std::string, LoggerStatePtrVector> d_map;
+  static std::unique_ptr<LoggerStateSingletons> d_instance;
+};
+}  // end anonymous namespace
+
+class LogHandle {
+ public:
+  ~LogHandle() {
+#ifdef RDK_BUILD_THREADSAFE_SSS
+    std::lock_guard<std::mutex> lock(getLoggerMutex());
+#endif
+    close();
+  }
+  static bool enableLogging(const char *logNameCStr = nullptr) {
+    return LoggerStateSingletons::enable(logNameCStr, true);
+  }
+  static bool disableLogging(const char *logNameCStr = nullptr) {
+    return LoggerStateSingletons::enable(logNameCStr, false);
   }
   void clearBuffer() {
     d_stream.str({});
@@ -1127,111 +1264,58 @@ struct LogHandle {
   }
 
  private:
-  struct LoggerState {
-   public:
-    LoggerState(RDLogger &logger) : d_logger(logger) {
-      if (d_logger) {
-        d_prevDest = d_logger->dp_dest;
-        d_prevWasEnabled = d_logger->df_enabled;
-      }
-    }
-    ~LoggerState() {
-      if (!d_prevDest) {
-        d_logger = nullptr;
-      } else {
-        if (d_logger->dp_dest) {
-          d_logger->dp_dest->flush();
-        }
-        d_logger->dp_dest = d_prevDest;
-        d_logger->df_enabled = d_prevWasEnabled;
-      }
-    }
-    const RDLogger &logger() const { return d_logger; }
-    std::ostream *stream() const { return d_logger->dp_dest; }
-    void setStream(std::ostream &ostream) {
-      if (!d_logger) {
-        d_logger = std::make_shared<boost::logging::rdLogger>(&ostream);
-      } else {
-        if (d_logger->dp_dest) {
-          d_logger->dp_dest->flush();
-        }
-        d_logger->dp_dest = &ostream;
-      }
-    }
-
-   private:
-    RDLogger &d_logger;
-    std::ostream *d_prevDest = nullptr;
-    bool d_prevWasEnabled = false;
-  };
-  typedef std::vector<LoggerState> LoggerStateVector;
-#ifdef RDK_BUILD_THREADSAFE_SSS
-  typedef std::atomic_bool LoggingFlag;
-#else
-  typedef bool LoggingFlag;
-#endif
-  bool open(bool setTee) {
-    d_haveTee = setTee;
-    auto loggerStates = getLoggerStates();
-    if (!loggerStates) {
-      return false;
-    }
-    clearBuffer();
-    if (d_haveTee) {
-      initLogsIfNeeded();
-    }
+  LogHandle(const std::string &logName, bool isTee)
+      : d_logName(logName), d_isTee(isTee) {
+    open();
+  }
+  void open() {
+    // this is called under mutex lock
+    auto loggerStates = LoggerStateSingletons::get(d_logName);
+    CHECK_INVARIANT(loggerStates, "loggerStates must not be nullptr");
     for (auto &loggerState : *loggerStates) {
-      if (d_haveTee) {
-        CHECK_INVARIANT(loggerState.logger(), "");
-        loggerState.logger()->SetTee(d_stream);
+      CHECK_INVARIANT(loggerState->setLock(), "Failed to acquire lock");
+      if (d_isTee) {
+        loggerState->setTee(d_stream);
       } else {
-        loggerState.setStream(d_stream);
+        loggerState->setStream(&d_stream);
       }
-      loggerState.logger()->df_enabled = true;
+      loggerState->setEnabled(true);
     }
-    return true;
   }
   void close() {
-    const auto loggerStates = getLoggerStates();
-    if (!loggerStates) {
-      return;
-    }
+    // this is called under mutex lock
+    auto loggerStates = LoggerStateSingletons::get(d_logName);
+    CHECK_INVARIANT(loggerStates, "loggerStates must not be nullptr");
     for (const auto &loggerState : *loggerStates) {
-      if (d_haveTee) {
-        CHECK_INVARIANT(loggerState.logger(), "");
-        loggerState.logger()->ClearTee();
+      if (d_isTee) {
+        loggerState->clearTee();
+      } else {
+        loggerState->resetStream();
       }
+      loggerState->releaseLock();
     }
   }
-  static LogHandle *setLogCommon(const char *logNameCStr, bool setTee) {
-    const auto logName = std::string(logNameCStr);
-    std::unique_ptr<MinimalLib::LogHandle> log_handle(
-        new MinimalLib::LogHandle(logName));
-    return (log_handle->open(setTee) ? log_handle.release() : nullptr);
-  }
-  // init logs if not yet initialized; returns true
-  // if they were actually initialized, false if not
-  static bool initLogsIfNeeded() {
-    if (d_loggingNeedsInit) {
-      RDLog::InitLogs();
-      d_loggingNeedsInit = false;
-      return true;
-    }
-    return false;
-  }
-  // returns nullptr if no loggers can be found
-  LoggerStateVector *getLoggerStates() {
-    const auto it = d_logNameToLoggers.find(d_logName);
-    if (it == d_logNameToLoggers.end()) {
+  // returns nullptr if the requested log does not exist or is already captured
+  static LogHandle *setLogCommon(const char *logNameCStr, bool isTee) {
+    if (!logNameCStr) {
       return nullptr;
     }
-    return &it->second;
+    std::string logName(logNameCStr);
+#ifdef RDK_BUILD_THREADSAFE_SSS
+    std::lock_guard<std::mutex> lock(getLoggerMutex());
+#endif
+    auto loggerStates = LoggerStateSingletons::get(logName);
+    if (loggerStates && std::none_of(loggerStates->begin(), loggerStates->end(),
+                                     [](const auto &loggerState) {
+                                       return loggerState->hasLock();
+                                     })) {
+      return new LogHandle(logName, isTee);
+    }
+    return nullptr;
   }
-  bool d_haveTee;
-  std::map<std::string, LoggerStateVector> d_logNameToLoggers;
   std::string d_logName;
+  bool d_isTee;
   std::stringstream d_stream;
-  static LoggingFlag d_loggingNeedsInit;
 };
 
 }  // namespace MinimalLib

--- a/Code/MinimalLib/jswrapper.cpp
+++ b/Code/MinimalLib/jswrapper.cpp
@@ -354,6 +354,10 @@ JSRGroupDecomposition *get_rgd_helper(
   return res;
 }
 
+void enable_logging_all() { enable_logging("rdApp.*"); }
+
+void disable_logging_all() { disable_logging("rdApp.*"); }
+
 JSRGroupDecomposition *get_rgd_no_details_helper(
     const emscripten::val &singleOrMultipleCores) {
   return get_rgd_helper(singleOrMultipleCores, "");
@@ -711,7 +715,9 @@ EMSCRIPTEN_BINDINGS(RDKit_minimal) {
   function("get_mol_copy", &get_mol_copy, allow_raw_pointers());
   function("get_qmol", &get_qmol, allow_raw_pointers());
   function("enable_logging", &enable_logging);
+  function("enable_logging", &enable_logging_all);
   function("disable_logging", &disable_logging);
+  function("disable_logging", &disable_logging_all);
   function("set_log_capture", &set_log_capture, allow_raw_pointers());
   function("set_log_tee", &set_log_tee, allow_raw_pointers());
 #ifdef RDK_BUILD_MINIMAL_LIB_RXN

--- a/Code/MinimalLib/jswrapper.cpp
+++ b/Code/MinimalLib/jswrapper.cpp
@@ -354,10 +354,6 @@ JSRGroupDecomposition *get_rgd_helper(
   return res;
 }
 
-void enable_logging_all() { enable_logging("rdApp.*"); }
-
-void disable_logging_all() { disable_logging("rdApp.*"); }
-
 JSRGroupDecomposition *get_rgd_no_details_helper(
     const emscripten::val &singleOrMultipleCores) {
   return get_rgd_helper(singleOrMultipleCores, "");
@@ -391,6 +387,11 @@ emscripten::val get_rgroups_as_rows_helper(const JSRGroupDecomposition &self) {
   return arr;
 }
 #endif
+
+void enable_logging_all() { enable_logging("rdApp.*"); }
+
+void disable_logging_all() { disable_logging("rdApp.*"); }
+
 }  // namespace
 
 using namespace emscripten;

--- a/Code/MinimalLib/minilib.cpp
+++ b/Code/MinimalLib/minilib.cpp
@@ -900,10 +900,10 @@ JSMolBase *get_mcs_as_mol(const JSMolList &molList,
 }
 #endif
 
-RDKit::MinimalLib::LogHandle::LoggingFlag
-    RDKit::MinimalLib::LogHandle::d_loggingNeedsInit = true;
+std::unique_ptr<MinimalLib::LoggerStateSingletons>
+    MinimalLib::LoggerStateSingletons::d_instance;
 
-JSLog::JSLog(RDKit::MinimalLib::LogHandle *logHandle) : d_logHandle(logHandle) {
+JSLog::JSLog(MinimalLib::LogHandle *logHandle) : d_logHandle(logHandle) {
   assert(d_logHandle);
 }
 
@@ -914,17 +914,22 @@ std::string JSLog::get_buffer() const { return d_logHandle->getBuffer(); }
 void JSLog::clear_buffer() const { d_logHandle->clearBuffer(); }
 
 JSLog *set_log_tee(const std::string &log_name) {
-  auto logHandle = RDKit::MinimalLib::LogHandle::setLogTee(log_name.c_str());
+  auto logHandle = MinimalLib::LogHandle::setLogTee(log_name.c_str());
   return logHandle ? new JSLog(logHandle) : nullptr;
 }
 
 JSLog *set_log_capture(const std::string &log_name) {
-  auto logHandle =
-      RDKit::MinimalLib::LogHandle::setLogCapture(log_name.c_str());
+  auto logHandle = MinimalLib::LogHandle::setLogCapture(log_name.c_str());
   return logHandle ? new JSLog(logHandle) : nullptr;
 }
 
-void enable_logging() { RDKit::MinimalLib::LogHandle::enableLogging(); }
+bool enable_logging(const std::string &logName) {
+  return MinimalLib::LogHandle::enableLogging(logName.c_str());
+}
+
+bool disable_logging(const std::string &logName) {
+  return MinimalLib::LogHandle::disableLogging(logName.c_str());
+}
 
 void disable_logging() { RDKit::MinimalLib::LogHandle::disableLogging(); }
 

--- a/Code/MinimalLib/minilib.h
+++ b/Code/MinimalLib/minilib.h
@@ -243,7 +243,7 @@ class JSMolList {
 
 namespace RDKit {
 namespace MinimalLib {
-struct LogHandle;
+class LogHandle;
 }
 }  // namespace RDKit
 
@@ -344,8 +344,8 @@ std::string version();
 void prefer_coordgen(bool prefer);
 bool use_legacy_stereo_perception(bool value);
 bool allow_non_tetrahedral_chirality(bool value);
-void enable_logging();
-void disable_logging();
+bool enable_logging(const std::string &logName);
+bool disable_logging(const std::string &logName);
 JSLog *set_log_tee(const std::string &log_name);
 JSLog *set_log_capture(const std::string &log_name);
 #ifdef RDK_BUILD_MINIMAL_LIB_MCS

--- a/Code/MinimalLib/tests/tests.js
+++ b/Code/MinimalLib/tests/tests.js
@@ -2677,24 +2677,135 @@ function test_partial_sanitization() {
     mol2.delete();
 }
 
+function captureStdoutStderr(stdoutCallback, optStderrCallback) {
+    if (!stdoutCallback) {
+        return null;
+    }
+    const stderrCallback = optStderrCallback || stdoutCallback;
+    const origStdoutWrite = process.stdout.write;
+    const origStderrWrite = process.stderr.write;
+    process.stdout.write = (chunk) => stdoutCallback(chunk);
+    process.stderr.write = (chunk) => stderrCallback(chunk);
+    return () => {
+        process.stdout.write = origStdoutWrite;
+        process.stderr.write = origStderrWrite;
+    };
+}
+
 function test_capture_logs() {
-    ["set_log_tee", "set_log_capture"].forEach((func, i) => {
-        console.log(`${i + 1}. ${func}`);
-        var logHandle = RDKitModule[func]("dummy");
-        assert(!logHandle);
-        var logHandle = RDKitModule[func]("rdApp.*");
-        assert(logHandle);
-        var logBuffer = logHandle.get_buffer();
-        assert(!logBuffer);
-        var mol = RDKitModule.get_mol("CN(C)(C)C");
+    const PENTAVALENT_CARBON = 'CC(C)(C)(C)C';
+    const PENTAVALENT_CARBON_VALENCE_ERROR = 'Explicit valence for atom # 1 C, 5, is greater than permitted';
+    const TETRAVALENT_NITROGEN = 'CN(C)(C)C';
+    const TETRAVALENT_NITROGEN_VALENCE_ERROR = 'Explicit valence for atom # 1 N, 4, is greater than permitted';
+    RDKitModule.disable_logging();
+    assert(!RDKitModule.enable_logging('dummy'));
+    assert(RDKitModule.enable_logging('rdApp.info'));
+    var restoreStreams;
+    var captureHasHappened;
+    // Should see no warning on pentavalent carbon below
+    captureHasHappened = false;
+    restoreStreams = captureStdoutStderr((capturedStreams) => {
+        captureHasHappened = true;
+    });
+    assert(restoreStreams);
+    try {
+        var mol = RDKitModule.get_mol(PENTAVALENT_CARBON);
         assert(!mol);
-        logBuffer = logHandle.get_buffer();
-        assert(logBuffer);
-        assert(logBuffer.includes('Explicit valence for atom # 1 N, 4, is greater than permitted'));
-        logHandle.clear_buffer();
-        assert(!logHandle.get_buffer());
-        logHandle.delete();
+    } finally {
+        restoreStreams();
+    }
+    assert(!captureHasHappened);
+    RDKitModule.enable_logging("rdApp.error");
+    // Should see warning on pentavalent carbon below
+    restoreStreams = captureStdoutStderr((capturedStreams) => {
+        captureHasHappened = true;
+        assert(capturedStreams.includes(PENTAVALENT_CARBON_VALENCE_ERROR));
+    });
+    assert(restoreStreams);
+    try {
+        var mol = RDKitModule.get_mol(PENTAVALENT_CARBON);
+        assert(!mol);
+    } finally {
+        restoreStreams();
+    }
+    assert(captureHasHappened);
+    captureHasHappened = false;
+    RDKitModule.disable_logging();
+    // Should again see no warning on pentavalent carbon below
+    restoreStreams = captureStdoutStderr((capturedStreams) => {
+        captureHasHappened = true;
+    });
+    assert(restoreStreams);
+    try {
+        var mol = RDKitModule.get_mol(PENTAVALENT_CARBON);
+        assert(!mol);
+    } finally {
+        restoreStreams();
+    }
+    assert(!captureHasHappened);
+    var logHandle1;
+    var logHandle2;
+    var logBuffer1;
+    var mol;
+    ['set_log_tee', 'set_log_capture'].forEach((func, i) => {
+        logHandle1 = RDKitModule[func]('rdApp.*');
+        assert(logHandle1);
+        logBuffer1 = logHandle1.get_buffer();
+        assert(!logBuffer1);
+        restoreStreams = captureStdoutStderr((capturedStreams) => {
+            captureHasHappened = true;
+            assert(capturedStreams.includes(TETRAVALENT_NITROGEN_VALENCE_ERROR));
+        });
+        assert(restoreStreams);
+        try {
+            mol = RDKitModule.get_mol(TETRAVALENT_NITROGEN);
+            assert(!mol);
+        } finally {
+            restoreStreams();
+        }
+        assert(!((func === 'set_log_tee') ^ captureHasHappened));
+        captureHasHappened = false;
+        logBuffer1 = logHandle1.get_buffer();
+        assert(logBuffer1);
+        assert(logBuffer1.includes(TETRAVALENT_NITROGEN_VALENCE_ERROR));
+        logHandle1.clear_buffer();
+        assert(!logHandle1.get_buffer());
+        logHandle2 = RDKitModule[func]('rdApp.*');
+        assert(!logHandle2);
+        restoreStreams = captureStdoutStderr((capturedStreams) => {
+            captureHasHappened = true;
+            assert(capturedStreams.includes(PENTAVALENT_CARBON_VALENCE_ERROR));
+        });
+        assert(restoreStreams);
+        try {
+            mol = RDKitModule.get_mol(PENTAVALENT_CARBON);
+            assert(!mol);
+        } finally {
+            restoreStreams();
+        }
+        assert(!((func === 'set_log_tee') ^ captureHasHappened));
+        captureHasHappened = false;
+        logBuffer1 = logHandle1.get_buffer();
+        assert(logBuffer1);
+        assert(logBuffer1.includes(PENTAVALENT_CARBON_VALENCE_ERROR));
+        assert(!logBuffer1.includes(TETRAVALENT_NITROGEN_VALENCE_ERROR));
+        logHandle1.delete();
+        logHandle2 = RDKitModule[func]('rdApp.*');
+        assert(logHandle2);
+        logHandle2.delete();
     })
+    // Should again see no warning on pentavalent carbon below
+    restoreStreams = captureStdoutStderr((capturedStreams) => {
+        captureHasHappened = true;
+    });
+    assert(restoreStreams);
+    try {
+        var mol = RDKitModule.get_mol(PENTAVALENT_CARBON);
+        assert(!mol);
+    } finally {
+        restoreStreams();
+    }
+    assert(!captureHasHappened);
 }
 
 function test_rgroup_match_heavy_hydro_none_charged() {


### PR DESCRIPTION
I realized that log enabling/disabling/capture/tee were not quite working as expected from CFFI/MinimalLib, therefore I made them more robust and added relevant CFFI and MinimalLib tests.