### PR TITLE
Implements #TODO

### DIFF
--- a/Code/GraphMol/SmilesParse/CMakeLists.txt
+++ b/Code/GraphMol/SmilesParse/CMakeLists.txt
@@ -1,6 +1,8 @@
-if(RDK_USE_FLEXBISON)
-  FIND_PACKAGE(BISON)
-  FIND_PACKAGE(FLEX)
+set(FLEX_VERSION 2.6.4)
+
+if (RDK_USE_FLEXBISON)
+  FIND_PACKAGE(BISON 3.8.2 REQUIRED)
+  FIND_PACKAGE(FLEX ${FLEX_VERSION} REQUIRED)
 else(RDK_USE_FLEXBISON)
   set(FLEX_EXECUTABLE "")
   set(BISON_EXECUTABLE "")
@@ -18,7 +20,7 @@ endif()
 if(FLEX_EXECUTABLE)
   FLEX_TARGET(SmilesL smiles.ll
               ${CMAKE_CURRENT_SOURCE_DIR}/lex.yysmiles.cpp
-             COMPILE_FLAGS "-Pyysmiles_" )
+             COMPILE_FLAGS "-Pyysmiles_ --noline" )
   FLEX_TARGET(SmartsL smarts.ll
               ${CMAKE_CURRENT_SOURCE_DIR}/lex.yysmarts.cpp
               COMPILE_FLAGS "-Pyysmarts_" )
@@ -34,7 +36,7 @@ endif(FLEX_EXECUTABLE)
 if(BISON_EXECUTABLE)
   BISON_TARGET(SmilesY smiles.yy
                ${CMAKE_CURRENT_SOURCE_DIR}/smiles.tab.cpp
-               COMPILE_FLAGS "-pyysmiles_" )
+               COMPILE_FLAGS "-pyysmiles_ --no-lines" )
   BISON_TARGET(SmartsY smarts.yy
                ${CMAKE_CURRENT_SOURCE_DIR}/smarts.tab.cpp
                COMPILE_FLAGS "-pyysmarts_" )

--- a/Code/GraphMol/SmilesParse/SmilesParse.cpp
+++ b/Code/GraphMol/SmilesParse/SmilesParse.cpp
@@ -125,9 +125,12 @@ int smiles_parse_helper(const std::string &inp,
   TEST_ASSERT(!yysmiles_lex_init(&scanner));
   try {
     size_t ltrim = setup_smiles_string(inp, scanner);
+    // NOTE: This variable will be used to point to the location of the
+    // offending token if we encounter a syntax error
+    unsigned int current_token_position = 0;
     res = yysmiles_parse(inp.c_str() + ltrim, &molVect, atom, bond,
                          numAtomsParsed, numBondsParsed, &branchPoints, scanner,
-                         start_tok);
+                         start_tok, current_token_position);
   } catch (...) {
     yysmiles_lex_destroy(scanner);
     throw;

--- a/Code/GraphMol/SmilesParse/lex.yysmiles.cpp.cmake
+++ b/Code/GraphMol/SmilesParse/lex.yysmiles.cpp.cmake
@@ -1,6 +1,3 @@
-#line 1 "/localhome/glandrum/RDKit_git/Code/GraphMol/SmilesParse/lex.yysmiles.cpp"
-
-#line 3 "/localhome/glandrum/RDKit_git/Code/GraphMol/SmilesParse/lex.yysmiles.cpp"
 
 #define  YY_INT_ALIGNED short int
 
@@ -800,8 +797,6 @@ static const flex_int16_t yy_chk[358] =
 #define yymore() yymore_used_but_not_detected
 #define YY_MORE_ADJ 0
 #define YY_RESTORE_YY_MORE_OFFSET
-#line 1 "smiles.ll"
-#line 9 "smiles.ll"
 
 // $Id$
 //
@@ -825,6 +820,11 @@ static const flex_int16_t yy_chk[358] =
 #include "smiles.tab.hpp"
 
 using namespace RDKit;
+
+// This will be called every time we construct a token an will allow us to track
+// the position of the current token.
+#undef YY_USER_ACTION
+#define YY_USER_ACTION current_token_position += yyleng;
 
 #define YY_FATAL_ERROR(msg) smiles_lexer_error(msg)
 
@@ -859,7 +859,6 @@ size_t setup_smiles_string(const std::string &text,yyscan_t yyscanner){
   n = _yybytes_len + 2;
   memcpy(buf, yybytes+start, _yybytes_len);
 
-
   buf[_yybytes_len] = buf[_yybytes_len+1] = YY_END_OF_BUFFER_CHAR;
 
   b = yysmiles__scan_buffer(buf,n ,yyscanner);
@@ -871,14 +870,10 @@ size_t setup_smiles_string(const std::string &text,yyscan_t yyscanner){
    */
   b->yy_is_our_buffer = 1;
 
-
   POSTCONDITION(b,"invalid buffer");
   return start;
 
 }
-#line 879 "/localhome/glandrum/RDKit_git/Code/GraphMol/SmilesParse/lex.yysmiles.cpp"
-
-#line 881 "/localhome/glandrum/RDKit_git/Code/GraphMol/SmilesParse/lex.yysmiles.cpp"
 
 #define INITIAL 0
 #define IN_ATOM_STATE 1
@@ -1153,20 +1148,13 @@ YY_DECL
 		}
 
 	{
-#line 86 "smiles.ll"
 
-
-
-#line 90 "smiles.ll"
   if (start_token)
     {
       int t = start_token;
       start_token = 0;
       return t;
     }
-
-
-#line 1169 "/localhome/glandrum/RDKit_git/Code/GraphMol/SmilesParse/lex.yysmiles.cpp"
 
 	while ( /*CONSTCOND*/1 )		/* loops until end-of-file is reached */
 		{
@@ -1221,674 +1209,540 @@ do_action:	/* This label is used only to access EOF actions. */
 
 case 1:
 YY_RULE_SETUP
-#line 98 "smiles.ll"
 { yylval->chiraltype = Atom::ChiralType::CHI_TETRAHEDRAL; return CHI_CLASS_TOKEN; }
 	YY_BREAK
 case 2:
 YY_RULE_SETUP
-#line 99 "smiles.ll"
 { yylval->chiraltype = Atom::ChiralType::CHI_ALLENE; return CHI_CLASS_TOKEN; }
 	YY_BREAK
 case 3:
 YY_RULE_SETUP
-#line 100 "smiles.ll"
 { yylval->chiraltype = Atom::ChiralType::CHI_SQUAREPLANAR; return CHI_CLASS_TOKEN; }
 	YY_BREAK
 case 4:
 YY_RULE_SETUP
-#line 101 "smiles.ll"
 { yylval->chiraltype = Atom::ChiralType::CHI_TRIGONALBIPYRAMIDAL; return CHI_CLASS_TOKEN; }
 	YY_BREAK
 case 5:
 YY_RULE_SETUP
-#line 102 "smiles.ll"
 { yylval->chiraltype = Atom::ChiralType::CHI_OCTAHEDRAL; return CHI_CLASS_TOKEN; }
 	YY_BREAK
 case 6:
 YY_RULE_SETUP
-#line 104 "smiles.ll"
 { return AT_TOKEN; }
 	YY_BREAK
 case 7:
 YY_RULE_SETUP
-#line 107 "smiles.ll"
 { yylval->atom = new Atom(2); return ATOM_TOKEN; }
 	YY_BREAK
 case 8:
 YY_RULE_SETUP
-#line 108 "smiles.ll"
 { yylval->atom = new Atom(3); return ATOM_TOKEN; }
 	YY_BREAK
 case 9:
 YY_RULE_SETUP
-#line 109 "smiles.ll"
 { yylval->atom = new Atom(4); return ATOM_TOKEN; }
 	YY_BREAK
 case 10:
 YY_RULE_SETUP
-#line 110 "smiles.ll"
 { yylval->atom = new Atom(10); return ATOM_TOKEN; }
 	YY_BREAK
 case 11:
 YY_RULE_SETUP
-#line 111 "smiles.ll"
 { yylval->atom = new Atom(11); return ATOM_TOKEN; }
 	YY_BREAK
 case 12:
 YY_RULE_SETUP
-#line 112 "smiles.ll"
 { yylval->atom = new Atom(12); return ATOM_TOKEN; }
 	YY_BREAK
 case 13:
 YY_RULE_SETUP
-#line 113 "smiles.ll"
 { yylval->atom = new Atom(13); return ATOM_TOKEN; }
 	YY_BREAK
 case 14:
 YY_RULE_SETUP
-#line 114 "smiles.ll"
 { yylval->atom = new Atom(14); return ATOM_TOKEN; }
 	YY_BREAK
 case 15:
 YY_RULE_SETUP
-#line 115 "smiles.ll"
 { yylval->atom = new Atom(18); return ATOM_TOKEN; }
 	YY_BREAK
 case 16:
 YY_RULE_SETUP
-#line 116 "smiles.ll"
 { yylval->atom = new Atom(19); return ATOM_TOKEN; }
 	YY_BREAK
 case 17:
 YY_RULE_SETUP
-#line 117 "smiles.ll"
 { yylval->atom = new Atom(20); return ATOM_TOKEN; }
 	YY_BREAK
 case 18:
 YY_RULE_SETUP
-#line 118 "smiles.ll"
 { yylval->atom = new Atom(21); return ATOM_TOKEN; }
 	YY_BREAK
 case 19:
 YY_RULE_SETUP
-#line 119 "smiles.ll"
 { yylval->atom = new Atom(22); return ATOM_TOKEN; }
 	YY_BREAK
 case 20:
 YY_RULE_SETUP
-#line 120 "smiles.ll"
 { yylval->atom = new Atom(23); return ATOM_TOKEN; }
 	YY_BREAK
 case 21:
 YY_RULE_SETUP
-#line 121 "smiles.ll"
 { yylval->atom = new Atom(24); return ATOM_TOKEN; }
 	YY_BREAK
 case 22:
 YY_RULE_SETUP
-#line 122 "smiles.ll"
 { yylval->atom = new Atom(25); return ATOM_TOKEN; }
 	YY_BREAK
 case 23:
 YY_RULE_SETUP
-#line 123 "smiles.ll"
 { yylval->atom = new Atom(26); return ATOM_TOKEN; }
 	YY_BREAK
 case 24:
 YY_RULE_SETUP
-#line 124 "smiles.ll"
 { yylval->atom = new Atom(27); return ATOM_TOKEN; }
 	YY_BREAK
 case 25:
 YY_RULE_SETUP
-#line 125 "smiles.ll"
 { yylval->atom = new Atom(28); return ATOM_TOKEN; }
 	YY_BREAK
 case 26:
 YY_RULE_SETUP
-#line 126 "smiles.ll"
 { yylval->atom = new Atom(29); return ATOM_TOKEN; }
 	YY_BREAK
 case 27:
 YY_RULE_SETUP
-#line 127 "smiles.ll"
 { yylval->atom = new Atom(30); return ATOM_TOKEN; }
 	YY_BREAK
 case 28:
 YY_RULE_SETUP
-#line 128 "smiles.ll"
 { yylval->atom = new Atom(31); return ATOM_TOKEN; }
 	YY_BREAK
 case 29:
 YY_RULE_SETUP
-#line 129 "smiles.ll"
 { yylval->atom = new Atom(32); return ATOM_TOKEN; }
 	YY_BREAK
 case 30:
 YY_RULE_SETUP
-#line 130 "smiles.ll"
 { yylval->atom = new Atom(33); return ATOM_TOKEN; }
 	YY_BREAK
 case 31:
 YY_RULE_SETUP
-#line 131 "smiles.ll"
 { yylval->atom = new Atom(34); return ATOM_TOKEN; }
 	YY_BREAK
 case 32:
 YY_RULE_SETUP
-#line 132 "smiles.ll"
 { yylval->atom = new Atom(36); return ATOM_TOKEN; }
 	YY_BREAK
 case 33:
 YY_RULE_SETUP
-#line 133 "smiles.ll"
 { yylval->atom = new Atom(37); return ATOM_TOKEN; }
 	YY_BREAK
 case 34:
 YY_RULE_SETUP
-#line 134 "smiles.ll"
 { yylval->atom = new Atom(38); return ATOM_TOKEN; }
 	YY_BREAK
 case 35:
 YY_RULE_SETUP
-#line 135 "smiles.ll"
 { yylval->atom = new Atom(39); return ATOM_TOKEN; }
 	YY_BREAK
 case 36:
 YY_RULE_SETUP
-#line 136 "smiles.ll"
 { yylval->atom = new Atom(40); return ATOM_TOKEN; }
 	YY_BREAK
 case 37:
 YY_RULE_SETUP
-#line 137 "smiles.ll"
 { yylval->atom = new Atom(41); return ATOM_TOKEN; }
 	YY_BREAK
 case 38:
 YY_RULE_SETUP
-#line 138 "smiles.ll"
 { yylval->atom = new Atom(42); return ATOM_TOKEN; }
 	YY_BREAK
 case 39:
 YY_RULE_SETUP
-#line 139 "smiles.ll"
 { yylval->atom = new Atom(43); return ATOM_TOKEN; }
 	YY_BREAK
 case 40:
 YY_RULE_SETUP
-#line 140 "smiles.ll"
 { yylval->atom = new Atom(44); return ATOM_TOKEN; }
 	YY_BREAK
 case 41:
 YY_RULE_SETUP
-#line 141 "smiles.ll"
 { yylval->atom = new Atom(45); return ATOM_TOKEN; }
 	YY_BREAK
 case 42:
 YY_RULE_SETUP
-#line 142 "smiles.ll"
 { yylval->atom = new Atom(46); return ATOM_TOKEN; }
 	YY_BREAK
 case 43:
 YY_RULE_SETUP
-#line 143 "smiles.ll"
 { yylval->atom = new Atom(47); return ATOM_TOKEN; }
 	YY_BREAK
 case 44:
 YY_RULE_SETUP
-#line 144 "smiles.ll"
 { yylval->atom = new Atom(48); return ATOM_TOKEN; }
 	YY_BREAK
 case 45:
 YY_RULE_SETUP
-#line 145 "smiles.ll"
 { yylval->atom = new Atom(49); return ATOM_TOKEN; }
 	YY_BREAK
 case 46:
 YY_RULE_SETUP
-#line 146 "smiles.ll"
 { yylval->atom = new Atom(50); return ATOM_TOKEN; }
 	YY_BREAK
 case 47:
 YY_RULE_SETUP
-#line 147 "smiles.ll"
 { yylval->atom = new Atom(51); return ATOM_TOKEN; }
 	YY_BREAK
 case 48:
 YY_RULE_SETUP
-#line 148 "smiles.ll"
 { yylval->atom = new Atom(52); return ATOM_TOKEN; }
 	YY_BREAK
 case 49:
 YY_RULE_SETUP
-#line 149 "smiles.ll"
 { yylval->atom = new Atom(54); return ATOM_TOKEN; }
 	YY_BREAK
 case 50:
 YY_RULE_SETUP
-#line 150 "smiles.ll"
 { yylval->atom = new Atom(55); return ATOM_TOKEN; }
 	YY_BREAK
 case 51:
 YY_RULE_SETUP
-#line 151 "smiles.ll"
 { yylval->atom = new Atom(56); return ATOM_TOKEN; }
 	YY_BREAK
 case 52:
 YY_RULE_SETUP
-#line 152 "smiles.ll"
 { yylval->atom = new Atom(57); return ATOM_TOKEN; }
 	YY_BREAK
 case 53:
 YY_RULE_SETUP
-#line 153 "smiles.ll"
 { yylval->atom = new Atom(58); return ATOM_TOKEN; }
 	YY_BREAK
 case 54:
 YY_RULE_SETUP
-#line 154 "smiles.ll"
 { yylval->atom = new Atom(59); return ATOM_TOKEN; }
 	YY_BREAK
 case 55:
 YY_RULE_SETUP
-#line 155 "smiles.ll"
 { yylval->atom = new Atom(60); return ATOM_TOKEN; }
 	YY_BREAK
 case 56:
 YY_RULE_SETUP
-#line 156 "smiles.ll"
 { yylval->atom = new Atom(61); return ATOM_TOKEN; }
 	YY_BREAK
 case 57:
 YY_RULE_SETUP
-#line 157 "smiles.ll"
 { yylval->atom = new Atom(62); return ATOM_TOKEN; }
 	YY_BREAK
 case 58:
 YY_RULE_SETUP
-#line 158 "smiles.ll"
 { yylval->atom = new Atom(63); return ATOM_TOKEN; }
 	YY_BREAK
 case 59:
 YY_RULE_SETUP
-#line 159 "smiles.ll"
 { yylval->atom = new Atom(64); return ATOM_TOKEN; }
 	YY_BREAK
 case 60:
 YY_RULE_SETUP
-#line 160 "smiles.ll"
 { yylval->atom = new Atom(65); return ATOM_TOKEN; }
 	YY_BREAK
 case 61:
 YY_RULE_SETUP
-#line 161 "smiles.ll"
 { yylval->atom = new Atom(66); return ATOM_TOKEN; }
 	YY_BREAK
 case 62:
 YY_RULE_SETUP
-#line 162 "smiles.ll"
 { yylval->atom = new Atom(67); return ATOM_TOKEN; }
 	YY_BREAK
 case 63:
 YY_RULE_SETUP
-#line 163 "smiles.ll"
 { yylval->atom = new Atom(68); return ATOM_TOKEN; }
 	YY_BREAK
 case 64:
 YY_RULE_SETUP
-#line 164 "smiles.ll"
 { yylval->atom = new Atom(69); return ATOM_TOKEN; }
 	YY_BREAK
 case 65:
 YY_RULE_SETUP
-#line 165 "smiles.ll"
 { yylval->atom = new Atom(70); return ATOM_TOKEN; }
 	YY_BREAK
 case 66:
 YY_RULE_SETUP
-#line 166 "smiles.ll"
 { yylval->atom = new Atom(71); return ATOM_TOKEN; }
 	YY_BREAK
 case 67:
 YY_RULE_SETUP
-#line 167 "smiles.ll"
 { yylval->atom = new Atom(72); return ATOM_TOKEN; }
 	YY_BREAK
 case 68:
 YY_RULE_SETUP
-#line 168 "smiles.ll"
 { yylval->atom = new Atom(73); return ATOM_TOKEN; }
 	YY_BREAK
 case 69:
 YY_RULE_SETUP
-#line 169 "smiles.ll"
 { yylval->atom = new Atom(74); return ATOM_TOKEN; }
 	YY_BREAK
 case 70:
 YY_RULE_SETUP
-#line 170 "smiles.ll"
 { yylval->atom = new Atom(75); return ATOM_TOKEN; }
 	YY_BREAK
 case 71:
 YY_RULE_SETUP
-#line 171 "smiles.ll"
 { yylval->atom = new Atom(76); return ATOM_TOKEN; }
 	YY_BREAK
 case 72:
 YY_RULE_SETUP
-#line 172 "smiles.ll"
 { yylval->atom = new Atom(77); return ATOM_TOKEN; }
 	YY_BREAK
 case 73:
 YY_RULE_SETUP
-#line 173 "smiles.ll"
 { yylval->atom = new Atom(78); return ATOM_TOKEN; }
 	YY_BREAK
 case 74:
 YY_RULE_SETUP
-#line 174 "smiles.ll"
 { yylval->atom = new Atom(79); return ATOM_TOKEN; }
 	YY_BREAK
 case 75:
 YY_RULE_SETUP
-#line 175 "smiles.ll"
 { yylval->atom = new Atom(80); return ATOM_TOKEN; }
 	YY_BREAK
 case 76:
 YY_RULE_SETUP
-#line 176 "smiles.ll"
 { yylval->atom = new Atom(81); return ATOM_TOKEN; }
 	YY_BREAK
 case 77:
 YY_RULE_SETUP
-#line 177 "smiles.ll"
 { yylval->atom = new Atom(82); return ATOM_TOKEN; }
 	YY_BREAK
 case 78:
 YY_RULE_SETUP
-#line 178 "smiles.ll"
 { yylval->atom = new Atom(83); return ATOM_TOKEN; }
 	YY_BREAK
 case 79:
 YY_RULE_SETUP
-#line 179 "smiles.ll"
 { yylval->atom = new Atom(84); return ATOM_TOKEN; }
 	YY_BREAK
 case 80:
 YY_RULE_SETUP
-#line 180 "smiles.ll"
 { yylval->atom = new Atom(85); return ATOM_TOKEN; }
 	YY_BREAK
 case 81:
 YY_RULE_SETUP
-#line 181 "smiles.ll"
 { yylval->atom = new Atom(86); return ATOM_TOKEN; }
 	YY_BREAK
 case 82:
 YY_RULE_SETUP
-#line 182 "smiles.ll"
 { yylval->atom = new Atom(87); return ATOM_TOKEN; }
 	YY_BREAK
 case 83:
 YY_RULE_SETUP
-#line 183 "smiles.ll"
 { yylval->atom = new Atom(88); return ATOM_TOKEN; }
 	YY_BREAK
 case 84:
 YY_RULE_SETUP
-#line 184 "smiles.ll"
 { yylval->atom = new Atom(89); return ATOM_TOKEN; }
 	YY_BREAK
 case 85:
 YY_RULE_SETUP
-#line 185 "smiles.ll"
 { yylval->atom = new Atom(90); return ATOM_TOKEN; }
 	YY_BREAK
 case 86:
 YY_RULE_SETUP
-#line 186 "smiles.ll"
 { yylval->atom = new Atom(91); return ATOM_TOKEN; }
 	YY_BREAK
 case 87:
 YY_RULE_SETUP
-#line 187 "smiles.ll"
 { yylval->atom = new Atom(92); return ATOM_TOKEN; }
 	YY_BREAK
 case 88:
 YY_RULE_SETUP
-#line 188 "smiles.ll"
 { yylval->atom = new Atom(93); return ATOM_TOKEN; }
 	YY_BREAK
 case 89:
 YY_RULE_SETUP
-#line 189 "smiles.ll"
 { yylval->atom = new Atom(94); return ATOM_TOKEN; }
 	YY_BREAK
 case 90:
 YY_RULE_SETUP
-#line 190 "smiles.ll"
 { yylval->atom = new Atom(95); return ATOM_TOKEN; }
 	YY_BREAK
 case 91:
 YY_RULE_SETUP
-#line 191 "smiles.ll"
 { yylval->atom = new Atom(96); return ATOM_TOKEN; }
 	YY_BREAK
 case 92:
 YY_RULE_SETUP
-#line 192 "smiles.ll"
 { yylval->atom = new Atom(97); return ATOM_TOKEN; }
 	YY_BREAK
 case 93:
 YY_RULE_SETUP
-#line 193 "smiles.ll"
 { yylval->atom = new Atom(98); return ATOM_TOKEN; }
 	YY_BREAK
 case 94:
 YY_RULE_SETUP
-#line 194 "smiles.ll"
 { yylval->atom = new Atom(99); return ATOM_TOKEN; }
 	YY_BREAK
 case 95:
 YY_RULE_SETUP
-#line 195 "smiles.ll"
 { yylval->atom = new Atom(100); return ATOM_TOKEN; }
 	YY_BREAK
 case 96:
 YY_RULE_SETUP
-#line 196 "smiles.ll"
 { yylval->atom = new Atom(101); return ATOM_TOKEN; }
 	YY_BREAK
 case 97:
 YY_RULE_SETUP
-#line 197 "smiles.ll"
 { yylval->atom = new Atom(102); return ATOM_TOKEN; }
 	YY_BREAK
 case 98:
 YY_RULE_SETUP
-#line 198 "smiles.ll"
 { yylval->atom = new Atom(103); return ATOM_TOKEN; }
 	YY_BREAK
 case 99:
 YY_RULE_SETUP
-#line 199 "smiles.ll"
 { yylval->atom = new Atom(104); return ATOM_TOKEN; }
 	YY_BREAK
 case 100:
 YY_RULE_SETUP
-#line 200 "smiles.ll"
 { yylval->atom = new Atom(105); return ATOM_TOKEN; }
 	YY_BREAK
 case 101:
 YY_RULE_SETUP
-#line 201 "smiles.ll"
 { yylval->atom = new Atom(106); return ATOM_TOKEN; }
 	YY_BREAK
 case 102:
 YY_RULE_SETUP
-#line 202 "smiles.ll"
 { yylval->atom = new Atom(107); return ATOM_TOKEN; }
 	YY_BREAK
 case 103:
 YY_RULE_SETUP
-#line 203 "smiles.ll"
 { yylval->atom = new Atom(108); return ATOM_TOKEN; }
 	YY_BREAK
 case 104:
 YY_RULE_SETUP
-#line 204 "smiles.ll"
 { yylval->atom = new Atom(109); return ATOM_TOKEN; }
 	YY_BREAK
 case 105:
 YY_RULE_SETUP
-#line 205 "smiles.ll"
 { yylval->atom = new Atom(110); return ATOM_TOKEN; }
 	YY_BREAK
 case 106:
 YY_RULE_SETUP
-#line 206 "smiles.ll"
 { yylval->atom = new Atom(111); return ATOM_TOKEN; }
 	YY_BREAK
 case 107:
 YY_RULE_SETUP
-#line 207 "smiles.ll"
 { yylval->atom = new Atom(112); return ATOM_TOKEN; }
 	YY_BREAK
 case 108:
 YY_RULE_SETUP
-#line 208 "smiles.ll"
 { yylval->atom = new Atom(113); return ATOM_TOKEN; }
 	YY_BREAK
 case 109:
 YY_RULE_SETUP
-#line 209 "smiles.ll"
 { yylval->atom = new Atom(114); return ATOM_TOKEN; }
 	YY_BREAK
 case 110:
 YY_RULE_SETUP
-#line 210 "smiles.ll"
 { yylval->atom = new Atom(115); return ATOM_TOKEN; }
 	YY_BREAK
 case 111:
 YY_RULE_SETUP
-#line 211 "smiles.ll"
 { yylval->atom = new Atom(116); return ATOM_TOKEN; }
 	YY_BREAK
 case 112:
 YY_RULE_SETUP
-#line 212 "smiles.ll"
 { yylval->atom = new Atom(117); return ATOM_TOKEN; }
 	YY_BREAK
 case 113:
 YY_RULE_SETUP
-#line 213 "smiles.ll"
 { yylval->atom = new Atom(118); return ATOM_TOKEN; }
 	YY_BREAK
 case 114:
 YY_RULE_SETUP
-#line 215 "smiles.ll"
 { yylval->atom = new Atom(110); return ATOM_TOKEN; }
 	YY_BREAK
 case 115:
 YY_RULE_SETUP
-#line 216 "smiles.ll"
 { yylval->atom = new Atom(111); return ATOM_TOKEN; }
 	YY_BREAK
 case 116:
 YY_RULE_SETUP
-#line 217 "smiles.ll"
 { yylval->atom = new Atom(112); return ATOM_TOKEN; }
 	YY_BREAK
 case 117:
 YY_RULE_SETUP
-#line 218 "smiles.ll"
 { yylval->atom = new Atom(113); return ATOM_TOKEN; }
 	YY_BREAK
 case 118:
 YY_RULE_SETUP
-#line 219 "smiles.ll"
 { yylval->atom = new Atom(114); return ATOM_TOKEN; }
 	YY_BREAK
 case 119:
 YY_RULE_SETUP
-#line 220 "smiles.ll"
 { yylval->atom = new Atom(115); return ATOM_TOKEN; }
 	YY_BREAK
 case 120:
 YY_RULE_SETUP
-#line 221 "smiles.ll"
 { yylval->atom = new Atom(116); return ATOM_TOKEN; }
 	YY_BREAK
 case 121:
 YY_RULE_SETUP
-#line 222 "smiles.ll"
 { yylval->atom = new Atom(117); return ATOM_TOKEN; }
 	YY_BREAK
 case 122:
 YY_RULE_SETUP
-#line 223 "smiles.ll"
 { yylval->atom = new Atom(118); return ATOM_TOKEN; }
 	YY_BREAK
 case 123:
 YY_RULE_SETUP
-#line 225 "smiles.ll"
 { yylval->atom = new Atom(5);return ORGANIC_ATOM_TOKEN; }
 	YY_BREAK
 case 124:
 YY_RULE_SETUP
-#line 226 "smiles.ll"
 { yylval->atom = new Atom(6);return ORGANIC_ATOM_TOKEN; }
 	YY_BREAK
 case 125:
 YY_RULE_SETUP
-#line 227 "smiles.ll"
 { yylval->atom = new Atom(7);return ORGANIC_ATOM_TOKEN; }
 	YY_BREAK
 case 126:
 YY_RULE_SETUP
-#line 228 "smiles.ll"
 { yylval->atom = new Atom(8);return ORGANIC_ATOM_TOKEN; }
 	YY_BREAK
 case 127:
 YY_RULE_SETUP
-#line 229 "smiles.ll"
 { yylval->atom = new Atom(15);return ORGANIC_ATOM_TOKEN; }
 	YY_BREAK
 case 128:
 YY_RULE_SETUP
-#line 230 "smiles.ll"
 { yylval->atom = new Atom(16);return ORGANIC_ATOM_TOKEN; }
 	YY_BREAK
 case 129:
 YY_RULE_SETUP
-#line 231 "smiles.ll"
 { yylval->atom = new Atom(9);return ORGANIC_ATOM_TOKEN; }
 	YY_BREAK
 case 130:
 YY_RULE_SETUP
-#line 232 "smiles.ll"
 { yylval->atom = new Atom(17);return ORGANIC_ATOM_TOKEN; }
 	YY_BREAK
 case 131:
 YY_RULE_SETUP
-#line 233 "smiles.ll"
 { yylval->atom = new Atom(35);return ORGANIC_ATOM_TOKEN; }
 	YY_BREAK
 case 132:
 YY_RULE_SETUP
-#line 234 "smiles.ll"
 { yylval->atom = new Atom(53);return ORGANIC_ATOM_TOKEN; }
 	YY_BREAK
 case 133:
 YY_RULE_SETUP
-#line 236 "smiles.ll"
 {
 				return H_TOKEN;
 			}
 	YY_BREAK
 case 134:
 YY_RULE_SETUP
-#line 240 "smiles.ll"
 {	yylval->atom = new Atom ( 5 );
 			yylval->atom->setIsAromatic(true);
 				return AROMATIC_ATOM_TOKEN;
@@ -1896,7 +1750,6 @@ YY_RULE_SETUP
 	YY_BREAK
 case 135:
 YY_RULE_SETUP
-#line 244 "smiles.ll"
 {	yylval->atom = new Atom ( 6 );
 			yylval->atom->setIsAromatic(true);
 				return AROMATIC_ATOM_TOKEN;
@@ -1904,7 +1757,6 @@ YY_RULE_SETUP
 	YY_BREAK
 case 136:
 YY_RULE_SETUP
-#line 248 "smiles.ll"
 {	yylval->atom = new Atom( 7 );
 			yylval->atom->setIsAromatic(true);
 				return AROMATIC_ATOM_TOKEN;
@@ -1912,7 +1764,6 @@ YY_RULE_SETUP
 	YY_BREAK
 case 137:
 YY_RULE_SETUP
-#line 252 "smiles.ll"
 {	yylval->atom = new Atom( 8 );
 			yylval->atom->setIsAromatic(true);
 				return AROMATIC_ATOM_TOKEN;
@@ -1920,7 +1771,6 @@ YY_RULE_SETUP
 	YY_BREAK
 case 138:
 YY_RULE_SETUP
-#line 256 "smiles.ll"
 {	yylval->atom = new Atom( 15 );
 			yylval->atom->setIsAromatic(true);
 				return AROMATIC_ATOM_TOKEN;
@@ -1928,7 +1778,6 @@ YY_RULE_SETUP
 	YY_BREAK
 case 139:
 YY_RULE_SETUP
-#line 260 "smiles.ll"
 {	yylval->atom = new Atom( 16 );
 			yylval->atom->setIsAromatic(true);
 				return AROMATIC_ATOM_TOKEN;
@@ -1936,7 +1785,6 @@ YY_RULE_SETUP
 	YY_BREAK
 case 140:
 YY_RULE_SETUP
-#line 265 "smiles.ll"
 {	yylval->atom = new Atom( 14 );
 			yylval->atom->setIsAromatic(true);
 				return AROMATIC_ATOM_TOKEN;
@@ -1944,7 +1792,6 @@ YY_RULE_SETUP
 	YY_BREAK
 case 141:
 YY_RULE_SETUP
-#line 269 "smiles.ll"
 {	yylval->atom = new Atom( 33 );
 			yylval->atom->setIsAromatic(true);
 				return AROMATIC_ATOM_TOKEN;
@@ -1952,7 +1799,6 @@ YY_RULE_SETUP
 	YY_BREAK
 case 142:
 YY_RULE_SETUP
-#line 273 "smiles.ll"
 {	yylval->atom = new Atom( 34 );
 			yylval->atom->setIsAromatic(true);
 				return AROMATIC_ATOM_TOKEN;
@@ -1960,7 +1806,6 @@ YY_RULE_SETUP
 	YY_BREAK
 case 143:
 YY_RULE_SETUP
-#line 277 "smiles.ll"
 {	yylval->atom = new Atom( 52 );
 			yylval->atom->setIsAromatic(true);
 				return AROMATIC_ATOM_TOKEN;
@@ -1968,7 +1813,6 @@ YY_RULE_SETUP
 	YY_BREAK
 case 144:
 YY_RULE_SETUP
-#line 282 "smiles.ll"
 {   yylval->atom = new Atom( 0 );
 		            yylval->atom->setProp(common_properties::dummyLabel,
                                                         std::string("*"));
@@ -1979,12 +1823,10 @@ YY_RULE_SETUP
 	YY_BREAK
 case 145:
 YY_RULE_SETUP
-#line 290 "smiles.ll"
 { return COLON_TOKEN; }
 	YY_BREAK
 case 146:
 YY_RULE_SETUP
-#line 292 "smiles.ll"
 { return HASH_TOKEN; }
 	YY_BREAK
 
@@ -1993,126 +1835,103 @@ YY_RULE_SETUP
 
 case 147:
 YY_RULE_SETUP
-#line 299 "smiles.ll"
 { yylval->atom = new Atom(104); return ATOM_TOKEN; }
 	YY_BREAK
 case 148:
 YY_RULE_SETUP
-#line 300 "smiles.ll"
 { yylval->atom = new Atom(105); return ATOM_TOKEN; }
 	YY_BREAK
 case 149:
 YY_RULE_SETUP
-#line 301 "smiles.ll"
 { yylval->atom = new Atom(106); return ATOM_TOKEN; }
 	YY_BREAK
 case 150:
 YY_RULE_SETUP
-#line 302 "smiles.ll"
 { yylval->atom = new Atom(107); return ATOM_TOKEN; }
 	YY_BREAK
 case 151:
 YY_RULE_SETUP
-#line 303 "smiles.ll"
 { yylval->atom = new Atom(108); return ATOM_TOKEN; }
 	YY_BREAK
 case 152:
 YY_RULE_SETUP
-#line 304 "smiles.ll"
 { yylval->atom = new Atom(109); return ATOM_TOKEN; }
 	YY_BREAK
 case 153:
 YY_RULE_SETUP
-#line 305 "smiles.ll"
 { yylval->atom = new Atom(110); return ATOM_TOKEN; }
 	YY_BREAK
 case 154:
 YY_RULE_SETUP
-#line 306 "smiles.ll"
 { yylval->atom = new Atom(111); return ATOM_TOKEN; }
 	YY_BREAK
 case 155:
 YY_RULE_SETUP
-#line 307 "smiles.ll"
 { yylval->atom = new Atom(112); return ATOM_TOKEN; }
 	YY_BREAK
 case 156:
 YY_RULE_SETUP
-#line 308 "smiles.ll"
 { yylval->atom = new Atom(113); return ATOM_TOKEN; }
 	YY_BREAK
 case 157:
 YY_RULE_SETUP
-#line 309 "smiles.ll"
 { yylval->atom = new Atom(114); return ATOM_TOKEN; }
 	YY_BREAK
 case 158:
 YY_RULE_SETUP
-#line 310 "smiles.ll"
 { yylval->atom = new Atom(115); return ATOM_TOKEN; }
 	YY_BREAK
 case 159:
 YY_RULE_SETUP
-#line 311 "smiles.ll"
 { yylval->atom = new Atom(116); return ATOM_TOKEN; }
 	YY_BREAK
 case 160:
 YY_RULE_SETUP
-#line 312 "smiles.ll"
 { yylval->atom = new Atom(117); return ATOM_TOKEN; }
 	YY_BREAK
 case 161:
 YY_RULE_SETUP
-#line 313 "smiles.ll"
 { yylval->atom = new Atom(118); return ATOM_TOKEN; }
 	YY_BREAK
 case 162:
 YY_RULE_SETUP
-#line 315 "smiles.ll"
 { yylval->bond = new Bond(Bond::DOUBLE);
 	  return BOND_TOKEN; }
 	YY_BREAK
 case 163:
 YY_RULE_SETUP
-#line 317 "smiles.ll"
 { yylval->bond = new Bond(Bond::TRIPLE);
 	  return BOND_TOKEN; }
 	YY_BREAK
 case 164:
 YY_RULE_SETUP
-#line 319 "smiles.ll"
 { yylval->bond = new Bond(Bond::AROMATIC);
 	  yylval->bond->setIsAromatic(true);
 	  return BOND_TOKEN; }
 	YY_BREAK
 case 165:
 YY_RULE_SETUP
-#line 322 "smiles.ll"
 { yylval->bond = new Bond(Bond::QUADRUPLE);
 	  return BOND_TOKEN; }
 	YY_BREAK
 case 166:
 YY_RULE_SETUP
-#line 324 "smiles.ll"
 { yylval->bond = new Bond(Bond::DATIVER);
 	  return BOND_TOKEN; }
 	YY_BREAK
 case 167:
 YY_RULE_SETUP
-#line 326 "smiles.ll"
 { yylval->bond = new Bond(Bond::DATIVEL);
 	  return BOND_TOKEN; }
 	YY_BREAK
 case 168:
 YY_RULE_SETUP
-#line 328 "smiles.ll"
 { yylval->bond = new QueryBond();
 	  yylval->bond->setQuery(makeBondNullQuery());
 	  return BOND_TOKEN;  }
 	YY_BREAK
 case 169:
 YY_RULE_SETUP
-#line 332 "smiles.ll"
 { yylval->bond = new Bond(Bond::UNSPECIFIED);
 	yylval->bond->setProp(RDKit::common_properties::_unspecifiedOrder,1);
 	yylval->bond->setBondDir(Bond::ENDDOWNRIGHT);
@@ -2120,7 +1939,6 @@ YY_RULE_SETUP
 	YY_BREAK
 case 170:
 YY_RULE_SETUP
-#line 337 "smiles.ll"
 { yylval->bond = new Bond(Bond::UNSPECIFIED);
 	yylval->bond->setProp(RDKit::common_properties::_unspecifiedOrder,1);
 	yylval->bond->setBondDir(Bond::ENDUPRIGHT);
@@ -2128,76 +1946,61 @@ YY_RULE_SETUP
 	YY_BREAK
 case 171:
 YY_RULE_SETUP
-#line 342 "smiles.ll"
 { return MINUS_TOKEN; }
 	YY_BREAK
 case 172:
 YY_RULE_SETUP
-#line 344 "smiles.ll"
 { return PLUS_TOKEN; }
 	YY_BREAK
 case 173:
 YY_RULE_SETUP
-#line 346 "smiles.ll"
 { return GROUP_OPEN_TOKEN; }
 	YY_BREAK
 case 174:
 YY_RULE_SETUP
-#line 347 "smiles.ll"
 { return GROUP_CLOSE_TOKEN; }
 	YY_BREAK
 case 175:
 YY_RULE_SETUP
-#line 350 "smiles.ll"
 { BEGIN IN_ATOM_STATE; return ATOM_OPEN_TOKEN; }
 	YY_BREAK
 case 176:
 YY_RULE_SETUP
-#line 351 "smiles.ll"
 { BEGIN INITIAL; return ATOM_CLOSE_TOKEN; }
 	YY_BREAK
 case 177:
 YY_RULE_SETUP
-#line 353 "smiles.ll"
 { return SEPARATOR_TOKEN; }
 	YY_BREAK
 case 178:
 YY_RULE_SETUP
-#line 355 "smiles.ll"
 { return PERCENT_TOKEN; }
 	YY_BREAK
 case 179:
 YY_RULE_SETUP
-#line 357 "smiles.ll"
 { yylval->ival = 0; return ZERO_TOKEN; }
 	YY_BREAK
 case 180:
 YY_RULE_SETUP
-#line 358 "smiles.ll"
 { yylval->ival = yytext[0] - '0'; return NONZERO_DIGIT_TOKEN; }
 	YY_BREAK
 case 181:
 /* rule 181 can match eol */
 YY_RULE_SETUP
-#line 362 "smiles.ll"
 return 0;
 	YY_BREAK
 case YY_STATE_EOF(INITIAL):
 case YY_STATE_EOF(IN_ATOM_STATE):
-#line 364 "smiles.ll"
 { return EOS_TOKEN; }
 	YY_BREAK
 case 182:
 YY_RULE_SETUP
-#line 365 "smiles.ll"
 return yytext[0];
 	YY_BREAK
 case 183:
 YY_RULE_SETUP
-#line 367 "smiles.ll"
 YY_FATAL_ERROR( "flex scanner jammed" );
 	YY_BREAK
-#line 2200 "/localhome/glandrum/RDKit_git/Code/GraphMol/SmilesParse/lex.yysmiles.cpp"
 
 	case YY_END_OF_BUFFER:
 		{
@@ -3376,9 +3179,6 @@ void yyfree (void * ptr , yyscan_t yyscanner)
 }
 
 #define YYTABLES_NAME "yytables"
-
-#line 367 "smiles.ll"
-
 
 #undef yysmiles_wrap
 int yysmiles_wrap( void ) { return 1; }

--- a/Code/GraphMol/SmilesParse/smiles.ll
+++ b/Code/GraphMol/SmilesParse/smiles.ll
@@ -30,6 +30,12 @@
 
 using namespace RDKit;
 
+// This will be called every time we construct a token an will allow us to track
+// the position of the current token.
+#undef YY_USER_ACTION
+#define YY_USER_ACTION current_token_position += yyleng;
+
+
 #define YY_FATAL_ERROR(msg) smiles_lexer_error(msg)
 
 void smiles_lexer_error(const char *msg) {

--- a/Code/GraphMol/SmilesParse/smiles.tab.cpp.cmake
+++ b/Code/GraphMol/SmilesParse/smiles.tab.cpp.cmake
@@ -1,8 +1,8 @@
-/* A Bison parser, made by GNU Bison 3.5.1.  */
+/* A Bison parser, made by GNU Bison 3.8.2.  */
 
 /* Bison implementation for Yacc-like parsers in C
 
-   Copyright (C) 1984, 1989-1990, 2000-2015, 2018-2020 Free Software Foundation,
+   Copyright (C) 1984, 1989-1990, 2000-2015, 2018-2021 Free Software Foundation,
    Inc.
 
    This program is free software: you can redistribute it and/or modify
@@ -16,7 +16,7 @@
    GNU General Public License for more details.
 
    You should have received a copy of the GNU General Public License
-   along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.  */
 
 /* As a special exception, you may create a larger work that contains
    part or all of the Bison parser skeleton and distribute that work
@@ -34,6 +34,10 @@
 /* C LALR(1) parser skeleton written by Richard Stallman, by
    simplifying the original so-called "semantic" parser.  */
 
+/* DO NOT RELY ON FEATURES THAT ARE NOT DOCUMENTED in the manual,
+   especially those whose name start with YY_ or yy_.  They are
+   private implementation details that can be changed or removed.  */
+
 /* All symbols defined below should begin with yy or YY, to avoid
    infringing on user name space.  This should be done even for local
    variables, as they might otherwise be expanded by user macros.
@@ -41,14 +45,11 @@
    define necessary library symbols; they are noted "INFRINGES ON
    USER NAME SPACE" below.  */
 
-/* Undocumented macros, especially those whose name start with YY_,
-   are private implementation details.  Do not rely on them.  */
+/* Identify Bison output, and Bison version.  */
+#define YYBISON 30802
 
-/* Identify Bison output.  */
-#define YYBISON 1
-
-/* Bison version.  */
-#define YYBISON_VERSION "3.5.1"
+/* Bison version string.  */
+#define YYBISON_VERSION "3.8.2"
 
 /* Skeleton name.  */
 #define YYSKELETON_NAME "yacc.c"
@@ -62,26 +63,28 @@
 /* Pull parsers.  */
 #define YYPULL 1
 
+
 /* Substitute the variable and function names.  */
-#define yyparse yysmiles_parse
-#define yylex yysmiles_lex
-#define yyerror yysmiles_error
-#define yydebug yysmiles_debug
-#define yynerrs yysmiles_nerrs
+#define yyparse         yysmiles_parse
+#define yylex           yysmiles_lex
+#define yyerror         yysmiles_error
+#define yydebug         yysmiles_debug
+#define yynerrs         yysmiles_nerrs
 
 /* First part of user prologue.  */
-#line 1 "smiles.yy"
 
-// $Id$
-//
-//  Copyright (C) 2001-2016 Randal Henne, Greg Landrum and Rational Discovery
-//  LLC
-//
-//   @@ All Rights Reserved  @@
-//
+
+  // $Id$
+  //
+  //  Copyright (C) 2001-2016 Randal Henne, Greg Landrum and Rational Discovery LLC
+  //
+  //   @@ All Rights Reserved  @@
+  //
 
 #include <cstring>
 #include <iostream>
+#include <string>
+#include <string_view>
 #include <vector>
 #include <list>
 #include <limits>
@@ -94,146 +97,151 @@
 #define YYDEBUG 1
 #include "smiles.tab.hpp"
 
-extern int yysmiles_lex(YYSTYPE *, void *, int &);
+extern int yysmiles_lex(YYSTYPE *,void *,int &, unsigned int&);
 
 using namespace RDKit;
 namespace {
-void yyErrorCleanup(std::vector<RDKit::RWMol *> *molList) {
-  for (std::vector<RDKit::RWMol *>::iterator iter = molList->begin();
-       iter != molList->end(); ++iter) {
-    SmilesParseOps::CleanupAfterParseError(*iter);
-    delete *iter;
+ void yyErrorCleanup(std::vector<RDKit::RWMol *> *molList){
+  for(std::vector<RDKit::RWMol *>::iterator iter=molList->begin();
+      iter != molList->end(); ++iter){
+      SmilesParseOps::CleanupAfterParseError(*iter);
+      delete *iter;
   }
   molList->clear();
   molList->resize(0);
+ }
 }
-}  // namespace
-void yysmiles_error(const char *input, std::vector<RDKit::RWMol *> *ms,
-                    RDKit::Atom *&, RDKit::Bond *&, unsigned int &,
-                    unsigned int &, std::list<unsigned int> *, void *, int,
-                    const char *msg) {
+
+void printSyntaxErrorMessage(std::string_view input,
+                             std::string_view err_message,
+                             unsigned int bad_token_position) {
+    // NOTE: If the input is very long, the pointer to the failed location
+    // becomes less useful. We should truncate the length of the error message
+    // to 101 chars.
+    constexpr unsigned int error_size{101};
+    constexpr unsigned int prefix_size{error_size / 2};
+    static auto truncate_input = [](const auto& input, const unsigned int pos) {
+        if ((pos >= prefix_size) && (pos + prefix_size) < input.size()) {
+            return input.substr(pos - prefix_size, error_size);
+        } else if (pos >= prefix_size) {
+            return input.substr(pos - prefix_size);
+        } else {
+            return input.substr(
+                0, std::min(input.size(), static_cast<size_t>(error_size)));
+        }
+    };
+
+    size_t num_dashes =
+        (bad_token_position >= prefix_size ? prefix_size : bad_token_position -1);
+
+    BOOST_LOG(rdErrorLog) << "SMILES Parse Error: " << err_message << " while parsing: " << input << std::endl;
+    BOOST_LOG(rdErrorLog) << "SMILES Parse Error: check for mistakes around position " << bad_token_position << ":" << std::endl;
+    BOOST_LOG(rdErrorLog) << truncate_input(input, bad_token_position) << std::endl;
+    BOOST_LOG(rdErrorLog) << std::string(num_dashes, '~') << "^\n" << std::endl;
+}
+
+void
+yysmiles_error( const char *input,
+                std::vector<RDKit::RWMol *> *ms,
+                RDKit::Atom* &,
+                RDKit::Bond* &,
+                unsigned int &,unsigned int &,
+                std::list<unsigned int> *,
+		void *,int, unsigned int bad_token_position, const char * msg )
+{
   yyErrorCleanup(ms);
-  BOOST_LOG(rdErrorLog) << "SMILES Parse Error: " << msg
-                        << " while parsing: " << input << std::endl;
+  printSyntaxErrorMessage(input, msg, bad_token_position);
 }
 
-void yysmiles_error(const char *input, std::vector<RDKit::RWMol *> *ms,
-                    std::list<unsigned int> *, void *, int, const char *msg) {
+void
+yysmiles_error( const char *input,
+                std::vector<RDKit::RWMol *> *ms,
+                std::list<unsigned int> *,
+		void *,int, unsigned int bad_token_position, const char * msg )
+{
   yyErrorCleanup(ms);
-  BOOST_LOG(rdErrorLog) << "SMILES Parse Error: " << msg
-                        << " while parsing: " << input << std::endl;
+  printSyntaxErrorMessage(input, msg, bad_token_position);
 }
 
-#line 138 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp"
 
-#ifndef YY_CAST
-#ifdef __cplusplus
-#define YY_CAST(Type, Val) static_cast<Type>(Val)
-#define YY_REINTERPRET_CAST(Type, Val) reinterpret_cast<Type>(Val)
-#else
-#define YY_CAST(Type, Val) ((Type)(Val))
-#define YY_REINTERPRET_CAST(Type, Val) ((Type)(Val))
-#endif
-#endif
-#ifndef YY_NULLPTR
-#if defined __cplusplus
-#if 201103L <= __cplusplus
-#define YY_NULLPTR nullptr
-#else
-#define YY_NULLPTR 0
-#endif
-#else
-#define YY_NULLPTR ((void *)0)
-#endif
-#endif
 
-/* Enabling verbose error messages.  */
-#ifdef YYERROR_VERBOSE
-#undef YYERROR_VERBOSE
-#define YYERROR_VERBOSE 1
-#else
-#define YYERROR_VERBOSE 0
-#endif
 
-/* Use api.header.include to #include this header
-   instead of duplicating it here.  */
-#ifndef YY_YYSMILES_SCRATCH_RDKIT_GIT_CODE_GRAPHMOL_SMILESPARSE_SMILES_TAB_HPP_INCLUDED
-#define YY_YYSMILES_SCRATCH_RDKIT_GIT_CODE_GRAPHMOL_SMILESPARSE_SMILES_TAB_HPP_INCLUDED
-/* Debug traces.  */
-#ifndef YYDEBUG
-#define YYDEBUG 0
-#endif
-#if YYDEBUG
-extern int yysmiles_debug;
-#endif
+# ifndef YY_CAST
+#  ifdef __cplusplus
+#   define YY_CAST(Type, Val) static_cast<Type> (Val)
+#   define YY_REINTERPRET_CAST(Type, Val) reinterpret_cast<Type> (Val)
+#  else
+#   define YY_CAST(Type, Val) ((Type) (Val))
+#   define YY_REINTERPRET_CAST(Type, Val) ((Type) (Val))
+#  endif
+# endif
+# ifndef YY_NULLPTR
+#  if defined __cplusplus
+#   if 201103L <= __cplusplus
+#    define YY_NULLPTR nullptr
+#   else
+#    define YY_NULLPTR 0
+#   endif
+#  else
+#   define YY_NULLPTR ((void*)0)
+#  endif
+# endif
 
-/* Token type.  */
-#ifndef YYTOKENTYPE
-#define YYTOKENTYPE
-enum yytokentype {
-  START_MOL = 258,
-  START_ATOM = 259,
-  START_BOND = 260,
-  AROMATIC_ATOM_TOKEN = 261,
-  ATOM_TOKEN = 262,
-  ORGANIC_ATOM_TOKEN = 263,
-  NONZERO_DIGIT_TOKEN = 264,
-  ZERO_TOKEN = 265,
-  GROUP_OPEN_TOKEN = 266,
-  GROUP_CLOSE_TOKEN = 267,
-  SEPARATOR_TOKEN = 268,
-  LOOP_CONNECTOR_TOKEN = 269,
-  MINUS_TOKEN = 270,
-  PLUS_TOKEN = 271,
-  H_TOKEN = 272,
-  AT_TOKEN = 273,
-  PERCENT_TOKEN = 274,
-  COLON_TOKEN = 275,
-  HASH_TOKEN = 276,
-  BOND_TOKEN = 277,
-  CHI_CLASS_TOKEN = 278,
-  ATOM_OPEN_TOKEN = 279,
-  ATOM_CLOSE_TOKEN = 280,
-  EOS_TOKEN = 281
+#include "smiles.tab.hpp"
+/* Symbol kind.  */
+enum yysymbol_kind_t
+{
+  YYSYMBOL_YYEMPTY = -2,
+  YYSYMBOL_YYEOF = 0,                      /* "end of file"  */
+  YYSYMBOL_YYerror = 1,                    /* error  */
+  YYSYMBOL_YYUNDEF = 2,                    /* "invalid token"  */
+  YYSYMBOL_START_MOL = 3,                  /* START_MOL  */
+  YYSYMBOL_START_ATOM = 4,                 /* START_ATOM  */
+  YYSYMBOL_START_BOND = 5,                 /* START_BOND  */
+  YYSYMBOL_AROMATIC_ATOM_TOKEN = 6,        /* AROMATIC_ATOM_TOKEN  */
+  YYSYMBOL_ATOM_TOKEN = 7,                 /* ATOM_TOKEN  */
+  YYSYMBOL_ORGANIC_ATOM_TOKEN = 8,         /* ORGANIC_ATOM_TOKEN  */
+  YYSYMBOL_NONZERO_DIGIT_TOKEN = 9,        /* NONZERO_DIGIT_TOKEN  */
+  YYSYMBOL_ZERO_TOKEN = 10,                /* ZERO_TOKEN  */
+  YYSYMBOL_GROUP_OPEN_TOKEN = 11,          /* GROUP_OPEN_TOKEN  */
+  YYSYMBOL_GROUP_CLOSE_TOKEN = 12,         /* GROUP_CLOSE_TOKEN  */
+  YYSYMBOL_SEPARATOR_TOKEN = 13,           /* SEPARATOR_TOKEN  */
+  YYSYMBOL_LOOP_CONNECTOR_TOKEN = 14,      /* LOOP_CONNECTOR_TOKEN  */
+  YYSYMBOL_MINUS_TOKEN = 15,               /* MINUS_TOKEN  */
+  YYSYMBOL_PLUS_TOKEN = 16,                /* PLUS_TOKEN  */
+  YYSYMBOL_H_TOKEN = 17,                   /* H_TOKEN  */
+  YYSYMBOL_AT_TOKEN = 18,                  /* AT_TOKEN  */
+  YYSYMBOL_PERCENT_TOKEN = 19,             /* PERCENT_TOKEN  */
+  YYSYMBOL_COLON_TOKEN = 20,               /* COLON_TOKEN  */
+  YYSYMBOL_HASH_TOKEN = 21,                /* HASH_TOKEN  */
+  YYSYMBOL_BOND_TOKEN = 22,                /* BOND_TOKEN  */
+  YYSYMBOL_CHI_CLASS_TOKEN = 23,           /* CHI_CLASS_TOKEN  */
+  YYSYMBOL_ATOM_OPEN_TOKEN = 24,           /* ATOM_OPEN_TOKEN  */
+  YYSYMBOL_ATOM_CLOSE_TOKEN = 25,          /* ATOM_CLOSE_TOKEN  */
+  YYSYMBOL_EOS_TOKEN = 26,                 /* EOS_TOKEN  */
+  YYSYMBOL_YYACCEPT = 27,                  /* $accept  */
+  YYSYMBOL_meta_start = 28,                /* meta_start  */
+  YYSYMBOL_bad_atom_def = 29,              /* bad_atom_def  */
+  YYSYMBOL_mol = 30,                       /* mol  */
+  YYSYMBOL_bondd = 31,                     /* bondd  */
+  YYSYMBOL_atomd = 32,                     /* atomd  */
+  YYSYMBOL_charge_element = 33,            /* charge_element  */
+  YYSYMBOL_h_element = 34,                 /* h_element  */
+  YYSYMBOL_chiral_element = 35,            /* chiral_element  */
+  YYSYMBOL_element = 36,                   /* element  */
+  YYSYMBOL_simple_atom = 37,               /* simple_atom  */
+  YYSYMBOL_ring_number = 38,               /* ring_number  */
+  YYSYMBOL_number = 39,                    /* number  */
+  YYSYMBOL_nonzero_number = 40,            /* nonzero_number  */
+  YYSYMBOL_digit = 41                      /* digit  */
 };
-#endif
+typedef enum yysymbol_kind_t yysymbol_kind_t;
 
-/* Value type.  */
-#if !defined YYSTYPE && !defined YYSTYPE_IS_DECLARED
-union YYSTYPE {
-#line 82 "smiles.yy"
 
-  int moli;
-  RDKit::Atom *atom;
-  RDKit::Bond *bond;
-  RDKit::Atom::ChiralType chiraltype;
-  int ival;
 
-#line 225 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp"
-};
-typedef union YYSTYPE YYSTYPE;
-#define YYSTYPE_IS_TRIVIAL 1
-#define YYSTYPE_IS_DECLARED 1
-#endif
-
-int yysmiles_parse(const char *input, std::vector<RDKit::RWMol *> *molList,
-                   RDKit::Atom *&lastAtom, RDKit::Bond *&lastBond,
-                   unsigned &numAtomsParsed, unsigned &numBondsParsed,
-                   std::list<unsigned int> *branchPoints, void *scanner,
-                   int &start_token);
-/* "%code provides" blocks.  */
-#line 77 "smiles.yy"
-
-#define YY_DECL \
-  int yylex(YYSTYPE *yylval_param, yyscan_t yyscanner, int &start_token)
-
-#line 242 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp"
-
-#endif /* !YY_YYSMILES_SCRATCH_RDKIT_GIT_CODE_GRAPHMOL_SMILESPARSE_SMILES_TAB_HPP_INCLUDED \
-        */
 
 #ifdef short
-#undef short
+# undef short
 #endif
 
 /* On compilers that do not define __PTRDIFF_MAX__ etc., make sure
@@ -241,11 +249,11 @@ int yysmiles_parse(const char *input, std::vector<RDKit::RWMol *> *molList,
    so that the code can choose integer types of a good width.  */
 
 #ifndef __PTRDIFF_MAX__
-#include <limits.h> /* INFRINGES ON USER NAME SPACE */
-#if defined __STDC_VERSION__ && 199901 <= __STDC_VERSION__
-#include <stdint.h> /* INFRINGES ON USER NAME SPACE */
-#define YY_STDINT_H
-#endif
+# include <limits.h> /* INFRINGES ON USER NAME SPACE */
+# if defined __STDC_VERSION__ && 199901 <= __STDC_VERSION__
+#  include <stdint.h> /* INFRINGES ON USER NAME SPACE */
+#  define YY_STDINT_H
+# endif
 #endif
 
 /* Narrow types that promote to a signed type and that can represent a
@@ -269,10 +277,22 @@ typedef int_least16_t yytype_int16;
 typedef short yytype_int16;
 #endif
 
+/* Work around bug in HP-UX 11.23, which defines these macros
+   incorrectly for preprocessor constants.  This workaround can likely
+   be removed in 2023, as HPE has promised support for HP-UX 11.23
+   (aka HP-UX 11i v2) only through the end of 2022; see Table 2 of
+   <https://h20195.www2.hpe.com/V2/getpdf.aspx/4AA4-7673ENW.pdf>.  */
+#ifdef __hpux
+# undef UINT_LEAST8_MAX
+# undef UINT_LEAST16_MAX
+# define UINT_LEAST8_MAX 255
+# define UINT_LEAST16_MAX 65535
+#endif
+
 #if defined __UINT_LEAST8_MAX__ && __UINT_LEAST8_MAX__ <= __INT_MAX__
 typedef __UINT_LEAST8_TYPE__ yytype_uint8;
-#elif (!defined __UINT_LEAST8_MAX__ && defined YY_STDINT_H && \
-       UINT_LEAST8_MAX <= INT_MAX)
+#elif (!defined __UINT_LEAST8_MAX__ && defined YY_STDINT_H \
+       && UINT_LEAST8_MAX <= INT_MAX)
 typedef uint_least8_t yytype_uint8;
 #elif !defined __UINT_LEAST8_MAX__ && UCHAR_MAX <= INT_MAX
 typedef unsigned char yytype_uint8;
@@ -282,8 +302,8 @@ typedef short yytype_uint8;
 
 #if defined __UINT_LEAST16_MAX__ && __UINT_LEAST16_MAX__ <= __INT_MAX__
 typedef __UINT_LEAST16_TYPE__ yytype_uint16;
-#elif (!defined __UINT_LEAST16_MAX__ && defined YY_STDINT_H && \
-       UINT_LEAST16_MAX <= INT_MAX)
+#elif (!defined __UINT_LEAST16_MAX__ && defined YY_STDINT_H \
+       && UINT_LEAST16_MAX <= INT_MAX)
 typedef uint_least16_t yytype_uint16;
 #elif !defined __UINT_LEAST16_MAX__ && USHRT_MAX <= INT_MAX
 typedef unsigned short yytype_uint16;
@@ -292,40 +312,42 @@ typedef int yytype_uint16;
 #endif
 
 #ifndef YYPTRDIFF_T
-#if defined __PTRDIFF_TYPE__ && defined __PTRDIFF_MAX__
-#define YYPTRDIFF_T __PTRDIFF_TYPE__
-#define YYPTRDIFF_MAXIMUM __PTRDIFF_MAX__
-#elif defined PTRDIFF_MAX
-#ifndef ptrdiff_t
-#include <stddef.h> /* INFRINGES ON USER NAME SPACE */
-#endif
-#define YYPTRDIFF_T ptrdiff_t
-#define YYPTRDIFF_MAXIMUM PTRDIFF_MAX
-#else
-#define YYPTRDIFF_T long
-#define YYPTRDIFF_MAXIMUM LONG_MAX
-#endif
+# if defined __PTRDIFF_TYPE__ && defined __PTRDIFF_MAX__
+#  define YYPTRDIFF_T __PTRDIFF_TYPE__
+#  define YYPTRDIFF_MAXIMUM __PTRDIFF_MAX__
+# elif defined PTRDIFF_MAX
+#  ifndef ptrdiff_t
+#   include <stddef.h> /* INFRINGES ON USER NAME SPACE */
+#  endif
+#  define YYPTRDIFF_T ptrdiff_t
+#  define YYPTRDIFF_MAXIMUM PTRDIFF_MAX
+# else
+#  define YYPTRDIFF_T long
+#  define YYPTRDIFF_MAXIMUM LONG_MAX
+# endif
 #endif
 
 #ifndef YYSIZE_T
-#ifdef __SIZE_TYPE__
-#define YYSIZE_T __SIZE_TYPE__
-#elif defined size_t
-#define YYSIZE_T size_t
-#elif defined __STDC_VERSION__ && 199901 <= __STDC_VERSION__
-#include <stddef.h> /* INFRINGES ON USER NAME SPACE */
-#define YYSIZE_T size_t
-#else
-#define YYSIZE_T unsigned
-#endif
+# ifdef __SIZE_TYPE__
+#  define YYSIZE_T __SIZE_TYPE__
+# elif defined size_t
+#  define YYSIZE_T size_t
+# elif defined __STDC_VERSION__ && 199901 <= __STDC_VERSION__
+#  include <stddef.h> /* INFRINGES ON USER NAME SPACE */
+#  define YYSIZE_T size_t
+# else
+#  define YYSIZE_T unsigned
+# endif
 #endif
 
-#define YYSIZE_MAXIMUM                                                   \
-  YY_CAST(YYPTRDIFF_T,                                                   \
-          (YYPTRDIFF_MAXIMUM < YY_CAST(YYSIZE_T, -1) ? YYPTRDIFF_MAXIMUM \
-                                                     : YY_CAST(YYSIZE_T, -1)))
+#define YYSIZE_MAXIMUM                                  \
+  YY_CAST (YYPTRDIFF_T,                                 \
+           (YYPTRDIFF_MAXIMUM < YY_CAST (YYSIZE_T, -1)  \
+            ? YYPTRDIFF_MAXIMUM                         \
+            : YY_CAST (YYSIZE_T, -1)))
 
-#define YYSIZEOF(X) YY_CAST(YYPTRDIFF_T, sizeof(X))
+#define YYSIZEOF(X) YY_CAST (YYPTRDIFF_T, sizeof (X))
+
 
 /* Stored state numbers (used for stacks). */
 typedef yytype_int8 yy_state_t;
@@ -334,495 +356,563 @@ typedef yytype_int8 yy_state_t;
 typedef int yy_state_fast_t;
 
 #ifndef YY_
-#if defined YYENABLE_NLS && YYENABLE_NLS
-#if ENABLE_NLS
-#include <libintl.h> /* INFRINGES ON USER NAME SPACE */
-#define YY_(Msgid) dgettext("bison-runtime", Msgid)
-#endif
-#endif
-#ifndef YY_
-#define YY_(Msgid) Msgid
-#endif
+# if defined YYENABLE_NLS && YYENABLE_NLS
+#  if ENABLE_NLS
+#   include <libintl.h> /* INFRINGES ON USER NAME SPACE */
+#   define YY_(Msgid) dgettext ("bison-runtime", Msgid)
+#  endif
+# endif
+# ifndef YY_
+#  define YY_(Msgid) Msgid
+# endif
 #endif
 
+
 #ifndef YY_ATTRIBUTE_PURE
-#if defined __GNUC__ && 2 < __GNUC__ + (96 <= __GNUC_MINOR__)
-#define YY_ATTRIBUTE_PURE __attribute__((__pure__))
-#else
-#define YY_ATTRIBUTE_PURE
-#endif
+# if defined __GNUC__ && 2 < __GNUC__ + (96 <= __GNUC_MINOR__)
+#  define YY_ATTRIBUTE_PURE __attribute__ ((__pure__))
+# else
+#  define YY_ATTRIBUTE_PURE
+# endif
 #endif
 
 #ifndef YY_ATTRIBUTE_UNUSED
-#if defined __GNUC__ && 2 < __GNUC__ + (7 <= __GNUC_MINOR__)
-#define YY_ATTRIBUTE_UNUSED __attribute__((__unused__))
-#else
-#define YY_ATTRIBUTE_UNUSED
-#endif
+# if defined __GNUC__ && 2 < __GNUC__ + (7 <= __GNUC_MINOR__)
+#  define YY_ATTRIBUTE_UNUSED __attribute__ ((__unused__))
+# else
+#  define YY_ATTRIBUTE_UNUSED
+# endif
 #endif
 
 /* Suppress unused-variable warnings by "using" E.  */
-#if !defined lint || defined __GNUC__
-#define YYUSE(E) ((void)(E))
+#if ! defined lint || defined __GNUC__
+# define YY_USE(E) ((void) (E))
 #else
-#define YYUSE(E) /* empty */
+# define YY_USE(E) /* empty */
 #endif
 
-#if defined __GNUC__ && !defined __ICC && 407 <= __GNUC__ * 100 + __GNUC_MINOR__
 /* Suppress an incorrect diagnostic about yylval being uninitialized.  */
-#define YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN                 \
-  _Pragma("GCC diagnostic push")                            \
-      _Pragma("GCC diagnostic ignored \"-Wuninitialized\"") \
-          _Pragma("GCC diagnostic ignored \"-Wmaybe-uninitialized\"")
-#define YY_IGNORE_MAYBE_UNINITIALIZED_END _Pragma("GCC diagnostic pop")
+#if defined __GNUC__ && ! defined __ICC && 406 <= __GNUC__ * 100 + __GNUC_MINOR__
+# if __GNUC__ * 100 + __GNUC_MINOR__ < 407
+#  define YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN                           \
+    _Pragma ("GCC diagnostic push")                                     \
+    _Pragma ("GCC diagnostic ignored \"-Wuninitialized\"")
+# else
+#  define YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN                           \
+    _Pragma ("GCC diagnostic push")                                     \
+    _Pragma ("GCC diagnostic ignored \"-Wuninitialized\"")              \
+    _Pragma ("GCC diagnostic ignored \"-Wmaybe-uninitialized\"")
+# endif
+# define YY_IGNORE_MAYBE_UNINITIALIZED_END      \
+    _Pragma ("GCC diagnostic pop")
 #else
-#define YY_INITIAL_VALUE(Value) Value
+# define YY_INITIAL_VALUE(Value) Value
 #endif
 #ifndef YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
-#define YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
-#define YY_IGNORE_MAYBE_UNINITIALIZED_END
+# define YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
+# define YY_IGNORE_MAYBE_UNINITIALIZED_END
 #endif
 #ifndef YY_INITIAL_VALUE
-#define YY_INITIAL_VALUE(Value) /* Nothing. */
+# define YY_INITIAL_VALUE(Value) /* Nothing. */
 #endif
 
-#if defined __cplusplus && defined __GNUC__ && !defined __ICC && 6 <= __GNUC__
-#define YY_IGNORE_USELESS_CAST_BEGIN \
-  _Pragma("GCC diagnostic push")     \
-      _Pragma("GCC diagnostic ignored \"-Wuseless-cast\"")
-#define YY_IGNORE_USELESS_CAST_END _Pragma("GCC diagnostic pop")
+#if defined __cplusplus && defined __GNUC__ && ! defined __ICC && 6 <= __GNUC__
+# define YY_IGNORE_USELESS_CAST_BEGIN                          \
+    _Pragma ("GCC diagnostic push")                            \
+    _Pragma ("GCC diagnostic ignored \"-Wuseless-cast\"")
+# define YY_IGNORE_USELESS_CAST_END            \
+    _Pragma ("GCC diagnostic pop")
 #endif
 #ifndef YY_IGNORE_USELESS_CAST_BEGIN
-#define YY_IGNORE_USELESS_CAST_BEGIN
-#define YY_IGNORE_USELESS_CAST_END
+# define YY_IGNORE_USELESS_CAST_BEGIN
+# define YY_IGNORE_USELESS_CAST_END
 #endif
 
-#define YY_ASSERT(E) ((void)(0 && (E)))
 
-#if !defined yyoverflow || YYERROR_VERBOSE
+#define YY_ASSERT(E) ((void) (0 && (E)))
+
+#if !defined yyoverflow
 
 /* The parser invokes alloca or malloc; define the necessary symbols.  */
 
-#ifdef YYSTACK_USE_ALLOCA
-#if YYSTACK_USE_ALLOCA
-#ifdef __GNUC__
-#define YYSTACK_ALLOC __builtin_alloca
-#elif defined __BUILTIN_VA_ARG_INCR
-#include <alloca.h> /* INFRINGES ON USER NAME SPACE */
-#elif defined _AIX
-#define YYSTACK_ALLOC __alloca
-#elif defined _MSC_VER
-#include <malloc.h> /* INFRINGES ON USER NAME SPACE */
-#define alloca _alloca
-#else
-#define YYSTACK_ALLOC alloca
-#if !defined _ALLOCA_H && !defined EXIT_SUCCESS
-#include <stdlib.h> /* INFRINGES ON USER NAME SPACE */
-/* Use EXIT_SUCCESS as a witness for stdlib.h.  */
-#ifndef EXIT_SUCCESS
-#define EXIT_SUCCESS 0
-#endif
-#endif
-#endif
-#endif
-#endif
+# ifdef YYSTACK_USE_ALLOCA
+#  if YYSTACK_USE_ALLOCA
+#   ifdef __GNUC__
+#    define YYSTACK_ALLOC __builtin_alloca
+#   elif defined __BUILTIN_VA_ARG_INCR
+#    include <alloca.h> /* INFRINGES ON USER NAME SPACE */
+#   elif defined _AIX
+#    define YYSTACK_ALLOC __alloca
+#   elif defined _MSC_VER
+#    include <malloc.h> /* INFRINGES ON USER NAME SPACE */
+#    define alloca _alloca
+#   else
+#    define YYSTACK_ALLOC alloca
+#    if ! defined _ALLOCA_H && ! defined EXIT_SUCCESS
+#     include <stdlib.h> /* INFRINGES ON USER NAME SPACE */
+      /* Use EXIT_SUCCESS as a witness for stdlib.h.  */
+#     ifndef EXIT_SUCCESS
+#      define EXIT_SUCCESS 0
+#     endif
+#    endif
+#   endif
+#  endif
+# endif
 
-#ifdef YYSTACK_ALLOC
-/* Pacify GCC's 'empty if-body' warning.  */
-#define YYSTACK_FREE(Ptr) \
-  do { /* empty */        \
-    ;                     \
-  } while (0)
-#ifndef YYSTACK_ALLOC_MAXIMUM
-/* The OS might guarantee only one guard page at the bottom of the stack,
-   and a page size can be as small as 4096 bytes.  So we cannot safely
-   invoke alloca (N) if N exceeds 4096.  Use a slightly smaller number
-   to allow for a few compiler-allocated temporary stack slots.  */
-#define YYSTACK_ALLOC_MAXIMUM 4032 /* reasonable circa 2006 */
-#endif
-#else
-#define YYSTACK_ALLOC YYMALLOC
-#define YYSTACK_FREE YYFREE
-#ifndef YYSTACK_ALLOC_MAXIMUM
-#define YYSTACK_ALLOC_MAXIMUM YYSIZE_MAXIMUM
-#endif
-#if (defined __cplusplus && !defined EXIT_SUCCESS && \
-     !((defined YYMALLOC || defined malloc) &&       \
-       (defined YYFREE || defined free)))
-#include <stdlib.h> /* INFRINGES ON USER NAME SPACE */
-#ifndef EXIT_SUCCESS
-#define EXIT_SUCCESS 0
-#endif
-#endif
-#ifndef YYMALLOC
-#define YYMALLOC malloc
-#if !defined malloc && !defined EXIT_SUCCESS
-void *malloc(YYSIZE_T); /* INFRINGES ON USER NAME SPACE */
-#endif
-#endif
-#ifndef YYFREE
-#define YYFREE free
-#if !defined free && !defined EXIT_SUCCESS
-void free(void *);      /* INFRINGES ON USER NAME SPACE */
-#endif
-#endif
-#endif
-#endif /* ! defined yyoverflow || YYERROR_VERBOSE */
+# ifdef YYSTACK_ALLOC
+   /* Pacify GCC's 'empty if-body' warning.  */
+#  define YYSTACK_FREE(Ptr) do { /* empty */; } while (0)
+#  ifndef YYSTACK_ALLOC_MAXIMUM
+    /* The OS might guarantee only one guard page at the bottom of the stack,
+       and a page size can be as small as 4096 bytes.  So we cannot safely
+       invoke alloca (N) if N exceeds 4096.  Use a slightly smaller number
+       to allow for a few compiler-allocated temporary stack slots.  */
+#   define YYSTACK_ALLOC_MAXIMUM 4032 /* reasonable circa 2006 */
+#  endif
+# else
+#  define YYSTACK_ALLOC YYMALLOC
+#  define YYSTACK_FREE YYFREE
+#  ifndef YYSTACK_ALLOC_MAXIMUM
+#   define YYSTACK_ALLOC_MAXIMUM YYSIZE_MAXIMUM
+#  endif
+#  if (defined __cplusplus && ! defined EXIT_SUCCESS \
+       && ! ((defined YYMALLOC || defined malloc) \
+             && (defined YYFREE || defined free)))
+#   include <stdlib.h> /* INFRINGES ON USER NAME SPACE */
+#   ifndef EXIT_SUCCESS
+#    define EXIT_SUCCESS 0
+#   endif
+#  endif
+#  ifndef YYMALLOC
+#   define YYMALLOC malloc
+#   if ! defined malloc && ! defined EXIT_SUCCESS
+void *malloc (YYSIZE_T); /* INFRINGES ON USER NAME SPACE */
+#   endif
+#  endif
+#  ifndef YYFREE
+#   define YYFREE free
+#   if ! defined free && ! defined EXIT_SUCCESS
+void free (void *); /* INFRINGES ON USER NAME SPACE */
+#   endif
+#  endif
+# endif
+#endif /* !defined yyoverflow */
 
-#if (!defined yyoverflow &&   \
-     (!defined __cplusplus || \
-      (defined YYSTYPE_IS_TRIVIAL && YYSTYPE_IS_TRIVIAL)))
+#if (! defined yyoverflow \
+     && (! defined __cplusplus \
+         || (defined YYSTYPE_IS_TRIVIAL && YYSTYPE_IS_TRIVIAL)))
 
 /* A type that is properly aligned for any stack member.  */
-union yyalloc {
+union yyalloc
+{
   yy_state_t yyss_alloc;
   YYSTYPE yyvs_alloc;
 };
 
 /* The size of the maximum gap between one aligned stack and the next.  */
-#define YYSTACK_GAP_MAXIMUM (YYSIZEOF(union yyalloc) - 1)
+# define YYSTACK_GAP_MAXIMUM (YYSIZEOF (union yyalloc) - 1)
 
 /* The size of an array large to enough to hold all stacks, each with
    N elements.  */
-#define YYSTACK_BYTES(N) \
-  ((N) * (YYSIZEOF(yy_state_t) + YYSIZEOF(YYSTYPE)) + YYSTACK_GAP_MAXIMUM)
+# define YYSTACK_BYTES(N) \
+     ((N) * (YYSIZEOF (yy_state_t) + YYSIZEOF (YYSTYPE)) \
+      + YYSTACK_GAP_MAXIMUM)
 
-#define YYCOPY_NEEDED 1
+# define YYCOPY_NEEDED 1
 
 /* Relocate STACK from its old location to the new one.  The
    local variables YYSIZE and YYSTACKSIZE give the old and new number of
    elements in the stack, and YYPTR gives the new location of the
    stack.  Advance YYPTR to a properly aligned location for the next
    stack.  */
-#define YYSTACK_RELOCATE(Stack_alloc, Stack)                           \
-  do {                                                                 \
-    YYPTRDIFF_T yynewbytes;                                            \
-    YYCOPY(&yyptr->Stack_alloc, Stack, yysize);                        \
-    Stack = &yyptr->Stack_alloc;                                       \
-    yynewbytes = yystacksize * YYSIZEOF(*Stack) + YYSTACK_GAP_MAXIMUM; \
-    yyptr += yynewbytes / YYSIZEOF(*yyptr);                            \
-  } while (0)
+# define YYSTACK_RELOCATE(Stack_alloc, Stack)                           \
+    do                                                                  \
+      {                                                                 \
+        YYPTRDIFF_T yynewbytes;                                         \
+        YYCOPY (&yyptr->Stack_alloc, Stack, yysize);                    \
+        Stack = &yyptr->Stack_alloc;                                    \
+        yynewbytes = yystacksize * YYSIZEOF (*Stack) + YYSTACK_GAP_MAXIMUM; \
+        yyptr += yynewbytes / YYSIZEOF (*yyptr);                        \
+      }                                                                 \
+    while (0)
 
 #endif
 
 #if defined YYCOPY_NEEDED && YYCOPY_NEEDED
 /* Copy COUNT objects from SRC to DST.  The source and destination do
    not overlap.  */
-#ifndef YYCOPY
-#if defined __GNUC__ && 1 < __GNUC__
-#define YYCOPY(Dst, Src, Count) \
-  __builtin_memcpy(Dst, Src, YY_CAST(YYSIZE_T, (Count)) * sizeof(*(Src)))
-#else
-#define YYCOPY(Dst, Src, Count)                                  \
-  do {                                                           \
-    YYPTRDIFF_T yyi;                                             \
-    for (yyi = 0; yyi < (Count); yyi++) (Dst)[yyi] = (Src)[yyi]; \
-  } while (0)
-#endif
-#endif
+# ifndef YYCOPY
+#  if defined __GNUC__ && 1 < __GNUC__
+#   define YYCOPY(Dst, Src, Count) \
+      __builtin_memcpy (Dst, Src, YY_CAST (YYSIZE_T, (Count)) * sizeof (*(Src)))
+#  else
+#   define YYCOPY(Dst, Src, Count)              \
+      do                                        \
+        {                                       \
+          YYPTRDIFF_T yyi;                      \
+          for (yyi = 0; yyi < (Count); yyi++)   \
+            (Dst)[yyi] = (Src)[yyi];            \
+        }                                       \
+      while (0)
+#  endif
+# endif
 #endif /* !YYCOPY_NEEDED */
 
 /* YYFINAL -- State number of the termination state.  */
-#define YYFINAL 33
+#define YYFINAL  33
 /* YYLAST -- Last index in YYTABLE.  */
-#define YYLAST 149
+#define YYLAST   149
 
 /* YYNTOKENS -- Number of terminals.  */
-#define YYNTOKENS 27
+#define YYNTOKENS  27
 /* YYNNTS -- Number of nonterminals.  */
-#define YYNNTS 15
+#define YYNNTS  15
 /* YYNRULES -- Number of rules.  */
-#define YYNRULES 73
+#define YYNRULES  73
 /* YYNSTATES -- Number of states.  */
-#define YYNSTATES 107
+#define YYNSTATES  107
 
-#define YYUNDEFTOK 2
-#define YYMAXUTOK 281
+/* YYMAXUTOK -- Last valid token kind.  */
+#define YYMAXUTOK   281
+
 
 /* YYTRANSLATE(TOKEN-NUM) -- Symbol number corresponding to TOKEN-NUM
    as returned by yylex, with out-of-bounds checking.  */
-#define YYTRANSLATE(YYX) \
-  (0 <= (YYX) && (YYX) <= YYMAXUTOK ? yytranslate[YYX] : YYUNDEFTOK)
+#define YYTRANSLATE(YYX)                                \
+  (0 <= (YYX) && (YYX) <= YYMAXUTOK                     \
+   ? YY_CAST (yysymbol_kind_t, yytranslate[YYX])        \
+   : YYSYMBOL_YYUNDEF)
 
 /* YYTRANSLATE[TOKEN-NUM] -- Symbol number corresponding to TOKEN-NUM
    as returned by yylex.  */
-static const yytype_int8 yytranslate[] = {
-    0,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2, 2, 2, 2,
-    2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2, 2, 2, 2,
-    2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2, 2, 2, 2,
-    2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2, 2, 2, 2,
-    2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2, 2, 2, 2,
-    2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2, 2, 2, 2,
-    2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2, 2, 2, 2,
-    2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2, 2, 2, 2,
-    2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2, 2, 2, 2,
-    2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2, 2, 2, 2,
-    2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2, 2, 2, 2,
-    2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2, 2, 2, 2,
-    2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2, 2, 2, 2,
-    2,  2,  2,  2,  2,  2,  2,  2,  2,  1,  2,  3,  4,  5,  6,  7, 8, 9, 10,
-    11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26};
+static const yytype_int8 yytranslate[] =
+{
+       0,     2,     2,     2,     2,     2,     2,     2,     2,     2,
+       2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
+       2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
+       2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
+       2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
+       2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
+       2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
+       2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
+       2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
+       2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
+       2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
+       2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
+       2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
+       2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
+       2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
+       2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
+       2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
+       2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
+       2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
+       2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
+       2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
+       2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
+       2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
+       2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
+       2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
+       2,     2,     2,     2,     2,     2,     1,     2,     3,     4,
+       5,     6,     7,     8,     9,    10,    11,    12,    13,    14,
+      15,    16,    17,    18,    19,    20,    21,    22,    23,    24,
+      25,    26
+};
 
 #if YYDEBUG
 /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
-static const yytype_int16 yyrline[] = {
-    0,   114, 114, 117, 121, 124, 128, 132, 135, 140, 143, 151, 152, 153, 154,
-    162, 173, 184, 205, 214, 220, 241, 265, 284, 295, 317, 326, 339, 340, 346,
-    347, 353, 361, 362, 363, 364, 365, 366, 367, 371, 372, 373, 374, 375, 376,
-    377, 378, 379, 383, 384, 385, 386, 387, 391, 392, 393, 394, 395, 396, 400,
-    401, 405, 406, 407, 408, 409, 410, 411, 415, 416, 420, 421, 432, 433};
+static const yytype_int16 yyrline[] =
+{
+       0,   147,   147,   150,   154,   157,   161,   165,   168,   173,
+     176,   184,   185,   186,   187,   195,   206,   217,   238,   247,
+     253,   274,   298,   317,   328,   350,   359,   372,   373,   379,
+     380,   386,   394,   395,   396,   397,   398,   399,   400,   404,
+     405,   406,   407,   408,   409,   410,   411,   412,   416,   417,
+     418,   419,   420,   424,   425,   426,   427,   428,   429,   433,
+     434,   438,   439,   440,   441,   442,   443,   444,   448,   449,
+     453,   454,   465,   466
+};
 #endif
 
-#if YYDEBUG || YYERROR_VERBOSE || 0
+/** Accessing symbol of state STATE.  */
+#define YY_ACCESSING_SYMBOL(State) YY_CAST (yysymbol_kind_t, yystos[State])
+
+#if YYDEBUG || 0
+/* The user-facing name of the symbol whose (internal) number is
+   YYSYMBOL.  No bounds checking.  */
+static const char *yysymbol_name (yysymbol_kind_t yysymbol) YY_ATTRIBUTE_UNUSED;
+
 /* YYTNAME[SYMBOL-NUM] -- String name of the symbol SYMBOL-NUM.
    First, the terminals, then, starting at YYNTOKENS, nonterminals.  */
-static const char *const yytname[] = {"$end",
-                                      "error",
-                                      "$undefined",
-                                      "START_MOL",
-                                      "START_ATOM",
-                                      "START_BOND",
-                                      "AROMATIC_ATOM_TOKEN",
-                                      "ATOM_TOKEN",
-                                      "ORGANIC_ATOM_TOKEN",
-                                      "NONZERO_DIGIT_TOKEN",
-                                      "ZERO_TOKEN",
-                                      "GROUP_OPEN_TOKEN",
-                                      "GROUP_CLOSE_TOKEN",
-                                      "SEPARATOR_TOKEN",
-                                      "LOOP_CONNECTOR_TOKEN",
-                                      "MINUS_TOKEN",
-                                      "PLUS_TOKEN",
-                                      "H_TOKEN",
-                                      "AT_TOKEN",
-                                      "PERCENT_TOKEN",
-                                      "COLON_TOKEN",
-                                      "HASH_TOKEN",
-                                      "BOND_TOKEN",
-                                      "CHI_CLASS_TOKEN",
-                                      "ATOM_OPEN_TOKEN",
-                                      "ATOM_CLOSE_TOKEN",
-                                      "EOS_TOKEN",
-                                      "$accept",
-                                      "meta_start",
-                                      "bad_atom_def",
-                                      "mol",
-                                      "bondd",
-                                      "atomd",
-                                      "charge_element",
-                                      "h_element",
-                                      "chiral_element",
-                                      "element",
-                                      "simple_atom",
-                                      "ring_number",
-                                      "number",
-                                      "nonzero_number",
-                                      "digit",
-                                      YY_NULLPTR};
-#endif
+static const char *const yytname[] =
+{
+  "\"end of file\"", "error", "\"invalid token\"", "START_MOL",
+  "START_ATOM", "START_BOND", "AROMATIC_ATOM_TOKEN", "ATOM_TOKEN",
+  "ORGANIC_ATOM_TOKEN", "NONZERO_DIGIT_TOKEN", "ZERO_TOKEN",
+  "GROUP_OPEN_TOKEN", "GROUP_CLOSE_TOKEN", "SEPARATOR_TOKEN",
+  "LOOP_CONNECTOR_TOKEN", "MINUS_TOKEN", "PLUS_TOKEN", "H_TOKEN",
+  "AT_TOKEN", "PERCENT_TOKEN", "COLON_TOKEN", "HASH_TOKEN", "BOND_TOKEN",
+  "CHI_CLASS_TOKEN", "ATOM_OPEN_TOKEN", "ATOM_CLOSE_TOKEN", "EOS_TOKEN",
+  "$accept", "meta_start", "bad_atom_def", "mol", "bondd", "atomd",
+  "charge_element", "h_element", "chiral_element", "element",
+  "simple_atom", "ring_number", "number", "nonzero_number", "digit", YY_NULLPTR
+};
 
-#ifdef YYPRINT
-/* YYTOKNUM[NUM] -- (External) token number corresponding to the
-   (internal) symbol number NUM (which must be that of a token).  */
-static const yytype_int16 yytoknum[] = {
-    0,   256, 257, 258, 259, 260, 261, 262, 263, 264, 265, 266, 267, 268,
-    269, 270, 271, 272, 273, 274, 275, 276, 277, 278, 279, 280, 281};
+static const char *
+yysymbol_name (yysymbol_kind_t yysymbol)
+{
+  return yytname[yysymbol];
+}
 #endif
 
 #define YYPACT_NINF (-30)
 
-#define yypact_value_is_default(Yyn) ((Yyn) == YYPACT_NINF)
+#define yypact_value_is_default(Yyn) \
+  ((Yyn) == YYPACT_NINF)
 
 #define YYTABLE_NINF (-30)
 
-#define yytable_value_is_error(Yyn) 0
+#define yytable_value_is_error(Yyn) \
+  0
 
 /* YYPACT[STATE-NUM] -- Index in YYTABLE of the portion describing
    STATE-NUM.  */
-static const yytype_int16 yypact[] = {
-    135, -25, 33,  70,  -12, 5,   -30, -30, -30, 96,  110, -30, -30, -30,
-    -30, -30, -10, 90,  13,  90,  90,  -30, -13, -30, 77,  21,  14,  4,
-    120, 99,  -30, -30, 26,  -30, 47,  -30, 39,  -30, -30, -30, 18,  -30,
-    33,  10,  137, 10,  -30, -30, -30, 13,  90,  -30, -30, -30, 39,  -30,
-    -30, 52,  -1,  13,  63,  13,  -30, 48,  13,  -30, -30, -30, -30, 13,
-    -30, 33,  33,  -30, -30, -30, -30, 99,  99,  -30, -30, -30, -30, -30,
-    -30, -30, -30, -30, -30, 13,  -30, 64,  -30, -30, -30, 59,  -30, -30,
-    -30, 76,  -30, 121, -30, 133, -30, 72,  -30};
+static const yytype_int16 yypact[] =
+{
+     135,   -25,    33,    70,   -12,     5,   -30,   -30,   -30,    96,
+     110,   -30,   -30,   -30,   -30,   -30,   -10,    90,    13,    90,
+      90,   -30,   -13,   -30,    77,    21,    14,     4,   120,    99,
+     -30,   -30,    26,   -30,    47,   -30,    39,   -30,   -30,   -30,
+      18,   -30,    33,    10,   137,    10,   -30,   -30,   -30,    13,
+      90,   -30,   -30,   -30,    39,   -30,   -30,    52,    -1,    13,
+      63,    13,   -30,    48,    13,   -30,   -30,   -30,   -30,    13,
+     -30,    33,    33,   -30,   -30,   -30,   -30,    99,    99,   -30,
+     -30,   -30,   -30,   -30,   -30,   -30,   -30,   -30,   -30,    13,
+     -30,    64,   -30,   -30,   -30,    59,   -30,   -30,   -30,    76,
+     -30,   121,   -30,   133,   -30,    72,   -30
+};
 
 /* YYDEFACT[STATE-NUM] -- Default reduction number in state STATE-NUM.
    Performed when YYTABLE does not specify something else to do.  Zero
    means the default is an error.  */
-static const yytype_int8 yydefact[] = {
-    0,  0,  0,  0,  7,  0,  10, 60, 59, 0,  2,  15, 29, 55, 70, 68, 39, 0,
-    0,  0,  0,  4,  0,  14, 32, 45, 48, 53, 0,  69, 28, 27, 6,  1,  0,  9,
-    0,  53, 72, 73, 0,  26, 0,  0,  0,  0,  16, 20, 61, 41, 0,  13, 57, 11,
-    14, 12, 3,  36, 33, 46, 49, 51, 56, 40, 0,  54, 71, 5,  8,  0,  31, 0,
-    0,  23, 19, 18, 22, 0,  0,  17, 21, 43, 37, 38, 34, 35, 47, 50, 52, 42,
-    58, 0,  25, 24, 62, 0,  44, 30, 63, 0,  64, 0,  65, 0,  66, 0,  67};
+static const yytype_int8 yydefact[] =
+{
+       0,     0,     0,     0,     7,     0,    10,    60,    59,     0,
+       2,    15,    29,    55,    70,    68,    39,     0,     0,     0,
+       0,     4,     0,    14,    32,    45,    48,    53,     0,    69,
+      28,    27,     6,     1,     0,     9,     0,    53,    72,    73,
+       0,    26,     0,     0,     0,     0,    16,    20,    61,    41,
+       0,    13,    57,    11,    14,    12,     3,    36,    33,    46,
+      49,    51,    56,    40,     0,    54,    71,     5,     8,     0,
+      31,     0,     0,    23,    19,    18,    22,     0,     0,    17,
+      21,    43,    37,    38,    34,    35,    47,    50,    52,    42,
+      58,     0,    25,    24,    62,     0,    44,    30,    63,     0,
+      64,     0,    65,     0,    66,     0,    67
+};
 
 /* YYPGOTO[NTERM-NUM].  */
-static const yytype_int8 yypgoto[] = {-30, -30, 43, -30, -30, 11,  -7, -30,
-                                      -30, -30, 8,  104, -14, -30, -29};
+static const yytype_int8 yypgoto[] =
+{
+     -30,   -30,    43,   -30,   -30,    11,    -7,   -30,   -30,   -30,
+       8,   104,   -14,   -30,   -29
+};
 
 /* YYDEFGOTO[NTERM-NUM].  */
-static const yytype_int8 yydefgoto[] = {-1, 5,  53, 10, 32, 11, 23, 24,
-                                        25, 26, 12, 47, 28, 29, 48};
+static const yytype_int8 yydefgoto[] =
+{
+       0,     5,    53,    10,    32,    11,    23,    24,    25,    26,
+      12,    47,    28,    29,    48
+};
 
 /* YYTABLE[YYPACT[STATE-NUM]] -- What to do in state STATE-NUM.  If
    positive, shift that token.  If negative, reduce the rule whose
    number is the opposite.  If YYTABLE_NINF, syntax error.  */
-static const yytype_int8 yytable[] = {
-    66, 6,  36,  30,  52,  33, 34,  49, 14, 15,  31, 27, 54, 56,  22,  84, 7,
-    37, 8,  38,  39,  46,  14, 15,  7,  37, 8,   37, 37, 44, -29, 35,  60, 71,
-    9,  81, 65,  61,  59,  7,  72,  8,  9,  83,  85, 86, 21, 88,  94,  95, 90,
-    73, 67, 74,  75,  91,  79, 9,   37, 69, 51,  14, 15, 55, 70,  89,  99, 82,
-    38, 39, 101, 98,  103, 68, 105, 96, 7,  13,  8,  14, 15, 87,  92,  93, 106,
-    38, 39, 16,  100, 97,  17, 18,  57, 58, 19,  20, 7,  13, 8,   14,  15, 0,
-    7,  13, 8,   14,  15,  16, 38,  39, 17, 18,  0,  16, 50, 20,  7,   18, 8,
-    38, 39, 40,  41,  42,  0,  43,  7,  62, 8,   44, 38, 39, 45,  102, 9,  0,
-    1,  63, 2,   3,   4,   64, 38,  39, 0,  104, 77, 76, 78, 80};
+static const yytype_int8 yytable[] =
+{
+      66,     6,    36,    30,    52,    33,    34,    49,    14,    15,
+      31,    27,    54,    56,    22,    84,     7,    37,     8,    38,
+      39,    46,    14,    15,     7,    37,     8,    37,    37,    44,
+     -29,    35,    60,    71,     9,    81,    65,    61,    59,     7,
+      72,     8,     9,    83,    85,    86,    21,    88,    94,    95,
+      90,    73,    67,    74,    75,    91,    79,     9,    37,    69,
+      51,    14,    15,    55,    70,    89,    99,    82,    38,    39,
+     101,    98,   103,    68,   105,    96,     7,    13,     8,    14,
+      15,    87,    92,    93,   106,    38,    39,    16,   100,    97,
+      17,    18,    57,    58,    19,    20,     7,    13,     8,    14,
+      15,     0,     7,    13,     8,    14,    15,    16,    38,    39,
+      17,    18,     0,    16,    50,    20,     7,    18,     8,    38,
+      39,    40,    41,    42,     0,    43,     7,    62,     8,    44,
+      38,    39,    45,   102,     9,     0,     1,    63,     2,     3,
+       4,    64,    38,    39,     0,   104,    77,    76,    78,    80
+};
 
-static const yytype_int8 yycheck[] = {
-    29, 26, 9,  15, 18,  0,  1,   17, 9,  10, 22, 3,  19, 26, 3,  16, 6,
-    9,  8,  9,  10, 10,  9,  10,  6,  17, 8,  19, 20, 19, 26, 26, 18, 15,
-    24, 49, 28, 23, 17,  6,  22,  8,  24, 57, 58, 59, 3,  61, 77, 78, 64,
-    40, 26, 42, 43, 69,  45, 24,  50, 20, 17, 9,  10, 20, 25, 17, 95, 15,
-    9,  10, 99, 12, 101, 26, 103, 89, 6,  7,  8,  9,  10, 18, 71, 72, 12,
-    9,  10, 17, 12, 25,  20, 21,  15, 16, 24, 25, 6,  7,  8,  9,  10, -1,
-    6,  7,  8,  9,  10,  17, 9,   10, 20, 21, -1, 17, 24, 25, 6,  21, 8,
-    9,  10, 11, 12, 13,  -1, 15,  6,  7,  8,  19, 9,  10, 22, 12, 24, -1,
-    1,  17, 3,  4,  5,   21, 9,   10, -1, 12, 9,  43, 11, 45};
+static const yytype_int8 yycheck[] =
+{
+      29,    26,     9,    15,    18,     0,     1,    17,     9,    10,
+      22,     3,    19,    26,     3,    16,     6,     9,     8,     9,
+      10,    10,     9,    10,     6,    17,     8,    19,    20,    19,
+      26,    26,    18,    15,    24,    49,    28,    23,    17,     6,
+      22,     8,    24,    57,    58,    59,     3,    61,    77,    78,
+      64,    40,    26,    42,    43,    69,    45,    24,    50,    20,
+      17,     9,    10,    20,    25,    17,    95,    15,     9,    10,
+      99,    12,   101,    26,   103,    89,     6,     7,     8,     9,
+      10,    18,    71,    72,    12,     9,    10,    17,    12,    25,
+      20,    21,    15,    16,    24,    25,     6,     7,     8,     9,
+      10,    -1,     6,     7,     8,     9,    10,    17,     9,    10,
+      20,    21,    -1,    17,    24,    25,     6,    21,     8,     9,
+      10,    11,    12,    13,    -1,    15,     6,     7,     8,    19,
+       9,    10,    22,    12,    24,    -1,     1,    17,     3,     4,
+       5,    21,     9,    10,    -1,    12,     9,    43,    11,    45
+};
 
-/* YYSTOS[STATE-NUM] -- The (internal number of the) accessing
-   symbol of state STATE-NUM.  */
-static const yytype_int8 yystos[] = {
-    0,  1,  3,  4,  5,  28, 26, 6,  8,  24, 30, 32, 37, 7,  9,  10, 17, 20,
-    21, 24, 25, 29, 32, 33, 34, 35, 36, 37, 39, 40, 15, 22, 31, 0,  1,  26,
-    33, 37, 9,  10, 11, 12, 13, 15, 19, 22, 32, 38, 41, 17, 24, 29, 39, 29,
-    33, 29, 26, 15, 16, 17, 18, 23, 7,  17, 21, 37, 41, 26, 26, 20, 25, 15,
-    22, 32, 32, 32, 38, 9,  11, 32, 38, 39, 15, 39, 16, 39, 39, 18, 39, 17,
-    39, 39, 32, 32, 41, 41, 39, 25, 12, 41, 12, 41, 12, 41, 12, 41, 12};
+/* YYSTOS[STATE-NUM] -- The symbol kind of the accessing symbol of
+   state STATE-NUM.  */
+static const yytype_int8 yystos[] =
+{
+       0,     1,     3,     4,     5,    28,    26,     6,     8,    24,
+      30,    32,    37,     7,     9,    10,    17,    20,    21,    24,
+      25,    29,    32,    33,    34,    35,    36,    37,    39,    40,
+      15,    22,    31,     0,     1,    26,    33,    37,     9,    10,
+      11,    12,    13,    15,    19,    22,    32,    38,    41,    17,
+      24,    29,    39,    29,    33,    29,    26,    15,    16,    17,
+      18,    23,     7,    17,    21,    37,    41,    26,    26,    20,
+      25,    15,    22,    32,    32,    32,    38,     9,    11,    32,
+      38,    39,    15,    39,    16,    39,    39,    18,    39,    17,
+      39,    39,    32,    32,    41,    41,    39,    25,    12,    41,
+      12,    41,    12,    41,    12,    41,    12
+};
 
-/* YYR1[YYN] -- Symbol number of symbol that rule YYN derives.  */
-static const yytype_int8 yyr1[] = {
-    0,  27, 28, 28, 28, 28, 28, 28, 28, 28, 28, 29, 29, 29, 29, 30, 30, 30, 30,
-    30, 30, 30, 30, 30, 30, 30, 30, 31, 31, 32, 32, 32, 33, 33, 33, 33, 33, 33,
-    33, 34, 34, 34, 34, 34, 34, 34, 34, 34, 35, 35, 35, 35, 35, 36, 36, 36, 36,
-    36, 36, 37, 37, 38, 38, 38, 38, 38, 38, 38, 39, 39, 40, 40, 41, 41};
+/* YYR1[RULE-NUM] -- Symbol kind of the left-hand side of rule RULE-NUM.  */
+static const yytype_int8 yyr1[] =
+{
+       0,    27,    28,    28,    28,    28,    28,    28,    28,    28,
+      28,    29,    29,    29,    29,    30,    30,    30,    30,    30,
+      30,    30,    30,    30,    30,    30,    30,    31,    31,    32,
+      32,    32,    33,    33,    33,    33,    33,    33,    33,    34,
+      34,    34,    34,    34,    34,    34,    34,    34,    35,    35,
+      35,    35,    35,    36,    36,    36,    36,    36,    36,    37,
+      37,    38,    38,    38,    38,    38,    38,    38,    39,    39,
+      40,    40,    41,    41
+};
 
-/* YYR2[YYN] -- Number of symbols on the right hand side of rule YYN.  */
-static const yytype_int8 yyr2[] = {
-    0, 2, 2, 3, 2, 3, 2, 1, 3, 2, 2, 2, 2, 2, 1, 1, 2, 3, 3, 3, 2, 3, 3, 3, 4,
-    4, 2, 1, 1, 1, 5, 3, 1, 2, 3, 3, 2, 3, 3, 1, 2, 2, 3, 3, 4, 1, 2, 3, 1, 2,
-    3, 2, 3, 1, 2, 1, 2, 2, 3, 1, 1, 1, 3, 4, 5, 6, 7, 8, 1, 1, 1, 2, 1, 1};
+/* YYR2[RULE-NUM] -- Number of symbols on the right-hand side of rule RULE-NUM.  */
+static const yytype_int8 yyr2[] =
+{
+       0,     2,     2,     3,     2,     3,     2,     1,     3,     2,
+       2,     2,     2,     2,     1,     1,     2,     3,     3,     3,
+       2,     3,     3,     3,     4,     4,     2,     1,     1,     1,
+       5,     3,     1,     2,     3,     3,     2,     3,     3,     1,
+       2,     2,     3,     3,     4,     1,     2,     3,     1,     2,
+       3,     2,     3,     1,     2,     1,     2,     2,     3,     1,
+       1,     1,     3,     4,     5,     6,     7,     8,     1,     1,
+       1,     2,     1,     1
+};
 
-#define yyerrok (yyerrstatus = 0)
-#define yyclearin (yychar = YYEMPTY)
-#define YYEMPTY (-2)
-#define YYEOF 0
 
-#define YYACCEPT goto yyacceptlab
-#define YYABORT goto yyabortlab
-#define YYERROR goto yyerrorlab
+enum { YYENOMEM = -2 };
 
-#define YYRECOVERING() (!!yyerrstatus)
+#define yyerrok         (yyerrstatus = 0)
+#define yyclearin       (yychar = YYEMPTY)
+
+#define YYACCEPT        goto yyacceptlab
+#define YYABORT         goto yyabortlab
+#define YYERROR         goto yyerrorlab
+#define YYNOMEM         goto yyexhaustedlab
+
+
+#define YYRECOVERING()  (!!yyerrstatus)
 
 #define YYBACKUP(Token, Value)                                    \
   do                                                              \
-    if (yychar == YYEMPTY) {                                      \
-      yychar = (Token);                                           \
-      yylval = (Value);                                           \
-      YYPOPSTACK(yylen);                                          \
-      yystate = *yyssp;                                           \
-      goto yybackup;                                              \
-    } else {                                                      \
-      yyerror(input, molList, lastAtom, lastBond, numAtomsParsed, \
-              numBondsParsed, branchPoints, scanner, start_token, \
-              YY_("syntax error: cannot back up"));               \
-      YYERROR;                                                    \
-    }                                                             \
+    if (yychar == YYEMPTY)                                        \
+      {                                                           \
+        yychar = (Token);                                         \
+        yylval = (Value);                                         \
+        YYPOPSTACK (yylen);                                       \
+        yystate = *yyssp;                                         \
+        goto yybackup;                                            \
+      }                                                           \
+    else                                                          \
+      {                                                           \
+        yyerror (input, molList, lastAtom, lastBond, numAtomsParsed, numBondsParsed, branchPoints, scanner, start_token, current_token_position, YY_("syntax error: cannot back up")); \
+        YYERROR;                                                  \
+      }                                                           \
   while (0)
 
-/* Error token number */
-#define YYTERROR 1
-#define YYERRCODE 256
+/* Backward compatibility with an undocumented macro.
+   Use YYerror or YYUNDEF. */
+#define YYERRCODE YYUNDEF
+
 
 /* Enable debugging if requested.  */
 #if YYDEBUG
 
-#ifndef YYFPRINTF
-#include <stdio.h> /* INFRINGES ON USER NAME SPACE */
-#define YYFPRINTF fprintf
-#endif
+# ifndef YYFPRINTF
+#  include <stdio.h> /* INFRINGES ON USER NAME SPACE */
+#  define YYFPRINTF fprintf
+# endif
 
-#define YYDPRINTF(Args)          \
-  do {                           \
-    if (yydebug) YYFPRINTF Args; \
-  } while (0)
+# define YYDPRINTF(Args)                        \
+do {                                            \
+  if (yydebug)                                  \
+    YYFPRINTF Args;                             \
+} while (0)
 
-/* This macro is provided for backward compatibility. */
-#ifndef YY_LOCATION_PRINT
-#define YY_LOCATION_PRINT(File, Loc) ((void)0)
-#endif
 
-#define YY_SYMBOL_PRINT(Title, Type, Value, Location)                          \
-  do {                                                                         \
-    if (yydebug) {                                                             \
-      YYFPRINTF(stderr, "%s ", Title);                                         \
-      yy_symbol_print(stderr, Type, Value, input, molList, lastAtom, lastBond, \
-                      numAtomsParsed, numBondsParsed, branchPoints, scanner,   \
-                      start_token);                                            \
-      YYFPRINTF(stderr, "\n");                                                 \
-    }                                                                          \
-  } while (0)
+
+
+# define YY_SYMBOL_PRINT(Title, Kind, Value, Location)                    \
+do {                                                                      \
+  if (yydebug)                                                            \
+    {                                                                     \
+      YYFPRINTF (stderr, "%s ", Title);                                   \
+      yy_symbol_print (stderr,                                            \
+                  Kind, Value, input, molList, lastAtom, lastBond, numAtomsParsed, numBondsParsed, branchPoints, scanner, start_token, current_token_position); \
+      YYFPRINTF (stderr, "\n");                                           \
+    }                                                                     \
+} while (0)
+
 
 /*-----------------------------------.
 | Print this symbol's value on YYO.  |
 `-----------------------------------*/
 
-static void yy_symbol_value_print(
-    FILE *yyo, int yytype, YYSTYPE const *const yyvaluep, const char *input,
-    std::vector<RDKit::RWMol *> *molList, RDKit::Atom *&lastAtom,
-    RDKit::Bond *&lastBond, unsigned &numAtomsParsed, unsigned &numBondsParsed,
-    std::list<unsigned int> *branchPoints, void *scanner, int &start_token) {
+static void
+yy_symbol_value_print (FILE *yyo,
+                       yysymbol_kind_t yykind, YYSTYPE const * const yyvaluep, const char *input, std::vector<RDKit::RWMol *> *molList, RDKit::Atom* &lastAtom, RDKit::Bond* &lastBond, unsigned &numAtomsParsed, unsigned &numBondsParsed, std::list<unsigned int> *branchPoints, void *scanner, int& start_token, unsigned int& current_token_position)
+{
   FILE *yyoutput = yyo;
-  YYUSE(yyoutput);
-  YYUSE(input);
-  YYUSE(molList);
-  YYUSE(lastAtom);
-  YYUSE(lastBond);
-  YYUSE(numAtomsParsed);
-  YYUSE(numBondsParsed);
-  YYUSE(branchPoints);
-  YYUSE(scanner);
-  YYUSE(start_token);
-  if (!yyvaluep) return;
-#ifdef YYPRINT
-  if (yytype < YYNTOKENS) YYPRINT(yyo, yytoknum[yytype], *yyvaluep);
-#endif
+  YY_USE (yyoutput);
+  YY_USE (input);
+  YY_USE (molList);
+  YY_USE (lastAtom);
+  YY_USE (lastBond);
+  YY_USE (numAtomsParsed);
+  YY_USE (numBondsParsed);
+  YY_USE (branchPoints);
+  YY_USE (scanner);
+  YY_USE (start_token);
+  YY_USE (current_token_position);
+  if (!yyvaluep)
+    return;
   YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
-  YYUSE(yytype);
+  YY_USE (yykind);
   YY_IGNORE_MAYBE_UNINITIALIZED_END
 }
+
 
 /*---------------------------.
 | Print this symbol on YYO.  |
 `---------------------------*/
 
-static void yy_symbol_print(FILE *yyo, int yytype,
-                            YYSTYPE const *const yyvaluep, const char *input,
-                            std::vector<RDKit::RWMol *> *molList,
-                            RDKit::Atom *&lastAtom, RDKit::Bond *&lastBond,
-                            unsigned &numAtomsParsed, unsigned &numBondsParsed,
-                            std::list<unsigned int> *branchPoints,
-                            void *scanner, int &start_token) {
-  YYFPRINTF(yyo, "%s %s (", yytype < YYNTOKENS ? "token" : "nterm",
-            yytname[yytype]);
+static void
+yy_symbol_print (FILE *yyo,
+                 yysymbol_kind_t yykind, YYSTYPE const * const yyvaluep, const char *input, std::vector<RDKit::RWMol *> *molList, RDKit::Atom* &lastAtom, RDKit::Bond* &lastBond, unsigned &numAtomsParsed, unsigned &numBondsParsed, std::list<unsigned int> *branchPoints, void *scanner, int& start_token, unsigned int& current_token_position)
+{
+  YYFPRINTF (yyo, "%s %s (",
+             yykind < YYNTOKENS ? "token" : "nterm", yysymbol_name (yykind));
 
-  yy_symbol_value_print(yyo, yytype, yyvaluep, input, molList, lastAtom,
-                        lastBond, numAtomsParsed, numBondsParsed, branchPoints,
-                        scanner, start_token);
-  YYFPRINTF(yyo, ")");
+  yy_symbol_value_print (yyo, yykind, yyvaluep, input, molList, lastAtom, lastBond, numAtomsParsed, numBondsParsed, branchPoints, scanner, start_token, current_token_position);
+  YYFPRINTF (yyo, ")");
 }
 
 /*------------------------------------------------------------------.
@@ -830,68 +920,69 @@ static void yy_symbol_print(FILE *yyo, int yytype,
 | TOP (included).                                                   |
 `------------------------------------------------------------------*/
 
-static void yy_stack_print(yy_state_t *yybottom, yy_state_t *yytop) {
-  YYFPRINTF(stderr, "Stack now");
-  for (; yybottom <= yytop; yybottom++) {
-    int yybot = *yybottom;
-    YYFPRINTF(stderr, " %d", yybot);
-  }
-  YYFPRINTF(stderr, "\n");
+static void
+yy_stack_print (yy_state_t *yybottom, yy_state_t *yytop)
+{
+  YYFPRINTF (stderr, "Stack now");
+  for (; yybottom <= yytop; yybottom++)
+    {
+      int yybot = *yybottom;
+      YYFPRINTF (stderr, " %d", yybot);
+    }
+  YYFPRINTF (stderr, "\n");
 }
 
-#define YY_STACK_PRINT(Bottom, Top)               \
-  do {                                            \
-    if (yydebug) yy_stack_print((Bottom), (Top)); \
-  } while (0)
+# define YY_STACK_PRINT(Bottom, Top)                            \
+do {                                                            \
+  if (yydebug)                                                  \
+    yy_stack_print ((Bottom), (Top));                           \
+} while (0)
+
 
 /*------------------------------------------------.
 | Report that the YYRULE is going to be reduced.  |
 `------------------------------------------------*/
 
-static void yy_reduce_print(yy_state_t *yyssp, YYSTYPE *yyvsp, int yyrule,
-                            const char *input,
-                            std::vector<RDKit::RWMol *> *molList,
-                            RDKit::Atom *&lastAtom, RDKit::Bond *&lastBond,
-                            unsigned &numAtomsParsed, unsigned &numBondsParsed,
-                            std::list<unsigned int> *branchPoints,
-                            void *scanner, int &start_token) {
+static void
+yy_reduce_print (yy_state_t *yyssp, YYSTYPE *yyvsp,
+                 int yyrule, const char *input, std::vector<RDKit::RWMol *> *molList, RDKit::Atom* &lastAtom, RDKit::Bond* &lastBond, unsigned &numAtomsParsed, unsigned &numBondsParsed, std::list<unsigned int> *branchPoints, void *scanner, int& start_token, unsigned int& current_token_position)
+{
   int yylno = yyrline[yyrule];
   int yynrhs = yyr2[yyrule];
   int yyi;
-  YYFPRINTF(stderr, "Reducing stack by rule %d (line %d):\n", yyrule - 1,
-            yylno);
+  YYFPRINTF (stderr, "Reducing stack by rule %d (line %d):\n",
+             yyrule - 1, yylno);
   /* The symbols being reduced.  */
-  for (yyi = 0; yyi < yynrhs; yyi++) {
-    YYFPRINTF(stderr, "   $%d = ", yyi + 1);
-    yy_symbol_print(stderr, yystos[+yyssp[yyi + 1 - yynrhs]],
-                    &yyvsp[(yyi + 1) - (yynrhs)], input, molList, lastAtom,
-                    lastBond, numAtomsParsed, numBondsParsed, branchPoints,
-                    scanner, start_token);
-    YYFPRINTF(stderr, "\n");
-  }
+  for (yyi = 0; yyi < yynrhs; yyi++)
+    {
+      YYFPRINTF (stderr, "   $%d = ", yyi + 1);
+      yy_symbol_print (stderr,
+                       YY_ACCESSING_SYMBOL (+yyssp[yyi + 1 - yynrhs]),
+                       &yyvsp[(yyi + 1) - (yynrhs)], input, molList, lastAtom, lastBond, numAtomsParsed, numBondsParsed, branchPoints, scanner, start_token, current_token_position);
+      YYFPRINTF (stderr, "\n");
+    }
 }
 
-#define YY_REDUCE_PRINT(Rule)                                                 \
-  do {                                                                        \
-    if (yydebug)                                                              \
-      yy_reduce_print(yyssp, yyvsp, Rule, input, molList, lastAtom, lastBond, \
-                      numAtomsParsed, numBondsParsed, branchPoints, scanner,  \
-                      start_token);                                           \
-  } while (0)
+# define YY_REDUCE_PRINT(Rule)          \
+do {                                    \
+  if (yydebug)                          \
+    yy_reduce_print (yyssp, yyvsp, Rule, input, molList, lastAtom, lastBond, numAtomsParsed, numBondsParsed, branchPoints, scanner, start_token, current_token_position); \
+} while (0)
 
 /* Nonzero means print parse trace.  It is left uninitialized so that
    multiple parsers can coexist.  */
 int yydebug;
 #else /* !YYDEBUG */
-#define YYDPRINTF(Args)
-#define YY_SYMBOL_PRINT(Title, Type, Value, Location)
-#define YY_STACK_PRINT(Bottom, Top)
-#define YY_REDUCE_PRINT(Rule)
+# define YYDPRINTF(Args) ((void) 0)
+# define YY_SYMBOL_PRINT(Title, Kind, Value, Location)
+# define YY_STACK_PRINT(Bottom, Top)
+# define YY_REDUCE_PRINT(Rule)
 #endif /* !YYDEBUG */
+
 
 /* YYINITDEPTH -- initial size of the parser's stacks.  */
 #ifndef YYINITDEPTH
-#define YYINITDEPTH 200
+# define YYINITDEPTH 200
 #endif
 
 /* YYMAXDEPTH -- maximum size the stacks can grow to (effective only
@@ -902,412 +993,158 @@ int yydebug;
    evaluated with infinite-precision integer arithmetic.  */
 
 #ifndef YYMAXDEPTH
-#define YYMAXDEPTH 10000
+# define YYMAXDEPTH 10000
 #endif
 
-#if YYERROR_VERBOSE
 
-#ifndef yystrlen
-#if defined __GLIBC__ && defined _STRING_H
-#define yystrlen(S) (YY_CAST(YYPTRDIFF_T, strlen(S)))
-#else
-/* Return the length of YYSTR.  */
-static YYPTRDIFF_T yystrlen(const char *yystr) {
-  YYPTRDIFF_T yylen;
-  for (yylen = 0; yystr[yylen]; yylen++) continue;
-  return yylen;
-}
-#endif
-#endif
 
-#ifndef yystpcpy
-#if defined __GLIBC__ && defined _STRING_H && defined _GNU_SOURCE
-#define yystpcpy stpcpy
-#else
-/* Copy YYSRC to YYDEST, returning the address of the terminating '\0' in
-   YYDEST.  */
-static char *yystpcpy(char *yydest, const char *yysrc) {
-  char *yyd = yydest;
-  const char *yys = yysrc;
 
-  while ((*yyd++ = *yys++) != '\0') continue;
 
-  return yyd - 1;
-}
-#endif
-#endif
-
-#ifndef yytnamerr
-/* Copy to YYRES the contents of YYSTR after stripping away unnecessary
-   quotes and backslashes, so that it's suitable for yyerror.  The
-   heuristic is that double-quoting is unnecessary unless the string
-   contains an apostrophe, a comma, or backslash (other than
-   backslash-backslash).  YYSTR is taken from yytname.  If YYRES is
-   null, do not copy; instead, return the length of what the result
-   would have been.  */
-static YYPTRDIFF_T yytnamerr(char *yyres, const char *yystr) {
-  if (*yystr == '"') {
-    YYPTRDIFF_T yyn = 0;
-    char const *yyp = yystr;
-
-    for (;;) switch (*++yyp) {
-        case '\'':
-        case ',':
-          goto do_not_strip_quotes;
-
-        case '\\':
-          if (*++yyp != '\\')
-            goto do_not_strip_quotes;
-          else
-            goto append;
-
-        append:
-        default:
-          if (yyres) yyres[yyn] = *yyp;
-          yyn++;
-          break;
-
-        case '"':
-          if (yyres) yyres[yyn] = '\0';
-          return yyn;
-      }
-  do_not_strip_quotes:;
-  }
-
-  if (yyres)
-    return yystpcpy(yyres, yystr) - yyres;
-  else
-    return yystrlen(yystr);
-}
-#endif
-
-/* Copy into *YYMSG, which is of size *YYMSG_ALLOC, an error message
-   about the unexpected token YYTOKEN for the state stack whose top is
-   YYSSP.
-
-   Return 0 if *YYMSG was successfully written.  Return 1 if *YYMSG is
-   not large enough to hold the message.  In that case, also set
-   *YYMSG_ALLOC to the required number of bytes.  Return 2 if the
-   required number of bytes is too large to store.  */
-static int yysyntax_error(YYPTRDIFF_T *yymsg_alloc, char **yymsg,
-                          yy_state_t *yyssp, int yytoken) {
-  enum { YYERROR_VERBOSE_ARGS_MAXIMUM = 5 };
-  /* Internationalized format string. */
-  const char *yyformat = YY_NULLPTR;
-  /* Arguments of yyformat: reported tokens (one for the "unexpected",
-     one per "expected"). */
-  char const *yyarg[YYERROR_VERBOSE_ARGS_MAXIMUM];
-  /* Actual size of YYARG. */
-  int yycount = 0;
-  /* Cumulated lengths of YYARG.  */
-  YYPTRDIFF_T yysize = 0;
-
-  /* There are many possibilities here to consider:
-     - If this state is a consistent state with a default action, then
-       the only way this function was invoked is if the default action
-       is an error action.  In that case, don't check for expected
-       tokens because there are none.
-     - The only way there can be no lookahead present (in yychar) is if
-       this state is a consistent state with a default action.  Thus,
-       detecting the absence of a lookahead is sufficient to determine
-       that there is no unexpected or expected token to report.  In that
-       case, just report a simple "syntax error".
-     - Don't assume there isn't a lookahead just because this state is a
-       consistent state with a default action.  There might have been a
-       previous inconsistent state, consistent state with a non-default
-       action, or user semantic action that manipulated yychar.
-     - Of course, the expected token list depends on states to have
-       correct lookahead information, and it depends on the parser not
-       to perform extra reductions after fetching a lookahead from the
-       scanner and before detecting a syntax error.  Thus, state merging
-       (from LALR or IELR) and default reductions corrupt the expected
-       token list.  However, the list is correct for canonical LR with
-       one exception: it will still contain any token that will not be
-       accepted due to an error action in a later state.
-  */
-  if (yytoken != YYEMPTY) {
-    int yyn = yypact[+*yyssp];
-    YYPTRDIFF_T yysize0 = yytnamerr(YY_NULLPTR, yytname[yytoken]);
-    yysize = yysize0;
-    yyarg[yycount++] = yytname[yytoken];
-    if (!yypact_value_is_default(yyn)) {
-      /* Start YYX at -YYN if negative to avoid negative indexes in
-         YYCHECK.  In other words, skip the first -YYN actions for
-         this state because they are default actions.  */
-      int yyxbegin = yyn < 0 ? -yyn : 0;
-      /* Stay within bounds of both yycheck and yytname.  */
-      int yychecklim = YYLAST - yyn + 1;
-      int yyxend = yychecklim < YYNTOKENS ? yychecklim : YYNTOKENS;
-      int yyx;
-
-      for (yyx = yyxbegin; yyx < yyxend; ++yyx)
-        if (yycheck[yyx + yyn] == yyx && yyx != YYTERROR &&
-            !yytable_value_is_error(yytable[yyx + yyn])) {
-          if (yycount == YYERROR_VERBOSE_ARGS_MAXIMUM) {
-            yycount = 1;
-            yysize = yysize0;
-            break;
-          }
-          yyarg[yycount++] = yytname[yyx];
-          {
-            YYPTRDIFF_T yysize1 = yysize + yytnamerr(YY_NULLPTR, yytname[yyx]);
-            if (yysize <= yysize1 && yysize1 <= YYSTACK_ALLOC_MAXIMUM)
-              yysize = yysize1;
-            else
-              return 2;
-          }
-        }
-    }
-  }
-
-  switch (yycount) {
-#define YYCASE_(N, S) \
-  case N:             \
-    yyformat = S;     \
-    break
-    default: /* Avoid compiler warnings. */
-      YYCASE_(0, YY_("syntax error"));
-      YYCASE_(1, YY_("syntax error, unexpected %s"));
-      YYCASE_(2, YY_("syntax error, unexpected %s, expecting %s"));
-      YYCASE_(3, YY_("syntax error, unexpected %s, expecting %s or %s"));
-      YYCASE_(4, YY_("syntax error, unexpected %s, expecting %s or %s or %s"));
-      YYCASE_(
-          5,
-          YY_("syntax error, unexpected %s, expecting %s or %s or %s or %s"));
-#undef YYCASE_
-  }
-
-  {
-    /* Don't count the "%s"s in the final size, but reserve room for
-       the terminator.  */
-    YYPTRDIFF_T yysize1 = yysize + (yystrlen(yyformat) - 2 * yycount) + 1;
-    if (yysize <= yysize1 && yysize1 <= YYSTACK_ALLOC_MAXIMUM)
-      yysize = yysize1;
-    else
-      return 2;
-  }
-
-  if (*yymsg_alloc < yysize) {
-    *yymsg_alloc = 2 * yysize;
-    if (!(yysize <= *yymsg_alloc && *yymsg_alloc <= YYSTACK_ALLOC_MAXIMUM))
-      *yymsg_alloc = YYSTACK_ALLOC_MAXIMUM;
-    return 1;
-  }
-
-  /* Avoid sprintf, as that infringes on the user's name space.
-     Don't have undefined behavior even if the translation
-     produced a string with the wrong number of "%s"s.  */
-  {
-    char *yyp = *yymsg;
-    int yyi = 0;
-    while ((*yyp = *yyformat) != '\0')
-      if (*yyp == '%' && yyformat[1] == 's' && yyi < yycount) {
-        yyp += yytnamerr(yyp, yyarg[yyi++]);
-        yyformat += 2;
-      } else {
-        ++yyp;
-        ++yyformat;
-      }
-  }
-  return 0;
-}
-#endif /* YYERROR_VERBOSE */
 
 /*-----------------------------------------------.
 | Release the memory associated to this symbol.  |
 `-----------------------------------------------*/
 
-static void yydestruct(const char *yymsg, int yytype, YYSTYPE *yyvaluep,
-                       const char *input, std::vector<RDKit::RWMol *> *molList,
-                       RDKit::Atom *&lastAtom, RDKit::Bond *&lastBond,
-                       unsigned &numAtomsParsed, unsigned &numBondsParsed,
-                       std::list<unsigned int> *branchPoints, void *scanner,
-                       int &start_token) {
-  YYUSE(yyvaluep);
-  YYUSE(input);
-  YYUSE(molList);
-  YYUSE(lastAtom);
-  YYUSE(lastBond);
-  YYUSE(numAtomsParsed);
-  YYUSE(numBondsParsed);
-  YYUSE(branchPoints);
-  YYUSE(scanner);
-  YYUSE(start_token);
-  if (!yymsg) yymsg = "Deleting";
-  YY_SYMBOL_PRINT(yymsg, yytype, yyvaluep, yylocationp);
+static void
+yydestruct (const char *yymsg,
+            yysymbol_kind_t yykind, YYSTYPE *yyvaluep, const char *input, std::vector<RDKit::RWMol *> *molList, RDKit::Atom* &lastAtom, RDKit::Bond* &lastBond, unsigned &numAtomsParsed, unsigned &numBondsParsed, std::list<unsigned int> *branchPoints, void *scanner, int& start_token, unsigned int& current_token_position)
+{
+  YY_USE (yyvaluep);
+  YY_USE (input);
+  YY_USE (molList);
+  YY_USE (lastAtom);
+  YY_USE (lastBond);
+  YY_USE (numAtomsParsed);
+  YY_USE (numBondsParsed);
+  YY_USE (branchPoints);
+  YY_USE (scanner);
+  YY_USE (start_token);
+  YY_USE (current_token_position);
+  if (!yymsg)
+    yymsg = "Deleting";
+  YY_SYMBOL_PRINT (yymsg, yykind, yyvaluep, yylocationp);
 
   YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
-  switch (yytype) {
-    case 6: /* AROMATIC_ATOM_TOKEN  */
-#line 105 "smiles.yy"
+  switch (yykind)
     {
-      delete ((*yyvaluep).atom);
-    }
-#line 1245 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp"
-    break;
+    case YYSYMBOL_AROMATIC_ATOM_TOKEN: /* AROMATIC_ATOM_TOKEN  */
+            { delete ((*yyvaluep).atom); }
+        break;
 
-    case 7: /* ATOM_TOKEN  */
-#line 105 "smiles.yy"
-    {
-      delete ((*yyvaluep).atom);
-    }
-#line 1251 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp"
-    break;
+    case YYSYMBOL_ATOM_TOKEN: /* ATOM_TOKEN  */
+            { delete ((*yyvaluep).atom); }
+        break;
 
-    case 8: /* ORGANIC_ATOM_TOKEN  */
-#line 105 "smiles.yy"
-    {
-      delete ((*yyvaluep).atom);
-    }
-#line 1257 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp"
-    break;
+    case YYSYMBOL_ORGANIC_ATOM_TOKEN: /* ORGANIC_ATOM_TOKEN  */
+            { delete ((*yyvaluep).atom); }
+        break;
 
-    case 22: /* BOND_TOKEN  */
-#line 106 "smiles.yy"
-    {
-      delete ((*yyvaluep).bond);
-    }
-#line 1263 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp"
-    break;
+    case YYSYMBOL_BOND_TOKEN: /* BOND_TOKEN  */
+            { delete ((*yyvaluep).bond); }
+        break;
 
-    case 31: /* bondd  */
-#line 106 "smiles.yy"
-    {
-      delete ((*yyvaluep).bond);
-    }
-#line 1269 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp"
-    break;
+    case YYSYMBOL_bondd: /* bondd  */
+            { delete ((*yyvaluep).bond); }
+        break;
 
-    case 32: /* atomd  */
-#line 105 "smiles.yy"
-    {
-      delete ((*yyvaluep).atom);
-    }
-#line 1275 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp"
-    break;
+    case YYSYMBOL_atomd: /* atomd  */
+            { delete ((*yyvaluep).atom); }
+        break;
 
-    case 33: /* charge_element  */
-#line 105 "smiles.yy"
-    {
-      delete ((*yyvaluep).atom);
-    }
-#line 1281 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp"
-    break;
+    case YYSYMBOL_charge_element: /* charge_element  */
+            { delete ((*yyvaluep).atom); }
+        break;
 
-    case 34: /* h_element  */
-#line 105 "smiles.yy"
-    {
-      delete ((*yyvaluep).atom);
-    }
-#line 1287 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp"
-    break;
+    case YYSYMBOL_h_element: /* h_element  */
+            { delete ((*yyvaluep).atom); }
+        break;
 
-    case 35: /* chiral_element  */
-#line 105 "smiles.yy"
-    {
-      delete ((*yyvaluep).atom);
-    }
-#line 1293 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp"
-    break;
+    case YYSYMBOL_chiral_element: /* chiral_element  */
+            { delete ((*yyvaluep).atom); }
+        break;
 
-    case 36: /* element  */
-#line 105 "smiles.yy"
-    {
-      delete ((*yyvaluep).atom);
-    }
-#line 1299 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp"
-    break;
+    case YYSYMBOL_element: /* element  */
+            { delete ((*yyvaluep).atom); }
+        break;
 
-    case 37: /* simple_atom  */
-#line 105 "smiles.yy"
-    {
-      delete ((*yyvaluep).atom);
-    }
-#line 1305 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp"
-    break;
+    case YYSYMBOL_simple_atom: /* simple_atom  */
+            { delete ((*yyvaluep).atom); }
+        break;
 
-    default:
-      break;
-  }
+      default:
+        break;
+    }
   YY_IGNORE_MAYBE_UNINITIALIZED_END
 }
+
+
+
+
+
 
 /*----------.
 | yyparse.  |
 `----------*/
 
-int yyparse(const char *input, std::vector<RDKit::RWMol *> *molList,
-            RDKit::Atom *&lastAtom, RDKit::Bond *&lastBond,
-            unsigned &numAtomsParsed, unsigned &numBondsParsed,
-            std::list<unsigned int> *branchPoints, void *scanner,
-            int &start_token) {
-  /* The lookahead symbol.  */
-  int yychar;
+int
+yyparse (const char *input, std::vector<RDKit::RWMol *> *molList, RDKit::Atom* &lastAtom, RDKit::Bond* &lastBond, unsigned &numAtomsParsed, unsigned &numBondsParsed, std::list<unsigned int> *branchPoints, void *scanner, int& start_token, unsigned int& current_token_position)
+{
+/* Lookahead token kind.  */
+int yychar;
 
-  /* The semantic value of the lookahead symbol.  */
-  /* Default value used for initialization, for pacifying older GCCs
-     or non-GCC compilers.  */
-  YY_INITIAL_VALUE(static YYSTYPE yyval_default;)
-  YYSTYPE yylval YY_INITIAL_VALUE(= yyval_default);
 
-  /* Number of syntax errors so far.  */
-  int yynerrs;
+/* The semantic value of the lookahead symbol.  */
+/* Default value used for initialization, for pacifying older GCCs
+   or non-GCC compilers.  */
+YY_INITIAL_VALUE (static YYSTYPE yyval_default;)
+YYSTYPE yylval YY_INITIAL_VALUE (= yyval_default);
 
-  yy_state_fast_t yystate;
-  /* Number of tokens to shift before error messages enabled.  */
-  int yyerrstatus;
+    /* Number of syntax errors so far.  */
+    int yynerrs = 0;
 
-  /* The stacks and their tools:
-     'yyss': related to states.
-     'yyvs': related to semantic values.
+    yy_state_fast_t yystate = 0;
+    /* Number of tokens to shift before error messages enabled.  */
+    int yyerrstatus = 0;
 
-     Refer to the stacks through separate pointers, to allow yyoverflow
-     to reallocate them elsewhere.  */
+    /* Refer to the stacks through separate pointers, to allow yyoverflow
+       to reallocate them elsewhere.  */
 
-  /* The state stack.  */
-  yy_state_t yyssa[YYINITDEPTH];
-  yy_state_t *yyss;
-  yy_state_t *yyssp;
+    /* Their size.  */
+    YYPTRDIFF_T yystacksize = YYINITDEPTH;
 
-  /* The semantic value stack.  */
-  YYSTYPE yyvsa[YYINITDEPTH];
-  YYSTYPE *yyvs;
-  YYSTYPE *yyvsp;
+    /* The state stack: array, bottom, top.  */
+    yy_state_t yyssa[YYINITDEPTH];
+    yy_state_t *yyss = yyssa;
+    yy_state_t *yyssp = yyss;
 
-  YYPTRDIFF_T yystacksize;
+    /* The semantic value stack: array, bottom, top.  */
+    YYSTYPE yyvsa[YYINITDEPTH];
+    YYSTYPE *yyvs = yyvsa;
+    YYSTYPE *yyvsp = yyvs;
 
   int yyn;
+  /* The return value of yyparse.  */
   int yyresult;
-  /* Lookahead token as an internal (translated) token number.  */
-  int yytoken = 0;
+  /* Lookahead symbol kind.  */
+  yysymbol_kind_t yytoken = YYSYMBOL_YYEMPTY;
   /* The variables used to return semantic value and location from the
      action routines.  */
   YYSTYPE yyval;
 
-#if YYERROR_VERBOSE
-  /* Buffer for error messages, and its allocated size.  */
-  char yymsgbuf[128];
-  char *yymsg = yymsgbuf;
-  YYPTRDIFF_T yymsg_alloc = sizeof yymsgbuf;
-#endif
 
-#define YYPOPSTACK(N) (yyvsp -= (N), yyssp -= (N))
+
+#define YYPOPSTACK(N)   (yyvsp -= (N), yyssp -= (N))
 
   /* The number of symbols on the RHS of the reduced rule.
      Keep to zero when no symbol should be popped.  */
   int yylen = 0;
 
-  yyssp = yyss = yyssa;
-  yyvsp = yyvs = yyvsa;
-  yystacksize = YYINITDEPTH;
+  YYDPRINTF ((stderr, "Starting parse\n"));
 
-  YYDPRINTF((stderr, "Starting parse\n"));
-
-  yystate = 0;
-  yyerrstatus = 0;
-  yynerrs = 0;
   yychar = YYEMPTY; /* Cause a token to be read.  */
+
   goto yysetstate;
+
 
 /*------------------------------------------------------------.
 | yynewstate -- push a new state, which is found in yystate.  |
@@ -1317,75 +1154,87 @@ yynewstate:
      have just been pushed.  So pushing a state here evens the stacks.  */
   yyssp++;
 
+
 /*--------------------------------------------------------------------.
 | yysetstate -- set current state (the top of the stack) to yystate.  |
 `--------------------------------------------------------------------*/
 yysetstate:
-  YYDPRINTF((stderr, "Entering state %d\n", yystate));
-  YY_ASSERT(0 <= yystate && yystate < YYNSTATES);
+  YYDPRINTF ((stderr, "Entering state %d\n", yystate));
+  YY_ASSERT (0 <= yystate && yystate < YYNSTATES);
   YY_IGNORE_USELESS_CAST_BEGIN
-  *yyssp = YY_CAST(yy_state_t, yystate);
+  *yyssp = YY_CAST (yy_state_t, yystate);
   YY_IGNORE_USELESS_CAST_END
+  YY_STACK_PRINT (yyss, yyssp);
 
   if (yyss + yystacksize - 1 <= yyssp)
 #if !defined yyoverflow && !defined YYSTACK_RELOCATE
-    goto yyexhaustedlab;
+    YYNOMEM;
 #else
-  {
-    /* Get the current used size of the three stacks, in elements.  */
-    YYPTRDIFF_T yysize = yyssp - yyss + 1;
-
-#if defined yyoverflow
     {
-      /* Give user a chance to reallocate the stack.  Use copies of
-         these so that the &'s don't force the real ones into
-         memory.  */
-      yy_state_t *yyss1 = yyss;
-      YYSTYPE *yyvs1 = yyvs;
+      /* Get the current used size of the three stacks, in elements.  */
+      YYPTRDIFF_T yysize = yyssp - yyss + 1;
 
-      /* Each stack pointer address is followed by the size of the
-         data in use in that stack, in bytes.  This used to be a
-         conditional around just the two extra args, but that might
-         be undefined if yyoverflow is a macro.  */
-      yyoverflow(YY_("memory exhausted"), &yyss1, yysize * YYSIZEOF(*yyssp),
-                 &yyvs1, yysize * YYSIZEOF(*yyvsp), &yystacksize);
-      yyss = yyss1;
-      yyvs = yyvs1;
+# if defined yyoverflow
+      {
+        /* Give user a chance to reallocate the stack.  Use copies of
+           these so that the &'s don't force the real ones into
+           memory.  */
+        yy_state_t *yyss1 = yyss;
+        YYSTYPE *yyvs1 = yyvs;
+
+        /* Each stack pointer address is followed by the size of the
+           data in use in that stack, in bytes.  This used to be a
+           conditional around just the two extra args, but that might
+           be undefined if yyoverflow is a macro.  */
+        yyoverflow (YY_("memory exhausted"),
+                    &yyss1, yysize * YYSIZEOF (*yyssp),
+                    &yyvs1, yysize * YYSIZEOF (*yyvsp),
+                    &yystacksize);
+        yyss = yyss1;
+        yyvs = yyvs1;
+      }
+# else /* defined YYSTACK_RELOCATE */
+      /* Extend the stack our own way.  */
+      if (YYMAXDEPTH <= yystacksize)
+        YYNOMEM;
+      yystacksize *= 2;
+      if (YYMAXDEPTH < yystacksize)
+        yystacksize = YYMAXDEPTH;
+
+      {
+        yy_state_t *yyss1 = yyss;
+        union yyalloc *yyptr =
+          YY_CAST (union yyalloc *,
+                   YYSTACK_ALLOC (YY_CAST (YYSIZE_T, YYSTACK_BYTES (yystacksize))));
+        if (! yyptr)
+          YYNOMEM;
+        YYSTACK_RELOCATE (yyss_alloc, yyss);
+        YYSTACK_RELOCATE (yyvs_alloc, yyvs);
+#  undef YYSTACK_RELOCATE
+        if (yyss1 != yyssa)
+          YYSTACK_FREE (yyss1);
+      }
+# endif
+
+      yyssp = yyss + yysize - 1;
+      yyvsp = yyvs + yysize - 1;
+
+      YY_IGNORE_USELESS_CAST_BEGIN
+      YYDPRINTF ((stderr, "Stack size increased to %ld\n",
+                  YY_CAST (long, yystacksize)));
+      YY_IGNORE_USELESS_CAST_END
+
+      if (yyss + yystacksize - 1 <= yyssp)
+        YYABORT;
     }
-#else /* defined YYSTACK_RELOCATE */
-    /* Extend the stack our own way.  */
-    if (YYMAXDEPTH <= yystacksize) goto yyexhaustedlab;
-    yystacksize *= 2;
-    if (YYMAXDEPTH < yystacksize) yystacksize = YYMAXDEPTH;
-
-    {
-      yy_state_t *yyss1 = yyss;
-      union yyalloc *yyptr =
-          YY_CAST(union yyalloc *,
-                  YYSTACK_ALLOC(YY_CAST(YYSIZE_T, YYSTACK_BYTES(yystacksize))));
-      if (!yyptr) goto yyexhaustedlab;
-      YYSTACK_RELOCATE(yyss_alloc, yyss);
-      YYSTACK_RELOCATE(yyvs_alloc, yyvs);
-#undef YYSTACK_RELOCATE
-      if (yyss1 != yyssa) YYSTACK_FREE(yyss1);
-    }
-#endif
-
-    yyssp = yyss + yysize - 1;
-    yyvsp = yyvs + yysize - 1;
-
-    YY_IGNORE_USELESS_CAST_BEGIN
-    YYDPRINTF(
-        (stderr, "Stack size increased to %ld\n", YY_CAST(long, yystacksize)));
-    YY_IGNORE_USELESS_CAST_END
-
-    if (yyss + yystacksize - 1 <= yyssp) YYABORT;
-  }
 #endif /* !defined yyoverflow && !defined YYSTACK_RELOCATE */
 
-  if (yystate == YYFINAL) YYACCEPT;
+
+  if (yystate == YYFINAL)
+    YYACCEPT;
 
   goto yybackup;
+
 
 /*-----------.
 | yybackup.  |
@@ -1396,41 +1245,61 @@ yybackup:
 
   /* First try to decide what to do without reference to lookahead token.  */
   yyn = yypact[yystate];
-  if (yypact_value_is_default(yyn)) goto yydefault;
+  if (yypact_value_is_default (yyn))
+    goto yydefault;
 
   /* Not known => get a lookahead token if don't already have one.  */
 
-  /* YYCHAR is either YYEMPTY or YYEOF or a valid lookahead symbol.  */
-  if (yychar == YYEMPTY) {
-    YYDPRINTF((stderr, "Reading a token: "));
-    yychar = yylex(&yylval, scanner, start_token);
-  }
+  /* YYCHAR is either empty, or end-of-input, or a valid lookahead.  */
+  if (yychar == YYEMPTY)
+    {
+      YYDPRINTF ((stderr, "Reading a token\n"));
+      yychar = yylex (&yylval, scanner, start_token, current_token_position);
+    }
 
-  if (yychar <= YYEOF) {
-    yychar = yytoken = YYEOF;
-    YYDPRINTF((stderr, "Now at end of input.\n"));
-  } else {
-    yytoken = YYTRANSLATE(yychar);
-    YY_SYMBOL_PRINT("Next token is", yytoken, &yylval, &yylloc);
-  }
+  if (yychar <= YYEOF)
+    {
+      yychar = YYEOF;
+      yytoken = YYSYMBOL_YYEOF;
+      YYDPRINTF ((stderr, "Now at end of input.\n"));
+    }
+  else if (yychar == YYerror)
+    {
+      /* The scanner already issued an error message, process directly
+         to error recovery.  But do not keep the error token as
+         lookahead, it is too special and may lead us to an endless
+         loop in error recovery. */
+      yychar = YYUNDEF;
+      yytoken = YYSYMBOL_YYerror;
+      goto yyerrlab1;
+    }
+  else
+    {
+      yytoken = YYTRANSLATE (yychar);
+      YY_SYMBOL_PRINT ("Next token is", yytoken, &yylval, &yylloc);
+    }
 
   /* If the proper action on seeing token YYTOKEN is to reduce or to
      detect an error, take that action.  */
   yyn += yytoken;
-  if (yyn < 0 || YYLAST < yyn || yycheck[yyn] != yytoken) goto yydefault;
+  if (yyn < 0 || YYLAST < yyn || yycheck[yyn] != yytoken)
+    goto yydefault;
   yyn = yytable[yyn];
-  if (yyn <= 0) {
-    if (yytable_value_is_error(yyn)) goto yyerrlab;
-    yyn = -yyn;
-    goto yyreduce;
-  }
+  if (yyn <= 0)
+    {
+      if (yytable_value_is_error (yyn))
+        goto yyerrlab;
+      yyn = -yyn;
+      goto yyreduce;
+    }
 
   /* Count tokens shifted since error; after three, turn off error
      status.  */
-  if (yyerrstatus) yyerrstatus--;
+  if (yyerrstatus)
+    yyerrstatus--;
 
   /* Shift the lookahead token.  */
-  YY_SYMBOL_PRINT("Shifting", yytoken, &yylval, &yylloc);
+  YY_SYMBOL_PRINT ("Shifting", yytoken, &yylval, &yylloc);
   yystate = yyn;
   YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
   *++yyvsp = yylval;
@@ -1440,13 +1309,16 @@ yybackup:
   yychar = YYEMPTY;
   goto yynewstate;
 
+
 /*-----------------------------------------------------------.
 | yydefault -- do the default action for the current state.  |
 `-----------------------------------------------------------*/
 yydefault:
   yyn = yydefact[yystate];
-  if (yyn == 0) goto yyerrlab;
+  if (yyn == 0)
+    goto yyerrlab;
   goto yyreduce;
+
 
 /*-----------------------------.
 | yyreduce -- do a reduction.  |
@@ -1463,623 +1335,431 @@ yyreduce:
      users should not rely upon it.  Assigning to YYVAL
      unconditionally makes the parser a bit smaller, and it avoids a
      GCC warning that YYVAL may be used uninitialized.  */
-  yyval = yyvsp[1 - yylen];
+  yyval = yyvsp[1-yylen];
 
-  YY_REDUCE_PRINT(yyn);
-  switch (yyn) {
-    case 2:
-#line 114 "smiles.yy"
+
+  YY_REDUCE_PRINT (yyn);
+  switch (yyn)
     {
-      // the molList has already been updated, no need to do anything
-    }
-#line 1581 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp"
+  case 2: /* meta_start: START_MOL mol  */
+              {
+// the molList has already been updated, no need to do anything
+}
     break;
 
-    case 3:
-#line 117 "smiles.yy"
-    {
-      lastAtom = (yyvsp[-1].atom);
-      YYACCEPT;
-    }
-#line 1590 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp"
+  case 3: /* meta_start: START_ATOM atomd EOS_TOKEN  */
+                             {
+  lastAtom = (yyvsp[-1].atom);
+  YYACCEPT;
+}
     break;
 
-    case 4:
-#line 121 "smiles.yy"
-    {
-      YYABORT;
-    }
-#line 1598 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp"
+  case 4: /* meta_start: START_ATOM bad_atom_def  */
+                          {
+  YYABORT;
+}
     break;
 
-    case 5:
-#line 124 "smiles.yy"
-    {
-      lastBond = (yyvsp[-1].bond);
-      YYACCEPT;
-    }
-#line 1607 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp"
+  case 5: /* meta_start: START_BOND bondd EOS_TOKEN  */
+                             {
+  lastBond = (yyvsp[-1].bond);
+  YYACCEPT;
+}
     break;
 
-    case 6:
-#line 128 "smiles.yy"
-    {
-      delete (yyvsp[0].bond);
-      YYABORT;
-    }
-#line 1616 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp"
+  case 6: /* meta_start: START_BOND bondd  */
+                   {
+  delete (yyvsp[0].bond);
+  YYABORT;
+}
     break;
 
-    case 7:
-#line 132 "smiles.yy"
-    {
-      YYABORT;
-    }
-#line 1624 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp"
+  case 7: /* meta_start: START_BOND  */
+             {
+  YYABORT;
+}
     break;
 
-    case 8:
-#line 135 "smiles.yy"
-    {
-      yyerrok;
-      yyErrorCleanup(molList);
-      YYABORT;
-    }
-#line 1634 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp"
+  case 8: /* meta_start: meta_start error EOS_TOKEN  */
+                            {
+  yyerrok;
+  yyErrorCleanup(molList);
+  YYABORT;
+}
     break;
 
-    case 9:
-#line 140 "smiles.yy"
-    {
-      YYACCEPT;
-    }
-#line 1642 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp"
+  case 9: /* meta_start: meta_start EOS_TOKEN  */
+                       {
+  YYACCEPT;
+}
     break;
 
-    case 10:
-#line 143 "smiles.yy"
-    {
-      yyerrok;
-      yyErrorCleanup(molList);
-      YYABORT;
-    }
-#line 1652 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp"
+  case 10: /* meta_start: error EOS_TOKEN  */
+                  {
+  yyerrok;
+  yyErrorCleanup(molList);
+  YYABORT;
+}
     break;
 
-    case 14:
-#line 154 "smiles.yy"
-    {
-      delete (yyvsp[0].atom);
-      YYABORT;
-    }
-#line 1661 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp"
+  case 14: /* bad_atom_def: charge_element  */
+                 {
+  delete (yyvsp[0].atom);
+  YYABORT;
+}
     break;
 
-    case 15:
-#line 162 "smiles.yy"
-    {
-      int sz = molList->size();
-      molList->resize(sz + 1);
-      (*molList)[sz] = new RWMol();
-      RDKit::RWMol *curMol = (*molList)[sz];
-      (yyvsp[0].atom)->setProp(RDKit::common_properties::_SmilesStart, 1);
-      curMol->addAtom((yyvsp[0].atom), true, true);
-      // delete $1;
-      (yyval.moli) = sz;
-    }
-#line 1676 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp"
+  case 15: /* mol: atomd  */
+           {
+  int sz     = molList->size();
+  molList->resize( sz + 1);
+  (*molList)[ sz ] = new RWMol();
+  RDKit::RWMol *curMol = (*molList)[ sz ];
+  (yyvsp[0].atom)->setProp(RDKit::common_properties::_SmilesStart,1);
+  curMol->addAtom((yyvsp[0].atom), true, true);
+  //delete $1;
+  (yyval.moli) = sz;
+}
     break;
 
-    case 16:
-#line 173 "smiles.yy"
-    {
-      RWMol *mp = (*molList)[(yyval.moli)];
-      Atom *a1 = mp->getActiveAtom();
-      int atomIdx1 = a1->getIdx();
-      int atomIdx2 = mp->addAtom((yyvsp[0].atom), true, true);
-      mp->addBond(atomIdx1, atomIdx2,
-                  SmilesParseOps::GetUnspecifiedBondType(
-                      mp, a1, mp->getAtomWithIdx(atomIdx2)));
-      mp->getBondBetweenAtoms(atomIdx1, atomIdx2)
-          ->setProp("_cxsmilesBondIdx", numBondsParsed++);
-      // delete $2;
-    }
-#line 1691 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp"
+  case 16: /* mol: mol atomd  */
+                  {
+  RWMol *mp = (*molList)[(yyval.moli)];
+  Atom *a1 = mp->getActiveAtom();
+  int atomIdx1=a1->getIdx();
+  int atomIdx2=mp->addAtom((yyvsp[0].atom),true,true);
+  mp->addBond(atomIdx1,atomIdx2,
+	      SmilesParseOps::GetUnspecifiedBondType(mp,a1,mp->getAtomWithIdx(atomIdx2)));
+  mp->getBondBetweenAtoms(atomIdx1,atomIdx2)->setProp("_cxsmilesBondIdx",numBondsParsed++);
+  //delete $2;
+}
     break;
 
-    case 17:
-#line 184 "smiles.yy"
-    {
-      RWMol *mp = (*molList)[(yyval.moli)];
-      int atomIdx1 = mp->getActiveAtom()->getIdx();
-      int atomIdx2 = mp->addAtom((yyvsp[0].atom), true, true);
-      if ((yyvsp[-1].bond)->getBondType() == Bond::DATIVER) {
-        (yyvsp[-1].bond)->setBeginAtomIdx(atomIdx1);
-        (yyvsp[-1].bond)->setEndAtomIdx(atomIdx2);
-        (yyvsp[-1].bond)->setBondType(Bond::DATIVE);
-      } else if ((yyvsp[-1].bond)->getBondType() == Bond::DATIVEL) {
-        (yyvsp[-1].bond)->setBeginAtomIdx(atomIdx2);
-        (yyvsp[-1].bond)->setEndAtomIdx(atomIdx1);
-        (yyvsp[-1].bond)->setBondType(Bond::DATIVE);
-      } else {
-        (yyvsp[-1].bond)->setBeginAtomIdx(atomIdx1);
-        (yyvsp[-1].bond)->setEndAtomIdx(atomIdx2);
-      }
-      (yyvsp[-1].bond)->setProp("_cxsmilesBondIdx", numBondsParsed++);
-      mp->addBond((yyvsp[-1].bond), true);
-      // delete $3;
-    }
-#line 1716 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp"
-    break;
-
-    case 18:
-#line 205 "smiles.yy"
-    {
-      RWMol *mp = (*molList)[(yyval.moli)];
-      int atomIdx1 = mp->getActiveAtom()->getIdx();
-      int atomIdx2 = mp->addAtom((yyvsp[0].atom), true, true);
-      mp->addBond(atomIdx1, atomIdx2, Bond::SINGLE);
-      mp->getBondBetweenAtoms(atomIdx1, atomIdx2)
-          ->setProp("_cxsmilesBondIdx", numBondsParsed++);
-      // delete $3;
-    }
-#line 1729 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp"
-    break;
-
-    case 19:
-#line 214 "smiles.yy"
-    {
-      RWMol *mp = (*molList)[(yyval.moli)];
-      (yyvsp[0].atom)->setProp(RDKit::common_properties::_SmilesStart, 1, true);
-      mp->addAtom((yyvsp[0].atom), true, true);
-    }
-#line 1739 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp"
-    break;
-
-    case 20:
-#line 220 "smiles.yy"
-    {
-      RWMol *mp = (*molList)[(yyval.moli)];
-      Atom *atom = mp->getActiveAtom();
-      mp->setAtomBookmark(atom, (yyvsp[0].ival));
-
-      Bond *newB = mp->createPartialBond(atom->getIdx(), Bond::UNSPECIFIED);
-      mp->setBondBookmark(newB, (yyvsp[0].ival));
-      newB->setProp(RDKit::common_properties::_unspecifiedOrder, 1);
-      if (!(mp->getAllBondsWithBookmark((yyvsp[0].ival)).size() % 2)) {
-        newB->setProp("_cxsmilesBondIdx", numBondsParsed++);
-      }
-
-      SmilesParseOps::CheckRingClosureBranchStatus(atom, mp);
-
-      INT_VECT tmp;
-      atom->getPropIfPresent(RDKit::common_properties::_RingClosures, tmp);
-      tmp.push_back(-((yyvsp[0].ival) + 1));
-      atom->setProp(RDKit::common_properties::_RingClosures, tmp);
-    }
-#line 1764 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp"
-    break;
-
-    case 21:
-#line 241 "smiles.yy"
-    {
-      RWMol *mp = (*molList)[(yyval.moli)];
-      Atom *atom = mp->getActiveAtom();
-      Bond *newB = mp->createPartialBond(atom->getIdx(),
-                                         (yyvsp[-1].bond)->getBondType());
-      if ((yyvsp[-1].bond)
-              ->hasProp(RDKit::common_properties::_unspecifiedOrder)) {
-        newB->setProp(RDKit::common_properties::_unspecifiedOrder, 1);
-      }
-      newB->setBondDir((yyvsp[-1].bond)->getBondDir());
-      mp->setAtomBookmark(atom, (yyvsp[0].ival));
-      mp->setBondBookmark(newB, (yyvsp[0].ival));
-      if (!(mp->getAllBondsWithBookmark((yyvsp[0].ival)).size() % 2)) {
-        newB->setProp("_cxsmilesBondIdx", numBondsParsed++);
-      }
-
-      SmilesParseOps::CheckRingClosureBranchStatus(atom, mp);
-
-      INT_VECT tmp;
-      atom->getPropIfPresent(RDKit::common_properties::_RingClosures, tmp);
-      tmp.push_back(-((yyvsp[0].ival) + 1));
-      atom->setProp(RDKit::common_properties::_RingClosures, tmp);
-      delete (yyvsp[-1].bond);
-    }
-#line 1792 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp"
-    break;
-
-    case 22:
-#line 265 "smiles.yy"
-    {
-      RWMol *mp = (*molList)[(yyval.moli)];
-      Atom *atom = mp->getActiveAtom();
-      Bond *newB = mp->createPartialBond(atom->getIdx(), Bond::SINGLE);
-      mp->setAtomBookmark(atom, (yyvsp[0].ival));
-      mp->setBondBookmark(newB, (yyvsp[0].ival));
-      if (!(mp->getAllBondsWithBookmark((yyvsp[0].ival)).size() % 2)) {
-        newB->setProp("_cxsmilesBondIdx", numBondsParsed++);
-      }
-
-      SmilesParseOps::CheckRingClosureBranchStatus(atom, mp);
-
-      INT_VECT tmp;
-      atom->getPropIfPresent(RDKit::common_properties::_RingClosures, tmp);
-      tmp.push_back(-((yyvsp[0].ival) + 1));
-      atom->setProp(RDKit::common_properties::_RingClosures, tmp);
-    }
-#line 1815 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp"
-    break;
-
-    case 23:
-#line 284 "smiles.yy"
-    {
-      RWMol *mp = (*molList)[(yyval.moli)];
-      Atom *a1 = mp->getActiveAtom();
-      int atomIdx1 = a1->getIdx();
-      int atomIdx2 = mp->addAtom((yyvsp[0].atom), true, true);
-      mp->addBond(atomIdx1, atomIdx2,
-                  SmilesParseOps::GetUnspecifiedBondType(
-                      mp, a1, mp->getAtomWithIdx(atomIdx2)));
-      mp->getBondBetweenAtoms(atomIdx1, atomIdx2)
-          ->setProp("_cxsmilesBondIdx", numBondsParsed++);
-      // delete $3;
-      branchPoints->push_back(atomIdx1);
-    }
-#line 1831 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp"
-    break;
-
-    case 24:
-#line 295 "smiles.yy"
-    {
-      RWMol *mp = (*molList)[(yyval.moli)];
-      int atomIdx1 = mp->getActiveAtom()->getIdx();
-      int atomIdx2 = mp->addAtom((yyvsp[0].atom), true, true);
-      if ((yyvsp[-1].bond)->getBondType() == Bond::DATIVER) {
-        (yyvsp[-1].bond)->setBeginAtomIdx(atomIdx1);
-        (yyvsp[-1].bond)->setEndAtomIdx(atomIdx2);
-        (yyvsp[-1].bond)->setBondType(Bond::DATIVE);
-      } else if ((yyvsp[-1].bond)->getBondType() == Bond::DATIVEL) {
-        (yyvsp[-1].bond)->setBeginAtomIdx(atomIdx2);
-        (yyvsp[-1].bond)->setEndAtomIdx(atomIdx1);
-        (yyvsp[-1].bond)->setBondType(Bond::DATIVE);
-      } else {
-        (yyvsp[-1].bond)->setBeginAtomIdx(atomIdx1);
-        (yyvsp[-1].bond)->setEndAtomIdx(atomIdx2);
-      }
-      (yyvsp[-1].bond)->setProp("_cxsmilesBondIdx", numBondsParsed++);
-      mp->addBond((yyvsp[-1].bond), true);
-
-      // delete $4;
-      branchPoints->push_back(atomIdx1);
-    }
-#line 1858 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp"
-    break;
-
-    case 25:
-#line 317 "smiles.yy"
-    {
-      RWMol *mp = (*molList)[(yyval.moli)];
-      int atomIdx1 = mp->getActiveAtom()->getIdx();
-      int atomIdx2 = mp->addAtom((yyvsp[0].atom), true, true);
-      mp->addBond(atomIdx1, atomIdx2, Bond::SINGLE);
-      mp->getBondBetweenAtoms(atomIdx1, atomIdx2)
-          ->setProp("_cxsmilesBondIdx", numBondsParsed++);
-      // delete $4;
-      branchPoints->push_back(atomIdx1);
-    }
-#line 1872 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp"
-    break;
-
-    case 26:
-#line 326 "smiles.yy"
-    {
-      if (branchPoints->empty()) {
-        yyerror(input, molList, branchPoints, scanner, start_token,
-                "extra close parentheses");
-        yyErrorCleanup(molList);
-        YYABORT;
-      }
-      RWMol *mp = (*molList)[(yyval.moli)];
-      mp->setActiveAtom(branchPoints->back());
-      branchPoints->pop_back();
-    }
-#line 1887 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp"
-    break;
-
-    case 28:
-#line 340 "smiles.yy"
-    {
-      (yyval.bond) = new Bond(Bond::SINGLE);
-    }
-#line 1895 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp"
-    break;
-
-    case 30:
-#line 348 "smiles.yy"
-    {
-      (yyval.atom) = (yyvsp[-3].atom);
-      (yyval.atom)->setNoImplicit(true);
-      (yyval.atom)
-          ->setProp(RDKit::common_properties::molAtomMapNumber,
-                    (yyvsp[-1].ival));
-    }
-#line 1905 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp"
-    break;
-
-    case 31:
-#line 354 "smiles.yy"
-    {
-      (yyval.atom) = (yyvsp[-1].atom);
-      (yyvsp[-1].atom)->setNoImplicit(true);
-    }
-#line 1914 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp"
-    break;
-
-    case 33:
-#line 362 "smiles.yy"
-    {
-      (yyvsp[-1].atom)->setFormalCharge(1);
-    }
-#line 1920 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp"
-    break;
-
-    case 34:
-#line 363 "smiles.yy"
-    {
-      (yyvsp[-2].atom)->setFormalCharge(2);
-    }
-#line 1926 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp"
-    break;
-
-    case 35:
-#line 364 "smiles.yy"
-    {
-      (yyvsp[-2].atom)->setFormalCharge((yyvsp[0].ival));
-    }
-#line 1932 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp"
-    break;
-
-    case 36:
-#line 365 "smiles.yy"
-    {
-      (yyvsp[-1].atom)->setFormalCharge(-1);
-    }
-#line 1938 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp"
-    break;
-
-    case 37:
-#line 366 "smiles.yy"
-    {
-      (yyvsp[-2].atom)->setFormalCharge(-2);
-    }
-#line 1944 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp"
-    break;
-
-    case 38:
-#line 367 "smiles.yy"
-    {
-      (yyvsp[-2].atom)->setFormalCharge(-(yyvsp[0].ival));
-    }
-#line 1950 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp"
-    break;
-
-    case 39:
-#line 371 "smiles.yy"
-    {
-      (yyval.atom) = new Atom(1);
-    }
-#line 1956 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp"
-    break;
-
-    case 40:
-#line 372 "smiles.yy"
-    {
-      (yyval.atom) = new Atom(1);
-      (yyval.atom)->setIsotope((yyvsp[-1].ival));
-    }
-#line 1962 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp"
-    break;
-
-    case 41:
-#line 373 "smiles.yy"
-    {
-      (yyval.atom) = new Atom(1);
-      (yyval.atom)->setNumExplicitHs(1);
-    }
-#line 1968 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp"
-    break;
-
-    case 42:
-#line 374 "smiles.yy"
-    {
-      (yyval.atom) = new Atom(1);
-      (yyval.atom)->setIsotope((yyvsp[-2].ival));
-      (yyval.atom)->setNumExplicitHs(1);
-    }
-#line 1974 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp"
-    break;
-
-    case 43:
-#line 375 "smiles.yy"
-    {
-      (yyval.atom) = new Atom(1);
-      (yyval.atom)->setNumExplicitHs((yyvsp[0].ival));
-    }
-#line 1980 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp"
-    break;
-
-    case 44:
-#line 376 "smiles.yy"
-    {
-      (yyval.atom) = new Atom(1);
-      (yyval.atom)->setIsotope((yyvsp[-3].ival));
-      (yyval.atom)->setNumExplicitHs((yyvsp[0].ival));
-    }
-#line 1986 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp"
-    break;
-
-    case 46:
-#line 378 "smiles.yy"
-    {
-      (yyval.atom) = (yyvsp[-1].atom);
-      (yyvsp[-1].atom)->setNumExplicitHs(1);
-    }
-#line 1992 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp"
-    break;
-
-    case 47:
-#line 379 "smiles.yy"
-    {
-      (yyval.atom) = (yyvsp[-2].atom);
-      (yyvsp[-2].atom)->setNumExplicitHs((yyvsp[0].ival));
-    }
-#line 1998 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp"
-    break;
-
-    case 49:
-#line 384 "smiles.yy"
-    {
-      (yyvsp[-1].atom)->setChiralTag(Atom::CHI_TETRAHEDRAL_CCW);
-    }
-#line 2004 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp"
-    break;
-
-    case 50:
-#line 385 "smiles.yy"
-    {
-      (yyvsp[-2].atom)->setChiralTag(Atom::CHI_TETRAHEDRAL_CW);
-    }
-#line 2010 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp"
-    break;
-
-    case 51:
-#line 386 "smiles.yy"
-    {
-      (yyvsp[-1].atom)->setChiralTag((yyvsp[0].chiraltype));
-      (yyvsp[-1].atom)->setProp(common_properties::_chiralPermutation, 0);
-    }
-#line 2016 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp"
-    break;
-
-    case 52:
-#line 387 "smiles.yy"
-    {
-      (yyvsp[-2].atom)->setChiralTag((yyvsp[-1].chiraltype));
-      (yyvsp[-2].atom)
-          ->setProp(common_properties::_chiralPermutation, (yyvsp[0].ival));
-    }
-#line 2022 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp"
-    break;
-
-    case 54:
-#line 392 "smiles.yy"
-    {
-      (yyvsp[0].atom)->setIsotope((yyvsp[-1].ival));
-      (yyval.atom) = (yyvsp[0].atom);
-    }
-#line 2028 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp"
-    break;
-
-    case 56:
-#line 394 "smiles.yy"
-    {
-      (yyvsp[0].atom)->setIsotope((yyvsp[-1].ival));
-      (yyval.atom) = (yyvsp[0].atom);
-    }
-#line 2034 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp"
-    break;
-
-    case 57:
-#line 395 "smiles.yy"
-    {
-      (yyval.atom) = new Atom((yyvsp[0].ival));
-    }
-#line 2040 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp"
-    break;
-
-    case 58:
-#line 396 "smiles.yy"
-    {
-      (yyval.atom) = new Atom((yyvsp[0].ival));
-      (yyval.atom)->setIsotope((yyvsp[-2].ival));
-    }
-#line 2046 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp"
-    break;
-
-    case 62:
-#line 406 "smiles.yy"
-    {
-      (yyval.ival) = (yyvsp[-1].ival) * 10 + (yyvsp[0].ival);
-    }
-#line 2052 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp"
-    break;
-
-    case 63:
-#line 407 "smiles.yy"
-    {
-      (yyval.ival) = (yyvsp[-1].ival);
-    }
-#line 2058 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp"
-    break;
-
-    case 64:
-#line 408 "smiles.yy"
-    {
-      (yyval.ival) = (yyvsp[-2].ival) * 10 + (yyvsp[-1].ival);
-    }
-#line 2064 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp"
-    break;
-
-    case 65:
-#line 409 "smiles.yy"
-    {
-      (yyval.ival) =
-          (yyvsp[-3].ival) * 100 + (yyvsp[-2].ival) * 10 + (yyvsp[-1].ival);
-    }
-#line 2070 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp"
-    break;
-
-    case 66:
-#line 410 "smiles.yy"
-    {
-      (yyval.ival) = (yyvsp[-4].ival) * 1000 + (yyvsp[-3].ival) * 100 +
-                     (yyvsp[-2].ival) * 10 + (yyvsp[-1].ival);
-    }
-#line 2076 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp"
-    break;
-
-    case 67:
-#line 411 "smiles.yy"
-    {
-      (yyval.ival) = (yyvsp[-5].ival) * 10000 + (yyvsp[-4].ival) * 1000 +
-                     (yyvsp[-3].ival) * 100 + (yyvsp[-2].ival) * 10 +
-                     (yyvsp[-1].ival);
-    }
-#line 2082 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp"
-    break;
-
-    case 71:
-#line 421 "smiles.yy"
-    {
-      if ((yyvsp[-1].ival) >= std::numeric_limits<std::int32_t>::max() / 10 ||
-          (yyvsp[-1].ival) * 10 >=
-              std::numeric_limits<std::int32_t>::max() - (yyvsp[0].ival)) {
-        yyerror(input, molList, branchPoints, scanner, start_token,
-                "number too large");
-        yyErrorCleanup(molList);
-        YYABORT;
-      }
-      (yyval.ival) = (yyvsp[-1].ival) * 10 + (yyvsp[0].ival);
-    }
-#line 2096 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp"
-    break;
-
-#line 2100 "/scratch/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.cpp"
-
-    default:
-      break;
+  case 17: /* mol: mol BOND_TOKEN atomd  */
+                        {
+  RWMol *mp = (*molList)[(yyval.moli)];
+  int atomIdx1 = mp->getActiveAtom()->getIdx();
+  int atomIdx2 = mp->addAtom((yyvsp[0].atom),true,true);
+  if( (yyvsp[-1].bond)->getBondType() == Bond::DATIVER ){
+    (yyvsp[-1].bond)->setBeginAtomIdx(atomIdx1);
+    (yyvsp[-1].bond)->setEndAtomIdx(atomIdx2);
+    (yyvsp[-1].bond)->setBondType(Bond::DATIVE);
+  }else if ( (yyvsp[-1].bond)->getBondType() == Bond::DATIVEL ){
+    (yyvsp[-1].bond)->setBeginAtomIdx(atomIdx2);
+    (yyvsp[-1].bond)->setEndAtomIdx(atomIdx1);
+    (yyvsp[-1].bond)->setBondType(Bond::DATIVE);
+  } else {
+    (yyvsp[-1].bond)->setBeginAtomIdx(atomIdx1);
+    (yyvsp[-1].bond)->setEndAtomIdx(atomIdx2);
   }
+  (yyvsp[-1].bond)->setProp("_cxsmilesBondIdx",numBondsParsed++);
+  mp->addBond((yyvsp[-1].bond),true);
+  //delete $3;
+}
+    break;
+
+  case 18: /* mol: mol MINUS_TOKEN atomd  */
+                        {
+  RWMol *mp = (*molList)[(yyval.moli)];
+  int atomIdx1 = mp->getActiveAtom()->getIdx();
+  int atomIdx2 = mp->addAtom((yyvsp[0].atom),true,true);
+  mp->addBond(atomIdx1,atomIdx2,Bond::SINGLE);
+  mp->getBondBetweenAtoms(atomIdx1,atomIdx2)->setProp("_cxsmilesBondIdx",numBondsParsed++);
+  //delete $3;
+}
+    break;
+
+  case 19: /* mol: mol SEPARATOR_TOKEN atomd  */
+                            {
+  RWMol *mp = (*molList)[(yyval.moli)];
+  (yyvsp[0].atom)->setProp(RDKit::common_properties::_SmilesStart,1,true);
+  mp->addAtom((yyvsp[0].atom),true,true);
+}
+    break;
+
+  case 20: /* mol: mol ring_number  */
+                  {
+  RWMol * mp = (*molList)[(yyval.moli)];
+  Atom *atom=mp->getActiveAtom();
+  mp->setAtomBookmark(atom,(yyvsp[0].ival));
+
+  Bond *newB = mp->createPartialBond(atom->getIdx(),
+				     Bond::UNSPECIFIED);
+  mp->setBondBookmark(newB,(yyvsp[0].ival));
+  newB->setProp(RDKit::common_properties::_unspecifiedOrder,1);
+  if(!(mp->getAllBondsWithBookmark((yyvsp[0].ival)).size()%2)){
+    newB->setProp("_cxsmilesBondIdx",numBondsParsed++);
+  }
+
+  SmilesParseOps::CheckRingClosureBranchStatus(atom,mp);
+
+  INT_VECT tmp;
+  atom->getPropIfPresent(RDKit::common_properties::_RingClosures,tmp);
+  tmp.push_back(-((yyvsp[0].ival)+1));
+  atom->setProp(RDKit::common_properties::_RingClosures,tmp);
+}
+    break;
+
+  case 21: /* mol: mol BOND_TOKEN ring_number  */
+                             {
+  RWMol * mp = (*molList)[(yyval.moli)];
+  Atom *atom=mp->getActiveAtom();
+  Bond *newB = mp->createPartialBond(atom->getIdx(),
+				     (yyvsp[-1].bond)->getBondType());
+  if((yyvsp[-1].bond)->hasProp(RDKit::common_properties::_unspecifiedOrder)){
+    newB->setProp(RDKit::common_properties::_unspecifiedOrder,1);
+  }
+  newB->setBondDir((yyvsp[-1].bond)->getBondDir());
+  mp->setAtomBookmark(atom,(yyvsp[0].ival));
+  mp->setBondBookmark(newB,(yyvsp[0].ival));
+  if(!(mp->getAllBondsWithBookmark((yyvsp[0].ival)).size()%2)){
+    newB->setProp("_cxsmilesBondIdx",numBondsParsed++);
+  }
+
+  SmilesParseOps::CheckRingClosureBranchStatus(atom,mp);
+
+  INT_VECT tmp;
+  atom->getPropIfPresent(RDKit::common_properties::_RingClosures,tmp);
+  tmp.push_back(-((yyvsp[0].ival)+1));
+  atom->setProp(RDKit::common_properties::_RingClosures,tmp);
+  delete (yyvsp[-1].bond);
+}
+    break;
+
+  case 22: /* mol: mol MINUS_TOKEN ring_number  */
+                              {
+  RWMol * mp = (*molList)[(yyval.moli)];
+  Atom *atom=mp->getActiveAtom();
+  Bond *newB = mp->createPartialBond(atom->getIdx(),
+				     Bond::SINGLE);
+  mp->setAtomBookmark(atom,(yyvsp[0].ival));
+  mp->setBondBookmark(newB,(yyvsp[0].ival));
+  if(!(mp->getAllBondsWithBookmark((yyvsp[0].ival)).size()%2)){
+    newB->setProp("_cxsmilesBondIdx",numBondsParsed++);
+  }
+
+  SmilesParseOps::CheckRingClosureBranchStatus(atom,mp);
+
+  INT_VECT tmp;
+  atom->getPropIfPresent(RDKit::common_properties::_RingClosures,tmp);
+  tmp.push_back(-((yyvsp[0].ival)+1));
+  atom->setProp(RDKit::common_properties::_RingClosures,tmp);
+}
+    break;
+
+  case 23: /* mol: mol GROUP_OPEN_TOKEN atomd  */
+                             {
+  RWMol *mp = (*molList)[(yyval.moli)];
+  Atom *a1 = mp->getActiveAtom();
+  int atomIdx1=a1->getIdx();
+  int atomIdx2=mp->addAtom((yyvsp[0].atom),true,true);
+  mp->addBond(atomIdx1,atomIdx2,
+	      SmilesParseOps::GetUnspecifiedBondType(mp,a1,mp->getAtomWithIdx(atomIdx2)));
+  mp->getBondBetweenAtoms(atomIdx1,atomIdx2)->setProp("_cxsmilesBondIdx",numBondsParsed++);
+  //delete $3;
+  branchPoints->push_back(atomIdx1);
+}
+    break;
+
+  case 24: /* mol: mol GROUP_OPEN_TOKEN BOND_TOKEN atomd  */
+                                         {
+  RWMol *mp = (*molList)[(yyval.moli)];
+  int atomIdx1 = mp->getActiveAtom()->getIdx();
+  int atomIdx2 = mp->addAtom((yyvsp[0].atom),true,true);
+  if( (yyvsp[-1].bond)->getBondType() == Bond::DATIVER ){
+    (yyvsp[-1].bond)->setBeginAtomIdx(atomIdx1);
+    (yyvsp[-1].bond)->setEndAtomIdx(atomIdx2);
+    (yyvsp[-1].bond)->setBondType(Bond::DATIVE);
+  }else if ( (yyvsp[-1].bond)->getBondType() == Bond::DATIVEL ){
+    (yyvsp[-1].bond)->setBeginAtomIdx(atomIdx2);
+    (yyvsp[-1].bond)->setEndAtomIdx(atomIdx1);
+    (yyvsp[-1].bond)->setBondType(Bond::DATIVE);
+  } else {
+    (yyvsp[-1].bond)->setBeginAtomIdx(atomIdx1);
+    (yyvsp[-1].bond)->setEndAtomIdx(atomIdx2);
+  }
+  (yyvsp[-1].bond)->setProp("_cxsmilesBondIdx",numBondsParsed++);
+  mp->addBond((yyvsp[-1].bond),true);
+
+  //delete $4;
+  branchPoints->push_back(atomIdx1);
+}
+    break;
+
+  case 25: /* mol: mol GROUP_OPEN_TOKEN MINUS_TOKEN atomd  */
+                                         {
+  RWMol *mp = (*molList)[(yyval.moli)];
+  int atomIdx1 = mp->getActiveAtom()->getIdx();
+  int atomIdx2 = mp->addAtom((yyvsp[0].atom),true,true);
+  mp->addBond(atomIdx1,atomIdx2,Bond::SINGLE);
+  mp->getBondBetweenAtoms(atomIdx1,atomIdx2)->setProp("_cxsmilesBondIdx",numBondsParsed++);
+  //delete $4;
+  branchPoints->push_back(atomIdx1);
+}
+    break;
+
+  case 26: /* mol: mol GROUP_CLOSE_TOKEN  */
+                        {
+  if(branchPoints->empty()){
+     yyerror(input,molList,branchPoints,scanner,start_token,current_token_position,"extra close parentheses");
+     yyErrorCleanup(molList);
+     YYABORT;
+  }
+  RWMol *mp = (*molList)[(yyval.moli)];
+  mp->setActiveAtom(branchPoints->back());
+  branchPoints->pop_back();
+}
+    break;
+
+  case 28: /* bondd: MINUS_TOKEN  */
+                        {
+          (yyval.bond) = new Bond(Bond::SINGLE);
+          }
+    break;
+
+  case 30: /* atomd: ATOM_OPEN_TOKEN charge_element COLON_TOKEN number ATOM_CLOSE_TOKEN  */
+{
+  (yyval.atom) = (yyvsp[-3].atom);
+  (yyval.atom)->setNoImplicit(true);
+  (yyval.atom)->setProp(RDKit::common_properties::molAtomMapNumber,(yyvsp[-1].ival));
+}
+    break;
+
+  case 31: /* atomd: ATOM_OPEN_TOKEN charge_element ATOM_CLOSE_TOKEN  */
+{
+  (yyval.atom) = (yyvsp[-1].atom);
+  (yyvsp[-1].atom)->setNoImplicit(true);
+}
+    break;
+
+  case 33: /* charge_element: h_element PLUS_TOKEN  */
+                       { (yyvsp[-1].atom)->setFormalCharge(1); }
+    break;
+
+  case 34: /* charge_element: h_element PLUS_TOKEN PLUS_TOKEN  */
+                                  { (yyvsp[-2].atom)->setFormalCharge(2); }
+    break;
+
+  case 35: /* charge_element: h_element PLUS_TOKEN number  */
+                              { (yyvsp[-2].atom)->setFormalCharge((yyvsp[0].ival)); }
+    break;
+
+  case 36: /* charge_element: h_element MINUS_TOKEN  */
+                        { (yyvsp[-1].atom)->setFormalCharge(-1); }
+    break;
+
+  case 37: /* charge_element: h_element MINUS_TOKEN MINUS_TOKEN  */
+                                    { (yyvsp[-2].atom)->setFormalCharge(-2); }
+    break;
+
+  case 38: /* charge_element: h_element MINUS_TOKEN number  */
+                               { (yyvsp[-2].atom)->setFormalCharge(-(yyvsp[0].ival)); }
+    break;
+
+  case 39: /* h_element: H_TOKEN  */
+                        { (yyval.atom) = new Atom(1); }
+    break;
+
+  case 40: /* h_element: number H_TOKEN  */
+                                 { (yyval.atom) = new Atom(1); (yyval.atom)->setIsotope((yyvsp[-1].ival)); }
+    break;
+
+  case 41: /* h_element: H_TOKEN H_TOKEN  */
+                                  { (yyval.atom) = new Atom(1); (yyval.atom)->setNumExplicitHs(1); }
+    break;
+
+  case 42: /* h_element: number H_TOKEN H_TOKEN  */
+                                         { (yyval.atom) = new Atom(1); (yyval.atom)->setIsotope((yyvsp[-2].ival)); (yyval.atom)->setNumExplicitHs(1);}
+    break;
+
+  case 43: /* h_element: H_TOKEN H_TOKEN number  */
+                                         { (yyval.atom) = new Atom(1); (yyval.atom)->setNumExplicitHs((yyvsp[0].ival)); }
+    break;
+
+  case 44: /* h_element: number H_TOKEN H_TOKEN number  */
+                                                { (yyval.atom) = new Atom(1); (yyval.atom)->setIsotope((yyvsp[-3].ival)); (yyval.atom)->setNumExplicitHs((yyvsp[0].ival));}
+    break;
+
+  case 46: /* h_element: chiral_element H_TOKEN  */
+                                                        { (yyval.atom) = (yyvsp[-1].atom); (yyvsp[-1].atom)->setNumExplicitHs(1);}
+    break;
+
+  case 47: /* h_element: chiral_element H_TOKEN number  */
+                                                { (yyval.atom) = (yyvsp[-2].atom); (yyvsp[-2].atom)->setNumExplicitHs((yyvsp[0].ival));}
+    break;
+
+  case 49: /* chiral_element: element AT_TOKEN  */
+                   { (yyvsp[-1].atom)->setChiralTag(Atom::CHI_TETRAHEDRAL_CCW); }
+    break;
+
+  case 50: /* chiral_element: element AT_TOKEN AT_TOKEN  */
+                            { (yyvsp[-2].atom)->setChiralTag(Atom::CHI_TETRAHEDRAL_CW); }
+    break;
+
+  case 51: /* chiral_element: element CHI_CLASS_TOKEN  */
+                          { (yyvsp[-1].atom)->setChiralTag((yyvsp[0].chiraltype)); (yyvsp[-1].atom)->setProp(common_properties::_chiralPermutation,0); }
+    break;
+
+  case 52: /* chiral_element: element CHI_CLASS_TOKEN number  */
+                                 { (yyvsp[-2].atom)->setChiralTag((yyvsp[-1].chiraltype)); (yyvsp[-2].atom)->setProp(common_properties::_chiralPermutation,(yyvsp[0].ival)); }
+    break;
+
+  case 54: /* element: number simple_atom  */
+                                           { (yyvsp[0].atom)->setIsotope( (yyvsp[-1].ival) ); (yyval.atom) = (yyvsp[0].atom); }
+    break;
+
+  case 56: /* element: number ATOM_TOKEN  */
+                                                   { (yyvsp[0].atom)->setIsotope( (yyvsp[-1].ival) ); (yyval.atom) = (yyvsp[0].atom); }
+    break;
+
+  case 57: /* element: HASH_TOKEN number  */
+                                                 { (yyval.atom) = new Atom((yyvsp[0].ival)); }
+    break;
+
+  case 58: /* element: number HASH_TOKEN number  */
+                                                         { (yyval.atom) = new Atom((yyvsp[0].ival)); (yyval.atom)->setIsotope((yyvsp[-2].ival)); }
+    break;
+
+  case 62: /* ring_number: PERCENT_TOKEN NONZERO_DIGIT_TOKEN digit  */
+                                          { (yyval.ival) = (yyvsp[-1].ival)*10+(yyvsp[0].ival); }
+    break;
+
+  case 63: /* ring_number: PERCENT_TOKEN GROUP_OPEN_TOKEN digit GROUP_CLOSE_TOKEN  */
+                                                         { (yyval.ival) = (yyvsp[-1].ival); }
+    break;
+
+  case 64: /* ring_number: PERCENT_TOKEN GROUP_OPEN_TOKEN digit digit GROUP_CLOSE_TOKEN  */
+                                                               { (yyval.ival) = (yyvsp[-2].ival)*10+(yyvsp[-1].ival); }
+    break;
+
+  case 65: /* ring_number: PERCENT_TOKEN GROUP_OPEN_TOKEN digit digit digit GROUP_CLOSE_TOKEN  */
+                                                                     { (yyval.ival) = (yyvsp[-3].ival)*100+(yyvsp[-2].ival)*10+(yyvsp[-1].ival); }
+    break;
+
+  case 66: /* ring_number: PERCENT_TOKEN GROUP_OPEN_TOKEN digit digit digit digit GROUP_CLOSE_TOKEN  */
+                                                                           { (yyval.ival) = (yyvsp[-4].ival)*1000+(yyvsp[-3].ival)*100+(yyvsp[-2].ival)*10+(yyvsp[-1].ival); }
+    break;
+
+  case 67: /* ring_number: PERCENT_TOKEN GROUP_OPEN_TOKEN digit digit digit digit digit GROUP_CLOSE_TOKEN  */
+                                                                                 { (yyval.ival) = (yyvsp[-5].ival)*10000+(yyvsp[-4].ival)*1000+(yyvsp[-3].ival)*100+(yyvsp[-2].ival)*10+(yyvsp[-1].ival); }
+    break;
+
+  case 71: /* nonzero_number: nonzero_number digit  */
+                       {
+  if((yyvsp[-1].ival) >= std::numeric_limits<std::int32_t>::max()/10 ||
+     (yyvsp[-1].ival)*10 >= std::numeric_limits<std::int32_t>::max()-(yyvsp[0].ival) ){
+     yyerror(input,molList,branchPoints,scanner,start_token,current_token_position,"number too large");
+     yyErrorCleanup(molList);
+     YYABORT;
+  }
+  (yyval.ival) = (yyvsp[-1].ival)*10 + (yyvsp[0].ival);
+  }
+    break;
+
+
+
+      default: break;
+    }
   /* User semantic actions sometimes alter yychar, and that requires
      that yytoken be updated with the new translation.  We take the
      approach of translating immediately before every use of yytoken.
@@ -2091,11 +1771,10 @@ yyreduce:
      case of YYERROR or YYBACKUP, subsequent parser actions might lead
      to an incorrect destructor call or verbose syntax error message
      before the lookahead is translated.  */
-  YY_SYMBOL_PRINT("-> $$ =", yyr1[yyn], &yyval, &yyloc);
+  YY_SYMBOL_PRINT ("-> $$ =", YY_CAST (yysymbol_kind_t, yyr1[yyn]), &yyval, &yyloc);
 
-  YYPOPSTACK(yylen);
+  YYPOPSTACK (yylen);
   yylen = 0;
-  YY_STACK_PRINT(yyss, yyssp);
 
   *++yyvsp = yyval;
 
@@ -2106,11 +1785,12 @@ yyreduce:
     const int yylhs = yyr1[yyn] - YYNTOKENS;
     const int yyi = yypgoto[yylhs] + *yyssp;
     yystate = (0 <= yyi && yyi <= YYLAST && yycheck[yyi] == *yyssp
-                   ? yytable[yyi]
-                   : yydefgoto[yylhs]);
+               ? yytable[yyi]
+               : yydefgoto[yylhs]);
   }
 
   goto yynewstate;
+
 
 /*--------------------------------------.
 | yyerrlab -- here on detecting error.  |
@@ -2118,60 +1798,37 @@ yyreduce:
 yyerrlab:
   /* Make sure we have latest lookahead translation.  See comments at
      user semantic actions for why this is necessary.  */
-  yytoken = yychar == YYEMPTY ? YYEMPTY : YYTRANSLATE(yychar);
-
+  yytoken = yychar == YYEMPTY ? YYSYMBOL_YYEMPTY : YYTRANSLATE (yychar);
   /* If not already recovering from an error, report this error.  */
-  if (!yyerrstatus) {
-    ++yynerrs;
-#if !YYERROR_VERBOSE
-    yyerror(input, molList, lastAtom, lastBond, numAtomsParsed, numBondsParsed,
-            branchPoints, scanner, start_token, YY_("syntax error"));
-#else
-#define YYSYNTAX_ERROR yysyntax_error(&yymsg_alloc, &yymsg, yyssp, yytoken)
+  if (!yyerrstatus)
     {
-      char const *yymsgp = YY_("syntax error");
-      int yysyntax_error_status;
-      yysyntax_error_status = YYSYNTAX_ERROR;
-      if (yysyntax_error_status == 0)
-        yymsgp = yymsg;
-      else if (yysyntax_error_status == 1) {
-        if (yymsg != yymsgbuf) YYSTACK_FREE(yymsg);
-        yymsg = YY_CAST(char *, YYSTACK_ALLOC(YY_CAST(YYSIZE_T, yymsg_alloc)));
-        if (!yymsg) {
-          yymsg = yymsgbuf;
-          yymsg_alloc = sizeof yymsgbuf;
-          yysyntax_error_status = 2;
-        } else {
-          yysyntax_error_status = YYSYNTAX_ERROR;
-          yymsgp = yymsg;
+      ++yynerrs;
+      yyerror (input, molList, lastAtom, lastBond, numAtomsParsed, numBondsParsed, branchPoints, scanner, start_token, current_token_position, YY_("syntax error"));
+    }
+
+  if (yyerrstatus == 3)
+    {
+      /* If just tried and failed to reuse lookahead token after an
+         error, discard it.  */
+
+      if (yychar <= YYEOF)
+        {
+          /* Return failure if at end of input.  */
+          if (yychar == YYEOF)
+            YYABORT;
         }
-      }
-      yyerror(input, molList, lastAtom, lastBond, numAtomsParsed,
-              numBondsParsed, branchPoints, scanner, start_token, yymsgp);
-      if (yysyntax_error_status == 2) goto yyexhaustedlab;
+      else
+        {
+          yydestruct ("Error: discarding",
+                      yytoken, &yylval, input, molList, lastAtom, lastBond, numAtomsParsed, numBondsParsed, branchPoints, scanner, start_token, current_token_position);
+          yychar = YYEMPTY;
+        }
     }
-#undef YYSYNTAX_ERROR
-#endif
-  }
-
-  if (yyerrstatus == 3) {
-    /* If just tried and failed to reuse lookahead token after an
-       error, discard it.  */
-
-    if (yychar <= YYEOF) {
-      /* Return failure if at end of input.  */
-      if (yychar == YYEOF) YYABORT;
-    } else {
-      yydestruct("Error: discarding", yytoken, &yylval, input, molList,
-                 lastAtom, lastBond, numAtomsParsed, numBondsParsed,
-                 branchPoints, scanner, start_token);
-      yychar = YYEMPTY;
-    }
-  }
 
   /* Else will try to reuse lookahead token after shifting the error
      token.  */
   goto yyerrlab1;
+
 
 /*---------------------------------------------------.
 | yyerrorlab -- error raised explicitly by YYERROR.  |
@@ -2179,106 +1836,117 @@ yyerrlab:
 yyerrorlab:
   /* Pacify compilers when the user code never invokes YYERROR and the
      label yyerrorlab therefore never appears in user code.  */
-  if (0) YYERROR;
+  if (0)
+    YYERROR;
+  ++yynerrs;
 
   /* Do not reclaim the symbols of the rule whose action triggered
      this YYERROR.  */
-  YYPOPSTACK(yylen);
+  YYPOPSTACK (yylen);
   yylen = 0;
-  YY_STACK_PRINT(yyss, yyssp);
+  YY_STACK_PRINT (yyss, yyssp);
   yystate = *yyssp;
   goto yyerrlab1;
+
 
 /*-------------------------------------------------------------.
 | yyerrlab1 -- common code for both syntax error and YYERROR.  |
 `-------------------------------------------------------------*/
 yyerrlab1:
-  yyerrstatus = 3; /* Each real token shifted decrements this.  */
+  yyerrstatus = 3;      /* Each real token shifted decrements this.  */
 
-  for (;;) {
-    yyn = yypact[yystate];
-    if (!yypact_value_is_default(yyn)) {
-      yyn += YYTERROR;
-      if (0 <= yyn && yyn <= YYLAST && yycheck[yyn] == YYTERROR) {
-        yyn = yytable[yyn];
-        if (0 < yyn) break;
-      }
+  /* Pop stack until we find a state that shifts the error token.  */
+  for (;;)
+    {
+      yyn = yypact[yystate];
+      if (!yypact_value_is_default (yyn))
+        {
+          yyn += YYSYMBOL_YYerror;
+          if (0 <= yyn && yyn <= YYLAST && yycheck[yyn] == YYSYMBOL_YYerror)
+            {
+              yyn = yytable[yyn];
+              if (0 < yyn)
+                break;
+            }
+        }
+
+      /* Pop the current state because it cannot handle the error token.  */
+      if (yyssp == yyss)
+        YYABORT;
+
+
+      yydestruct ("Error: popping",
+                  YY_ACCESSING_SYMBOL (yystate), yyvsp, input, molList, lastAtom, lastBond, numAtomsParsed, numBondsParsed, branchPoints, scanner, start_token, current_token_position);
+      YYPOPSTACK (1);
+      yystate = *yyssp;
+      YY_STACK_PRINT (yyss, yyssp);
     }
-
-    /* Pop the current state because it cannot handle the error token.  */
-    if (yyssp == yyss) YYABORT;
-
-    yydestruct("Error: popping", yystos[yystate], yyvsp, input, molList,
-               lastAtom, lastBond, numAtomsParsed, numBondsParsed, branchPoints,
-               scanner, start_token);
-    YYPOPSTACK(1);
-    yystate = *yyssp;
-    YY_STACK_PRINT(yyss, yyssp);
-  }
 
   YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
   *++yyvsp = yylval;
   YY_IGNORE_MAYBE_UNINITIALIZED_END
 
+
   /* Shift the error token.  */
-  YY_SYMBOL_PRINT("Shifting", yystos[yyn], yyvsp, yylsp);
+  YY_SYMBOL_PRINT ("Shifting", YY_ACCESSING_SYMBOL (yyn), yyvsp, yylsp);
 
   yystate = yyn;
   goto yynewstate;
+
 
 /*-------------------------------------.
 | yyacceptlab -- YYACCEPT comes here.  |
 `-------------------------------------*/
 yyacceptlab:
   yyresult = 0;
-  goto yyreturn;
+  goto yyreturnlab;
+
 
 /*-----------------------------------.
 | yyabortlab -- YYABORT comes here.  |
 `-----------------------------------*/
 yyabortlab:
   yyresult = 1;
-  goto yyreturn;
+  goto yyreturnlab;
 
-#if !defined yyoverflow || YYERROR_VERBOSE
-/*-------------------------------------------------.
-| yyexhaustedlab -- memory exhaustion comes here.  |
-`-------------------------------------------------*/
+
+/*-----------------------------------------------------------.
+| yyexhaustedlab -- YYNOMEM (memory exhaustion) comes here.  |
+`-----------------------------------------------------------*/
 yyexhaustedlab:
-  yyerror(input, molList, lastAtom, lastBond, numAtomsParsed, numBondsParsed,
-          branchPoints, scanner, start_token, YY_("memory exhausted"));
+  yyerror (input, molList, lastAtom, lastBond, numAtomsParsed, numBondsParsed, branchPoints, scanner, start_token, current_token_position, YY_("memory exhausted"));
   yyresult = 2;
-  /* Fall through.  */
-#endif
+  goto yyreturnlab;
 
-/*-----------------------------------------------------.
-| yyreturn -- parsing is finished, return the result.  |
-`-----------------------------------------------------*/
-yyreturn:
-  if (yychar != YYEMPTY) {
-    /* Make sure we have latest lookahead translation.  See comments at
-       user semantic actions for why this is necessary.  */
-    yytoken = YYTRANSLATE(yychar);
-    yydestruct("Cleanup: discarding lookahead", yytoken, &yylval, input,
-               molList, lastAtom, lastBond, numAtomsParsed, numBondsParsed,
-               branchPoints, scanner, start_token);
-  }
+
+/*----------------------------------------------------------.
+| yyreturnlab -- parsing is finished, clean up and return.  |
+`----------------------------------------------------------*/
+yyreturnlab:
+  if (yychar != YYEMPTY)
+    {
+      /* Make sure we have latest lookahead translation.  See comments at
+         user semantic actions for why this is necessary.  */
+      yytoken = YYTRANSLATE (yychar);
+      yydestruct ("Cleanup: discarding lookahead",
+                  yytoken, &yylval, input, molList, lastAtom, lastBond, numAtomsParsed, numBondsParsed, branchPoints, scanner, start_token, current_token_position);
+    }
   /* Do not reclaim the symbols of the rule whose action triggered
      this YYABORT or YYACCEPT.  */
-  YYPOPSTACK(yylen);
-  YY_STACK_PRINT(yyss, yyssp);
-  while (yyssp != yyss) {
-    yydestruct("Cleanup: popping", yystos[+*yyssp], yyvsp, input, molList,
-               lastAtom, lastBond, numAtomsParsed, numBondsParsed, branchPoints,
-               scanner, start_token);
-    YYPOPSTACK(1);
-  }
+  YYPOPSTACK (yylen);
+  YY_STACK_PRINT (yyss, yyssp);
+  while (yyssp != yyss)
+    {
+      yydestruct ("Cleanup: popping",
+                  YY_ACCESSING_SYMBOL (+*yyssp), yyvsp, input, molList, lastAtom, lastBond, numAtomsParsed, numBondsParsed, branchPoints, scanner, start_token, current_token_position);
+      YYPOPSTACK (1);
+    }
 #ifndef yyoverflow
-  if (yyss != yyssa) YYSTACK_FREE(yyss);
+  if (yyss != yyssa)
+    YYSTACK_FREE (yyss);
 #endif
-#if YYERROR_VERBOSE
-  if (yymsg != yymsgbuf) YYSTACK_FREE(yymsg);
-#endif
+
   return yyresult;
 }
-#line 443 "smiles.yy"
+
+

--- a/Code/GraphMol/SmilesParse/smiles.tab.hpp.cmake
+++ b/Code/GraphMol/SmilesParse/smiles.tab.hpp.cmake
@@ -1,8 +1,9 @@
-/* A Bison parser, made by GNU Bison 3.0.4.  */
+/* A Bison parser, made by GNU Bison 3.8.2.  */
 
 /* Bison interface for Yacc-like parsers in C
 
-   Copyright (C) 1984, 1989-1990, 2000-2015 Free Software Foundation, Inc.
+   Copyright (C) 1984, 1989-1990, 2000-2015, 2018-2021 Free Software Foundation,
+   Inc.
 
    This program is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -15,7 +16,7 @@
    GNU General Public License for more details.
 
    You should have received a copy of the GNU General Public License
-   along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.  */
 
 /* As a special exception, you may create a larger work that contains
    part or all of the Bison parser skeleton and distribute that work
@@ -30,79 +31,84 @@
    This special exception was added by the Free Software Foundation in
    version 2.2 of Bison.  */
 
-#ifndef YY_YYSMILES_C_USERS_GLANDRUM_RDKIT_GIT_CODE_GRAPHMOL_SMILESPARSE_SMILES_TAB_HPP_INCLUDED
-#define YY_YYSMILES_C_USERS_GLANDRUM_RDKIT_GIT_CODE_GRAPHMOL_SMILESPARSE_SMILES_TAB_HPP_INCLUDED
+/* DO NOT RELY ON FEATURES THAT ARE NOT DOCUMENTED in the manual,
+   especially those whose name start with YY_ or yy_.  They are
+   private implementation details that can be changed or removed.  */
+
+#ifndef YY_YYSMILES_USERS_FAARA_DOCUMENTS_CODE_RDKIT_BUILDER_RDKIT_CODE_GRAPHMOL_SMILESPARSE_SMILES_TAB_HPP_INCLUDED
+# define YY_YYSMILES_USERS_FAARA_DOCUMENTS_CODE_RDKIT_BUILDER_RDKIT_CODE_GRAPHMOL_SMILESPARSE_SMILES_TAB_HPP_INCLUDED
 /* Debug traces.  */
 #ifndef YYDEBUG
-#define YYDEBUG 0
+# define YYDEBUG 0
 #endif
 #if YYDEBUG
 extern int yysmiles_debug;
 #endif
 
-/* Token type.  */
+/* Token kinds.  */
 #ifndef YYTOKENTYPE
-#define YYTOKENTYPE
-enum yytokentype {
-  START_MOL = 258,
-  START_ATOM = 259,
-  START_BOND = 260,
-  AROMATIC_ATOM_TOKEN = 261,
-  ATOM_TOKEN = 262,
-  ORGANIC_ATOM_TOKEN = 263,
-  NONZERO_DIGIT_TOKEN = 264,
-  ZERO_TOKEN = 265,
-  GROUP_OPEN_TOKEN = 266,
-  GROUP_CLOSE_TOKEN = 267,
-  SEPARATOR_TOKEN = 268,
-  LOOP_CONNECTOR_TOKEN = 269,
-  MINUS_TOKEN = 270,
-  PLUS_TOKEN = 271,
-  H_TOKEN = 272,
-  AT_TOKEN = 273,
-  PERCENT_TOKEN = 274,
-  COLON_TOKEN = 275,
-  HASH_TOKEN = 276,
-  BOND_TOKEN = 277,
-  CHI_CLASS_TOKEN = 278,
-  ATOM_OPEN_TOKEN = 279,
-  ATOM_CLOSE_TOKEN = 280,
-  EOS_TOKEN = 281
-};
+# define YYTOKENTYPE
+  enum yytokentype
+  {
+    YYEMPTY = -2,
+    YYEOF = 0,                     /* "end of file"  */
+    YYerror = 256,                 /* error  */
+    YYUNDEF = 257,                 /* "invalid token"  */
+    START_MOL = 258,               /* START_MOL  */
+    START_ATOM = 259,              /* START_ATOM  */
+    START_BOND = 260,              /* START_BOND  */
+    AROMATIC_ATOM_TOKEN = 261,     /* AROMATIC_ATOM_TOKEN  */
+    ATOM_TOKEN = 262,              /* ATOM_TOKEN  */
+    ORGANIC_ATOM_TOKEN = 263,      /* ORGANIC_ATOM_TOKEN  */
+    NONZERO_DIGIT_TOKEN = 264,     /* NONZERO_DIGIT_TOKEN  */
+    ZERO_TOKEN = 265,              /* ZERO_TOKEN  */
+    GROUP_OPEN_TOKEN = 266,        /* GROUP_OPEN_TOKEN  */
+    GROUP_CLOSE_TOKEN = 267,       /* GROUP_CLOSE_TOKEN  */
+    SEPARATOR_TOKEN = 268,         /* SEPARATOR_TOKEN  */
+    LOOP_CONNECTOR_TOKEN = 269,    /* LOOP_CONNECTOR_TOKEN  */
+    MINUS_TOKEN = 270,             /* MINUS_TOKEN  */
+    PLUS_TOKEN = 271,              /* PLUS_TOKEN  */
+    H_TOKEN = 272,                 /* H_TOKEN  */
+    AT_TOKEN = 273,                /* AT_TOKEN  */
+    PERCENT_TOKEN = 274,           /* PERCENT_TOKEN  */
+    COLON_TOKEN = 275,             /* COLON_TOKEN  */
+    HASH_TOKEN = 276,              /* HASH_TOKEN  */
+    BOND_TOKEN = 277,              /* BOND_TOKEN  */
+    CHI_CLASS_TOKEN = 278,         /* CHI_CLASS_TOKEN  */
+    ATOM_OPEN_TOKEN = 279,         /* ATOM_OPEN_TOKEN  */
+    ATOM_CLOSE_TOKEN = 280,        /* ATOM_CLOSE_TOKEN  */
+    EOS_TOKEN = 281                /* EOS_TOKEN  */
+  };
+  typedef enum yytokentype yytoken_kind_t;
 #endif
 
 /* Value type.  */
-#if !defined YYSTYPE && !defined YYSTYPE_IS_DECLARED
+#if ! defined YYSTYPE && ! defined YYSTYPE_IS_DECLARED
+union YYSTYPE
+{
 
-union YYSTYPE {
-#line 82 "smiles.yy" /* yacc.c:1909  */
-
-  int moli;
-  RDKit::Atom *atom;
-  RDKit::Bond *bond;
+  int                      moli;
+  RDKit::Atom * atom;
+  RDKit::Bond * bond;
   RDKit::Atom::ChiralType chiraltype;
-  int ival;
+  int                      ival;
 
-#line 89 "C:/Users/glandrum/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.hpp" /* yacc.c:1909  */
+
 };
-
 typedef union YYSTYPE YYSTYPE;
-#define YYSTYPE_IS_TRIVIAL 1
-#define YYSTYPE_IS_DECLARED 1
+# define YYSTYPE_IS_TRIVIAL 1
+# define YYSTYPE_IS_DECLARED 1
 #endif
 
-int yysmiles_parse(const char *input, std::vector<RDKit::RWMol *> *molList,
-                   RDKit::Atom *&lastAtom, RDKit::Bond *&lastBond,
-                   unsigned &numAtomsParsed, unsigned &numBondsParsed,
-                   std::list<unsigned int> *branchPoints, void *scanner,
-                   int &start_token);
+
+
+
+int yysmiles_parse (const char *input, std::vector<RDKit::RWMol *> *molList, RDKit::Atom* &lastAtom, RDKit::Bond* &lastBond, unsigned &numAtomsParsed, unsigned &numBondsParsed, std::list<unsigned int> *branchPoints, void *scanner, int& start_token, unsigned int& current_token_position);
+
 /* "%code provides" blocks.  */
-#line 77 "smiles.yy" /* yacc.c:1909  */
 
-#define YY_DECL \
-  int yylex(YYSTYPE *yylval_param, yyscan_t yyscanner, int &start_token)
+#define YY_DECL int yylex \
+               (YYSTYPE * yylval_param , yyscan_t yyscanner, int& start_token, unsigned int& current_token_position)
 
-#line 106 "C:/Users/glandrum/RDKit_git/Code/GraphMol/SmilesParse/smiles.tab.hpp" /* yacc.c:1909  */
 
-#endif /* !YY_YYSMILES_C_USERS_GLANDRUM_RDKIT_GIT_CODE_GRAPHMOL_SMILESPARSE_SMILES_TAB_HPP_INCLUDED \
-        */
+#endif /* !YY_YYSMILES_USERS_FAARA_DOCUMENTS_CODE_RDKIT_BUILDER_RDKIT_CODE_GRAPHMOL_SMILESPARSE_SMILES_TAB_HPP_INCLUDED  */


### PR DESCRIPTION
This attempts to improve the SMILES parsing procedure to provide more information about bad inputs by pointing to general location of the offending token. The improved error messages currently only apply to syntax errors, inputs with extra close parentheses, and inputs with too large numbers, but this will provide a way to extend that in the future

Some examples of the improved error messages

| old version                            | new version            |
|----------------------------------------|------------------------|
|syntax error while parsing: c%()ccccc%() | syntax error while parsing input:<br /> `c%()ccccc%()` <br /> `~~~^` |
|syntax error while parsing: c%(100000)ccccc%(100000) | syntax error while parsing input: <br /> `c%(100000)ccccc%(100000)` <br /> `~~~~~~~~^` |
|syntax error while parsing: COc(c1)cccc1C#|syntax error while parsing input: <br /> `COc(c1)cccc1C#` <br /> `~~~~~~~~~~~~~^` |
|extra close parentheses while parsing: C) | extra close parentheses while parsing input: <br /> `C)` <br /> `~^` |
| extra close parentheses while parsing: C1C)foo | extra close parentheses while parsing input: <br /> `C1C)foo` <br /> `~~~^` |
| number too large while parsing: [555555555555555555C] | number too large while parsing input: <br /> `[555555555555555555C]` <br /> `~~~~~~~~~~^` |

This was achieves by extending the lexing and parsing procedure to track the current token position with a new variable, so the reported position may not be 100% accurate at all times but should be helpful in reducing the amount of work done to find the bad location.

Additionally, I updated the build instructions to strip the #line macros from the generated C++ files, which required a modern flex/bison versions.

<!--
Thanks for contributing a pull request! 
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.


#### Any other comments?

