### PR TITLE
Move CI builds to macos-14

### DIFF
--- a/.azure-pipelines/mac_build.yml
+++ b/.azure-pipelines/mac_build.yml
@@ -1,6 +1,6 @@
 steps:
 - bash: | 
-    export CONDA=$(pwd)/miniforge
+    export CONDA=/tmp/miniforge
     wget https://github.com/conda-forge/miniforge/releases/download/24.9.0-0/Miniforge3-24.9.0-0-MacOSX-x86_64.sh
     bash Miniforge3-24.9.0-0-MacOSX-x86_64.sh -b -p ${CONDA}
   displayName: install conda
@@ -12,7 +12,7 @@ steps:
     rm ~/uninstall_homebrew
   displayName: Remove homebrew
 - bash: |
-    export CONDA=$(pwd)/miniforge
+    export CONDA=/tmp/miniforge
     source ${CONDA}/etc/profile.d/conda.sh
     sudo chown -R ${USER} ${CONDA}
     mkdir -p $HOME/.matplotlib
@@ -30,7 +30,7 @@ steps:
         jupyter=1.0 ipython=8.20 sphinx myst-parser pytest nbval
   displayName: Setup build environment
 - bash: |
-    export CONDA=$(pwd)/miniforge
+    export CONDA=/tmp/miniforge
     source ${CONDA}/etc/profile.d/conda.sh
     conda activate rdkit_build
     export SDKROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX$(target_platform).sdk
@@ -63,7 +63,7 @@ steps:
     -DCMAKE_OSX_DEPLOYMENT_TARGET=$(target_platform)
   displayName: Configure build (Run CMake)
 - bash: |
-    export CONDA=$(pwd)/miniforge
+    export CONDA=/tmp/miniforge
     source ${CONDA}/etc/profile.d/conda.sh
     conda activate rdkit_build
     export SDKROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX$(target_platform).sdk
@@ -72,7 +72,7 @@ steps:
     make -j $( $(number_of_cores) ) install
   displayName: Build
 - bash: |
-    export CONDA=$(pwd)/miniforge
+    export CONDA=/tmp/miniforge
     source ${CONDA}/etc/profile.d/conda.sh
     conda activate rdkit_build
     export RDBASE=`pwd`

--- a/.azure-pipelines/mac_build.yml
+++ b/.azure-pipelines/mac_build.yml
@@ -1,8 +1,4 @@
 steps:
-- bash: |
-    wget https://github.com/phracker/MacOSX-SDKs/releases/download/10.15/MacOSX$(target_platform).sdk.tar.xz
-    tar Jxvf MacOSX$(target_platform).sdk.tar.xz
-  displayName: Install MacOSX $(target_platform) SDK
 - script: |
     echo "Removing homebrew from Azure to avoid conflicts."
     curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/uninstall > ~/uninstall_homebrew
@@ -30,7 +26,7 @@ steps:
 - bash: |
     source ${CONDA}/etc/profile.d/conda.sh
     conda activate rdkit_build
-    export SDKROOT="$(pwd)/MacOSX$(target_platform).sdk/"
+    export SDKROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX$(target_platform).sdk
     export CONDA_BUILD_SYSROOT=${SDKROOT}
     export CXXFLAGS="${CXXFLAGS} -Wall -Wextra -Werror"
     mkdir build && cd build && \
@@ -62,7 +58,7 @@ steps:
 - bash: |
     source ${CONDA}/etc/profile.d/conda.sh
     conda activate rdkit_build
-    export SDKROOT="$(pwd)/MacOSX$(target_platform).sdk/"
+    export SDKROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX$(target_platform).sdk
     export CONDA_BUILD_SYSROOT=${SDKROOT}
     cd build
     make -j $( $(number_of_cores) ) install
@@ -73,7 +69,7 @@ steps:
     export RDBASE=`pwd`
     export PYTHONPATH=${RDBASE}:${PYTHONPATH}
     export DYLD_FALLBACK_LIBRARY_PATH=${RDBASE}/lib:${RDBASE}/rdkit:${CONDA_PREFIX}/lib:${DYLD_FALLBACK_LIBRARY_PATH}
-    export SDKROOT="$(pwd)/MacOSX$(target_platform).sdk/"
+    export SDKROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX$(target_platform).sdk
     export CONDA_BUILD_SYSROOT=${SDKROOT}
     export QT_QPA_PLATFORM='offscreen'
     cd build

--- a/.azure-pipelines/mac_build.yml
+++ b/.azure-pipelines/mac_build.yml
@@ -1,5 +1,5 @@
 steps:
-- bash | 
+- bash: | 
     export CONDA=$(pwd)/miniforge
     wget https://github.com/conda-forge/miniforge/releases/download/24.9.0-0/Miniforge3-24.9.0-0-MacOSX-x86_64.sh
     bash Miniforge3-24.9.0-0-Linux-x86_64.sh -b -p ${CONDA}

--- a/.azure-pipelines/mac_build.yml
+++ b/.azure-pipelines/mac_build.yml
@@ -1,4 +1,9 @@
 steps:
+- bash | 
+    export CONDA=$(pwd)/miniforge
+    wget https://github.com/conda-forge/miniforge/releases/download/24.9.0-0/Miniforge3-24.9.0-0-MacOSX-x86_64.sh
+    bash Miniforge3-24.9.0-0-Linux-x86_64.sh -b -p ${CONDA}
+  displayName: install conda
 - script: |
     echo "Removing homebrew from Azure to avoid conflicts."
     curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/uninstall > ~/uninstall_homebrew
@@ -7,6 +12,7 @@ steps:
     rm ~/uninstall_homebrew
   displayName: Remove homebrew
 - bash: |
+    export CONDA=$(pwd)/miniforge
     source ${CONDA}/etc/profile.d/conda.sh
     sudo chown -R ${USER} ${CONDA}
     mkdir -p $HOME/.matplotlib
@@ -24,6 +30,7 @@ steps:
         jupyter=1.0 ipython=8.20 sphinx myst-parser pytest nbval
   displayName: Setup build environment
 - bash: |
+    export CONDA=$(pwd)/miniforge
     source ${CONDA}/etc/profile.d/conda.sh
     conda activate rdkit_build
     export SDKROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX$(target_platform).sdk
@@ -56,6 +63,7 @@ steps:
     -DCMAKE_OSX_DEPLOYMENT_TARGET=$(target_platform)
   displayName: Configure build (Run CMake)
 - bash: |
+    export CONDA=$(pwd)/miniforge
     source ${CONDA}/etc/profile.d/conda.sh
     conda activate rdkit_build
     export SDKROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX$(target_platform).sdk
@@ -64,6 +72,7 @@ steps:
     make -j $( $(number_of_cores) ) install
   displayName: Build
 - bash: |
+    export CONDA=$(pwd)/miniforge
     source ${CONDA}/etc/profile.d/conda.sh
     conda activate rdkit_build
     export RDBASE=`pwd`

--- a/.azure-pipelines/mac_build.yml
+++ b/.azure-pipelines/mac_build.yml
@@ -2,7 +2,7 @@ steps:
 - bash: | 
     export CONDA=$(pwd)/miniforge
     wget https://github.com/conda-forge/miniforge/releases/download/24.9.0-0/Miniforge3-24.9.0-0-MacOSX-x86_64.sh
-    bash Miniforge3-24.9.0-0-Linux-x86_64.sh -b -p ${CONDA}
+    bash Miniforge3-24.9.0-0-MacOSX-x86_64.sh -b -p ${CONDA}
   displayName: install conda
 - script: |
     echo "Removing homebrew from Azure to avoid conflicts."

--- a/.azure-pipelines/mac_build_java.yml
+++ b/.azure-pipelines/mac_build_java.yml
@@ -1,8 +1,8 @@
 steps:
-- bash: |
-    wget https://github.com/phracker/MacOSX-SDKs/releases/download/10.15/MacOSX$(target_platform).sdk.tar.xz
-    tar Jxvf MacOSX$(target_platform).sdk.tar.xz
-  displayName: Install MacOSX $(target_platform) SDK
+# - bash: |
+#     wget https://github.com/phracker/MacOSX-SDKs/releases/download/10.15/MacOSX$(target_platform).sdk.tar.xz
+#     tar Jxvf MacOSX$(target_platform).sdk.tar.xz
+#   displayName: Install MacOSX $(target_platform) SDK
 - script: |
     echo "Removing homebrew from Azure to avoid conflicts."
     curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/uninstall > ~/uninstall_homebrew
@@ -27,7 +27,7 @@ steps:
 - bash: |
     source ${CONDA}/etc/profile.d/conda.sh
     conda activate rdkit_build
-    export SDKROOT="$(pwd)/MacOSX$(target_platform).sdk/"
+    export SDKROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX$(target_platform).sdk
     export CONDA_BUILD_SYSROOT=${SDKROOT}
     mkdir build && cd build && \
     cmake .. \
@@ -53,7 +53,7 @@ steps:
 - bash: |
     source ${CONDA}/etc/profile.d/conda.sh
     conda activate rdkit_build
-    export SDKROOT="$(pwd)/MacOSX$(target_platform).sdk/"
+    export SDKROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX$(target_platform).sdk
     export CONDA_BUILD_SYSROOT=${SDKROOT}
     cd build
     make -j $( $(number_of_cores) ) install
@@ -64,7 +64,7 @@ steps:
     export RDBASE=`pwd`
     export PYTHONPATH=${RDBASE}:${PYTHONPATH}
     export DYLD_FALLBACK_LIBRARY_PATH=${RDBASE}/lib:${RDBASE}/rdkit:${CONDA_PREFIX}/lib:${DYLD_FALLBACK_LIBRARY_PATH}
-    export SDKROOT="$(pwd)/MacOSX$(target_platform).sdk/"
+    export SDKROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX$(target_platform).sdk
     export CONDA_BUILD_SYSROOT=${SDKROOT}
     export QT_QPA_PLATFORM='offscreen'
     cd build

--- a/.azure-pipelines/mac_build_java.yml
+++ b/.azure-pipelines/mac_build_java.yml
@@ -1,8 +1,9 @@
 steps:
-# - bash: |
-#     wget https://github.com/phracker/MacOSX-SDKs/releases/download/10.15/MacOSX$(target_platform).sdk.tar.xz
-#     tar Jxvf MacOSX$(target_platform).sdk.tar.xz
-#   displayName: Install MacOSX $(target_platform) SDK
+- bash: | 
+    export CONDA=/tmp/miniforge
+    wget https://github.com/conda-forge/miniforge/releases/download/24.9.0-0/Miniforge3-24.9.0-0-MacOSX-x86_64.sh
+    bash Miniforge3-24.9.0-0-MacOSX-x86_64.sh -b -p ${CONDA}
+  displayName: install conda
 - script: |
     echo "Removing homebrew from Azure to avoid conflicts."
     curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/uninstall > ~/uninstall_homebrew
@@ -11,6 +12,7 @@ steps:
     rm ~/uninstall_homebrew
   displayName: Remove homebrew
 - bash: |
+    export CONDA=/tmp/miniforge
     source ${CONDA}/etc/profile.d/conda.sh
     sudo chown -R ${USER} ${CONDA}
     mkdir -p $HOME/.matplotlib
@@ -25,6 +27,7 @@ steps:
     conda activate rdkit_build
   displayName: Setup build environment
 - bash: |
+    export CONDA=/tmp/miniforge
     source ${CONDA}/etc/profile.d/conda.sh
     conda activate rdkit_build
     export SDKROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX$(target_platform).sdk
@@ -51,6 +54,7 @@ steps:
     -DRDK_TEST_MULTITHREADED=ON
   displayName: Configure build (Run CMake)
 - bash: |
+    export CONDA=/tmp/miniforge
     source ${CONDA}/etc/profile.d/conda.sh
     conda activate rdkit_build
     export SDKROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX$(target_platform).sdk
@@ -59,6 +63,7 @@ steps:
     make -j $( $(number_of_cores) ) install
   displayName: Build
 - bash: |
+    export CONDA=/tmp/miniforge
     source ${CONDA}/etc/profile.d/conda.sh
     conda activate rdkit_build
     export RDBASE=`pwd`

--- a/.azure-pipelines/mac_build_java.yml
+++ b/.azure-pipelines/mac_build_java.yml
@@ -19,7 +19,7 @@ steps:
     echo -e "backend: TkAgg\n" > $HOME/.matplotlib/matplotlibrc
     conda config --set always_yes yes --set changeps1 no
     conda update -q conda
-    conda create --name rdkit_build  -c conda-forge $(compiler)=$(compiler_version) \
+    conda create --name rdkit_build  -c conda-forge $(compiler) \
         libcxx=$(compiler_version) cmake=3.26 \
         libboost=$(boost_version) \
         libboost-devel=$(boost_version) \

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,34 +4,34 @@ trigger:
 - dev/*
 
 jobs:
-# - job: Ubuntu_x64
-#   timeoutInMinutes: 90
-#   pool:
-#     vmImage: ubuntu-20.04
-#   variables:
-#     python: python=3.8
-#     boost_version: 1.71.0
-#     compiler: gxx_linux-64
-#     number_of_cores: nproc
-#     python_name: python38
-#     cc: gcc-10
-#     cxx: g++-10
-#   steps:
-#   - template: .azure-pipelines/linux_build.yml
-# - job: Ubuntu_x64_py311
-#   timeoutInMinutes: 90
-#   pool:
-#     vmImage: ubuntu-latest
-#   variables:
-#     python: python=3.11
-#     boost_version: 1.82.0
-#     compiler: gxx_linux-64
-#     cc: gcc-10
-#     cxx: g++-10
-#     number_of_cores: nproc
-#     python_name: python311
-#   steps:
-#   - template: .azure-pipelines/linux_build_py311.yml
+- job: Ubuntu_x64
+  timeoutInMinutes: 90
+  pool:
+    vmImage: ubuntu-20.04
+  variables:
+    python: python=3.8
+    boost_version: 1.71.0
+    compiler: gxx_linux-64
+    number_of_cores: nproc
+    python_name: python38
+    cc: gcc-10
+    cxx: g++-10
+  steps:
+  - template: .azure-pipelines/linux_build.yml
+- job: Ubuntu_x64_py311
+  timeoutInMinutes: 90
+  pool:
+    vmImage: ubuntu-latest
+  variables:
+    python: python=3.11
+    boost_version: 1.82.0
+    compiler: gxx_linux-64
+    cc: gcc-10
+    cxx: g++-10
+    number_of_cores: nproc
+    python_name: python311
+  steps:
+  - template: .azure-pipelines/linux_build_py311.yml
 - job: macOS_x64
   timeoutInMinutes: 120
   pool:
@@ -57,88 +57,88 @@ jobs:
     target_platform: 14.5
   steps:
   - template: .azure-pipelines/mac_build_java.yml
-# - job: Windows_VS2022_x64
-#   timeoutInMinutes: 90
-#   pool:
-#     vmImage: windows-2019
-#   variables:
-#     boost_version: 1.84.0
-#     number_of_cores: '%NUMBER_OF_PROCESSORS%'
-#     python: python=3.12
-#   steps:
-#   - template: .azure-pipelines/vs_build.yml
-# - job: Windows_VS2022_x64_dll
-#   timeoutInMinutes: 90
-#   pool:
-#     vmImage: windows-2019
-#   variables:
-#     boost_version: 1.84.0
-#     number_of_cores: '%NUMBER_OF_PROCESSORS%'
-#     python: python=3.12
-#   steps:
-#   - template: .azure-pipelines/vs_build_dll.yml
-# - job: Ubuntu_x64_cartridge
-#   timeoutInMinutes: 90
-#   pool:
-#     vmImage: ubuntu-20.04
-#   variables:
-#     boost_version: 1.71.0
-#     number_of_cores: nproc
-#     compiler: gxx_linux-64
-#     cc: gcc-10
-#     cxx: g++-10
-#   steps:
-#   - template: .azure-pipelines/linux_build_cartridge.yml
-# - job: Ubuntu_x64_limitexternaldependencies
-#   timeoutInMinutes: 90
-#   pool:
-#     vmImage: ubuntu-22.04
-#   variables:
-#     python: python=3.11
-#     boost_version: 1.82.0
-#     number_of_cores: nproc
-#     compiler: gxx_linux-64
-#     cc: gcc-11
-#     cxx: g++-11
-#   steps:
-#   - template: .azure-pipelines/linux_build_limitexternal.yml
-# - job: Ubuntu_x64_java
-#   timeoutInMinutes: 90
-#   pool:
-#     vmImage: ubuntu-20.04
-#   variables:
-#     boost_version: 1.84.0
-#     number_of_cores: nproc
-#     python_name: python37
-#     compiler: gxx_linux-64
-#     cc: gcc-10
-#     cxx: g++-10
-#   steps:
-#   - template: .azure-pipelines/linux_build_java.yml
-# - job: Windows_VS2022_x64_swig
-#   timeoutInMinutes: 90
-#   pool:
-#     vmImage: windows-2019
-#   variables:
-#     boost_version: 1.84.0
-#     number_of_cores: '%NUMBER_OF_PROCESSORS%'
-#     python_name: python38
-#   steps:
-#   - template: .azure-pipelines/vs_build_swig.yml
-# - job: Ubuntu_x64_ubsan
-#   timeoutInMinutes: 120
-#   pool:
-#     vmImage: ubuntu-latest
-#   variables:
-#     python: python=3.11
-#     boost_version: 1.82.0
-#     compiler: gxx_linux-64
-#     cc: gcc-10
-#     cxx: g++-10
-#     number_of_cores: nproc
-#     python_name: python311
-#   steps:
-#   - template: .azure-pipelines/linux_build_ubsan.yml
+- job: Windows_VS2022_x64
+  timeoutInMinutes: 90
+  pool:
+    vmImage: windows-2019
+  variables:
+    boost_version: 1.84.0
+    number_of_cores: '%NUMBER_OF_PROCESSORS%'
+    python: python=3.12
+  steps:
+  - template: .azure-pipelines/vs_build.yml
+- job: Windows_VS2022_x64_dll
+  timeoutInMinutes: 90
+  pool:
+    vmImage: windows-2019
+  variables:
+    boost_version: 1.84.0
+    number_of_cores: '%NUMBER_OF_PROCESSORS%'
+    python: python=3.12
+  steps:
+  - template: .azure-pipelines/vs_build_dll.yml
+- job: Ubuntu_x64_cartridge
+  timeoutInMinutes: 90
+  pool:
+    vmImage: ubuntu-20.04
+  variables:
+    boost_version: 1.71.0
+    number_of_cores: nproc
+    compiler: gxx_linux-64
+    cc: gcc-10
+    cxx: g++-10
+  steps:
+  - template: .azure-pipelines/linux_build_cartridge.yml
+- job: Ubuntu_x64_limitexternaldependencies
+  timeoutInMinutes: 90
+  pool:
+    vmImage: ubuntu-22.04
+  variables:
+    python: python=3.11
+    boost_version: 1.82.0
+    number_of_cores: nproc
+    compiler: gxx_linux-64
+    cc: gcc-11
+    cxx: g++-11
+  steps:
+  - template: .azure-pipelines/linux_build_limitexternal.yml
+- job: Ubuntu_x64_java
+  timeoutInMinutes: 90
+  pool:
+    vmImage: ubuntu-20.04
+  variables:
+    boost_version: 1.84.0
+    number_of_cores: nproc
+    python_name: python37
+    compiler: gxx_linux-64
+    cc: gcc-10
+    cxx: g++-10
+  steps:
+  - template: .azure-pipelines/linux_build_java.yml
+- job: Windows_VS2022_x64_swig
+  timeoutInMinutes: 90
+  pool:
+    vmImage: windows-2019
+  variables:
+    boost_version: 1.84.0
+    number_of_cores: '%NUMBER_OF_PROCESSORS%'
+    python_name: python38
+  steps:
+  - template: .azure-pipelines/vs_build_swig.yml
+- job: Ubuntu_x64_ubsan
+  timeoutInMinutes: 120
+  pool:
+    vmImage: ubuntu-latest
+  variables:
+    python: python=3.11
+    boost_version: 1.82.0
+    compiler: gxx_linux-64
+    cc: gcc-10
+    cxx: g++-10
+    number_of_cores: nproc
+    python_name: python311
+  steps:
+  - template: .azure-pipelines/linux_build_ubsan.yml
 
 # - job: Ubuntu_18_04_x64_fuzzer
 #  timeoutInMinutes: 90

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -57,88 +57,88 @@ jobs:
     target_platform: 14.5
   steps:
   - template: .azure-pipelines/mac_build_java.yml
-- job: Windows_VS2022_x64
-  timeoutInMinutes: 90
-  pool:
-    vmImage: windows-2019
-  variables:
-    boost_version: 1.84.0
-    number_of_cores: '%NUMBER_OF_PROCESSORS%'
-    python: python=3.12
-  steps:
-  - template: .azure-pipelines/vs_build.yml
-- job: Windows_VS2022_x64_dll
-  timeoutInMinutes: 90
-  pool:
-    vmImage: windows-2019
-  variables:
-    boost_version: 1.84.0
-    number_of_cores: '%NUMBER_OF_PROCESSORS%'
-    python: python=3.12
-  steps:
-  - template: .azure-pipelines/vs_build_dll.yml
-- job: Ubuntu_x64_cartridge
-  timeoutInMinutes: 90
-  pool:
-    vmImage: ubuntu-20.04
-  variables:
-    boost_version: 1.71.0
-    number_of_cores: nproc
-    compiler: gxx_linux-64
-    cc: gcc-10
-    cxx: g++-10
-  steps:
-  - template: .azure-pipelines/linux_build_cartridge.yml
-- job: Ubuntu_x64_limitexternaldependencies
-  timeoutInMinutes: 90
-  pool:
-    vmImage: ubuntu-22.04
-  variables:
-    python: python=3.11
-    boost_version: 1.82.0
-    number_of_cores: nproc
-    compiler: gxx_linux-64
-    cc: gcc-11
-    cxx: g++-11
-  steps:
-  - template: .azure-pipelines/linux_build_limitexternal.yml
-- job: Ubuntu_x64_java
-  timeoutInMinutes: 90
-  pool:
-    vmImage: ubuntu-20.04
-  variables:
-    boost_version: 1.84.0
-    number_of_cores: nproc
-    python_name: python37
-    compiler: gxx_linux-64
-    cc: gcc-10
-    cxx: g++-10
-  steps:
-  - template: .azure-pipelines/linux_build_java.yml
-- job: Windows_VS2022_x64_swig
-  timeoutInMinutes: 90
-  pool:
-    vmImage: windows-2019
-  variables:
-    boost_version: 1.84.0
-    number_of_cores: '%NUMBER_OF_PROCESSORS%'
-    python_name: python38
-  steps:
-  - template: .azure-pipelines/vs_build_swig.yml
-- job: Ubuntu_x64_ubsan
-  timeoutInMinutes: 120
-  pool:
-    vmImage: ubuntu-latest
-  variables:
-    python: python=3.11
-    boost_version: 1.82.0
-    compiler: gxx_linux-64
-    cc: gcc-10
-    cxx: g++-10
-    number_of_cores: nproc
-    python_name: python311
-  steps:
-  - template: .azure-pipelines/linux_build_ubsan.yml
+# - job: Windows_VS2022_x64
+#   timeoutInMinutes: 90
+#   pool:
+#     vmImage: windows-2019
+#   variables:
+#     boost_version: 1.84.0
+#     number_of_cores: '%NUMBER_OF_PROCESSORS%'
+#     python: python=3.12
+#   steps:
+#   - template: .azure-pipelines/vs_build.yml
+# - job: Windows_VS2022_x64_dll
+#   timeoutInMinutes: 90
+#   pool:
+#     vmImage: windows-2019
+#   variables:
+#     boost_version: 1.84.0
+#     number_of_cores: '%NUMBER_OF_PROCESSORS%'
+#     python: python=3.12
+#   steps:
+#   - template: .azure-pipelines/vs_build_dll.yml
+# - job: Ubuntu_x64_cartridge
+#   timeoutInMinutes: 90
+#   pool:
+#     vmImage: ubuntu-20.04
+#   variables:
+#     boost_version: 1.71.0
+#     number_of_cores: nproc
+#     compiler: gxx_linux-64
+#     cc: gcc-10
+#     cxx: g++-10
+#   steps:
+#   - template: .azure-pipelines/linux_build_cartridge.yml
+# - job: Ubuntu_x64_limitexternaldependencies
+#   timeoutInMinutes: 90
+#   pool:
+#     vmImage: ubuntu-22.04
+#   variables:
+#     python: python=3.11
+#     boost_version: 1.82.0
+#     number_of_cores: nproc
+#     compiler: gxx_linux-64
+#     cc: gcc-11
+#     cxx: g++-11
+#   steps:
+#   - template: .azure-pipelines/linux_build_limitexternal.yml
+# - job: Ubuntu_x64_java
+#   timeoutInMinutes: 90
+#   pool:
+#     vmImage: ubuntu-20.04
+#   variables:
+#     boost_version: 1.84.0
+#     number_of_cores: nproc
+#     python_name: python37
+#     compiler: gxx_linux-64
+#     cc: gcc-10
+#     cxx: g++-10
+#   steps:
+#   - template: .azure-pipelines/linux_build_java.yml
+# - job: Windows_VS2022_x64_swig
+#   timeoutInMinutes: 90
+#   pool:
+#     vmImage: windows-2019
+#   variables:
+#     boost_version: 1.84.0
+#     number_of_cores: '%NUMBER_OF_PROCESSORS%'
+#     python_name: python38
+#   steps:
+#   - template: .azure-pipelines/vs_build_swig.yml
+# - job: Ubuntu_x64_ubsan
+#   timeoutInMinutes: 120
+#   pool:
+#     vmImage: ubuntu-latest
+#   variables:
+#     python: python=3.11
+#     boost_version: 1.82.0
+#     compiler: gxx_linux-64
+#     cc: gcc-10
+#     cxx: g++-10
+#     number_of_cores: nproc
+#     python_name: python311
+#   steps:
+#   - template: .azure-pipelines/linux_build_ubsan.yml
 
 # - job: Ubuntu_18_04_x64_fuzzer
 #  timeoutInMinutes: 90

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -54,92 +54,91 @@ jobs:
     compiler_version: 15.0
     boost_version: 1.84.0
     number_of_cores: sysctl -n hw.ncpu
-    python_name: python38
     target_platform: 14.5
   steps:
   - template: .azure-pipelines/mac_build_java.yml
-# - job: Windows_VS2022_x64
-#   timeoutInMinutes: 90
-#   pool:
-#     vmImage: windows-2019
-#   variables:
-#     boost_version: 1.84.0
-#     number_of_cores: '%NUMBER_OF_PROCESSORS%'
-#     python: python=3.12
-#   steps:
-#   - template: .azure-pipelines/vs_build.yml
-# - job: Windows_VS2022_x64_dll
-#   timeoutInMinutes: 90
-#   pool:
-#     vmImage: windows-2019
-#   variables:
-#     boost_version: 1.84.0
-#     number_of_cores: '%NUMBER_OF_PROCESSORS%'
-#     python: python=3.12
-#   steps:
-#   - template: .azure-pipelines/vs_build_dll.yml
-# - job: Ubuntu_x64_cartridge
-#   timeoutInMinutes: 90
-#   pool:
-#     vmImage: ubuntu-20.04
-#   variables:
-#     boost_version: 1.71.0
-#     number_of_cores: nproc
-#     compiler: gxx_linux-64
-#     cc: gcc-10
-#     cxx: g++-10
-#   steps:
-#   - template: .azure-pipelines/linux_build_cartridge.yml
-# - job: Ubuntu_x64_limitexternaldependencies
-#   timeoutInMinutes: 90
-#   pool:
-#     vmImage: ubuntu-22.04
-#   variables:
-#     python: python=3.11
-#     boost_version: 1.82.0
-#     number_of_cores: nproc
-#     compiler: gxx_linux-64
-#     cc: gcc-11
-#     cxx: g++-11
-#   steps:
-#   - template: .azure-pipelines/linux_build_limitexternal.yml
-# - job: Ubuntu_x64_java
-#   timeoutInMinutes: 90
-#   pool:
-#     vmImage: ubuntu-20.04
-#   variables:
-#     boost_version: 1.84.0
-#     number_of_cores: nproc
-#     python_name: python37
-#     compiler: gxx_linux-64
-#     cc: gcc-10
-#     cxx: g++-10
-#   steps:
-#   - template: .azure-pipelines/linux_build_java.yml
-# - job: Windows_VS2022_x64_swig
-#   timeoutInMinutes: 90
-#   pool:
-#     vmImage: windows-2019
-#   variables:
-#     boost_version: 1.84.0
-#     number_of_cores: '%NUMBER_OF_PROCESSORS%'
-#     python_name: python38
-#   steps:
-#   - template: .azure-pipelines/vs_build_swig.yml
-# - job: Ubuntu_x64_ubsan
-#   timeoutInMinutes: 120
-#   pool:
-#     vmImage: ubuntu-latest
-#   variables:
-#     python: python=3.11
-#     boost_version: 1.82.0
-#     compiler: gxx_linux-64
-#     cc: gcc-10
-#     cxx: g++-10
-#     number_of_cores: nproc
-#     python_name: python311
-#   steps:
-#   - template: .azure-pipelines/linux_build_ubsan.yml
+- job: Windows_VS2022_x64
+  timeoutInMinutes: 90
+  pool:
+    vmImage: windows-2019
+  variables:
+    boost_version: 1.84.0
+    number_of_cores: '%NUMBER_OF_PROCESSORS%'
+    python: python=3.12
+  steps:
+  - template: .azure-pipelines/vs_build.yml
+- job: Windows_VS2022_x64_dll
+  timeoutInMinutes: 90
+  pool:
+    vmImage: windows-2019
+  variables:
+    boost_version: 1.84.0
+    number_of_cores: '%NUMBER_OF_PROCESSORS%'
+    python: python=3.12
+  steps:
+  - template: .azure-pipelines/vs_build_dll.yml
+- job: Ubuntu_x64_cartridge
+  timeoutInMinutes: 90
+  pool:
+    vmImage: ubuntu-20.04
+  variables:
+    boost_version: 1.71.0
+    number_of_cores: nproc
+    compiler: gxx_linux-64
+    cc: gcc-10
+    cxx: g++-10
+  steps:
+  - template: .azure-pipelines/linux_build_cartridge.yml
+- job: Ubuntu_x64_limitexternaldependencies
+  timeoutInMinutes: 90
+  pool:
+    vmImage: ubuntu-22.04
+  variables:
+    python: python=3.11
+    boost_version: 1.82.0
+    number_of_cores: nproc
+    compiler: gxx_linux-64
+    cc: gcc-11
+    cxx: g++-11
+  steps:
+  - template: .azure-pipelines/linux_build_limitexternal.yml
+- job: Ubuntu_x64_java
+  timeoutInMinutes: 90
+  pool:
+    vmImage: ubuntu-20.04
+  variables:
+    boost_version: 1.84.0
+    number_of_cores: nproc
+    python_name: python37
+    compiler: gxx_linux-64
+    cc: gcc-10
+    cxx: g++-10
+  steps:
+  - template: .azure-pipelines/linux_build_java.yml
+- job: Windows_VS2022_x64_swig
+  timeoutInMinutes: 90
+  pool:
+    vmImage: windows-2019
+  variables:
+    boost_version: 1.84.0
+    number_of_cores: '%NUMBER_OF_PROCESSORS%'
+    python_name: python38
+  steps:
+  - template: .azure-pipelines/vs_build_swig.yml
+- job: Ubuntu_x64_ubsan
+  timeoutInMinutes: 120
+  pool:
+    vmImage: ubuntu-latest
+  variables:
+    python: python=3.11
+    boost_version: 1.82.0
+    compiler: gxx_linux-64
+    cc: gcc-10
+    cxx: g++-10
+    number_of_cores: nproc
+    python_name: python311
+  steps:
+  - template: .azure-pipelines/linux_build_ubsan.yml
 
 # - job: Ubuntu_18_04_x64_fuzzer
 #  timeoutInMinutes: 90

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -52,7 +52,7 @@ jobs:
   variables:
     compiler: clangxx_osx-64=18.1
     compiler_version: 15.0
-    boost_version: 1.86
+    boost_version: 1.84
     number_of_cores: sysctl -n hw.ncpu
     target_platform: 14.5
   steps:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,142 +4,142 @@ trigger:
 - dev/*
 
 jobs:
-- job: Ubuntu_x64
-  timeoutInMinutes: 90
-  pool:
-    vmImage: ubuntu-20.04
-  variables:
-    python: python=3.8
-    boost_version: 1.71.0
-    compiler: gxx_linux-64
-    number_of_cores: nproc
-    python_name: python38
-    cc: gcc-10
-    cxx: g++-10
-  steps:
-  - template: .azure-pipelines/linux_build.yml
-- job: Ubuntu_x64_py311
-  timeoutInMinutes: 90
-  pool:
-    vmImage: ubuntu-latest
-  variables:
-    python: python=3.11
-    boost_version: 1.82.0
-    compiler: gxx_linux-64
-    cc: gcc-10
-    cxx: g++-10
-    number_of_cores: nproc
-    python_name: python311
-  steps:
-  - template: .azure-pipelines/linux_build_py311.yml
+# - job: Ubuntu_x64
+#   timeoutInMinutes: 90
+#   pool:
+#     vmImage: ubuntu-20.04
+#   variables:
+#     python: python=3.8
+#     boost_version: 1.71.0
+#     compiler: gxx_linux-64
+#     number_of_cores: nproc
+#     python_name: python38
+#     cc: gcc-10
+#     cxx: g++-10
+#   steps:
+#   - template: .azure-pipelines/linux_build.yml
+# - job: Ubuntu_x64_py311
+#   timeoutInMinutes: 90
+#   pool:
+#     vmImage: ubuntu-latest
+#   variables:
+#     python: python=3.11
+#     boost_version: 1.82.0
+#     compiler: gxx_linux-64
+#     cc: gcc-10
+#     cxx: g++-10
+#     number_of_cores: nproc
+#     python_name: python311
+#   steps:
+#   - template: .azure-pipelines/linux_build_py311.yml
 - job: macOS_x64
   timeoutInMinutes: 120
   pool:
-    vmImage: macos-12
+    vmImage: macos-14
   variables:
     compiler: clangxx_osx-64=18.1
-    compiler_version: 12.0
-    boost_version: 1.82.0
+    compiler_version: 15.0
+    boost_version: 1.84.0
     number_of_cores: sysctl -n hw.ncpu
+    target_platform: 14.5
     python: python=3.11
-    target_platform: 10.13
   steps:
   - template: .azure-pipelines/mac_build.yml
-- job: Windows_VS2022_x64
-  timeoutInMinutes: 90
-  pool:
-    vmImage: windows-2019
-  variables:
-    boost_version: 1.84.0
-    number_of_cores: '%NUMBER_OF_PROCESSORS%'
-    python: python=3.12
-  steps:
-  - template: .azure-pipelines/vs_build.yml
-- job: Windows_VS2022_x64_dll
-  timeoutInMinutes: 90
-  pool:
-    vmImage: windows-2019
-  variables:
-    boost_version: 1.84.0
-    number_of_cores: '%NUMBER_OF_PROCESSORS%'
-    python: python=3.12
-  steps:
-  - template: .azure-pipelines/vs_build_dll.yml
-- job: Ubuntu_x64_cartridge
-  timeoutInMinutes: 90
-  pool:
-    vmImage: ubuntu-20.04
-  variables:
-    boost_version: 1.71.0
-    number_of_cores: nproc
-    compiler: gxx_linux-64
-    cc: gcc-10
-    cxx: g++-10
-  steps:
-  - template: .azure-pipelines/linux_build_cartridge.yml
-- job: Ubuntu_x64_limitexternaldependencies
-  timeoutInMinutes: 90
-  pool:
-    vmImage: ubuntu-22.04
-  variables:
-    python: python=3.11
-    boost_version: 1.82.0
-    number_of_cores: nproc
-    compiler: gxx_linux-64
-    cc: gcc-11
-    cxx: g++-11
-  steps:
-  - template: .azure-pipelines/linux_build_limitexternal.yml
-- job: Ubuntu_x64_java
-  timeoutInMinutes: 90
-  pool:
-    vmImage: ubuntu-20.04
-  variables:
-    boost_version: 1.84.0
-    number_of_cores: nproc
-    python_name: python37
-    compiler: gxx_linux-64
-    cc: gcc-10
-    cxx: g++-10
-  steps:
-  - template: .azure-pipelines/linux_build_java.yml
 - job: macOS_x64_java
   timeoutInMinutes: 90
   pool:
-    vmImage: macos-12
+    vmImage: macos-14
   variables:
     compiler: clangxx_osx-64
     compiler_version: 15.0
     boost_version: 1.84.0
     number_of_cores: sysctl -n hw.ncpu
     python_name: python38
-    target_platform: 10.13
+    target_platform: 14.5
   steps:
   - template: .azure-pipelines/mac_build_java.yml
-- job: Windows_VS2022_x64_swig
-  timeoutInMinutes: 90
-  pool:
-    vmImage: windows-2019
-  variables:
-    boost_version: 1.84.0
-    number_of_cores: '%NUMBER_OF_PROCESSORS%'
-    python_name: python38
-  steps:
-  - template: .azure-pipelines/vs_build_swig.yml
-- job: Ubuntu_x64_ubsan
-  timeoutInMinutes: 120
-  pool:
-    vmImage: ubuntu-latest
-  variables:
-    python: python=3.11
-    boost_version: 1.82.0
-    compiler: gxx_linux-64
-    cc: gcc-10
-    cxx: g++-10
-    number_of_cores: nproc
-    python_name: python311
-  steps:
-  - template: .azure-pipelines/linux_build_ubsan.yml
+# - job: Windows_VS2022_x64
+#   timeoutInMinutes: 90
+#   pool:
+#     vmImage: windows-2019
+#   variables:
+#     boost_version: 1.84.0
+#     number_of_cores: '%NUMBER_OF_PROCESSORS%'
+#     python: python=3.12
+#   steps:
+#   - template: .azure-pipelines/vs_build.yml
+# - job: Windows_VS2022_x64_dll
+#   timeoutInMinutes: 90
+#   pool:
+#     vmImage: windows-2019
+#   variables:
+#     boost_version: 1.84.0
+#     number_of_cores: '%NUMBER_OF_PROCESSORS%'
+#     python: python=3.12
+#   steps:
+#   - template: .azure-pipelines/vs_build_dll.yml
+# - job: Ubuntu_x64_cartridge
+#   timeoutInMinutes: 90
+#   pool:
+#     vmImage: ubuntu-20.04
+#   variables:
+#     boost_version: 1.71.0
+#     number_of_cores: nproc
+#     compiler: gxx_linux-64
+#     cc: gcc-10
+#     cxx: g++-10
+#   steps:
+#   - template: .azure-pipelines/linux_build_cartridge.yml
+# - job: Ubuntu_x64_limitexternaldependencies
+#   timeoutInMinutes: 90
+#   pool:
+#     vmImage: ubuntu-22.04
+#   variables:
+#     python: python=3.11
+#     boost_version: 1.82.0
+#     number_of_cores: nproc
+#     compiler: gxx_linux-64
+#     cc: gcc-11
+#     cxx: g++-11
+#   steps:
+#   - template: .azure-pipelines/linux_build_limitexternal.yml
+# - job: Ubuntu_x64_java
+#   timeoutInMinutes: 90
+#   pool:
+#     vmImage: ubuntu-20.04
+#   variables:
+#     boost_version: 1.84.0
+#     number_of_cores: nproc
+#     python_name: python37
+#     compiler: gxx_linux-64
+#     cc: gcc-10
+#     cxx: g++-10
+#   steps:
+#   - template: .azure-pipelines/linux_build_java.yml
+# - job: Windows_VS2022_x64_swig
+#   timeoutInMinutes: 90
+#   pool:
+#     vmImage: windows-2019
+#   variables:
+#     boost_version: 1.84.0
+#     number_of_cores: '%NUMBER_OF_PROCESSORS%'
+#     python_name: python38
+#   steps:
+#   - template: .azure-pipelines/vs_build_swig.yml
+# - job: Ubuntu_x64_ubsan
+#   timeoutInMinutes: 120
+#   pool:
+#     vmImage: ubuntu-latest
+#   variables:
+#     python: python=3.11
+#     boost_version: 1.82.0
+#     compiler: gxx_linux-64
+#     cc: gcc-10
+#     cxx: g++-10
+#     number_of_cores: nproc
+#     python_name: python311
+#   steps:
+#   - template: .azure-pipelines/linux_build_ubsan.yml
 
 # - job: Ubuntu_18_04_x64_fuzzer
 #  timeoutInMinutes: 90

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,7 +39,7 @@ jobs:
   variables:
     compiler: clangxx_osx-64=18.1
     compiler_version: 15.0
-    boost_version: 1.84.0
+    boost_version: 1.84
     number_of_cores: sysctl -n hw.ncpu
     target_platform: 14.5
     python: python=3.11
@@ -50,9 +50,9 @@ jobs:
   pool:
     vmImage: macos-14
   variables:
-    compiler: clangxx_osx-64
+    compiler: clangxx_osx-64=18.1
     compiler_version: 15.0
-    boost_version: 1.84.0
+    boost_version: 1.86
     number_of_cores: sysctl -n hw.ncpu
     target_platform: 14.5
   steps:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -38,7 +38,7 @@ jobs:
     vmImage: macos-14
   variables:
     compiler: clangxx_osx-64=18.1
-    compiler_version: 15.0
+    compiler_version: 16
     boost_version: 1.84
     number_of_cores: sysctl -n hw.ncpu
     target_platform: 14.5
@@ -51,7 +51,7 @@ jobs:
     vmImage: macos-14
   variables:
     compiler: clangxx_osx-64=18.1
-    compiler_version: 15.0
+    compiler_version: 16
     boost_version: 1.84
     number_of_cores: sysctl -n hw.ncpu
     target_platform: 14.5


### PR DESCRIPTION
The macos-12 image we've been using is deprecated
This also bumps the SDK version

This is probably going to take 53 attempts to get it right