### PR TITLE
One final round of mem errors

### DIFF
--- a/Code/ForceField/ForceField.cpp
+++ b/Code/ForceField/ForceField.cpp
@@ -283,18 +283,17 @@ int ForceField::minimize(unsigned int snapshotFreq,
   unsigned int numIters = 0;
   unsigned int dim = this->d_numPoints * d_dimension;
   double finalForce = 0.0;
-  auto *points = new double[dim];
+  std::vector<double> points(dim);
 
-  this->scatter(points);
+  this->scatter(points.data());
   ForceFieldsHelper::calcEnergy eCalc(this);
   ForceFieldsHelper::calcGradient gCalc(this);
 
   int res =
-      BFGSOpt::minimize(dim, points, forceTol, numIters, finalForce, eCalc,
+      BFGSOpt::minimize(dim, points.data(), forceTol, numIters, finalForce, eCalc,
                         gCalc, snapshotFreq, snapshotVect, energyTol, maxIts);
-  this->gather(points);
+  this->gather(points.data());
 
-  delete[] points;
   return res;
 }
 

--- a/Code/GraphMol/ChemReactions/Wrap/Enumerate.cpp
+++ b/Code/GraphMol/ChemReactions/Wrap/Enumerate.cpp
@@ -12,7 +12,7 @@
 //       copyright notice, this list of conditions and the following
 //       disclaimer in the documentation and/or other materials provided
 //       with the distribution.
-//     * Neither the name of Novartis Institutues for BioMedical Research Inc.
+//     * Neither the name of Novartis Institutes for BioMedical Research Inc.
 //       nor the names of its contributors may be used to endorse or promote
 //       products derived from this software without specific prior written
 //       permission.
@@ -144,7 +144,8 @@ struct enumeration_wrapper {
 
     RegisterVectorConverter<MOL_SPTR_VECT>("VectMolVect");
 
-    python::class_<RDKit::EnumerateLibraryBase, RDKit::EnumerateLibraryBase *,
+    python::class_<RDKit::EnumerateLibraryBase,
+                   boost::shared_ptr<RDKit::EnumerateLibraryBase>,
                    RDKit::EnumerateLibraryBase &, boost::noncopyable>(
         "EnumerateLibraryBase", python::no_init)
         .def("__nonzero__", &EnumerateLibraryBase__nonzero__,
@@ -210,7 +211,8 @@ Options:\n\
      does not pass sanitization, then none of the products will.\n\
 ";
 
-    python::class_<RDKit::EnumerationParams, RDKit::EnumerationParams *,
+    python::class_<RDKit::EnumerationParams,
+                   boost::shared_ptr<RDKit::EnumerationParams>,
                    RDKit::EnumerationParams &>(
         "EnumerationParams", docString.c_str(),
         python::init<>(python::args("self")))
@@ -315,7 +317,7 @@ for result in itertools.islice(libary2, 1000):\n\
     // iterator_wrappers<EnumerateLibrary>().wrap("EnumerateLibraryIterator");
 
     python::class_<RDKit::EnumerationStrategyBase,
-                   RDKit::EnumerationStrategyBase *,
+                   boost::shared_ptr<RDKit::EnumerationStrategyBase>,
                    RDKit::EnumerationStrategyBase &, boost::noncopyable>(
         "EnumerationStrategyBase", python::no_init)
         .def("__nonzero__", &EnumerationStrategyBase__nonzero__,
@@ -364,7 +366,7 @@ for result in itertools.islice(libary2, 1000):\n\
         "(0,0,0), (1,0,0), (2,0,0) ...\n";
 
     python::class_<RDKit::CartesianProductStrategy,
-                   RDKit::CartesianProductStrategy *,
+                   boost::shared_ptr<RDKit::CartesianProductStrategy>,
                    RDKit::CartesianProductStrategy &,
                    python::bases<EnumerationStrategyBase>>(
         "CartesianProductStrategy", docString.c_str(),
@@ -376,7 +378,8 @@ for result in itertools.islice(libary2, 1000):\n\
     docString =
         "RandomSampleStrategy simply randomly samples from the reagent sets.\n"
         "Note that this strategy never halts and can produce duplicates.";
-    python::class_<RDKit::RandomSampleStrategy, RDKit::RandomSampleStrategy *,
+    python::class_<RDKit::RandomSampleStrategy,
+                   boost::shared_ptr<RDKit::RandomSampleStrategy>,
                    RDKit::RandomSampleStrategy &,
                    python::bases<EnumerationStrategyBase>>(
         "RandomSampleStrategy", docString.c_str(),
@@ -391,7 +394,7 @@ for result in itertools.islice(libary2, 1000):\n\
         "possible.\n"
         "Note that this strategy never halts and can produce duplicates.";
     python::class_<RDKit::RandomSampleAllBBsStrategy,
-                   RDKit::RandomSampleAllBBsStrategy *,
+                   boost::shared_ptr<RDKit::RandomSampleAllBBsStrategy>,
                    RDKit::RandomSampleAllBBsStrategy &,
                    python::bases<EnumerationStrategyBase>>(
         "RandomSampleAllBBsStrategy", docString.c_str(),
@@ -410,7 +413,7 @@ for result in itertools.islice(libary2, 1000):\n\
         "See EnumerationStrategyBase for more details.\n";
 
     python::class_<RDKit::EvenSamplePairsStrategy,
-                   RDKit::EvenSamplePairsStrategy *,
+                   boost::shared_ptr<RDKit::EvenSamplePairsStrategy>,
                    RDKit::EvenSamplePairsStrategy &,
                    python::bases<EnumerationStrategyBase>>(
         "EvenSamplePairsStrategy", docString.c_str(),

--- a/Code/GraphMol/Descriptors/Property.cpp
+++ b/Code/GraphMol/Descriptors/Property.cpp
@@ -117,7 +117,7 @@ int Properties::registerProperty(PropertyFunctor *prop) {
   }
   // XXX Add mutex?
   Properties::registry.emplace_back(prop);
-  return Properties::registry.size();
+  return Properties::registry.size() - 1;
 }
 
 std::vector<std::string> Properties::getAvailableProperties() {

--- a/Code/GraphMol/Descriptors/Property.cpp
+++ b/Code/GraphMol/Descriptors/Property.cpp
@@ -108,16 +108,20 @@ void registerDescriptors() {
 }
 
 std::vector<boost::shared_ptr<PropertyFunctor>> Properties::registry;
-int Properties::registerProperty(PropertyFunctor *prop) {
+int Properties::registerProperty(boost::shared_ptr<PropertyFunctor> prop) {
   for (size_t i = 0; i < Properties::registry.size(); ++i) {
     if (registry[i]->getName() == prop->getName()) {
-      Properties::registry[i] = boost::shared_ptr<PropertyFunctor>(prop);
+      Properties::registry[i] = std::move(prop);
       return i;
     }
   }
   // XXX Add mutex?
-  Properties::registry.emplace_back(prop);
+  Properties::registry.push_back(std::move(prop));
   return Properties::registry.size() - 1;
+}
+
+int Properties::registerProperty(PropertyFunctor *prop) {
+  return Properties::registerProperty(boost::shared_ptr<PropertyFunctor>(prop));
 }
 
 std::vector<std::string> Properties::getAvailableProperties() {

--- a/Code/GraphMol/Descriptors/Property.h
+++ b/Code/GraphMol/Descriptors/Property.h
@@ -59,7 +59,9 @@ struct RDKIT_DESCRIPTORS_EXPORT PropertyFunctor {
   virtual ~PropertyFunctor() {}
 
   //! Compute the value of the property
-  virtual double operator()(const RDKit::ROMol &) const = 0;
+  virtual double operator()(const RDKit::ROMol &mol) const {
+    return (*d_dataFunc)(mol);
+  }
 
   //! Return the name of the property
   const std::string getName() const { return propName; }

--- a/Code/GraphMol/Descriptors/Property.h
+++ b/Code/GraphMol/Descriptors/Property.h
@@ -84,8 +84,8 @@ class RDKIT_DESCRIPTORS_EXPORT Properties {
   void annotateProperties(RDKit::ROMol &mol) const;
 
   //! Register a property function - takes ownership
-  static int registerProperty(boost::shared_ptr<PropertyFunctor> prop);
   static int registerProperty(PropertyFunctor *ptr);
+  static int registerProperty(boost::shared_ptr<PropertyFunctor> prop);
   static boost::shared_ptr<PropertyFunctor> getProperty(
       const std::string &name);
   static std::vector<std::string> getAvailableProperties();

--- a/Code/GraphMol/Descriptors/Property.h
+++ b/Code/GraphMol/Descriptors/Property.h
@@ -84,6 +84,7 @@ class RDKIT_DESCRIPTORS_EXPORT Properties {
   void annotateProperties(RDKit::ROMol &mol) const;
 
   //! Register a property function - takes ownership
+  static int registerProperty(boost::shared_ptr<PropertyFunctor> prop);
   static int registerProperty(PropertyFunctor *ptr);
   static boost::shared_ptr<PropertyFunctor> getProperty(
       const std::string &name);

--- a/Code/GraphMol/Descriptors/RegisterDescriptor.h
+++ b/Code/GraphMol/Descriptors/RegisterDescriptor.h
@@ -29,14 +29,9 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
-
-#include <RDGeneral/export.h>
 #ifndef RDKIT_REGISTER_DESCRIPTOR_H
 #define RDKIT_REGISTER_DESCRIPTOR_H
 
-#include <RDGeneral/BoostStartInclude.h>
-#include <boost/shared_ptr.hpp>
-#include <RDGeneral/BoostEndInclude.h>
 #include "Property.h"
 
 namespace RDKit {
@@ -65,19 +60,11 @@ NAME##PropertyFunctor(false)); \
 static NAME##PropertyFunctor NAME##PropertyFunctor__;
 */
 
-#define REGISTER_DESCRIPTOR(NAME, FUNC)                                     \
-  struct NAME##PropertyFunctor : public PropertyFunctor {                   \
-    static double _func(const ROMol &m) {                                   \
-      return static_cast<double>(FUNC(m));                                  \
-    }                                                                       \
-    NAME##PropertyFunctor(bool registerProp = true)                         \
-        : PropertyFunctor(#NAME, NAME##Version, _func) {                    \
-      if (registerProp)                                                     \
-        Properties::registerProperty(new NAME##PropertyFunctor(false));     \
-    }                                                                       \
-    double operator()(const RDKit::ROMol &mol) const { return _func(mol); } \
-  };                                                                        \
-  static NAME##PropertyFunctor NAME##PropertyFunctor__;
+#define REGISTER_DESCRIPTOR(NAME, FUNC)             \
+  Properties::registerProperty(new PropertyFunctor( \
+      #NAME, NAME##Version,                         \
+      [](const ROMol &m) { return static_cast<double>(FUNC(m)); }));
+
 }  // namespace Descriptors
 }  // namespace RDKit
 

--- a/Code/GraphMol/Descriptors/Wrap/testMolDescriptors.py
+++ b/Code/GraphMol/Descriptors/Wrap/testMolDescriptors.py
@@ -526,21 +526,21 @@ class TestCase(unittest.TestCase):
     class NumAtoms(Descriptors.PropertyFunctor):
 
       def __init__(self):
-        Descriptors.PropertyFunctor.__init__(self, "NumAtoms", "1.0.0")
+        Descriptors.PropertyFunctor.__init__(self, "CustomNumAtoms", "1.0.0")
 
       def __call__(self, mol):
         return mol.GetNumAtoms()
 
     numAtoms = NumAtoms()
     rdMD.Properties.RegisterProperty(numAtoms)
-    props = rdMD.Properties(["NumAtoms"])
+    props = rdMD.Properties(["CustomNumAtoms"])
     self.assertEqual(1, props.ComputeProperties(Chem.MolFromSmiles("C"))[0])
 
-    self.assertTrue("NumAtoms" in rdMD.Properties.GetAvailableProperties())
+    self.assertTrue("CustomNumAtoms" in rdMD.Properties.GetAvailableProperties())
     # check memory
     del numAtoms
     self.assertEqual(1, props.ComputeProperties(Chem.MolFromSmiles("C"))[0])
-    self.assertTrue("NumAtoms" in rdMD.Properties.GetAvailableProperties())
+    self.assertTrue("CustomNumAtoms" in rdMD.Properties.GetAvailableProperties())
 
     m = Chem.MolFromSmiles("c1ccccc1")
     properties = rdMD.Properties()
@@ -709,7 +709,7 @@ class TestCase(unittest.TestCase):
       bcut2 = rdMD.BCUT2D(m, "bad_prop")
       self.assertTrue(0, "Failed to handle bad prop (not a double)")
     except RuntimeError as e:
-      self.assertTrue(re.search(r"[B,b]ad any[\ ,_]cast",str(e)))
+      self.assertTrue(re.search(r"[B,b]ad any[\ ,_]cast", str(e)))
 
   def testOxidationNumbers(self):
     # majority of tests are in the C++ layer.  These are just to make
@@ -741,7 +741,8 @@ class TestCase(unittest.TestCase):
     self.assertTrue(abs(default.GetPackingDensity() - 0.48303) < 0.05)
 
     # test set depth and radius
-    depthrad = rdMD.DoubleCubicLatticeVolume(mol1, isProtein=True, includeLigand=False, probeRadius=1.6, depth=6)
+    depthrad = rdMD.DoubleCubicLatticeVolume(mol1, isProtein=True, includeLigand=False,
+                                             probeRadius=1.6, depth=6)
 
     self.assertTrue(abs(depthrad.GetSurfaceArea() - 8186.06) < 0.05)
     self.assertTrue(abs(depthrad.GetVolume() - 33464.5) < 0.05)
@@ -757,11 +758,11 @@ class TestCase(unittest.TestCase):
     self.assertTrue(abs(withlig.GetVDWVolume() - 15155.7) < 0.05)
     self.assertTrue(abs(withlig.GetCompactness() - 1.67037) < 0.05)
     self.assertTrue(abs(withlig.GetPackingDensity() - 0.48532) < 0.05)
-    
+
     fname2 = str(Path(rdbase) / 'Code' / 'GraphMol' / 'Descriptors' / 'test_data' / 'TZL_model.sdf')
     suppl = Chem.SDMolSupplier(fname2)
     for mol in suppl:
-        mol2 = mol
+      mol2 = mol
 
     # test from SDF file with defaults
     sdf = rdMD.DoubleCubicLatticeVolume(mol2, isProtein=False)
@@ -769,6 +770,7 @@ class TestCase(unittest.TestCase):
     self.assertTrue(abs(sdf.GetSurfaceArea() - 296.466) < 0.05)
     self.assertTrue(abs(sdf.GetVolume() - 411.972) < 0.05)
     self.assertTrue(abs(sdf.GetVDWVolume() - 139.97) < 0.05)
+
 
 if __name__ == '__main__':
   unittest.main()

--- a/Code/GraphMol/FilterCatalog/Wrap/FilterCatalog.cpp
+++ b/Code/GraphMol/FilterCatalog/Wrap/FilterCatalog.cpp
@@ -405,7 +405,8 @@ struct filtercat_wrapper {
              python::args("self", "base"),
              "Add a FilterMatcherBase that should not appear in a molecule");
 
-    python::class_<FilterHierarchyMatcher, FilterHierarchyMatcher *,
+    python::class_<FilterHierarchyMatcher,
+                   boost::shared_ptr<FilterHierarchyMatcher>,
                    python::bases<FilterMatcherBase>>(
         "FilterHierarchyMatcher", FilterHierarchyMatcherDoc,
         python::init<>(python::args("self")))
@@ -425,7 +426,7 @@ struct filtercat_wrapper {
     bool noproxy = true;
     RegisterVectorConverter<RDKit::ROMol *>("MolList", noproxy);
 
-    python::class_<FilterCatalogEntry, FilterCatalogEntry *,
+    python::class_<FilterCatalogEntry, boost::shared_ptr<FilterCatalogEntry>,
                    boost::shared_ptr<const FilterCatalogEntry>>(
         "FilterCatalogEntry", FilterCatalogEntryDoc,
         python::init<>(python::args("self")))
@@ -492,7 +493,8 @@ struct filtercat_wrapper {
 
     {
       python::scope in_FilterCatalogParams =
-          python::class_<FilterCatalogParams, FilterCatalogParams *>(
+          python::class_<FilterCatalogParams,
+                         boost::shared_ptr<FilterCatalogParams>>(
               "FilterCatalogParams", python::init<>(python::args("self")))
               .def(python::init<FilterCatalogParams::FilterCatalogs>(
                   python::args("self", "catalogs"),

--- a/Code/Numerics/Optimizer/BFGSOpt.h
+++ b/Code/Numerics/Optimizer/BFGSOpt.h
@@ -155,15 +155,6 @@ void linearSearch(unsigned int dim, double *oldPt, double oldVal, double *grad,
   }
 }
 
-#define CLEANUP()        \
-  {                      \
-    delete[] grad;       \
-    delete[] dGrad;      \
-    delete[] hessDGrad;  \
-    delete[] newPos;     \
-    delete[] xi;         \
-    delete[] invHessian; \
-  }
 //! Do a BFGS minimization of a function.
 /*!
    See Numerical Recipes in C, Section 10.7 for a description of the algorithm.
@@ -199,26 +190,19 @@ int minimize(unsigned int dim, double *pos, double gradTol,
   PRECONDITION(pos, "bad input array");
   PRECONDITION(gradTol > 0, "bad tolerance");
 
-  double sum, maxStep, fp;
-
-  double *grad, *dGrad, *hessDGrad;
-  double *newPos, *xi;
-  double *invHessian;
-
-  grad = new double[dim];
-  dGrad = new double[dim];
-  hessDGrad = new double[dim];
-  newPos = new double[dim];
-  xi = new double[dim];
-  invHessian = new double[dim * dim];
+  std::vector<double> grad(dim);
+  std::vector<double> dGrad(dim);
+  std::vector<double> hessDGrad(dim);
+  std::vector<double> xi(dim);
+  std::vector<double> invHessian(dim * dim, 0);
+  std::unique_ptr<double[]> newPos(new double[dim]);
   snapshotFreq = std::min(snapshotFreq, maxIts);
 
   // evaluate the function and gradient in our current position:
-  fp = func(pos);
-  gradFunc(pos, grad);
+  double fp = func(pos);
+  gradFunc(pos, grad.data());
 
-  sum = 0.0;
-  memset(invHessian, 0, dim * dim * sizeof(double));
+  double sum = 0.0;
   for (unsigned int i = 0; i < dim; i++) {
     unsigned int itab = i * dim;
     // initialize the inverse hessian to be identity:
@@ -228,15 +212,15 @@ int minimize(unsigned int dim, double *pos, double gradTol,
     sum += pos[i] * pos[i];
   }
   // pick a max step size:
-  maxStep = MAXSTEP * std::max(sqrt(sum), static_cast<double>(dim));
+  double maxStep = MAXSTEP * std::max(sqrt(sum), static_cast<double>(dim));
 
-  for (unsigned int iter = 1; iter <= maxIts; iter++) {
+  for (unsigned int iter = 1; iter <= maxIts; ++iter) {
     numIters = iter;
-    int status;
+    int status = -1;
 
     // do the line search:
-    linearSearch(dim, pos, fp, grad, xi, newPos, funcVal, func, maxStep,
-                 status);
+    linearSearch(dim, pos, fp, grad.data(), xi.data(), newPos.get(), funcVal, func,
+                 maxStep, status);
     CHECK_INVARIANT(status >= 0, "bad direction in linearSearch");
 
     // save the function value for the next search:
@@ -257,16 +241,14 @@ int minimize(unsigned int dim, double *pos, double gradTol,
     // "<<TOLX<<std::endl;
     if (test < TOLX) {
       if (snapshotVect && snapshotFreq) {
-        RDKit::Snapshot s(boost::shared_array<double>(newPos), fp);
+        RDKit::Snapshot s(boost::shared_array<double>(newPos.release()), fp);
         snapshotVect->push_back(s);
-        newPos = nullptr;
-      }
-      CLEANUP();
+              }
       return 0;
     }
 
     // update the gradient:
-    double gradScale = gradFunc(pos, grad);
+    double gradScale = gradFunc(pos, grad.data());
 
     // is the gradient converged?
     test = 0.0;
@@ -281,11 +263,9 @@ int minimize(unsigned int dim, double *pos, double gradTol,
     // "<<gradTol<<std::endl;
     if (test < gradTol) {
       if (snapshotVect && snapshotFreq) {
-        RDKit::Snapshot s(boost::shared_array<double>(newPos), fp);
+        RDKit::Snapshot s(boost::shared_array<double>(newPos.release()), fp);
         snapshotVect->push_back(s);
-        newPos = nullptr;
       }
-      CLEANUP();
       return 0;
     }
 
@@ -306,7 +286,7 @@ int minimize(unsigned int dim, double *pos, double gradTol,
 #else
       double *ivh = &(invHessian[i * dim]);
       double &hdgradi = hessDGrad[i];
-      double *dgj = dGrad;
+      double *dgj = dGrad.data();
       hdgradi = 0.0;
       for (unsigned int j = 0; j < dim; ++j, ++ivh, ++dgj) {
         hdgradi += *ivh * *dgj;
@@ -353,19 +333,20 @@ int minimize(unsigned int dim, double *pos, double gradTol,
         xi[i] -= invHessian[itab + j] * grad[j];
       }
 #else
-      double &pxi = xi[i], *ivh = &(invHessian[itab]), *gj = grad;
+      double &pxi = xi[i];
+      double *ivh = &(invHessian[itab]);
+      double *gj = grad.data();
       for (unsigned int j = 0; j < dim; ++j, ++ivh, ++gj) {
         pxi -= *ivh * *gj;
       }
 #endif
     }
     if (snapshotVect && snapshotFreq && !(iter % snapshotFreq)) {
-      RDKit::Snapshot s(boost::shared_array<double>(newPos), fp);
+      RDKit::Snapshot s(boost::shared_array<double>(newPos.release()), fp);
       snapshotVect->push_back(s);
-      newPos = new double[dim];
+      newPos.reset(new double[dim]);
     }
   }
-  CLEANUP();
   return 1;
 }
 

--- a/Code/SimDivPickers/MaxMinPicker.h
+++ b/Code/SimDivPickers/MaxMinPicker.h
@@ -156,8 +156,8 @@ RDKit::INT_VECT MaxMinPicker::lazyPick(T &func, unsigned int poolSize,
   RDKit::INT_VECT picks;
 
   unsigned int memsize = (unsigned int)(poolSize * sizeof(MaxMinPickInfo));
-  MaxMinPickInfo *pinfo = new MaxMinPickInfo[memsize];
-  memset(pinfo, 0, memsize);
+  std::unique_ptr<MaxMinPickInfo[]> pinfo(new MaxMinPickInfo[memsize]);
+  memset(pinfo.get(), 0, memsize);
 
   picks.reserve(pickSize);
   unsigned int picked = 0;  // picks.size()
@@ -189,7 +189,6 @@ RDKit::INT_VECT MaxMinPicker::lazyPick(T &func, unsigned int poolSize,
          pIdx != firstPicks.end(); ++pIdx) {
       pick = static_cast<unsigned int>(*pIdx);
       if (pick >= poolSize) {
-        delete[] pinfo;
         throw ValueErrorException("pick index was larger than the poolSize");
       }
       picks.push_back(pick);
@@ -200,7 +199,6 @@ RDKit::INT_VECT MaxMinPicker::lazyPick(T &func, unsigned int poolSize,
 
   if (picked >= pickSize) {
     threshold = -1.0;
-    delete[] pinfo;
     return picks;
   }
 
@@ -271,11 +269,10 @@ RDKit::INT_VECT MaxMinPicker::lazyPick(T &func, unsigned int poolSize,
     // now add the new pick to picks and remove it from the pool
     *pick_prev = pinfo[pick].next;
     picks.push_back(pick);
-    picked++;
+    ++picked;
   }
 
   threshold = tmpThreshold;
-  delete[] pinfo;
   return picks;
 }
 

--- a/Code/SimDivPickers/Wrap/MaxMinPicker.cpp
+++ b/Code/SimDivPickers/Wrap/MaxMinPicker.cpp
@@ -51,8 +51,13 @@ RDKit::INT_VECT MaxMinPicks(MaxMinPicker *picker, python::object distMat,
        i < python::extract<unsigned int>(firstPicks.attr("__len__")()); ++i) {
     firstPickVect.push_back(python::extract<int>(firstPicks[i]));
   }
-  RDKit::INT_VECT res =
-      picker->pick(dMat, poolSize, pickSize, firstPickVect, seed);
+  RDKit::INT_VECT res;
+  try {
+    res = picker->pick(dMat, poolSize, pickSize, firstPickVect, seed);
+  } catch (...) {
+    Py_DECREF(copy);
+    throw;
+  }
   Py_DECREF(copy);
   return res;
 }


### PR DESCRIPTION
The final round of leak fixes (and some more). These took longer than the rest because I made the mistake of looking into the Mol Descriptor issues first, which, unfortunately, were not just leaks, but also a couple other issues on top.

In any case, here we have:
- Fixes to leaking objects in  `Wrap/Enumerate.cpp`, `Wrap/FilterCatalog.cpp` and `Wrap/rdMolDescriptors.cpp`: we need to declare those wrappers as `shared_ptr`s, and not plain pointers, or else Python won't take care of cleaning up the new objects it creates.

- in `testMolDescriptors.py`, registering the Python declared `NumAtoms` `PropertyFunctor` was overwriting the C++ functor with the same name that is initialized [here](https://github.com/rdkit/rdkit/blob/cf29f0895fbe7397c38a2e6c0b52f70ab9dd5108/Code/GraphMol/Descriptors/Property.cpp#L58). I'm not quite sure why this doesn't break the test as it is now (the C++ `NumAtoms` is called with `onlyExplicit = false`, while the Python one defaults to `true`), but the test fails if none of the other tests in the file is executed first. I don't think that overwriting the C++ functor is intentional, so I just changed the internal name of the Python one to avoid it. 
 
- in `registerProperty()`, when overriding an existing functor, we return the index of the functor in the registry, but when adding the new one we return the number of registered functors, which is off-by-one from the index of one we just added. I fixed this to always return the index. I don't think this is relevant, but it's probably good to be consistent :)

- in `RegisterDescriptor.h` I noticed that we created a bunch of subclasses of `PropertyFunctor` and create a static instance of each of them, which isn't used for anything except adding the functor to the registry. I took the liberty of refactoring this code, dropping the subclasses and the static instances. The change in `PropertyFunctor::operator()` in `Property.h` is also related to this.

- finally, there was a life time issue with  `PythonPropertyFunctor`: the `decref()` call in the destructor would only be hit when the object (coming from Python) would be in the process of being cleaned up, meaning that either its ref count is already at 0, or that Python is shutting down, and no longer cares about ref counts. Even worse: since `registerProperty()` takes ownership of the pointers it receives (stated in `Property.h`, and due to `registry` being declared as `vector<shared_ptr<PropertyFunctor>>`), the destructor will be called when `registry` itself is being destroyed, which, again, will happen when Python is shutting down. This gives us nice errors like this one:
    ```
    133: Fatal Python error: PyThreadState_Get: the function must be called with the GIL held, but the GIL is released (the current Python thread state is NULL)
    133: Python runtime state: finalizing (tstate=0x0000612000000050)
    133: 
     ```
    To avoid such issues, I added `registerPropertyHelper()`. As the comment says, it ~creates a copy of the functor, so that the `registry` can take ownership and manage it, and it also~ increases the ref count of the original functor so that Python doesn't clean it up when it goes out of scope (we still need the Python-declared `__call__` function) . ~This way, Python can clean up the original functor when it is shutting down, and the `registry`'s destruction will take care of the copy, and none will interfere with the other one~. Then, it registers the shared pointer to the functor so that Python and the static vector share ownership.
    
    Note that removing the `incref()` from the `PythonPropertyFunctor` constructor doesn't have any adverse effects: Python will manage the lifetime of such objects. We don't really care about them being cleaned up when going out of scope unless they get registered, and then `registerPropertyHelper()` takes care of incrementing the ref count so they don't go away.

And with this, and once https://github.com/rdkit/rdkit/pull/7872 is finished and merged, the code covered by tests will practically be leak free.

(... to be continued ... but hopefully not anytime soon).