### PR TITLE
Initial Rascal results sort the wrong way round on number of atoms and bonds.

### DIFF
--- a/Code/GraphMol/RascalMCES/RascalMCES.cpp
+++ b/Code/GraphMol/RascalMCES/RascalMCES.cpp
@@ -1126,10 +1126,6 @@ std::vector<RascalResult> findMCES(RascalStartPoint &starter,
                      opts.maxFragSeparation, opts.exactConnectionsMatch,
                      opts.equivalentAtoms, opts.ignoreBondOrders));
   }
-  // If 2 cliques are the same size, this sort puts the one with the smaller
-  // number of fragments first, which may have fewer atoms.
-  std::sort(results.begin(), results.end(), details::resultCompare);
-
   if (opts.singleLargestFrag) {
     std::sort(
         results.begin(), results.end(),
@@ -1174,6 +1170,10 @@ std::vector<RascalResult> findMCES(RascalStartPoint &starter,
       }
       results.erase(results.begin() + j, results.end());
     }
+  } else {
+    // If 2 cliques are the same size, this sort puts the one with the smaller
+    // number of fragments first, which may have fewer atoms.
+    std::sort(results.begin(), results.end(), details::resultCompare);
   }
   return results;
 }

--- a/Code/GraphMol/RascalMCES/RascalMCES.cpp
+++ b/Code/GraphMol/RascalMCES/RascalMCES.cpp
@@ -1126,15 +1126,25 @@ std::vector<RascalResult> findMCES(RascalStartPoint &starter,
                      opts.maxFragSeparation, opts.exactConnectionsMatch,
                      opts.equivalentAtoms, opts.ignoreBondOrders));
   }
+  // If 2 cliques are the same size, this sort puts the one with the smaller
+  // number of fragments first, which may have fewer atoms.
+  std::sort(results.begin(), results.end(), details::resultCompare);
 
   if (opts.singleLargestFrag) {
-    std::sort(results.begin(), results.end(),
-              [](const RascalResult &r1, const RascalResult &r2) -> bool {
-                if (r1.getAtomMatches() == r2.getAtomMatches()) {
-                  return (r1.getBondMatches() > r2.getBondMatches());
-                }
-                return (r1.getAtomMatches() > r2.getAtomMatches());
-              });
+    std::sort(
+        results.begin(), results.end(),
+        [](const RascalResult &r1, const RascalResult &r2) -> bool {
+          if (r1.getAtomMatches().size() == r2.getAtomMatches().size()) {
+            if (r1.getBondMatches().size() == r2.getBondMatches().size()) {
+              if (r1.getAtomMatches() == r2.getAtomMatches()) {
+                return (r1.getBondMatches() < r2.getBondMatches());
+              }
+              return r1.getAtomMatches() < r2.getAtomMatches();
+            }
+            return r1.getBondMatches().size() > r2.getBondMatches().size();
+          }
+          return (r1.getAtomMatches().size() > r2.getAtomMatches().size());
+        });
 
     // the singleLargestFrag method throws bits of solutions out, so there may
     // now be duplicates and results that are different sizes.

--- a/Code/GraphMol/RascalMCES/RascalMCES.cpp
+++ b/Code/GraphMol/RascalMCES/RascalMCES.cpp
@@ -1131,9 +1131,9 @@ std::vector<RascalResult> findMCES(RascalStartPoint &starter,
     std::sort(results.begin(), results.end(),
               [](const RascalResult &r1, const RascalResult &r2) -> bool {
                 if (r1.getAtomMatches() == r2.getAtomMatches()) {
-                  return (r1.getBondMatches() < r2.getBondMatches());
+                  return (r1.getBondMatches() > r2.getBondMatches());
                 }
-                return (r1.getAtomMatches() < r2.getAtomMatches());
+                return (r1.getAtomMatches() > r2.getAtomMatches());
               });
 
     // the singleLargestFrag method throws bits of solutions out, so there may
@@ -1165,7 +1165,6 @@ std::vector<RascalResult> findMCES(RascalStartPoint &starter,
       results.erase(results.begin() + j, results.end());
     }
   }
-  std::sort(results.begin(), results.end(), details::resultCompare);
   return results;
 }
 

--- a/Code/GraphMol/RascalMCES/mces_catch.cpp
+++ b/Code/GraphMol/RascalMCES/mces_catch.cpp
@@ -1517,3 +1517,36 @@ TEST_CASE("Duplicate Single Largest Frag") {
     CHECK(res.back().getBondMatches().size() == 23);
   }
 }
+
+TEST_CASE("Github8255 - incorrect MCES with singleLargestFrag=true") {
+  RascalOptions opts;
+  opts.singleLargestFrag = true;
+  opts.allBestMCESs = true;
+  opts.ignoreAtomAromaticity = true;
+  opts.ringMatchesRingOnly = true;
+  opts.completeAromaticRings = false;
+  {
+    auto m1 = "Cc1ccc(cn1)-c1ccc(cn1)-c1ccc2ccccc2n1"_smiles;
+    REQUIRE(m1);
+    auto m2 = "Cc1ccc(cn1)-c1ccc(cn1)-c1cc2ccccc2[nH]1"_smiles;
+    REQUIRE(m2);
+    auto res = rascalMCES(*m1, *m2, opts);
+    CHECK(res.size() == 3);
+    for (auto &r : res) {
+      CHECK(r.getAtomMatches().size() == 20);
+      CHECK(r.getBondMatches().size() == 21);
+    }
+  }
+  {
+    auto m1 = "Cc1ncc(cc1)c2ncc(cc2)c3ccc4c(c3)cn[nH]4"_smiles;
+    REQUIRE(m1);
+    auto m2 = "Cc1ncc(cc1)c2ncc(cc2)c3ccc4c(c3)nccn4"_smiles;
+    REQUIRE(m2);
+    auto res = rascalMCES(*m1, *m2, opts);
+    CHECK(res.size() == 2);
+    for (auto &r : res) {
+      CHECK(r.getAtomMatches().size() == 20);
+      CHECK(r.getBondMatches().size() == 22);
+    }
+  }
+}

--- a/Code/GraphMol/RascalMCES/mces_catch.cpp
+++ b/Code/GraphMol/RascalMCES/mces_catch.cpp
@@ -680,7 +680,7 @@ TEST_CASE("ring matches ring", "[basics]") {
   REQUIRE(res.front().getBondMatches().size() == 9);
   REQUIRE_THAT(res.front().getSimilarity(),
                Catch::Matchers::WithinAbs(0.1863, 0.0001));
-  REQUIRE(res.front().getSmarts() == "C(-C=O)-c1:c:c:c:c:c:1");
+  REQUIRE(res.front().getSmarts() == "c1:c:c:c:c:c:1-CC=O");
   check_smarts_ok(*m1, *m2, res.front());
 }
 
@@ -717,7 +717,6 @@ TEST_CASE("multiple cliques returned") {
 
   RascalOptions opts;
   opts.similarityThreshold = 0.5;
-  opts.allBestMCESs = true;
 
   for (auto &test : tests) {
     opts.allBestMCESs = true;
@@ -725,9 +724,10 @@ TEST_CASE("multiple cliques returned") {
     std::unique_ptr<RDKit::RWMol> m2(RDKit::SmilesToMol(std::get<1>(test)));
 
     auto res = rascalMCES(*m1, *m2, opts);
-    REQUIRE(res.size() == std::get<2>(test));
-    REQUIRE(res.front().getBondMatches().size() == std::get<3>(test));
-    REQUIRE(res.front().getBondMatches() == std::get<4>(test));
+    REQUIRE(!res.empty());
+    CHECK(res.size() == std::get<2>(test));
+    CHECK(res.front().getBondMatches().size() == std::get<3>(test));
+    CHECK(res.front().getBondMatches() == std::get<4>(test));
     check_smarts_ok(*m1, *m2, res.front());
 
     opts.allBestMCESs = false;
@@ -735,7 +735,7 @@ TEST_CASE("multiple cliques returned") {
     REQUIRE(res.size() == 1);
     // The clique won't necessarily be the best-scoring one, but it should be
     // the same size.
-    REQUIRE(res.front().getBondMatches().size() == std::get<4>(test).size());
+    CHECK(res.front().getBondMatches().size() == std::get<4>(test).size());
     check_smarts_ok(*m1, *m2, res.front());
   }
 }


### PR DESCRIPTION

#### Reference Issue
Fixes #8255

#### What does this implement/fix? Explain your changes.
In the singleLargestFrag = true option, the initial sort of the results should have been in descending order of number of bonds and number of atoms but was ascending so the removal of smaller hits failed.

#### Any other comments?
Doh!
