### PR TITLE
Rascal left some high atomic numbers in the output SMARTS

### DIFF
--- a/Code/GraphMol/RascalMCES/RascalResult.cpp
+++ b/Code/GraphMol/RascalMCES/RascalResult.cpp
@@ -784,7 +784,7 @@ void cleanSmarts(std::string &smarts, const std::string &equivalentAtoms) {
     }
   }
 
-  // Convert the equivalent atoms from wierd atomic numbers to the
+  // Convert the equivalent atoms from weird atomic numbers to the
   // original SMARTS pattern
   std::vector<std::string> classSmarts;
   boost::split(classSmarts, equivalentAtoms, boost::is_any_of(" "));
@@ -799,8 +799,20 @@ void cleanSmarts(std::string &smarts, const std::string &equivalentAtoms) {
     auto atNumStr = std::to_string(atNum);
     std::regex a1(R"(\[#)" + atNumStr + R"(&[Aa]\])");
     smarts = std::regex_replace(smarts, a1, smt);
+
+    // If it's a plain atomic number, it's safe to do a straight
+    // replacement with the smt.
     std::regex a2(R"(\[#)" + atNumStr + R"(\])");
     smarts = std::regex_replace(smarts, a2, smt);
+
+    // There may also be other bits of SMARTS after the &[Aa] that we need
+    // to keep.  Most likely this is &R from the option ringMatchesRingOnly
+    // In this case, wrap the smt into a recursive SMARTS so that
+    // any logical operators are protected from whatever comes after.
+    std::regex a3(R"(#)" + atNumStr + R"(&[Aa])");
+    std::string replaceWith("$(" + smt + ")");
+    smarts = std::regex_replace(smarts, a3, replaceWith);
+
     ++atNum;
   }
 }

--- a/Code/GraphMol/RascalMCES/RascalResult.cpp
+++ b/Code/GraphMol/RascalMCES/RascalResult.cpp
@@ -805,14 +805,14 @@ void cleanSmarts(std::string &smarts, const std::string &equivalentAtoms) {
     std::regex a2(R"(\[#)" + atNumStr + R"(\])");
     smarts = std::regex_replace(smarts, a2, smt);
 
-    // There may also be other bits of SMARTS after the &[Aa] that we need
-    // to keep.  Most likely this is &R from the option ringMatchesRingOnly.
-    // In this case, wrap the smt into a recursive SMARTS so that
-    // any logical operators are protected from whatever comes after.
-    std::regex a3(R"(#)" + atNumStr + R"(&[Aa])");
-    std::string replaceWith("$(" + smt + ")");
+    // If the ringMatchesRingOnly option has been used, there may
+    // be [#110&A&R] or [#110&a&R] or [#110&R].  In these cases
+    // it needs to end ;R] but again without the &A or &a.  The
+    // SMARTS has to match to a single atom, so must end with
+    // a ]. e.g. [O,S] or [c,$(o1cccc1),$(n1cccc1)]
+    std::regex a3(R"(\[#)" + atNumStr + R"((?:&[Aa])*&R)");
+    std::string replaceWith(smt.substr(0, smt.length() - 1) + ";R");
     smarts = std::regex_replace(smarts, a3, replaceWith);
-
     ++atNum;
   }
 }

--- a/Code/GraphMol/RascalMCES/RascalResult.cpp
+++ b/Code/GraphMol/RascalMCES/RascalResult.cpp
@@ -806,7 +806,7 @@ void cleanSmarts(std::string &smarts, const std::string &equivalentAtoms) {
     smarts = std::regex_replace(smarts, a2, smt);
 
     // There may also be other bits of SMARTS after the &[Aa] that we need
-    // to keep.  Most likely this is &R from the option ringMatchesRingOnly
+    // to keep.  Most likely this is &R from the option ringMatchesRingOnly.
     // In this case, wrap the smt into a recursive SMARTS so that
     // any logical operators are protected from whatever comes after.
     std::regex a3(R"(#)" + atNumStr + R"(&[Aa])");

--- a/Code/GraphMol/RascalMCES/mces_catch.cpp
+++ b/Code/GraphMol/RascalMCES/mces_catch.cpp
@@ -37,9 +37,10 @@ using namespace RDKit::RascalMCES::details;
 void check_smarts_ok(const RDKit::ROMol &mol1, const RDKit::ROMol &mol2,
                      const RascalResult &res) {
   auto qmol = v2::SmilesParse::MolFromSmarts(res.getSmarts());
+  REQUIRE(qmol);
   RDKit::MatchVectType dont_care;
-  REQUIRE(RDKit::SubstructMatch(mol1, *qmol, dont_care));
-  REQUIRE(RDKit::SubstructMatch(mol2, *qmol, dont_care));
+  CHECK(RDKit::SubstructMatch(mol1, *qmol, dont_care));
+  CHECK(RDKit::SubstructMatch(mol2, *qmol, dont_care));
 }
 
 void check_expected_bonds(
@@ -47,7 +48,7 @@ void check_expected_bonds(
     const std::vector<std::vector<std::pair<int, int>>> &exp_bond_matches) {
   auto found_it = std::find(exp_bond_matches.begin(), exp_bond_matches.end(),
                             res.getBondMatches());
-  REQUIRE(found_it != exp_bond_matches.end());
+  CHECK(found_it != exp_bond_matches.end());
 }
 
 TEST_CASE("Very small test", "[basics]") {
@@ -1529,9 +1530,8 @@ TEST_CASE(
   opts.ringMatchesRingOnly = true;
   auto res = rascalMCES(*m1, *m2, opts);
   REQUIRE(!res.empty());
-  std::cout << res.front().getSmarts() << std::endl;
   CHECK(
       res.front().getSmarts() ==
-      "C-[O,S]-[C&R]1=&@[C&R]-&@[C&R]2(-&@[$([O,S])&R]-&@c3:c:c:c(-c4:c:c:c:c:c:4):c:c:3-&@[C&R]-&@2=[O,S])-&@[C&R](-[O,S]-C)=&@[C&R]-&@[C&R]-&@1-[O,S]");
+      "C-[O,S]-[C&R]1=&@[C&R]-&@[C&R]2(-&@[O,S;R]-&@c3:c:c:c(-c4:c:c:c:c:c:4):c:c:3-&@[C&R]-&@2=[O,S])-&@[C&R](-[O,S]-C)=&@[C&R]-&@[C&R]-&@1-[O,S]");
   check_smarts_ok(*m1, *m2, res.front());
 }

--- a/Code/GraphMol/RascalMCES/mces_catch.cpp
+++ b/Code/GraphMol/RascalMCES/mces_catch.cpp
@@ -1477,3 +1477,18 @@ TEST_CASE("Duplicate Single Largest Frag") {
     CHECK(res.back().getBondMatches().size() == 23);
   }
 }
+
+TEST_CASE("Github 8246 - equivalentAtoms SMARTS not translated back in the SMARTS string") {
+  auto m1 = "COC1=CC2(Oc3ccc(-c4ccc(OC)c(OC)c4)cc3C2=O)C(OC)=CC1O"_smiles;
+  REQUIRE(m1);
+  auto m2 = "COC1=CC2(Oc3ccc(-c4ccccc4)cc3C2=O)C(OC)=CC1O"_smiles;
+  REQUIRE(m2);
+  RascalOptions opts;
+  opts.equivalentAtoms = "[O,S]";
+  opts.ringMatchesRingOnly = true;
+  auto res = rascalMCES(*m1, *m2, opts);
+  REQUIRE(!res.empty());
+  std::cout << res.front().getSmarts() << std::endl;
+  CHECK(res.front().getSmarts() == "C-[O,S]-[C&R]1=&@[C&R]-&@[C&R]2(-&@[$([O,S])&R]-&@c3:c:c:c(-c4:c:c:c:c:c:4):c:c:3-&@[C&R]-&@2=[O,S])-&@[C&R](-[O,S]-C)=&@[C&R]-&@[C&R]-&@1-[O,S]");
+  check_smarts_ok(*m1, *m2, res.front());
+}

--- a/Code/GraphMol/RascalMCES/mces_catch.cpp
+++ b/Code/GraphMol/RascalMCES/mces_catch.cpp
@@ -1518,7 +1518,8 @@ TEST_CASE("Duplicate Single Largest Frag") {
   }
 }
 
-TEST_CASE("Github 8246 - equivalentAtoms SMARTS not translated back in the SMARTS string") {
+TEST_CASE(
+    "Github 8246 - equivalentAtoms SMARTS not translated back in the SMARTS string") {
   auto m1 = "COC1=CC2(Oc3ccc(-c4ccc(OC)c(OC)c4)cc3C2=O)C(OC)=CC1O"_smiles;
   REQUIRE(m1);
   auto m2 = "COC1=CC2(Oc3ccc(-c4ccccc4)cc3C2=O)C(OC)=CC1O"_smiles;
@@ -1529,6 +1530,8 @@ TEST_CASE("Github 8246 - equivalentAtoms SMARTS not translated back in the SMART
   auto res = rascalMCES(*m1, *m2, opts);
   REQUIRE(!res.empty());
   std::cout << res.front().getSmarts() << std::endl;
-  CHECK(res.front().getSmarts() == "C-[O,S]-[C&R]1=&@[C&R]-&@[C&R]2(-&@[$([O,S])&R]-&@c3:c:c:c(-c4:c:c:c:c:c:4):c:c:3-&@[C&R]-&@2=[O,S])-&@[C&R](-[O,S]-C)=&@[C&R]-&@[C&R]-&@1-[O,S]");
+  CHECK(
+      res.front().getSmarts() ==
+      "C-[O,S]-[C&R]1=&@[C&R]-&@[C&R]2(-&@[$([O,S])&R]-&@c3:c:c:c(-c4:c:c:c:c:c:4):c:c:3-&@[C&R]-&@2=[O,S])-&@[C&R](-[O,S]-C)=&@[C&R]-&@[C&R]-&@1-[O,S]");
   check_smarts_ok(*m1, *m2, res.front());
 }


### PR DESCRIPTION
#### Reference Issue
Fixes #8246


#### What does this implement/fix? Explain your changes.
The code that corrects the output SMARTS to remove atomic numbers >= 110 wasn't dealing with the case where the ringMatchesRingOnly option causes a &R addition to the SMARTS for the atoms in question.  It now does.

#### Any other comments?

