### PR TITLE
Trim results after singleLargestFrag = true applied.

### DIFF
--- a/Code/GraphMol/RascalMCES/RascalMCES.cpp
+++ b/Code/GraphMol/RascalMCES/RascalMCES.cpp
@@ -1135,7 +1135,39 @@ std::vector<RascalResult> findMCES(RascalStartPoint &starter,
                      opts.maxFragSeparation, opts.exactConnectionsMatch,
                      opts.equivalentAtoms, opts.ignoreBondOrders));
   }
+
   std::sort(results.begin(), results.end(), details::resultCompare);
+
+  if (opts.singleLargestFrag) {
+    // the singleLargestFrag method throws bits of solutions out, so there may
+    // now be duplicates and results that are different sizes.
+    results.erase(
+        std::unique(results.begin(), results.end(),
+                    [](const RascalResult &r1, const RascalResult &r2) -> bool {
+                      return (r1.getAtomMatches() == r2.getAtomMatches() &&
+                              r1.getBondMatches() == r2.getBondMatches());
+                    }),
+        results.end());
+    boost::dynamic_bitset<> want(results.size());
+    want.set();
+    for (size_t i = 1; i < results.size(); ++i) {
+      if (results[i].getAtomMatches().size() <
+              results[0].getAtomMatches().size() ||
+          results[i].getBondMatches().size() <
+              results[0].getBondMatches().size()) {
+        want[i] = false;
+      }
+    }
+    if (want.count() < results.size()) {
+      size_t j = 0;
+      for (size_t i = 0; i < results.size(); ++i) {
+        if (want[i]) {
+          results[j++] = results[i];
+        }
+      }
+      results.erase(results.begin() + j, results.end());
+    }
+  }
   return results;
 }
 

--- a/Code/GraphMol/RascalMCES/RascalMCES.cpp
+++ b/Code/GraphMol/RascalMCES/RascalMCES.cpp
@@ -1136,9 +1136,15 @@ std::vector<RascalResult> findMCES(RascalStartPoint &starter,
                      opts.equivalentAtoms, opts.ignoreBondOrders));
   }
 
-  std::sort(results.begin(), results.end(), details::resultCompare);
-
   if (opts.singleLargestFrag) {
+    std::sort(results.begin(), results.end(),
+              [](const RascalResult &r1, const RascalResult &r2) -> bool {
+                if (r1.getAtomMatches() == r2.getAtomMatches()) {
+                  return (r1.getBondMatches() < r2.getBondMatches());
+                }
+                return (r1.getAtomMatches() < r2.getAtomMatches());
+              });
+
     // the singleLargestFrag method throws bits of solutions out, so there may
     // now be duplicates and results that are different sizes.
     results.erase(
@@ -1168,6 +1174,7 @@ std::vector<RascalResult> findMCES(RascalStartPoint &starter,
       results.erase(results.begin() + j, results.end());
     }
   }
+  std::sort(results.begin(), results.end(), details::resultCompare);
   return results;
 }
 

--- a/Code/GraphMol/RascalMCES/RascalResult.h
+++ b/Code/GraphMol/RascalMCES/RascalResult.h
@@ -71,7 +71,7 @@ class RDKIT_RASCALMCES_EXPORT RascalResult {
   int getNumFrags() const;
 
   // returns how many bonds in the clique don't match
-  // cyclic/non-cyclic i.e. count as a matche in the MCES but
+  // cyclic/non-cyclic i.e. count as a match in the MCES but
   // are ring bonds in one of the molecules and not in the other.
   int getRingNonRingBondScore() const;
 

--- a/Code/GraphMol/RascalMCES/mces_catch.cpp
+++ b/Code/GraphMol/RascalMCES/mces_catch.cpp
@@ -1442,3 +1442,37 @@ TEST_CASE("Empty results bug") {
   auto res = rascalMCES(*m1, *m2, opts);
   REQUIRE(!res.empty());
 }
+
+TEST_CASE("Duplicate Single Largest Frag") {
+  {
+    auto m1 = "c1ccc2c(c1)c(ncn2)CNCc3ccc(cc3)Cl"_smiles;
+    REQUIRE(m1);
+    auto m2 = "c1ccc2c(c1)c(ncn2)CCCc3ccc(cc3)Cl"_smiles;
+    REQUIRE(m2);
+    RascalOptions opts;
+    opts.singleLargestFrag = true;
+    opts.allBestMCESs = true;
+    auto res = rascalMCES(*m1, *m2, opts);
+    REQUIRE(res.size() == 1);
+    CHECK(res.front().getAtomMatches().size() == 11);
+    CHECK(res.front().getBondMatches().size() == 12);
+  }
+  {
+    // Without the fix, there were 156 results sets, with different breaks
+    // in the long chain giving different numbers of atoms in the largest
+    // fragment.
+    auto m1 = "CN(C)c1ccc(CC(=O)NCCCCCCCCCCNC23CC4CC(C2)CC(C3)C4)cc1"_smiles;
+    REQUIRE(m1);
+    auto m2 = "CN(C)c1ccc(CC(=O)NCCCCCCCCCCCCNC23CC4CC(C2)CC(C3)C4)cc1"_smiles;
+    REQUIRE(m2);
+    RascalOptions opts;
+    opts.singleLargestFrag = true;
+    opts.allBestMCESs = true;
+    auto res = rascalMCES(*m1, *m2, opts);
+    REQUIRE(res.size() == 20);
+    CHECK(res.front().getAtomMatches().size() == 23);
+    CHECK(res.front().getBondMatches().size() == 23);
+    CHECK(res.back().getAtomMatches().size() == 23);
+    CHECK(res.back().getBondMatches().size() == 23);
+  }
+}

--- a/Code/GraphMol/RascalMCES/mces_catch.cpp
+++ b/Code/GraphMol/RascalMCES/mces_catch.cpp
@@ -1469,7 +1469,8 @@ TEST_CASE("Duplicate Single Largest Frag") {
     opts.singleLargestFrag = true;
     opts.allBestMCESs = true;
     auto res = rascalMCES(*m1, *m2, opts);
-    REQUIRE(res.size() == 20);
+    REQUIRE(!res.empty());
+    CHECK(res.size() == 4);
     CHECK(res.front().getAtomMatches().size() == 23);
     CHECK(res.front().getBondMatches().size() == 23);
     CHECK(res.back().getAtomMatches().size() == 23);


### PR DESCRIPTION
#### Reference Issue
Fixes #8200


#### What does this implement/fix? Explain your changes.
After singleLargestFrag has been applied, re-sorts the results by size and takes out any duplicates and any that are now smaller than the largest one.

#### Any other comments?

