### PR TITLE
Use GetUniqueCombinations_new instead of GetUniqueCombinations

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,5 +1,7 @@
 # Release_2025.03.1
 (Changes relative to Release_2024.09.1)
+## Backwards incompatible changes
+- The order of combinations returned by Chem.Pharm2D.Utils.GetUniqueCombinations has changed to be in numerical order. The combinations themselves are unchanged.
 
 ## Acknowledgements
 (Note: I'm no longer attempting to manually curate names. If you would like to

--- a/rdkit/Chem/Pharm2D/Generate.py
+++ b/rdkit/Chem/Pharm2D/Generate.py
@@ -146,7 +146,7 @@ def Gen2DFingerprint(mol, sigFactory, perms=None, dMat=None, bitInfo=None):
       print(f'    matchPerms: {str(matchPerms)}')
 
     # Get all unique combinations of those possible matches:
-    matchesToMap = Utils.GetUniqueCombinations_new(matchPerms, featClasses)
+    matchesToMap = Utils.GetUniqueCombinations(matchPerms, featClasses)
     for i, entry in enumerate(matchesToMap):
       matchesToMap[i] = [x[1] for x in entry]
     if _verbose:

--- a/rdkit/Chem/Pharm2D/Generate.py
+++ b/rdkit/Chem/Pharm2D/Generate.py
@@ -146,7 +146,7 @@ def Gen2DFingerprint(mol, sigFactory, perms=None, dMat=None, bitInfo=None):
       print(f'    matchPerms: {str(matchPerms)}')
 
     # Get all unique combinations of those possible matches:
-    matchesToMap = Utils.GetUniqueCombinations(matchPerms, featClasses)
+    matchesToMap = Utils.GetUniqueCombinations_new(matchPerms, featClasses)
     for i, entry in enumerate(matchesToMap):
       matchesToMap[i] = [x[1] for x in entry]
     if _verbose:

--- a/rdkit/Chem/Pharm2D/UnitTestUtils.py
+++ b/rdkit/Chem/Pharm2D/UnitTestUtils.py
@@ -132,12 +132,12 @@ class TestCase(unittest.TestCase):
          [(1, (13, )), (1, (14, )), (2, (31, ))], [(1, (13, )), (1, (14, )), (2, (32, ))]]
 
     # yapf: disable
-    GetUniqueCombinations = Utils.GetUniqueCombinations
+    GetUniqueCombinations_new = Utils.GetUniqueCombinations_new
 
     choices = [[(11,), (12,)], [(21,), (22,)], [(31,), (32,)]]
     classes = [1, 2, 3]
     self._compareCombinations(
-      GetUniqueCombinations(choices, classes),
+      GetUniqueCombinations_new(choices, classes),
       [[(1, (11,)), (2, (21,)), (3, (31,))], [(1, (11,)), (2, (21,)), (3, (32,))],
        [(1, (11,)), (2, (22,)), (3, (31,))], [(1, (11,)), (2, (22,)), (3, (32,))],
        [(1, (12,)), (2, (21,)), (3, (31,))], [(1, (12,)), (2, (21,)), (3, (32,))],
@@ -145,7 +145,7 @@ class TestCase(unittest.TestCase):
 
     classes = [1, 1, 2]
     self._compareCombinations(
-      GetUniqueCombinations(choices, classes),
+      GetUniqueCombinations_new(choices, classes),
       [[(1, (11,)), (1, (21,)), (2, (31,))], [(1, (11,)), (1, (21,)), (2, (32,))],
        [(1, (11,)), (1, (22,)), (2, (31,))], [(1, (11,)), (1, (22,)), (2, (32,))],
        [(1, (12,)), (1, (21,)), (2, (31,))], [(1, (12,)), (1, (21,)), (2, (32,))],
@@ -153,19 +153,19 @@ class TestCase(unittest.TestCase):
 
     choices = [[(11,), (12,)], [(11,), (12,)], [(31,), (32,)]]
     self._compareCombinations(
-      GetUniqueCombinations(choices, classes),
+      GetUniqueCombinations_new(choices, classes),
       [[(1, (11,)), (1, (12,)), (2, (31,))], [(1, (11,)), (1, (12,)), (2, (32,))]])
 
     choices = [[(11,), (12,)], [(11,), (12,), (13,)], [(31,), (32,)]]
     self._compareCombinations(
-      GetUniqueCombinations(choices, classes),
+      GetUniqueCombinations_new(choices, classes),
       [[(1, (11,)), (1, (12,)), (2, (31,))], [(1, (11,)), (1, (12,)), (2, (32,))],
        [(1, (11,)), (1, (13,)), (2, (31,))], [(1, (11,)), (1, (13,)), (2, (32,))],
        [(1, (12,)), (1, (13,)), (2, (31,))], [(1, (12,)), (1, (13,)), (2, (32,))]])
 
     choices = [[(11,), (12,), (14,)], [(11,), (12,), (13,)], [(31,), (32,)]]
     self._compareCombinations(
-      GetUniqueCombinations(choices, classes),
+      GetUniqueCombinations_new(choices, classes),
       [[(1, (11,)), (1, (12,)), (2, (31,))], [(1, (11,)), (1, (12,)), (2, (32,))],
        [(1, (11,)), (1, (13,)), (2, (31,))], [(1, (11,)), (1, (13,)), (2, (32,))],
        [(1, (12,)), (1, (13,)), (2, (31,))], [(1, (12,)), (1, (13,)), (2, (32,))],
@@ -175,7 +175,7 @@ class TestCase(unittest.TestCase):
 
     choices = [[(11, 111,), (12,), (14,)], [(11, 111,), (12,), (13,)], [(31,), (32,)]]
     self._compareCombinations(
-      GetUniqueCombinations(choices, classes),
+      GetUniqueCombinations_new(choices, classes),
       [[(1, (11, 111)), (1, (12,)), (2, (31,))], [(1, (11, 111)), (1, (12,)), (2, (32,))],
        [(1, (11, 111)), (1, (13,)), (2, (31,))], [(1, (11, 111)), (1, (13,)), (2, (32,))],
        [(1, (12,)), (1, (13,)), (2, (31,))], [(1, (12,)), (1, (13,)), (2, (32,))],
@@ -186,31 +186,31 @@ class TestCase(unittest.TestCase):
     choices = [[(11,), (12,), ], [(11,), (13,), ], [(11,), (14,), ]]
     classes = [1, 1, 1]
     self._compareCombinations(
-      GetUniqueCombinations(choices, classes),
+      GetUniqueCombinations_new(choices, classes),
       [[(1, (11,)), (1, (13,)), (1, (14,))], [(1, (11,)), (1, (12,)), (1, (14,))],
        [(1, (11,)), (1, (12,)), (1, (13,))], [(1, (12,)), (1, (13,)), (1, (14,))]])
 
     choices = [[(0,), (4,)], [(0,)]]
     classes = [0, 1]
-    self._compareCombinations(GetUniqueCombinations(choices, classes), [[(0, (4,)), (1, (0,))]])
+    self._compareCombinations(GetUniqueCombinations_new(choices, classes), [[(0, (4,)), (1, (0,))]])
 
     choices = [[], [], []]
     classes = [0, 1, 1]
-    self.assertEqual(GetUniqueCombinations(choices, classes), [])
+    self.assertEqual(GetUniqueCombinations_new(choices, classes), [])
 
     choices = [[(0,), (4,)], [(0,), (4,)], [(0,), (4,)]]
     classes = [0, 0, 0]
-    self.assertEqual(GetUniqueCombinations(choices, classes), [])
+    self.assertEqual(GetUniqueCombinations_new(choices, classes), [])
 
     choices = [[(0,), (4,)], [(0,), (4,)], []]
     classes = [0, 0, 1]
-    self.assertEqual(GetUniqueCombinations(choices, classes), [])
+    self.assertEqual(GetUniqueCombinations_new(choices, classes), [])
 
     choices = [[(4,), (6,), (7,), (10,)], [(2,), (3,), (5,), (13,), (14,)],
                [(2,), (3,), (5,), (13,), (14,)]]
     classes = [0, 1, 1]
     self._compareCombinations(
-      GetUniqueCombinations(choices, classes),
+      GetUniqueCombinations_new(choices, classes),
       [[(0, (4,)), (1, (2,)), (1, (3,))], [(0, (4,)), (1, (2,)), (1, (5,))],
        [(0, (4,)), (1, (2,)), (1, (13,))], [(0, (4,)), (1, (2,)), (1, (14,))],
        [(0, (4,)), (1, (3,)), (1, (5,))], [(0, (4,)), (1, (3,)), (1, (13,))],

--- a/rdkit/Chem/Pharm2D/UnitTestUtils.py
+++ b/rdkit/Chem/Pharm2D/UnitTestUtils.py
@@ -123,13 +123,16 @@ class TestCase(unittest.TestCase):
       print(actual)
     self.assertEqual(actual, expected, 'Combinations are not in the same order')
 
+  def _compareCombinationsOrderUnimportant(self, actual, expected):
+    self.assertEqual(sorted(actual), sorted(expected), 'Combinations are different')
+
   def testGetUniqueCombinations(self):
     # yapf: disable
     GetUniqueCombinations = Utils.GetUniqueCombinations
 
     choices = [[(11,), (12,)], [(21,), (22,)], [(31,), (32,)]]
     classes = [1, 2, 3]
-    self._compareCombinations(
+    self._compareCombinationsOrderUnimportant(
       GetUniqueCombinations(choices, classes),
       [[(1, (11,)), (2, (21,)), (3, (31,))], [(1, (11,)), (2, (21,)), (3, (32,))],
        [(1, (11,)), (2, (22,)), (3, (31,))], [(1, (11,)), (2, (22,)), (3, (32,))],
@@ -137,7 +140,7 @@ class TestCase(unittest.TestCase):
        [(1, (12,)), (2, (22,)), (3, (31,))], [(1, (12,)), (2, (22,)), (3, (32,))]])
 
     classes = [1, 1, 2]
-    self._compareCombinations(
+    self._compareCombinationsOrderUnimportant(
       GetUniqueCombinations(choices, classes),
       [[(1, (11,)), (1, (21,)), (2, (31,))], [(1, (11,)), (1, (21,)), (2, (32,))],
        [(1, (11,)), (1, (22,)), (2, (31,))], [(1, (11,)), (1, (22,)), (2, (32,))],
@@ -145,19 +148,19 @@ class TestCase(unittest.TestCase):
        [(1, (12,)), (1, (22,)), (2, (31,))], [(1, (12,)), (1, (22,)), (2, (32,))]])
 
     choices = [[(11,), (12,)], [(11,), (12,)], [(31,), (32,)]]
-    self._compareCombinations(
+    self._compareCombinationsOrderUnimportant(
       GetUniqueCombinations(choices, classes),
       [[(1, (11,)), (1, (12,)), (2, (31,))], [(1, (11,)), (1, (12,)), (2, (32,))]])
 
     choices = [[(11,), (12,)], [(11,), (12,), (13,)], [(31,), (32,)]]
-    self._compareCombinations(
+    self._compareCombinationsOrderUnimportant(
       GetUniqueCombinations(choices, classes),
       [[(1, (11,)), (1, (12,)), (2, (31,))], [(1, (11,)), (1, (12,)), (2, (32,))],
        [(1, (11,)), (1, (13,)), (2, (31,))], [(1, (11,)), (1, (13,)), (2, (32,))],
        [(1, (12,)), (1, (13,)), (2, (31,))], [(1, (12,)), (1, (13,)), (2, (32,))]])
 
     choices = [[(11,), (12,), (14,)], [(11,), (12,), (13,)], [(31,), (32,)]]
-    self._compareCombinations(
+    self._compareCombinationsOrderUnimportant(
       GetUniqueCombinations(choices, classes),
       [[(1, (11,)), (1, (12,)), (2, (31,))], [(1, (11,)), (1, (12,)), (2, (32,))],
        [(1, (11,)), (1, (13,)), (2, (31,))], [(1, (11,)), (1, (13,)), (2, (32,))],
@@ -167,7 +170,7 @@ class TestCase(unittest.TestCase):
        [(1, (13,)), (1, (14,)), (2, (31,))], [(1, (13,)), (1, (14,)), (2, (32,))]])
 
     choices = [[(11, 111,), (12,), (14,)], [(11, 111,), (12,), (13,)], [(31,), (32,)]]
-    self._compareCombinations(
+    self._compareCombinationsOrderUnimportant(
       GetUniqueCombinations(choices, classes),
       [[(1, (11, 111)), (1, (12,)), (2, (31,))], [(1, (11, 111)), (1, (12,)), (2, (32,))],
        [(1, (11, 111)), (1, (13,)), (2, (31,))], [(1, (11, 111)), (1, (13,)), (2, (32,))],
@@ -178,14 +181,14 @@ class TestCase(unittest.TestCase):
 
     choices = [[(11,), (12,), ], [(11,), (13,), ], [(11,), (14,), ]]
     classes = [1, 1, 1]
-    self._compareCombinations(
+    self._compareCombinationsOrderUnimportant(
       GetUniqueCombinations(choices, classes),
       [[(1, (11,)), (1, (12,)), (1, (13,))], [(1, (11,)), (1, (12,)), (1, (14,))],
        [(1, (11,)), (1, (13,)), (1, (14,))], [(1, (12,)), (1, (13,)), (1, (14,))]])
 
     choices = [[(0,), (4,)], [(0,)]]
     classes = [0, 1]
-    self._compareCombinations(GetUniqueCombinations(choices, classes), [[(0, (4,)), (1, (0,))]])
+    self._compareCombinationsOrderUnimportant(GetUniqueCombinations(choices, classes), [[(0, (4,)), (1, (0,))]])
 
     choices = [[], [], []]
     classes = [0, 1, 1]
@@ -202,7 +205,7 @@ class TestCase(unittest.TestCase):
     choices = [[(4,), (6,), (7,), (10,)], [(2,), (3,), (5,), (13,), (14,)],
                [(2,), (3,), (5,), (13,), (14,)]]
     classes = [0, 1, 1]
-    self._compareCombinations(
+    self._compareCombinationsOrderUnimportant(
       GetUniqueCombinations(choices, classes),
       [[(0, (4,)), (1, (2,)), (1, (3,))], [(0, (4,)), (1, (2,)), (1, (5,))],
        [(0, (4,)), (1, (2,)), (1, (13,))], [(0, (4,)), (1, (2,)), (1, (14,))],

--- a/rdkit/Chem/Pharm2D/UnitTestUtils.py
+++ b/rdkit/Chem/Pharm2D/UnitTestUtils.py
@@ -124,20 +124,13 @@ class TestCase(unittest.TestCase):
     self.assertEqual(actual, expected, 'Combinations are not in the same order')
 
   def testGetUniqueCombinations(self):
-    x = [[(1, (11, )), (1, (12, )), (2, (31, ))], [(1, (11, )), (1, (12, )), (2, (32, ))],
-         [(1, (11, )), (1, (13, )), (2, (31, ))], [(1, (11, )), (1, (13, )), (2, (32, ))],
-         [(1, (11, )), (1, (14, )), (2, (31, ))], [(1, (11, )), (1, (14, )), (2, (32, ))],
-         [(1, (12, )), (1, (13, )), (2, (31, ))], [(1, (12, )), (1, (13, )), (2, (32, ))],
-         [(1, (12, )), (1, (14, )), (2, (31, ))], [(1, (12, )), (1, (14, )), (2, (32, ))],
-         [(1, (13, )), (1, (14, )), (2, (31, ))], [(1, (13, )), (1, (14, )), (2, (32, ))]]
-
     # yapf: disable
-    GetUniqueCombinations_new = Utils.GetUniqueCombinations_new
+    GetUniqueCombinations = Utils.GetUniqueCombinations
 
     choices = [[(11,), (12,)], [(21,), (22,)], [(31,), (32,)]]
     classes = [1, 2, 3]
     self._compareCombinations(
-      GetUniqueCombinations_new(choices, classes),
+      GetUniqueCombinations(choices, classes),
       [[(1, (11,)), (2, (21,)), (3, (31,))], [(1, (11,)), (2, (21,)), (3, (32,))],
        [(1, (11,)), (2, (22,)), (3, (31,))], [(1, (11,)), (2, (22,)), (3, (32,))],
        [(1, (12,)), (2, (21,)), (3, (31,))], [(1, (12,)), (2, (21,)), (3, (32,))],
@@ -145,7 +138,7 @@ class TestCase(unittest.TestCase):
 
     classes = [1, 1, 2]
     self._compareCombinations(
-      GetUniqueCombinations_new(choices, classes),
+      GetUniqueCombinations(choices, classes),
       [[(1, (11,)), (1, (21,)), (2, (31,))], [(1, (11,)), (1, (21,)), (2, (32,))],
        [(1, (11,)), (1, (22,)), (2, (31,))], [(1, (11,)), (1, (22,)), (2, (32,))],
        [(1, (12,)), (1, (21,)), (2, (31,))], [(1, (12,)), (1, (21,)), (2, (32,))],
@@ -153,19 +146,19 @@ class TestCase(unittest.TestCase):
 
     choices = [[(11,), (12,)], [(11,), (12,)], [(31,), (32,)]]
     self._compareCombinations(
-      GetUniqueCombinations_new(choices, classes),
+      GetUniqueCombinations(choices, classes),
       [[(1, (11,)), (1, (12,)), (2, (31,))], [(1, (11,)), (1, (12,)), (2, (32,))]])
 
     choices = [[(11,), (12,)], [(11,), (12,), (13,)], [(31,), (32,)]]
     self._compareCombinations(
-      GetUniqueCombinations_new(choices, classes),
+      GetUniqueCombinations(choices, classes),
       [[(1, (11,)), (1, (12,)), (2, (31,))], [(1, (11,)), (1, (12,)), (2, (32,))],
        [(1, (11,)), (1, (13,)), (2, (31,))], [(1, (11,)), (1, (13,)), (2, (32,))],
        [(1, (12,)), (1, (13,)), (2, (31,))], [(1, (12,)), (1, (13,)), (2, (32,))]])
 
     choices = [[(11,), (12,), (14,)], [(11,), (12,), (13,)], [(31,), (32,)]]
     self._compareCombinations(
-      GetUniqueCombinations_new(choices, classes),
+      GetUniqueCombinations(choices, classes),
       [[(1, (11,)), (1, (12,)), (2, (31,))], [(1, (11,)), (1, (12,)), (2, (32,))],
        [(1, (11,)), (1, (13,)), (2, (31,))], [(1, (11,)), (1, (13,)), (2, (32,))],
        [(1, (12,)), (1, (13,)), (2, (31,))], [(1, (12,)), (1, (13,)), (2, (32,))],
@@ -175,42 +168,42 @@ class TestCase(unittest.TestCase):
 
     choices = [[(11, 111,), (12,), (14,)], [(11, 111,), (12,), (13,)], [(31,), (32,)]]
     self._compareCombinations(
-      GetUniqueCombinations_new(choices, classes),
+      GetUniqueCombinations(choices, classes),
       [[(1, (11, 111)), (1, (12,)), (2, (31,))], [(1, (11, 111)), (1, (12,)), (2, (32,))],
        [(1, (11, 111)), (1, (13,)), (2, (31,))], [(1, (11, 111)), (1, (13,)), (2, (32,))],
-       [(1, (12,)), (1, (13,)), (2, (31,))], [(1, (12,)), (1, (13,)), (2, (32,))],
        [(1, (11, 111)), (1, (14,)), (2, (31,))], [(1, (11, 111)), (1, (14,)), (2, (32,))],
+       [(1, (12,)), (1, (13,)), (2, (31,))], [(1, (12,)), (1, (13,)), (2, (32,))],
        [(1, (12,)), (1, (14,)), (2, (31,))], [(1, (12,)), (1, (14,)), (2, (32,))],
        [(1, (13,)), (1, (14,)), (2, (31,))], [(1, (13,)), (1, (14,)), (2, (32,))]])
 
     choices = [[(11,), (12,), ], [(11,), (13,), ], [(11,), (14,), ]]
     classes = [1, 1, 1]
     self._compareCombinations(
-      GetUniqueCombinations_new(choices, classes),
-      [[(1, (11,)), (1, (13,)), (1, (14,))], [(1, (11,)), (1, (12,)), (1, (14,))],
-       [(1, (11,)), (1, (12,)), (1, (13,))], [(1, (12,)), (1, (13,)), (1, (14,))]])
+      GetUniqueCombinations(choices, classes),
+      [[(1, (11,)), (1, (12,)), (1, (13,))], [(1, (11,)), (1, (12,)), (1, (14,))],
+       [(1, (11,)), (1, (13,)), (1, (14,))], [(1, (12,)), (1, (13,)), (1, (14,))]])
 
     choices = [[(0,), (4,)], [(0,)]]
     classes = [0, 1]
-    self._compareCombinations(GetUniqueCombinations_new(choices, classes), [[(0, (4,)), (1, (0,))]])
+    self._compareCombinations(GetUniqueCombinations(choices, classes), [[(0, (4,)), (1, (0,))]])
 
     choices = [[], [], []]
     classes = [0, 1, 1]
-    self.assertEqual(GetUniqueCombinations_new(choices, classes), [])
+    self.assertEqual(GetUniqueCombinations(choices, classes), [])
 
     choices = [[(0,), (4,)], [(0,), (4,)], [(0,), (4,)]]
     classes = [0, 0, 0]
-    self.assertEqual(GetUniqueCombinations_new(choices, classes), [])
+    self.assertEqual(GetUniqueCombinations(choices, classes), [])
 
     choices = [[(0,), (4,)], [(0,), (4,)], []]
     classes = [0, 0, 1]
-    self.assertEqual(GetUniqueCombinations_new(choices, classes), [])
+    self.assertEqual(GetUniqueCombinations(choices, classes), [])
 
     choices = [[(4,), (6,), (7,), (10,)], [(2,), (3,), (5,), (13,), (14,)],
                [(2,), (3,), (5,), (13,), (14,)]]
     classes = [0, 1, 1]
     self._compareCombinations(
-      GetUniqueCombinations_new(choices, classes),
+      GetUniqueCombinations(choices, classes),
       [[(0, (4,)), (1, (2,)), (1, (3,))], [(0, (4,)), (1, (2,)), (1, (5,))],
        [(0, (4,)), (1, (2,)), (1, (13,))], [(0, (4,)), (1, (2,)), (1, (14,))],
        [(0, (4,)), (1, (3,)), (1, (5,))], [(0, (4,)), (1, (3,)), (1, (13,))],

--- a/rdkit/Chem/Pharm2D/Utils.py
+++ b/rdkit/Chem/Pharm2D/Utils.py
@@ -321,7 +321,7 @@ def GetAllCombinations(choices, noDups=1, which=0):
   return res
 
 
-def GetUniqueCombinations_new(choices, classes, which=0):
+def GetUniqueCombinations_new(choices, classes):
   """  Does the combinatorial explosion of the possible combinations
     of the elements of _choices_.
 

--- a/rdkit/Chem/Pharm2D/Utils.py
+++ b/rdkit/Chem/Pharm2D/Utils.py
@@ -321,12 +321,11 @@ def GetAllCombinations(choices, noDups=1, which=0):
   return res
 
 
-def GetUniqueCombinations_new(choices, classes):
+def GetUniqueCombinations(choices, classes):
   """  Does the combinatorial explosion of the possible combinations
     of the elements of _choices_.
 
     """
-  #   print(choices, classes)
   assert len(choices) == len(classes)
   combos = set()
   for choice in itertools.product(*choices):
@@ -336,6 +335,7 @@ def GetUniqueCombinations_new(choices, classes):
     combos.add(tuple(sorted((cls, ch) for cls, ch in zip(classes, choice))))
   return [list(combo) for combo in sorted(combos)]
 
+GetUniqueCombinations_new = GetUniqueCombinations
 
 def UniquifyCombinations(combos):
   """ uniquifies the combinations in the argument

--- a/rdkit/Chem/Pharm2D/Utils.py
+++ b/rdkit/Chem/Pharm2D/Utils.py
@@ -321,30 +321,6 @@ def GetAllCombinations(choices, noDups=1, which=0):
   return res
 
 
-def GetUniqueCombinations(choices, classes, which=0):
-  """  Does the combinatorial explosion of the possible combinations
-    of the elements of _choices_.
-
-    """
-  #   print(choices, classes)
-  assert len(choices) == len(classes)
-  if which >= len(choices):
-    return []
-  if which == len(choices) - 1:
-    return [[(classes[which], x)] for x in choices[which]]
-
-  res = []
-  tmp = GetUniqueCombinations(choices, classes, which=which + 1)
-  for thing in choices[which]:
-    for other in tmp:
-      if not any(x[1] == thing for x in other):
-        newL = [(classes[which], thing)] + other
-        newL.sort()
-        if newL not in res:
-          res.append(newL)
-  return res
-
-
 def GetUniqueCombinations_new(choices, classes, which=0):
   """  Does the combinatorial explosion of the possible combinations
     of the elements of _choices_.


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! 
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->
Fixes #8207

#### What does this implement/fix? Explain your changes.
Remove `GetUniqueCombinations`, use instead `GetUniqueCombinations_new` for improved speed; remove `GetUniqueCombinations_new`'s unused and uncalled parameter `which`. Update related tests.

#### Any other comments?
This PR makes the following choices; alternatives are noted:

- Removes the old function `GetUniqueCombinations` to prevent its use in the future; that old function could instead be kept.
- Keeps the name `GetUniqueCombinations_new` to indicate that it's the new algorithm; the name of the new function could be changed to `GetUniqueCombinations` to prevent confusion over why there's a function with the prefix `_new` and no function without that prefix.