### PR TITLE
Fixes a regression introduced in #7582 which made all SWIG enums become type-unsafe

### DIFF
--- a/Code/JavaWrappers/MolStandardize.i
+++ b/Code/JavaWrappers/MolStandardize.i
@@ -21,7 +21,5 @@ namespace std {
 
 %include <GraphMol/MolStandardize/MolStandardize.h>
 
-#if defined SWIGJAVA
-%include "enumtypeunsafe.swg"
-#endif
+%include "enums.swg"
 %include <GraphMol/MolStandardize/Pipeline.h>

--- a/Code/JavaWrappers/gmwrapper/src-test/org/RDKit/MolStandardizeTest.java
+++ b/Code/JavaWrappers/gmwrapper/src-test/org/RDKit/MolStandardizeTest.java
@@ -26,7 +26,7 @@ import org.junit.*;
 
 	    assertEquals(result.getStage(), PipelineStage.PARSING_INPUT);
         assertFalse(result.getStatus() == PipelineStatus.NO_EVENT);
-        assertTrue((result.getStatus() & PipelineStatus.INPUT_ERROR) != PipelineStatus.NO_EVENT);
+        assertTrue(PipelineStatus.swigToEnum(result.getStatus().swigValue() & PipelineStatus.INPUT_ERROR.swigValue()) != PipelineStatus.NO_EVENT);
 
 		result.delete();
 		pipeline.delete();
@@ -55,8 +55,8 @@ import org.junit.*;
 
 	    assertEquals(result.getStage(), PipelineStage.COMPLETED);
         assertFalse(result.getStatus() == PipelineStatus.NO_EVENT);
-        assertTrue((result.getStatus() & PipelineStatus.VALIDATION_ERROR) != PipelineStatus.NO_EVENT);
-        assertTrue((result.getStatus() & PipelineStatus.FEATURES_VALIDATION_ERROR) != PipelineStatus.NO_EVENT);
+        assertTrue(PipelineStatus.swigToEnum(result.getStatus().swigValue() & PipelineStatus.VALIDATION_ERROR.swigValue()) != PipelineStatus.NO_EVENT);
+        assertTrue(PipelineStatus.swigToEnum(result.getStatus().swigValue() & PipelineStatus.FEATURES_VALIDATION_ERROR.swigValue()) != PipelineStatus.NO_EVENT);
 
 		result.delete();
 		pipeline.delete();

--- a/Code/JavaWrappers/gmwrapper/src-test/org/RDKit/MolStandardizeTest.java
+++ b/Code/JavaWrappers/gmwrapper/src-test/org/RDKit/MolStandardizeTest.java
@@ -24,7 +24,7 @@ import org.junit.*;
             "M  V30 BEGIN CTAB"
 		);
 
-	    assertEquals(result.getStage(), PipelineStage.PARSING_INPUT);
+	    assertEquals(PipelineStage.swigToEnum((int)result.getStage()), PipelineStage.PARSING_INPUT);
         assertFalse(result.getStatus() == PipelineStatus.NO_EVENT);
         assertTrue(PipelineStatus.swigToEnum(result.getStatus().swigValue() & PipelineStatus.INPUT_ERROR.swigValue()) != PipelineStatus.NO_EVENT);
 
@@ -53,7 +53,7 @@ import org.junit.*;
             "M  END"
 		);
 
-	    assertEquals(result.getStage(), PipelineStage.COMPLETED);
+	    assertEquals(PipelineStage.swigToEnum((int)result.getStage()), PipelineStage.COMPLETED);
         assertFalse(result.getStatus() == PipelineStatus.NO_EVENT);
         assertTrue(PipelineStatus.swigToEnum(result.getStatus().swigValue() & PipelineStatus.VALIDATION_ERROR.swigValue()) != PipelineStatus.NO_EVENT);
         assertTrue(PipelineStatus.swigToEnum(result.getStatus().swigValue() & PipelineStatus.FEATURES_VALIDATION_ERROR.swigValue()) != PipelineStatus.NO_EVENT);


### PR DESCRIPTION
`MolStandardize.i` includes `enumtypeunsafe.swg`, which has the undesired side effect of making all `enums` downstream type-unsafe. For example, the `RGroupMatching.java` wrapper changes as follows:
### Before #7582
```
/* ----------------------------------------------------------------------------
 * This file was automatically generated by SWIG (https://www.swig.org).
 * Version 4.2.1
 *
 * Do not make changes to this file unless you know what you are doing - modify
 * the SWIG interface file instead.
 * ----------------------------------------------------------------------------- */

package org.RDKit;

public enum RGroupMatching {
  Greedy(RDKFuncsJNI.Greedy_get()),
  GreedyChunks(RDKFuncsJNI.GreedyChunks_get()),
  Exhaustive(RDKFuncsJNI.Exhaustive_get()),
  NoSymmetrization(RDKFuncsJNI.NoSymmetrization_get()),
  GA(RDKFuncsJNI.GA_get());

  public final int swigValue() {
    return swigValue;
  }

  public static RGroupMatching swigToEnum(int swigValue) {
    RGroupMatching[] swigValues = RGroupMatching.class.getEnumConstants();
    if (swigValue < swigValues.length && swigValue >= 0 && swigValues[swigValue].swigValue == swigValue)
      return swigValues[swigValue];
    for (RGroupMatching swigEnum : swigValues)
      if (swigEnum.swigValue == swigValue)
        return swigEnum;
    throw new IllegalArgumentException("No enum " + RGroupMatching.class + " with value " + swigValue);
  }

  @SuppressWarnings("unused")
  private RGroupMatching() {
    this.swigValue = SwigNext.next++;
  }

  @SuppressWarnings("unused")
  private RGroupMatching(int swigValue) {
    this.swigValue = swigValue;
    SwigNext.next = swigValue+1;
  }

  @SuppressWarnings("unused")
  private RGroupMatching(RGroupMatching swigEnum) {
    this.swigValue = swigEnum.swigValue;
    SwigNext.next = this.swigValue+1;
  }

  private final int swigValue;

  private static class SwigNext {
    private static int next = 0;
  }
}
```
### After #7582
```
/* ----------------------------------------------------------------------------
 * This file was automatically generated by SWIG (https://www.swig.org).
 * Version 4.2.1
 *
 * Do not make changes to this file unless you know what you are doing - modify
 * the SWIG interface file instead.
 * ----------------------------------------------------------------------------- */

package org.RDKit;

public final class RGroupMatching {
  public final static int Greedy = RDKFuncsJNI.Greedy_get();
  public final static int GreedyChunks = RDKFuncsJNI.GreedyChunks_get();
  public final static int Exhaustive = RDKFuncsJNI.Exhaustive_get();
  public final static int NoSymmetrization = RDKFuncsJNI.NoSymmetrization_get();
  public final static int GA = RDKFuncsJNI.GA_get();
}
```
While the `RGroupMatching` values can still be accessed, the `RGroupMatching` Java class has become a simple collection of `static int` values, rather than being a type-safe Java `enum`, which breaks a number of use cases (e.g., in KNIME RDKit nodes).

This PR reverts the regression by switching `MolStandardize.i` to type-safe `enum`s (as for all other SWIG-wrapped RDKit enums), and adjusting the `MolStandardizeTest.java` test accordingly.
The presence of a Java test the accesses the `swigValue()` and `swigToEnum()` method should avoid similar regressions in the future.