### PR TITLE
Resolve clashing atom labels in 2D drawing

### DIFF
--- a/Code/GraphMol/MolDraw2D/AtomSymbol.cpp
+++ b/Code/GraphMol/MolDraw2D/AtomSymbol.cpp
@@ -62,7 +62,14 @@ void AtomSymbol::findExtremes(double &xmin, double &xmax, double &ymin,
 void AtomSymbol::scale(const Point2D &scaleFactor) {
   cds_.x *= scaleFactor.x;
   cds_.y *= scaleFactor.y;
+  recalculateRects();
+}
 
+// ****************************************************************************
+void AtomSymbol::move(const Point2D &trans) { cds_ += trans; }
+
+// ****************************************************************************
+void AtomSymbol::recalculateRects() {
   // rebuild the rectangles, because the fontScale may be different,
   // and the widths etc might not scale by the same amount.
   rects_.clear();
@@ -71,9 +78,6 @@ void AtomSymbol::scale(const Point2D &scaleFactor) {
   textDrawer_.getStringRects(symbol_, orient_, rects_, drawModes_, drawChars_,
                              false, TextAlignType::MIDDLE);
 }
-
-// ****************************************************************************
-void AtomSymbol::move(const Point2D &trans) { cds_ += trans; }
 
 // ****************************************************************************
 void AtomSymbol::draw(MolDraw2D &molDrawer) const {

--- a/Code/GraphMol/MolDraw2D/AtomSymbol.h
+++ b/Code/GraphMol/MolDraw2D/AtomSymbol.h
@@ -67,6 +67,7 @@ class AtomSymbol {
   // we might be scaling the font differently from the drawing as a whole.
   virtual void scale(const Point2D &scaleFactor);
   virtual void move(const Point2D &trans);
+  virtual void recalculateRects();
   void draw(MolDraw2D &molDrawer) const;
   bool doesRectClash(const StringRect &rect, double padding) const;
   // Because a colon is a lot shorter than other characters, there are cases,

--- a/Code/GraphMol/MolDraw2D/AtomSymbol.h
+++ b/Code/GraphMol/MolDraw2D/AtomSymbol.h
@@ -31,12 +31,15 @@ namespace MolDraw2D_detail {
 
 class AtomSymbol {
  public:
-  virtual ~AtomSymbol() = default;
+  ~AtomSymbol() = default;
 
   /*!
    *
    * @param symbol     : the full symbol
+   * @param atIdx      : index of atom that this is the symbol of
    * @param orient     : text orientation (up, down, left, right)
+   * @param cds        : coords for symbol
+   * @param colour     : colour for symbol
    * @param textDrawer : instance of DrawText to get the character sizes
    * etc.
    */
@@ -61,13 +64,13 @@ class AtomSymbol {
   std::vector<char> drawChars_;
 
   // expects xmin etc to be initialised to something sensible.
-  virtual void findExtremes(double &xmin, double &xmax, double &ymin,
-                            double &ymax) const;
+  void findExtremes(double &xmin, double &xmax, double &ymin,
+                    double &ymax) const;
   // scaleFactor moves the cds_, but the fontScaleFactor changes rects_, because
   // we might be scaling the font differently from the drawing as a whole.
-  virtual void scale(const Point2D &scaleFactor);
-  virtual void move(const Point2D &trans);
-  virtual void recalculateRects();
+  void scale(const Point2D &scaleFactor);
+  void move(const Point2D &trans);
+  void recalculateRects();
   void draw(MolDraw2D &molDrawer) const;
   bool doesRectClash(const StringRect &rect, double padding) const;
   // Because a colon is a lot shorter than other characters, there are cases,

--- a/Code/GraphMol/MolDraw2D/DrawMol.cpp
+++ b/Code/GraphMol/MolDraw2D/DrawMol.cpp
@@ -287,9 +287,6 @@ void DrawMol::extractAtomSymbols() {
     }
     std::pair<std::string, OrientType> atSym =
         getAtomSymbolAndOrientation(*at1);
-    // std::cout << at1->getIdx() << " : " << atSym.first << " : " <<
-    // atSym.second
-    //           << "\n";
     atomSyms_.push_back(atSym);
     if (!atSym.first.empty()) {
       DrawColour atCol = getColour(at1->getIdx());

--- a/Code/GraphMol/MolDraw2D/DrawMol.h
+++ b/Code/GraphMol/MolDraw2D/DrawMol.h
@@ -125,6 +125,7 @@ class DrawMol {
   // at the end of changeToDrawCoords() and any necessary DrawShapePolyLines
   // added to postShapes_ in drawCoords.
   void extractCloseContacts();
+  void resolveAtomSymbolClashes();
   void calculateScale();
   void findExtremes();
   void changeToDrawCoords();

--- a/Code/GraphMol/MolDraw2D/catch_tests.cpp
+++ b/Code/GraphMol/MolDraw2D/catch_tests.cpp
@@ -103,10 +103,10 @@ const std::map<std::string, std::hash_result_t> SVG_HASHES = {
     {"testBrackets-2b.svg", 776446765U},
     {"testBrackets-2c.svg", 1050851904U},
     {"testBrackets-2d.svg", 776446765U},
-    {"testBrackets-3a.svg", 1374944956U},
+    {"testBrackets-3a.svg", 3096284602U},
     {"testBrackets-4a.svg", 3837821771U},
     {"testBrackets-4b.svg", 1477006167U},
-    {"testBrackets-5a.svg", 3061667963U},
+    {"testBrackets-5a.svg", 2676997151U},
     {"testBrackets-5768.svg", 2559120196U},
     {"testSGroupData-1a.svg", 426096222U},
     {"testSGroupData-1b.svg", 1688385103U},
@@ -348,7 +348,7 @@ const std::map<std::string, std::hash_result_t> SVG_HASHES = {
     {"testGithub_7739_5.svg", 2541364166U},
     {"testHighlightHeteroAtoms_1.svg", 1769258632U},
     {"testHighlightHeteroAtoms_2.svg", 893937335U},
-    {"testAtomAbbreviationsClash.svg", 137773688U},
+    {"testAtomAbbreviationsClash.svg", 1847939197U},
 };
 
 // These PNG hashes aren't completely reliable due to floating point cruft,
@@ -10106,11 +10106,12 @@ TEST_CASE("idx out of bounds should not cause a segfault") {
 }
 
 TEST_CASE("Atom abbreviations clash") {
-  auto m = "C(OC)C(OC)C(OC)C(OC)C(OC)C(OC)C(OC)COC"_smiles;
+  auto m = "C(OC)C(OC)C(OC)C(OC)C(OC)C(OC)C(Cl)COC"_smiles;
   RDDepict::preferCoordGen = false;
   MolDraw2DUtils::prepareMolForDrawing(*m);
   MolDraw2DSVG drawer(300, 300, -1, -1, NO_FREETYPE);
   drawer.drawOptions().explicitMethyl = true;
+  drawer.drawOptions().addAtomIndices = true;
   drawer.drawOptions().baseFontSize = 1.2;
   drawer.drawMolecule(*m);
   drawer.finishDrawing();
@@ -10119,7 +10120,7 @@ TEST_CASE("Atom abbreviations clash") {
   outs << text;
   outs.flush();
   // If this is worked correctly, the first 2 characters of atoms 8 and 14
-  // should be below each other, and the characters of atom 20 should
+  // should be above each other, and the characters of atom 22 should
   // be in increasing x, with the y of 1 and 3 (H and C) the same.
   // If this wasn't a test, this would probably be done more elegantly.
   {
@@ -10138,7 +10139,7 @@ TEST_CASE("Atom abbreviations clash") {
     double x2 = stod(match[1]);
     double y2 = stod(match[2]);
     CHECK_THAT(x1, Catch::Matchers::WithinAbs(x2, 0.1));
-    CHECK(y2 > y1);
+    CHECK(y1 > y2);
   }
   {
     const static std::regex text14(
@@ -10156,16 +10157,16 @@ TEST_CASE("Atom abbreviations clash") {
     double x2 = stod(match[1]);
     double y2 = stod(match[2]);
     CHECK_THAT(x1, Catch::Matchers::WithinAbs(x2, 0.1));
-    CHECK(y2 > y1);
+    CHECK(y1 > y2);
   }
   {
-    const static std::regex text20(
-        "<text x='(\\d+\\.\\d+)' y='(\\d+\\.\\d+)' class='atom-20'.*</text>");
+    const static std::regex text22(
+        "<text x='(\\d+\\.\\d+)' y='(\\d+\\.\\d+)' class='atom-22'.*</text>");
     std::ptrdiff_t const match_count(
-        std::distance(std::sregex_iterator(text.begin(), text.end(), text20),
+        std::distance(std::sregex_iterator(text.begin(), text.end(), text22),
                       std::sregex_iterator()));
     CHECK(match_count == 3);
-    auto match_begin = std::sregex_iterator(text.begin(), text.end(), text20);
+    auto match_begin = std::sregex_iterator(text.begin(), text.end(), text22);
     std::smatch match = *match_begin;
     double x1 = stod(match[1]);
     double y1 = stod(match[2]);


### PR DESCRIPTION
#### Reference Issue
This came up in discussion #8044.


#### What does this implement/fix? Explain your changes.
If 2 atom labels are seen to clash, the orientation of one or the other is changed to try and fix it.
So
![image](https://github.com/user-attachments/assets/1eaefa09-01a4-451d-bdb2-d36926f1671a)
becomes
![image](https://github.com/user-attachments/assets/0180ca47-f507-4383-81f7-979c0f1e604c)


#### Any other comments?
Probably it could be a bit better, such that the upper methyls went up rather than down but that seemed like a bit more effort than is warranted by the frequency that the issue occurs.
