### PR TITLE
GetAtomsMatchingQuery: Tell where to find query options for

### DIFF
--- a/Code/GraphMol/Wrap/Mol.cpp
+++ b/Code/GraphMol/Wrap/Mol.cpp
@@ -806,7 +806,7 @@ struct mol_wrapper {
              python::args("self", "qa"),
              "Returns a read-only sequence containing all of the atoms in a "
              "molecule that match the query atom. "
-             "Atom query options are given in the rdkit.Chem.rdqueries module.\n")
+             "Atom query options are defined in the rdkit.Chem.rdqueries module.\n")
 
         // enable pickle support
         .def_pickle(mol_pickle_suite())

--- a/Code/GraphMol/Wrap/Mol.cpp
+++ b/Code/GraphMol/Wrap/Mol.cpp
@@ -805,7 +805,8 @@ struct mol_wrapper {
                  python::with_custodian_and_ward_postcall<0, 1>>(),
              python::args("self", "qa"),
              "Returns a read-only sequence containing all of the atoms in a "
-             "molecule that match the query atom.\n")
+             "molecule that match the query atom. "
+             "Atom query options are given in the rdkit.Chem.rdqueries module.\n")
 
         // enable pickle support
         .def_pickle(mol_pickle_suite())


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! 
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.
Note that "Atom query options are given in the rdkit.Chem.rdqueries module"

#### Any other comments?

