### PR TITLE
Fix shifting of a potentially negative number

### DIFF
--- a/Code/GraphMol/MMPA/MMPA.cpp
+++ b/Code/GraphMol/MMPA/MMPA.cpp
@@ -28,7 +28,8 @@ namespace MMPA {
 typedef std::vector<std::pair<unsigned, unsigned>>
     BondVector_t;  // pair of BeginAtomIdx, EndAtomIdx
 
-static inline unsigned long long computeMorganCodeHash(const ROMol &mol) {
+namespace detail {
+unsigned long long computeMorganCodeHash(const ROMol &mol) {
   size_t nv = mol.getNumAtoms();
   size_t ne = mol.getNumBonds();
   std::vector<unsigned long> currCodes(nv);
@@ -77,6 +78,7 @@ static inline unsigned long long computeMorganCodeHash(const ROMol &mol) {
   }
   return result;
 }
+}  // namespace detail
 
 static inline void convertMatchingToBondVect(
     std::vector<BondVector_t> &matching_bonds,
@@ -294,10 +296,10 @@ static void addResult(std::vector<std::pair<ROMOL_SPTR, ROMOL_SPTR>>
           core->getNumBonds() == r.first->getNumBonds()))) {
       // ToDo accurate check:
       // 1. compare hash code
-      if (computeMorganCodeHash(*side_chains) ==
-              computeMorganCodeHash(*r.second) &&
-          (nullptr == core ||
-           computeMorganCodeHash(*core) == computeMorganCodeHash(*r.first))) {
+      if (detail::computeMorganCodeHash(*side_chains) ==
+              detail::computeMorganCodeHash(*r.second) &&
+          (nullptr == core || detail::computeMorganCodeHash(*core) ==
+                                  detail::computeMorganCodeHash(*r.first))) {
         // 2. final check to exclude hash collisions
         // We decided that it is not necessary to implement
         resFound = true;

--- a/Code/GraphMol/MMPA/MMPA.cpp
+++ b/Code/GraphMol/MMPA/MMPA.cpp
@@ -42,7 +42,12 @@ static inline unsigned long long computeMorganCodeHash(const ROMol &mol) {
     const Atom &a = *mol.getAtomWithIdx(ai);
     unsigned atomCode = a.getAtomicNum();
     atomCode |= a.getIsotope() << 8;
-    atomCode |= a.getFormalCharge() << 16;
+
+    auto charge = a.getFormalCharge();
+    atomCode |= std::abs(charge) << 16;
+    if (charge < 0) {
+      atomCode |= 1 << 29;
+    }
     atomCode |= (a.getIsAromatic() ? 1 : 0) << 30;
     currCodes[ai] = atomCode;
   }

--- a/Code/GraphMol/MMPA/MMPA.h
+++ b/Code/GraphMol/MMPA/MMPA.h
@@ -17,6 +17,11 @@
 namespace RDKit {
 
 namespace MMPA {
+
+namespace detail {
+RDKIT_MMPA_EXPORT unsigned long long computeMorganCodeHash(const ROMol &mol);
+}
+
 //! fragments a Molecule for processing with the Matched Molecular Pairs
 //!  MMPA algorithm (Hussain et al)
 /*!

--- a/Code/GraphMol/MMPA/MMPA_UnitTest.cpp
+++ b/Code/GraphMol/MMPA/MMPA_UnitTest.cpp
@@ -699,6 +699,25 @@ void testGithub6900() {
   std::vector<std::pair<ROMOL_SPTR, ROMOL_SPTR>> res;
   RDKit::MMPA::fragmentMol(*mol, res, 3);
 }
+
+void testMorganCodeHashChargeShift() {
+  auto m = "Cc1ccccc1"_smiles;
+  TEST_ASSERT(m);
+
+  auto at = m->getAtomWithIdx(0);
+  std::vector<unsigned long long> hashes;
+  for (auto charge : {-2, -1, 0, 1, 2}) {
+    at->setFormalCharge(charge);
+    hashes.push_back(MMPA::detail::computeMorganCodeHash(*m));
+  }
+
+  for (int i = 0; i < hashes.size() - 1; ++i) {
+    for (int j = i + 1; j < hashes.size(); ++j) {
+      TEST_ASSERT(hashes[i] != hashes[j]);
+    }
+  }
+}
+
 int main() {
   BOOST_LOG(rdInfoLog)
       << "*******************************************************\n";
@@ -720,6 +739,8 @@ int main() {
   // /*
   test2();
   test3();
+
+  testMorganCodeHashChargeShift();
 
   //    test4();
   // */

--- a/Code/GraphMol/MMPA/MMPA_UnitTest.cpp
+++ b/Code/GraphMol/MMPA/MMPA_UnitTest.cpp
@@ -711,8 +711,8 @@ void testMorganCodeHashChargeShift() {
     hashes.push_back(MMPA::detail::computeMorganCodeHash(*m));
   }
 
-  for (int i = 0; i < hashes.size() - 1; ++i) {
-    for (int j = i + 1; j < hashes.size(); ++j) {
+  for (unsigned i = 0; i < hashes.size() - 1; ++i) {
+    for (unsigned j = i + 1; j < hashes.size(); ++j) {
       TEST_ASSERT(hashes[i] != hashes[j]);
     }
   }


### PR DESCRIPTION
Shifting negative numbers is undefined behavior.

This fixes the issue by shifting the absolute value of the charge, and setting bit 30 (which is unlikely to be touched by any of the previous shifts) if the value was negative.