### PR TITLE
Add helper apis to access commonly used residue info on atom

### DIFF
--- a/Code/GraphMol/Atom.cpp
+++ b/Code/GraphMol/Atom.cpp
@@ -628,7 +628,83 @@ void Atom::setMonomerInfo(AtomMonomerInfo *info) {
   delete dp_monomerInfo;
   dp_monomerInfo = info;
 }
-  
+
+const AtomPDBResidueInfo *Atom::getPDBResidueInfo() const {
+  return dynamic_cast<const AtomPDBResidueInfo *>(dp_monomerInfo);
+}
+
+AtomPDBResidueInfo *Atom::getPDBResidueInfo() {
+  return dynamic_cast<AtomPDBResidueInfo *>(dp_monomerInfo);
+}
+
+std::string Atom::getResidueName() const {
+  if (auto res_info = getPDBResidueInfo(); res_info) {
+    return res_info->getResidueName();
+  }
+  return "";
+}
+
+void Atom::setResidueName(const std::string &residue_name) {
+  auto res_info = getPDBResidueInfo();
+  if (!res_info) {
+    res_info = new RDKit::AtomPDBResidueInfo();
+    setMonomerInfo(res_info);
+  }
+  res_info->setResidueName(residue_name);
+}
+
+int Atom::getResidueNumber() const {
+  if (auto res_info = getPDBResidueInfo(); res_info) {
+    return res_info->getResidueNumber();
+  }
+
+  return 0;
+}
+
+void Atom::setResidueNumber(int residue_number) {
+  auto res_info = getPDBResidueInfo();
+  if (!res_info) {
+    res_info = new RDKit::AtomPDBResidueInfo();
+    setMonomerInfo(res_info);
+  }
+  res_info->setResidueNumber(residue_number);
+}
+
+std::string Atom::getChainId() const {
+  if (auto res_info = getPDBResidueInfo(); res_info) {
+    return res_info->getChainId();
+  }
+
+  return "";
+}
+
+void Atom::setChainId(const std::string &chain_id) {
+  auto res_info = getPDBResidueInfo();
+  if (!res_info) {
+    res_info = new RDKit::AtomPDBResidueInfo();
+    setMonomerInfo(res_info);
+  }
+
+  res_info->setChainId(chain_id);
+}
+
+std::string Atom::getInsertionCode() const {
+  if (auto res_info = getPDBResidueInfo(); res_info) {
+    return res_info->getInsertionCode();
+  }
+
+  return "";
+}
+
+void Atom::setInsertionCode(const std::string &insertion_code) {
+  auto res_info = getPDBResidueInfo();
+  if (!res_info) {
+    res_info = new RDKit::AtomPDBResidueInfo();
+    setMonomerInfo(res_info);
+  }
+  res_info->setInsertionCode(insertion_code);
+}
+
 void Atom::setIsotope(unsigned int what) { d_isotope = what; }
 
 double Atom::getMass() const {

--- a/Code/GraphMol/Atom.h
+++ b/Code/GraphMol/Atom.h
@@ -37,6 +37,7 @@ namespace RDKit {
 class ROMol;
 class RWMol;
 class AtomMonomerInfo;
+class AtomPDBResidueInfo;
 
 //! The class for representing atoms
 /*!
@@ -406,7 +407,39 @@ class RDKIT_GRAPHMOL_EXPORT Atom : public RDProps {
     return mapno;
   }
 
+  //! Get the residue name of the atom. If no residue name exists, an empty
+  //! string is returned
+  std::string getResidueName() const;
+
+  //! Set the residue name of the atom.
+  void setResidueName(const std::string &residue_name);
+
+  //! Get the residue number of the atom. If no residue number exists, 0
+  //! is returned
+  int getResidueNumber() const;
+
+  //! Set the residue number of the atom.
+  void setResidueNumber(int residue_number);
+
+  //! Get the residue chain id of the atom. If no chain id exists, an empty
+  //! string is returned
+  std::string getChainId() const;
+
+  //! Set the residue chain id of the atom.
+  void setChainId(const std::string &chain_id);
+
+  //! Get the residue insertion code of the atom. If no insertion code exists,
+  //! an empty string is returned
+  std::string getInsertionCode() const;
+
+  //! Set the residue insertion code of the atom.
+  void setInsertionCode(const std::string &insertion_code);
+
  protected:
+  //! Get the residue information on the atom
+  const AtomPDBResidueInfo *getPDBResidueInfo() const;
+  AtomPDBResidueInfo *getPDBResidueInfo();
+
   //! sets our owning molecule
   void setOwningMol(ROMol *other);
   //! sets our owning molecule

--- a/Code/GraphMol/FileParsers/testGeneralFileReader.cpp
+++ b/Code/GraphMol/FileParsers/testGeneralFileReader.cpp
@@ -224,10 +224,9 @@ void testMae() {
 
   std::shared_ptr<ROMol> nmol2(cmaesup->next());
   const Atom *atom = nmol2->getAtomWithIdx(0);
-  auto *info = (AtomPDBResidueInfo *)(atom->getMonomerInfo());
-  TEST_ASSERT(info->getResidueName() == "ARG ");
-  TEST_ASSERT(info->getChainId() == "A");
-  TEST_ASSERT(info->getResidueNumber() == 5);
+  TEST_ASSERT(atom->getResidueName() == "ARG ");
+  TEST_ASSERT(atom->getChainId() == "A");
+  TEST_ASSERT(atom->getResidueNumber() == 5);
 #endif
 #endif
 }

--- a/Code/GraphMol/FileParsers/testMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/testMolSupplier.cpp
@@ -305,10 +305,9 @@ int testMolSup() {
     std::shared_ptr<ROMol> nmol;
     nmol.reset(maesup.next());
     const Atom *atom = nmol->getAtomWithIdx(0);
-    auto *info = (AtomPDBResidueInfo *)(atom->getMonomerInfo());
-    TEST_ASSERT(info->getResidueName() == "ARG ");
-    TEST_ASSERT(info->getChainId() == "A");
-    TEST_ASSERT(info->getResidueNumber() == 5);
+    TEST_ASSERT(atom->getResidueName() == "ARG ");
+    TEST_ASSERT(atom->getChainId() == "A");
+    TEST_ASSERT(atom->getResidueNumber() == 5);
   }
 #endif
 #endif  // RDK_BUILD_MAEPARSER_SUPPORT

--- a/Code/GraphMol/Wrap/MolOps.cpp
+++ b/Code/GraphMol/Wrap/MolOps.cpp
@@ -190,20 +190,10 @@ ROMol *renumberAtomsHelper(const ROMol &mol, python::object &pyNewOrder) {
 
 namespace {
 std::string getResidue(const ROMol &, const Atom *at) {
-  auto monomerInfo = at->getMonomerInfo();
-  if (!monomerInfo ||
-      monomerInfo->getMonomerType() != AtomMonomerInfo::PDBRESIDUE) {
-    return "";
-  }
-  return static_cast<const AtomPDBResidueInfo *>(monomerInfo)->getResidueName();
+  return at->getResidueName();
 }
 std::string getChainId(const ROMol &, const Atom *at) {
-  auto monomerInfo = at->getMonomerInfo();
-  if (!monomerInfo ||
-      monomerInfo->getMonomerType() != AtomMonomerInfo::PDBRESIDUE) {
-    return "";
-  }
-  return static_cast<const AtomPDBResidueInfo *>(monomerInfo)->getChainId();
+  return at->getChainId();
 }
 }  // namespace
 python::dict splitMolByPDBResidues(const ROMol &mol, python::object pyWhiteList,
@@ -2150,9 +2140,9 @@ RETURNS:
     - cleanIt: (optional) if provided, any existing values of the property `_CIPCode`
         will be cleared, atoms with a chiral specifier that aren't
       actually chiral (e.g. atoms with duplicate substituents or only 2 substituents,
-      etc.) will have their chiral code set to CHI_UNSPECIFIED. Bonds with 
-      STEREOCIS/STEREOTRANS specified that have duplicate substituents based upon the CIP 
-      atom ranks will be marked STEREONONE. 
+      etc.) will have their chiral code set to CHI_UNSPECIFIED. Bonds with
+      STEREOCIS/STEREOTRANS specified that have duplicate substituents based upon the CIP
+      atom ranks will be marked STEREONONE.
     - force: (optional) causes the calculation to be repeated, even if it has already
       been done
     - flagPossibleStereoCenters (optional)   set the _ChiralityPossible property on
@@ -2258,9 +2248,9 @@ RETURNS:
                 docString.c_str());
 
     docString = R"DOC(returns the meso centers in a molecule (if any).
-    
+
   ARGUMENTS:
-    
+
     - mol: the molecule to use
     - includeIsotopes: (optional) toggles whether or not isotopes should be included in the
       calculation.
@@ -3024,7 +3014,7 @@ Note that some of the options here are either directly contradictory or make
   is doing something sensible and don't attempt to detect possible conflicts or
   problems.
 
-A note on the flags controlling which atoms/bonds are modified: 
+A note on the flags controlling which atoms/bonds are modified:
    These generally limit the set of atoms/bonds to be modified.
    For example:
        - ADJUST_IGNORERINGS atoms/bonds in rings will not be modified.
@@ -3183,7 +3173,7 @@ A note on the flags controlling which atoms/bonds are modified:
    - mol: molecule to be modified
    - addAsQueries: if true, the dummy atoms will be added as null queries
         (i.e. they will match any atom in a substructure search)
-   - addCoords: if true and the molecule has one or more conformers, 
+   - addCoords: if true and the molecule has one or more conformers,
         positions for the attachment points will be added to the conformer(s)
 )DOC");
     python::def(


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! 
-->

#### What does this implement/fix? Explain your changes.
This adds some convenient apis to access the following atom-level residue information on atoms:
        * chain id
        * insertion code
        * residue name
        * residue number

