### PR TITLE
Update RDKit_Book.rst

### DIFF
--- a/Docs/Book/RDKit_Book.rst
+++ b/Docs/Book/RDKit_Book.rst
@@ -970,8 +970,8 @@ This also works with multiple implicit Hs: ``C[Pt@SP1H2]Cl`` and ``C[Pt@SP1]([H]
 Missing ligands
 ^^^^^^^^^^^^^^^
 
-Coordination environments with missing ligands are treated as if the missing ligands were at the end of the ligand ordering.
-For example, this invented complex can be presented with the SMILES ``O[Mn@OH1](Cl)(C)(N)F``.
+Internally coordination environments with missing ligands are treated as if the missing ligands were at the end of the ligand ordering.
+However in SMILES they are treated the same as implicit hydrogens. For example, this invented square pyramidal complex can be presented with the SMILES ``O[Mn@OH28](Cl)(C)(N)F`` which is interpreted as: ``O[Mn@OH28](*)(Cl)(C)(N)F``.
 
 .. |nts_missing1| image:: images/nontetstereo_missing1.png
    :align: middle


### PR DESCRIPTION
Update the section on missing ligands following #6777. 

<!--
Thanks for contributing a pull request! 
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.

Documentation

#### Any other comments?

It should also be noted the existing diagram was not correct and actually depicted ``O[Mn@OH10](Cl)(C)(N)(F)`` and *not* ``O[Mn@OH1](Cl)(C)(N)(F)``, if it were ``@OH1`` then when they were at the end ``O[Mn@OH1](Cl)(C)(N)(F)*`` the Cl < C < N < F would go CCW looking from the oxygen.

![image](https://github.com/user-attachments/assets/f7c5c953-4212-413a-a17a-cd3c07827454)

Might be worth double checking the depiction code.