### PR TITLE
Fix two out-of-bounds bugs in inchi interface

### DIFF
--- a/External/INCHI-API/inchi.cpp
+++ b/External/INCHI-API/inchi.cpp
@@ -1866,6 +1866,10 @@ std::string MolToInchi(const ROMol &mol, ExtraInchiReturnValues &rv,
       for (const auto &p : neighbors) {
         stereo0D.neighbor[nid++] = p.second;
         // std::cerr<<" "<<p.second;
+        // stereo0D.neighbor has fixed length of 4
+        if (nid > 3) {
+          break;
+        }
       }
       if (nid == 3) {
         // std::cerr<<" nid==3, reorder";
@@ -1964,6 +1968,12 @@ std::string MolToInchi(const ROMol &mol, ExtraInchiReturnValues &rv,
 
     // neighbor
     unsigned int idx = inchiAtoms[atomIndex1].num_bonds;
+    // neighbor array has fixed length of MAXVAL (20)
+    if (idx >= MAXVAL) {
+      BOOST_LOG(rdErrorLog) << "illegally large idx (" << idx
+                            << ") in bond neighbors" << std::endl;
+      return std::string();
+    }
     inchiAtoms[atomIndex1].neighbor[idx] = atomIndex2;
 
     // bond type


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! 
-->

#### What does this implement/fix? Explain your changes.

We (https://patents.google.com/) encountered some out of bounds bugs while converting the following SMILES strings to InChI:

* `CC[C@H]1OC(=O)C[C@@H](O)[C@H](C)[C@@H](O[C@@H]2O[C@H](C)[C@@H](O)C(N(C)C)C2O)[C@@H](CC=O)C[C@@H](C)C(=O)/C=C/C(C)=C/[C@@H]1CO.CC[C@H]1OC(=O)C[C@@H](O)[C@H](C)[C@@H](O[C@@H]2O[C@H](C)[C@@H](O[C@H]3CC(C)(O)[C@@H](O)C(C)O3)C(N(C)C)C2O)[C@@H](CC=O)C[C@@H](C)C(=O)/C=C/C(C)=C/[C@@H]1CO[C@@H]1OC(C)[C@@H](O)[C@H](OC)C1OC.[3H][Y]([3H])([3H])([3H])([3H])([3H])([3H])([3H])([3H])([3H])([3H])([3H])([3H])([3H])([3H])([3H])([3H])([3H])([3H])([3H])([3H])([3H])([3H])([3H])([3H])([3H])([3H])([3H])([3H])([3H])([3H])([3H])([3H])([3H])([3H])([3H])([3H])([3H])([3H])([3H])([3H])([3H])([3H])([3H])([3H])([3H])([3H])([3H])([3H])([3H])([3H])([3H])([3H])([3H])([3H])([3H])([3H])([3H])([3H])([3H])([3H])([3H])([3H])([3H])([3H])([3H])([3H])([3H])([3H])([3H])([3H])([3H])([3H])([3H])([3H])([3H])([3H])([3H])([3H])([3H])([3H])([3H])([3H])([3H])([3H])([3H])([3H])([3H])([3H])([3H])([3H])([3H])([3H])([3H])([3H])([3H])([3H])([3H])([3H])([3H])([3H])([3H])([3H])([3H])([3H])[3H]`
* `Cc1cc(C)c(N2CCN(c3c(C)cc(C)cc3C)C2[Ru@OH28]2(Cl)(Cl)=Cc3cc([S@SP3](=O)(=O)N(C)C)ccc3O->2C(C)C)c(C)c1`

#### Any other comments?

This may not be the most correct fix :/ but it's better than segfaulting :)

Thanks!