### PR TITLE
Expose basinThresh to the python layer

### DIFF
--- a/Code/GraphMol/DistGeomHelpers/Wrap/rdDistGeom.cpp
+++ b/Code/GraphMol/DistGeomHelpers/Wrap/rdDistGeom.cpp
@@ -509,6 +509,8 @@ BOOST_PYTHON_MODULE(rdDistGeom) {
       .def_readwrite("optimizerForceTol", &PyEmbedParameters::optimizerForceTol,
                      "the tolerance to be used during the distance-geometry "
                      "force field minimization")
+      .def_readwrite("basinThresh", &PyEmbedParameters::basinThresh,
+                     "set the basin threshold for the DGeom force field.")
       .def_readwrite("ignoreSmoothingFailures",
                      &PyEmbedParameters::ignoreSmoothingFailures,
                      "try and embed the molecule if if triangle smoothing of "

--- a/Code/GraphMol/DistGeomHelpers/Wrap/rdDistGeom.cpp
+++ b/Code/GraphMol/DistGeomHelpers/Wrap/rdDistGeom.cpp
@@ -510,7 +510,8 @@ BOOST_PYTHON_MODULE(rdDistGeom) {
                      "the tolerance to be used during the distance-geometry "
                      "force field minimization")
       .def_readwrite("basinThresh", &PyEmbedParameters::basinThresh,
-                     "set the basin threshold for the DGeom force field.")
+                     "set the basin threshold for the DGeom force field. "
+                     "This shouldn't be changed in client code!")
       .def_readwrite("ignoreSmoothingFailures",
                      &PyEmbedParameters::ignoreSmoothingFailures,
                      "try and embed the molecule if if triangle smoothing of "

--- a/Code/GraphMol/DistGeomHelpers/Wrap/rdDistGeom.cpp
+++ b/Code/GraphMol/DistGeomHelpers/Wrap/rdDistGeom.cpp
@@ -510,8 +510,7 @@ BOOST_PYTHON_MODULE(rdDistGeom) {
                      "the tolerance to be used during the distance-geometry "
                      "force field minimization")
       .def_readwrite("basinThresh", &PyEmbedParameters::basinThresh,
-                     "set the basin threshold for the DGeom force field. "
-                     "This shouldn't be changed in client code!")
+                     "set the basin threshold for the DGeom force field.")
       .def_readwrite("ignoreSmoothingFailures",
                      &PyEmbedParameters::ignoreSmoothingFailures,
                      "try and embed the molecule if if triangle smoothing of "


### PR DESCRIPTION
Apparently, the basinThresh was not exposed to python.
This adds  `basinThresh` in the `PyEmbedParameters`


