### PR TITLE
Improve doc string for ParseAbbreviations in python wrapper.

### DIFF
--- a/Code/GraphMol/Abbreviations/Wrap/rdAbbreviations.cpp
+++ b/Code/GraphMol/Abbreviations/Wrap/rdAbbreviations.cpp
@@ -76,13 +76,26 @@ BOOST_PYTHON_MODULE(rdAbbreviations) {
               "returns a list of the default abbreviation definitions");
   python::def("GetDefaultLinkers", &Abbreviations::Utils::getDefaultLinkers,
               "returns a list of the default linker definitions");
-  python::def("ParseAbbreviations", &Abbreviations::Utils::parseAbbreviations,
-              (python::arg("text"), python::arg("removeExtraDummies") = false,
-               python::arg("allowConnectionToDummies") = false),
-              "returns a set of abbreviation definitions from a string");
+  python::def(
+      "ParseAbbreviations", &Abbreviations::Utils::parseAbbreviations,
+      (python::arg("text"), python::arg("removeExtraDummies") = false,
+       python::arg("allowConnectionToDummies") = false),
+      "Returns a set of abbreviation definitions from a string."
+      "  Format of the text data:  A series of lines, each of which contains:"
+      " label SMARTS displayLabel displayLabelW"
+      "  Where label is the label used for the abbreviation,"
+      " SMARTS is the SMARTS definition of the abbreviation,"
+      " displayLabel is used in drawings to render the abbreviations and"
+      " displayLabelW is the display label if a bond comes in from the right."
+      "  The 'displayLabel' and 'displayLabelW' fields are optional."
+      "  Use dummies in the SMARTS to indicate attachment points. The assumption"
+      " is that the first atom is a dummy (one will be added if this is not"
+      " true) and that the second atom is the surrogate for the rest of"
+      " the group.");
   python::def("ParseLinkers", &Abbreviations::Utils::parseLinkers,
               (python::arg("text")),
-              "returns a set of linker definitions from a string");
+              "Returns a set of linker definitions from a string."
+              "  Equivalent to calling ParseAbbreviations(text, True True).");
   python::def(
       "CondenseMolAbbreviations", &condenseMolAbbreviationsHelper,
       (python::arg("mol"), python::arg("abbrevs"),


### PR DESCRIPTION
#### Reference Issue
Discussion #8044


#### What does this implement/fix? Explain your changes.
Adds some extra documentation explaining the format of the abbreviations table.

#### Any other comments?

