### PR TITLE
Restore functionality of the MinimalLib Dockerfile and improve exception handling performance

### DIFF
--- a/Code/MinimalLib/docker/Dockerfile
+++ b/Code/MinimalLib/docker/Dockerfile
@@ -23,8 +23,9 @@ ARG RDKIT_GIT_URL="https://github.com/rdkit/rdkit.git"
 ARG RDKIT_BRANCH="master"
 ARG EMSDK_VERSION="latest"
 ARG BOOST_MAJOR_VERSION="1"
-ARG BOOST_MINOR_VERSION="84"
+ARG BOOST_MINOR_VERSION="87"
 ARG BOOST_PATCH_VERSION="0"
+ARG FREETYPE_VERSION="2.13.3"
 
 FROM debian:bookworm as build-stage
 ARG RDKIT_GIT_URL
@@ -33,6 +34,7 @@ ARG EMSDK_VERSION
 ARG BOOST_MAJOR_VERSION
 ARG BOOST_MINOR_VERSION
 ARG BOOST_PATCH_VERSION
+ARG FREETYPE_VERSION
 
 LABEL maintainer="Greg Landrum <greg.landrum@t5informatics.com>"
 
@@ -49,15 +51,14 @@ RUN apt-get update && apt-get upgrade -y && apt install -y \
 
 ENV LANG C
 
-WORKDIR /opt
+WORKDIR /src
 ARG BOOST_DOT_VERSION="${BOOST_MAJOR_VERSION}.${BOOST_MINOR_VERSION}.${BOOST_PATCH_VERSION}"
 ARG BOOST_UNDERSCORE_VERSION="${BOOST_MAJOR_VERSION}_${BOOST_MINOR_VERSION}_${BOOST_PATCH_VERSION}"
-RUN wget -q https://boostorg.jfrog.io/artifactory/main/release/${BOOST_DOT_VERSION}/source/boost_${BOOST_UNDERSCORE_VERSION}.tar.gz && \
+RUN wget -q https://archives.boost.io/release/${BOOST_DOT_VERSION}/source/boost_${BOOST_UNDERSCORE_VERSION}.tar.gz && \
   tar xzf boost_${BOOST_UNDERSCORE_VERSION}.tar.gz
-WORKDIR /opt/boost_${BOOST_UNDERSCORE_VERSION}
+WORKDIR /src/boost_${BOOST_UNDERSCORE_VERSION}
 RUN ./bootstrap.sh --prefix=/opt/boost --with-libraries=system && \
   ./b2 install
-
 
 WORKDIR /opt
 RUN git clone https://github.com/emscripten-core/emsdk.git
@@ -68,30 +69,41 @@ RUN ./emsdk install ${EMSDK_VERSION} && \
 
 #RUN source ./emsdk_env.sh
 
-RUN mkdir /src
+RUN echo "source /opt/emsdk/emsdk_env.sh > /dev/null 2>&1" >> ~/.bashrc
+SHELL ["/bin/bash", "-c", "-l"]
+
+WORKDIR /src
+RUN wget -q https://download.savannah.gnu.org/releases/freetype/freetype-${FREETYPE_VERSION}.tar.gz && \
+  tar xzf freetype-${FREETYPE_VERSION}.tar.gz
+WORKDIR /src/freetype-${FREETYPE_VERSION}
+RUN mkdir build
+WORKDIR /src/freetype-${FREETYPE_VERSION}/build
+RUN emcmake cmake -DCMAKE_BUILD_TYPE=Release -DWITH_ZLIB=OFF -DWITH_BZip2=OFF -DWITH_PNG=OFF \
+  -DCMAKE_C_FLAGS="-fwasm-exceptions" -DCMAKE_EXE_LINKER_FLAGS="-fwasm-exceptions" \
+  -DCMAKE_INSTALL_PREFIX=/opt/freetype ..
+RUN make -j2 && make -j2 install
+
 WORKDIR /src
 ENV RDBASE=/src/rdkit
 RUN git clone ${RDKIT_GIT_URL}
 WORKDIR $RDBASE
 RUN git fetch --all --tags && \
   git checkout ${RDKIT_BRANCH}
-
 RUN mkdir build
 WORKDIR $RDBASE/build
-
-RUN echo "source /opt/emsdk/emsdk_env.sh > /dev/null 2>&1" >> ~/.bashrc
-SHELL ["/bin/bash", "-c", "-l"]
-RUN emcmake cmake -DBoost_INCLUDE_DIR=/opt/boost/include -DRDK_BUILD_FREETYPE_SUPPORT=ON -DRDK_BUILD_MINIMAL_LIB=ON \
+RUN emcmake cmake -DRDK_BUILD_FREETYPE_SUPPORT=ON -DRDK_BUILD_MINIMAL_LIB=ON \
   -DRDK_BUILD_PYTHON_WRAPPERS=OFF -DRDK_BUILD_CPP_TESTS=OFF -DRDK_BUILD_INCHI_SUPPORT=ON \
   -DRDK_USE_BOOST_SERIALIZATION=OFF -DRDK_OPTIMIZE_POPCNT=OFF -DRDK_BUILD_THREADSAFE_SSS=OFF \
   -DRDK_BUILD_DESCRIPTORS3D=OFF -DRDK_TEST_MULTITHREADED=OFF \
   -DRDK_BUILD_MAEPARSER_SUPPORT=OFF -DRDK_BUILD_COORDGEN_SUPPORT=ON \
+  -DBoost_DIR=/opt/boost/lib/cmake/Boost-${BOOST_DOT_VERSION} \
+  -Dboost_headers_DIR=/opt/boost/lib/cmake/boost_headers-${BOOST_DOT_VERSION} \
   -DRDK_BUILD_SLN_SUPPORT=OFF -DRDK_USE_BOOST_IOSTREAMS=OFF \
-  -DFREETYPE_INCLUDE_DIRS=/opt/emsdk/upstream/emscripten/cache/sysroot/include/freetype2 \
-  -DFREETYPE_LIBRARY=/opt/emsdk/upstream/emscripten/cache/sysroot/lib/wasm32-emscripten/libfreetype.a \
-  -DCMAKE_CXX_FLAGS="-Wno-enum-constexpr-conversion -s DISABLE_EXCEPTION_CATCHING=0" \
-  -DCMAKE_C_FLAGS="-Wno-enum-constexpr-conversion -DCOMPILE_ANSI_ONLY" \
-  -DCMAKE_EXE_LINKER_FLAGS="-s MODULARIZE=1 -s EXPORT_NAME=\"'initRDKitModule'\"" ..
+  -DFREETYPE_INCLUDE_DIRS=/opt/freetype/include/freetype2 \
+  -DFREETYPE_LIBRARY=/opt/freetype/lib/libfreetype.a \
+  -DCMAKE_CXX_FLAGS="-O3 -DNDEBUG -fwasm-exceptions" \
+  -DCMAKE_C_FLAGS="-O3 -DNDEBUG -DCOMPILE_ANSI_ONLY" \
+  -DCMAKE_EXE_LINKER_FLAGS="-fwasm-exceptions -s STACK_OVERFLOW_CHECK=1 -s USE_PTHREADS=0 -s ALLOW_MEMORY_GROWTH=1 -s MAXIMUM_MEMORY=4GB -s MODULARIZE=1 -s EXPORT_NAME=\"'initRDKitModule'\"" ..
 
 # "patch" to make the InChI code work with emscripten:
 RUN cp /src/rdkit/External/INCHI-API/src/INCHI_BASE/src/util.c /src/rdkit/External/INCHI-API/src/INCHI_BASE/src/util.c.bak && \


### PR DESCRIPTION
@greglandrum This PR restores functionality of the MinimalLib Dockerfile and switches exception handling to native WebAssembly exception handling [which has much better performance](https://emscripten.org/docs/porting/exceptions.html#webassembly-exception-handling-based-support) than the legacy JS handling. I have been building MinimalLib with `-fwasm-exceptions` for the past 2 years and I never incurred into problems.

- bump `boost` version to `1.87`
- fetch `boost` sources from `archives.boost.io`
- build in `/src` rather than in `/opt`
- build `freetype` from source with `-fwasm-exceptions` support as the emscripten port on GitHub is outdated and archived
- build RDKit with `-fwasm-exceptions` support as performance is significantly better than with `DISABLE_EXCEPTION_CATCHING=0`
