### PR TITLE
improve defaults for the shape-based alignment

### DIFF
--- a/External/pubchem_shape/PubChemShape.hpp
+++ b/External/pubchem_shape/PubChemShape.hpp
@@ -43,20 +43,20 @@ RDKIT_PUBCHEMSHAPE_EXPORT ShapeInput PrepareConformer(const RDKit::ROMol &mol,
 */
 RDKIT_PUBCHEMSHAPE_EXPORT std::pair<double, double> AlignMolecule(
     const ShapeInput &refShape, RDKit::ROMol &fit, std::vector<float> &matrix,
-    int fitConfId = -1, bool useColors = true, double opt_param = 0.5,
-    unsigned int max_preiters = 3u, unsigned int max_postiters = 16u);
+    int fitConfId = -1, bool useColors = true, double opt_param = 1.0,
+    unsigned int max_preiters = 10u, unsigned int max_postiters = 30u);
 
 //! Align a molecule to a reference molecule
 /*!
   \param ref           the reference molecule
   \param fit           the molecule to align
   \param matrix        the transformation matrix (populated on return)
-  \param refConfId     (optional) the conformer to use for the reference molecule
-  \param fitConfId     (optional) the conformer to use for the fit molecule
-  \param useColors     (optional) whether or not to use colors in the scoring
-  \param opt_param     (optional) the optimization parameter
-  \param max_preiters  (optional) the max number of pre-optimization iterations
-  \param max_postiters (optional) the max number of post-optimization iterationsa
+  \param refConfId     (optional) the conformer to use for the reference
+  molecule \param fitConfId     (optional) the conformer to use for the fit
+  molecule \param useColors     (optional) whether or not to use colors in the
+  scoring \param opt_param     (optional) the optimization parameter \param
+  max_preiters  (optional) the max number of pre-optimization iterations \param
+  max_postiters (optional) the max number of post-optimization iterationsa
 
   \return a pair of the shape Tanimoto value and the color Tanimoto value (zero
   if useColors is false)
@@ -64,5 +64,5 @@ RDKIT_PUBCHEMSHAPE_EXPORT std::pair<double, double> AlignMolecule(
 RDKIT_PUBCHEMSHAPE_EXPORT std::pair<double, double> AlignMolecule(
     const RDKit::ROMol &ref, RDKit::ROMol &fit, std::vector<float> &matrix,
     int refConfId = -1, int fitConfId = -1, bool useColors = true,
-    double opt_param = 0.5, unsigned int max_preiters = 3u,
-    unsigned int max_postiters = 16u);
+    double opt_param = 1.0, unsigned int max_preiters = 10u,
+    unsigned int max_postiters = 30u);

--- a/External/pubchem_shape/Wrap/cshapealign.cpp
+++ b/External/pubchem_shape/Wrap/cshapealign.cpp
@@ -66,8 +66,8 @@ void wrap_pubchemshape() {
       "AlignMol", &helpers::alignMol,
       (python::arg("ref"), python::arg("probe"), python::arg("refConfId") = -1,
        python::arg("probeConfId") = -1, python::arg("useColors") = true,
-       python::arg("opt_param") = 0.5, python::arg("max_preiters") = 3,
-       python::arg("max_postiters") = 16),
+       python::arg("opt_param") = 1.0, python::arg("max_preiters") = 10,
+       python::arg("max_postiters") = 30),
       R"DOC(Aligns a probe molecule to a reference molecule. The probe is modified.
 
 Parameters
@@ -97,8 +97,8 @@ Returns
       "AlignMol", &helpers::alignMol2,
       (python::arg("refShape"), python::arg("probe"),
        python::arg("probeConfId") = -1, python::arg("useColors") = true,
-       python::arg("opt_param") = 0.5, python::arg("max_preiters") = 3,
-       python::arg("max_postiters") = 16),
+       python::arg("opt_param") = 1.0, python::arg("max_preiters") = 10,
+       python::arg("max_postiters") = 30),
       R"DOC(Aligns a probe molecule to a reference shape. The probe is modified.
 
 Parameters

--- a/External/pubchem_shape/Wrap/test_rdshapealign.py
+++ b/External/pubchem_shape/Wrap/test_rdshapealign.py
@@ -3,33 +3,35 @@ from rdkit import Chem
 from rdkit.Chem import rdShapeAlign
 from rdkit import RDConfig
 
-datadir = RDConfig.RDBaseDir + '/External/pubchem_shape/test_data';
+datadir = RDConfig.RDBaseDir + '/External/pubchem_shape/test_data'
 
 
 class TestCase(unittest.TestCase):
 
-    def setUp(self):
-        suppl = Chem.SDMolSupplier(datadir + '/test1.sdf')
-        self.ref = suppl[0]
-        self.probe = suppl[1]
+  def setUp(self):
+    suppl = Chem.SDMolSupplier(datadir + '/test1.sdf')
+    self.ref = suppl[0]
+    self.probe = suppl[1]
 
-    def test1_Defaults(self):
-        tpl = rdShapeAlign.AlignMol(self.ref, self.probe)
-        self.assertAlmostEqual(tpl[0], 0.773, places=3)
-        self.assertAlmostEqual(tpl[1], 0.303, places=3)
+  def test1_Defaults(self):
+    tpl = rdShapeAlign.AlignMol(self.ref, self.probe, opt_param=0.5, max_preiters=3,
+                                max_postiters=16)
+    self.assertAlmostEqual(tpl[0], 0.773, places=3)
+    self.assertAlmostEqual(tpl[1], 0.303, places=3)
 
-    def test2_NoColor(self):
-        tpl = rdShapeAlign.AlignMol(self.ref, self.probe, useColors=False)
-        self.assertAlmostEqual(tpl[0], 0.773, places=3)
-        self.assertAlmostEqual(tpl[1], 0.0, places=3)
+  def test2_NoColor(self):
+    tpl = rdShapeAlign.AlignMol(self.ref, self.probe, useColors=False, opt_param=0.5,
+                                max_preiters=3, max_postiters=16)
+    self.assertAlmostEqual(tpl[0], 0.773, places=3)
+    self.assertAlmostEqual(tpl[1], 0.0, places=3)
 
-    def test3_FromShape(self):
-        shp = rdShapeAlign.PrepareConformer(self.ref)
-        self.assertTrue(type(shp) == rdShapeAlign.ShapeInput)
-        tpl = rdShapeAlign.AlignMol(shp, self.probe)
-        self.assertAlmostEqual(tpl[0], 0.773, places=3)
-        self.assertAlmostEqual(tpl[1], 0.303, places=3)
+  def test3_FromShape(self):
+    shp = rdShapeAlign.PrepareConformer(self.ref)
+    self.assertTrue(type(shp) == rdShapeAlign.ShapeInput)
+    tpl = rdShapeAlign.AlignMol(shp, self.probe, opt_param=0.5, max_preiters=3, max_postiters=16)
+    self.assertAlmostEqual(tpl[0], 0.773, places=3)
+    self.assertAlmostEqual(tpl[1], 0.303, places=3)
 
 
 if __name__ == '__main__':
-    unittest.main()
+  unittest.main()

--- a/External/pubchem_shape/test.cpp
+++ b/External/pubchem_shape/test.cpp
@@ -12,6 +12,11 @@
 
 using namespace RDKit;
 
+constexpr double test_opt_param = 0.5;
+constexpr unsigned int test_max_preiters = 3;
+constexpr unsigned int test_max_postiters = 16;
+constexpr double test_use_colors = true;
+
 TEST_CASE("basic alignment") {
   std::string dirName = getenv("RDBASE");
   dirName += "/External/pubchem_shape/test_data";
@@ -24,7 +29,9 @@ TEST_CASE("basic alignment") {
   SECTION("basics") {
     RWMol cp(*probe);
     std::vector<float> matrix(12, 0.0);
-    auto [nbr_st, nbr_ct] = AlignMolecule(*ref, cp, matrix);
+    auto [nbr_st, nbr_ct] =
+        AlignMolecule(*ref, cp, matrix, -1, -1, test_use_colors, test_opt_param,
+                      test_max_preiters, test_max_postiters);
     CHECK_THAT(nbr_st, Catch::Matchers::WithinAbs(0.773, 0.005));
     CHECK_THAT(nbr_ct, Catch::Matchers::WithinAbs(0.303, 0.005));
     for (auto i = 0u; i < probe->getNumAtoms(); ++i) {
@@ -35,7 +42,9 @@ TEST_CASE("basic alignment") {
   SECTION("from shape") {
     auto ref_shape = PrepareConformer(*ref);
     std::vector<float> matrix(12, 0.0);
-    auto [nbr_st, nbr_ct] = AlignMolecule(ref_shape, *probe, matrix);
+    auto [nbr_st, nbr_ct] =
+        AlignMolecule(ref_shape, *probe, matrix, -1, test_use_colors,
+                      test_opt_param, test_max_preiters, test_max_postiters);
     CHECK_THAT(nbr_st, Catch::Matchers::WithinAbs(0.773, 0.005));
     CHECK_THAT(nbr_ct, Catch::Matchers::WithinAbs(0.303, 0.005));
   }
@@ -43,7 +52,9 @@ TEST_CASE("basic alignment") {
     ref->clearProp("PUBCHEM_PHARMACOPHORE_FEATURES");
     probe->clearProp("PUBCHEM_PHARMACOPHORE_FEATURES");
     std::vector<float> matrix(12, 0.0);
-    auto [nbr_st, nbr_ct] = AlignMolecule(*ref, *probe, matrix);
+    auto [nbr_st, nbr_ct] =
+        AlignMolecule(*ref, *probe, matrix, -1, -1, test_use_colors,
+                      test_opt_param, test_max_preiters, test_max_postiters);
     CHECK_THAT(nbr_st, Catch::Matchers::WithinAbs(0.773, 0.005));
     CHECK_THAT(nbr_ct, Catch::Matchers::WithinAbs(0.231, 0.005));
   }
@@ -53,16 +64,21 @@ TEST_CASE("basic alignment") {
     int prbConfId = -1;
     bool useColors = false;
     auto [nbr_st, nbr_ct] =
-        AlignMolecule(*ref, *probe, matrix, refConfId, prbConfId, useColors);
+        AlignMolecule(*ref, *probe, matrix, refConfId, prbConfId, useColors,
+                      test_opt_param, test_max_preiters, test_max_postiters);
     CHECK_THAT(nbr_st, Catch::Matchers::WithinAbs(0.773, 0.005));
     CHECK_THAT(nbr_ct, Catch::Matchers::WithinAbs(0.000, 0.005));
   }
   SECTION("we are re-entrant") {
     RWMol cp(*probe);
     std::vector<float> matrix(12, 0.0);
-    auto [nbr_st, nbr_ct] = AlignMolecule(*ref, cp, matrix);
+    auto [nbr_st, nbr_ct] =
+        AlignMolecule(*ref, cp, matrix, -1, -1, test_use_colors, test_opt_param,
+                      test_max_preiters, test_max_postiters);
     RWMol cp2(cp);
-    auto [nbr_st2, nbr_ct2] = AlignMolecule(*ref, cp2, matrix);
+    auto [nbr_st2, nbr_ct2] =
+        AlignMolecule(*ref, cp2, matrix, -1, -1, test_use_colors,
+                      test_opt_param, test_max_preiters, test_max_postiters);
     CHECK_THAT(nbr_st, Catch::Matchers::WithinAbs(nbr_st2, 0.005));
     CHECK_THAT(nbr_ct, Catch::Matchers::WithinAbs(nbr_ct2, 0.005));
 
@@ -84,7 +100,9 @@ TEST_CASE("bulk") {
     auto probe = suppl[1];
     REQUIRE(probe);
     std::vector<float> matrix(12, 0.0);
-    auto [nbr_st, nbr_ct] = AlignMolecule(*ref, *probe, matrix);
+    auto [nbr_st, nbr_ct] =
+        AlignMolecule(*ref, *probe, matrix, -1, -1, test_use_colors,
+                      test_opt_param, test_max_preiters, test_max_postiters);
     CHECK_THAT(nbr_st,
                Catch::Matchers::WithinAbs(
                    probe->getProp<float>("shape_align_shape_tanimoto"), 0.005));
@@ -109,7 +127,9 @@ TEST_CASE("handling molecules with Hs") {
   SECTION("basics") {
     RWMol cp(*probe);
     std::vector<float> matrix(12, 0.0);
-    auto [nbr_st, nbr_ct] = AlignMolecule(*ref, cp, matrix);
+    auto [nbr_st, nbr_ct] =
+        AlignMolecule(*ref, cp, matrix, -1, -1, test_use_colors, test_opt_param,
+                      test_max_preiters, test_max_postiters);
     CHECK_THAT(nbr_st, Catch::Matchers::WithinAbs(0.837, 0.005));
     CHECK_THAT(nbr_ct, Catch::Matchers::WithinAbs(0.694, 0.005));
     for (auto i = 0u; i < cp.getNumAtoms(); ++i) {


### PR DESCRIPTION
The updated defaults are based on some experiments that @brje01 and I did over the past week.

We may want to tweak these parameters again at some point in the future (and will do a quick writeup of how we got here), but these new defaults produce better alignments thatn the current defaults without completely exploding the calculation time, so I think it's worth getting them out there now.