### PR TITLE
Rascal: Add option to specify minimum clique size directly.

### DIFF
--- a/Code/GraphMol/RascalMCES/RascalMCES.cpp
+++ b/Code/GraphMol/RascalMCES/RascalMCES.cpp
@@ -492,8 +492,8 @@ void makeModularProduct(const ROMol &mol1,
     return;
   }
   if (vtxPairs.size() > opts.maxBondMatchPairs) {
-    std::cerr << "Too many matching bond pairs (" << vtxPairs.size()
-              << ") so can't continue." << std::endl;
+    BOOST_LOG(rdErrorLog) << "Too many matching bond pairs (" << vtxPairs.size()
+                          << ") so can't continue." << std::endl;
     modProd.clear();
     return;
   }
@@ -1124,7 +1124,7 @@ std::vector<RascalResult> findMCES(RascalStartPoint &starter,
   try {
     explorePartitions(starter, startTime, tmpOpts, maxCliques);
   } catch (TimedOutException &e) {
-    std::cout << e.what() << std::endl;
+    BOOST_LOG(rdWarningLog) << e.what() << std::endl;
     maxCliques = e.d_cliques;
     timedOut = true;
   }

--- a/Code/GraphMol/RascalMCES/RascalMCES.cpp
+++ b/Code/GraphMol/RascalMCES/RascalMCES.cpp
@@ -1085,9 +1085,12 @@ RascalStartPoint makeInitialPartitionSet(const ROMol *mol1, const ROMol *mol2,
   if (starter.d_modProd.empty()) {
     return starter;
   }
-  starter.d_lowerBound = calcLowerBound(*starter.d_mol1, *starter.d_mol2,
-                                        opts.similarityThreshold);
-
+  if (opts.minCliqueSize > 0) {
+    starter.d_lowerBound = opts.minCliqueSize;
+  } else {
+    starter.d_lowerBound = calcLowerBound(*starter.d_mol1, *starter.d_mol2,
+                                          opts.similarityThreshold);
+  }
   starter.d_partSet.reset(new PartitionSet(starter.d_modProd,
                                            starter.d_vtxPairs, bondLabels1,
                                            bondLabels2, starter.d_lowerBound));

--- a/Code/GraphMol/RascalMCES/RascalOptions.h
+++ b/Code/GraphMol/RascalMCES/RascalOptions.h
@@ -58,6 +58,12 @@ struct RDKIT_RASCALMCES_EXPORT RascalOptions {
   bool ignoreAtomAromaticity = true; /* If true, atoms are matched just on
                                         atomic number; if false, will treat
                                         aromatic and aliphatic as different. */
+  int minCliqueSize = -1; /* Normally, the minimum clique size is specified
+                             via the similarityThreshold.  Sometimes it's
+                             more convenient to specify it directly.  If this
+                             is > 0, it will over-ride the
+                             similarityThreshold.  Note that this refers to
+                             the minimum number of BONDS in the MCES. */
 };
 }  // namespace RascalMCES
 }  // namespace RDKit

--- a/Code/GraphMol/RascalMCES/RascalOptions.h
+++ b/Code/GraphMol/RascalMCES/RascalOptions.h
@@ -58,7 +58,7 @@ struct RDKIT_RASCALMCES_EXPORT RascalOptions {
   bool ignoreAtomAromaticity = true; /* If true, atoms are matched just on
                                         atomic number; if false, will treat
                                         aromatic and aliphatic as different. */
-  int minCliqueSize = -1; /* Normally, the minimum clique size is specified
+  uint minCliqueSize = 0; /* Normally, the minimum clique size is specified
                              via the similarityThreshold.  Sometimes it's
                              more convenient to specify it directly.  If this
                              is > 0, it will over-ride the

--- a/Code/GraphMol/RascalMCES/RascalOptions.h
+++ b/Code/GraphMol/RascalMCES/RascalOptions.h
@@ -58,12 +58,13 @@ struct RDKIT_RASCALMCES_EXPORT RascalOptions {
   bool ignoreAtomAromaticity = true; /* If true, atoms are matched just on
                                         atomic number; if false, will treat
                                         aromatic and aliphatic as different. */
-  uint minCliqueSize = 0; /* Normally, the minimum clique size is specified
-                             via the similarityThreshold.  Sometimes it's
-                             more convenient to specify it directly.  If this
-                             is > 0, it will over-ride the
-                             similarityThreshold.  Note that this refers to
-                             the minimum number of BONDS in the MCES. */
+  unsigned int minCliqueSize = 0;    /* Normally, the minimum clique size is
+                                        specified via the similarityThreshold.
+                                        Sometimes it's more convenient to
+                                        specify it directly.  If this is > 0,
+                                        it will over-ride the similarityThreshold.
+                                        Note that this refers to the minimum
+                                        number of BONDS in the MCES. */
 };
 }  // namespace RascalMCES
 }  // namespace RDKit

--- a/Code/GraphMol/RascalMCES/Wrap/rdRascalMCES.cpp
+++ b/Code/GraphMol/RascalMCES/Wrap/rdRascalMCES.cpp
@@ -229,7 +229,7 @@ BOOST_PYTHON_MODULE(rdRascalMCES) {
                      " is > 0, it will over-ride the"
                      " similarityThreshold."
                      "  Note that this refers to the"
-                     " minimum number of BONDS in the MCES. Default=-1.");
+                     " minimum number of BONDS in the MCES. Default=0.");
 
   docString =
       "Find one or more MCESs between the 2 molecules given.  Returns a list of "

--- a/Code/GraphMol/RascalMCES/Wrap/rdRascalMCES.cpp
+++ b/Code/GraphMol/RascalMCES/Wrap/rdRascalMCES.cpp
@@ -220,7 +220,16 @@ BOOST_PYTHON_MODULE(rdRascalMCES) {
                      &RDKit::RascalMCES::RascalOptions::ignoreAtomAromaticity,
                      "If True, matches atoms solely on atomic number."
                      "  If False, will treat aromatic and aliphatic atoms"
-                     " as different.  Default=True.");
+                     " as different.  Default=True.")
+      .def_readwrite("minCliqueSize",
+                     &RDKit::RascalMCES::RascalOptions::minCliqueSize,
+                     "Normally, the minimum clique size is specified"
+                     " via the similarityThreshold.  Sometimes it's"
+                     " more convenient to specify it directly.  If this"
+                     " is > 0, it will over-ride the"
+                     " similarityThreshold."
+                     "  Note that this refers to the"
+                     " minimum number of BONDS in the MCES. Default=-1.");
 
   docString =
       "Find one or more MCESs between the 2 molecules given.  Returns a list of "

--- a/Code/GraphMol/RascalMCES/Wrap/testRascalMCES.py
+++ b/Code/GraphMol/RascalMCES/Wrap/testRascalMCES.py
@@ -210,6 +210,15 @@ class TestCase(unittest.TestCase):
     self.assertEqual(results[0].numFragments, 1)
     self.assertEqual(results[0].smartsString, 'NCC')
 
+  def testMinCliqueSize(self):
+    opts = rdRascalMCES.RascalOptions()
+    opts.similarityThreshold = 0.1
+    opts.minCliqueSize = 17
+    mol1 = Chem.MolFromSmiles('CC12CCC3C(C1CCC2O)CCC4=CC(=O)CCC34C')
+    mol2 = Chem.MolFromSmiles('CC12CCC3C(C1CCC2O)CCC4=C3C=CC(=C4)O')
+    results = rdRascalMCES.FindMCES(mol1, mol2, opts)
+    self.assertFalse(results)
+    
     
 if __name__ == "__main__":
   unittest.main()

--- a/Code/GraphMol/RascalMCES/mces_catch.cpp
+++ b/Code/GraphMol/RascalMCES/mces_catch.cpp
@@ -1477,3 +1477,20 @@ TEST_CASE("Duplicate Single Largest Frag") {
     CHECK(res.back().getBondMatches().size() == 23);
   }
 }
+
+TEST_CASE("Specify minimum clique size directly.") {
+  auto m1 = "CC12CCC3C(C1CCC2O)CCC4=CC(=O)CCC34C"_smiles;
+  REQUIRE(m1);
+  auto m2 = "CC12CCC3C(C1CCC2O)CCC4=C3C=CC(=C4)O"_smiles;
+  REQUIRE(m2);
+
+  RascalOptions opts;
+  opts.similarityThreshold = 0.6;
+  opts.minCliqueSize = 15;
+  auto res1 = rascalMCES(*m1, *m2, opts);
+  REQUIRE(res1.size() == 1);
+  CHECK(res1.front().getBondMatches().size() == 16);
+  opts.minCliqueSize = 17;
+  auto res2 = rascalMCES(*m1, *m2, opts);
+  REQUIRE(res2.empty());
+}


### PR DESCRIPTION
#### Reference Issue
No issue.  Requested by Lauren Reid of MedChemica.


#### What does this implement/fix? Explain your changes.
Normally the lower bound on the clique size is calculated from the similarityThreshold.  Sometimes it's convenient to specify it directly.

#### Any other comments?

