### PR TITLE
Fix some minor issues reported by ubsan and the compiler

### DIFF
--- a/Code/DataStructs/Wrap/SparseIntVect.cpp
+++ b/Code/DataStructs/Wrap/SparseIntVect.cpp
@@ -74,8 +74,8 @@ python::list BulkDice(const T &siv1, python::list sivs, bool returnDistance) {
   unsigned int nsivs = python::extract<unsigned int>(sivs.attr("__len__")());
   for (unsigned int i = 0; i < nsivs; ++i) {
     double simVal;
-    const T &siv2 = python::extract<T>(sivs[i])();
-    simVal = DiceSimilarity(siv1, siv2, returnDistance);
+    const T *siv2 = python::extract<T *>(sivs[i])();
+    simVal = DiceSimilarity(siv1, *siv2, returnDistance);
     res.append(simVal);
   }
   return res;
@@ -87,8 +87,8 @@ python::list BulkTanimoto(const T &siv1, python::list sivs,
   unsigned int nsivs = python::extract<unsigned int>(sivs.attr("__len__")());
   for (unsigned int i = 0; i < nsivs; ++i) {
     double simVal;
-    const T &siv2 = python::extract<T>(sivs[i])();
-    simVal = TanimotoSimilarity(siv1, siv2, returnDistance);
+    const T *siv2 = python::extract<T *>(sivs[i])();
+    simVal = TanimotoSimilarity(siv1, *siv2, returnDistance);
     res.append(simVal);
   }
   return res;
@@ -101,8 +101,8 @@ python::list BulkTversky(const T &siv1, python::list sivs, double a, double b,
   unsigned int nsivs = python::extract<unsigned int>(sivs.attr("__len__")());
   for (unsigned int i = 0; i < nsivs; ++i) {
     double simVal;
-    const T &siv2 = python::extract<T>(sivs[i])();
-    simVal = TverskySimilarity(siv1, siv2, a, b, returnDistance);
+    const T *siv2 = python::extract<T *>(sivs[i])();
+    simVal = TverskySimilarity(siv1, *siv2, a, b, returnDistance);
     res.append(simVal);
   }
   return res;

--- a/Code/GraphMol/CIPLabeler/catch_tests.cpp
+++ b/Code/GraphMol/CIPLabeler/catch_tests.cpp
@@ -41,8 +41,8 @@
 using namespace RDKit;
 using namespace RDKit::CIPLabeler;
 
-std::string toBinaryString(int value) {
-  return std::bitset<32>(value).to_string();
+std::string toBinaryString(PairList::pairing_t value) {
+  return std::bitset<PairList::pairing_nbits>(value).to_string();
 }
 
 TEST_CASE("Descriptor lists", "[accurateCIP]") {
@@ -63,51 +63,51 @@ TEST_CASE("Descriptor lists", "[accurateCIP]") {
   SECTION("Pairing") {
     REQUIRE(descriptors.getPairing() == 0);
 
-    CHECK("00000000000000000000000000000000" ==
+    CHECK("0000000000000000000000000000000000000000000000000000000000000000" ==
           toBinaryString(descriptors.getPairing()));
 
     descriptors.add(Descriptor::R);
-    CHECK("00000000000000000000000000000000" ==
-          toBinaryString(descriptors.getPairing()));
-
-    // like
-    descriptors.add(Descriptor::R);
-    CHECK("01000000000000000000000000000000" ==
+    CHECK("0000000000000000000000000000000000000000000000000000000000000000" ==
           toBinaryString(descriptors.getPairing()));
 
     // like
     descriptors.add(Descriptor::R);
-    CHECK("01100000000000000000000000000000" ==
+    CHECK("0100000000000000000000000000000000000000000000000000000000000000" ==
+          toBinaryString(descriptors.getPairing()));
+
+    // like
+    descriptors.add(Descriptor::R);
+    CHECK("0110000000000000000000000000000000000000000000000000000000000000" ==
           toBinaryString(descriptors.getPairing()));
 
     // unlike
     descriptors.add(Descriptor::S);
-    CHECK("01100000000000000000000000000000" ==
+    CHECK("0110000000000000000000000000000000000000000000000000000000000000" ==
           toBinaryString(descriptors.getPairing()));
 
     // like
     descriptors.add(Descriptor::R);
-    CHECK("01101000000000000000000000000000" ==
+    CHECK("0110100000000000000000000000000000000000000000000000000000000000" ==
           toBinaryString(descriptors.getPairing()));
 
     // like
     descriptors.add(Descriptor::R);
-    CHECK("01101100000000000000000000000000" ==
+    CHECK("0110110000000000000000000000000000000000000000000000000000000000" ==
           toBinaryString(descriptors.getPairing()));
 
     // like
     descriptors.add(Descriptor::R);
-    CHECK("01101110000000000000000000000000" ==
+    CHECK("0110111000000000000000000000000000000000000000000000000000000000" ==
           toBinaryString(descriptors.getPairing()));
 
     // unlike
     descriptors.add(Descriptor::S);
-    CHECK("01101110000000000000000000000000" ==
+    CHECK("0110111000000000000000000000000000000000000000000000000000000000" ==
           toBinaryString(descriptors.getPairing()));
 
     // like
     descriptors.add(Descriptor::R);
-    CHECK("01101110100000000000000000000000" ==
+    CHECK("0110111010000000000000000000000000000000000000000000000000000000" ==
           toBinaryString(descriptors.getPairing()));
   }
 
@@ -943,7 +943,6 @@ TEST_CASE("atropisomers", "[basic]") {
     }
   }
 }
-
 
 TEST_CASE("CipLabelAtropsOnRing", "[basic]") {
   SECTION("atropisomers1") {

--- a/Code/GraphMol/CIPLabeler/catch_tests.cpp
+++ b/Code/GraphMol/CIPLabeler/catch_tests.cpp
@@ -42,7 +42,7 @@ using namespace RDKit;
 using namespace RDKit::CIPLabeler;
 
 std::string toBinaryString(PairList::pairing_t value) {
-  return std::bitset<PairList::pairing_nbits>(value).to_string();
+  return std::bitset<PairList::numPairingBits>(value).to_string();
 }
 
 TEST_CASE("Descriptor lists", "[accurateCIP]") {

--- a/Code/GraphMol/CIPLabeler/rules/Pairlist.h
+++ b/Code/GraphMol/CIPLabeler/rules/Pairlist.h
@@ -172,7 +172,7 @@ class PairList {
     if (!d_descriptors.empty() && d_descriptors[0] == descriptor) {
       // set the bit to indicate a pair
       d_pairing |= static_cast<pairing_t>(1)
-                   << (pairing_nbits - 1 - d_descriptors.size());
+                   << (numPairingBits - 1 - d_descriptors.size());
     }
     d_descriptors.push_back(ref(descriptor));
   }

--- a/Code/GraphMol/CIPLabeler/rules/Pairlist.h
+++ b/Code/GraphMol/CIPLabeler/rules/Pairlist.h
@@ -31,6 +31,9 @@ namespace CIPLabeler {
  */
 class PairList {
  public:
+  using pairing_t = std::uint64_t;
+  static constexpr int pairing_nbits = sizeof(pairing_t) * 8;
+
   static Descriptor ref(Descriptor descriptor) {
     switch (descriptor) {
       case Descriptor::R:
@@ -111,7 +114,7 @@ class PairList {
    *
    * @return an integer representing the descriptor pairings
    */
-  std::uint32_t getPairing() const { return d_pairing; }
+  pairing_t getPairing() const { return d_pairing; }
 
   int compareTo(const PairList &that) const {
     if (d_descriptors.size() != that.d_descriptors.size()) {
@@ -155,11 +158,11 @@ class PairList {
  private:
   std::vector<Descriptor> d_descriptors;
 
-  std::uint32_t d_pairing = 0;
+  pairing_t d_pairing = 0;
 
   /**
    * Adds the descriptor to the descriptor list and stores the pair in an set
-   * bit (32-bit integer).
+   * bit (64-bit integer).
    *
    * @param descriptor the descriptor to add an pair
    * @return whether the descriptor was added
@@ -168,7 +171,8 @@ class PairList {
     // if this isn't the first descriptor - check the pairing
     if (!d_descriptors.empty() && d_descriptors[0] == descriptor) {
       // set the bit to indicate a pair
-      d_pairing |= 0x1 << (31 - d_descriptors.size());
+      d_pairing |= static_cast<pairing_t>(1)
+                   << (pairing_nbits - 1 - d_descriptors.size());
     }
     d_descriptors.push_back(ref(descriptor));
   }

--- a/Code/GraphMol/CIPLabeler/rules/Pairlist.h
+++ b/Code/GraphMol/CIPLabeler/rules/Pairlist.h
@@ -32,7 +32,7 @@ namespace CIPLabeler {
 class PairList {
  public:
   using pairing_t = std::uint64_t;
-  static constexpr int pairing_nbits = sizeof(pairing_t) * 8;
+  static constexpr int numPairingBits = sizeof(pairing_t) * 8;
 
   static Descriptor ref(Descriptor descriptor) {
     switch (descriptor) {

--- a/Code/GraphMol/ChemReactions/MDLParser.cpp
+++ b/Code/GraphMol/ChemReactions/MDLParser.cpp
@@ -283,7 +283,7 @@ void ParseV3000RxnBlock(std::istream &inStream, unsigned int &line,
   for (unsigned int i = 0; i < nAgents; ++i) {
     RWMol *agent;
     unsigned int natoms, nbonds;
-    bool chiralityPossible;
+    bool chiralityPossible = false;
     Conformer *conf = nullptr;
     agent = new RWMol();
     try {

--- a/Code/GraphMol/MarvinParse/MarvinParser.cpp
+++ b/Code/GraphMol/MarvinParse/MarvinParser.cpp
@@ -675,7 +675,7 @@ class MarvinCMLReader {
 
   MarvinMolBase *parseMarvinMolecule(
       boost::property_tree::ptree molTree,
-      MarvinMol *parentMol = nullptr)  // parent is for sub-mols
+      MarvinMolBase *parentMol = nullptr)  // parent is for sub-mols
   {
     MarvinMolBase *res = nullptr;
 
@@ -732,8 +732,7 @@ class MarvinCMLReader {
 
       for (auto &v : molTree) {
         if (v.first == "molecule") {
-          MarvinMolBase *subMol =
-              parseMarvinMolecule(v.second, (MarvinMol *)res);
+          auto *subMol = parseMarvinMolecule(v.second, res);
           res->sgroups.push_back(std::unique_ptr<MarvinMolBase>(subMol));
         }
       }

--- a/Code/GraphMol/Substruct/test1.cpp
+++ b/Code/GraphMol/Substruct/test1.cpp
@@ -1897,10 +1897,10 @@ void testMostSubstitutedCoreMatch() {
   };
 
   const auto &coreRef = *core;
-  for (auto &molResPair :
-       {std::make_pair(orthoMeta.get(), 0u), std::make_pair(ortho.get(), 1u),
-        std::make_pair(meta.get(), 1u), std::make_pair(biphenyl.get(), 2u),
-        std::make_pair(phenyl.get(), 3u)}) {
+  for (auto &molResPair : std::vector<std::pair<RDKit::RWMol *, unsigned>>{
+           std::make_pair(orthoMeta.get(), 0u), std::make_pair(ortho.get(), 1u),
+           std::make_pair(meta.get(), 1u), std::make_pair(biphenyl.get(), 2u),
+           std::make_pair(phenyl.get(), 3u)}) {
     auto &mol = *molResPair.first;
     const auto res = molResPair.second;
     MolOps::addHs(mol);

--- a/Code/RDGeneral/testDict.cpp
+++ b/Code/RDGeneral/testDict.cpp
@@ -185,7 +185,10 @@ void testRDAny() {
       TEST_ASSERT(rdany_cast<std::vector<double>>(b)[i] == i);
     }
   }
-  const int loops = 10000000;
+
+  // growth in the loops below is loop * loops / 2, so going higher
+  // than this will cause and overflow of std::any_cast<int>(*v)
+  const int loops = sqrt(std::numeric_limits<int>::max());
   {
     std::clock_t clock1 = std::clock();
     std::any v;
@@ -202,7 +205,7 @@ void testRDAny() {
     std::clock_t clock1 = std::clock();
     std::any *v = nullptr, *vv;
     for (int i = 0; i < loops; ++i) {
-      vv = new std::any(v ? std::any_cast<long int>(*v) + i : i);
+      vv = new std::any(v ? std::any_cast<int>(*v) + i : i);
       delete v;
       v = vv;
     }
@@ -230,7 +233,7 @@ void testRDAny() {
     std::clock_t clock1 = std::clock();
     RDAny *v = nullptr, *vv;
     for (int i = 0; i < loops; ++i) {
-      vv = new RDAny(v ? rdany_cast<long int>(*v) + i : i);
+      vv = new RDAny(v ? rdany_cast<int>(*v) + i : i);
       delete v;
       v = vv;
     }
@@ -257,7 +260,7 @@ void testRDAny() {
     std::clock_t clock1 = std::clock();
     RDValue v(0);
     for (int i = 0; i < loops; ++i) {
-      v = RDValue(rdvalue_cast<long int>(v) + i);
+      v = RDValue(rdvalue_cast<int>(v) + i);
     }
 
     std::clock_t clock2 = std::clock();

--- a/Code/RDGeneral/testDict.cpp
+++ b/Code/RDGeneral/testDict.cpp
@@ -202,7 +202,7 @@ void testRDAny() {
     std::clock_t clock1 = std::clock();
     std::any *v = nullptr, *vv;
     for (int i = 0; i < loops; ++i) {
-      vv = new std::any(v ? std::any_cast<int>(*v) + i : i);
+      vv = new std::any(v ? std::any_cast<long int>(*v) + i : i);
       delete v;
       v = vv;
     }
@@ -230,7 +230,7 @@ void testRDAny() {
     std::clock_t clock1 = std::clock();
     RDAny *v = nullptr, *vv;
     for (int i = 0; i < loops; ++i) {
-      vv = new RDAny(v ? rdany_cast<int>(*v) + i : i);
+      vv = new RDAny(v ? rdany_cast<long int>(*v) + i : i);
       delete v;
       v = vv;
     }
@@ -257,7 +257,7 @@ void testRDAny() {
     std::clock_t clock1 = std::clock();
     RDValue v(0);
     for (int i = 0; i < loops; ++i) {
-      v = RDValue(rdvalue_cast<int>(v) + i);
+      v = RDValue(rdvalue_cast<long int>(v) + i);
     }
 
     std::clock_t clock2 = std::clock();

--- a/Code/RDGeneral/testDict.cpp
+++ b/Code/RDGeneral/testDict.cpp
@@ -187,7 +187,7 @@ void testRDAny() {
   }
 
   // growth in the loops below is loop * loops / 2, so going higher
-  // than this will cause and overflow of std::any_cast<int>(*v)
+  // than this will cause an overflow of std::any_cast<int>(*v)
   const int loops = sqrt(std::numeric_limits<int>::max());
   {
     std::clock_t clock1 = std::clock();


### PR DESCRIPTION

- `Code/DataStructs/Wrap/SparseIntVect.cpp` and `Code/GraphMol/Substruct/test1.cpp`: fix several build waringings about "possibly dangling reference to a temporary".

- `Code/GraphMol/CIPLabeler/rules/Pairlist.h` and `Code/GraphMol/CIPLabeler/catch_tests.cpp`: increase the size of `d_pairing`, as it overflowed when running `pyCIPLabelsValidation`.

- `Code/GraphMol/ChemReactions/MDLParser.cpp`: initialize chiralityPossible, which was passed as a reference to an uninitialized value to `ParseV3000CTAB()` and `finishMolProcessing()` (it would be assigned a value in `ParseV3000CTAB()`).

- `Code/GraphMol/MarvinParse/MarvinParser.cpp`: Fix downcasting `MarvinMolBase` `res` to `MarvinMol`.

- `Code/RDGeneral/testDict.cpp`:  fix some integer overflow issues.
