### PR TITLE
Fix #7983

### DIFF
--- a/Code/GraphMol/Atom.cpp
+++ b/Code/GraphMol/Atom.cpp
@@ -742,6 +742,11 @@ bool Atom::needsUpdatePropertyCache() const {
            (this->df_noImplicit || this->d_implicitValence >= 0));
 }
 
+void Atom::clearPropertyCache() {
+  d_explicitValence = -1;
+  d_implicitValence = -1;
+}
+
 // returns the number of swaps required to convert the ordering
 // of the probe list to match the order of our incoming bonds:
 //

--- a/Code/GraphMol/Atom.h
+++ b/Code/GraphMol/Atom.h
@@ -346,6 +346,7 @@ class RDKIT_GRAPHMOL_EXPORT Atom : public RDProps {
   void updatePropertyCache(bool strict = true);
 
   bool needsUpdatePropertyCache() const;
+  void clearPropertyCache();
 
   //! calculates and returns our explicit valence
   /*!

--- a/Code/GraphMol/FileParsers/file_parsers_catch.cpp
+++ b/Code/GraphMol/FileParsers/file_parsers_catch.cpp
@@ -7562,3 +7562,71 @@ M  END)CTAB";
     }
   }
 }
+
+TEST_CASE("github #7983 : stereo groups lost on sulfoxide from ctab") {
+  SECTION("as reported") {
+    std::string molblock = R"CTAB(
+  Mrv2317 02032512242D          
+
+  0  0  0     0  0            999 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 21 22 0 0 0
+M  V30 BEGIN ATOM
+M  V30 1 C -4.001 -2.31 0 0
+M  V30 2 C -2.6674 -3.08 0 0
+M  V30 3 C -1.3337 -2.31 0 0
+M  V30 4 C 0 -3.08 0 0
+M  V30 5 C 0 -4.6198 0 0
+M  V30 6 N 1.3337 -5.3898 0 0
+M  V30 7 C 2.6674 -4.6198 0 0
+M  V30 8 O 2.6674 -3.08 0 0
+M  V30 9 O 4.001 -5.3898 0 0
+M  V30 10 C 5.3345 -4.6198 0 0
+M  V30 11 C 6.6682 -5.3898 0 0
+M  V30 12 C 8.0019 -4.6198 0 0
+M  V30 13 C 9.3356 -5.3898 0 0
+M  V30 14 C 9.3356 -6.9298 0 0
+M  V30 15 C 8.0019 -7.6998 0 0
+M  V30 16 C 6.6682 -6.9298 0 0
+M  V30 17 S 5.3345 -7.6998 0 0 CFG=2
+M  V30 18 C 4.001 -6.9298 0 0
+M  V30 19 O 5.3345 -9.2398 0 0
+M  V30 20 C -1.3337 -5.3898 0 0
+M  V30 21 C -2.6674 -4.6198 0 0
+M  V30 END ATOM
+M  V30 BEGIN BOND
+M  V30 1 1 1 2
+M  V30 2 4 2 3
+M  V30 3 4 3 4
+M  V30 4 4 4 5
+M  V30 5 1 5 6
+M  V30 6 1 6 7
+M  V30 7 2 7 8
+M  V30 8 1 7 9
+M  V30 9 1 9 10
+M  V30 10 1 10 11
+M  V30 11 4 11 12
+M  V30 12 4 12 13
+M  V30 13 4 13 14
+M  V30 14 4 14 15
+M  V30 15 4 15 16
+M  V30 16 4 11 16
+M  V30 17 1 17 16
+M  V30 18 2 17 19
+M  V30 19 4 5 20
+M  V30 20 4 20 21
+M  V30 21 4 2 21
+M  V30 22 1 17 18 CFG=1
+M  V30 END BOND
+M  V30 BEGIN COLLECTION
+M  V30 MDLV30/STEABS ATOMS=(1 17)
+M  V30 END COLLECTION
+M  V30 END CTAB
+M  END)CTAB";
+    auto m = v2::FileParsers::MolFromMolBlock(molblock);
+    REQUIRE(m);
+    CHECK(m->getAtomWithIdx(16)->getChiralTag() == Atom::CHI_TETRAHEDRAL_CW);
+    CHECK(m->getStereoGroups().size() == 1);
+    // m->debugMol(std::cerr);
+  }
+}

--- a/Code/GraphMol/FileParsers/testMolWriter.cpp
+++ b/Code/GraphMol/FileParsers/testMolWriter.cpp
@@ -1423,6 +1423,7 @@ void testNeedsUpdatePropertyCacheSDWriter() {
   {
     ROMol *m1 = SmilesToMol("c1ccccc1[NH]C(=O)", 0, false);
     TEST_ASSERT(m1);
+    m1->clearPropertyCache();
     TEST_ASSERT(m1->needsUpdatePropertyCache() == true);
     std::string mb = MolToMolBlock(*m1);
     delete m1;

--- a/Code/GraphMol/ROMol.cpp
+++ b/Code/GraphMol/ROMol.cpp
@@ -604,6 +604,12 @@ bool ROMol::needsUpdatePropertyCache() const {
   return false;
 }
 
+void ROMol::clearPropertyCache() {
+  for (auto atom : atoms()) {
+    atom->clearPropertyCache();
+  }
+}
+
 const Conformer &ROMol::getConformer(int id) const {
   // make sure we have more than one conformation
   if (d_confs.size() == 0) {

--- a/Code/GraphMol/ROMol.h
+++ b/Code/GraphMol/ROMol.h
@@ -765,6 +765,7 @@ class RDKIT_GRAPHMOL_EXPORT ROMol : public RDProps {
   void updatePropertyCache(bool strict = true);
 
   bool needsUpdatePropertyCache() const;
+  void clearPropertyCache();
 
   //! @}
 

--- a/Code/GraphMol/Wrap/Atom.cpp
+++ b/Code/GraphMol/Wrap/Atom.cpp
@@ -453,6 +453,10 @@ struct atom_wrapper {
              "Returns true or false depending on whether implicit and explicit "
              "valence of the molecule have already been calculated.\n\n")
 
+        .def("ClearPropertyCache", &Atom::clearPropertyCache,
+             (python::arg("self")),
+             "Clears implicit and explicit valence information.\n\n")
+
         .def("GetMonomerInfo", AtomGetMonomerInfo,
              python::return_internal_reference<
                  1, python::with_custodian_and_ward_postcall<0, 1>>(),

--- a/Code/GraphMol/Wrap/Mol.cpp
+++ b/Code/GraphMol/Wrap/Mol.cpp
@@ -755,6 +755,11 @@ struct mol_wrapper {
              "explicit "
              "valence of the molecule have already been calculated.\n\n")
 
+        .def(
+            "ClearPropertyCache", &ROMol::clearPropertyCache,
+            (python::arg("self")),
+            "Clears implicit and explicit valence information from all atoms.\n\n")
+
         .def("GetStereoGroups", &ROMol::getStereoGroups,
              "Returns a list of StereoGroups defining the relative "
              "stereochemistry "

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -8297,6 +8297,16 @@ M  END
       except Exception as e:
         assert "Python argument types" in str(e), f"{func}: {str(e)}"
 
+  def testClearPropertyCache(self):
+    m = Chem.MolFromSmiles("CC")
+    self.assertFalse(m.NeedsUpdatePropertyCache())
+    for atom in m.GetAtoms():
+      self.assertFalse(atom.NeedsUpdatePropertyCache())
+    m.ClearPropertyCache()
+    self.assertTrue(m.NeedsUpdatePropertyCache())
+    for atom in m.GetAtoms():
+      self.assertTrue(atom.NeedsUpdatePropertyCache())
+    
 
 if __name__ == '__main__':
   if "RDTESTCASE" in os.environ:

--- a/Code/GraphMol/catch_chirality.cpp
+++ b/Code/GraphMol/catch_chirality.cpp
@@ -6000,3 +6000,9 @@ TEST_CASE(
     CHECK(m->getBondWithIdx(0)->hasProp(common_properties::_CIPCode) == false);
   }
 }
+
+TEST_CASE("aromatic N and atropisomers") {
+  auto m = "Cc1ccc(F)n1C1=C(O)C=CC=C1C |wU:6.5|"_smiles;
+  REQUIRE(m);
+  CHECK(m->getBondWithIdx(6)->getStereo() == Bond::BondStereo::STEREOATROPCW);
+}

--- a/Code/GraphMol/catch_graphmol.cpp
+++ b/Code/GraphMol/catch_graphmol.cpp
@@ -4887,3 +4887,17 @@ TEST_CASE("Github #7873: monomer info segfaults and mem leaks", "[PDB]") {
     CHECK(was_deleted == true);
   }
 }
+
+TEST_CASE("clearPropertyCache") {
+  auto m = "CC"_smiles;
+  REQUIRE(m);
+  CHECK(!m->needsUpdatePropertyCache());
+  for (const auto atom : m->atoms()) {
+    CHECK(!atom->needsUpdatePropertyCache());
+  }
+  m->clearPropertyCache();
+  CHECK(m->needsUpdatePropertyCache());
+  for (const auto atom : m->atoms()) {
+    CHECK(atom->needsUpdatePropertyCache());
+  }
+}


### PR DESCRIPTION
Chiral sulfoxides and related things are no longer recognized as marking atropisomeric bonds.