### PR TITLE
Remove deprecation warnings by switching MinimalLib to fingerprint generators

### DIFF
--- a/Code/MinimalLib/CMakeLists.txt
+++ b/Code/MinimalLib/CMakeLists.txt
@@ -6,7 +6,7 @@ if(RDK_BUILD_MINIMAL_LIB)
         "CIPLabeler_static;MolDraw2D_static;Depictor_static;"
         "Descriptors_static;SubstructMatch_static;FileParsers_static;"
         "SmilesParse_static;GraphMol_static;RDGeometryLib_static;"
-        "RDGeneral_static;RGroupDecomposition_static")
+        "RDGeneral_static;RGroupDecomposition_static;Fingerprints_static")
     if(RDK_BUILD_INCHI_SUPPORT)
         add_definitions(-DRDK_BUILD_INCHI_SUPPORT)
         set(MINIMAL_LIB_LIBRARIES "${MINIMAL_LIB_LIBRARIES};RDInchiLib_static")
@@ -22,10 +22,6 @@ if(RDK_BUILD_MINIMAL_LIB)
     if(RDK_BUILD_MINIMAL_LIB_MCS)
         add_definitions(-DRDK_BUILD_MINIMAL_LIB_MCS)
         set(MINIMAL_LIB_LIBRARIES "${MINIMAL_LIB_LIBRARIES};FMCS_static")
-    endif()
-    if(RDK_BUILD_MINIMAL_LIB_RGROUPDECOMP)
-        add_definitions(-DRDK_BUILD_MINIMAL_LIB_RGROUPDECOMP)
-        set(MINIMAL_LIB_LIBRARIES "${MINIMAL_LIB_LIBRARIES};RGroupDecomposition")
     endif()
     if(RDK_BUILD_MINIMAL_LIB_MMPA)
         add_definitions(-DRDK_BUILD_MINIMAL_LIB_MMPA)
@@ -52,8 +48,8 @@ if(RDK_BUILD_CFFI_LIB)
         ForceField Alignment
         MolInterchange Abbreviations CIPLabeler 
         MolDraw2D Depictor Descriptors
-        SubstructMatch FileParsers 
-        SmilesParse GraphMol RDGeometryLib RDGeneral RGroupDecomposition)
+        SubstructMatch FileParsers SmilesParse GraphMol
+        RDGeometryLib RDGeneral RGroupDecomposition Fingerprints)
     if(RDK_BUILD_INCHI_SUPPORT)
         add_definitions(-DRDK_BUILD_INCHI_SUPPORT)
         list(APPEND LIBS_TO_USE RDInchiLib)


### PR DESCRIPTION
This PR also contains small cleanup to MinimalLib `CMakeLists.txt`.