### PR TITLE
Remove explicit default constructor from Compute2DCoordParameters

### DIFF
--- a/Code/GraphMol/Depictor/RDDepictor.h
+++ b/Code/GraphMol/Depictor/RDDepictor.h
@@ -91,7 +91,6 @@ struct RDKIT_DEPICTOR_EXPORT Compute2DCoordParameters {
   bool useRingTemplates = false;  //!< whether to use ring system templates for
                                   //!< generating initial coordinates
 
-  Compute2DCoordParameters() = default;
 };
 
 //! \brief Generate 2D coordinates (a depiction) for a molecule


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
The explicit default constructor actually blocks the other defaults. It also means this is no longer a "plain struct", and so designated initializers aren't available.

I wanna be able to do:

    Compute2DCoordParameters params{.useRingTemplates = true};

Or even:

    RDDepict::compute2DCoords(*mol, {.useRingTemplates = true};

#### Any other comments?
I know that we haven't moved the RDKit code to C++20 - but I'm using it from C++20.
