### PR TITLE
Expose tautomer scoring functions to python

### DIFF
--- a/Code/GraphMol/MolStandardize/Tautomer.cpp
+++ b/Code/GraphMol/MolStandardize/Tautomer.cpp
@@ -17,9 +17,6 @@
 #include <algorithm>
 #include <limits>
 
-#include <boost/flyweight.hpp>
-#include <boost/flyweight/key_value.hpp>
-#include <boost/flyweight/no_tracking.hpp>
 #include <utility>
 
 // #define VERBOSE_ENUMERATION 1
@@ -75,35 +72,13 @@ int scoreRings(const ROMol &mol) {
   return score;
 };
 
-struct smarts_mol_holder {
-  std::string d_smarts;
-  ROMOL_SPTR dp_mol;
-  smarts_mol_holder(const std::string &smarts) : d_smarts(smarts) {
-    dp_mol.reset(SmartsToMol(smarts));
-  }
-};
+SubstructTerm::SubstructTerm(std::string aname, std::string asmarts, int ascore)
+  : name(std::move(aname)), smarts(std::move(asmarts)), score(ascore), matcher(SmartsToMol(smarts)) {
+}
 
-typedef boost::flyweight<
-    boost::flyweights::key_value<std::string, smarts_mol_holder>,
-    boost::flyweights::no_tracking>
-    smarts_mol_flyweight;
-
-struct SubstructTerm {
-  std::string name;
-  std::string smarts;
-  int score;
-  ROMOL_SPTR matcher;
-  SubstructTerm(std::string aname, std::string asmarts, int ascore)
-      : name(std::move(aname)), smarts(std::move(asmarts)), score(ascore) {
-    matcher = smarts_mol_flyweight(smarts).get().dp_mol;
-  };
-};
-
-int scoreSubstructs(const ROMol &mol) {
-  // a note on efficiency here: we'll construct the SubstructTerm objects here
-  // repeatedly, but the SMARTS parsing for each entry will only be done once
-  // since we're using the boost::flyweights above to cache them
-  const std::vector<SubstructTerm> substructureTerms{
+const std::vector<SubstructTerm> &getDefaultTautomerSubstructs()
+{
+  static std::vector<SubstructTerm> substructureTerms{
       {"benzoquinone", "[#6]1([#6]=[#6][#6]([#6]=[#6]1)=,:[N,S,O])=,:[N,S,O]",
        25},
       {"oxim", "[#6]=[N][OH]", 4},
@@ -117,6 +92,10 @@ int scoreSubstructs(const ROMol &mol) {
       {"guanidine terminal=N", "[#7]C(=[NR0])[#7H0]", 1},
       {"guanidine endocyclic=N", "[#7;R][#6;R]([N])=[#7;R]", 2},
       {"aci-nitro", "[#6]=[N+]([O-])[OH]", -4}};
+  return substructureTerms;
+}
+  
+int scoreSubstructs(const ROMol &mol,  const std::vector<SubstructTerm> &substructureTerms) {
   int score = 0;
   for (const auto &term : substructureTerms) {
     if (!term.matcher) {

--- a/Code/GraphMol/MolStandardize/Tautomer.cpp
+++ b/Code/GraphMol/MolStandardize/Tautomer.cpp
@@ -76,7 +76,7 @@ SubstructTerm::SubstructTerm(std::string aname, std::string asmarts, int ascore)
   : name(std::move(aname)), smarts(std::move(asmarts)), score(ascore), matcher(SmartsToMol(smarts)) {
 }
 
-const std::vector<SubstructTerm> &getDefaultTautomerSubstructs()
+const std::vector<SubstructTerm> &getDefaultTautomerScoreSubstructs()
 {
   static std::vector<SubstructTerm> substructureTerms{
       {"benzoquinone", "[#6]1([#6]=[#6][#6]([#6]=[#6]1)=,:[N,S,O])=,:[N,S,O]",

--- a/Code/GraphMol/MolStandardize/Tautomer.cpp
+++ b/Code/GraphMol/MolStandardize/Tautomer.cpp
@@ -73,15 +73,14 @@ int scoreRings(const ROMol &mol) {
 };
 
 SubstructTerm::SubstructTerm(std::string aname, std::string asmarts, int ascore)
-  : name(std::move(aname)), smarts(std::move(asmarts)), score(ascore) {
+    : name(std::move(aname)), smarts(std::move(asmarts)), score(ascore) {
   std::unique_ptr<ROMol> pattern(SmartsToMol(smarts));
-  if(pattern) {
+  if (pattern) {
     matcher = std::move(*pattern);
   }
 }
 
-const std::vector<SubstructTerm> &getDefaultTautomerScoreSubstructs()
-{
+const std::vector<SubstructTerm> &getDefaultTautomerScoreSubstructs() {
   static std::vector<SubstructTerm> substructureTerms{
       {"benzoquinone", "[#6]1([#6]=[#6][#6]([#6]=[#6]1)=,:[N,S,O])=,:[N,S,O]",
        25},
@@ -98,8 +97,9 @@ const std::vector<SubstructTerm> &getDefaultTautomerScoreSubstructs()
       {"aci-nitro", "[#6]=[N+]([O-])[OH]", -4}};
   return substructureTerms;
 }
-  
-int scoreSubstructs(const ROMol &mol,  const std::vector<SubstructTerm> &substructureTerms) {
+
+int scoreSubstructs(const ROMol &mol,
+                    const std::vector<SubstructTerm> &substructureTerms) {
   int score = 0;
   for (const auto &term : substructureTerms) {
     if (!term.matcher.getNumAtoms()) {

--- a/Code/GraphMol/MolStandardize/Tautomer.h
+++ b/Code/GraphMol/MolStandardize/Tautomer.h
@@ -41,7 +41,7 @@ const std::string tautomerScoringVersion = "1.0.0";
 ///    SubstructTerm("C=O", "[#6]=,:[#8]", 2)
 ///   This gets a score of +2 for each Carbon doubly or aromatically
 ///   Bonded to an Oxygen.
-///   For a list of current definitions, see getDefaultTautomerSubstructs
+///   For a list of current definitions, see getDefaultTautomerScoreSubstructs
 struct RDKIT_MOLSTANDARDIZE_EXPORT SubstructTerm {
   std::string name;
   std::string smarts;
@@ -59,7 +59,7 @@ struct RDKIT_MOLSTANDARDIZE_EXPORT SubstructTerm {
 
 //! getDefaultTautomerSubstructs returns the SubstructTerms used in scoring
 /// tautomer forms.  See SubstructTerm for details.
-RDKIT_MOLSTANDARDIZE_EXPORT const std::vector<SubstructTerm> &getDefaultTautomerSubstructs();
+RDKIT_MOLSTANDARDIZE_EXPORT const std::vector<SubstructTerm> &getDefaultTautomerScoreSubstructs();
 
 //! Score the rings of the current tautomer
 /// Aromatic rings score 100, all carbon aromatic rings score 250
@@ -76,7 +76,7 @@ RDKIT_MOLSTANDARDIZE_EXPORT int scoreRings(const ROMol &mol);
   \returns integer score for the molecule's substructure terms
 */
 RDKIT_MOLSTANDARDIZE_EXPORT int scoreSubstructs(const ROMol &mol,
-						const std::vector<SubstructTerm> &terms=getDefaultTautomerSubstructs());
+						const std::vector<SubstructTerm> &terms=getDefaultTautomerScoreSubstructs());
 //! scoreHeteroHs score the molecules hydrogens
 /// This gives a negative penalty to hydrogens attached to S,P, Se and Te
 /*!

--- a/Code/GraphMol/MolStandardize/Tautomer.h
+++ b/Code/GraphMol/MolStandardize/Tautomer.h
@@ -35,6 +35,13 @@ typedef RDCatalog::HierarchCatalog<TautomerCatalogEntry, TautomerCatalogParams,
 namespace TautomerScoringFunctions {
 const std::string tautomerScoringVersion = "1.0.0";
 
+//! The SubstructTerm controls how Tautomers are generated
+///   Each Term is defined by a name, smarts pattern and score
+///   For example, the C=O term is defined as
+///    SubstructTerm("C=O", "[#6]=,:[#8]", 2)
+///   This gets a score of +2 for each Carbon doubly or aromatically
+///   Bonded to an Oxygen.
+///   For a list of current definitions, see getDefaultTautomerSubstructs
 struct RDKIT_MOLSTANDARDIZE_EXPORT SubstructTerm {
   std::string name;
   std::string smarts;
@@ -50,10 +57,32 @@ struct RDKIT_MOLSTANDARDIZE_EXPORT SubstructTerm {
   }
 };
 
+//! getDefaultTautomerSubstructs returns the SubstructTerms used in scoring
+/// tautomer forms.  See SubstructTerm for details.
 RDKIT_MOLSTANDARDIZE_EXPORT const std::vector<SubstructTerm> &getDefaultTautomerSubstructs();
+
+//! Score the rings of the current tautomer
+/// Aromatic rings score 100, all carbon aromatic rings score 250
+/*!
+  \param mol Molcule to score
+  \returns integer score for the molecule's rings
+*/
 RDKIT_MOLSTANDARDIZE_EXPORT int scoreRings(const ROMol &mol);
+
+//! scoreSubstructs scores the molecule based on the substructure definitions
+/*!
+  \param mol Molecule to score
+  \param terms Substruct Terms used for scoring this particular tautomer form
+  \returns integer score for the molecule's substructure terms
+*/
 RDKIT_MOLSTANDARDIZE_EXPORT int scoreSubstructs(const ROMol &mol,
 						const std::vector<SubstructTerm> &terms=getDefaultTautomerSubstructs());
+//! scoreHeteroHs score the molecules hydrogens
+/// This gives a negative penalty to hydrogens attached to S,P, Se and Te
+/*!
+  \param mol Molecule to score
+  \returns integer score for the molecule hetero hydrogens
+*/
 RDKIT_MOLSTANDARDIZE_EXPORT int scoreHeteroHs(const ROMol &mol);
 
 inline int scoreTautomer(const ROMol &mol) {

--- a/Code/GraphMol/MolStandardize/Tautomer.h
+++ b/Code/GraphMol/MolStandardize/Tautomer.h
@@ -46,13 +46,15 @@ struct RDKIT_MOLSTANDARDIZE_EXPORT SubstructTerm {
   std::string name;
   std::string smarts;
   int score;
-  RWMol matcher; // requires assignment
-  
+  RWMol matcher;  // requires assignment
+
   SubstructTerm(std::string aname, std::string asmarts, int ascore);
-  SubstructTerm(const SubstructTerm &rhs) :
-    name(rhs.name), smarts(rhs.smarts), score(rhs.score), matcher(rhs.matcher) {
-  }
-  
+  SubstructTerm(const SubstructTerm &rhs)
+      : name(rhs.name),
+        smarts(rhs.smarts),
+        score(rhs.score),
+        matcher(rhs.matcher) {}
+
   bool operator==(const SubstructTerm &rhs) const {
     return name == rhs.name && smarts == rhs.smarts && score == rhs.score;
   }
@@ -60,7 +62,8 @@ struct RDKIT_MOLSTANDARDIZE_EXPORT SubstructTerm {
 
 //! getDefaultTautomerSubstructs returns the SubstructTerms used in scoring
 /// tautomer forms.  See SubstructTerm for details.
-RDKIT_MOLSTANDARDIZE_EXPORT const std::vector<SubstructTerm> &getDefaultTautomerScoreSubstructs();
+RDKIT_MOLSTANDARDIZE_EXPORT const std::vector<SubstructTerm>
+    &getDefaultTautomerScoreSubstructs();
 
 //! Score the rings of the current tautomer
 /// Aromatic rings score 100, all carbon aromatic rings score 250
@@ -76,8 +79,9 @@ RDKIT_MOLSTANDARDIZE_EXPORT int scoreRings(const ROMol &mol);
   \param terms Substruct Terms used for scoring this particular tautomer form
   \returns integer score for the molecule's substructure terms
 */
-RDKIT_MOLSTANDARDIZE_EXPORT int scoreSubstructs(const ROMol &mol,
-						const std::vector<SubstructTerm> &terms=getDefaultTautomerScoreSubstructs());
+RDKIT_MOLSTANDARDIZE_EXPORT int scoreSubstructs(
+    const ROMol &mol, const std::vector<SubstructTerm> &terms =
+                          getDefaultTautomerScoreSubstructs());
 //! scoreHeteroHs score the molecules hydrogens
 /// This gives a negative penalty to hydrogens attached to S,P, Se and Te
 /*!

--- a/Code/GraphMol/MolStandardize/Tautomer.h
+++ b/Code/GraphMol/MolStandardize/Tautomer.h
@@ -49,11 +49,7 @@ struct RDKIT_MOLSTANDARDIZE_EXPORT SubstructTerm {
   RWMol matcher;  // requires assignment
 
   SubstructTerm(std::string aname, std::string asmarts, int ascore);
-  SubstructTerm(const SubstructTerm &rhs)
-      : name(rhs.name),
-        smarts(rhs.smarts),
-        score(rhs.score),
-        matcher(rhs.matcher) {}
+  SubstructTerm(const SubstructTerm &rhs) = default;
 
   bool operator==(const SubstructTerm &rhs) const {
     return name == rhs.name && smarts == rhs.smarts && score == rhs.score;

--- a/Code/GraphMol/MolStandardize/Tautomer.h
+++ b/Code/GraphMol/MolStandardize/Tautomer.h
@@ -46,12 +46,13 @@ struct RDKIT_MOLSTANDARDIZE_EXPORT SubstructTerm {
   std::string name;
   std::string smarts;
   int score;
-  ROMOL_SPTR matcher;
+  RWMol matcher; // requires assignment
   
   SubstructTerm(std::string aname, std::string asmarts, int ascore);
   SubstructTerm(const SubstructTerm &rhs) :
     name(rhs.name), smarts(rhs.smarts), score(rhs.score), matcher(rhs.matcher) {
   }
+  
   bool operator==(const SubstructTerm &rhs) const {
     return name == rhs.name && smarts == rhs.smarts && score == rhs.score;
   }

--- a/Code/GraphMol/MolStandardize/Tautomer.h
+++ b/Code/GraphMol/MolStandardize/Tautomer.h
@@ -35,8 +35,25 @@ typedef RDCatalog::HierarchCatalog<TautomerCatalogEntry, TautomerCatalogParams,
 namespace TautomerScoringFunctions {
 const std::string tautomerScoringVersion = "1.0.0";
 
+struct RDKIT_MOLSTANDARDIZE_EXPORT SubstructTerm {
+  std::string name;
+  std::string smarts;
+  int score;
+  ROMOL_SPTR matcher;
+  
+  SubstructTerm(std::string aname, std::string asmarts, int ascore);
+  SubstructTerm(const SubstructTerm &rhs) :
+    name(rhs.name), smarts(rhs.smarts), score(rhs.score), matcher(rhs.matcher) {
+  }
+  bool operator==(const SubstructTerm &rhs) const {
+    return name == rhs.name && smarts == rhs.smarts && score == rhs.score;
+  }
+};
+
+RDKIT_MOLSTANDARDIZE_EXPORT const std::vector<SubstructTerm> &getDefaultTautomerSubstructs();
 RDKIT_MOLSTANDARDIZE_EXPORT int scoreRings(const ROMol &mol);
-RDKIT_MOLSTANDARDIZE_EXPORT int scoreSubstructs(const ROMol &mol);
+RDKIT_MOLSTANDARDIZE_EXPORT int scoreSubstructs(const ROMol &mol,
+						const std::vector<SubstructTerm> &terms=getDefaultTautomerSubstructs());
 RDKIT_MOLSTANDARDIZE_EXPORT int scoreHeteroHs(const ROMol &mol);
 
 inline int scoreTautomer(const ROMol &mol) {

--- a/Code/GraphMol/MolStandardize/Wrap/Tautomer.cpp
+++ b/Code/GraphMol/MolStandardize/Wrap/Tautomer.cpp
@@ -507,20 +507,23 @@ struct tautomer_wrapper {
                 python::return_value_policy<python::manage_new_object>());
 
     std::string docString =
-      "scores the ring system of the tautomer for canonicalization";
+      "scores the ring system of the tautomer for canonicalization\n"
+      "Aromatic rings score 100, all carbon aromatic rings score 250";
     python::def("ScoreRings", MolStandardize::TautomerScoringFunctions::scoreRings,
 		python::arg("mol"),
 		docString.c_str());
     
     docString =
-      "scores the number of heteroHs of the tautomer for canonicalization";
+      "scores the number of heteroHs of the tautomer for canonicalization\n"
+      "This gives a negative penalty to hydrogens attached to S,P, Se and Te";
     python::def("ScoreHeteroHs", MolStandardize::TautomerScoringFunctions::scoreHeteroHs,
 		python::arg("mol"),
 		docString.c_str());
     
     python::class_<MolStandardize::TautomerScoringFunctions::SubstructTerm> (
 		    "SubstructTerm",
-		    "Sets the score of this particular tautomer substructure, higher scores are more preferable",
+		    "Sets the score of this particular tautomer substructure, higher scores are more preferable\n"
+		    "Aromatic rings score 100, all carbon aromatic rings score 250",
 		    python::init<std::string, std::string, int>(
 								python::args("self", "name", "smarts", "score")))
 		    .def_readonly("name", &MolStandardize::TautomerScoringFunctions::SubstructTerm::name)

--- a/Code/GraphMol/MolStandardize/Wrap/Tautomer.cpp
+++ b/Code/GraphMol/MolStandardize/Wrap/Tautomer.cpp
@@ -277,12 +277,14 @@ GetDefaultTautomerSubstructsHelper() {
   }
   return terms;
 }
-
-int ScoreSubstructsHelper(const ROMol &mol) {
-  return MolStandardize::TautomerScoringFunctions::scoreSubstructs(mol);
-}
+  
 
 }  // namespace
+
+// This indicates that the scoreSubstructs takes a minimum of 1 argument and a maximum of 2
+// so we can call it ScoreSubstructs(mol) or ScoreSubstructs(mol, terms)
+BOOST_PYTHON_FUNCTION_OVERLOADS(scoreSubstructs_overloads,
+				RDKit::MolStandardize::TautomerScoringFunctions::scoreSubstructs, 1, 2)
 
 struct tautomer_wrapper {
   static void wrap() {
@@ -543,15 +545,13 @@ struct tautomer_wrapper {
         "SubstructTermVector")
         .def(python::vector_indexing_suite<std::vector<
                  MolStandardize::TautomerScoringFunctions::SubstructTerm>>());
-
+    
     docString = "scores the tautomer substructures";
-    python::def("ScoreSubstructs", ScoreSubstructsHelper, python::arg("mol"),
-                docString.c_str());
+    python::def("ScoreSubstructs", &MolStandardize::TautomerScoringFunctions::scoreSubstructs,
+		scoreSubstructs_overloads((python::arg("mol"), python::arg("terms")),
+					  docString.c_str())
+		);
 
-    docString = "scores the tautomer substructures";
-    python::def("ScoreSubstructs",
-                MolStandardize::TautomerScoringFunctions::scoreSubstructs,
-                (python::arg("mol"), python::arg("terms")), docString.c_str());
 
     python::def("GetDefaultTautomerScoreSubstructs",
                 GetDefaultTautomerSubstructsHelper,

--- a/Code/GraphMol/MolStandardize/Wrap/Tautomer.cpp
+++ b/Code/GraphMol/MolStandardize/Wrap/Tautomer.cpp
@@ -268,6 +268,18 @@ PyTautomerEnumeratorResult *enumerateHelper(
   return new PyTautomerEnumeratorResult(self.enumerate(mol));
 }
 
+std::vector<MolStandardize::TautomerScoringFunctions::SubstructTerm> GetDefaultTautomerSubstructsHelper() {
+  std::vector<MolStandardize::TautomerScoringFunctions::SubstructTerm> terms;
+  for(auto term: MolStandardize::TautomerScoringFunctions::getDefaultTautomerSubstructs()) {
+    terms.emplace_back(term);
+  }
+  return terms;
+}
+
+int ScoreSubstructsHelper(const ROMol &mol) {
+  return MolStandardize::TautomerScoringFunctions::scoreSubstructs(mol);
+}
+
 }  // namespace
 
 struct tautomer_wrapper {
@@ -493,6 +505,50 @@ struct tautomer_wrapper {
                 MolStandardize::getV1TautomerEnumerator,
                 "return a TautomerEnumerator using v1 of the enumeration rules",
                 python::return_value_policy<python::manage_new_object>());
+
+    std::string docString =
+      "scores the ring system of the tautomer for canonicalization";
+    python::def("ScoreRings", MolStandardize::TautomerScoringFunctions::scoreRings,
+		python::arg("mol"),
+		docString.c_str());
+    
+    docString =
+      "scores the number of heteroHs of the tautomer for canonicalization";
+    python::def("ScoreHeteroHs", MolStandardize::TautomerScoringFunctions::scoreHeteroHs,
+		python::arg("mol"),
+		docString.c_str());
+    
+    python::class_<MolStandardize::TautomerScoringFunctions::SubstructTerm> (
+		    "SubstructTerm",
+		    "Sets the score of this particular tautomer substructure, higher scores are more preferable",
+		    python::init<std::string, std::string, int>(
+								python::args("self", "name", "smarts", "score")))
+		    .def_readonly("name", &MolStandardize::TautomerScoringFunctions::SubstructTerm::name)
+		    .def_readonly("smarts", &MolStandardize::TautomerScoringFunctions::SubstructTerm::smarts)
+		    .def_readonly("score", &MolStandardize::TautomerScoringFunctions::SubstructTerm::score);
+
+    
+    python::class_<std::vector<MolStandardize::TautomerScoringFunctions::SubstructTerm>>("SubstructTermVector")
+      .def(python::vector_indexing_suite<std::vector<MolStandardize::TautomerScoringFunctions::SubstructTerm>>());
+
+
+    docString =
+      "scores the tautomer substructures";
+    python::def("ScoreSubstructs", ScoreSubstructsHelper,
+		python::arg("mol"),
+		docString.c_str());
+    
+    docString =
+      "scores the tautomer substructures";
+    python::def("ScoreSubstructs", MolStandardize::TautomerScoringFunctions::scoreSubstructs,
+		(python::arg("mol"), python::arg("terms")),
+		docString.c_str());
+
+    
+    python::def("GetDefaultTautomerSubstructs", GetDefaultTautomerSubstructsHelper,
+    		"Return the default tautomer substructure scoring terms");
+  
+
   }
 };
 

--- a/Code/GraphMol/MolStandardize/Wrap/Tautomer.cpp
+++ b/Code/GraphMol/MolStandardize/Wrap/Tautomer.cpp
@@ -270,7 +270,7 @@ PyTautomerEnumeratorResult *enumerateHelper(
 
 std::vector<MolStandardize::TautomerScoringFunctions::SubstructTerm> GetDefaultTautomerSubstructsHelper() {
   std::vector<MolStandardize::TautomerScoringFunctions::SubstructTerm> terms;
-  for(auto term: MolStandardize::TautomerScoringFunctions::getDefaultTautomerSubstructs()) {
+  for(auto term: MolStandardize::TautomerScoringFunctions::getDefaultTautomerScoreSubstructs()) {
     terms.emplace_back(term);
   }
   return terms;
@@ -548,7 +548,7 @@ struct tautomer_wrapper {
 		docString.c_str());
 
     
-    python::def("GetDefaultTautomerSubstructs", GetDefaultTautomerSubstructsHelper,
+    python::def("GetDefaultTautomerScoreSubstructs", GetDefaultTautomerSubstructsHelper,
     		"Return the default tautomer substructure scoring terms");
   
 

--- a/Code/GraphMol/MolStandardize/Wrap/Tautomer.cpp
+++ b/Code/GraphMol/MolStandardize/Wrap/Tautomer.cpp
@@ -268,9 +268,11 @@ PyTautomerEnumeratorResult *enumerateHelper(
   return new PyTautomerEnumeratorResult(self.enumerate(mol));
 }
 
-std::vector<MolStandardize::TautomerScoringFunctions::SubstructTerm> GetDefaultTautomerSubstructsHelper() {
+std::vector<MolStandardize::TautomerScoringFunctions::SubstructTerm>
+GetDefaultTautomerSubstructsHelper() {
   std::vector<MolStandardize::TautomerScoringFunctions::SubstructTerm> terms;
-  for(auto term: MolStandardize::TautomerScoringFunctions::getDefaultTautomerScoreSubstructs()) {
+  for (auto term : MolStandardize::TautomerScoringFunctions::
+           getDefaultTautomerScoreSubstructs()) {
     terms.emplace_back(term);
   }
   return terms;
@@ -507,51 +509,53 @@ struct tautomer_wrapper {
                 python::return_value_policy<python::manage_new_object>());
 
     std::string docString =
-      "scores the ring system of the tautomer for canonicalization\n"
-      "Aromatic rings score 100, all carbon aromatic rings score 250";
-    python::def("ScoreRings", MolStandardize::TautomerScoringFunctions::scoreRings,
-		python::arg("mol"),
-		docString.c_str());
-    
-    docString =
-      "scores the number of heteroHs of the tautomer for canonicalization\n"
-      "This gives a negative penalty to hydrogens attached to S,P, Se and Te";
-    python::def("ScoreHeteroHs", MolStandardize::TautomerScoringFunctions::scoreHeteroHs,
-		python::arg("mol"),
-		docString.c_str());
-    
-    python::class_<MolStandardize::TautomerScoringFunctions::SubstructTerm> (
-		    "SubstructTerm",
-		    "Sets the score of this particular tautomer substructure, higher scores are more preferable\n"
-		    "Aromatic rings score 100, all carbon aromatic rings score 250",
-		    python::init<std::string, std::string, int>(
-								python::args("self", "name", "smarts", "score")))
-		    .def_readonly("name", &MolStandardize::TautomerScoringFunctions::SubstructTerm::name)
-		    .def_readonly("smarts", &MolStandardize::TautomerScoringFunctions::SubstructTerm::smarts)
-		    .def_readonly("score", &MolStandardize::TautomerScoringFunctions::SubstructTerm::score);
-
-    
-    python::class_<std::vector<MolStandardize::TautomerScoringFunctions::SubstructTerm>>("SubstructTermVector")
-      .def(python::vector_indexing_suite<std::vector<MolStandardize::TautomerScoringFunctions::SubstructTerm>>());
-
+        "scores the ring system of the tautomer for canonicalization\n"
+        "Aromatic rings score 100, all carbon aromatic rings score 250";
+    python::def("ScoreRings",
+                MolStandardize::TautomerScoringFunctions::scoreRings,
+                python::arg("mol"), docString.c_str());
 
     docString =
-      "scores the tautomer substructures";
-    python::def("ScoreSubstructs", ScoreSubstructsHelper,
-		python::arg("mol"),
-		docString.c_str());
-    
-    docString =
-      "scores the tautomer substructures";
-    python::def("ScoreSubstructs", MolStandardize::TautomerScoringFunctions::scoreSubstructs,
-		(python::arg("mol"), python::arg("terms")),
-		docString.c_str());
+        "scores the number of heteroHs of the tautomer for canonicalization\n"
+        "This gives a negative penalty to hydrogens attached to S,P, Se and Te";
+    python::def("ScoreHeteroHs",
+                MolStandardize::TautomerScoringFunctions::scoreHeteroHs,
+                python::arg("mol"), docString.c_str());
 
-    
-    python::def("GetDefaultTautomerScoreSubstructs", GetDefaultTautomerSubstructsHelper,
-    		"Return the default tautomer substructure scoring terms");
-  
+    python::class_<MolStandardize::TautomerScoringFunctions::SubstructTerm>(
+        "SubstructTerm",
+        "Sets the score of this particular tautomer substructure, higher scores are more preferable\n"
+        "Aromatic rings score 100, all carbon aromatic rings score 250",
+        python::init<std::string, std::string, int>(
+            python::args("self", "name", "smarts", "score")))
+        .def_readonly(
+            "name",
+            &MolStandardize::TautomerScoringFunctions::SubstructTerm::name)
+        .def_readonly(
+            "smarts",
+            &MolStandardize::TautomerScoringFunctions::SubstructTerm::smarts)
+        .def_readonly(
+            "score",
+            &MolStandardize::TautomerScoringFunctions::SubstructTerm::score);
 
+    python::class_<
+        std::vector<MolStandardize::TautomerScoringFunctions::SubstructTerm>>(
+        "SubstructTermVector")
+        .def(python::vector_indexing_suite<std::vector<
+                 MolStandardize::TautomerScoringFunctions::SubstructTerm>>());
+
+    docString = "scores the tautomer substructures";
+    python::def("ScoreSubstructs", ScoreSubstructsHelper, python::arg("mol"),
+                docString.c_str());
+
+    docString = "scores the tautomer substructures";
+    python::def("ScoreSubstructs",
+                MolStandardize::TautomerScoringFunctions::scoreSubstructs,
+                (python::arg("mol"), python::arg("terms")), docString.c_str());
+
+    python::def("GetDefaultTautomerScoreSubstructs",
+                GetDefaultTautomerSubstructsHelper,
+                "Return the default tautomer substructure scoring terms");
   }
 };
 

--- a/Code/GraphMol/MolStandardize/Wrap/testMolStandardize.py
+++ b/Code/GraphMol/MolStandardize/Wrap/testMolStandardize.py
@@ -1788,7 +1788,7 @@ M  END
     self.assertEqual(rdMolStandardize.ScoreSubstructs(m), 6)
 
     # check the default terms
-    terms = rdMolStandardize.GetDefaultTautomerSubstructs()
+    terms = rdMolStandardize.GetDefaultTautomerScoreSubstructs()
     for term, (name, smarts, score) in zip(terms, [["benzoquinone", "[#6]1([#6]=[#6][#6]([#6]=[#6]1)=,:[N,S,O])=,:[N,S,O]",
                                                     25],
                                                    ["oxim", "[#6]=[N][OH]", 4],
@@ -1809,7 +1809,7 @@ M  END
       terms.append(rdMolStandardize.SubstructTerm("C=0", "[#6]=,:[#8]", 1000))
       self.assertEqual(rdMolStandardize.ScoreSubstructs(m, terms), 1000)
 
-      self.assertEqual(rdMolStandardize.ScoreSubstructs(m, rdMolStandardize.GetDefaultTautomerSubstructs()), 6)
+      self.assertEqual(rdMolStandardize.ScoreSubstructs(m, rdMolStandardize.GetDefaultTautomerScoreSubstructs()), 6)
                                           
     
     

--- a/Code/GraphMol/MolStandardize/catch_tests.cpp
+++ b/Code/GraphMol/MolStandardize/catch_tests.cpp
@@ -1731,3 +1731,23 @@ M  END)CTAB";
           0);
   }
 }
+
+TEST_CASE("Custom Scoring Functions") {
+  SECTION("basics") {
+    auto mol = "CC\\C=C(/O)[C@@H](C)C(C)=O"_smiles;
+    REQUIRE(MolStandardize::TautomerScoringFunctions::scoreRings(*mol) == 0);
+    REQUIRE(MolStandardize::TautomerScoringFunctions::scoreHeteroHs(*mol) == 0);
+    REQUIRE(MolStandardize::TautomerScoringFunctions::scoreSubstructs(*mol) == 6);
+
+    auto terms = MolStandardize::TautomerScoringFunctions::getDefaultTautomerSubstructs();
+    REQUIRE(terms.size() == 12);
+  }
+  
+  SECTION("Over ride default tautomer scoring functions") {
+    auto mol = "CC\\C=C(/O)[C@@H](C)C(C)=O"_smiles;
+    std::vector<MolStandardize::TautomerScoringFunctions::SubstructTerm> terms = {
+      {"C=O","[#6]=,:[#8]", 1000} };
+    REQUIRE(MolStandardize::TautomerScoringFunctions::scoreSubstructs(*mol, terms) == 1000);
+  }
+}
+  

--- a/Code/GraphMol/MolStandardize/catch_tests.cpp
+++ b/Code/GraphMol/MolStandardize/catch_tests.cpp
@@ -1739,11 +1739,11 @@ TEST_CASE("Custom Scoring Functions") {
     REQUIRE(MolStandardize::TautomerScoringFunctions::scoreHeteroHs(*mol) == 0);
     REQUIRE(MolStandardize::TautomerScoringFunctions::scoreSubstructs(*mol) == 6);
 
-    auto terms = MolStandardize::TautomerScoringFunctions::getDefaultTautomerSubstructs();
+    auto terms = MolStandardize::TautomerScoringFunctions::getDefaultTautomerScoreSubstructs();
     REQUIRE(terms.size() == 12);
   }
   
-  SECTION("Over ride default tautomer scoring functions") {
+  SECTION("Override default tautomer scoring functions") {
     auto mol = "CC\\C=C(/O)[C@@H](C)C(C)=O"_smiles;
     std::vector<MolStandardize::TautomerScoringFunctions::SubstructTerm> terms = {
       {"C=O","[#6]=,:[#8]", 1000} };

--- a/Code/GraphMol/MolStandardize/catch_tests.cpp
+++ b/Code/GraphMol/MolStandardize/catch_tests.cpp
@@ -1737,17 +1737,19 @@ TEST_CASE("Custom Scoring Functions") {
     auto mol = "CC\\C=C(/O)[C@@H](C)C(C)=O"_smiles;
     REQUIRE(MolStandardize::TautomerScoringFunctions::scoreRings(*mol) == 0);
     REQUIRE(MolStandardize::TautomerScoringFunctions::scoreHeteroHs(*mol) == 0);
-    REQUIRE(MolStandardize::TautomerScoringFunctions::scoreSubstructs(*mol) == 6);
+    REQUIRE(MolStandardize::TautomerScoringFunctions::scoreSubstructs(*mol) ==
+            6);
 
-    auto terms = MolStandardize::TautomerScoringFunctions::getDefaultTautomerScoreSubstructs();
+    auto terms = MolStandardize::TautomerScoringFunctions::
+        getDefaultTautomerScoreSubstructs();
     REQUIRE(terms.size() == 12);
   }
-  
+
   SECTION("Override default tautomer scoring functions") {
     auto mol = "CC\\C=C(/O)[C@@H](C)C(C)=O"_smiles;
-    std::vector<MolStandardize::TautomerScoringFunctions::SubstructTerm> terms = {
-      {"C=O","[#6]=,:[#8]", 1000} };
-    REQUIRE(MolStandardize::TautomerScoringFunctions::scoreSubstructs(*mol, terms) == 1000);
+    std::vector<MolStandardize::TautomerScoringFunctions::SubstructTerm> terms =
+        {{"C=O", "[#6]=,:[#8]", 1000}};
+    REQUIRE(MolStandardize::TautomerScoringFunctions::scoreSubstructs(
+                *mol, terms) == 1000);
   }
 }
-  


### PR DESCRIPTION
This exposes the pieces of the tautomer scoring function to make it easier to adjust from python and other languages.

Example

```
      terms = rdMolStandardize.SubstructTermVector()
      terms.append(rdMolStandardize.SubstructTerm("C=0", "[#6]=,:[#8]", 1000))

      rdMolStandardize.ScoreSubstructs(m, terms) # now == 1000
```
