### PR TITLE
fixing the doc string in the shape alignment code

### DIFF
--- a/External/pubchem_shape/Wrap/cshapealign.cpp
+++ b/External/pubchem_shape/Wrap/cshapealign.cpp
@@ -82,7 +82,7 @@ probeConfId : int, optional
     Probe conformer ID (default is -1)
 useColors : bool, optional
     Whether or not to use colors in the scoring (default is True)
-optParam : float, optional
+opt_param : float, optional
 max_preiters : int, optional
 max_postiters : int, optional
 


### PR DESCRIPTION
#### Reference Issue
--

#### What does this implement/fix? Explain your changes.
The doc string for the rdShapeAlign.AlignMol function had a small spelling mistake: The variable name is opt_param not optParam.

#### Any other comments?
--

