### PR TITLE
Fix leaks in MIF wrappers

### DIFF
--- a/Code/GraphMol/MolInteractionFields/Wrap/rdMIF.cpp
+++ b/Code/GraphMol/MolInteractionFields/Wrap/rdMIF.cpp
@@ -72,6 +72,9 @@ extractChargesAndPositions(const python::object &charges,
   for (unsigned int i = 0; i < nrows; ++i) {
     const auto pyXyz = PySequence_GetItem(pyPos, i);
     if (!pyXyz || !PySequence_Check(pyXyz) || PySequence_Size(pyXyz) != 3) {
+      if (pyXyz) {
+        Py_DecRef(pyXyz);
+      }
       throw_value_error(
           "all elements in positions argument must be x,y,z sequences");
     }


### PR DESCRIPTION
I had some time and ran asan on `testMIF.py`:
- `extractChargesAndPositions()` was leaking Python objects, as `PySequence_GetItem()` returns a new reference, which needs to be dec ref'd to be cleaned up.
- `makeAltCoulomb()`and `makeAltCoulombDielectric()` returned raw pointers, that were never cleaned up, as the `Coulomb` and `CoulombDielectric` wrappers didn´t manage them. I changed them to return shared ptrs.
- Also added shared_ptr wrappers to other classes in this file (including the two that included wrappers for raw pointers, which are not managed).
