### PR TITLE
Add missing atom mapping number after reaction

### DIFF
--- a/Code/GraphMol/ChemReactions/ReactionRunner.cpp
+++ b/Code/GraphMol/ChemReactions/ReactionRunner.cpp
@@ -850,12 +850,10 @@ void setReactantAtomPropertiesToProduct(Atom *productAtom,
   productAtom->setProp<unsigned int>(common_properties::reactantAtomIdx,
                                      reactantAtom.getIdx());
 
-  // preserve the atom map number from the reactant and drop old atom map
+  // preserve the atom map number from the reactant
   int mapNum;
   if (reactantAtom.getPropIfPresent(common_properties::molAtomMapNumber, mapNum)) {
     productAtom->setProp<unsigned int>(common_properties::molAtomMapNumber, mapNum);
-  } else {
-    productAtom->clearProp(common_properties::molAtomMapNumber);
   }
 
   if (setImplicitProperties) {

--- a/Code/GraphMol/ChemReactions/ReactionRunner.cpp
+++ b/Code/GraphMol/ChemReactions/ReactionRunner.cpp
@@ -849,6 +849,15 @@ void setReactantAtomPropertiesToProduct(Atom *productAtom,
   }
   productAtom->setProp<unsigned int>(common_properties::reactantAtomIdx,
                                      reactantAtom.getIdx());
+
+  // preserve the atom map number from the reactant and drop old atom map
+  int mapNum;
+  if (reactantAtom.getPropIfPresent(common_properties::molAtomMapNumber, mapNum)) {
+    productAtom->setProp<unsigned int>(common_properties::molAtomMapNumber, mapNum);
+  } else {
+    productAtom->clearProp(common_properties::molAtomMapNumber);
+  }
+
   if (setImplicitProperties) {
     updateImplicitAtomProperties(productAtom, &reactantAtom);
   }

--- a/Code/GraphMol/ChemReactions/testReaction.cpp
+++ b/Code/GraphMol/ChemReactions/testReaction.cpp
@@ -5629,7 +5629,7 @@ void test57IntroductionOfNewChiralCenters() {
     TEST_ASSERT(prods.size() == 1);
     TEST_ASSERT(prods[0].size() == 1);
     BOOST_LOG(rdInfoLog) << MolToSmiles(*prods[0][0], true) << std::endl;
-    TEST_ASSERT(MolToSmiles(*prods[0][0], true) == "C[C@H](F)CCC[C@@H](C)Cl");
+    TEST_ASSERT(MolToSmiles(*prods[0][0], true) == "C[C@@H](Cl)C[CH2:5][CH2:4][C@@H:1]([F:2])[CH3:3]");
 
     delete rxn;
   }
@@ -5665,7 +5665,7 @@ void test57IntroductionOfNewChiralCenters() {
     TEST_ASSERT(prods.size() == 1);
     TEST_ASSERT(prods[0].size() == 1);
     BOOST_LOG(rdInfoLog) << MolToSmiles(*prods[0][0], true) << std::endl;
-    TEST_ASSERT(MolToSmiles(*prods[0][0], true) == "C[C@H](F)CCC[C@@H](C)Cl");
+    TEST_ASSERT(MolToSmiles(*prods[0][0], true) == "C[C@@H](Cl)C[CH2:5][CH2:4][C@@H:1]([F:2])[CH3:3]");
 
     delete rxn;
   }


### PR DESCRIPTION
#### Reference Issue
Fixes #8206 

#### What does this implement/fix? Explain your changes.
After `RunReactants`, atom-mapping number in the matched atoms are removed.  
This remains the atom mapping number after `RunReactants`.  
I also changed some test cases to make them consistent with this patch.  

#### Any other comments?
There is a small difference from I suggested in #8206. This feature may not be related with `Issue3140490`.