### PR TITLE
fixes #8001

### DIFF
--- a/Code/GraphMol/DistGeomHelpers/Embedder.cpp
+++ b/Code/GraphMol/DistGeomHelpers/Embedder.cpp
@@ -1254,7 +1254,7 @@ bool _isConfFarFromRest(
   RDGeom::Point3DConstPtrVect prbPoints(selfMatches[0].size());
   _fillAtomPositions(refPoints, conf, mol, selfMatches[0]);
 
-  double ssrThres = conf.getNumAtoms() * threshold * threshold;
+  double ssrThres = selfMatches[0].size() * threshold * threshold;
   for (const auto &match : selfMatches) {
     for (auto confi = mol.beginConformers(); confi != mol.endConformers();
          ++confi) {

--- a/Code/GraphMol/DistGeomHelpers/catch_tests.cpp
+++ b/Code/GraphMol/DistGeomHelpers/catch_tests.cpp
@@ -1020,3 +1020,17 @@ TEST_CASE("No overlapping atoms") {
     }
   }
 }
+
+TEST_CASE("github #8001: RMS pruning misses conformers") {
+  auto mol = "OCCCCCCC"_smiles;
+  REQUIRE(mol);
+  MolOps::addHs(*mol);
+  DGeomHelpers::EmbedParameters ps = DGeomHelpers::KDG;
+  ps.randomSeed = 1;
+  ps.pruneRmsThresh = 0.5;
+  auto cids = DGeomHelpers::EmbedMultipleConfs(*mol, 200, ps);
+  CHECK(cids.size() == 88);
+  ps.pruneRmsThresh = 1.0;
+  cids = DGeomHelpers::EmbedMultipleConfs(*mol, 200, ps);
+  CHECK(cids.size() == 4);
+}

--- a/Code/GraphMol/DistGeomHelpers/testDgeomHelpers.cpp
+++ b/Code/GraphMol/DistGeomHelpers/testDgeomHelpers.cpp
@@ -2434,11 +2434,11 @@ void testSymmetryPruning() {
   params.pruneRmsThresh = 0.5;
   params.randomSeed = 0xf00d;
   auto cids = DGeomHelpers::EmbedMultipleConfs(*mol, 50, params);
-  TEST_ASSERT(cids.size() == 1);
+  TEST_ASSERT(cids.size() == 2);
 
   params.useSymmetryForPruning = false;
   cids = DGeomHelpers::EmbedMultipleConfs(*mol, 50, params);
-  TEST_ASSERT(cids.size() == 3);
+  TEST_ASSERT(cids.size() == 8);
 }
 
 void testMissingHsWarning() {


### PR DESCRIPTION
This was another one of those embarassing ones: the total number of atoms was being used as the denominator in the RMSD calculation, but only the heavy atoms are used to calculated the SSD

