### PR TITLE
fix SetPositions when using strided numpy array

### DIFF
--- a/Code/GraphMol/Wrap/Conformer.cpp
+++ b/Code/GraphMol/Wrap/Conformer.cpp
@@ -95,15 +95,15 @@ void SetPos(Conformer *conf, np::ndarray const &array) {
   RDGeom::POINT3D_VECT &pos = conf->getPositions();
   if (array.shape(1) == 2) {
     for (size_t i = 0; i < conf->getNumAtoms(); ++i) {
-      pos[i].x = * reinterpret_cast<double*>(dataptr + i * stride_atom);
-      pos[i].y = * reinterpret_cast<double*>(dataptr + i * stride_atom + stride_dim);
+      pos[i].x = * reinterpret_cast<const double *>(dataptr + i * stride_atom);
+      pos[i].y = * reinterpret_cast<const double *>(dataptr + i * stride_atom + stride_dim);
       pos[i].z = 0.0;
     }
   } else {
     for (size_t i = 0; i < conf->getNumAtoms(); ++i) {
-      pos[i].x = * reinterpret_cast<double*>(dataptr + i * stride_atom);
-      pos[i].y = * reinterpret_cast<double*>(dataptr + i * stride_atom + stride_dim);
-      pos[i].z = * reinterpret_cast<double*>(dataptr + i * stride_atom + 2 * stride_dim);
+      pos[i].x = * reinterpret_cast<const double *>(dataptr + i * stride_atom);
+      pos[i].y = * reinterpret_cast<const double *>(dataptr + i * stride_atom + stride_dim);
+      pos[i].z = * reinterpret_cast<const double *>(dataptr + i * stride_atom + 2 * stride_dim);
     }
   }
 }

--- a/Code/GraphMol/Wrap/Conformer.cpp
+++ b/Code/GraphMol/Wrap/Conformer.cpp
@@ -82,19 +82,28 @@ void SetPos(Conformer *conf, np::ndarray const &array) {
     python::throw_error_already_set();
   }
 
-  const auto *data = reinterpret_cast<double *>(array.get_data());
+  // pointer to start of contiguous data block that numpy holds
+  // this isn't necessarily in pure C order
+  const auto *dataptr = array.get_data();
+  // the number of *bytes* to skip to jump to next row in data array
+  int stride_atom = array.strides(0);
+  // the number of *bytes* to skip to move between x, y, z in a row
+  int stride_dim = array.strides(1);
+  // i.e. stride_atom/dim would be 24 & 8 in a contiguous 3D input,
+  // but numpy will play with this when doing slicing/transposing etc
+
   RDGeom::POINT3D_VECT &pos = conf->getPositions();
   if (array.shape(1) == 2) {
     for (size_t i = 0; i < conf->getNumAtoms(); ++i) {
-      pos[i].x = data[i * 2];
-      pos[i].y = data[i * 2 + 1];
+      pos[i].x = * reinterpret_cast<double*>(dataptr + i * stride_atom);
+      pos[i].y = * reinterpret_cast<double*>(dataptr + i * stride_atom + stride_dim);
       pos[i].z = 0.0;
     }
   } else {
     for (size_t i = 0; i < conf->getNumAtoms(); ++i) {
-      pos[i].x = data[i * 3];
-      pos[i].y = data[i * 3 + 1];
-      pos[i].z = data[i * 3 + 2];
+      pos[i].x = * reinterpret_cast<double*>(dataptr + i * stride_atom);
+      pos[i].y = * reinterpret_cast<double*>(dataptr + i * stride_atom + stride_dim);
+      pos[i].z = * reinterpret_cast<double*>(dataptr + i * stride_atom + 2 * stride_dim);
     }
   }
 }

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -6732,7 +6732,28 @@ M  END
     pos2 = m.GetConformer(0).GetPositions()
 
     self.assertTrue( (pos==pos2).all())
-    
+
+
+  def test_get_set_positions_stride(self):
+    m = Chem.MolFromSmiles('CCC |(-1.29904,-0.25,;0,0.5,;1.29904,-0.25,)|')
+    # to check stride walking in SetPositions
+    # allocate a double size array, then slice every other element
+    # numpy will mess with the striding to create the view onto the double size array
+    pos = np.zeros([6,3], np.double)[::2]
+    pos[0][1] = 1
+    pos[0][2] = 2
+    pos[1][0] = 3
+    pos[1][1] = 4
+    pos[1][2] = 5
+    pos[2][0] = 6
+    pos[2][1] = 6
+    pos[2][2] = 7
+
+    m.GetConformer(0).SetPositions(pos)
+    pos2 = m.GetConformer(0).GetPositions()
+
+    self.assertTrue( (pos==pos2).all())
+
 
   def test_github3553(self):
     fileN = os.path.join(RDConfig.RDBaseDir, 'Code', 'GraphMol', 'Wrap', 'test_data',


### PR DESCRIPTION
Fixes a weird bug in Conformer.SetPositions when you've provided a strided numpy array - previously SetPositions assumed that the provided numpy array used contiguous-C stride patterns.

A realistic time you could hit this would be if you were playing with rotational matrices:

```python
pos = conformer.GetPositions()

# quick and dirty way of applying rotational matrix
# the transpose doesn't copy all the data, but instead changes the strides on the array to achieve the same effect
pos = (rotmat @ pos.T).T

conformer.SetPositions(pos)

# at this point, conformer.GetPositions() != pos, instead it's the transpose
```

see also:

https://numpy.org/doc/2.1/reference/arrays.ndarray.html#internal-memory-layout-of-an-ndarray