### PR TITLE
Fix buffer size in pickersCLI.cpp

### DIFF
--- a/Code/SimDivPickers/pickersCLI.cpp
+++ b/Code/SimDivPickers/pickersCLI.cpp
@@ -34,7 +34,7 @@ static unsigned int LoadDatabase(FILE *fp) {
   char buffer[32768];
   unsigned int result = 0;
 
-  while (fgets(buffer, 327666, fp)) {
+  while (fgets(buffer, sizeof(buffer), fp)) {
     if (buffer[0] == '#' || buffer[0] == ' ' || buffer[0] == '\t') continue;
     char *ptr = buffer;
     while (*ptr && *ptr != ' ' && *ptr != '\t') ptr++;


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! 
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.

Reading up to 327666 bytes into a buffer of size 32768 is not good. 

`fgets` reads size-1 bytes and writes `\0` after it, so we should be fine with `sizeof(buffer)` here, which also more resilient to future errors than any duplicated value.

#### Any other comments?

