### PR TITLE
Fix reaction panel bug.

### DIFF
--- a/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
@@ -1022,13 +1022,16 @@ void MolDraw2D::calcReactionOffsets(
   // it's too wide for the panel.
   const int arrowMult = 2;  // number of plusWidths for an empty arrow.
 
-  if (width_ == -1) {
-    width_ = reactionWidth(reagents, products, agents, drawOptions(), arrowMult,
-                           plusWidth);
+  int widthToUse = panel_width_ == -1 ? width_ : panel_width_;
+  if (widthToUse == -1) {
+    widthToUse = reactionWidth(reagents, products, agents, drawOptions(),
+                               arrowMult, plusWidth);
+    if (width_ == -1) {
+      width_ = widthToUse;
+    }
   }
-
   // The DrawMols are sized/scaled according to the panelHeight() which is all
-  // there is to go on initially, so they may be wider than the width() in
+  // there is to go on initially, so they may be wider than the widthToUse in
   // total. If so, shrink them to fit.  Because the shrinking imposes min and
   // max font sizes, we may not get the smaller size we want first go, so
   // iterate until we do or we give up.
@@ -1042,10 +1045,10 @@ void MolDraw2D::calcReactionOffsets(
                            return lhs->width_ < rhs->width_;
                          });
     plusWidth = (*maxWidthIt)->width_ / 4;
-    plusWidth = plusWidth > width() / 20 ? width() / 20 : plusWidth;
+    plusWidth = plusWidth > widthToUse / 20 ? widthToUse / 20 : plusWidth;
     auto oldTotWidth = totWidth;
     auto stretch =
-        double(width_ * (1 - 2.0 * drawOptions().padding)) / totWidth;
+        double(widthToUse * (1 - 2.0 * drawOptions().padding)) / totWidth;
     // If stretch < 1, we need to shrink the DrawMols to fit.  This isn't
     // necessary if we're just stretching them along the panel as they already
     // fit for height.
@@ -1058,7 +1061,7 @@ void MolDraw2D::calcReactionOffsets(
     }
     totWidth = reactionWidth(reagents, products, agents, drawOptions(),
                              arrowMult, plusWidth);
-    if (fabs(totWidth - oldTotWidth) < 0.01 * width()) {
+    if (fabs(totWidth - oldTotWidth) < 0.01 * widthToUse) {
       break;
     }
   }
@@ -1078,7 +1081,7 @@ void MolDraw2D::calcReactionOffsets(
   numGaps += products.empty() ? 0 : products.size() - 1;
   numGaps += 1;  // for either side of the arrow
   numGaps += agents.empty() ? 2 : agents.size() - 1;
-  if (width() - totWidth > numGaps * 5) {
+  if (widthToUse - totWidth > numGaps * 5) {
     plusWidth += 5;
   }
   totWidth = reactionWidth(reagents, products, agents, drawOptions(), arrowMult,
@@ -1086,7 +1089,9 @@ void MolDraw2D::calcReactionOffsets(
   // And finally work out where to put all the pieces, centring them.
   // The padding is already taken care of, so take it out.
   int xOffset =
-      std::round((width() - totWidth / (1 + 2.0 * drawOptions().padding)) / 2);
+      x_offset_ +
+      std::round((widthToUse - totWidth / (1 + 2.0 * drawOptions().padding)) /
+                 2);
   for (size_t i = 0; i < reagents.size(); ++i) {
     double hOffset = y_offset_ + (panelHeight() - reagents[i]->height_) / 2.0;
     offsets.emplace_back(xOffset, hOffset);


### PR DESCRIPTION
#### Reference Issue
Fixes #8213


#### What does this implement/fix? Explain your changes.
Uses the panel width rather than the full canvas width when drawing reactions.

Now gives this for the test code given in the issue.

![image](https://github.com/user-attachments/assets/bfb66694-5fb8-4914-b09e-0aedfa617fa1)


#### Any other comments?
Will merge this in when the other drawing PRs go through.
