### PR TITLE
Add molecules names into ScaffoldNetwork

### DIFF
--- a/Code/GraphMol/ScaffoldNetwork/ScaffoldNetwork.cpp
+++ b/Code/GraphMol/ScaffoldNetwork/ScaffoldNetwork.cpp
@@ -201,6 +201,9 @@ size_t addEntryIfMissing(T &vect, const V &e,
 void addMolToNetwork(const ROMol &mol, ScaffoldNetwork &network,
                      const ScaffoldNetworkParams &params) {
   auto ismi = MolToSmiles(mol);
+  if (params.includeNames & mol.hasProp("_Name")) {
+    ismi += ' ' + mol.getProp<std::string>("_Name");
+  }
   boost::shared_ptr<ROMol> fmol(flattenMol(mol, params));
   if (params.pruneBeforeFragmenting) {
     boost::shared_ptr<ROMol> pmol(pruneMol(*fmol, params));

--- a/Code/GraphMol/ScaffoldNetwork/ScaffoldNetwork.h
+++ b/Code/GraphMol/ScaffoldNetwork/ScaffoldNetwork.h
@@ -44,6 +44,8 @@ struct RDKIT_SCAFFOLDNETWORK_EXPORT ScaffoldNetworkParams {
       true;  ///< remove attachment points from scaffolds and include the result
   bool includeScaffoldsWithAttachments =
       true;  ///< Include the version of the scaffold with attachment points
+  bool includeNames =
+      false;  ///< Include molecules names of the input molecules
   bool keepOnlyFirstFragment =
       true;  ///<  keep only the first fragment from the bond breaking rule
   bool pruneBeforeFragmenting =

--- a/Code/GraphMol/ScaffoldNetwork/Wrap/rdScaffoldNetwork.cpp
+++ b/Code/GraphMol/ScaffoldNetwork/Wrap/rdScaffoldNetwork.cpp
@@ -103,6 +103,11 @@ BOOST_PYTHON_MODULE(rdScaffoldNetwork) {
               includeScaffoldsWithAttachments,
           "Include the version of the scaffold with attachment points")
       .def_readwrite(
+          "includeNames",
+          &ScaffoldNetwork::ScaffoldNetworkParams::
+              includeNames,
+          "Include molecules names of the input molecules")
+      .def_readwrite(
           "keepOnlyFirstFragment",
           &ScaffoldNetwork::ScaffoldNetworkParams::keepOnlyFirstFragment,
           "keep only the first fragment from the bond breaking rule")

--- a/Code/GraphMol/ScaffoldNetwork/catch_tests.cpp
+++ b/Code/GraphMol/ScaffoldNetwork/catch_tests.cpp
@@ -270,6 +270,19 @@ TEST_CASE("addMolToNetwork", "[unittest][scaffolds]") {
     CHECK(std::find(net.nodes.begin(), net.nodes.end(),
                     "*1**1**1:*:*:*:*:*:1") != net.nodes.end());
   }
+  SECTION("includes names") {
+    auto m = "CC(=O)Oc1ccccc1C(=O)O aspirin"_smiles;
+    REQUIRE(m);
+    ScaffoldNetwork::ScaffoldNetworkParams ps;
+    ScaffoldNetwork::ScaffoldNetwork net;
+    ScaffoldNetwork::detail::addMolToNetwork(*m, net, ps);
+    CHECK(net.nodes.at(0) == "CC(=O)Oc1ccccc1C(=O)O");
+
+    ps.includeNames = true;
+    ScaffoldNetwork::ScaffoldNetwork otherNet;
+    ScaffoldNetwork::detail::addMolToNetwork(*m, otherNet, ps);
+    CHECK(otherNet.nodes.at(0) == "CC(=O)Oc1ccccc1C(=O)O aspirin");
+  }
 }
 TEST_CASE("Network defaults", "[scaffolds]") {
   auto smis = {"c1ccccc1CC1NC(=O)CCC1", "c1cccnc1CC1NC(=O)CCC1"};


### PR DESCRIPTION
#### Reference Issue

#### What does this implement/fix? Explain your changes.

- added parameter to ScaffoldNetwork Params to include molecule names in the ScaffoldNetwork nodes corresponding to input molecules
- mapping back nodes of a ScaffoldNetwork is more deterministic over molecule names
- mapping back over SMILES at the very least requires canonicalization of the input molecules
- molecule names are a valid part of a SMILES string

#### Any other comments?

Default is backwards compatible in case we expect adding molecules to break other SMILES parsers, for example, that of visualization software using the scaffold network.