### PR TITLE
MolDraw2D: add separate colors for atom and bond annotations

### DIFF
--- a/Code/GraphMol/MolDraw2D/DrawMol.cpp
+++ b/Code/GraphMol/MolDraw2D/DrawMol.cpp
@@ -457,7 +457,7 @@ void DrawMol::extractAtomNotes() {
         DrawAnnotation *annot = new DrawAnnotation(
             note, TextAlignType::MIDDLE, "note",
             drawOptions_.annotationFontScale, Point2D(0.0, 0.0),
-            drawOptions_.annotationColour, textDrawer_);
+            drawOptions_.atomNoteColour, textDrawer_);
         calcAnnotationPosition(atom, *annot);
         annotations_.emplace_back(annot);
       }
@@ -512,7 +512,7 @@ void DrawMol::extractBondNotes() {
         DrawAnnotation *annot = new DrawAnnotation(
             note, TextAlignType::MIDDLE, "note",
             drawOptions_.annotationFontScale, Point2D(0.0, 0.0),
-            drawOptions_.annotationColour, textDrawer_);
+            drawOptions_.bondNoteColour, textDrawer_);
         calcAnnotationPosition(bond, *annot);
         annotations_.emplace_back(annot);
       }

--- a/Code/GraphMol/MolDraw2D/MolDraw2D.h
+++ b/Code/GraphMol/MolDraw2D/MolDraw2D.h
@@ -547,7 +547,7 @@ class RDKIT_MOLDRAW2D_EXPORT MolDraw2D {
 inline void setDarkMode(MolDrawOptions &opts) {
   assignDarkModePalette(opts.atomColourPalette);
   opts.backgroundColour = DrawColour{0.0, 0.0, 0.0, 1.0};
-  opts.annotationColour = DrawColour{0.9, 0.9, 0.9, 1.0};
+  opts.atomNoteColour = opts.annotationColour = DrawColour{0.9, 0.9, 0.9, 1.0};
   opts.legendColour = DrawColour{0.9, 0.9, 0.9, 1.0};
   opts.symbolColour = DrawColour{0.9, 0.9, 0.9, 1.0};
   opts.variableAttachmentColour = DrawColour{0.3, 0.3, 0.3, 1.0};
@@ -558,7 +558,7 @@ inline void setMonochromeMode(MolDrawOptions &opts, const DrawColour &fgColour,
   opts.atomColourPalette.clear();
   opts.atomColourPalette[-1] = fgColour;
   opts.backgroundColour = bgColour;
-  opts.annotationColour = fgColour;
+  opts.atomNoteColour = opts.bondNoteColour = opts.annotationColour = fgColour;
   opts.legendColour = fgColour;
   opts.symbolColour = fgColour;
   opts.variableAttachmentColour = fgColour;

--- a/Code/GraphMol/MolDraw2D/MolDraw2DHelpers.h
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DHelpers.h
@@ -221,7 +221,11 @@ struct RDKIT_MOLDRAW2D_EXPORT MolDrawOptions {
       1.0};  // color to be used for the symbols and arrows in reactions
   DrawColour annotationColour{0.0, 0.0, 0.0,
                               1.0};  // color to be used for annotations
-  double bondLineWidth = 2.0;        // default line width when drawing bonds
+  DrawColour atomNoteColour{
+      0.0, 0.0, 0.0, 1.0};  // color to be used for atom indices and notes
+  DrawColour bondNoteColour{
+      0.5, 0.5, 1.0, 1.0};      // color to be used for bond indices and notes
+  double bondLineWidth = 2.0;   // default line width when drawing bonds
   bool scaleBondWidth = false;  // whether to apply scale() to the bond width
   bool scaleHighlightBondWidth = true;   // likewise with bond highlights.
   int highlightBondWidthMultiplier = 8;  // what to multiply standard bond width

--- a/Code/GraphMol/MolDraw2D/MolDraw2DUtils.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DUtils.cpp
@@ -265,6 +265,8 @@ void updateMolDrawOptionsFromJSON(MolDrawOptions &opts,
   get_colour_option(pt, "legendColour", opts.legendColour);
   get_colour_option(pt, "symbolColour", opts.symbolColour);
   get_colour_option(pt, "annotationColour", opts.annotationColour);
+  get_colour_option(pt, "atomNoteColour", opts.atomNoteColour);
+  get_colour_option(pt, "bondNoteColour", opts.bondNoteColour);
   get_colour_option(pt, "variableAttachmentColour",
                     opts.variableAttachmentColour);
   get_colour_palette_option(pt, "atomColourPalette", opts.atomColourPalette);

--- a/Code/GraphMol/MolDraw2D/Wrap/rdMolDraw2D.cpp
+++ b/Code/GraphMol/MolDraw2D/Wrap/rdMolDraw2D.cpp
@@ -487,8 +487,7 @@ void setAtomNoteColour(RDKit::MolDrawOptions &self, python::tuple tpl) {
 python::object getAtomNoteColour(const RDKit::MolDrawOptions &self) {
   return colourToPyTuple(self.atomNoteColour);
 }
-python::object setBondNoteColour(RDKit::MolDrawOptions &self,
-                                 python::tuple tpl) {
+void setBondNoteColour(RDKit::MolDrawOptions &self, python::tuple tpl) {
   self.bondNoteColour = pyTupleToDrawColour(tpl);
 }
 python::object getBondNoteColour(const RDKit::MolDrawOptions &self) {

--- a/Code/GraphMol/MolDraw2D/Wrap/rdMolDraw2D.cpp
+++ b/Code/GraphMol/MolDraw2D/Wrap/rdMolDraw2D.cpp
@@ -481,7 +481,19 @@ python::object getAnnotationColour(const RDKit::MolDrawOptions &self) {
 void setAnnotationColour(RDKit::MolDrawOptions &self, python::tuple tpl) {
   self.annotationColour = pyTupleToDrawColour(tpl);
 }
-
+void setAtomNoteColour(RDKit::MolDrawOptions &self, python::tuple tpl) {
+  self.atomNoteColour = pyTupleToDrawColour(tpl);
+}
+python::object getAtomNoteColour(const RDKit::MolDrawOptions &self) {
+  return colourToPyTuple(self.atomNoteColour);
+}
+python::object setBondNoteColour(RDKit::MolDrawOptions &self,
+                                 python::tuple tpl) {
+  self.bondNoteColour = pyTupleToDrawColour(tpl);
+}
+python::object getBondNoteColour(const RDKit::MolDrawOptions &self) {
+  return colourToPyTuple(self.bondNoteColour);
+}
 python::object getVariableAttachmentColour(const RDKit::MolDrawOptions &self) {
   return colourToPyTuple(self.variableAttachmentColour);
 }
@@ -790,6 +802,16 @@ BOOST_PYTHON_MODULE(rdMolDraw2D) {
       .def("setAnnotationColour", &RDKit::setAnnotationColour,
            python::args("self", "tpl"),
            "method for setting the annotation colour")
+      .def("setAtomNoteColour", &RDKit::setAtomNoteColour,
+           python::args("self", "tpl"),
+           "method for setting the atom note colour")
+      .def("getAtomNoteColour", &RDKit::getAtomNoteColour, python::args("self"),
+           "method returning the atom note colour")
+      .def("setBondNoteColour", &RDKit::setBondNoteColour,
+           python::args("self", "tpl"),
+           "method for setting the bond note colour")
+      .def("getBondNoteColour", &RDKit::getBondNoteColour, python::args("self"),
+           "method returning the bond note colour")
       .def("getLegendColour", &RDKit::getLegendColour, python::args("self"),
            "method returning the legend colour")
       .def("setLegendColour", &RDKit::setLegendColour,
@@ -1437,9 +1459,10 @@ https://en.wikipedia.org/wiki/Wikipedia:Manual_of_Style/Chemistry/Structure_draw
               (python::arg("mol"), python::arg("confId") = -1),
               "Calculate the mean bond length for the molecule.");
   python::def("SetDarkMode",
-              (void (*)(RDKit::MolDrawOptions &))&RDKit::setDarkMode,
+              (void (*)(RDKit::MolDrawOptions &)) & RDKit::setDarkMode,
               python::args("d2d"), "set dark mode for a MolDrawOptions object");
-  python::def("SetDarkMode", (void (*)(RDKit::MolDraw2D &))&RDKit::setDarkMode,
+  python::def("SetDarkMode",
+              (void (*)(RDKit::MolDraw2D &)) & RDKit::setDarkMode,
               python::args("d2d"), "set dark mode for a MolDraw2D object");
   python::def("SetMonochromeMode", RDKit::setMonochromeMode_helper1,
               (python::arg("options"), python::arg("fgColour"),

--- a/Code/GraphMol/MolDraw2D/catch_tests.cpp
+++ b/Code/GraphMol/MolDraw2D/catch_tests.cpp
@@ -3475,6 +3475,7 @@ TEST_CASE("support annotation colors", "[drawing]") {
     MolDraw2DSVG drawer(300, 300, panelWidth, panelHeight, noFreeType);
     drawer.drawOptions().annotationColour = DrawColour{0, 0, 1, 1};
     drawer.drawOptions().addAtomIndices = true;
+    m->setProp("molNote", "foo");
     drawer.drawMolecule(*m, "blue annotations");
     drawer.finishDrawing();
     std::ofstream outs("testAnnotationColors.svg");
@@ -3482,7 +3483,9 @@ TEST_CASE("support annotation colors", "[drawing]") {
     outs << txt;
     outs.close();
     check_file_hash("testAnnotationColors.svg");
-    CHECK(txt.find("fill:#0000FF' >2<") != std::string::npos);
+    CHECK(txt.find("fill:#0000FF' >f<") != std::string::npos);
+    // the general annotation colour change does not affect atom annotations:
+    CHECK(txt.find("fill:#000000' >2<") != std::string::npos);
   }
 }
 

--- a/Code/GraphMol/MolDraw2D/catch_tests.cpp
+++ b/Code/GraphMol/MolDraw2D/catch_tests.cpp
@@ -358,6 +358,10 @@ const std::map<std::string, std::hash_result_t> SVG_HASHES = {
     {"testComponentPadding_1.svg", 2106266352U},
     {"testComponentPadding_2.svg", 1006560295U},
     {"testReactionPanels.svg", 3629304831U},
+    {"testAtomAndBondLabels_1.svg", 288825710U},
+    {"testAtomAndBondLabels_2.svg", 3501435082U},
+    {"testAtomAndBondLabels_3.svg", 3056536314U},
+    {"testAtomAndBondLabels_4.svg", 229616498U},
 };
 
 // These PNG hashes aren't completely reliable due to floating point cruft,
@@ -10474,5 +10478,78 @@ TEST_CASE("Optionally increase padding round components in reaction drawing") {
       outs.close();
     }
 #endif
+  }
+}
+
+TEST_CASE("atom and bond label colors") {
+  auto m = "c1ncccc1CCCc1ccccc1"_smiles;
+  REQUIRE(m);
+
+  {
+    MolDraw2DSVG drawer(300, 300, -1, -1, NO_FREETYPE);
+    drawer.drawOptions().addAtomIndices = true;
+    drawer.drawOptions().addBondIndices = true;
+    drawer.drawMolecule(*m);
+    drawer.finishDrawing();
+    auto text = drawer.getDrawingText();
+    std::ofstream outs("testAtomAndBondLabels_1.svg");
+    outs << text;
+    outs.close();
+    check_file_hash("testAtomAndBondLabels_1.svg");
+    CHECK(text.find("fill:#000000' >1</text>") != std::string::npos);
+    CHECK(text.find("fill:#7F7FFF' >1</text>") != std::string::npos);
+  }
+
+  {
+    MolDraw2DSVG drawer(300, 300, -1, -1, NO_FREETYPE);
+    drawer.drawOptions().addAtomIndices = true;
+    drawer.drawOptions().addBondIndices = true;
+    drawer.drawOptions().bondNoteColour = DrawColour(0, 0, 1.);
+    drawer.drawOptions().atomNoteColour = DrawColour(1., 0, 1.);
+
+    drawer.drawMolecule(*m);
+    drawer.finishDrawing();
+    auto text = drawer.getDrawingText();
+    std::ofstream outs("testAtomAndBondLabels_2.svg");
+    outs << text;
+    outs.close();
+    check_file_hash("testAtomAndBondLabels_2.svg");
+    CHECK(text.find("fill:#FF00FF' >1</text>") != std::string::npos);
+    CHECK(text.find("fill:#0000FF' >1</text>") != std::string::npos);
+  }
+  {
+    MolDraw2DSVG drawer(300, 300, -1, -1, NO_FREETYPE);
+    drawer.drawOptions().addAtomIndices = true;
+    drawer.drawOptions().addBondIndices = true;
+    setDarkMode(drawer.drawOptions());
+    drawer.drawMolecule(*m);
+    drawer.finishDrawing();
+    auto text = drawer.getDrawingText();
+    std::ofstream outs("testAtomAndBondLabels_3.svg");
+    outs << text;
+    outs.close();
+    check_file_hash("testAtomAndBondLabels_3.svg");
+    CHECK(text.find("fill:#E5E5E5' >1</text>") != std::string::npos);
+    CHECK(text.find("fill:#7F7FFF' >1</text>") != std::string::npos);
+  }
+  {
+    MolDraw2DSVG drawer(300, 300, -1, -1, NO_FREETYPE);
+    drawer.drawOptions().addAtomIndices = true;
+    drawer.drawOptions().addBondIndices = true;
+    setMonochromeMode(drawer.drawOptions(), DrawColour(0.1, 0.1, 0.1),
+                      DrawColour(0.9, 0.9, 0.9));
+    drawer.drawMolecule(*m);
+    drawer.finishDrawing();
+    auto text = drawer.getDrawingText();
+    std::ofstream outs("testAtomAndBondLabels_4.svg");
+    outs << text;
+    outs.close();
+    check_file_hash("testAtomAndBondLabels_4.svg");
+    CHECK(text.find("fill:#191919' >1</text>") != std::string::npos);
+    // check for a second occurrence of the same text since atoms and bonds are
+    // the same color
+    CHECK(text.find("fill:#191919' >1</text>",
+                    text.find("fill:#191919' >1</text>") + 1) !=
+          std::string::npos);
   }
 }

--- a/Code/GraphMol/MolDraw2D/test1.cpp
+++ b/Code/GraphMol/MolDraw2D/test1.cpp
@@ -4040,7 +4040,7 @@ void test20Annotate() {
     TEST_ASSERT(text.find("<text x='260.3' y='232.0' class='note' "
                           "style='font-size:20px;font-style:normal;font-weight:"
                           "normal;fill-opacity:1;stroke:none;font-family:sans-"
-                          "serif;text-anchor:start;fill:#000000' >E</text>") !=
+                          "serif;text-anchor:start;fill:#7F7FFF' >E</text>") !=
                 std::string::npos);
 #endif
     check_file_hash("test20_2.svg");

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -19,6 +19,7 @@ GraphMol/RGroupDecomposition/RGroupDecompJSONParsers.h, respectively.
 with the underlying types. This may require existing C++ code using those
 functions to be updated accordingly.
 - HasPropWithValueQueryBase used RDKit::Dict::Pair to return data used for serializing object in a molecule  pickle.  This has been changed to RDKit::PairHolder which automatically manages memory.
+- The colors of annotations on atoms and bonds are now controlled by the drawing options `atomNoteColour` and `bondNoteColour` instead of the general `annotationColour`.
 
 ## New Features and Enhancements:
 


### PR DESCRIPTION
It is very often difficult to distinguish between atom and bond indices when both are displayed at the same time.
This changes that by adding new parameters to control the color of the atom and bond indices separately and to make them, by default, different.

Here's what the default behavior looks like when this PR is applied:
![image](https://github.com/user-attachments/assets/17b36a12-3766-4e43-a67f-5e34bc83b199)
