### PR TITLE
Condense MMFF Contribs into single contrib per type.

### DIFF
--- a/Code/DistGeom/DistGeomUtils.cpp
+++ b/Code/DistGeom/DistGeomUtils.cpp
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2004-2024 Greg Landrum and other RDKit contributors
+//  Copyright (C) 2004-2025 Greg Landrum and other RDKit contributors
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -532,11 +532,11 @@ ForceFields::ForceField *construct3DForceField(
   bool is1_4 = false;
   // double dielConst = 1.0;
   boost::uint8_t dielModel = 1;
+  auto *contrib = new ForceFields::MMFF::EleContrib(field);
+  field->contribs().emplace_back(contrib);
   for (const auto &charge : CPCI) {
-    auto *contrib = new ForceFields::MMFF::EleContrib(
-        field, charge.first.first, charge.first.second, charge.second,
-        dielModel, is1_4);
-    field->contribs().emplace_back(contrib);
+    contrib->addTerm(charge.first.first, charge.first.second, charge.second,
+                     dielModel, is1_4);
   }
 
   return field;

--- a/Code/ForceField/MMFF/AngleBend.cpp
+++ b/Code/ForceField/MMFF/AngleBend.cpp
@@ -1,4 +1,5 @@
 // $Id$
+//  Copyright (C) 2014-2025 Greg Landrum and other RDKit contributors
 //
 //  Copyright (C) 2013 Paolo Tosco
 //
@@ -85,81 +86,102 @@ void calcAngleBendGrad(RDGeom::Point3D *r, double *dist, double **g,
 }
 }  // end of namespace Utils
 
-AngleBendContrib::AngleBendContrib(ForceField *owner, unsigned int idx1,
-                                   unsigned int idx2, unsigned int idx3,
-                                   const MMFFAngle *mmffAngleParams,
-                                   const MMFFProp *mmffPropParamsCentralAtom) {
+AngleBendContrib::AngleBendContrib(ForceField *owner) {
   PRECONDITION(owner, "bad owner");
+  dp_forceField = owner;
+}
+
+void AngleBendContrib::addTerm(unsigned int idx1,
+                               unsigned int idx2,
+                               unsigned int idx3,
+                               const ForceFields::MMFF::MMFFAngle *mmffAngleParams,
+                               const ForceFields::MMFF::MMFFProp *mmffPropParamsCentralAtom) {
+  URANGE_CHECK(idx1, dp_forceField->positions().size());
+  URANGE_CHECK(idx2, dp_forceField->positions().size());
+  URANGE_CHECK(idx3, dp_forceField->positions().size());
   PRECONDITION(((idx1 != idx2) && (idx2 != idx3) && (idx1 != idx3)),
                "degenerate points");
-  URANGE_CHECK(idx1, owner->positions().size());
-  URANGE_CHECK(idx2, owner->positions().size());
-  URANGE_CHECK(idx3, owner->positions().size());
-
-  dp_forceField = owner;
-  d_at1Idx = idx1;
-  d_at2Idx = idx2;
-  d_at3Idx = idx3;
-  d_isLinear = mmffPropParamsCentralAtom->linh > 0u;
-
-  d_theta0 = mmffAngleParams->theta0;
-  d_ka = mmffAngleParams->ka;
+  d_at1Idxs.push_back(idx1);
+  d_at2Idxs.push_back(idx2);
+  d_at3Idxs.push_back(idx3);
+  d_isLinear.push_back(mmffPropParamsCentralAtom->linh > 0u);
+  d_theta0.push_back(mmffAngleParams->theta0);
+  d_ka.push_back(mmffAngleParams->ka);
 }
+
 
 double AngleBendContrib::getEnergy(double *pos) const {
   PRECONDITION(dp_forceField, "no owner");
   PRECONDITION(pos, "bad vector");
+  double res = 0.0;
+  const int numTerms = d_at1Idxs.size();
 
-  double dist1 = dp_forceField->distance(d_at1Idx, d_at2Idx, pos);
-  double dist2 = dp_forceField->distance(d_at2Idx, d_at3Idx, pos);
+  for (int i = 0; i < numTerms; i++) {
+    const int d_at1Idx = d_at1Idxs[i];
+    const int d_at2Idx = d_at2Idxs[i];
+    const int d_at3Idx = d_at3Idxs[i];
 
-  RDGeom::Point3D p1(pos[3 * d_at1Idx], pos[3 * d_at1Idx + 1],
-                     pos[3 * d_at1Idx + 2]);
-  RDGeom::Point3D p2(pos[3 * d_at2Idx], pos[3 * d_at2Idx + 1],
-                     pos[3 * d_at2Idx + 2]);
-  RDGeom::Point3D p3(pos[3 * d_at3Idx], pos[3 * d_at3Idx + 1],
-                     pos[3 * d_at3Idx + 2]);
+    double dist1 = dp_forceField->distance(d_at1Idx, d_at2Idx, pos);
+    double dist2 = dp_forceField->distance(d_at2Idx, d_at3Idx, pos);
 
-  return Utils::calcAngleBendEnergy(
-      d_theta0, d_ka, d_isLinear,
-      Utils::calcCosTheta(p1, p2, p3, dist1, dist2));
+    RDGeom::Point3D p1(pos[3 * d_at1Idx], pos[3 * d_at1Idx + 1],
+                       pos[3 * d_at1Idx + 2]);
+    RDGeom::Point3D p2(pos[3 * d_at2Idx], pos[3 * d_at2Idx + 1],
+                       pos[3 * d_at2Idx + 2]);
+    RDGeom::Point3D p3(pos[3 * d_at3Idx], pos[3 * d_at3Idx + 1],
+                       pos[3 * d_at3Idx + 2]);
+
+    res += Utils::calcAngleBendEnergy(
+        d_theta0[i], d_ka[i], d_isLinear[i],
+        Utils::calcCosTheta(p1, p2, p3, dist1, dist2));
+  }
+  return res;
 }
 
 void AngleBendContrib::getGrad(double *pos, double *grad) const {
   PRECONDITION(dp_forceField, "no owner");
   PRECONDITION(pos, "bad vector");
   PRECONDITION(grad, "bad vector");
-  double dist[2] = {dp_forceField->distance(d_at1Idx, d_at2Idx, pos),
-                    dp_forceField->distance(d_at2Idx, d_at3Idx, pos)};
 
-  RDGeom::Point3D p1(pos[3 * d_at1Idx], pos[3 * d_at1Idx + 1],
-                     pos[3 * d_at1Idx + 2]);
-  RDGeom::Point3D p2(pos[3 * d_at2Idx], pos[3 * d_at2Idx + 1],
-                     pos[3 * d_at2Idx + 2]);
-  RDGeom::Point3D p3(pos[3 * d_at3Idx], pos[3 * d_at3Idx + 1],
-                     pos[3 * d_at3Idx + 2]);
-  double *g[3] = {&(grad[3 * d_at1Idx]), &(grad[3 * d_at2Idx]),
-                  &(grad[3 * d_at3Idx])};
-  RDGeom::Point3D r[2] = {(p1 - p2) / dist[0], (p3 - p2) / dist[1]};
-  double cosTheta = r[0].dotProduct(r[1]);
-  clipToOne(cosTheta);
-  double sinThetaSq = 1.0 - cosTheta * cosTheta;
-  double sinTheta =
-      std::max(((sinThetaSq > 0.0) ? sqrt(sinThetaSq) : 0.0), 1.0e-8);
+  const int numTerms = d_at1Idxs.size();
+  for (int i =0; i < numTerms; i++) {
+    const int d_at1Idx = d_at1Idxs[i];
+    const int d_at2Idx = d_at2Idxs[i];
+    const int d_at3Idx = d_at3Idxs[i];
 
-  // use the chain rule:
-  // dE/dx = dE/dTheta * dTheta/dx
+    double dist[2] = {dp_forceField->distance(d_at1Idx, d_at2Idx, pos),
+                      dp_forceField->distance(d_at2Idx, d_at3Idx, pos)};
 
-  // dE/dTheta is independent of cartesians:
-  double angleTerm = RAD2DEG * acos(cosTheta) - d_theta0;
-  double const cb = -0.006981317;
-  double const c2 = MDYNE_A_TO_KCAL_MOL * DEG2RAD * DEG2RAD;
+    RDGeom::Point3D p1(pos[3 * d_at1Idx], pos[3 * d_at1Idx + 1],
+                       pos[3 * d_at1Idx + 2]);
+    RDGeom::Point3D p2(pos[3 * d_at2Idx], pos[3 * d_at2Idx + 1],
+                       pos[3 * d_at2Idx + 2]);
+    RDGeom::Point3D p3(pos[3 * d_at3Idx], pos[3 * d_at3Idx + 1],
+                       pos[3 * d_at3Idx + 2]);
+    double *g[3] = {&(grad[3 * d_at1Idx]), &(grad[3 * d_at2Idx]),
+                    &(grad[3 * d_at3Idx])};
+    RDGeom::Point3D r[2] = {(p1 - p2) / dist[0], (p3 - p2) / dist[1]};
+    double cosTheta = r[0].dotProduct(r[1]);
+    clipToOne(cosTheta);
+    double sinThetaSq = 1.0 - cosTheta * cosTheta;
+    double sinTheta =
+        std::max(((sinThetaSq > 0.0) ? sqrt(sinThetaSq) : 0.0), 1.0e-8);
 
-  double dE_dTheta = (d_isLinear ? -MDYNE_A_TO_KCAL_MOL * d_ka * sinTheta
-                                 : RAD2DEG * c2 * d_ka * angleTerm *
-                                       (1.0 + 1.5 * cb * angleTerm));
+    // use the chain rule:
+    // dE/dx = dE/dTheta * dTheta/dx
 
-  Utils::calcAngleBendGrad(r, dist, g, dE_dTheta, cosTheta, sinTheta);
+    // dE/dTheta is independent of cartesians:
+    double angleTerm = RAD2DEG * acos(cosTheta) - d_theta0[i];
+    double const cb = -0.006981317;
+    double const c2 = MDYNE_A_TO_KCAL_MOL * DEG2RAD * DEG2RAD;
+
+    double dE_dTheta = (d_isLinear[i] ? -MDYNE_A_TO_KCAL_MOL * d_ka[i] * sinTheta
+                                   : RAD2DEG * c2 * d_ka[i] * angleTerm *
+                                         (1.0 + 1.5 * cb * angleTerm));
+
+    Utils::calcAngleBendGrad(r, dist, g, dE_dTheta, cosTheta, sinTheta);
+  }
 }
+
 }  // namespace MMFF
 }  // namespace ForceFields

--- a/Code/ForceField/MMFF/AngleBend.cpp
+++ b/Code/ForceField/MMFF/AngleBend.cpp
@@ -1,9 +1,4 @@
-// $Id$
-//  Copyright (C) 2014-2025 Greg Landrum and other RDKit contributors
-//
-//  Copyright (C) 2013 Paolo Tosco
-//
-//  Copyright (C) 2004-2006 Rational Discovery LLC
+//  Copyright (C) 2013-2025 Paolo Tosco and other RDKit contributors
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.

--- a/Code/ForceField/MMFF/AngleBend.h
+++ b/Code/ForceField/MMFF/AngleBend.h
@@ -1,4 +1,6 @@
 //
+//  Copyright (C) 2014-2025 Greg Landrum and Other RDKit Contributors
+//
 //  Copyright (C) 2013 Paolo Tosco
 //
 //  Copyright (C) 2004-2006 Rational Discovery LLC
@@ -27,19 +29,20 @@ class RDKIT_FORCEFIELD_EXPORT AngleBendContrib : public ForceFieldContrib {
  public:
   AngleBendContrib() {}
   //! Constructor
-  /*!
-    The angle is between atom1 - atom2 - atom3
+  AngleBendContrib(ForceField *owner);
+  /*! Adds an angle to the contrib
+  The angle is between atom1 - atom2 - atom3
 
-    \param owner       pointer to the owning ForceField
-    \param idx1        index of atom1 in the ForceField's positions
-    \param idx2        index of atom2 in the ForceField's positions
-    \param idx3        index of atom3 in the ForceField's positions
-    \param angleType   MMFF type of the angle (as an unsigned int)
+  \param idx1        index of atom1 in the ForceField's positions
+  \param idx2        index of atom2 in the ForceField's positions
+  \param idx3        index of atom3 in the ForceField's positions
+  \param angleType   MMFF type of the angle (as an unsigned int)
 
   */
-  AngleBendContrib(ForceField *owner, unsigned int idx1, unsigned int idx2,
-                   unsigned int idx3, const MMFFAngle *mmffAngleParams,
-                   const MMFFProp *mmffPropParamsCentralAtom);
+  void addTerm(unsigned int idx1, unsigned int idx2,
+               unsigned int idx3, const MMFFAngle *mmffAngleParams,
+               const MMFFProp *mmffPropParamsCentralAtom);
+
   double getEnergy(double *pos) const override;
   void getGrad(double *pos, double *grad) const override;
   AngleBendContrib *copy() const override {
@@ -47,9 +50,9 @@ class RDKIT_FORCEFIELD_EXPORT AngleBendContrib : public ForceFieldContrib {
   }
 
  private:
-  bool d_isLinear;
-  int d_at1Idx{-1}, d_at2Idx{-1}, d_at3Idx{-1};
-  double d_ka, d_theta0;
+  std::vector<bool> d_isLinear;
+  std::vector<int16_t> d_at1Idxs, d_at2Idxs, d_at3Idxs;
+  std::vector<double> d_ka, d_theta0;
 };
 namespace Utils {
 //! returns the MMFF rest value for an angle

--- a/Code/ForceField/MMFF/AngleBend.h
+++ b/Code/ForceField/MMFF/AngleBend.h
@@ -1,9 +1,4 @@
-//
-//  Copyright (C) 2014-2025 Greg Landrum and Other RDKit Contributors
-//
-//  Copyright (C) 2013 Paolo Tosco
-//
-//  Copyright (C) 2004-2006 Rational Discovery LLC
+//  Copyright (C) 2013-2025 Paolo Tosco and other RDKit contributors
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.

--- a/Code/ForceField/MMFF/BondStretch.cpp
+++ b/Code/ForceField/MMFF/BondStretch.cpp
@@ -1,9 +1,4 @@
-// $Id$
-//  Copyright (C) 2014-2025 Greg Landrum and Other RDKit Contributors
-//
-//  Copyright (C) 2013 Paolo Tosco
-//
-//  Copyright (C) 2004-2006 Rational Discovery LLC
+//  Copyright (C) 2013-2025 Paolo Tosco and other RDKit contributors
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.

--- a/Code/ForceField/MMFF/BondStretch.cpp
+++ b/Code/ForceField/MMFF/BondStretch.cpp
@@ -1,4 +1,5 @@
 // $Id$
+//  Copyright (C) 2014-2025 Greg Landrum and Other RDKit Contributors
 //
 //  Copyright (C) 2013 Paolo Tosco
 //
@@ -13,7 +14,6 @@
 
 #include "BondStretch.h"
 #include "Params.h"
-#include <cmath>
 #include <ForceField/ForceField.h>
 #include <RDGeneral/Invariant.h>
 #include <RDGeneral/utils.h>
@@ -47,27 +47,38 @@ double calcBondStretchEnergy(const double r0, const double kb,
 }
 }  // end of namespace Utils
 
-BondStretchContrib::BondStretchContrib(ForceField *owner,
-                                       const unsigned int idx1,
-                                       const unsigned int idx2,
-                                       const MMFFBond *mmffBondParams) {
+BondStretchContrib::BondStretchContrib(ForceField *owner) {
   PRECONDITION(owner, "bad owner");
-  URANGE_CHECK(idx1, owner->positions().size());
-  URANGE_CHECK(idx2, owner->positions().size());
+
 
   dp_forceField = owner;
-  d_at1Idx = idx1;
-  d_at2Idx = idx2;
-  d_r0 = mmffBondParams->r0;
-  d_kb = mmffBondParams->kb;
+
+}
+
+void BondStretchContrib::addTerm(const unsigned int idx1,
+                                 const unsigned int idx2,
+                                 const ForceFields::MMFF::MMFFBond *mmffBondParams) {
+  URANGE_CHECK(idx1, dp_forceField->positions().size());
+  URANGE_CHECK(idx2, dp_forceField->positions().size());
+  PRECONDITION(mmffBondParams, "bond parameters not found");
+
+  d_at1Idxs.push_back(idx1);
+  d_at2Idxs.push_back(idx2);
+  d_r0.push_back(mmffBondParams->r0);
+  d_kb.push_back(mmffBondParams->kb);
 }
 
 double BondStretchContrib::getEnergy(double *pos) const {
   PRECONDITION(dp_forceField, "no owner");
   PRECONDITION(pos, "bad vector");
 
-  return Utils::calcBondStretchEnergy(
-      d_r0, d_kb, dp_forceField->distance(d_at1Idx, d_at2Idx, pos));
+  const int numTerms = d_at1Idxs.size();
+  double energySum = 0.0;
+  for (int i =0; i < numTerms; i++) {
+    energySum += Utils::calcBondStretchEnergy(
+        d_r0[i], d_kb[i], dp_forceField->distance(d_at1Idxs[i], d_at2Idxs[i], pos));
+  }
+  return energySum;
 }
 
 void BondStretchContrib::getGrad(double *pos, double *grad) const {
@@ -75,25 +86,32 @@ void BondStretchContrib::getGrad(double *pos, double *grad) const {
   PRECONDITION(pos, "bad vector");
   PRECONDITION(grad, "bad vector");
 
-  double dist = dp_forceField->distance(d_at1Idx, d_at2Idx, pos);
+  const int numTerms = d_at1Idxs.size();
+  constexpr double cs = -2.0;
+  constexpr double c1 = MDYNE_A_TO_KCAL_MOL;
+  constexpr double c3 = 7.0 / 12.0;
+  for (int termIdx = 0; termIdx < numTerms; termIdx++) {
+    const int d_at1Idx = d_at1Idxs[termIdx];
+    const int d_at2Idx = d_at2Idxs[termIdx];
 
-  double *at1Coords = &(pos[3 * d_at1Idx]);
-  double *at2Coords = &(pos[3 * d_at2Idx]);
-  double *g1 = &(grad[3 * d_at1Idx]);
-  double *g2 = &(grad[3 * d_at2Idx]);
-  double const cs = -2.0;
-  double const c1 = MDYNE_A_TO_KCAL_MOL;
-  double const c3 = 7.0 / 12.0;
-  double distTerm = dist - d_r0;
-  double dE_dr =
-      c1 * d_kb * distTerm *
-      (1.0 + 1.5 * cs * distTerm + 2.0 * c3 * cs * cs * distTerm * distTerm);
-  double dGrad;
-  for (unsigned int i = 0; i < 3; ++i) {
-    dGrad = ((dist > 0.0) ? (dE_dr * (at1Coords[i] - at2Coords[i]) / dist)
-                          : d_kb * 0.01);
-    g1[i] += dGrad;
-    g2[i] -= dGrad;
+    double dist = dp_forceField->distance(d_at1Idx, d_at2Idx, pos);
+
+    double *at1Coords = &(pos[3 * d_at1Idx]);
+    double *at2Coords = &(pos[3 * d_at2Idx]);
+    double *g1 = &(grad[3 * d_at1Idx]);
+    double *g2 = &(grad[3 * d_at2Idx]);
+
+    double distTerm = dist - d_r0[termIdx];
+    double dE_dr =
+        c1 * d_kb[termIdx] * distTerm *
+        (1.0 + 1.5 * cs * distTerm + 2.0 * c3 * cs * cs * distTerm * distTerm);
+    double dGrad;
+    for (unsigned int i = 0; i < 3; ++i) {
+      dGrad = ((dist > 0.0) ? (dE_dr * (at1Coords[i] - at2Coords[i]) / dist)
+                            : d_kb[termIdx] * 0.01);
+      g1[i] += dGrad;
+      g2[i] -= dGrad;
+    }
   }
 }
 }  // namespace MMFF

--- a/Code/ForceField/MMFF/BondStretch.h
+++ b/Code/ForceField/MMFF/BondStretch.h
@@ -1,4 +1,6 @@
 //
+//  Copyright (C) 2014-2025 Greg Landrum and Other RDKit Contributors
+//
 //  Copyright (C) 2013 Paolo Tosco
 //
 //  Copyright (C) 2004-2006 Rational Discovery LLC
@@ -14,6 +16,8 @@
 #define __RD_MMFFBONDSTRETCH_H__
 #include <ForceField/Contrib.h>
 
+#include <vector>
+
 namespace ForceFields {
 namespace MMFF {
 class MMFFBond;
@@ -24,8 +28,8 @@ class RDKIT_FORCEFIELD_EXPORT BondStretchContrib : public ForceFieldContrib {
  public:
   BondStretchContrib() {}
   //! Constructor
-  /*!
-    \param owner       pointer to the owning ForceField
+  BondStretchContrib(ForceField *owner);
+  /*! Adds a bond stretch to the contrib
     \param idx1        index of end1 in the ForceField's positions
     \param idx2        index of end2 in the ForceField's positions
     \param bondType    MMFF94 type of the bond (as an unsigned int)
@@ -33,8 +37,9 @@ class RDKIT_FORCEFIELD_EXPORT BondStretchContrib : public ForceFieldContrib {
     \param end2Params  pointer to the parameters for end2
 
   */
-  BondStretchContrib(ForceField *owner, const unsigned int idx1,
-                     const unsigned int idx2, const MMFFBond *mmffBondParams);
+  void addTerm(const unsigned int idx1,
+               const unsigned int idx2,
+               const MMFFBond *mmffBondParams);
 
   double getEnergy(double *pos) const override;
 
@@ -45,9 +50,9 @@ class RDKIT_FORCEFIELD_EXPORT BondStretchContrib : public ForceFieldContrib {
   }
 
  private:
-  int d_at1Idx{-1}, d_at2Idx{-1};  //!< indices of end points
-  double d_r0;                     //!< rest length of the bond
-  double d_kb;                     //!< force constant of the bond
+  std::vector<int> d_at1Idxs, d_at2Idxs;  //!< indices of end points
+  std::vector<double> d_r0;               //!< rest length of the bond
+  std::vector<double> d_kb;               //!< force constant of the bond
 };
 
 namespace Utils {

--- a/Code/ForceField/MMFF/BondStretch.h
+++ b/Code/ForceField/MMFF/BondStretch.h
@@ -1,9 +1,4 @@
-//
-//  Copyright (C) 2014-2025 Greg Landrum and Other RDKit Contributors
-//
-//  Copyright (C) 2013 Paolo Tosco
-//
-//  Copyright (C) 2004-2006 Rational Discovery LLC
+//  Copyright (C) 2013-2025 Paolo Tosco and other RDKit contributors
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.

--- a/Code/ForceField/MMFF/Nonbonded.cpp
+++ b/Code/ForceField/MMFF/Nonbonded.cpp
@@ -1,10 +1,4 @@
-// $Id$
-//
-//  Copyright (C) 2014-2025 Greg Landrum and other RDKit contributors
-//
-//  Copyright (C) 2013 Paolo Tosco
-//
-//  Copyright (C) 2004-2008 Greg Landrum and Rational Discovery LLC
+//  Copyright (C) 2013-2025 Paolo Tosco and other RDKit contributors
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.

--- a/Code/ForceField/MMFF/Nonbonded.cpp
+++ b/Code/ForceField/MMFF/Nonbonded.cpp
@@ -1,5 +1,7 @@
 // $Id$
 //
+//  Copyright (C) 2014-2025 Greg Landrum and other RDKit contributors
+//
 //  Copyright (C) 2013 Paolo Tosco
 //
 //  Copyright (C) 2004-2008 Greg Landrum and Rational Discovery LLC
@@ -90,26 +92,35 @@ double calcEleEnergy(unsigned int, unsigned int, double dist, double chargeTerm,
 }
 }  // namespace Utils
 
-VdWContrib::VdWContrib(ForceField *owner, unsigned int idx1, unsigned int idx2,
-                       const MMFFVdWRijstarEps *mmffVdWConstants) {
+VdWContrib::VdWContrib(ForceField *owner) {
   PRECONDITION(owner, "bad owner");
-  PRECONDITION(mmffVdWConstants, "bad MMFFVdW parameters");
-  URANGE_CHECK(idx1, owner->positions().size());
-  URANGE_CHECK(idx2, owner->positions().size());
-
   dp_forceField = owner;
-  d_at1Idx = idx1;
-  d_at2Idx = idx2;
-  d_R_ij_star = mmffVdWConstants->R_ij_star;
-  d_wellDepth = mmffVdWConstants->epsilon;
+}
+
+void VdWContrib::addTerm(unsigned int idx1, unsigned int idx2, const MMFFVdWRijstarEps *mmffVdWConstants) {
+  PRECONDITION(mmffVdWConstants, "bad MMFFVdW parameters");
+  URANGE_CHECK(idx1, dp_forceField->positions().size());
+  URANGE_CHECK(idx2, dp_forceField->positions().size());
+  d_at1Idxs.push_back(idx1);
+  d_at2Idxs.push_back(idx2);
+  d_R_ij_stars.push_back(mmffVdWConstants->R_ij_star);
+  d_wellDepths.push_back(mmffVdWConstants->epsilon);
 }
 
 double VdWContrib::getEnergy(double *pos) const {
   PRECONDITION(dp_forceField, "no owner");
   PRECONDITION(pos, "bad vector");
+  double energySum = 0.0;
 
-  double dist = dp_forceField->distance(d_at1Idx, d_at2Idx, pos);
-  return Utils::calcVdWEnergy(dist, d_R_ij_star, d_wellDepth);
+  const int numPairs = d_at1Idxs.size();
+  for (int i = 0; i < numPairs; ++i) {
+    unsigned int d_at1Idx = d_at1Idxs[i];
+    unsigned int d_at2Idx = d_at2Idxs[i];
+    double dist = dp_forceField->distance(d_at1Idx, d_at2Idx, pos);
+    double res = Utils::calcVdWEnergy(dist, d_R_ij_stars[i], d_wellDepths[i]);
+    energySum += res;
+  }
+  return energySum;
 }
 
 void VdWContrib::getGrad(double *pos, double *grad) const {
@@ -122,52 +133,77 @@ void VdWContrib::getGrad(double *pos, double *grad) const {
   double const vdw2 = 1.12;
   double const vdw2m1 = vdw2 - 1.0;
   double const vdw2t7 = vdw2 * 7.0;
-  double dist = dp_forceField->distance(d_at1Idx, d_at2Idx, pos);
-  double *at1Coords = &(pos[3 * d_at1Idx]);
-  double *at2Coords = &(pos[3 * d_at2Idx]);
-  double *g1 = &(grad[3 * d_at1Idx]);
-  double *g2 = &(grad[3 * d_at2Idx]);
-  double q = dist / d_R_ij_star;
-  double q2 = q * q;
-  double q6 = q2 * q2 * q2;
-  double q7 = q6 * q;
-  double q7pvdw2m1 = q7 + vdw2m1;
-  double t = vdw1 / (q + vdw1 - 1.0);
-  double t2 = t * t;
-  double t7 = t2 * t2 * t2 * t;
-  double dE_dr = d_wellDepth / d_R_ij_star * t7 *
-                 (-vdw2t7 * q6 / (q7pvdw2m1 * q7pvdw2m1) +
-                  ((-vdw2t7 / q7pvdw2m1 + 14.0) / (q + vdw1m1)));
-  for (unsigned int i = 0; i < 3; ++i) {
-    double dGrad;
-    dGrad = ((dist > 0.0) ? (dE_dr * (at1Coords[i] - at2Coords[i]) / dist)
-                          : d_R_ij_star * 0.01);
-    g1[i] += dGrad;
-    g2[i] -= dGrad;
+
+
+  const int numPairs = d_at1Idxs.size();
+  for (int pairIdx = 0; pairIdx < numPairs; ++pairIdx) {
+    const int d_at1Idx = d_at1Idxs[pairIdx];
+    const int d_at2Idx = d_at2Idxs[pairIdx];
+    const double d_R_ij_star = d_R_ij_stars[pairIdx];
+    const double d_wellDepth = d_wellDepths[pairIdx];
+
+    double dist = dp_forceField->distance(d_at1Idx, d_at2Idx, pos);
+    double *at1Coords = &(pos[3 * d_at1Idx]);
+    double *at2Coords = &(pos[3 * d_at2Idx]);
+    double *g1 = &(grad[3 * d_at1Idx]);
+    double *g2 = &(grad[3 * d_at2Idx]);
+    double q = dist / d_R_ij_star;
+    double q2 = q * q;
+    double q6 = q2 * q2 * q2;
+    double q7 = q6 * q;
+    double q7pvdw2m1 = q7 + vdw2m1;
+    double t = vdw1 / (q + vdw1 - 1.0);
+    double t2 = t * t;
+    double t7 = t2 * t2 * t2 * t;
+    double dE_dr = d_wellDepth / d_R_ij_star * t7 *
+                   (-vdw2t7 * q6 / (q7pvdw2m1 * q7pvdw2m1) +
+                    ((-vdw2t7 / q7pvdw2m1 + 14.0) / (q + vdw1m1)));
+    for (unsigned int i = 0; i < 3; ++i) {
+      double dGrad;
+      dGrad = ((dist > 0.0) ? (dE_dr * (at1Coords[i] - at2Coords[i]) / dist)
+                            : d_R_ij_star * 0.01);
+      g1[i] += dGrad;
+      g2[i] -= dGrad;
+    }
   }
 }
 
-EleContrib::EleContrib(ForceField *owner, unsigned int idx1, unsigned int idx2,
-                       double chargeTerm, std::uint8_t dielModel, bool is1_4) {
+EleContrib::EleContrib(ForceField *owner) {
   PRECONDITION(owner, "bad owner");
-  URANGE_CHECK(idx1, owner->positions().size());
-  URANGE_CHECK(idx2, owner->positions().size());
-
   dp_forceField = owner;
-  d_at1Idx = idx1;
-  d_at2Idx = idx2;
-  d_chargeTerm = chargeTerm;
-  d_dielModel = dielModel;
-  d_is1_4 = is1_4;
 }
-
+void EleContrib::addTerm(unsigned int idx1, unsigned int idx2,
+             double chargeTerm, std::uint8_t dielModel, bool is1_4) {
+  URANGE_CHECK(idx1, dp_forceField->positions().size());
+  URANGE_CHECK(idx2, dp_forceField->positions().size());
+  d_at1Idxs.push_back(idx1);
+  d_at2Idxs.push_back(idx2);
+  d_chargeTerms.push_back(chargeTerm);
+  d_dielModels.push_back(dielModel);
+  d_is_1_4s.push_back(is1_4);
+}
 double EleContrib::getEnergy(double *pos) const {
   PRECONDITION(dp_forceField, "no owner");
   PRECONDITION(pos, "bad vector");
 
-  return Utils::calcEleEnergy(d_at1Idx, d_at2Idx,
-                              dp_forceField->distance(d_at1Idx, d_at2Idx, pos),
-                              d_chargeTerm, d_dielModel, d_is1_4);
+  double res = 0.0;
+  const int numPairs = d_at1Idxs.size();
+
+  for (int i = 0; i < numPairs; ++i) {
+    unsigned int d_at1Idx = d_at1Idxs[i];
+    unsigned int d_at2Idx = d_at2Idxs[i];
+    double d_chargeTerm = d_chargeTerms[i];
+    std::uint8_t d_dielModel = d_dielModels[i];
+    bool d_is1_4 = d_is_1_4s[i];
+
+    res += Utils::calcEleEnergy(d_at1Idx,
+                                d_at2Idx,
+                                dp_forceField->distance(d_at1Idx, d_at2Idx, pos),
+                                d_chargeTerm,
+                                d_dielModel,
+                                d_is1_4);
+  }
+  return res;
 }
 
 void EleContrib::getGrad(double *pos, double *grad) const {
@@ -175,22 +211,31 @@ void EleContrib::getGrad(double *pos, double *grad) const {
   PRECONDITION(pos, "bad vector");
   PRECONDITION(grad, "bad vector");
 
-  double dist = dp_forceField->distance(d_at1Idx, d_at2Idx, pos);
-  double *at1Coords = &(pos[3 * d_at1Idx]);
-  double *at2Coords = &(pos[3 * d_at2Idx]);
-  double *g1 = &(grad[3 * d_at1Idx]);
-  double *g2 = &(grad[3 * d_at2Idx]);
-  double corr_dist = dist + 0.05;
-  corr_dist *= ((d_dielModel == RDKit::MMFF::DISTANCE) ? corr_dist * corr_dist
-                                                       : corr_dist);
-  double dE_dr = -332.0716 * (double)(d_dielModel)*d_chargeTerm / corr_dist *
-                 (d_is1_4 ? 0.75 : 1.0);
-  for (unsigned int i = 0; i < 3; ++i) {
-    double dGrad;
-    dGrad =
-        ((dist > 0.0) ? (dE_dr * (at1Coords[i] - at2Coords[i]) / dist) : 0.02);
-    g1[i] += dGrad;
-    g2[i] -= dGrad;
+  const int numPairs = d_at1Idxs.size();
+  for (int pairIdx = 0; pairIdx < numPairs; ++pairIdx) {
+    const int d_at1Idx = d_at1Idxs[pairIdx];
+    const int d_at2Idx = d_at2Idxs[pairIdx];
+    const double d_chargeTerm = d_chargeTerms[pairIdx];
+    const std::uint8_t d_dielModel = d_dielModels[pairIdx];
+    const bool d_is1_4 = d_is_1_4s[pairIdx];
+
+    double dist = dp_forceField->distance(d_at1Idx, d_at2Idx, pos);
+    double *at1Coords = &(pos[3 * d_at1Idx]);
+    double *at2Coords = &(pos[3 * d_at2Idx]);
+    double *g1 = &(grad[3 * d_at1Idx]);
+    double *g2 = &(grad[3 * d_at2Idx]);
+    double corr_dist = dist + 0.05;
+    corr_dist *= ((d_dielModel == RDKit::MMFF::DISTANCE) ? corr_dist * corr_dist
+                                                         : corr_dist);
+    double dE_dr = -332.0716 * (double)(d_dielModel)*d_chargeTerm / corr_dist *
+                   (d_is1_4 ? 0.75 : 1.0);
+    for (unsigned int i = 0; i < 3; ++i) {
+      double dGrad;
+      dGrad = ((dist > 0.0) ? (dE_dr * (at1Coords[i] - at2Coords[i]) / dist)
+                            : 0.02);
+      g1[i] += dGrad;
+      g2[i] -= dGrad;
+    }
   }
 }
 }  // namespace MMFF

--- a/Code/ForceField/MMFF/Nonbonded.h
+++ b/Code/ForceField/MMFF/Nonbonded.h
@@ -1,9 +1,4 @@
-//
-//  Copyright (C) 2014-2025 Greg Landrum and other RDKit contributors
-//
-//  Copyright (C) 2013 Paolo Tosco
-//
-//  Copyright (C) 2004-2006 Rational Discovery LLC
+//  Copyright (C) 2013-2025 Paolo Tosco and other RDKit contributors
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.

--- a/Code/ForceField/MMFF/Nonbonded.h
+++ b/Code/ForceField/MMFF/Nonbonded.h
@@ -1,4 +1,6 @@
 //
+//  Copyright (C) 2014-2025 Greg Landrum and other RDKit contributors
+//
 //  Copyright (C) 2013 Paolo Tosco
 //
 //  Copyright (C) 2004-2006 Rational Discovery LLC
@@ -24,24 +26,18 @@ class MMFFVdW;
 class RDKIT_FORCEFIELD_EXPORT VdWContrib : public ForceFieldContrib {
  public:
   VdWContrib() {}
-
-  //! Constructor
-  /*!
-    \param owner       pointer to the owning ForceField
-    \param idx1        index of end1 in the ForceField's positions
-    \param idx2        index of end2 in the ForceField's positions
-
-  */
-  VdWContrib(ForceField *owner, unsigned int idx1, unsigned int idx2,
-             const MMFFVdWRijstarEps *mmffVdWConstants);
+  VdWContrib(ForceField *owner);
+  //! Track a new VdW pair
+  void addTerm(unsigned int idx1, unsigned int idx2, const MMFFVdWRijstarEps *mmffVdWConstants);
   double getEnergy(double *pos) const override;
   void getGrad(double *pos, double *grad) const override;
   VdWContrib *copy() const override { return new VdWContrib(*this); }
 
  private:
-  int d_at1Idx{-1}, d_at2Idx{-1};
-  double d_R_ij_star;  //!< the preferred length of the contact
-  double d_wellDepth;  //!< the vdW well depth (strength of the interaction)
+  std::vector<int16_t> d_at1Idxs;
+  std::vector<int16_t> d_at2Idxs;
+  std::vector<double> d_R_ij_stars; //!< the preferred length of the contact
+  std::vector<double> d_wellDepths; //!< the vdW well depth (strength of the interaction)
 };
 
 //! the electrostatic term for MMFF
@@ -56,19 +52,21 @@ class RDKIT_FORCEFIELD_EXPORT EleContrib : public ForceFieldContrib {
     \param idx2        index of end2 in the ForceField's positions
 
   */
-  EleContrib(ForceField *owner, unsigned int idx1, unsigned int idx2,
-             double chargeTerm, std::uint8_t dielModel, bool is1_4);
+  EleContrib(ForceField *owner);
+  void addTerm(unsigned int idx1, unsigned int idx2,
+               double chargeTerm, std::uint8_t dielModel, bool is1_4);
   double getEnergy(double *pos) const override;
   void getGrad(double *pos, double *grad) const override;
 
   EleContrib *copy() const override { return new EleContrib(*this); }
 
  private:
-  int d_at1Idx{-1}, d_at2Idx{-1};
-  double d_chargeTerm;  //!< q1 * q2 / D
-  std::uint8_t
-      d_dielModel;  //!< dielectric model (1: constant; 2: distance-dependent)
-  bool d_is1_4;     //!< flag set for atoms in a 1,4 relationship
+  std::vector<int16_t> d_at1Idxs;
+  std::vector<int16_t> d_at2Idxs;
+  std::vector<double> d_chargeTerms;
+  std::vector<std::uint8_t> d_is_1_4s;
+  std::vector<std::uint8_t>
+      d_dielModels;  //!< dielectric model (1: constant; 2: distance-dependent)
 };
 
 namespace Utils {

--- a/Code/ForceField/MMFF/OopBend.cpp
+++ b/Code/ForceField/MMFF/OopBend.cpp
@@ -1,4 +1,6 @@
 // $Id$
+//  Copyright (C) 2014-2025 Greg Landrum and Other RDKit Contributors
+//
 //
 //  Copyright (C) 2013 Paolo Tosco
 //
@@ -49,47 +51,75 @@ double calcOopBendEnergy(const double chi, const double koop) {
 }
 }  // end of namespace Utils
 
-OopBendContrib::OopBendContrib(ForceField *owner, unsigned int idx1,
-                               unsigned int idx2, unsigned int idx3,
-                               unsigned int idx4,
-                               const MMFFOop *mmffOopParams) {
+OopBendContrib::OopBendContrib(ForceField *owner) {
   PRECONDITION(owner, "bad owner");
+  dp_forceField = owner;
+}
+
+void OopBendContrib::addTerm(unsigned int idx1,
+                             unsigned int idx2,
+                             unsigned int idx3,
+                             unsigned int idx4,
+                             const ForceFields::MMFF::MMFFOop *mmffOopParams) {
   PRECONDITION(mmffOopParams, "no OOP parameters");
   PRECONDITION((idx1 != idx2) && (idx1 != idx3) && (idx1 != idx4) &&
                    (idx2 != idx3) && (idx2 != idx4) && (idx3 != idx4),
                "degenerate points");
-  URANGE_CHECK(idx1, owner->positions().size());
-  URANGE_CHECK(idx2, owner->positions().size());
-  URANGE_CHECK(idx3, owner->positions().size());
-  URANGE_CHECK(idx4, owner->positions().size());
+  URANGE_CHECK(idx1, dp_forceField->positions().size());
+  URANGE_CHECK(idx2, dp_forceField->positions().size());
+  URANGE_CHECK(idx3, dp_forceField->positions().size());
+  URANGE_CHECK(idx4, dp_forceField->positions().size());
 
-  dp_forceField = owner;
-  d_at1Idx = idx1;
-  d_at2Idx = idx2;
-  d_at3Idx = idx3;
-  d_at4Idx = idx4;
-  d_koop = mmffOopParams->koop;
+  d_at1Idxs.push_back(idx1);
+  d_at2Idxs.push_back(idx2);
+  d_at3Idxs.push_back(idx3);
+  d_at4Idxs.push_back(idx4);
+  d_koop.push_back(mmffOopParams->koop);
 }
 
 double OopBendContrib::getEnergy(double *pos) const {
   PRECONDITION(dp_forceField, "no owner");
   PRECONDITION(pos, "bad vector");
-  RDGeom::Point3D p1(pos[3 * d_at1Idx], pos[3 * d_at1Idx + 1],
-                     pos[3 * d_at1Idx + 2]);
-  RDGeom::Point3D p2(pos[3 * d_at2Idx], pos[3 * d_at2Idx + 1],
-                     pos[3 * d_at2Idx + 2]);
-  RDGeom::Point3D p3(pos[3 * d_at3Idx], pos[3 * d_at3Idx + 1],
-                     pos[3 * d_at3Idx + 2]);
-  RDGeom::Point3D p4(pos[3 * d_at4Idx], pos[3 * d_at4Idx + 1],
-                     pos[3 * d_at4Idx + 2]);
 
-  return Utils::calcOopBendEnergy(Utils::calcOopChi(p1, p2, p3, p4), d_koop);
+  const int numTerms = d_at1Idxs.size();
+  double totalEnergy = 0.0;
+  for (int i = 0; i < numTerms; ++i) {
+    const int d_at1Idx = d_at1Idxs[i];
+    const int d_at2Idx = d_at2Idxs[i];
+    const int d_at3Idx = d_at3Idxs[i];
+    const int d_at4Idx = d_at4Idxs[i];
+
+    RDGeom::Point3D p1(pos[3 * d_at1Idx], pos[3 * d_at1Idx + 1],
+                       pos[3 * d_at1Idx + 2]);
+    RDGeom::Point3D p2(pos[3 * d_at2Idx], pos[3 * d_at2Idx + 1],
+                       pos[3 * d_at2Idx + 2]);
+    RDGeom::Point3D p3(pos[3 * d_at3Idx], pos[3 * d_at3Idx + 1],
+                       pos[3 * d_at3Idx + 2]);
+    RDGeom::Point3D p4(pos[3 * d_at4Idx], pos[3 * d_at4Idx + 1],
+                       pos[3 * d_at4Idx + 2]);
+
+    totalEnergy += Utils::calcOopBendEnergy(Utils::calcOopChi(p1, p2, p3, p4), d_koop[i]);
+  }
+  return totalEnergy;
 }
 
-void OopBendContrib::getGrad(double *pos, double *grad) const {
-  PRECONDITION(dp_forceField, "no owner");
+void OopBendContrib::getGrad(double* pos, double* grad) const {
   PRECONDITION(pos, "bad vector");
   PRECONDITION(grad, "bad vector");
+  PRECONDITION(dp_forceField, "no owner");
+
+  const int numTerms = d_at1Idxs.size();
+  for (int i =0; i < numTerms; i++) {
+    getSingleGrad(pos, grad, i);
+  }
+}
+
+void OopBendContrib::getSingleGrad(double *pos, double *grad, unsigned int termIdx) const {
+
+  const int d_at1Idx = d_at1Idxs[termIdx];
+  const int d_at2Idx = d_at2Idxs[termIdx];
+  const int d_at3Idx = d_at3Idxs[termIdx];
+  const int d_at4Idx = d_at4Idxs[termIdx];
 
   RDGeom::Point3D iPoint(pos[3 * d_at1Idx], pos[3 * d_at1Idx + 1],
                          pos[3 * d_at1Idx + 2]);
@@ -131,7 +161,7 @@ void OopBendContrib::getGrad(double *pos, double *grad) const {
   double sinTheta =
       std::max(((sinThetaSq > 0.0) ? sqrt(sinThetaSq) : 0.0), 1.0e-8);
 
-  double dE_dChi = RAD2DEG * c2 * d_koop * chi;
+  double dE_dChi = RAD2DEG * c2 * d_koop[termIdx] * chi;
   RDGeom::Point3D t1 = rJL.crossProduct(rJK);
   RDGeom::Point3D t2 = rJI.crossProduct(rJL);
   RDGeom::Point3D t3 = rJK.crossProduct(rJI);

--- a/Code/ForceField/MMFF/OopBend.cpp
+++ b/Code/ForceField/MMFF/OopBend.cpp
@@ -1,10 +1,4 @@
-// $Id$
-//  Copyright (C) 2014-2025 Greg Landrum and Other RDKit Contributors
-//
-//
-//  Copyright (C) 2013 Paolo Tosco
-//
-//  Copyright (C) 2004-2006 Rational Discovery LLC
+//  Copyright (C) 2013-2025 Paolo Tosco and other RDKit contributors
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.

--- a/Code/ForceField/MMFF/OopBend.h
+++ b/Code/ForceField/MMFF/OopBend.h
@@ -1,4 +1,6 @@
 //
+//  Copyright (C) 2014-2025 Greg Landrum and Other RDKit Contributors
+//
 //  Copyright (C) 2013 Paolo Tosco
 //
 //  Copyright (C) 2004-2006 Rational Discovery LLC
@@ -25,26 +27,30 @@ class RDKIT_FORCEFIELD_EXPORT OopBendContrib : public ForceFieldContrib {
  public:
   OopBendContrib() {}
   //! Constructor
-  /*!
-    The Wilson angle is between the vector formed by atom2-atom4
-and the angle formed by atom1-atom2-atom3
+  OopBendContrib(ForceField *owner);
+  /*! Adds an out-of-plane term to the force field contrib.
 
-    \param owner       pointer to the owning ForceField
+  The Wilson angle is between the vector formed by atom2-atom4
+  and the angle formed by atom1-atom2-atom3
+
     \param idx1        index of atom1 in the ForceField's positions
     \param idx2        index of atom2 in the ForceField's positions
     \param idx3        index of atom3 in the ForceField's positions
     \param idx4        index of atom4 in the ForceField's positions
   */
-  OopBendContrib(ForceField *owner, unsigned int idx1, unsigned int idx2,
-                 unsigned int idx3, unsigned int idx4,
-                 const MMFFOop *mmffOopParams);
+  void addTerm(unsigned int idx1, unsigned int idx2,
+               unsigned int idx3, unsigned int idx4,
+               const MMFFOop *mmffOopParams);
+
   double getEnergy(double *pos) const override;
   void getGrad(double *pos, double *grad) const override;
   OopBendContrib *copy() const override { return new OopBendContrib(*this); }
 
+  void getSingleGrad(double* pos, double* grad, unsigned int termIdx) const;
+
  private:
-  int d_at1Idx{-1}, d_at2Idx{-1}, d_at3Idx{-1}, d_at4Idx{-1};
-  double d_koop;
+  std::vector<int> d_at1Idxs, d_at2Idxs, d_at3Idxs, d_at4Idxs;
+  std::vector<double> d_koop;
 };
 
 namespace Utils {

--- a/Code/ForceField/MMFF/OopBend.h
+++ b/Code/ForceField/MMFF/OopBend.h
@@ -1,9 +1,4 @@
-//
-//  Copyright (C) 2014-2025 Greg Landrum and Other RDKit Contributors
-//
-//  Copyright (C) 2013 Paolo Tosco
-//
-//  Copyright (C) 2004-2006 Rational Discovery LLC
+//  Copyright (C) 2013-2025 Paolo Tosco and other RDKit contributors
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.

--- a/Code/ForceField/MMFF/StretchBend.cpp
+++ b/Code/ForceField/MMFF/StretchBend.cpp
@@ -40,113 +40,139 @@ std::pair<double, double> calcStretchBendEnergy(
 }
 }  // end of namespace Utils
 
-StretchBendContrib::StretchBendContrib(
-    ForceField *owner, const unsigned int idx1, const unsigned int idx2,
-    const unsigned int idx3, const MMFFStbn *mmffStbnParams,
-    const MMFFAngle *mmffAngleParams, const MMFFBond *mmffBondParams1,
-    const MMFFBond *mmffBondParams2) {
+StretchBendContrib::StretchBendContrib(ForceField *owner) {
   PRECONDITION(owner, "bad owner");
+  dp_forceField = owner;
+}
+
+void StretchBendContrib::addTerm(
+    const unsigned int idx1, const unsigned int idx2, const unsigned int idx3,
+    const ForceFields::MMFF::MMFFStbn *mmffStbnParams,
+    const ForceFields::MMFF::MMFFAngle *mmffAngleParams,
+    const ForceFields::MMFF::MMFFBond *mmffBondParams1,
+    const ForceFields::MMFF::MMFFBond *mmffBondParams2) {
   PRECONDITION(((idx1 != idx2) && (idx2 != idx3) && (idx1 != idx3)),
                "degenerate points");
-  URANGE_CHECK(idx1, owner->positions().size());
-  URANGE_CHECK(idx2, owner->positions().size());
-  URANGE_CHECK(idx3, owner->positions().size());
+  URANGE_CHECK(idx1, dp_forceField->positions().size());
+  URANGE_CHECK(idx2, dp_forceField->positions().size());
+  URANGE_CHECK(idx3, dp_forceField->positions().size());
 
-  dp_forceField = owner;
-  d_at1Idx = idx1;
-  d_at2Idx = idx2;
-  d_at3Idx = idx3;
-  d_restLen1 = Utils::calcBondRestLength(mmffBondParams1);
-  d_restLen2 = Utils::calcBondRestLength(mmffBondParams2);
-  d_theta0 = Utils::calcAngleRestValue(mmffAngleParams);
-  d_forceConstants = Utils::calcStbnForceConstants(mmffStbnParams);
+  d_at1Idxs.push_back(idx1);
+  d_at2Idxs.push_back(idx2);
+  d_at3Idxs.push_back(idx3);
+  d_restLen1s.push_back(Utils::calcBondRestLength(mmffBondParams1));
+  d_restLen2s.push_back(Utils::calcBondRestLength(mmffBondParams2));
+  d_theta0s.push_back(Utils::calcAngleRestValue(mmffAngleParams));
+  std::pair<double, double> forceConstants =
+      Utils::calcStbnForceConstants(mmffStbnParams);
+  d_forceConstants1.push_back(forceConstants.first);
+  d_forceConstants2.push_back(forceConstants.second);
 }
 
 double StretchBendContrib::getEnergy(double *pos) const {
   PRECONDITION(dp_forceField, "no owner");
   PRECONDITION(pos, "bad vector");
-  double dist1 = dp_forceField->distance(d_at1Idx, d_at2Idx, pos);
-  double dist2 = dp_forceField->distance(d_at2Idx, d_at3Idx, pos);
 
-  RDGeom::Point3D p1(pos[3 * d_at1Idx], pos[3 * d_at1Idx + 1],
-                     pos[3 * d_at1Idx + 2]);
-  RDGeom::Point3D p2(pos[3 * d_at2Idx], pos[3 * d_at2Idx + 1],
-                     pos[3 * d_at2Idx + 2]);
-  RDGeom::Point3D p3(pos[3 * d_at3Idx], pos[3 * d_at3Idx + 1],
-                     pos[3 * d_at3Idx + 2]);
+  double totalEnergy = 0.0;
+  const int numTerms = d_at1Idxs.size();
+  for (int i = 0; i < numTerms; i++) {
+    const int16_t at1Idx = d_at1Idxs[i];
+    const int16_t at2Idx = d_at2Idxs[i];
+    const int16_t at3Idx = d_at3Idxs[i];
 
-  std::pair<double, double> stretchBendEnergies = Utils::calcStretchBendEnergy(
-      dist1 - d_restLen1, dist2 - d_restLen2,
-      RAD2DEG * acos(Utils::calcCosTheta(p1, p2, p3, dist1, dist2)) - d_theta0,
-      d_forceConstants);
+    double dist1 = dp_forceField->distance(at1Idx, at2Idx, pos);
+    double dist2 = dp_forceField->distance(at2Idx, at3Idx, pos);
 
-  return (stretchBendEnergies.first + stretchBendEnergies.second);
+    RDGeom::Point3D p1(pos[3 * at1Idx], pos[3 * at1Idx + 1],
+                       pos[3 * at1Idx + 2]);
+    RDGeom::Point3D p2(pos[3 * at2Idx], pos[3 * at2Idx + 1],
+                       pos[3 * at2Idx + 2]);
+    RDGeom::Point3D p3(pos[3 * at3Idx], pos[3 * at3Idx + 1],
+                       pos[3 * at3Idx + 2]);
+    std::pair<double, double> forceConstantsPair =
+        std::make_pair(d_forceConstants1[i], d_forceConstants2[i]);
+    std::pair<double, double> stretchBendEnergies =
+        Utils::calcStretchBendEnergy(
+            dist1 - d_restLen1s[i], dist2 - d_restLen2s[i],
+            RAD2DEG * acos(Utils::calcCosTheta(p1, p2, p3, dist1, dist2)) -
+                d_theta0s[i],
+            forceConstantsPair);
+    totalEnergy += (stretchBendEnergies.first + stretchBendEnergies.second);
+  }
+  return totalEnergy;
 }
 
 void StretchBendContrib::getGrad(double *pos, double *grad) const {
   PRECONDITION(dp_forceField, "no owner");
   PRECONDITION(pos, "bad vector");
   PRECONDITION(grad, "bad vector");
-  double dist1 = dp_forceField->distance(d_at1Idx, d_at2Idx, pos);
-  double dist2 = dp_forceField->distance(d_at2Idx, d_at3Idx, pos);
 
-  RDGeom::Point3D p1(pos[3 * d_at1Idx], pos[3 * d_at1Idx + 1],
-                     pos[3 * d_at1Idx + 2]);
-  RDGeom::Point3D p2(pos[3 * d_at2Idx], pos[3 * d_at2Idx + 1],
-                     pos[3 * d_at2Idx + 2]);
-  RDGeom::Point3D p3(pos[3 * d_at3Idx], pos[3 * d_at3Idx + 1],
-                     pos[3 * d_at3Idx + 2]);
-  double *g1 = &(grad[3 * d_at1Idx]);
-  double *g2 = &(grad[3 * d_at2Idx]);
-  double *g3 = &(grad[3 * d_at3Idx]);
+  const int numTerms = d_at1Idxs.size();
+  for (int i = 0; i < numTerms; ++i) {
+    const int16_t at1Idx = d_at1Idxs[i];
+    const int16_t at2Idx = d_at2Idxs[i];
+    const int16_t at3Idx = d_at3Idxs[i];
+    const double theta0 = d_theta0s[i];
+    const double forceConstant1 = d_forceConstants1[i];
+    const double forceConstant2 = d_forceConstants2[i];
+    const double restLen1 = d_restLen1s[i];
+    const double restLen2 = d_restLen2s[i];
 
-  RDGeom::Point3D p12 = (p1 - p2) / dist1;
-  RDGeom::Point3D p32 = (p3 - p2) / dist2;
-  double const c5 = MDYNE_A_TO_KCAL_MOL * DEG2RAD;
-  double cosTheta = p12.dotProduct(p32);
-  clipToOne(cosTheta);
-  double sinThetaSq = 1.0 - cosTheta * cosTheta;
-  double sinTheta = std::max(sqrt(sinThetaSq), 1.0e-8);
-  double angleTerm = RAD2DEG * acos(cosTheta) - d_theta0;
-  double distTerm = RAD2DEG * (d_forceConstants.first * (dist1 - d_restLen1) +
-                               d_forceConstants.second * (dist2 - d_restLen2));
-  double dCos_dS1 = 1.0 / dist1 * (p32.x - cosTheta * p12.x);
-  double dCos_dS2 = 1.0 / dist1 * (p32.y - cosTheta * p12.y);
-  double dCos_dS3 = 1.0 / dist1 * (p32.z - cosTheta * p12.z);
+    double dist1 = dp_forceField->distance(at1Idx, at2Idx, pos);
+    double dist2 = dp_forceField->distance(at2Idx, at3Idx, pos);
 
-  double dCos_dS4 = 1.0 / dist2 * (p12.x - cosTheta * p32.x);
-  double dCos_dS5 = 1.0 / dist2 * (p12.y - cosTheta * p32.y);
-  double dCos_dS6 = 1.0 / dist2 * (p12.z - cosTheta * p32.z);
+    RDGeom::Point3D p1(pos[3 * at1Idx], pos[3 * at1Idx + 1],
+                       pos[3 * at1Idx + 2]);
+    RDGeom::Point3D p2(pos[3 * at2Idx], pos[3 * at2Idx + 1],
+                       pos[3 * at2Idx + 2]);
+    RDGeom::Point3D p3(pos[3 * at3Idx], pos[3 * at3Idx + 1],
+                       pos[3 * at3Idx + 2]);
+    double *g1 = &(grad[3 * at1Idx]);
+    double *g2 = &(grad[3 * at2Idx]);
+    double *g3 = &(grad[3 * at3Idx]);
 
-  g1[0] += c5 * (p12.x * d_forceConstants.first * angleTerm +
-                 dCos_dS1 / (-sinTheta) * distTerm);
-  g1[1] += c5 * (p12.y * d_forceConstants.first * angleTerm +
-                 dCos_dS2 / (-sinTheta) * distTerm);
-  g1[2] += c5 * (p12.z * d_forceConstants.first * angleTerm +
-                 dCos_dS3 / (-sinTheta) * distTerm);
+    RDGeom::Point3D p12 = (p1 - p2) / dist1;
+    RDGeom::Point3D p32 = (p3 - p2) / dist2;
+    double const c5 = MDYNE_A_TO_KCAL_MOL * DEG2RAD;
+    double cosTheta = p12.dotProduct(p32);
+    clipToOne(cosTheta);
+    double sinThetaSq = 1.0 - cosTheta * cosTheta;
+    double sinTheta = std::max(sqrt(sinThetaSq), 1.0e-8);
+    double angleTerm = RAD2DEG * acos(cosTheta) - theta0;
+    double distTerm = RAD2DEG * (forceConstant1 * (dist1 - restLen1) +
+                                 forceConstant2 * (dist2 - restLen2));
+    double dCos_dS1 = 1.0 / dist1 * (p32.x - cosTheta * p12.x);
+    double dCos_dS2 = 1.0 / dist1 * (p32.y - cosTheta * p12.y);
+    double dCos_dS3 = 1.0 / dist1 * (p32.z - cosTheta * p12.z);
 
-  g2[0] +=
-      c5 *
-      ((-p12.x * d_forceConstants.first - p32.x * d_forceConstants.second) *
-           angleTerm +
-       (-dCos_dS1 - dCos_dS4) / (-sinTheta) * distTerm);
-  g2[1] +=
-      c5 *
-      ((-p12.y * d_forceConstants.first - p32.y * d_forceConstants.second) *
-           angleTerm +
-       (-dCos_dS2 - dCos_dS5) / (-sinTheta) * distTerm);
-  g2[2] +=
-      c5 *
-      ((-p12.z * d_forceConstants.first - p32.z * d_forceConstants.second) *
-           angleTerm +
-       (-dCos_dS3 - dCos_dS6) / (-sinTheta) * distTerm);
+    double dCos_dS4 = 1.0 / dist2 * (p12.x - cosTheta * p32.x);
+    double dCos_dS5 = 1.0 / dist2 * (p12.y - cosTheta * p32.y);
+    double dCos_dS6 = 1.0 / dist2 * (p12.z - cosTheta * p32.z);
 
-  g3[0] += c5 * (p32.x * d_forceConstants.second * angleTerm +
-                 dCos_dS4 / (-sinTheta) * distTerm);
-  g3[1] += c5 * (p32.y * d_forceConstants.second * angleTerm +
-                 dCos_dS5 / (-sinTheta) * distTerm);
-  g3[2] += c5 * (p32.z * d_forceConstants.second * angleTerm +
-                 dCos_dS6 / (-sinTheta) * distTerm);
+    g1[0] += c5 * (p12.x * forceConstant1 * angleTerm +
+                   dCos_dS1 / (-sinTheta) * distTerm);
+    g1[1] += c5 * (p12.y * forceConstant1 * angleTerm +
+                   dCos_dS2 / (-sinTheta) * distTerm);
+    g1[2] += c5 * (p12.z * forceConstant1 * angleTerm +
+                   dCos_dS3 / (-sinTheta) * distTerm);
+
+    g2[0] +=
+        c5 * ((-p12.x * forceConstant1 - p32.x * forceConstant2) * angleTerm +
+              (-dCos_dS1 - dCos_dS4) / (-sinTheta) * distTerm);
+    g2[1] +=
+        c5 * ((-p12.y * forceConstant1 - p32.y * forceConstant2) * angleTerm +
+              (-dCos_dS2 - dCos_dS5) / (-sinTheta) * distTerm);
+    g2[2] +=
+        c5 * ((-p12.z * forceConstant1 - p32.z * forceConstant2) * angleTerm +
+              (-dCos_dS3 - dCos_dS6) / (-sinTheta) * distTerm);
+
+    g3[0] += c5 * (p32.x * forceConstant2 * angleTerm +
+                   dCos_dS4 / (-sinTheta) * distTerm);
+    g3[1] += c5 * (p32.y * forceConstant2 * angleTerm +
+                   dCos_dS5 / (-sinTheta) * distTerm);
+    g3[2] += c5 * (p32.z * forceConstant2 * angleTerm +
+                   dCos_dS6 / (-sinTheta) * distTerm);
+  }
 }
 }  // namespace MMFF
 }  // namespace ForceFields

--- a/Code/ForceField/MMFF/StretchBend.cpp
+++ b/Code/ForceField/MMFF/StretchBend.cpp
@@ -1,8 +1,4 @@
-// $Id$
-//
-//  Copyright (C) 2013 Paolo Tosco
-//
-//  Copyright (C) 2004-2006 Rational Discovery LLC
+//  Copyright (C) 2013-2025 Paolo Tosco and other RDKit contributors
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.

--- a/Code/ForceField/MMFF/StretchBend.h
+++ b/Code/ForceField/MMFF/StretchBend.h
@@ -1,4 +1,6 @@
 //
+//  Copyright (C) 2014-2025 Greg Landrum and Other RDKit Contributors
+//
 //  Copyright (C) 2013 Paolo Tosco
 //
 //  Copyright (C) 2004-2006 Rational Discovery LLC
@@ -14,6 +16,8 @@
 #define __RD_MMFFSTRETCHBEND_H__
 
 #include <utility>
+#include <vector>
+
 #include <ForceField/Contrib.h>
 
 namespace ForceFields {
@@ -28,23 +32,22 @@ class RDKIT_FORCEFIELD_EXPORT StretchBendContrib : public ForceFieldContrib {
  public:
   StretchBendContrib() {}
   //! Constructor
+  StretchBendContrib(ForceField *owner);
   /*!
+    Adds a stretch-bend term to the force field contrib.
+
     The angle is between atom1 - atom2 - atom3
 
-    \param owner       pointer to the owning ForceField
     \param idx1        index of atom1 in the ForceField's positions
     \param idx2        index of atom2 in the ForceField's positions
     \param idx3        index of atom3 in the ForceField's positions
     \param angleType   MMFF type of the angle (as an unsigned int)
-
   */
-  StretchBendContrib(ForceField *owner, const unsigned int idx1,
-                     const unsigned int idx2, const unsigned int idx3,
-                     const MMFFStbn *mmffStbnParams,
-                     const MMFFAngle *mmffAngleParams,
-                     const MMFFBond *mmffBondParams1,
-                     const MMFFBond *mmffBondParams2);
-
+  void addTerm(const unsigned int idx1, const unsigned int idx2,
+               const unsigned int idx3, const MMFFStbn *mmffStbnParams,
+               const MMFFAngle *mmffAngleParams,
+               const MMFFBond *mmffBondParams1,
+               const MMFFBond *mmffBondParams2);
   double getEnergy(double *pos) const override;
   void getGrad(double *pos, double *grad) const override;
   StretchBendContrib *copy() const override {
@@ -52,9 +55,14 @@ class RDKIT_FORCEFIELD_EXPORT StretchBendContrib : public ForceFieldContrib {
   }
 
  private:
-  int d_at1Idx{-1}, d_at2Idx{-1}, d_at3Idx{-1};
-  double d_restLen1, d_restLen2, d_theta0;
-  std::pair<double, double> d_forceConstants;
+  std::vector<int16_t> d_at1Idxs;
+  std::vector<int16_t> d_at2Idxs;
+  std::vector<int16_t> d_at3Idxs;
+  std::vector<double> d_restLen1s;
+  std::vector<double> d_restLen2s;
+  std::vector<double> d_theta0s;
+  std::vector<double> d_forceConstants1;
+  std::vector<double> d_forceConstants2;
 };
 namespace Utils {
 //! returns the std::pair of stretch-bend force constants for an angle

--- a/Code/ForceField/MMFF/StretchBend.h
+++ b/Code/ForceField/MMFF/StretchBend.h
@@ -1,9 +1,4 @@
-//
-//  Copyright (C) 2014-2025 Greg Landrum and Other RDKit Contributors
-//
-//  Copyright (C) 2013 Paolo Tosco
-//
-//  Copyright (C) 2004-2006 Rational Discovery LLC
+//  Copyright (C) 2013-2025 Paolo Tosco and other RDKit contributors
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.

--- a/Code/ForceField/MMFF/TorsionAngle.cpp
+++ b/Code/ForceField/MMFF/TorsionAngle.cpp
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2013-2022 Paolo Tosco and other RDKit contributors
+//  Copyright (C) 2013-2025 Paolo Tosco and other RDKit contributors
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -93,75 +93,96 @@ void calcTorsionGrad(RDGeom::Point3D *r, RDGeom::Point3D *t, double *d,
 }
 }  // namespace Utils
 
-TorsionAngleContrib::TorsionAngleContrib(ForceField *owner, unsigned int idx1,
-                                         unsigned int idx2, unsigned int idx3,
-                                         unsigned int idx4,
-                                         const MMFFTor *mmffTorParams) {
+TorsionAngleContrib::TorsionAngleContrib(ForceField *owner) {
   PRECONDITION(owner, "bad owner");
+  dp_forceField = owner;
+}
+
+void TorsionAngleContrib::addTerm(
+    unsigned int idx1, unsigned int idx2, unsigned int idx3, unsigned int idx4,
+    const ForceFields::MMFF::MMFFTor *mmffTorParams) {
   PRECONDITION((idx1 != idx2) && (idx1 != idx3) && (idx1 != idx4) &&
                    (idx2 != idx3) && (idx2 != idx4) && (idx3 != idx4),
                "degenerate points");
-  URANGE_CHECK(idx1, owner->positions().size());
-  URANGE_CHECK(idx2, owner->positions().size());
-  URANGE_CHECK(idx3, owner->positions().size());
-  URANGE_CHECK(idx4, owner->positions().size());
+  URANGE_CHECK(idx1, dp_forceField->positions().size());
+  URANGE_CHECK(idx2, dp_forceField->positions().size());
+  URANGE_CHECK(idx3, dp_forceField->positions().size());
+  URANGE_CHECK(idx4, dp_forceField->positions().size());
 
-  dp_forceField = owner;
-  d_at1Idx = idx1;
-  d_at2Idx = idx2;
-  d_at3Idx = idx3;
-  d_at4Idx = idx4;
-  d_V1 = mmffTorParams->V1;
-  d_V2 = mmffTorParams->V2;
-  d_V3 = mmffTorParams->V3;
+  d_at1Idx.push_back(idx1);
+  d_at2Idx.push_back(idx2);
+  d_at3Idx.push_back(idx3);
+  d_at4Idx.push_back(idx4);
+  d_V1.push_back(mmffTorParams->V1);
+  d_V2.push_back(mmffTorParams->V2);
+  d_V3.push_back(mmffTorParams->V3);
 }
 
 double TorsionAngleContrib::getEnergy(double *pos) const {
   PRECONDITION(dp_forceField, "no owner");
   PRECONDITION(pos, "bad vector");
 
-  RDGeom::Point3D iPoint(pos[3 * d_at1Idx], pos[3 * d_at1Idx + 1],
-                         pos[3 * d_at1Idx + 2]);
-  RDGeom::Point3D jPoint(pos[3 * d_at2Idx], pos[3 * d_at2Idx + 1],
-                         pos[3 * d_at2Idx + 2]);
-  RDGeom::Point3D kPoint(pos[3 * d_at3Idx], pos[3 * d_at3Idx + 1],
-                         pos[3 * d_at3Idx + 2]);
-  RDGeom::Point3D lPoint(pos[3 * d_at4Idx], pos[3 * d_at4Idx + 1],
-                         pos[3 * d_at4Idx + 2]);
+  const int numTorsions = d_at1Idx.size();
+  double totalEnergy = 0.0;
+  for (int i = 0; i < numTorsions; ++i) {
+    const int16_t at1Idx = d_at1Idx[i];
+    const int16_t at2Idx = d_at2Idx[i];
+    const int16_t at3Idx = d_at3Idx[i];
+    const int16_t at4Idx = d_at4Idx[i];
 
-  return Utils::calcTorsionEnergy(
-      d_V1, d_V2, d_V3,
-      Utils::calcTorsionCosPhi(iPoint, jPoint, kPoint, lPoint));
+    RDGeom::Point3D iPoint(pos[3 * at1Idx], pos[3 * at1Idx + 1],
+                           pos[3 * at1Idx + 2]);
+    RDGeom::Point3D jPoint(pos[3 * at2Idx], pos[3 * at2Idx + 1],
+                           pos[3 * at2Idx + 2]);
+    RDGeom::Point3D kPoint(pos[3 * at3Idx], pos[3 * at3Idx + 1],
+                           pos[3 * at3Idx + 2]);
+    RDGeom::Point3D lPoint(pos[3 * at4Idx], pos[3 * at4Idx + 1],
+                           pos[3 * at4Idx + 2]);
+
+    totalEnergy += Utils::calcTorsionEnergy(
+        d_V1[i], d_V2[i], d_V3[i],
+        Utils::calcTorsionCosPhi(iPoint, jPoint, kPoint, lPoint));
+  }
+  return totalEnergy;
 }
 
 void TorsionAngleContrib::getGrad(double *pos, double *grad) const {
   PRECONDITION(dp_forceField, "no owner");
   PRECONDITION(pos, "bad vector");
   PRECONDITION(grad, "bad vector");
-
-  double *g[4] = {&(grad[3 * d_at1Idx]), &(grad[3 * d_at2Idx]),
-                  &(grad[3 * d_at3Idx]), &(grad[3 * d_at4Idx])};
-
-  RDGeom::Point3D r[4];
-  RDGeom::Point3D t[2];
   double d[2];
   double cosPhi;
-  RDKit::ForceFieldsHelper::computeDihedral(
-      pos, d_at1Idx, d_at2Idx, d_at3Idx, d_at4Idx, nullptr, &cosPhi, r, t, d);
-  double sinPhiSq = 1.0 - cosPhi * cosPhi;
-  double sinPhi = ((sinPhiSq > 0.0) ? sqrt(sinPhiSq) : 0.0);
-  double sin2Phi = 2.0 * sinPhi * cosPhi;
-  double sin3Phi = 3.0 * sinPhi - 4.0 * sinPhi * sinPhiSq;
-  // dE/dPhi is independent of cartesians:
-  double dE_dPhi =
-      0.5 * (-(d_V1)*sinPhi + 2.0 * d_V2 * sin2Phi - 3.0 * d_V3 * sin3Phi);
-  // FIX: use a tolerance here
-  // this is hacky, but it's per the
-  // recommendation from Niketic and Rasmussen:
-  double sinTerm =
-      -dE_dPhi * (isDoubleZero(sinPhi) ? (1.0 / cosPhi) : (1.0 / sinPhi));
 
-  Utils::calcTorsionGrad(r, t, d, g, sinTerm, cosPhi);
+  const int numTorsions = d_at1Idx.size();
+  for (int i = 0; i < numTorsions; ++i) {
+    const int16_t at1Idx = d_at1Idx[i];
+    const int16_t at2Idx = d_at2Idx[i];
+    const int16_t at3Idx = d_at3Idx[i];
+    const int16_t at4Idx = d_at4Idx[i];
+
+    double *g[4] = {&(grad[3 * at1Idx]), &(grad[3 * at2Idx]),
+                    &(grad[3 * at3Idx]), &(grad[3 * at4Idx])};
+
+    RDGeom::Point3D r[4];
+    RDGeom::Point3D t[2];
+
+    RDKit::ForceFieldsHelper::computeDihedral(
+        pos, at1Idx, at2Idx, at3Idx, at4Idx, nullptr, &cosPhi, r, t, d);
+    double sinPhiSq = 1.0 - cosPhi * cosPhi;
+    double sinPhi = ((sinPhiSq > 0.0) ? sqrt(sinPhiSq) : 0.0);
+    double sin2Phi = 2.0 * sinPhi * cosPhi;
+    double sin3Phi = 3.0 * sinPhi - 4.0 * sinPhi * sinPhiSq;
+    // dE/dPhi is independent of cartesians:
+    double dE_dPhi = 0.5 * (-(d_V1[i]) * sinPhi + 2.0 * d_V2[i] * sin2Phi -
+                            3.0 * d_V3[i] * sin3Phi);
+    // FIX: use a tolerance here
+    // this is hacky, but it's per the
+    // recommendation from Niketic and Rasmussen:
+    double sinTerm =
+        -dE_dPhi * (isDoubleZero(sinPhi) ? (1.0 / cosPhi) : (1.0 / sinPhi));
+
+    Utils::calcTorsionGrad(r, t, d, g, sinTerm, cosPhi);
+  }
 }
 }  // namespace MMFF
 }  // namespace ForceFields

--- a/Code/ForceField/MMFF/TorsionAngle.h
+++ b/Code/ForceField/MMFF/TorsionAngle.h
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2013-2022 Paolo Tosco and other RDKit contributors
+//  Copyright (C) 2013-2025 Paolo Tosco and other RDKit contributors
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -13,6 +13,7 @@
 
 #include <ForceField/Contrib.h>
 #include <tuple>
+#include <vector>
 
 namespace RDGeom {
 class Point3D;
@@ -27,21 +28,22 @@ class RDKIT_FORCEFIELD_EXPORT TorsionAngleContrib : public ForceFieldContrib {
  public:
   TorsionAngleContrib() {}
   //! Constructor
+  TorsionAngleContrib(ForceField *owner);
   /*!
-    The torsion is between atom1 - atom2 - atom3 - atom4
-    (i.e the angle between bond atom1-atom2 and bond atom3-atom4
-    while looking down bond atom2-atom3)
+  Adds a torsion term to the force field contrib.
 
-    \param owner       pointer to the owning ForceField
+  The torsion is between atom1 - atom2 - atom3 - atom4
+  (i.e the angle between bond atom1-atom2 and bond atom3-atom4
+  while looking down bond atom2-atom3)
+
     \param idx1        index of atom1 in the ForceField's positions
     \param idx2        index of atom2 in the ForceField's positions
     \param idx3        index of atom3 in the ForceField's positions
     \param idx4        index of atom4 in the ForceField's positions
     \param torsionType MMFF type of the torsional bond between atoms 2 and 3
   */
-  TorsionAngleContrib(ForceField *owner, unsigned int idx1, unsigned int idx2,
-                      unsigned int idx3, unsigned int idx4,
-                      const MMFFTor *mmffTorParams);
+  void addTerm(unsigned int idx1, unsigned int idx2, unsigned int idx3,
+               unsigned int idx4, const MMFFTor *mmffTorParams);
   double getEnergy(double *pos) const override;
   void getGrad(double *pos, double *grad) const override;
   TorsionAngleContrib *copy() const override {
@@ -49,8 +51,13 @@ class RDKIT_FORCEFIELD_EXPORT TorsionAngleContrib : public ForceFieldContrib {
   }
 
  private:
-  int d_at1Idx{-1}, d_at2Idx{-1}, d_at3Idx{-1}, d_at4Idx{-1};
-  double d_V1, d_V2, d_V3;
+  std::vector<int16_t> d_at1Idx;
+  std::vector<int16_t> d_at2Idx;
+  std::vector<int16_t> d_at3Idx;
+  std::vector<int16_t> d_at4Idx;
+  std::vector<double> d_V1;
+  std::vector<double> d_V2;
+  std::vector<double> d_V3;
 };
 
 namespace Utils {

--- a/Code/GraphMol/ForceFieldHelpers/MMFF/Builder.cpp
+++ b/Code/GraphMol/ForceFieldHelpers/MMFF/Builder.cpp
@@ -1,3 +1,6 @@
+//
+//  Copyright (C) 2019-2025 Greg Landrum and other RDKit contributors
+//
 //  Copyright (C) 2013-2018 Paolo Tosco
 //
 //  Copyright (C) 2004-2010 Greg Landrum and Rational Discovery LLC
@@ -10,7 +13,6 @@
 //
 #include <iostream>
 #include <cmath>
-#include <cctype>
 
 #include <RDGeneral/Invariant.h>
 #include <GraphMol/RDKitBase.h>
@@ -53,6 +55,9 @@ void addBonds(const ROMol &mol, MMFFMolProperties *mmffMolProperties,
               << std::endl;
     }
   }
+
+  auto contrib = std::make_unique<BondStretchContrib>(field);
+  bool hasContrib = false;
   for (ROMol::ConstBondIterator bi = mol.beginBonds(); bi != mol.endBonds();
        ++bi) {
     unsigned int idx1 = (*bi)->getBeginAtomIdx();
@@ -61,9 +66,8 @@ void addBonds(const ROMol &mol, MMFFMolProperties *mmffMolProperties,
     MMFFBond mmffBondParams;
     if (mmffMolProperties->getMMFFBondStretchParams(mol, idx1, idx2, bondType,
                                                     mmffBondParams)) {
-      auto *contrib =
-          new BondStretchContrib(field, idx1, idx2, &mmffBondParams);
-      field->contribs().push_back(ForceFields::ContribPtr(contrib));
+      contrib->addTerm(idx1, idx2, &mmffBondParams);
+      hasContrib = true;
       if (mmffMolProperties->getMMFFVerbosity()) {
         unsigned int iAtomType = mmffMolProperties->getMMFFAtomType(idx1);
         unsigned int jAtomType = mmffMolProperties->getMMFFAtomType(idx2);
@@ -95,6 +99,9 @@ void addBonds(const ROMol &mol, MMFFMolProperties *mmffMolProperties,
     oStream << "TOTAL BOND STRETCH ENERGY      =" << std::right << std::setw(16)
             << std::fixed << std::setprecision(4) << totalBondStretchEnergy
             << std::endl;
+  }
+  if (hasContrib) {
+    field->contribs().push_back(ForceFields::ContribPtr(contrib.release()));
   }
 }
 
@@ -248,6 +255,8 @@ void addAngles(const ROMol &mol, MMFFMolProperties *mmffMolProperties,
     }
     points = field->positions();
   }
+  auto contrib = std::make_unique<AngleBendContrib>(field);
+  bool hasContrib = false;
   for (idx[1] = 0; idx[1] < nAtoms; ++idx[1]) {
     const Atom *jAtom = mol.getAtomWithIdx(idx[1]);
     if (jAtom->getDegree() == 1) {
@@ -270,11 +279,9 @@ void addAngles(const ROMol &mol, MMFFMolProperties *mmffMolProperties,
         MMFFAngle mmffAngleParams;
         if (mmffMolProperties->getMMFFAngleBendParams(
                 mol, idx[0], idx[1], idx[2], angleType, mmffAngleParams)) {
-          auto *contrib =
-              new AngleBendContrib(field, idx[0], idx[1], idx[2],
-                                   &mmffAngleParams, mmffPropParamsCentralAtom);
-          auto sptr = ForceFields::ContribPtr(contrib);
-          field->contribs().push_back(sptr);
+          hasContrib = true;
+          contrib->addTerm(idx[0], idx[1], idx[2],
+                           &mmffAngleParams, mmffPropParamsCentralAtom);
           if (mmffMolProperties->getMMFFVerbosity()) {
             unsigned int iAtomType = mmffMolProperties->getMMFFAtomType(idx[0]);
             unsigned int kAtomType = mmffMolProperties->getMMFFAtomType(idx[2]);
@@ -323,6 +330,9 @@ void addAngles(const ROMol &mol, MMFFMolProperties *mmffMolProperties,
             << std::fixed << std::setprecision(4) << totalAngleBendEnergy
             << std::endl;
   }
+  if (hasContrib) {
+    field->contribs().push_back(ForceFields::ContribPtr(contrib.release()));
+  }
 }
 
 // ------------------------------------------------------------------------
@@ -362,6 +372,10 @@ void addStretchBend(const ROMol &mol, MMFFMolProperties *mmffMolProperties,
     }
     points = field->positions();
   }
+
+  auto contrib = std::make_unique<StretchBendContrib>(field);
+  bool contribAdded = false;
+
   for (idx[1] = 0; idx[1] < nAtoms; ++idx[1]) {
     const Atom *jAtom = mol.getAtomWithIdx(idx[1]);
     if (jAtom->getDegree() == 1) {
@@ -393,10 +407,10 @@ void addStretchBend(const ROMol &mol, MMFFMolProperties *mmffMolProperties,
         if (mmffMolProperties->getMMFFStretchBendParams(
                 mol, idx[0], idx[1], idx[2], stretchBendType, mmffStbnParams,
                 mmffBondParams, mmffAngleParams)) {
-          auto *contrib = new StretchBendContrib(
-              field, idx[0], idx[1], idx[2], &mmffStbnParams, &mmffAngleParams,
-              &mmffBondParams[0], &mmffBondParams[1]);
-          field->contribs().push_back(ForceFields::ContribPtr(contrib));
+          contribAdded = true;
+          contrib->addTerm(idx[0], idx[1], idx[2], &mmffStbnParams,
+                           &mmffAngleParams, &mmffBondParams[0],
+                           &mmffBondParams[1]);
           if (mmffMolProperties->getMMFFVerbosity()) {
             unsigned int iAtomType = mmffMolProperties->getMMFFAtomType(idx[0]);
             unsigned int jAtomType = mmffMolProperties->getMMFFAtomType(idx[1]);
@@ -472,6 +486,9 @@ void addStretchBend(const ROMol &mol, MMFFMolProperties *mmffMolProperties,
             << std::fixed << std::setprecision(4) << totalStretchBendEnergy
             << std::endl;
   }
+  if (contribAdded) {
+    field->contribs().push_back(ForceFields::ContribPtr(contrib.release()));
+  }
 }
 
 void addOop(const ROMol &mol, MMFFMolProperties *mmffMolProperties,
@@ -505,6 +522,8 @@ void addOop(const ROMol &mol, MMFFMolProperties *mmffMolProperties,
     }
     points = field->positions();
   }
+  bool hasContrib = false;
+  auto contrib = std::make_unique<OopBendContrib>(field);
   for (idx[1] = 0; idx[1] < mol.getNumAtoms(); ++idx[1]) {
     atom[1] = mol.getAtomWithIdx(idx[1]);
     if (atom[1]->getDegree() != 3) {
@@ -549,9 +568,8 @@ void addOop(const ROMol &mol, MMFFMolProperties *mmffMolProperties,
           n[3] = 0;
           break;
       }
-      auto *contrib = new OopBendContrib(field, idx[n[0]], idx[n[1]], idx[n[2]],
-                                         idx[n[3]], &mmffOopParams);
-      field->contribs().push_back(ForceFields::ContribPtr(contrib));
+      contrib->addTerm(idx[n[0]], idx[n[1]], idx[n[2]], idx[n[3]], &mmffOopParams);
+      hasContrib = true;
       if (mmffMolProperties->getMMFFVerbosity()) {
         const RDGeom::Point3D p1((*(points[idx[n[0]]]))[0],
                                  (*(points[idx[n[0]]]))[1],
@@ -593,6 +611,9 @@ void addOop(const ROMol &mol, MMFFMolProperties *mmffMolProperties,
     oStream << "TOTAL OUT-OF-PLANE BEND ENERGY =" << std::right << std::setw(16)
             << std::fixed << std::setprecision(4) << totalOopBendEnergy
             << std::endl;
+  }
+  if (hasContrib) {
+    field->contribs().push_back(ForceFields::ContribPtr(contrib.release()));
   }
 }
 
@@ -665,6 +686,9 @@ void addTorsions(const ROMol &mol, MMFFMolProperties *mmffMolProperties,
     delete query;
   }
 
+  auto contrib = std::make_unique<TorsionAngleContrib>(field);
+  bool contribAdded = false;
+
   for (unsigned int i = 0; i < nHits; ++i) {
     MatchVectType match = matchVect[i];
     TEST_ASSERT(match.size() == 2);
@@ -698,9 +722,8 @@ void addTorsions(const ROMol &mol, MMFFMolProperties *mmffMolProperties,
                 MMFFTor mmffTorParams;
                 if (mmffMolProperties->getMMFFTorsionParams(
                         mol, idx1, idx2, idx3, idx4, torType, mmffTorParams)) {
-                  auto *contrib = new TorsionAngleContrib(
-                      field, idx1, idx2, idx3, idx4, &mmffTorParams);
-                  field->contribs().push_back(ForceFields::ContribPtr(contrib));
+                  contrib->addTerm(idx1, idx2, idx3, idx4, &mmffTorParams);
+                  contribAdded = true;
                   if (mmffMolProperties->getMMFFVerbosity()) {
                     const Atom *iAtom = mol.getAtomWithIdx(idx1);
                     const Atom *lAtom = mol.getAtomWithIdx(idx4);
@@ -768,6 +791,9 @@ void addTorsions(const ROMol &mol, MMFFMolProperties *mmffMolProperties,
             << std::fixed << std::setprecision(4) << totalTorsionEnergy
             << std::endl;
   }
+  if (contribAdded) {
+    field->contribs().push_back(ForceFields::ContribPtr(contrib.release()));
+  }
 }
 
 // ------------------------------------------------------------------------
@@ -807,6 +833,8 @@ void addVdW(const ROMol &mol, int confId, MMFFMolProperties *mmffMolProperties,
     }
   }
   const Conformer &conf = mol.getConformer(confId);
+  auto contrib = std::make_unique<VdWContrib>(field);
+  bool hasContrib = false;
   for (unsigned int i = 0; i < nAtoms; ++i) {
     for (unsigned int j = i + 1; j < nAtoms; ++j) {
       if (ignoreInterfragInteractions && (fragMapping[i] != fragMapping[j])) {
@@ -820,8 +848,8 @@ void addVdW(const ROMol &mol, int confId, MMFFMolProperties *mmffMolProperties,
         }
         MMFFVdWRijstarEps mmffVdWConstants;
         if (mmffMolProperties->getMMFFVdWParams(i, j, mmffVdWConstants)) {
-          auto *contrib = new VdWContrib(field, i, j, &mmffVdWConstants);
-          field->contribs().push_back(ForceFields::ContribPtr(contrib));
+          contrib->addTerm(i, j, &mmffVdWConstants);
+          hasContrib = true;
           if (mmffMolProperties->getMMFFVerbosity()) {
             const Atom *iAtom = mol.getAtomWithIdx(i);
             const Atom *jAtom = mol.getAtomWithIdx(j);
@@ -852,6 +880,9 @@ void addVdW(const ROMol &mol, int confId, MMFFMolProperties *mmffMolProperties,
     oStream << "TOTAL VAN DER WAALS ENERGY     =" << std::right << std::setw(16)
             << std::fixed << std::setprecision(4) << totalVdWEnergy
             << std::endl;
+  }
+  if (hasContrib) {
+    field->contribs().push_back(ForceFields::ContribPtr(contrib.release()));
   }
 }
 
@@ -890,6 +921,8 @@ void addEle(const ROMol &mol, int confId, MMFFMolProperties *mmffMolProperties,
   const Conformer &conf = mol.getConformer(confId);
   double dielConst = mmffMolProperties->getMMFFDielectricConstant();
   std::uint8_t dielModel = mmffMolProperties->getMMFFDielectricModel();
+  auto contrib = std::make_unique<EleContrib>(field);
+  bool hasContrib = false;
   for (unsigned int i = 0; i < nAtoms; ++i) {
     for (unsigned int j = i + 1; j < nAtoms; ++j) {
       if (ignoreInterfragInteractions && (fragMapping[i] != fragMapping[j])) {
@@ -910,9 +943,9 @@ void addEle(const ROMol &mol, int confId, MMFFMolProperties *mmffMolProperties,
         double chargeTerm = mmffMolProperties->getMMFFPartialCharge(i) *
                             mmffMolProperties->getMMFFPartialCharge(j) /
                             dielConst;
-        auto *contrib =
-            new EleContrib(field, i, j, chargeTerm, dielModel, is1_4);
-        field->contribs().push_back(ForceFields::ContribPtr(contrib));
+        contrib->addTerm(i, j, chargeTerm, dielModel, is1_4);
+        hasContrib = true;
+
         if (mmffMolProperties->getMMFFVerbosity()) {
           const unsigned int iAtomType = mmffMolProperties->getMMFFAtomType(i);
           const unsigned int jAtomType = mmffMolProperties->getMMFFAtomType(j);
@@ -941,6 +974,9 @@ void addEle(const ROMol &mol, int confId, MMFFMolProperties *mmffMolProperties,
     oStream << "TOTAL ELECTROSTATIC ENERGY     =" << std::right << std::setw(16)
             << std::fixed << std::setprecision(4) << totalEleEnergy
             << std::endl;
+  }
+  if (hasContrib) {
+    field->contribs().push_back(ForceFields::ContribPtr(contrib.release()));
   }
 }
 

--- a/Code/GraphMol/ForceFieldHelpers/MMFF/Builder.cpp
+++ b/Code/GraphMol/ForceFieldHelpers/MMFF/Builder.cpp
@@ -1,10 +1,5 @@
-//
-//  Copyright (C) 2019-2025 Greg Landrum and other RDKit contributors
-//
-//  Copyright (C) 2013-2018 Paolo Tosco
-//
-//  Copyright (C) 2004-2010 Greg Landrum and Rational Discovery LLC
-//
+//  Copyright (C) 2014-2025 Greg Landrum and other RDKit contributors
+
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
 //  The contents are covered by the terms of the BSD license

--- a/Code/GraphMol/ForceFieldHelpers/MMFF/testMMFFHelpers.cpp
+++ b/Code/GraphMol/ForceFieldHelpers/MMFF/testMMFFHelpers.cpp
@@ -1,8 +1,5 @@
-//
-//  Copyright (C) 2019-2025 Greg Landrum and other RDKit contributors
-//
-//  Copyright (C) 2004-2018 Greg Landrum and Rational Discovery LLC
-//
+//  Copyright (C) 2004-2025 Greg Landrum and other RDKit contributors
+
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
 //  The contents are covered by the terms of the BSD license

--- a/Code/GraphMol/ForceFieldHelpers/MMFF/testMMFFHelpers.cpp
+++ b/Code/GraphMol/ForceFieldHelpers/MMFF/testMMFFHelpers.cpp
@@ -1,4 +1,6 @@
 //
+//  Copyright (C) 2019-2025 Greg Landrum and other RDKit contributors
+//
 //  Copyright (C) 2004-2018 Greg Landrum and Rational Discovery LLC
 //
 //   @@ All Rights Reserved @@
@@ -162,14 +164,14 @@ void testMMFFBuilder1() {
   TEST_ASSERT(mmffMolProperties);
   TEST_ASSERT(mmffMolProperties->isValid());
   field = new ForceFields::ForceField();
-  // add the atomic positions:
+  // add the atomic positions:f
   for (unsigned int i = 0; i < mol->getNumAtoms(); ++i) {
     field->positions().push_back(&(conf->getAtomPos(i)));
   }
 
   MMFF::Tools::addBonds(*mol, mmffMolProperties, field);
 
-  TEST_ASSERT(field->contribs().size() == 3);
+  TEST_ASSERT(field->contribs().size() == 1);
 
   nbrMat = MMFF::Tools::buildNeighborMatrix(*mol);
   // the neighbor matrix is an upper triangular matrix
@@ -191,15 +193,15 @@ void testMMFFBuilder1() {
               MMFF::Tools::RELATION_1_3);
 
   MMFF::Tools::addAngles(*mol, mmffMolProperties, field);
-  TEST_ASSERT(field->contribs().size() == 6);
+  TEST_ASSERT(field->contribs().size() == 2);
 
   // there are no non-bonded terms here:
   MMFF::Tools::addVdW(*mol, cid, mmffMolProperties, field, nbrMat);
-  TEST_ASSERT(field->contribs().size() == 6);
+  TEST_ASSERT(field->contribs().size() == 2);
 
   // and no torsions either, until we add Hs:
   MMFF::Tools::addTorsions(*mol, mmffMolProperties, field);
-  TEST_ASSERT(field->contribs().size() == 6);
+  TEST_ASSERT(field->contribs().size() == 2);
 
   delete mol;
   delete field;
@@ -219,7 +221,7 @@ void testMMFFBuilder1() {
 
   MMFF::Tools::addBonds(*mol, mmffMolProperties, field);
 
-  TEST_ASSERT(field->contribs().size() == 3);
+  TEST_ASSERT(field->contribs().size() == 1);
 
   nbrMat = MMFF::Tools::buildNeighborMatrix(*mol);
   TEST_ASSERT(MMFF::Tools::getTwoBitCell(nbrMat, 0) ==
@@ -232,11 +234,11 @@ void testMMFFBuilder1() {
               MMFF::Tools::RELATION_1_4);
 
   MMFF::Tools::addAngles(*mol, mmffMolProperties, field);
-  TEST_ASSERT(field->contribs().size() == 5);
+  TEST_ASSERT(field->contribs().size() == 2);
   MMFF::Tools::addVdW(*mol, cid, mmffMolProperties, field, nbrMat);
-  TEST_ASSERT(field->contribs().size() == 6);
+  TEST_ASSERT(field->contribs().size() == 3);
   MMFF::Tools::addTorsions(*mol, mmffMolProperties, field);
-  TEST_ASSERT(field->contribs().size() == 7);
+  TEST_ASSERT(field->contribs().size() == 4);
 
   delete mol;
   delete field;
@@ -291,15 +293,15 @@ void testMMFFBuilder1() {
   }
 
   MMFF::Tools::addBonds(*mol2, mmffMolProperties, field);
-  TEST_ASSERT(field->contribs().size() == 5);
+  TEST_ASSERT(field->contribs().size() == 1);
 
   nbrMat = MMFF::Tools::buildNeighborMatrix(*mol2);
   MMFF::Tools::addAngles(*mol2, mmffMolProperties, field);
-  TEST_ASSERT(field->contribs().size() == 12);
+  TEST_ASSERT(field->contribs().size() == 2);
   MMFF::Tools::addVdW(*mol2, cid, mmffMolProperties, field, nbrMat);
-  TEST_ASSERT(field->contribs().size() == 15);
+  TEST_ASSERT(field->contribs().size() == 3);
   MMFF::Tools::addTorsions(*mol2, mmffMolProperties, field);
-  TEST_ASSERT(field->contribs().size() == 18);
+  TEST_ASSERT(field->contribs().size() == 4);
   delete mol2;
 
   delete mol;
@@ -672,14 +674,14 @@ void testSFIssue1653802() {
   }
 
   MMFF::Tools::addBonds(*mol, mmffMolProperties, field);
-  TEST_ASSERT(field->contribs().size() == 8);
+  TEST_ASSERT(field->contribs().size() == 1);
 
   nbrMat = MMFF::Tools::buildNeighborMatrix(*mol);
   MMFF::Tools::addAngles(*mol, mmffMolProperties, field);
-  TEST_ASSERT(field->contribs().size() == 20);
+  TEST_ASSERT(field->contribs().size() == 2);
   MMFF::Tools::addTorsions(*mol, mmffMolProperties, field);
   // std::cout << field->contribs().size() << std::endl;
-  TEST_ASSERT(field->contribs().size() == 36);
+  TEST_ASSERT(field->contribs().size() == 3);
   MMFF::Tools::addVdW(*mol, 0, mmffMolProperties, field, nbrMat);
   delete field;
 

--- a/Code/GraphMol/ForceFieldHelpers/catch_tests.cpp
+++ b/Code/GraphMol/ForceFieldHelpers/catch_tests.cpp
@@ -1,6 +1,6 @@
 
 //
-//  Copyright (C) 2024 Niels Maeder and other RDKit contributors
+//  Copyright (C) 2024-2025 Niels Maeder and other RDKit contributors
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
 //  The contents are covered by the terms of the BSD license
@@ -41,8 +41,8 @@ TEST_CASE("Test empty force field") {
     auto forceField = ForceFieldsHelper::createEmptyForceFieldForMol(*mol);
     forceField->initialize();
     auto params = ForceFields::MMFF::MMFFBond{6.0, 100.0};
-    auto *contrib = new ForceFields::MMFF::BondStretchContrib(forceField.get(),
-                                                              0, 1, &params);
+    auto *contrib = new ForceFields::MMFF::BondStretchContrib(forceField.get());
+    contrib->addTerm(0, 1, &params);
     forceField->contribs().push_back(ForceFields::ContribPtr(contrib));
     CHECK(forceField->minimize() == 0);
     CHECK(std::round(forceField->distance(0, 1)) == 100);


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

Previously, a separate contrib had been added for each common term. Each of these required a separate allocation, and a separate dynamic dispatch on call. This change moves to a struct-of-arrays style, making data access contiguous and drastically reducing the number of calls.

#### Any other comments?

Performance gains vary based on system size, between 4% and 8% on systems we've benchmarked, with more gains for larger systems. 