### PR TITLE
Use  linux-arm64 CI runners

### DIFF
--- a/.azure-pipelines/linux_build_arm64.yml
+++ b/.azure-pipelines/linux_build_arm64.yml
@@ -1,0 +1,92 @@
+steps:
+- bash: | 
+    export CONDA=/tmp/miniforge
+    wget https://github.com/conda-forge/miniforge/releases/download/25.1.1-0/Miniforge3-25.1.1-0-Linux-aarch64.sh
+    bash Miniforge3-25.1.1-0-Linux-aarch64.sh -b -p ${CONDA}
+  displayName: install conda
+- bash: |
+    export CONDA=/tmp/miniforge
+    sudo apt-get install g++=$(cxx) wget make libgl1-mesa-dev mesa-common-dev
+    source ${CONDA}/etc/profile.d/conda.sh
+    sudo chown -R ${USER} ${CONDA}
+    conda config --set always_yes yes --set changeps1 no
+    conda update -q conda
+    conda info -a
+    conda create --name rdkit_build -c conda-forge $(python) cmake \
+        boost-cpp=$(boost_version) \
+        boost=$(boost_version) \
+        numpy=2.2 pillow eigen pandas=2.2 matplotlib-base=3.9 \
+        cairo
+    conda activate rdkit_build
+    conda install -c conda-forge ipython=8.20 jupyter nbval ipykernel>=6.0
+  displayName: Setup build environment (no Qt due to versioning problems)
+- bash: |
+    export CONDA=/tmp/miniforge
+    source ${CONDA}/etc/profile.d/conda.sh
+    conda activate rdkit_build
+    export CXXFLAGS="${CXXFLAGS} -Wall -Werror -Wextra"
+    mkdir build && cd build && \
+    cmake .. \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DRDK_INSTALL_INTREE=ON \
+    -DRDK_INSTALL_STATIC_LIBS=OFF \
+    -DRDK_BUILD_CPP_TESTS=ON \
+    -DRDK_BUILD_PYTHON_WRAPPERS=ON \
+    -DRDK_BUILD_COORDGEN_SUPPORT=ON \
+    -DRDK_BUILD_MAEPARSER_SUPPORT=ON \
+    -DRDK_OPTIMIZE_POPCNT=ON \
+    -DRDK_BUILD_TEST_GZIP=ON \
+    -DRDK_BUILD_FREESASA_SUPPORT=ON \
+    -DRDK_BUILD_AVALON_SUPPORT=ON \
+    -DRDK_BUILD_INCHI_SUPPORT=ON \
+    -DRDK_BUILD_YAEHMOP_SUPPORT=ON \
+    -DRDK_BUILD_XYZ2MOL_SUPPORT=ON \
+    -DRDK_BUILD_CAIRO_SUPPORT=ON \
+    -DRDK_BUILD_SWIG_WRAPPERS=OFF \
+    -DRDK_SWIG_STATIC=OFF \
+    -DRDK_BUILD_THREADSAFE_SSS=ON \
+    -DRDK_TEST_MULTITHREADED=ON \
+    -DRDK_BUILD_CFFI_LIB=ON \
+    -DBoost_NO_SYSTEM_PATHS=ON \
+    -DBoost_NO_BOOST_CMAKE=TRUE \
+    -DRDK_BOOST_PYTHON3_NAME=$(python_name) \
+    -DPYTHON_EXECUTABLE=${CONDA_PREFIX}/bin/python3 \
+    -DCMAKE_INCLUDE_PATH="${CONDA_PREFIX}/include" \
+    -DCMAKE_LIBRARY_PATH="${CONDA_PREFIX}/lib"
+  displayName: Configure build (Run CMake)
+- bash: |
+    export CONDA=/tmp/miniforge
+    source ${CONDA}/etc/profile.d/conda.sh
+    conda activate rdkit_build
+    cd build
+    make -j $( $(number_of_cores) ) install
+  displayName: Build
+- bash: |
+    export CONDA=/tmp/miniforge
+    source ${CONDA}/etc/profile.d/conda.sh
+    conda activate rdkit_build
+    export RDBASE=`pwd`
+    export PYTHONPATH=${RDBASE}:${PYTHONPATH}
+    export LD_LIBRARY_PATH=${RDBASE}/lib:${CONDA_PREFIX}/lib:${LD_LIBRARY_PATH}
+    echo "LD_LIBRARY_PATH: " $LD_LIBRARY_PATH
+    export QT_QPA_PLATFORM='offscreen'
+    cd build
+    ctest -j $( $(number_of_cores) ) --output-on-failure -T Test
+  displayName: Run tests
+- bash: |
+    export CONDA=/tmp/miniforge
+    source ${CONDA}/etc/profile.d/conda.sh
+    conda activate rdkit_build
+    conda install -c conda-forge sphinx myst-parser
+    export RDBASE=`pwd`
+    export PYTHONPATH=${RDBASE}:${PYTHONPATH}
+    export LD_LIBRARY_PATH=${RDBASE}/lib:${LD_LIBRARY_PATH}
+    export QT_QPA_PLATFORM='offscreen'
+    cd Docs/Book
+    make doctest
+  displayName: Run documentation tests
+- task: PublishTestResults@2
+  inputs:
+    testResultsFormat: 'CTest'
+    testResultsFiles: 'build/Testing/*/Test.xml'
+    testRunTitle: $(system.phasedisplayname) CTest Test Run

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,9 +11,8 @@ jobs:
   variables:
     python: python=3.13
     boost_version: 1.85.0
-    compiler: gxx_linux-64
-    cc: gcc-10
-    cxx: g++-10
+    cc: gcc-14
+    cxx: g++-14
     number_of_cores: nproc
     python_name: python313
   steps:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,127 +4,141 @@ trigger:
 - dev/*
 
 jobs:
-- job: Ubuntu_x64
+- job: Ubuntu_arm64
   timeoutInMinutes: 120
   pool:
-    vmImage: ubuntu-20.04
+    vmImage: ubuntu-24.04-arm
   variables:
-    python: python=3.8
-    boost_version: 1.71.0
-    compiler: gxx_linux-64
-    number_of_cores: nproc
-    python_name: python38
-    cc: gcc-10
-    cxx: g++-10
-  steps:
-  - template: .azure-pipelines/linux_build.yml
-- job: Ubuntu_x64_py311
-  timeoutInMinutes: 120
-  pool:
-    vmImage: ubuntu-latest
-  variables:
-    python: python=3.11
-    boost_version: 1.82.0
+    python: python=3.13
+    boost_version: 1.85.0
     compiler: gxx_linux-64
     cc: gcc-10
     cxx: g++-10
     number_of_cores: nproc
-    python_name: python311
+    python_name: python313
   steps:
-  - template: .azure-pipelines/linux_build_py311.yml
-- job: macOS_x64
-  timeoutInMinutes: 120
-  pool:
-    vmImage: macos-14
-  variables:
-    compiler: clangxx_osx-64=18.1
-    compiler_version: 16
-    boost_version: 1.84
-    number_of_cores: sysctl -n hw.ncpu
-    target_platform: 14.5
-    python: python=3.11
-  steps:
-  - template: .azure-pipelines/mac_build.yml
-- job: macOS_x64_java
-  timeoutInMinutes: 90
-  pool:
-    vmImage: macos-14
-  variables:
-    compiler: clangxx_osx-64=18.1
-    compiler_version: 16
-    boost_version: 1.84
-    number_of_cores: sysctl -n hw.ncpu
-    target_platform: 14.5
-  steps:
-  - template: .azure-pipelines/mac_build_java.yml
-- job: Windows_VS2022_x64
-  timeoutInMinutes: 120
-  pool:
-    vmImage: windows-2019
-  variables:
-    boost_version: 1.84.0
-    number_of_cores: '%NUMBER_OF_PROCESSORS%'
-    python: python=3.12
-  steps:
-  - template: .azure-pipelines/vs_build.yml
-- job: Windows_VS2022_x64_dll
-  timeoutInMinutes: 120
-  pool:
-    vmImage: windows-2019
-  variables:
-    boost_version: 1.84.0
-    number_of_cores: '%NUMBER_OF_PROCESSORS%'
-    python: python=3.12
-  steps:
-  - template: .azure-pipelines/vs_build_dll.yml
-- job: Ubuntu_x64_cartridge
-  timeoutInMinutes: 90
-  pool:
-    vmImage: ubuntu-20.04
-  variables:
-    boost_version: 1.71.0
-    number_of_cores: nproc
-    compiler: gxx_linux-64
-    cc: gcc-10
-    cxx: g++-10
-  steps:
-  - template: .azure-pipelines/linux_build_cartridge.yml
-- job: Ubuntu_x64_limitexternaldependencies
-  timeoutInMinutes: 90
-  pool:
-    vmImage: ubuntu-22.04
-  variables:
-    python: python=3.11
-    boost_version: 1.82.0
-    number_of_cores: nproc
-    compiler: gxx_linux-64
-    cc: gcc-11
-    cxx: g++-11
-  steps:
-  - template: .azure-pipelines/linux_build_limitexternal.yml
-- job: Ubuntu_x64_java
-  timeoutInMinutes: 90
-  pool:
-    vmImage: ubuntu-20.04
-  variables:
-    boost_version: 1.84.0
-    number_of_cores: nproc
-    python_name: python37
-    compiler: gxx_linux-64
-    cc: gcc-10
-    cxx: g++-10
-  steps:
-  - template: .azure-pipelines/linux_build_java.yml
-- job: Windows_VS2022_x64_swig
-  timeoutInMinutes: 90
-  pool:
-    vmImage: windows-2019
-  variables:
-    boost_version: 1.84.0
-    number_of_cores: '%NUMBER_OF_PROCESSORS%'
-    python_name: python38
-  steps:
-  - template: .azure-pipelines/vs_build_swig.yml
+  - template: .azure-pipelines/linux_build_arm64.yml
+# - job: Ubuntu_x64
+#   timeoutInMinutes: 120
+#   pool:
+#     vmImage: ubuntu-20.04
+#   variables:
+#     python: python=3.8
+#     boost_version: 1.71.0
+#     compiler: gxx_linux-64
+#     number_of_cores: nproc
+#     python_name: python38
+#     cc: gcc-10
+#     cxx: g++-10
+#   steps:
+#   - template: .azure-pipelines/linux_build.yml
+# - job: Ubuntu_x64_py311
+#   timeoutInMinutes: 120
+#   pool:
+#     vmImage: ubuntu-latest
+#   variables:
+#     python: python=3.11
+#     boost_version: 1.82.0
+#     compiler: gxx_linux-64
+#     cc: gcc-10
+#     cxx: g++-10
+#     number_of_cores: nproc
+#     python_name: python311
+#   steps:
+#   - template: .azure-pipelines/linux_build_py311.yml
+# - job: macOS_x64
+#   timeoutInMinutes: 120
+#   pool:
+#     vmImage: macos-14
+#   variables:
+#     compiler: clangxx_osx-64=18.1
+#     compiler_version: 16
+#     boost_version: 1.84
+#     number_of_cores: sysctl -n hw.ncpu
+#     target_platform: 14.5
+#     python: python=3.11
+#   steps:
+#   - template: .azure-pipelines/mac_build.yml
+# - job: macOS_x64_java
+#   timeoutInMinutes: 90
+#   pool:
+#     vmImage: macos-14
+#   variables:
+#     compiler: clangxx_osx-64=18.1
+#     compiler_version: 16
+#     boost_version: 1.84
+#     number_of_cores: sysctl -n hw.ncpu
+#     target_platform: 14.5
+#   steps:
+#   - template: .azure-pipelines/mac_build_java.yml
+# - job: Windows_VS2022_x64
+#   timeoutInMinutes: 120
+#   pool:
+#     vmImage: windows-2019
+#   variables:
+#     boost_version: 1.84.0
+#     number_of_cores: '%NUMBER_OF_PROCESSORS%'
+#     python: python=3.12
+#   steps:
+#   - template: .azure-pipelines/vs_build.yml
+# - job: Windows_VS2022_x64_dll
+#   timeoutInMinutes: 120
+#   pool:
+#     vmImage: windows-2019
+#   variables:
+#     boost_version: 1.84.0
+#     number_of_cores: '%NUMBER_OF_PROCESSORS%'
+#     python: python=3.12
+#   steps:
+#   - template: .azure-pipelines/vs_build_dll.yml
+# - job: Ubuntu_x64_cartridge
+#   timeoutInMinutes: 90
+#   pool:
+#     vmImage: ubuntu-20.04
+#   variables:
+#     boost_version: 1.71.0
+#     number_of_cores: nproc
+#     compiler: gxx_linux-64
+#     cc: gcc-10
+#     cxx: g++-10
+#   steps:
+#   - template: .azure-pipelines/linux_build_cartridge.yml
+# - job: Ubuntu_x64_limitexternaldependencies
+#   timeoutInMinutes: 90
+#   pool:
+#     vmImage: ubuntu-22.04
+#   variables:
+#     python: python=3.11
+#     boost_version: 1.82.0
+#     number_of_cores: nproc
+#     compiler: gxx_linux-64
+#     cc: gcc-11
+#     cxx: g++-11
+#   steps:
+#   - template: .azure-pipelines/linux_build_limitexternal.yml
+# - job: Ubuntu_x64_java
+#   timeoutInMinutes: 90
+#   pool:
+#     vmImage: ubuntu-20.04
+#   variables:
+#     boost_version: 1.84.0
+#     number_of_cores: nproc
+#     python_name: python37
+#     compiler: gxx_linux-64
+#     cc: gcc-10
+#     cxx: g++-10
+#   steps:
+#   - template: .azure-pipelines/linux_build_java.yml
+# - job: Windows_VS2022_x64_swig
+#   timeoutInMinutes: 90
+#   pool:
+#     vmImage: windows-2019
+#   variables:
+#     boost_version: 1.84.0
+#     number_of_cores: '%NUMBER_OF_PROCESSORS%'
+#     python_name: python38
+#   steps:
+#   - template: .azure-pipelines/vs_build_swig.yml
 
 # - job: Ubuntu_18_04_x64_fuzzer
 #  timeoutInMinutes: 90

--- a/rdkit/Chem/nbtests/github4823.ipynb
+++ b/rdkit/Chem/nbtests/github4823.ipynb
@@ -17,7 +17,9 @@
    "cell_type": "code",
    "execution_count": 2,
    "id": "complete-conversation",
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [
     {
      "data": {
@@ -48,43 +50,51 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th>count</th>\n",
-       "      <td>200</td>\n",
-       "      <td>200</td>\n",
-       "      <td>200</td>\n",
-       "      <td>200</td>\n",
+       "      <th>0</th>\n",
+       "      <td>122.12344</td>\n",
+       "      <td>0.79</td>\n",
+       "      <td>0.727;-0P;4.71</td>\n",
+       "      <td>2.963;-40R;4.71</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>unique</th>\n",
-       "      <td>183</td>\n",
-       "      <td>176</td>\n",
-       "      <td>193</td>\n",
-       "      <td>183</td>\n",
+       "      <th>1</th>\n",
+       "      <td>332.495</td>\n",
+       "      <td>4.66</td>\n",
+       "      <td>4.316;-0P;4.71</td>\n",
+       "      <td>9.384;-0R;4.71</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>top</th>\n",
-       "      <td>198.26456</td>\n",
-       "      <td>2.19</td>\n",
-       "      <td>1.498;-0P;4.71</td>\n",
-       "      <td>6.280;-0R;4.71</td>\n",
+       "      <th>2</th>\n",
+       "      <td>218.553</td>\n",
+       "      <td>-2.61</td>\n",
+       "      <td>2.239;-57P;4.71</td>\n",
+       "      <td>4.556;-0R;4.71</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>freq</th>\n",
-       "      <td>3</td>\n",
-       "      <td>3</td>\n",
-       "      <td>2</td>\n",
-       "      <td>3</td>\n",
+       "      <th>3</th>\n",
+       "      <td>145.14184</td>\n",
+       "      <td>-2.01</td>\n",
+       "      <td>0.519;-59P;4.71</td>\n",
+       "      <td>3.267;-42R;4.71</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>223.231</td>\n",
+       "      <td>2.43</td>\n",
+       "      <td>1.869;-0P;4.71</td>\n",
+       "      <td>6.390;-0R;4.71</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "              AMW CLOGP              CP              CR\n",
-       "count         200   200             200             200\n",
-       "unique        183   176             193             183\n",
-       "top     198.26456  2.19  1.498;-0P;4.71  6.280;-0R;4.71\n",
-       "freq            3     3               2               3"
+       "         AMW  CLOGP               CP               CR\n",
+       "0  122.12344   0.79   0.727;-0P;4.71  2.963;-40R;4.71\n",
+       "1    332.495   4.66   4.316;-0P;4.71   9.384;-0R;4.71\n",
+       "2    218.553  -2.61  2.239;-57P;4.71   4.556;-0R;4.71\n",
+       "3  145.14184  -2.01  0.519;-59P;4.71  3.267;-42R;4.71\n",
+       "4    223.231   2.43   1.869;-0P;4.71   6.390;-0R;4.71"
       ]
      },
      "execution_count": 2,
@@ -94,14 +104,37 @@
    ],
    "source": [
     "df = PandasTools.LoadSDF(os.path.join(RDConfig.RDDataDir,'NCI','first_200.props.sdf'))\n",
-    "df[['AMW','CLOGP','CP','CR']].describe()"
+    "df[['AMW','CLOGP','CP','CR']].head()"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "permanent-liechtenstein",
+   "id": "63de62cc",
    "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "200"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "permanent-liechtenstein",
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [
     {
      "data": {
@@ -114,7 +147,7 @@
        "      dtype='object')"
       ]
      },
-     "execution_count": 3,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -148,7 +181,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 6,
    "id": "identical-finder",
    "metadata": {},
    "outputs": [
@@ -181,53 +214,69 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th>count</th>\n",
-       "      <td>200</td>\n",
-       "      <td>200</td>\n",
-       "      <td>200</td>\n",
-       "      <td>200</td>\n",
+       "      <th>0</th>\n",
+       "      <td>122.12344</td>\n",
+       "      <td>0.79</td>\n",
+       "      <td>0.727;-0P;4.71</td>\n",
+       "      <td>2.963;-40R;4.71</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>unique</th>\n",
-       "      <td>183</td>\n",
-       "      <td>176</td>\n",
-       "      <td>193</td>\n",
-       "      <td>183</td>\n",
+       "      <th>1</th>\n",
+       "      <td>332.495</td>\n",
+       "      <td>4.66</td>\n",
+       "      <td>4.316;-0P;4.71</td>\n",
+       "      <td>9.384;-0R;4.71</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>top</th>\n",
-       "      <td>198.26456</td>\n",
-       "      <td>2.19</td>\n",
-       "      <td>1.498;-0P;4.71</td>\n",
-       "      <td>6.280;-0R;4.71</td>\n",
+       "      <th>2</th>\n",
+       "      <td>218.553</td>\n",
+       "      <td>-2.61</td>\n",
+       "      <td>2.239;-57P;4.71</td>\n",
+       "      <td>4.556;-0R;4.71</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>freq</th>\n",
-       "      <td>3</td>\n",
-       "      <td>3</td>\n",
-       "      <td>2</td>\n",
-       "      <td>3</td>\n",
+       "      <th>3</th>\n",
+       "      <td>145.14184</td>\n",
+       "      <td>-2.01</td>\n",
+       "      <td>0.519;-59P;4.71</td>\n",
+       "      <td>3.267;-42R;4.71</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>223.231</td>\n",
+       "      <td>2.43</td>\n",
+       "      <td>1.869;-0P;4.71</td>\n",
+       "      <td>6.390;-0R;4.71</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "              AMW CLOGP              CP              CR\n",
-       "count         200   200             200             200\n",
-       "unique        183   176             193             183\n",
-       "top     198.26456  2.19  1.498;-0P;4.71  6.280;-0R;4.71\n",
-       "freq            3     3               2               3"
+       "         AMW  CLOGP               CP               CR\n",
+       "0  122.12344   0.79   0.727;-0P;4.71  2.963;-40R;4.71\n",
+       "1    332.495   4.66   4.316;-0P;4.71   9.384;-0R;4.71\n",
+       "2    218.553  -2.61  2.239;-57P;4.71   4.556;-0R;4.71\n",
+       "3  145.14184  -2.01  0.519;-59P;4.71  3.267;-42R;4.71\n",
+       "4    223.231   2.43   1.869;-0P;4.71   6.390;-0R;4.71"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "df[['AMW','CLOGP','CP','CR']].describe()"
+    "df[['AMW','CLOGP','CP','CR']].head()"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7cea7bba",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -246,7 +295,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.11.8"
   },
   "toc": {
    "base_numbering": 1,


### PR DESCRIPTION
Also fixes one of the notebook tests that didn't pass with numpy 2.2 - the pandas `describe()` function chooses a different value in the `top` field for columns that have multiple values with the same frequency.