### PR TITLE
Implemented two more JSON parsers for CFFI and MinimalLib

### DIFF
--- a/Code/GraphMol/MolOps.h
+++ b/Code/GraphMol/MolOps.h
@@ -19,6 +19,7 @@
 #include <boost/dynamic_bitset.hpp>
 #include <RDGeneral/BoostEndInclude.h>
 #include <RDGeneral/types.h>
+#include <RDGeneral/BetterEnums.h>
 #include "SanitException.h"
 #include <RDGeneral/FileParseException.h>
 
@@ -307,6 +308,7 @@ struct RDKIT_GRAPHMOL_EXPORT RemoveHsParameters {
       false; /**<  remove Hs which are bonded to atoms with specified
                 non-tetrahedral stereochemistry */
 };
+
 //! \overload
 /// modifies the molecule in place
 RDKIT_GRAPHMOL_EXPORT void removeHs(RWMol &mol, const RemoveHsParameters &ps,
@@ -491,7 +493,8 @@ RDKIT_GRAPHMOL_EXPORT ROMol *renumberAtoms(
 //! \name Sanitization
 /// {
 
-typedef enum {
+// clang-format off
+BETTER_ENUM(SanitizeFlags, unsigned int,
   SANITIZE_NONE = 0x0,
   SANITIZE_CLEANUP = 0x1,
   SANITIZE_PROPERTIES = 0x2,
@@ -506,7 +509,8 @@ typedef enum {
   SANITIZE_CLEANUP_ORGANOMETALLICS = 0x400,
   SANITIZE_CLEANUPATROPISOMERS = 0x800,
   SANITIZE_ALL = 0xFFFFFFF
-} SanitizeFlags;
+);
+// clang-format on
 
 //! \brief carries out a collection of tasks for cleaning up a molecule and
 //! ensuring that it makes "chemical sense"
@@ -543,9 +547,9 @@ typedef enum {
       this function to a ROMol, so that new atoms and bonds cannot be added to
       the molecule and screw up the sanitizing that has been done here
 */
-RDKIT_GRAPHMOL_EXPORT void sanitizeMol(RWMol &mol,
-                                       unsigned int &operationThatFailed,
-                                       unsigned int sanitizeOps = SANITIZE_ALL);
+RDKIT_GRAPHMOL_EXPORT void sanitizeMol(
+    RWMol &mol, unsigned int &operationThatFailed,
+    unsigned int sanitizeOps = SanitizeFlags::SANITIZE_ALL);
 //! \overload
 RDKIT_GRAPHMOL_EXPORT void sanitizeMol(RWMol &mol);
 
@@ -573,7 +577,7 @@ RDKIT_GRAPHMOL_EXPORT void sanitizeMol(RWMol &mol);
 */
 RDKIT_GRAPHMOL_EXPORT
 std::vector<std::unique_ptr<MolSanitizeException>> detectChemistryProblems(
-    const ROMol &mol, unsigned int sanitizeOps = SANITIZE_ALL);
+    const ROMol &mol, unsigned int sanitizeOps = SanitizeFlags::SANITIZE_ALL);
 
 //! Possible aromaticity models
 /*!

--- a/Code/MinimalLib/JSONParsers.cpp
+++ b/Code/MinimalLib/JSONParsers.cpp
@@ -23,7 +23,7 @@ namespace MinimalLib {
 
 void updatePropertyPickleOptionsFromJSON(unsigned int &propFlags,
                                          const char *details_json) {
-  if (details_json && strlen(details_json)) {
+  if (details_json && details_json[0]) {
     std::istringstream ss;
     boost::property_tree::ptree pt;
     ss.str(details_json);
@@ -41,6 +41,61 @@ void updatePropertyPickleOptionsFromJSON(unsigned int &propFlags,
       }
       propFlags = propertyFlagsFromJson;
     }
+  }
+}
+
+void updateSanitizeFlagsFromJSON(unsigned int &sanitizeFlags,
+                                 const char *details_json) {
+  if (details_json && details_json[0]) {
+    std::istringstream ss;
+    boost::property_tree::ptree pt;
+    ss.str(details_json);
+    boost::property_tree::read_json(ss, pt);
+    auto sanitizeFlagsFromJson =
+        (+MolOps::SanitizeFlags::SANITIZE_NONE)._to_integral();
+    for (const auto *key : MolOps::SanitizeFlags::_names()) {
+      if (pt.get(key, false)) {
+        sanitizeFlagsFromJson |=
+            MolOps::SanitizeFlags::_from_string(key)._to_integral();
+      }
+    }
+    sanitizeFlags = sanitizeFlagsFromJson;
+  }
+}
+
+void updateRemoveHsParametersFromJSON(MolOps::RemoveHsParameters &ps,
+                                      bool &sanitize,
+                                      const char *details_json) {
+  if (details_json && details_json[0]) {
+    boost::property_tree::ptree pt;
+    std::istringstream ss;
+    ss.str(details_json);
+    boost::property_tree::read_json(ss, pt);
+    ps.removeDegreeZero = pt.get("removeDegreeZero", ps.removeDegreeZero);
+    ps.removeHigherDegrees =
+        pt.get("removeHigherDegrees", ps.removeHigherDegrees);
+    ps.removeOnlyHNeighbors =
+        pt.get("removeOnlyHNeighbors", ps.removeOnlyHNeighbors);
+    ps.removeIsotopes = pt.get("removeIsotopes", ps.removeIsotopes);
+    ps.removeAndTrackIsotopes =
+        pt.get("removeAndTrackIsotopes", ps.removeAndTrackIsotopes);
+    ps.removeDummyNeighbors =
+        pt.get("removeDummyNeighbors", ps.removeDummyNeighbors);
+    ps.removeDefiningBondStereo =
+        pt.get("removeDefiningBondStereo", ps.removeDefiningBondStereo);
+    ps.removeWithWedgedBond =
+        pt.get("removeWithWedgedBond", ps.removeWithWedgedBond);
+    ps.removeWithQuery = pt.get("removeWithQuery", ps.removeWithQuery);
+    ps.removeMapped = pt.get("removeMapped", ps.removeMapped);
+    ps.removeInSGroups = pt.get("removeInSGroups", ps.removeInSGroups);
+    ps.showWarnings = pt.get("showWarnings", ps.showWarnings);
+    ps.removeNonimplicit = pt.get("removeNonimplicit", ps.removeNonimplicit);
+    ps.updateExplicitCount =
+        pt.get("updateExplicitCount", ps.updateExplicitCount);
+    ps.removeHydrides = pt.get("removeHydrides", ps.removeHydrides);
+    ps.removeNontetrahedralNeighbors = pt.get("removeNontetrahedralNeighbors",
+                                              ps.removeNontetrahedralNeighbors);
+    sanitize = pt.get("sanitize", sanitize);
   }
 }
 

--- a/Code/MinimalLib/JSONParsers.h
+++ b/Code/MinimalLib/JSONParsers.h
@@ -11,12 +11,19 @@
 #pragma once
 
 #include <GraphMol/FileParsers/PNGParser.h>
+#include <GraphMol/MolOps.h>
 
 namespace RDKit {
 namespace MinimalLib {
 
 void updatePropertyPickleOptionsFromJSON(unsigned int &propFlags,
                                          const char *details_json);
+
+void updateSanitizeFlagsFromJSON(unsigned int &sanitizeFlags,
+                                 const char *details_json);
+
+void updateRemoveHsParametersFromJSON(MolOps::RemoveHsParameters &ps,
+                                      bool &sanitize, const char *details_json);
 
 }  // end namespace MinimalLib
 }  // end namespace RDKit

--- a/Code/MinimalLib/cffi_test.c
+++ b/Code/MinimalLib/cffi_test.c
@@ -757,6 +757,7 @@ void test_modifications() {
   printf("--------------------------\n");
   printf("  test_modifications\n");
   char *mpkl;
+  char *smi;
   size_t mpkl_size;
   mpkl = get_mol("CCC", &mpkl_size, "");
 
@@ -769,9 +770,23 @@ void test_modifications() {
   ctab = get_molblock(mpkl, mpkl_size, NULL);
   assert(!strstr(ctab, " H "));
   free(ctab);
-
   free(mpkl);
-  mpkl = NULL;
+
+  mpkl = get_mol("C([H])([H])([H])C([2H])([H])C([H])([H])[H]", &mpkl_size, "{\"removeHs\":false}");
+  smi = get_smiles(mpkl, mpkl_size, NULL);
+  assert(!strcmp(smi, "[H]C([H])([H])C([H])([2H])C([H])([H])[H]"));
+  free(smi);
+  assert(!remove_hs(NULL, NULL, NULL));
+  assert(remove_hs(&mpkl, &mpkl_size, "{\"removeIsotopes\":false}"));
+  smi = get_smiles(mpkl, mpkl_size, NULL);
+  assert(!strcmp(smi, "[2H]C(C)C"));
+  free(smi);
+  assert(remove_hs(&mpkl, &mpkl_size, "{\"removeIsotopes\":true}"));
+  smi = get_smiles(mpkl, mpkl_size, NULL);
+  assert(!strcmp(smi, "CCC"));
+  free(smi);
+  free(mpkl);
+
   printf("  done\n");
   printf("--------------------------\n");
 }
@@ -2130,6 +2145,7 @@ void test_partial_sanitization() {
   printf("--------------------------\n");
   printf("  test_partial_sanitization\n");
   char *mpkl;
+  char *mb;
   char *fp;
   size_t mpkl_size;
   const char *mfp_json = "{\"radius\":2,\"nBits\":32}";
@@ -2167,6 +2183,30 @@ void test_partial_sanitization() {
   assert(fp);
   free(fp);
 #endif
+  free(mpkl);
+
+  mpkl = get_mol("c1ccccc1N(=O)=O", &mpkl_size, "{\"sanitize\":false}");
+  mb = get_molblock(mpkl, mpkl_size, "{\"kekulize\":false}");
+  assert(strstr(mb, "  1  2  4  0"));
+  assert(strstr(mb, "  7  8  2  0") && strstr(mb, "  7  9  2  0"));
+  assert(!strstr(mb, "M  CHG"));
+  free(mb);
+  free(mpkl);
+  mpkl = get_mol("c1ccccc1N(=O)=O", &mpkl_size, "{\"sanitize\":{\"SANITIZE_CLEANUP\":true}}");
+  mb = get_molblock(mpkl, mpkl_size, "{\"kekulize\":false}");
+  assert(strstr(mb, "  1  2  4  0"));
+  assert((strstr(mb, "  7  8  1  0") && strstr(mb, "  7  9  2  0"))
+    || (strstr(mb, "  7  8  2  0") && strstr(mb, "  7  9  1  0")));
+  assert(strstr(mb, "M  CHG  2"));
+  free(mb);
+  free(mpkl);
+  mpkl = get_mol("c1ccccc1N(=O)=O", &mpkl_size, "{\"sanitize\":{\"SANITIZE_CLEANUP\":true,\"SANITIZE_KEKULIZE\":true}}");
+  mb = get_molblock(mpkl, mpkl_size, "{\"kekulize\":false}");
+  assert(!strstr(mb, "  1  2  4  0"));
+  assert((strstr(mb, "  7  8  1  0") && strstr(mb, "  7  9  2  0"))
+    || (strstr(mb, "  7  8  2  0") && strstr(mb, "  7  9  1  0")));
+  assert(strstr(mb, "M  CHG  2"));
+  free(mb);
   free(mpkl);
 }
 

--- a/Code/MinimalLib/cffiwrapper.cpp
+++ b/Code/MinimalLib/cffiwrapper.cpp
@@ -766,6 +766,21 @@ extern "C" short remove_all_hs(char **mol_pkl, size_t *mol_pkl_sz) {
   return 1;
 }
 
+extern "C" short remove_hs(char **mol_pkl, size_t *mol_pkl_sz,
+                           const char *details_json) {
+  if (!mol_pkl || !mol_pkl_sz || !*mol_pkl || !*mol_pkl_sz) {
+    return 0;
+  }
+  auto mol = mol_from_pkl(*mol_pkl, *mol_pkl_sz);
+  MolOps::RemoveHsParameters ps;
+  bool sanitize = true;
+  MinimalLib::updateRemoveHsParametersFromJSON(ps, sanitize, details_json);
+  MolOps::removeHs(mol, ps, sanitize);
+
+  mol_to_pkl(mol, mol_pkl, mol_pkl_sz);
+  return 1;
+}
+
 // standardization
 namespace {
 template <typename T>

--- a/Code/MinimalLib/cffiwrapper.h
+++ b/Code/MinimalLib/cffiwrapper.h
@@ -117,6 +117,8 @@ RDKIT_RDKITCFFI_EXPORT char *get_avalon_fp_as_bytes(const char *pkl,
 // modification
 RDKIT_RDKITCFFI_EXPORT short add_hs(char **pkl, size_t *pkl_sz);
 RDKIT_RDKITCFFI_EXPORT short remove_all_hs(char **pkl, size_t *pkl_sz);
+RDKIT_RDKITCFFI_EXPORT short remove_hs(char **pkl, size_t *pkl_sz,
+                                       const char *details_json);
 
 // standardization
 RDKIT_RDKITCFFI_EXPORT short cleanup(char **pkl, size_t *pkl_sz,

--- a/Code/MinimalLib/common.h
+++ b/Code/MinimalLib/common.h
@@ -60,6 +60,9 @@
 #include <boost/property_tree/ptree.hpp>
 #include <boost/property_tree/json_parser.hpp>
 #include <RDGeneral/BoostEndInclude.h>
+#ifdef RDK_BUILD_THREADSAFE_SSS
+#include <atomic>
+#endif
 
 #ifndef _MSC_VER
 // shutoff some warnings from rapidjson
@@ -113,11 +116,22 @@ RWMol *mol_from_input(const std::string &input,
   bool makeDummiesQueries = false;
   RWMol *res = nullptr;
   boost::property_tree::ptree pt;
+  unsigned int sanitizeOps = MolOps::SanitizeFlags::SANITIZE_ALL;
   if (!details_json.empty()) {
     std::istringstream ss;
     ss.str(details_json);
     boost::property_tree::read_json(ss, pt);
-    LPT_OPT_GET(sanitize);
+    auto sanitizeIt = pt.find("sanitize");
+    if (sanitizeIt != pt.not_found()) {
+      // Does the "sanitize" key correspond to a terminal value?
+      if (sanitizeIt->second.empty()) {
+        sanitize = sanitizeIt->second.get_value<bool>();
+      } else {
+        std::stringstream ss;
+        boost::property_tree::json_parser::write_json(ss, sanitizeIt->second);
+        updateSanitizeFlagsFromJSON(sanitizeOps, ss.str().c_str());
+      }
+    }
     LPT_OPT_GET(kekulize);
     LPT_OPT_GET(removeHs);
     LPT_OPT_GET(mergeQueryHs);
@@ -161,7 +175,6 @@ RWMol *mol_from_input(const std::string &input,
     try {
       if (sanitize) {
         unsigned int failedOp;
-        unsigned int sanitizeOps = MolOps::SANITIZE_ALL;
         if (!kekulize) {
           sanitizeOps ^= MolOps::SANITIZE_KEKULIZE;
         }

--- a/Code/MinimalLib/jswrapper.cpp
+++ b/Code/MinimalLib/jswrapper.cpp
@@ -663,8 +663,16 @@ EMSCRIPTEN_BINDINGS(RDKit_minimal) {
                     &JSMolBase::condense_abbreviations))
       .function("add_hs", &JSMolBase::add_hs)
       .function("add_hs_in_place", &JSMolBase::add_hs_in_place)
-      .function("remove_hs", &JSMolBase::remove_hs)
-      .function("remove_hs_in_place", &JSMolBase::remove_hs_in_place)
+      .function("remove_hs",
+                select_overload<std::string(const std::string &) const>(
+                    &JSMolBase::remove_hs))
+      .function("remove_hs",
+                select_overload<std::string() const>(&JSMolBase::remove_hs))
+      .function("remove_hs_in_place",
+                select_overload<bool(const std::string &)>(
+                    &JSMolBase::remove_hs_in_place))
+      .function("remove_hs_in_place",
+                select_overload<bool()>(&JSMolBase::remove_hs_in_place))
       .function("normalize_depiction",
                 select_overload<double()>(&JSMolBase::normalize_depiction))
       .function("normalize_depiction",

--- a/Code/MinimalLib/minilib.cpp
+++ b/Code/MinimalLib/minilib.cpp
@@ -91,6 +91,18 @@ std::string mappingToJsonArray(const ROMol &mol) {
   std::string res = buffer.GetString();
   return res;
 }
+
+void remove_hs_common(RWMol &mol, const std::string &details_json) {
+  if (details_json.empty()) {
+    MolOps::removeAllHs(mol);
+  } else {
+    MolOps::RemoveHsParameters ps;
+    bool sanitize = true;
+    MinimalLib::updateRemoveHsParametersFromJSON(ps, sanitize,
+                                                 details_json.c_str());
+    MolOps::removeHs(mol, ps, sanitize);
+  }
+}
 }  // end of anonymous namespace
 
 std::string JSMolBase::get_smiles() const { return MolToSmiles(get()); }
@@ -435,9 +447,9 @@ bool JSMolBase::clear_prop(const std::string &key) {
   return res;
 }
 
-std::string JSMolBase::remove_hs() const {
+std::string JSMolBase::remove_hs(const std::string &details_json) const {
   RWMol molCopy(get());
-  MolOps::removeAllHs(molCopy);
+  remove_hs_common(molCopy, details_json);
 
   bool includeStereo = true;
   int confId = -1;
@@ -445,8 +457,8 @@ std::string JSMolBase::remove_hs() const {
   return MolToMolBlock(molCopy, includeStereo, confId, kekulize);
 }
 
-bool JSMolBase::remove_hs_in_place() {
-  MolOps::removeAllHs(get());
+bool JSMolBase::remove_hs_in_place(const std::string &details_json) {
+  remove_hs_common(get(), details_json);
   MolOps::assignStereochemistry(get(), true, true);
   return true;
 }

--- a/Code/MinimalLib/minilib.h
+++ b/Code/MinimalLib/minilib.h
@@ -142,8 +142,10 @@ class JSMolBase {
   }
   std::string get_prop(const std::string &key) const;
   bool clear_prop(const std::string &key);
-  std::string remove_hs() const;
-  bool remove_hs_in_place();
+  std::string remove_hs(const std::string &details_json) const;
+  std::string remove_hs() const { return remove_hs(""); }
+  bool remove_hs_in_place(const std::string &details_json);
+  bool remove_hs_in_place() { return remove_hs_in_place(""); }
   std::string add_hs() const;
   bool add_hs_in_place();
   double normalize_depiction(int canonicalize, double scaleFactor);

--- a/Code/MinimalLib/tests/tests.js
+++ b/Code/MinimalLib/tests/tests.js
@@ -2064,16 +2064,22 @@ function test_hs_in_place() {
     }
     {
         var mol = RDKitModule.get_mol("C([H])([H])([H])C([H])([H])[H]", JSON.stringify({ removeHs: false }));
+        assert(mol.get_smiles() === '[H]C([H])([H])C([H])([H])[H]');
         assert(!mol.has_coords());
         var descH = JSON.parse(mol.get_descriptors());
         assert(`${descH.chi0v}` === '1');
         assert(`${descH.chi1v}` === '0.25');
-        mol.remove_hs_in_place();
-        assert(!mol.has_coords());
-        assert(mol.get_smiles() === 'CC');
-        var descNoH = JSON.parse(mol.get_descriptors());
-        assert(`${descNoH.chi0v}` === '2');
-        assert(`${descNoH.chi1v}` === '1');
+        // '' will use removeAllHs, while '{}' will use removeHs with default parameters
+        ['', '{}'].forEach((details) => {
+            var molCopy = mol.copy();
+            molCopy.remove_hs_in_place(details);
+            assert(!molCopy.has_coords());
+            assert(molCopy.get_smiles() === 'CC');
+            var descNoH = JSON.parse(molCopy.get_descriptors());
+            assert(`${descNoH.chi0v}` === '2');
+            assert(`${descNoH.chi1v}` === '1');
+            molCopy.delete();
+        });
         mol.delete();
     }
     {
@@ -2757,6 +2763,29 @@ function test_partial_sanitization() {
     }
     assert(exceptionThrown);
     mol2.delete();
+    let mb;
+    mol1 = RDKitModule.get_mol('c1ccccc1N(=O)=O', JSON.stringify({sanitize: false}));
+    mb = mol1.get_molblock(JSON.stringify({kekulize: false}));
+    assert(mb.includes('  1  2  4  0'));
+    assert(mb.includes('  7  8  2  0') && mb.includes('  7  9  2  0'));
+    assert(!mb.includes('M  CHG'));
+    mol1.delete();
+    mol1 = RDKitModule.get_mol('c1ccccc1N(=O)=O', JSON.stringify({sanitize: {SANITIZE_CLEANUP: true}}));
+    mb = mol1.get_molblock(JSON.stringify({kekulize: false}));
+    assert(mb.includes('  1  2  4  0'));
+    assert((mb.includes('  7  8  1  0') && mb.includes('  7  9  2  0'))
+        || (mb.includes('  7  8  2  0') && mb.includes('  7  9  1  0')));
+    assert(mb.includes('M  CHG  2'));
+    mol1.delete();
+    mol1 = RDKitModule.get_mol('c1ccccc1N(=O)=O', JSON.stringify({sanitize: {
+        SANITIZE_CLEANUP: true, SANITIZE_KEKULIZE: true
+    }}));
+    mb = mol1.get_molblock(JSON.stringify({kekulize: false}));
+    assert(!mb.includes('  1  2  4  0'));
+    assert((mb.includes('  7  8  1  0') && mb.includes('  7  9  2  0'))
+        || (mb.includes('  7  8  2  0') && mb.includes('  7  9  1  0')));
+    assert(mb.includes('M  CHG  2'));
+    mol1.delete();
 }
 
 function test_capture_logs() {
@@ -3503,6 +3532,21 @@ function test_pickle() {
     molFromPkl.delete();
 }
 
+function test_remove_hs_details() {
+    let mol;
+    let smi;
+    mol = RDKitModule.get_mol('C([H])([H])([H])C([2H])([H])C([H])([H])[H]', JSON.stringify({removeHs: false}));
+    smi = mol.get_smiles();
+    assert(smi === '[H]C([H])([H])C([H])([2H])C([H])([H])[H]');
+    assert(mol.remove_hs_in_place(JSON.stringify({removeIsotopes: false})));
+    smi = mol.get_smiles();
+    assert(smi === '[2H]C(C)C');
+    assert(mol.remove_hs_in_place(JSON.stringify({removeIsotopes: true})));
+    smi = mol.get_smiles();
+    assert(smi === 'CCC');
+    mol.delete();
+}
+
 initRDKitModule().then(function(instance) {
     var done = {};
     const waitAllTestsFinished = () => {
@@ -3595,6 +3639,7 @@ initRDKitModule().then(function(instance) {
         test_molzip();
     }
     test_pickle();
+    test_remove_hs_details();
 
     waitAllTestsFinished().then(() =>
         console.log("Tests finished successfully")


### PR DESCRIPTION
The JSON parsers allow to expose finer-grained control on sanitization and H atom removal to CFFI and MinmalLib.
This also addresses [a long-standing request in the rdkit-js repo](https://github.com/rdkit/rdkit-js/issues/438).