### PR TITLE
Some mem fixes.

### DIFF
--- a/Code/GraphMol/DistGeomHelpers/Embedder.cpp
+++ b/Code/GraphMol/DistGeomHelpers/Embedder.cpp
@@ -837,16 +837,19 @@ bool embedPoints(RDGeom::PointPtrVect *positions, detail::EmbedArgs eargs,
     embedParams.basinThresh = 1e8;
   }
 
+  std::unique_ptr<RDKit::rng_type> generator;
+  std::unique_ptr<RDKit::uniform_double> distrib;
+  std::unique_ptr<RDKit::double_source_type> rngMgr;
+
   RDKit::double_source_type *rng = nullptr;
-  RDKit::rng_type *generator = nullptr;
-  RDKit::uniform_double *distrib = nullptr;
   CHECK_INVARIANT(seed >= -1,
                   "random seed must either be positive, zero, or negative one");
   if (seed > -1) {
-    generator = new RDKit::rng_type(42u);
+    generator.reset(new RDKit::rng_type(42u));
     generator->seed(seed);
-    distrib = new RDKit::uniform_double(0.0, 1.0);
-    rng = new RDKit::double_source_type(*generator, *distrib);
+    distrib.reset(new RDKit::uniform_double(0.0, 1.0));
+    rngMgr.reset(new RDKit::double_source_type(*generator, *distrib));
+    rng = rngMgr.get();
   } else {
     rng = &RDKit::getDoubleRandomSource();
   }
@@ -987,11 +990,7 @@ bool embedPoints(RDGeom::PointPtrVect *positions, detail::EmbedArgs eargs,
     }
 
   }  // while
-  if (seed > -1) {
-    delete rng;
-    delete generator;
-    delete distrib;
-  }
+
   return gotCoords;
 }
 

--- a/Code/GraphMol/Fingerprints/fpgen_catch_tests.cpp
+++ b/Code/GraphMol/Fingerprints/fpgen_catch_tests.cpp
@@ -464,7 +464,8 @@ TEST_CASE("github #6679: suspicious value for atom pair code calculation") {
         {"C[I]", 7918328},  {"C[Te]", 7918456}, {"C[Sb]", 7918584},
         {"C[Sn]", 7918200}, {"C[Xe]", 7918200}, {"C[Li]", 7918200},
     };
-    auto fpg = AtomPair::getAtomPairGenerator<std::uint64_t>();
+    std::unique_ptr<FingerprintGenerator<std::uint64_t>> fpg{
+        AtomPair::getAtomPairGenerator<std::uint64_t>()};
     for (const auto &pr : data) {
       auto mol = v2::SmilesParse::MolFromSmiles(pr.first);
       REQUIRE(mol);


### PR DESCRIPTION
I ran the tests under asan again, and found some issues.

Besides the issues patched here, it's worth mentioning that the INCHI code has become way more leaky in v1.07.2: even after the attached fixes, running `testInchi' now leaks about 20 mb memory.