### PR TITLE
Fix #4570 Segfault on Property Getters/Setters

### DIFF
--- a/Code/GraphMol/Wrap/Atom.cpp
+++ b/Code/GraphMol/Wrap/Atom.cpp
@@ -104,7 +104,11 @@ std::string AtomGetSmarts(const Atom *atom, bool doKekule, bool allHsExplicit,
 }
 
 void SetAtomMonomerInfo(Atom *atom, const AtomMonomerInfo *info) {
-  atom->setMonomerInfo(info->copy());
+  if(!info) {
+    atom->setMonomerInfo(nullptr);
+  } else {
+    atom->setMonomerInfo(info->copy());
+  }
 }
 
 AtomMonomerInfo *AtomGetMonomerInfo(Atom *atom) {
@@ -112,6 +116,12 @@ AtomMonomerInfo *AtomGetMonomerInfo(Atom *atom) {
 }
 
 void AtomSetPDBResidueInfo(Atom *atom, const AtomMonomerInfo *info) {
+  if(!info) {
+    // This clears out the monomer info
+    atom->setMonomerInfo(nullptr);
+    return;
+  }
+  
   if (info->getMonomerType() != AtomMonomerInfo::PDBRESIDUE) {
     throw_value_error("MonomerInfo is not a PDB Residue");
   }

--- a/Code/GraphMol/Wrap/Atom.cpp
+++ b/Code/GraphMol/Wrap/Atom.cpp
@@ -42,18 +42,18 @@ void setQuery(QueryAtom *self, const QueryAtom *other) {
 }
 
 template <class T>
-void AtomSetProp(const Atom *atom, const char *key, const T &val) {
+void AtomSetProp(const Atom *atom, const std::string &key, const T &val) {
   // std::cerr<<"asp: "<<atom<<" " << key<<" - " << val << std::endl;
   atom->setProp<T>(key, val);
 }
 
-int AtomHasProp(const Atom *atom, const char *key) {
+int AtomHasProp(const Atom *atom, const std::string &key) {
   // std::cerr<<"ahp: "<<atom<<" " << key<< std::endl;
   int res = atom->hasProp(key);
   return res;
 }
 
-void AtomClearProp(const Atom *atom, const char *key) {
+void AtomClearProp(const Atom *atom, const std::string &key) {
   if (!atom->hasProp(key)) {
     return;
   }
@@ -104,11 +104,7 @@ std::string AtomGetSmarts(const Atom *atom, bool doKekule, bool allHsExplicit,
 }
 
 void SetAtomMonomerInfo(Atom *atom, const AtomMonomerInfo *info) {
-  if(!info) {
-    atom->setMonomerInfo(nullptr);
-  } else {
-    atom->setMonomerInfo(info->copy());
-  }
+  atom->setMonomerInfo(info->copy());
 }
 
 AtomMonomerInfo *AtomGetMonomerInfo(Atom *atom) {
@@ -116,12 +112,6 @@ AtomMonomerInfo *AtomGetMonomerInfo(Atom *atom) {
 }
 
 void AtomSetPDBResidueInfo(Atom *atom, const AtomMonomerInfo *info) {
-  if(!info) {
-    // This clears out the monomer info
-    atom->setMonomerInfo(nullptr);
-    return;
-  }
-  
   if (info->getMonomerType() != AtomMonomerInfo::PDBRESIDUE) {
     throw_value_error("MonomerInfo is not a PDB Residue");
   }

--- a/Code/GraphMol/Wrap/props.hpp
+++ b/Code/GraphMol/Wrap/props.hpp
@@ -167,11 +167,11 @@ boost::python::dict GetPropsAsDict(const T &obj, bool includePrivate,
 }
 
 template <class RDOb, class T>
-T GetProp(const RDOb *ob, const char *key) {
+T GetProp(const RDOb *ob, const std::string &key) {
   T res;
   try {
     if (!ob->getPropIfPresent(key, res)) {
-      PyErr_SetString(PyExc_KeyError, key);
+      PyErr_SetString(PyExc_KeyError, key.c_str());
       throw python::error_already_set();
     }
     return res;
@@ -203,7 +203,7 @@ template <class RDOb>
 python::object GetPyProp(const RDOb *obj, const std::string &key,
                          bool autoConvert) {
   if (!autoConvert) {
-    return python::object(GetProp<RDOb, std::string>(obj, key.c_str()));
+    return python::object(GetProp<RDOb, std::string>(obj, key));
   } else {
     auto &data = obj->getDict().getData();
     for (auto &rdvalue : data) {
@@ -283,20 +283,20 @@ python::object GetPyProp(const RDOb *obj, const std::string &key,
 }
 
 template <class RDOb>
-int MolHasProp(const RDOb &mol, const char *key) {
+int MolHasProp(const RDOb &mol, const std::string &key) {
   int res = mol.hasProp(key);
   // std::cout << "key: "  << key << ": " << res << std::endl;
   return res;
 }
 
 template <class RDOb, class T>
-void MolSetProp(const RDOb &mol, const char *key, const T &val,
+void MolSetProp(const RDOb &mol, const std::string &key, const T &val,
                 bool computed = false) {
   mol.setProp(key, val, computed);
 }
 
 template <class RDOb>
-void MolClearProp(const RDOb &mol, const char *key) {
+void MolClearProp(const RDOb &mol, const std::string &key) {
   if (!mol.hasProp(key)) {
     return;
   }

--- a/Code/GraphMol/Wrap/rdmolfiles.cpp
+++ b/Code/GraphMol/Wrap/rdmolfiles.cpp
@@ -415,8 +415,12 @@ std::vector<unsigned int> CanonicalRankAtoms(
     bool includeIsotopes = true, bool includeAtomMaps = true,
     bool includeChiralPresence = false) {
   std::vector<unsigned int> ranks(mol.getNumAtoms());
+  const bool includeStereoGroups = true;
+  const bool useNonStereoRanks = false;
+
   Canon::rankMolAtoms(mol, ranks, breakTies, includeChirality, includeIsotopes,
-                      includeAtomMaps, includeChiralPresence);
+                      includeAtomMaps, includeChiralPresence,
+                      includeStereoGroups, useNonStereoRanks);
   return ranks;
 }
 
@@ -1569,6 +1573,9 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
           "this will thrown an exception if the molecule cannot be kekulized")
       .def_readwrite("canonical", &RDKit::SmilesWriteParams::canonical,
                      "generate canonical SMILES")
+      .def_readwrite(
+          "cleanStereo", &RDKit::SmilesWriteParams::cleanStereo,
+          "chiral centers are removed if they have duplicate sidechains")
       .def_readwrite("allBondsExplicit",
                      &RDKit::SmilesWriteParams::allBondsExplicit,
                      "include symbols for all bonds")
@@ -1604,7 +1611,8 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
     - kekuleSmiles: (optional) use the Kekule form (no aromatic bonds) in\n\
       the SMILES.  Defaults to false.\n\
     - rootedAtAtom: (optional) if non-negative, this forces the SMILES \n\
-      to start at a particular atom. Defaults to -1.\n\
+      to start at a particular atom. Defaults to -1.  If not -1, overrides\n\
+      canonical setting.\n\
     - canonical: (optional) if false no attempt will be made to canonicalize\n\
       the molecule. Defaults to true.\n\
     - allBondsExplicit: (optional) if true, all bond orders will be explicitly indicated\n\
@@ -1612,7 +1620,8 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
     - allHsExplicit: (optional) if true, all H counts will be explicitly indicated\n\
       in the output SMILES. Defaults to false.\n\
     - doRandom: (optional) if true, randomize the traversal of the molecule graph,\n\
-      so we can generate random smiles. Defaults to false.\n\
+      so we can generate random smiles. Defaults to false.  If true, overrides\n\
+      canonical setting.\n\
     - ignoreAtomMapNumbers (optional) if true, ignores any atom map numbers when\n\
       canonicalizing the molecule \n\
 \n\
@@ -1674,7 +1683,8 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
     - kekuleSmiles: (optional) use the Kekule form (no aromatic bonds) in\n\
       the SMILES.  Defaults to false.\n\
     - rootedAtAtom: (optional) if non-negative, this forces the SMILES \n\
-      to start at a particular atom. Defaults to -1.\n\
+      to start at a particular atom. Defaults to -1.  If not -1, over-rides\n\
+      setting for canonical.\n\
     - canonical: (optional) if false no attempt will be made to canonicalize\n\
       the molecule. Defaults to true.\n\
     - allBondsExplicit: (optional) if true, all bond orders will be explicitly indicated\n\
@@ -1752,8 +1762,9 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
       in the output SMILES. Defaults to false.\n\
     - allHsExplicit: (optional) if true, all H counts will be explicitly indicated\n\
       in the output SMILES. Defaults to false.\n\
-    - doRandom: (optional) if true, randomized the trasversal of the molecule graph,\n\
-      so we can generate random smiles. Defaults to false.\n\
+    - doRandom: (optional) if true, randomizes the traversal of the molecule graph,\n\
+      so we can generate random smiles. Defaults to false.  If true, overrides\n\
+      canonical setting.\n\
 \n\
   RETURNS:\n\
 \n\
@@ -1813,7 +1824,8 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
     - kekuleSmiles: (optional) use the Kekule form (no aromatic bonds) in\n\
       the SMILES.  Defaults to false.\n\
     - rootedAtAtom: (optional) if non-negative, this forces the SMILES \n\
-      to start at a particular atom. Defaults to -1.\n\
+      to start at a particular atom. Defaults to -1.  If not -1, overrides\n\
+      canonical setting.\n\
     - canonical: (optional) if false no attempt will be made to canonicalize\n\
       the molecule. Defaults to true.\n\
     - allBondsExplicit: (optional) if true, all bond orders will be explicitly indicated\n\

--- a/Code/GraphMol/Wrap/rdmolfiles.cpp
+++ b/Code/GraphMol/Wrap/rdmolfiles.cpp
@@ -99,7 +99,7 @@ ROMol *MolFromSmarts(python::object ismarts, bool mergeHs,
   }
   return static_cast<ROMol *>(newM);
 }
-ROMol *MolFromTPLFile(const char *filename, bool sanitize = true,
+ROMol *MolFromTPLFile(const std::string &filename, bool sanitize = true,
                       bool skipFirstConf = false) {
   RWMol *newM;
   try {
@@ -126,7 +126,7 @@ ROMol *MolFromTPLBlock(python::object itplBlock, bool sanitize = true,
   return static_cast<ROMol *>(newM);
 }
 
-ROMol *MolFromMolFileHelper(const char *molFilename, bool sanitize,
+ROMol *MolFromMolFileHelper(const std::string &molFilename, bool sanitize,
                             bool removeHs, bool strictParsing) {
   RWMol *newM = nullptr;
   try {
@@ -156,7 +156,7 @@ ROMol *MolFromMolBlock(python::object imolBlock, bool sanitize, bool removeHs,
   return static_cast<ROMol *>(newM);
 }
 
-ROMol *MolFromMolFile(const char *molFilename, bool sanitize, bool removeHs,
+ROMol *MolFromMolFile(const std::string &molFilename, bool sanitize, bool removeHs,
                       bool strictParsing) {
   RWMol *newM = nullptr;
   try {
@@ -171,7 +171,7 @@ ROMol *MolFromMolFile(const char *molFilename, bool sanitize, bool removeHs,
   return static_cast<ROMol *>(newM);
 }
 
-ROMol *MolFromMrvFile(const char *molFilename, bool sanitize, bool removeHs) {
+ROMol *MolFromMrvFile(const std::string &molFilename, bool sanitize, bool removeHs) {
   RWMol *newM = nullptr;
   try {
     newM = MrvFileToMol(molFilename, sanitize, removeHs);
@@ -226,7 +226,7 @@ ROMol *MolFromSVG(python::object imolBlock, bool sanitize, bool removeHs) {
   return static_cast<ROMol *>(res);
 }
 
-ROMol *MolFromMol2File(const char *molFilename, bool sanitize = true,
+ROMol *MolFromMol2File(const std::string &molFilename, bool sanitize = true,
                        bool removeHs = true, bool cleanupSubstructures = true) {
   RWMol *newM;
   try {
@@ -255,7 +255,7 @@ ROMol *MolFromMol2Block(std::string mol2Block, bool sanitize = true,
   return static_cast<ROMol *>(newM);
 }
 
-ROMol *MolFromPDBFile(const char *filename, bool sanitize, bool removeHs,
+ROMol *MolFromPDBFile(const std::string &filename, bool sanitize, bool removeHs,
                       unsigned int flavor, bool proximityBonding) {
   RWMol *newM = nullptr;
   try {
@@ -415,12 +415,8 @@ std::vector<unsigned int> CanonicalRankAtoms(
     bool includeIsotopes = true, bool includeAtomMaps = true,
     bool includeChiralPresence = false) {
   std::vector<unsigned int> ranks(mol.getNumAtoms());
-  const bool includeStereoGroups = true;
-  const bool useNonStereoRanks = false;
-
   Canon::rankMolAtoms(mol, ranks, breakTies, includeChirality, includeIsotopes,
-                      includeAtomMaps, includeChiralPresence,
-                      includeStereoGroups, useNonStereoRanks);
+                      includeAtomMaps, includeChiralPresence);
   return ranks;
 }
 
@@ -506,7 +502,7 @@ python::list MolToRandomSmilesHelper(const ROMol &mol, unsigned int numSmiles,
   return pyres;
 }
 
-ROMol *MolFromPNGFile(const char *filename, python::object pyParams) {
+ROMol *MolFromPNGFile(const std::string &filename, python::object pyParams) {
   SmilesParserParams params;
   if (pyParams) {
     params = python::extract<SmilesParserParams>(pyParams);
@@ -604,7 +600,7 @@ python::object addMetadataToPNGStringHelper(python::dict pymetadata,
   return retval;
 }
 
-python::object MolsFromPNGFile(const char *filename, const std::string &tag,
+python::object MolsFromPNGFile(const std::string &filename, const std::string &tag,
                                python::object pyParams) {
   SmilesParserParams params;
   if (pyParams) {
@@ -645,7 +641,7 @@ python::tuple MolsFromPNGString(python::object png, const std::string &tag,
   return python::tuple(res);
 }
 
-python::object MolsFromCDXMLFile(const char *filename, bool sanitize,
+python::object MolsFromCDXMLFile(const std::string &filename, bool sanitize,
                                  bool removeHs) {
   std::vector<std::unique_ptr<RWMol>> mols;
   try {
@@ -1573,9 +1569,6 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
           "this will thrown an exception if the molecule cannot be kekulized")
       .def_readwrite("canonical", &RDKit::SmilesWriteParams::canonical,
                      "generate canonical SMILES")
-      .def_readwrite(
-          "cleanStereo", &RDKit::SmilesWriteParams::cleanStereo,
-          "chiral centers are removed if they have duplicate sidechains")
       .def_readwrite("allBondsExplicit",
                      &RDKit::SmilesWriteParams::allBondsExplicit,
                      "include symbols for all bonds")
@@ -1611,8 +1604,7 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
     - kekuleSmiles: (optional) use the Kekule form (no aromatic bonds) in\n\
       the SMILES.  Defaults to false.\n\
     - rootedAtAtom: (optional) if non-negative, this forces the SMILES \n\
-      to start at a particular atom. Defaults to -1.  If not -1, overrides\n\
-      canonical setting.\n\
+      to start at a particular atom. Defaults to -1.\n\
     - canonical: (optional) if false no attempt will be made to canonicalize\n\
       the molecule. Defaults to true.\n\
     - allBondsExplicit: (optional) if true, all bond orders will be explicitly indicated\n\
@@ -1620,8 +1612,7 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
     - allHsExplicit: (optional) if true, all H counts will be explicitly indicated\n\
       in the output SMILES. Defaults to false.\n\
     - doRandom: (optional) if true, randomize the traversal of the molecule graph,\n\
-      so we can generate random smiles. Defaults to false.  If true, overrides\n\
-      canonical setting.\n\
+      so we can generate random smiles. Defaults to false.\n\
     - ignoreAtomMapNumbers (optional) if true, ignores any atom map numbers when\n\
       canonicalizing the molecule \n\
 \n\
@@ -1683,8 +1674,7 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
     - kekuleSmiles: (optional) use the Kekule form (no aromatic bonds) in\n\
       the SMILES.  Defaults to false.\n\
     - rootedAtAtom: (optional) if non-negative, this forces the SMILES \n\
-      to start at a particular atom. Defaults to -1.  If not -1, over-rides\n\
-      setting for canonical.\n\
+      to start at a particular atom. Defaults to -1.\n\
     - canonical: (optional) if false no attempt will be made to canonicalize\n\
       the molecule. Defaults to true.\n\
     - allBondsExplicit: (optional) if true, all bond orders will be explicitly indicated\n\
@@ -1762,9 +1752,8 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
       in the output SMILES. Defaults to false.\n\
     - allHsExplicit: (optional) if true, all H counts will be explicitly indicated\n\
       in the output SMILES. Defaults to false.\n\
-    - doRandom: (optional) if true, randomizes the traversal of the molecule graph,\n\
-      so we can generate random smiles. Defaults to false.  If true, overrides\n\
-      canonical setting.\n\
+    - doRandom: (optional) if true, randomized the trasversal of the molecule graph,\n\
+      so we can generate random smiles. Defaults to false.\n\
 \n\
   RETURNS:\n\
 \n\
@@ -1824,8 +1813,7 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
     - kekuleSmiles: (optional) use the Kekule form (no aromatic bonds) in\n\
       the SMILES.  Defaults to false.\n\
     - rootedAtAtom: (optional) if non-negative, this forces the SMILES \n\
-      to start at a particular atom. Defaults to -1.  If not -1, overrides\n\
-      canonical setting.\n\
+      to start at a particular atom. Defaults to -1.\n\
     - canonical: (optional) if false no attempt will be made to canonicalize\n\
       the molecule. Defaults to true.\n\
     - allBondsExplicit: (optional) if true, all bond orders will be explicitly indicated\n\

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -7691,6 +7691,7 @@ CAS<~>
     self.assertTrue(m1 is not None)
     self.assertTrue(m1.GetNumAtoms() == 16)
     smi = Chem.MolToCXSmiles(m1)
+    print('smi: ', smi)
     print('inWedges: ', inNoWedges)
 
     self.assertTrue(smi == inNoWedges)
@@ -7768,9 +7769,11 @@ M  END
 
     ps = Chem.SmilesWriteParams()
     ps.canonical = True
-
     smi = Chem.MolToCXSmiles(m, ps, flags, Chem.RestoreBondDirOption.RestoreBondDirOptionTrue)
-    self.assertTrue(smi == 'CC1=C(n2cccc2[C@H](C)Cl)C(C)CCC1 |(2.679,0.4142,;1.3509,1.181,;0.0229,0.4141,;0.0229,-1.1195,;1.2645,-2.0302,;0.7901,-3.4813,;-0.7446,-3.4813,;-1.219,-2.0302,;-2.679,-1.5609,;-3.0039,-0.0556,;-3.8202,-2.595,;-1.3054,1.1809,;-2.6335,0.4141,;-1.3054,2.7145,;0.0229,3.4813,;1.3509,2.7146,),wD:2.11,wU:8.10,&1:8|')
+    self.assertTrue(
+      smi ==
+      'CC1=C(n2cccc2[C@H](C)Cl)C(C)CCC1 |(2.679,0.4142,;1.3509,1.181,;0.0229,0.4141,;0.0229,-1.1195,;1.2645,-2.0302,;0.7901,-3.4813,;-0.7446,-3.4813,;-1.219,-2.0302,;-2.679,-1.5609,;-3.0039,-0.0556,;-3.8202,-2.595,;-1.3054,1.1809,;-2.6335,0.4141,;-1.3054,2.7145,;0.0229,3.4813,;1.3509,2.7146,),wD:2.11,wU:8.10,&1:8|'
+    )
 
     flags = Chem.CXSmilesFields.CX_COORDS | \
                         Chem.CXSmilesFields.CX_MOLFILE_VALUES | \
@@ -7782,7 +7785,9 @@ M  END
 
     self.assertTrue(
       smi ==
-      'CC1=C(n2cccc2[C@H](C)Cl)C(C)CCC1 |(2.679,0.4142,;1.3509,1.181,;0.0229,0.4141,;0.0229,-1.1195,;1.2645,-2.0302,;0.7901,-3.4813,;-0.7446,-3.4813,;-1.219,-2.0302,;-2.679,-1.5609,;-3.0039,-0.0556,;-3.8202,-2.595,;-1.3054,1.1809,;-2.6335,0.4141,;-1.3054,2.7145,;0.0229,3.4813,;1.3509,2.7146,),wD:2.11,&1:8|')
+      'CC1=C(n2cccc2[C@H](C)Cl)C(C)CCC1 |(2.679,0.4142,;1.3509,1.181,;0.0229,0.4141,;0.0229,-1.1195,;1.2645,-2.0302,;0.7901,-3.4813,;-0.7446,-3.4813,;-1.219,-2.0302,;-2.679,-1.5609,;-3.0039,-0.0556,;-3.8202,-2.595,;-1.3054,1.1809,;-2.6335,0.4141,;-1.3054,2.7145,;0.0229,3.4813,;1.3509,2.7146,),wD:2.11,&1:8|'
+    )
+
     flags = Chem.CXSmilesFields.CX_COORDS | \
                         Chem.CXSmilesFields.CX_MOLFILE_VALUES | \
                         Chem.CXSmilesFields.CX_ATOM_PROPS | \
@@ -7793,28 +7798,6 @@ M  END
       smi ==
       'CC1=C(n2cccc2[C@H](C)Cl)C(C)CCC1 |(2.679,0.4142,;1.3509,1.181,;0.0229,0.4141,;0.0229,-1.1195,;1.2645,-2.0302,;0.7901,-3.4813,;-0.7446,-3.4813,;-1.219,-2.0302,;-2.679,-1.5609,;-3.0039,-0.0556,;-3.8202,-2.595,;-1.3054,1.1809,;-2.6335,0.4141,;-1.3054,2.7145,;0.0229,3.4813,;1.3509,2.7146,),&1:8|'
     )
-
-  def testAtropisomerWedgingRigorousEnhancedStereo(self):
-    m = Chem.MolFromSmiles(
-      'CC1=C(N2C=CC=C2[C@H](C)Cl)C(C)CCC1 |(2.679,0.4142,;1.3509,1.181,;0.0229,0.4141,;0.0229,-1.1195,;1.2645,-2.0302,;0.7901,-3.4813,;-0.7446,-3.4813,;-1.219,-2.0302,;-2.679,-1.5609,;-3.0039,-0.0556,;-3.8202,-2.595,;-1.3054,1.1809,;-2.6335,0.4141,;-1.3054,2.7145,;0.0229,3.4813,;1.3509,2.7146,),wD:2.11,wU:8.10,&1:8|'
-    )
-    self.assertTrue(m is not None)
-    self.assertTrue(m.GetNumAtoms() == 16)
-
-    sys.stdout.flush()
-    flags = Chem.CXSmilesFields.CX_COORDS | \
-                        Chem.CXSmilesFields.CX_MOLFILE_VALUES | \
-                        Chem.CXSmilesFields.CX_ATOM_PROPS | \
-                        Chem.CXSmilesFields.CX_BOND_CFG | \
-                        Chem.CXSmilesFields.CX_ENHANCEDSTEREO
-
-    ps = Chem.SmilesWriteParams()
-    ps.canonical = True
-
-    m = Chem.CanonicalizeStereoGroups(m)
-    smi = Chem.MolToCXSmiles(m, ps, flags, Chem.RestoreBondDirOption.RestoreBondDirOptionTrue)
-    print('smi: ', smi)
-    self.assertTrue(smi == 'CC1=C(n2cccc2[C@H](C)Cl)C(C)CCC1 |(2.679,0.4142,;1.3509,1.181,;0.0229,0.4141,;0.0229,-1.1195,;1.2645,-2.0302,;0.7901,-3.4813,;-0.7446,-3.4813,;-1.219,-2.0302,;-2.679,-1.5609,;-3.0039,-0.0556,;-3.8202,-2.595,;-1.3054,1.1809,;-2.6335,0.4141,;-1.3054,2.7145,;0.0229,3.4813,;1.3509,2.7146,),wD:8.9,2.11,a:2,&1:8|')
 
   def test_picklingWithAddedAttribs(self):
     m = Chem.MolFromSmiles("C")
@@ -8240,19 +8223,23 @@ M  END
     self.assertEqual(Chem.MolToSmiles(mol, ignoreAtomMapNumbers=False),
                      "c1ccc([NH2:1])cc1")
 
-  def github7873(self):
-    # this used to segfault
-    Chem.MolFromSmiles("C").GetAtomWithIdx(0).SetPDBResidueInfo(None)
+  def testGithub4570(self):
+    # test sending None to get/set prop
+    m = Chem.Mol()
+    # these should not seg fault
+    for func in ["HasProp", "GetProp", "GetIntProp", "GetDoubleProp"]:
+      try:
+        getattr(m, func)(None)
+      except Exception as e:
+        assert "Python argument types" in str(e), f"{func}: {str(e)}"
     
-  def testSplitMolByPDB(self):
-    mol = Chem.MolFromSmiles("C")
-    res2mol = Chem.SplitMolByPDBResidues(mol)
-    self.assertEqual(len(res2mol), 1)
-    self.assertIn("", res2mol)
-    chain2mol = Chem.SplitMolByPDBChainId(mol)
-    self.assertEqual(len(chain2mol), 1)
-    self.assertIn("", chain2mol)
-
+    for func, val in [("SetProp", ""), ("SetIntProp", 1), ("SetDoubleProp", 1.0)]:
+      try:
+        getattr(m, func)(None, val)
+      except Exception as e:
+        assert "Python argument types" in str(e), f"{func}: {str(e)}"
+      
+    
 if __name__ == '__main__':
   if "RDTESTCASE" in os.environ:
     suite = unittest.TestSuite()

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -7691,7 +7691,6 @@ CAS<~>
     self.assertTrue(m1 is not None)
     self.assertTrue(m1.GetNumAtoms() == 16)
     smi = Chem.MolToCXSmiles(m1)
-    print('smi: ', smi)
     print('inWedges: ', inNoWedges)
 
     self.assertTrue(smi == inNoWedges)

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -7769,11 +7769,9 @@ M  END
 
     ps = Chem.SmilesWriteParams()
     ps.canonical = True
+
     smi = Chem.MolToCXSmiles(m, ps, flags, Chem.RestoreBondDirOption.RestoreBondDirOptionTrue)
-    self.assertTrue(
-      smi ==
-      'CC1=C(n2cccc2[C@H](C)Cl)C(C)CCC1 |(2.679,0.4142,;1.3509,1.181,;0.0229,0.4141,;0.0229,-1.1195,;1.2645,-2.0302,;0.7901,-3.4813,;-0.7446,-3.4813,;-1.219,-2.0302,;-2.679,-1.5609,;-3.0039,-0.0556,;-3.8202,-2.595,;-1.3054,1.1809,;-2.6335,0.4141,;-1.3054,2.7145,;0.0229,3.4813,;1.3509,2.7146,),wD:2.11,wU:8.10,&1:8|'
-    )
+    self.assertTrue(smi == 'CC1=C(n2cccc2[C@H](C)Cl)C(C)CCC1 |(2.679,0.4142,;1.3509,1.181,;0.0229,0.4141,;0.0229,-1.1195,;1.2645,-2.0302,;0.7901,-3.4813,;-0.7446,-3.4813,;-1.219,-2.0302,;-2.679,-1.5609,;-3.0039,-0.0556,;-3.8202,-2.595,;-1.3054,1.1809,;-2.6335,0.4141,;-1.3054,2.7145,;0.0229,3.4813,;1.3509,2.7146,),wD:2.11,wU:8.10,&1:8|')
 
     flags = Chem.CXSmilesFields.CX_COORDS | \
                         Chem.CXSmilesFields.CX_MOLFILE_VALUES | \
@@ -7785,9 +7783,7 @@ M  END
 
     self.assertTrue(
       smi ==
-      'CC1=C(n2cccc2[C@H](C)Cl)C(C)CCC1 |(2.679,0.4142,;1.3509,1.181,;0.0229,0.4141,;0.0229,-1.1195,;1.2645,-2.0302,;0.7901,-3.4813,;-0.7446,-3.4813,;-1.219,-2.0302,;-2.679,-1.5609,;-3.0039,-0.0556,;-3.8202,-2.595,;-1.3054,1.1809,;-2.6335,0.4141,;-1.3054,2.7145,;0.0229,3.4813,;1.3509,2.7146,),wD:2.11,&1:8|'
-    )
-
+      'CC1=C(n2cccc2[C@H](C)Cl)C(C)CCC1 |(2.679,0.4142,;1.3509,1.181,;0.0229,0.4141,;0.0229,-1.1195,;1.2645,-2.0302,;0.7901,-3.4813,;-0.7446,-3.4813,;-1.219,-2.0302,;-2.679,-1.5609,;-3.0039,-0.0556,;-3.8202,-2.595,;-1.3054,1.1809,;-2.6335,0.4141,;-1.3054,2.7145,;0.0229,3.4813,;1.3509,2.7146,),wD:2.11,&1:8|')
     flags = Chem.CXSmilesFields.CX_COORDS | \
                         Chem.CXSmilesFields.CX_MOLFILE_VALUES | \
                         Chem.CXSmilesFields.CX_ATOM_PROPS | \
@@ -7798,6 +7794,28 @@ M  END
       smi ==
       'CC1=C(n2cccc2[C@H](C)Cl)C(C)CCC1 |(2.679,0.4142,;1.3509,1.181,;0.0229,0.4141,;0.0229,-1.1195,;1.2645,-2.0302,;0.7901,-3.4813,;-0.7446,-3.4813,;-1.219,-2.0302,;-2.679,-1.5609,;-3.0039,-0.0556,;-3.8202,-2.595,;-1.3054,1.1809,;-2.6335,0.4141,;-1.3054,2.7145,;0.0229,3.4813,;1.3509,2.7146,),&1:8|'
     )
+
+  def testAtropisomerWedgingRigorousEnhancedStereo(self):
+    m = Chem.MolFromSmiles(
+      'CC1=C(N2C=CC=C2[C@H](C)Cl)C(C)CCC1 |(2.679,0.4142,;1.3509,1.181,;0.0229,0.4141,;0.0229,-1.1195,;1.2645,-2.0302,;0.7901,-3.4813,;-0.7446,-3.4813,;-1.219,-2.0302,;-2.679,-1.5609,;-3.0039,-0.0556,;-3.8202,-2.595,;-1.3054,1.1809,;-2.6335,0.4141,;-1.3054,2.7145,;0.0229,3.4813,;1.3509,2.7146,),wD:2.11,wU:8.10,&1:8|'
+    )
+    self.assertTrue(m is not None)
+    self.assertTrue(m.GetNumAtoms() == 16)
+
+    sys.stdout.flush()
+    flags = Chem.CXSmilesFields.CX_COORDS | \
+                        Chem.CXSmilesFields.CX_MOLFILE_VALUES | \
+                        Chem.CXSmilesFields.CX_ATOM_PROPS | \
+                        Chem.CXSmilesFields.CX_BOND_CFG | \
+                        Chem.CXSmilesFields.CX_ENHANCEDSTEREO
+
+    ps = Chem.SmilesWriteParams()
+    ps.canonical = True
+
+    m = Chem.CanonicalizeStereoGroups(m)
+    smi = Chem.MolToCXSmiles(m, ps, flags, Chem.RestoreBondDirOption.RestoreBondDirOptionTrue)
+    print('smi: ', smi)
+    self.assertTrue(smi == 'CC1=C(n2cccc2[C@H](C)Cl)C(C)CCC1 |(2.679,0.4142,;1.3509,1.181,;0.0229,0.4141,;0.0229,-1.1195,;1.2645,-2.0302,;0.7901,-3.4813,;-0.7446,-3.4813,;-1.219,-2.0302,;-2.679,-1.5609,;-3.0039,-0.0556,;-3.8202,-2.595,;-1.3054,1.1809,;-2.6335,0.4141,;-1.3054,2.7145,;0.0229,3.4813,;1.3509,2.7146,),wD:8.9,2.11,a:2,&1:8|')
 
   def test_picklingWithAddedAttribs(self):
     m = Chem.MolFromSmiles("C")
@@ -8223,6 +8241,19 @@ M  END
     self.assertEqual(Chem.MolToSmiles(mol, ignoreAtomMapNumbers=False),
                      "c1ccc([NH2:1])cc1")
 
+  def github7873(self):
+    # this used to segfault
+    Chem.MolFromSmiles("C").GetAtomWithIdx(0).SetPDBResidueInfo(None)
+    
+  def testSplitMolByPDB(self):
+    mol = Chem.MolFromSmiles("C")
+    res2mol = Chem.SplitMolByPDBResidues(mol)
+    self.assertEqual(len(res2mol), 1)
+    self.assertIn("", res2mol)
+    chain2mol = Chem.SplitMolByPDBChainId(mol)
+    self.assertEqual(len(chain2mol), 1)
+    self.assertIn("", chain2mol)
+    
   def testGithub4570(self):
     # test sending None to get/set prop
     m = Chem.Mol()


### PR DESCRIPTION
Fixes #4570 

It turns out that any Boost python function that has a signature

```
T func(const char * value)
```

will segfault when called with

```
func(None)
```

Switching to:
```
T func(const std::string &value)
```

is the easy solution here as boost will not permit the type cast.  We should probably have a once over for char * in exposed functions.