### PR TITLE
Avoid expensive matching in conformer generation if it's not needed.

### DIFF
--- a/Code/GraphMol/DistGeomHelpers/Embedder.cpp
+++ b/Code/GraphMol/DistGeomHelpers/Embedder.cpp
@@ -37,6 +37,7 @@
 #include <iomanip>
 #include <RDGeneral/RDThreads.h>
 #include <typeinfo>
+#include <vector>
 
 #ifdef RDK_BUILD_THREADSAFE_SSS
 #include <future>
@@ -1574,7 +1575,10 @@ void EmbedMultipleConfs(ROMol &mol, INT_VECT &res, unsigned int numConfs,
     }
 #endif
   }
-  auto selfMatches = detail::getMolSelfMatches(mol, params);
+  std::vector<std::vector<unsigned int>> selfMatches;
+  if (params.pruneRmsThresh > 0.0) {
+    selfMatches = detail::getMolSelfMatches(mol, params);
+  }
 
   for (unsigned int ci = 0; ci < confs.size(); ++ci) {
     auto &conf = confs[ci];


### PR DESCRIPTION
### Avoid expensive matching in conformer generation if it's not needed.

> [!NOTE]
> The authors of this change are: Akvilė Žemgulytė with work done in Google Deepmind. I am porting this with their approval, and will be addressing any comments from reviews here.

Before the change, matching after conformer generation was done always despite the fact that it is's only used if pruning threshold for conformer similarity is provided. After the change, we check if the pruning threshold will require us to check for similarity and only do matching in that case. Matching can be very expensive for some molecules, so avoiding it when not needed will improve the performance of conformer embedding.
