### PR TITLE
Fix typo in documentation

### DIFF
--- a/Code/ForceField/UFF/AngleBend.h
+++ b/Code/ForceField/UFF/AngleBend.h
@@ -40,7 +40,7 @@ class RDKIT_FORCEFIELD_EXPORT AngleBendContrib : public ForceFieldContrib {
          - 0: not a special case, use the \c theta0 value from \c at2Params
          - 2: linear coordination
          - 3: trigonal planar coordination
-         - 4: square planar or tetrahedral coordination
+         - 4: square planar or octahedral coordination
 
   */
   AngleBendContrib(ForceField *owner, unsigned int idx1, unsigned int idx2,

--- a/Code/ForceField/UFF/AngleBend.h
+++ b/Code/ForceField/UFF/AngleBend.h
@@ -38,7 +38,7 @@ class RDKIT_FORCEFIELD_EXPORT AngleBendContrib : public ForceFieldContrib {
     \param order (optional) the order of the angle term, this is for
        special cases and should adopt values:
          - 0: not a special case, use the \c theta0 value from \c at2Params
-         - 2: linear coordination
+         - 1: linear coordination
          - 3: trigonal planar coordination
          - 4: square planar or octahedral coordination
 


### PR DESCRIPTION
Having a look at the paper and the code, there is a typo in the docstring.
n=4 for square-planar and octahedral coordination environments. 


