### PR TITLE
Fixes #8256

### DIFF
--- a/Code/GraphMol/catch_adjustquery.cpp
+++ b/Code/GraphMol/catch_adjustquery.cpp
@@ -815,3 +815,16 @@ TEST_CASE(
     // clang-format on
   }
 }
+
+TEST_CASE(
+    "Github #8256: PR #8192 breaks AdjustQueryProperties / aromatizeIfPossible for some molecules") {
+  SECTION("between aromatic atoms") {
+    auto mol =
+        R"SMARTS([#6]1=[#6]-[#6]=[#6]-[#6]=[#6]-1/[#7](=[#7]\[#8])-*)SMARTS"_smarts;
+    REQUIRE(mol);
+    auto ps = MolOps::AdjustQueryParameters::noAdjustments();
+    ps.aromatizeIfPossible = true;
+    MolOps::adjustQueryProperties(*mol, &ps);
+    CHECK(MolToSmiles(*mol) == "*/N(=N/O)c1ccccc1");
+  }
+}


### PR DESCRIPTION
Fixes #8256.

The issue is in `countAtomElec()`, which now returns a different electron count for the ring C atom connected to the N atom, than before #8256 was merged. 

The cause of this is the "single or aromatic" query that is added since #8256. This query is not caught by `isBondOrderQuery()` (a "single or aromatic" query is definitely a bond order query, even if a complex one), and causes `QueryBond::getValenceContrib()` to return 0, as query bonds don't contribute to valence. This means that `countAtomElec()` discounts the bond from the degree, which prevents the aromatization of the ring.

This patch updates `isBondOrderQuery()` to first check the bond order: if the bond is "real" (i.e. it has a non-zero order), and if that's not the case, then check if it's a bond order query bond (either a simple or complex query). In either of those cases, the bond will be considered to contribute to the atom's degree. Otherwise, it won't be counted.

The reason for the `static_cast<Bond *>(bond)` is that we don't want to use the `QueryBond` overload, as it will duplicate what we do in `isBondOrderQuery()`, but it will return "0" in case of a complex bond query, which we don't want.

