### PR TITLE
Fix for 8177 - bad conformer if prepareMolsBeforeDrawing is false and unspecifiedStereoIsUnknown is true

### DIFF
--- a/Code/GraphMol/FileParsers/MolFileStereochem.cpp
+++ b/Code/GraphMol/FileParsers/MolFileStereochem.cpp
@@ -228,6 +228,7 @@ void invertMolBlockWedgingInfo(ROMol &mol) {
 }
 
 void markUnspecifiedStereoAsUnknown(ROMol &mol, int confId) {
+  PRECONDITION(mol.getNumConformers(), "no conformer");
   const auto conf = mol.getConformer(confId);
   auto wedgeBonds = RDKit::Chirality::pickBondsToWedge(mol, nullptr, &conf);
   for (auto b : mol.bonds()) {

--- a/Code/GraphMol/MolDraw2D/catch_tests.cpp
+++ b/Code/GraphMol/MolDraw2D/catch_tests.cpp
@@ -10218,3 +10218,11 @@ TEST_CASE("DrawMol::getColour should not throw if the palette has no carbon colo
   check_file_hash("testBlackAtomsUnderHighlight.svg");
 }
 
+TEST_CASE("Github8177 - bad conformer if prepareMolsBeforeDrawing is false and unspecifiedStereoIsUnknown is true") {
+  auto m = "c1cccnc1CC"_smiles;
+  REQUIRE(m);
+  MolDraw2DSVG drawer(300, 300, -1, -1, NO_FREETYPE);
+  drawer.drawOptions().prepareMolsBeforeDrawing = false;
+  drawer.drawOptions().unspecifiedStereoIsUnknown = true;
+  REQUIRE_NOTHROW(drawer.drawMolecule(*m));
+}


### PR DESCRIPTION
#### Reference Issue
Fixes #8177


#### What does this implement/fix? Explain your changes.
The new atropisomer code requires 2D coordinates, but that is done before missing 2D coords were being created  in the drawing pipeline.  I've moved that to earlier.

#### Any other comments?
On my Mac, the tests complain about the hash codes for testWedgeNonSingleBonds-*.svg files.  I have done a diff on them against those produced by the current master and the files are identical.  I don't know what that means, but this PR has not affected those pictures.
