### PR TITLE
Minor MinimalLib cleanup

### DIFF
--- a/Code/MinimalLib/cffiwrapper.cpp
+++ b/Code/MinimalLib/cffiwrapper.cpp
@@ -56,6 +56,7 @@
 #include <rapidjson/document.h>
 #include <rapidjson/stringbuffer.h>
 #include <rapidjson/writer.h>
+#include "cffiwrapper.h"
 
 namespace rj = rapidjson;
 
@@ -69,18 +70,25 @@ using namespace RDKit;
 namespace {
 char *str_to_c(const std::string &str, size_t *len = nullptr) {
   if (len) {
-    *len = str.size();
+    *len = 0;
   }
   char *res;
   res = (char *)malloc(str.size() + 1);
-  memcpy((void *)res, (const void *)str.c_str(), str.size());
-  res[str.size()] = 0;
+  if (res) {
+    if (len) {
+      *len = str.size();
+    }
+    memcpy(res, str.c_str(), str.size());
+    res[str.size()] = '\0';
+  }
   return res;
 }
 char *str_to_c(const char *str) {
   char *res;
   res = (char *)malloc(strlen(str) + 1);
-  strcpy(res, str);
+  if (res) {
+    strcpy(res, str);
+  }
   return res;
 }
 }  // namespace
@@ -659,7 +667,7 @@ extern "C" void prefer_coordgen(short val) {
 #endif
 };
 
-extern "C" short has_coords(char *mol_pkl, size_t mol_pkl_sz) {
+extern "C" short has_coords(const char *mol_pkl, size_t mol_pkl_sz) {
   short res = 0;
   if (mol_pkl && mol_pkl_sz) {
     auto mol = mol_from_pkl(mol_pkl, mol_pkl_sz);

--- a/Code/MinimalLib/cffiwrapper.h
+++ b/Code/MinimalLib/cffiwrapper.h
@@ -138,7 +138,7 @@ RDKIT_RDKITCFFI_EXPORT short fragment_parent(char **pkl, size_t *pkl_sz,
 
 // coordinates
 RDKIT_RDKITCFFI_EXPORT void prefer_coordgen(short val);
-RDKIT_RDKITCFFI_EXPORT short has_coords(char *mol_pkl, size_t mol_pkl_sz);
+RDKIT_RDKITCFFI_EXPORT short has_coords(const char *mol_pkl, size_t mol_pkl_sz);
 RDKIT_RDKITCFFI_EXPORT short set_2d_coords(char **pkl, size_t *pkl_sz);
 RDKIT_RDKITCFFI_EXPORT short set_3d_coords(char **pkl, size_t *pkl_sz,
                                            const char *params_json);

--- a/Code/MinimalLib/tests/tests.js
+++ b/Code/MinimalLib/tests/tests.js
@@ -28,7 +28,7 @@ const extractBondCoords = (svg, bondDetail) => {
         return [[m[1], m[2]], [m[3], m[4]]];
     };
     const bond = svg.split('\n').filter(line => line.includes(bondDetail));
-    assert(bond.length === 1);
+    assert.equal(bond.length, 1);
     return getStartEndCoords(bond[0]);
 }
 const angleDegBetweenVectors = (v1, v2) => 180 / Math.PI * Math.acos((v1[0] * v2[0] + v1[1] * v2[1])
@@ -1026,10 +1026,10 @@ function test_has_coords() {
     var mol = RDKitModule.get_mol('CC');
     assert(!mol.has_coords());
     var mol2 = RDKitModule.get_mol(mol.get_new_coords());
-    assert(mol2.has_coords() === 2);
+    assert.equal(mol2.has_coords(), 2);
     assert(!mol.has_coords());
     mol.set_new_coords();
-    assert(mol.has_coords() === 2);
+    assert.equal(mol.has_coords(), 2);
     var mol3 = RDKitModule.get_mol(`
      RDKit          3D
 
@@ -1054,7 +1054,7 @@ function test_has_coords() {
   3  9  1  0
 M  END
 `);
-    assert(mol3.has_coords() === 3);
+    assert.equal(mol3.has_coords(), 3);
 }
 
 function test_kekulize() {
@@ -1861,7 +1861,7 @@ function test_get_frags() {
             fragsMolAtomMapping: [[0,1,2,3,4,5],[6,7,8,9],[10,11,12,13,14]],
         };
         var { molList, mappings } = mol.get_frags();
-        assert(molList.size() === 3);
+        assert.equal(molList.size(), 3);
         assert(JSON.stringify(JSON.parse(mappings)) === JSON.stringify(expectedMappings));
         var i = 0;
         while (!molList.at_end()) {
@@ -1882,7 +1882,7 @@ function test_get_frags() {
         }
         assert(exceptionThrown);
         var { molList, mappings } = mol.get_frags(JSON.stringify({sanitizeFrags: false}));
-        assert(molList.size() === 2);
+        assert.equal(molList.size(), 2);
         var i = 0;
         while (!molList.at_end()) {
             var mol = molList.next();
@@ -1906,9 +1906,9 @@ function test_get_mmpa_frags() {
         "C1CCC([*:1])CC1.CC(C)C[*:2]", "C1CCC([*:1])CC1.CC(C)CC[*:2]"];
         var pairs = mol.get_mmpa_frags(2, 2, 20);
         assert(pairs.cores);
-        assert(pairs.cores.size() === 11);
+        assert.equal(pairs.cores.size(), 11);
         assert(pairs.sidechains);
-        assert(pairs.sidechains.size() === 11);
+        assert.equal(pairs.sidechains.size(), 11);
         var i = 0;
         while (!pairs.cores.at_end()) {
             var m = pairs.cores.next();
@@ -1935,9 +1935,9 @@ function test_get_mmpa_frags() {
 
         var pairs = mol.get_mmpa_frags(1, 1, 20);
         assert(pairs.cores);
-        assert(pairs.cores.size() === 5);
+        assert.equal(pairs.cores.size(), 5);
         assert(pairs.sidechains);
-        assert(pairs.sidechains.size() === 5);
+        assert.equal(pairs.sidechains.size(), 5);
         while (!pairs.cores.at_end()) {
             var m = pairs.cores.next();
             assert(m === null);
@@ -1957,7 +1957,7 @@ function test_get_mmpa_frags() {
         for (i = 0; i < numCores; ++i) {
             assert(pairs.cores.pop(0) === null);
         }
-        assert(pairs.cores.size() === 0);
+        assert.equal(pairs.cores.size(), 0);
         assert(pairs.cores.next() === null);
         pairs.cores.delete();
         pairs.sidechains.delete();
@@ -2581,7 +2581,7 @@ function test_mcs() {
                 molList.delete();
             }
         }
-        assert(res.size === 4);
+        assert.equal(res.size, 4);
     }
     {
         const smiArray = [
@@ -2627,8 +2627,8 @@ function test_mcs() {
         mcs = JSON.parse(mcs);
         assert(!mcs.canceled);
         assert(!Array.isArray(mcs.smarts));
-        assert(mcs.numAtoms === 8);
-        assert(mcs.numBonds === 8);
+        assert.equal(mcs.numAtoms, 8);
+        assert.equal(mcs.numBonds, 8);
         assert(mcs.smarts === '[#7]-[#6]1:[#6]:[#6]:[#6](:[#6]:[#6]:1)-[#6]');
         try {
             molList = molListFromSmiArray(smiArray);
@@ -2642,9 +2642,9 @@ function test_mcs() {
         mcs = JSON.parse(mcs);
         assert(!mcs.canceled);
         assert(Array.isArray(mcs.smarts));
-        assert(mcs.numAtoms === 8);
-        assert(mcs.numBonds === 8);
-        assert(mcs.smarts.length === 2);
+        assert.equal(mcs.numAtoms, 8);
+        assert.equal(mcs.numBonds, 8);
+        assert.equal(mcs.smarts.length, 2);
         assert(mcs.smarts.includes('[#6]-[#6]1:[#6]:[#6]:[#6]:[#6]:[#6]:1-[#7]'));
         assert(mcs.smarts.includes('[#7]-[#6]1:[#6]:[#6]:[#6](:[#6]:[#6]:1)-[#6]'));
     }


### PR DESCRIPTION
- `str_to_c()` should initialize len to 0 even if memory allocation fails
- `str_to_c()` should check the ptr returned by malloc for non-nullness before using it
- change `has_coords()` `mol_pkl` parameter to `const`
- use `assert.equal` in JS tests where possible
