### PR TITLE
When ignoring tetrahedral chirality for inchi, case on degree, not valence

### DIFF
--- a/External/INCHI-API/inchi.cpp
+++ b/External/INCHI-API/inchi.cpp
@@ -1843,7 +1843,7 @@ std::string MolToInchi(const ROMol &mol, ExtraInchiReturnValues &rv,
     if (atom->getChiralTag() == Atom::ChiralType::CHI_TETRAHEDRAL_CCW ||
         atom->getChiralTag() == Atom::ChiralType::CHI_TETRAHEDRAL_CW) {
       atom->calcImplicitValence();
-      if (auto tval = atom->getTotalValence(); tval < 3 || tval > 4) {
+      if (auto tval = atom->getTotalDegree(); tval < 3 || tval > 4) {
         BOOST_LOG(rdWarningLog)
             << "tetrahedral chirality on atom with <3 or >4 neighbors will be ignored."
             << std::endl;

--- a/External/INCHI-API/test.cpp
+++ b/External/INCHI-API/test.cpp
@@ -938,6 +938,27 @@ void testGithub8123() {
   BOOST_LOG(rdInfoLog) << "done" << std::endl;
 }
 
+void testGithub8239() {
+  BOOST_LOG(rdErrorLog) << "-------------------------------------" << std::endl;
+  BOOST_LOG(rdInfoLog) << "testing github #8239" << std::endl;
+
+  {
+    auto m = "CO[P@](=O)(OCC1C(C(CO1)O)O)OP(=O)(O)O"_smiles;
+    TEST_ASSERT(m);
+    ExtraInchiReturnValues tmp;
+    auto inchi = MolToInchi(*m, tmp);
+    TEST_ASSERT(inchi == "InChI=1S/C6H14O10P2/c1-13-18(12,16-17(9,10)11)15-3-5-6(8)4(7)2-14-5/h4-8H,2-3H2,1H3,(H2,9,10,11)/t4?,5?,6?,18-/m1/s1");
+  }
+  {
+    auto m = "CO[P@@](=O)(OCC1C(C(CO1)O)O)OP(=O)(O)O"_smiles;
+    TEST_ASSERT(m);
+    ExtraInchiReturnValues tmp;
+    auto inchi = MolToInchi(*m, tmp);
+    TEST_ASSERT(inchi == "InChI=1S/C6H14O10P2/c1-13-18(12,16-17(9,10)11)15-3-5-6(8)4(7)2-14-5/h4-8H,2-3H2,1H3,(H2,9,10,11)/t4?,5?,6?,18-/m0/s1");
+  }
+  BOOST_LOG(rdInfoLog) << "done" << std::endl;
+}
+
 //-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
 //
 //-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
@@ -963,4 +984,5 @@ int main() {
   testGithub6172();
   testGithub5311();
   testGithub8123();
+  testGithub8239();
 }


### PR DESCRIPTION
#### Reference Issue
Fixes #8238
Fixes #8239
Modification of #8126


#### What does this implement/fix? Explain your changes.
The code and warning discussed neighbors, but cased on total valence. Switching to `totalDegree` brought chirality of chiral phosphates back to InChI. All existing tests pass, and a new test on these phosphates was added.


#### Any other comments?

