### PR TITLE
Fix misnamed test

### DIFF
--- a/Code/GraphMol/RascalMCES/Wrap/CMakeLists.txt
+++ b/Code/GraphMol/RascalMCES/Wrap/CMakeLists.txt
@@ -5,4 +5,4 @@ rdkit_python_extension(rdRascalMCES
         DEST Chem
         LINK_LIBRARIES RascalMCES)
 
-add_pytest(pyMolDraw2D ${CMAKE_CURRENT_SOURCE_DIR}/testRascalMCES.py)
+add_pytest(pyRascalMCES ${CMAKE_CURRENT_SOURCE_DIR}/testRascalMCES.py)


### PR DESCRIPTION
While working on https://github.com/rdkit/rdkit/pull/7943 I noticed that `pyMolDraw2D` was mentioned twice in the `ctest` tests list. I thought the test had been become duplicated somehow, but it's just that the Python Rascal MCE test is misnamed.
