### PR TITLE
try adding a CI job to build the minimallib docker image

### DIFF
--- a/.azure-pipelines/linux_minimal_build.yml
+++ b/.azure-pipelines/linux_minimal_build.yml
@@ -1,4 +1,0 @@
-steps:
-- bash: |
-    docker build -f ./Code/MinimalLib/docker/Dockerfile_CI .
-  displayName: build MinimalLib JS bindings

--- a/.azure-pipelines/linux_minimal_build.yml
+++ b/.azure-pipelines/linux_minimal_build.yml
@@ -1,0 +1,4 @@
+steps:
+- bash: |
+    docker build -f ./Code/MinimalLib/docker/Dockerfile_CI .
+  displayName: build MinimalLib JS bindings

--- a/Code/MinimalLib/docker/Dockerfile_CI
+++ b/Code/MinimalLib/docker/Dockerfile_CI
@@ -73,16 +73,6 @@ RUN ./emsdk install ${EMSDK_VERSION} && \
 RUN echo "source /opt/emsdk/emsdk_env.sh > /dev/null 2>&1" >> ~/.bashrc
 SHELL ["/bin/bash", "-c", "-l"]
 
-
-COPY Code /src/rdkit/Code
-COPY External /src/rdkit/External
-COPY CMakeLists.txt license.txt *.in *.md *.cmake /src/rdkit
-ENV RDBASE=/src/rdkit
-
-
-
-
-
 WORKDIR /src
 RUN wget -q https://download.savannah.gnu.org/releases/freetype/freetype-${FREETYPE_VERSION}.tar.gz && \
   tar xzf freetype-${FREETYPE_VERSION}.tar.gz
@@ -93,6 +83,11 @@ RUN emcmake cmake -DCMAKE_BUILD_TYPE=Release -DWITH_ZLIB=OFF -DWITH_BZip2=OFF -D
   -DCMAKE_C_FLAGS="${EXCEPTION_HANDLING}" -DCMAKE_EXE_LINKER_FLAGS="${EXCEPTION_HANDLING}" \
   -DCMAKE_INSTALL_PREFIX=/opt/freetype ..
 RUN make -j2 && make -j2 install
+
+COPY Code /src/rdkit/Code
+COPY External /src/rdkit/External
+COPY CMakeLists.txt license.txt *.in *.md *.cmake /src/rdkit
+ENV RDBASE=/src/rdkit
 
 WORKDIR $RDBASE
 RUN mkdir build

--- a/Code/MinimalLib/docker/Dockerfile_CI
+++ b/Code/MinimalLib/docker/Dockerfile_CI
@@ -84,6 +84,7 @@ RUN emcmake cmake -DCMAKE_BUILD_TYPE=Release -DWITH_ZLIB=OFF -DWITH_BZip2=OFF -D
   -DCMAKE_INSTALL_PREFIX=/opt/freetype ..
 RUN make -j2 && make -j2 install
 
+WORKDIR /
 COPY Code /src/rdkit/Code
 COPY External /src/rdkit/External
 COPY CMakeLists.txt license.txt *.in *.md *.cmake /src/rdkit

--- a/Code/MinimalLib/docker/Dockerfile_CI
+++ b/Code/MinimalLib/docker/Dockerfile_CI
@@ -124,9 +124,9 @@ RUN make -j2 RDKit_minimal && \
 WORKDIR /src/rdkit/Code/MinimalLib/tests
 RUN /opt/emsdk/node/*/bin/node tests.js
 
-# Copy js and wasm rdkit files to use in browser
-# This feature requires the BuildKit backend
-# https://docs.docker.com/engine/reference/commandline/build/#custom-build-outputs
-FROM scratch AS export-stage
-COPY --from=build-stage /src/rdkit/Code/MinimalLib/demo /
-COPY --from=build-stage /src/rdkit/Code/MinimalLib/docs /
+# # Copy js and wasm rdkit files to use in browser
+# # This feature requires the BuildKit backend
+# # https://docs.docker.com/engine/reference/commandline/build/#custom-build-outputs
+# FROM scratch AS export-stage
+# COPY --from=build-stage /src/rdkit/Code/MinimalLib/demo /
+# COPY --from=build-stage /src/rdkit/Code/MinimalLib/docs /

--- a/Code/MinimalLib/docker/Dockerfile_CI
+++ b/Code/MinimalLib/docker/Dockerfile_CI
@@ -1,0 +1,137 @@
+# Example usage of this Dockerfile:
+# (the build-arg arguments are all optional)
+#
+# 1. cd to Code/MinimalLib/docker
+# cd Code/MinimalLib/docker
+#
+# 2. build the JS and WASM libraries
+#    (the build-arg arguments are all optional; in the following
+#     example we select the more performant, though still experimental,
+#     native WASM exception handling):
+# docker build -t rdkit-minimallib --network=host \
+#  --build-arg "RDKIT_GIT_URL=https://github.com/myfork/rdkit.git" \
+#  --build-arg "RDKIT_BRANCH=mybranch" \
+#  --build-arg "EXCEPTION_HANDLING=-fwasm-exceptions".
+#
+# 3. create a temporary container and copy built libraries
+#    from the container to your local filesystem, then destroy
+#    the temporary container
+# docker create --name=rdkit-minimallib-container rdkit-minimallib:latest --entrypoint /
+# docker cp rdkit-minimallib-container:/RDKit_minimal.js ../demo
+# docker cp rdkit-minimallib-container:/RDKit_minimal.wasm ../demo
+# docker rm rdkit-minimallib-container
+
+
+ARG EMSDK_VERSION="latest"
+ARG EXCEPTION_HANDLING="-fexceptions -sNO_DISABLE_EXCEPTION_CATCHING"
+ARG BOOST_MAJOR_VERSION="1"
+ARG BOOST_MINOR_VERSION="87"
+ARG BOOST_PATCH_VERSION="0"
+ARG FREETYPE_VERSION="2.13.3"
+
+FROM debian:bookworm AS build-stage
+ARG EMSDK_VERSION
+ARG EXCEPTION_HANDLING
+ARG BOOST_MAJOR_VERSION
+ARG BOOST_MINOR_VERSION
+ARG BOOST_PATCH_VERSION
+ARG FREETYPE_VERSION
+
+LABEL maintainer="Greg Landrum <greg.landrum@t5informatics.com>"
+
+RUN apt-get update && apt-get upgrade -y && apt install -y \
+  curl \
+  wget \
+  cmake \
+  python3 \
+  g++ \
+  libeigen3-dev \
+  git \
+  xz-utils \
+  nodejs
+
+ENV LANG C
+
+WORKDIR /opt
+RUN git clone https://github.com/emscripten-core/emsdk.git
+
+WORKDIR /src
+ARG BOOST_DOT_VERSION="${BOOST_MAJOR_VERSION}.${BOOST_MINOR_VERSION}.${BOOST_PATCH_VERSION}"
+ARG BOOST_UNDERSCORE_VERSION="${BOOST_MAJOR_VERSION}_${BOOST_MINOR_VERSION}_${BOOST_PATCH_VERSION}"
+RUN wget -q https://archives.boost.io/release/${BOOST_DOT_VERSION}/source/boost_${BOOST_UNDERSCORE_VERSION}.tar.gz && \
+  tar xzf boost_${BOOST_UNDERSCORE_VERSION}.tar.gz
+WORKDIR /src/boost_${BOOST_UNDERSCORE_VERSION}
+RUN ./bootstrap.sh --prefix=/opt/boost --with-libraries=system && \
+  ./b2 install
+
+WORKDIR /opt/emsdk
+RUN ./emsdk install ${EMSDK_VERSION} && \
+  ./emsdk activate ${EMSDK_VERSION}
+
+#RUN source ./emsdk_env.sh
+
+RUN echo "source /opt/emsdk/emsdk_env.sh > /dev/null 2>&1" >> ~/.bashrc
+SHELL ["/bin/bash", "-c", "-l"]
+
+
+COPY Code /src/rdkit/Code
+COPY External /src/rdkit/External
+COPY CMakeLists.txt license.txt *.in *.md *.cmake /src/rdkit
+ENV RDBASE=/src/rdkit
+
+
+
+
+
+WORKDIR /src
+RUN wget -q https://download.savannah.gnu.org/releases/freetype/freetype-${FREETYPE_VERSION}.tar.gz && \
+  tar xzf freetype-${FREETYPE_VERSION}.tar.gz
+WORKDIR /src/freetype-${FREETYPE_VERSION}
+RUN mkdir build
+WORKDIR /src/freetype-${FREETYPE_VERSION}/build
+RUN emcmake cmake -DCMAKE_BUILD_TYPE=Release -DWITH_ZLIB=OFF -DWITH_BZip2=OFF -DWITH_PNG=OFF \
+  -DCMAKE_C_FLAGS="${EXCEPTION_HANDLING}" -DCMAKE_EXE_LINKER_FLAGS="${EXCEPTION_HANDLING}" \
+  -DCMAKE_INSTALL_PREFIX=/opt/freetype ..
+RUN make -j2 && make -j2 install
+
+WORKDIR $RDBASE
+RUN mkdir build
+WORKDIR $RDBASE/build
+RUN emcmake cmake -DRDK_BUILD_FREETYPE_SUPPORT=ON -DRDK_BUILD_MINIMAL_LIB=ON \
+  -DRDK_BUILD_PYTHON_WRAPPERS=OFF -DRDK_BUILD_CPP_TESTS=OFF -DRDK_BUILD_INCHI_SUPPORT=ON \
+  -DRDK_USE_BOOST_SERIALIZATION=OFF -DRDK_OPTIMIZE_POPCNT=OFF -DRDK_BUILD_THREADSAFE_SSS=OFF \
+  -DRDK_BUILD_DESCRIPTORS3D=OFF -DRDK_TEST_MULTITHREADED=OFF \
+  -DRDK_BUILD_MAEPARSER_SUPPORT=OFF -DRDK_BUILD_COORDGEN_SUPPORT=ON \
+  -DBoost_DIR=/opt/boost/lib/cmake/Boost-${BOOST_DOT_VERSION} \
+  -Dboost_headers_DIR=/opt/boost/lib/cmake/boost_headers-${BOOST_DOT_VERSION} \
+  -DRDK_BUILD_SLN_SUPPORT=OFF -DRDK_USE_BOOST_IOSTREAMS=OFF \
+  -DFREETYPE_INCLUDE_DIRS=/opt/freetype/include/freetype2 \
+  -DFREETYPE_LIBRARY=/opt/freetype/lib/libfreetype.a \
+  -DCMAKE_CXX_FLAGS="${EXCEPTION_HANDLING} -O3 -DNDEBUG" \
+  -DCMAKE_C_FLAGS="${EXCEPTION_HANDLING} -O3 -DNDEBUG -DCOMPILE_ANSI_ONLY" \
+  -DCMAKE_EXE_LINKER_FLAGS="${EXCEPTION_HANDLING} -s STACK_OVERFLOW_CHECK=1 -s USE_PTHREADS=0 -s ALLOW_MEMORY_GROWTH=1 -s MAXIMUM_MEMORY=4GB -s MODULARIZE=1 -s EXPORT_NAME=\"'initRDKitModule'\"" ..
+
+# "patch" to make the InChI code work with emscripten:
+RUN cp /src/rdkit/External/INCHI-API/src/INCHI_BASE/src/util.c /src/rdkit/External/INCHI-API/src/INCHI_BASE/src/util.c.bak && \
+  sed 's/&& defined(__APPLE__)//' /src/rdkit/External/INCHI-API/src/INCHI_BASE/src/util.c.bak > /src/rdkit/External/INCHI-API/src/INCHI_BASE/src/util.c
+
+# comment out a line which causes a compilation error on some platforms
+# (based on the change which has already been applied to the RapidJSON master branch, see
+# https://github.com/Tencent/rapidjson/blob/ab1842a2dae061284c0a62dca1cc6d5e7e37e346/include/rapidjson/document.h#L414)
+RUN sed -i 's|^\( *\)\(GenericStringRef\& operator=(const GenericStringRef\& rhs) { s = rhs.s; length = rhs.length; } *\)$|\1//\2|' \
+  /src/rdkit/External/rapidjson-1.1.0/include/rapidjson/document.h
+
+# build and "install"
+RUN make -j2 RDKit_minimal && \
+  cp Code/MinimalLib/RDKit_minimal.* ../Code/MinimalLib/demo/
+
+# run the tests
+WORKDIR /src/rdkit/Code/MinimalLib/tests
+RUN /opt/emsdk/node/*/bin/node tests.js
+
+# Copy js and wasm rdkit files to use in browser
+# This feature requires the BuildKit backend
+# https://docs.docker.com/engine/reference/commandline/build/#custom-build-outputs
+FROM scratch AS export-stage
+COPY --from=build-stage /src/rdkit/Code/MinimalLib/demo /
+COPY --from=build-stage /src/rdkit/Code/MinimalLib/docs /

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,127 +4,134 @@ trigger:
 - dev/*
 
 jobs:
-- job: Ubuntu_x64
-  timeoutInMinutes: 120
-  pool:
-    vmImage: ubuntu-20.04
-  variables:
-    python: python=3.8
-    boost_version: 1.71.0
-    compiler: gxx_linux-64
-    number_of_cores: nproc
-    python_name: python38
-    cc: gcc-10
-    cxx: g++-10
-  steps:
-  - template: .azure-pipelines/linux_build.yml
-- job: Ubuntu_x64_py311
+- job: Ubuntu_x64_minimallib_build
   timeoutInMinutes: 120
   pool:
     vmImage: ubuntu-latest
-  variables:
-    python: python=3.11
-    boost_version: 1.82.0
-    compiler: gxx_linux-64
-    cc: gcc-10
-    cxx: g++-10
-    number_of_cores: nproc
-    python_name: python311
   steps:
-  - template: .azure-pipelines/linux_build_py311.yml
-- job: macOS_x64
-  timeoutInMinutes: 120
-  pool:
-    vmImage: macos-14
-  variables:
-    compiler: clangxx_osx-64=18.1
-    compiler_version: 16
-    boost_version: 1.84
-    number_of_cores: sysctl -n hw.ncpu
-    target_platform: 14.5
-    python: python=3.11
-  steps:
-  - template: .azure-pipelines/mac_build.yml
-- job: macOS_x64_java
-  timeoutInMinutes: 90
-  pool:
-    vmImage: macos-14
-  variables:
-    compiler: clangxx_osx-64=18.1
-    compiler_version: 16
-    boost_version: 1.84
-    number_of_cores: sysctl -n hw.ncpu
-    target_platform: 14.5
-  steps:
-  - template: .azure-pipelines/mac_build_java.yml
-- job: Windows_VS2022_x64
-  timeoutInMinutes: 120
-  pool:
-    vmImage: windows-2019
-  variables:
-    boost_version: 1.84.0
-    number_of_cores: '%NUMBER_OF_PROCESSORS%'
-    python: python=3.12
-  steps:
-  - template: .azure-pipelines/vs_build.yml
-- job: Windows_VS2022_x64_dll
-  timeoutInMinutes: 120
-  pool:
-    vmImage: windows-2019
-  variables:
-    boost_version: 1.84.0
-    number_of_cores: '%NUMBER_OF_PROCESSORS%'
-    python: python=3.12
-  steps:
-  - template: .azure-pipelines/vs_build_dll.yml
-- job: Ubuntu_x64_cartridge
-  timeoutInMinutes: 90
-  pool:
-    vmImage: ubuntu-20.04
-  variables:
-    boost_version: 1.71.0
-    number_of_cores: nproc
-    compiler: gxx_linux-64
-    cc: gcc-10
-    cxx: g++-10
-  steps:
-  - template: .azure-pipelines/linux_build_cartridge.yml
-- job: Ubuntu_x64_limitexternaldependencies
-  timeoutInMinutes: 90
-  pool:
-    vmImage: ubuntu-22.04
-  variables:
-    python: python=3.11
-    boost_version: 1.82.0
-    number_of_cores: nproc
-    compiler: gxx_linux-64
-    cc: gcc-11
-    cxx: g++-11
-  steps:
-  - template: .azure-pipelines/linux_build_limitexternal.yml
-- job: Ubuntu_x64_java
-  timeoutInMinutes: 90
-  pool:
-    vmImage: ubuntu-20.04
-  variables:
-    boost_version: 1.84.0
-    number_of_cores: nproc
-    python_name: python37
-    compiler: gxx_linux-64
-    cc: gcc-10
-    cxx: g++-10
-  steps:
-  - template: .azure-pipelines/linux_build_java.yml
-- job: Windows_VS2022_x64_swig
-  timeoutInMinutes: 90
-  pool:
-    vmImage: windows-2019
-  variables:
-    boost_version: 1.84.0
-    number_of_cores: '%NUMBER_OF_PROCESSORS%'
-    python_name: python38
-  steps:
-  - template: .azure-pipelines/vs_build_swig.yml
+  - template: .azure-pipelines/linux_minimal_build.yml
+
+# - job: Ubuntu_x64
+#   timeoutInMinutes: 120
+#   pool:
+#     vmImage: ubuntu-20.04
+#   variables:
+#     python: python=3.8
+#     boost_version: 1.71.0
+#     compiler: gxx_linux-64
+#     number_of_cores: nproc
+#     python_name: python38
+#     cc: gcc-10
+#     cxx: g++-10
+#   steps:
+#   - template: .azure-pipelines/linux_build.yml
+# - job: Ubuntu_x64_py311
+#   timeoutInMinutes: 120
+#   pool:
+#     vmImage: ubuntu-latest
+#   variables:
+#     python: python=3.11
+#     boost_version: 1.82.0
+#     compiler: gxx_linux-64
+#     cc: gcc-10
+#     cxx: g++-10
+#     number_of_cores: nproc
+#     python_name: python311
+#   steps:
+#   - template: .azure-pipelines/linux_build_py311.yml
+# - job: macOS_x64
+#   timeoutInMinutes: 120
+#   pool:
+#     vmImage: macos-14
+#   variables:
+#     compiler: clangxx_osx-64=18.1
+#     compiler_version: 16
+#     boost_version: 1.84
+#     number_of_cores: sysctl -n hw.ncpu
+#     target_platform: 14.5
+#     python: python=3.11
+#   steps:
+#   - template: .azure-pipelines/mac_build.yml
+# - job: macOS_x64_java
+#   timeoutInMinutes: 90
+#   pool:
+#     vmImage: macos-14
+#   variables:
+#     compiler: clangxx_osx-64=18.1
+#     compiler_version: 16
+#     boost_version: 1.84
+#     number_of_cores: sysctl -n hw.ncpu
+#     target_platform: 14.5
+#   steps:
+#   - template: .azure-pipelines/mac_build_java.yml
+# - job: Windows_VS2022_x64
+#   timeoutInMinutes: 120
+#   pool:
+#     vmImage: windows-2019
+#   variables:
+#     boost_version: 1.84.0
+#     number_of_cores: '%NUMBER_OF_PROCESSORS%'
+#     python: python=3.12
+#   steps:
+#   - template: .azure-pipelines/vs_build.yml
+# - job: Windows_VS2022_x64_dll
+#   timeoutInMinutes: 120
+#   pool:
+#     vmImage: windows-2019
+#   variables:
+#     boost_version: 1.84.0
+#     number_of_cores: '%NUMBER_OF_PROCESSORS%'
+#     python: python=3.12
+#   steps:
+#   - template: .azure-pipelines/vs_build_dll.yml
+# - job: Ubuntu_x64_cartridge
+#   timeoutInMinutes: 90
+#   pool:
+#     vmImage: ubuntu-20.04
+#   variables:
+#     boost_version: 1.71.0
+#     number_of_cores: nproc
+#     compiler: gxx_linux-64
+#     cc: gcc-10
+#     cxx: g++-10
+#   steps:
+#   - template: .azure-pipelines/linux_build_cartridge.yml
+# - job: Ubuntu_x64_limitexternaldependencies
+#   timeoutInMinutes: 90
+#   pool:
+#     vmImage: ubuntu-22.04
+#   variables:
+#     python: python=3.11
+#     boost_version: 1.82.0
+#     number_of_cores: nproc
+#     compiler: gxx_linux-64
+#     cc: gcc-11
+#     cxx: g++-11
+#   steps:
+#   - template: .azure-pipelines/linux_build_limitexternal.yml
+# - job: Ubuntu_x64_java
+#   timeoutInMinutes: 90
+#   pool:
+#     vmImage: ubuntu-20.04
+#   variables:
+#     boost_version: 1.84.0
+#     number_of_cores: nproc
+#     python_name: python37
+#     compiler: gxx_linux-64
+#     cc: gcc-10
+#     cxx: g++-10
+#   steps:
+#   - template: .azure-pipelines/linux_build_java.yml
+# - job: Windows_VS2022_x64_swig
+#   timeoutInMinutes: 90
+#   pool:
+#     vmImage: windows-2019
+#   variables:
+#     boost_version: 1.84.0
+#     number_of_cores: '%NUMBER_OF_PROCESSORS%'
+#     python_name: python38
+#   steps:
+#   - template: .azure-pipelines/vs_build_swig.yml
 
 # - job: Ubuntu_18_04_x64_fuzzer
 #  timeoutInMinutes: 90

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,6 +14,7 @@ jobs:
     inputs:
       command: build
       Dockerfile: './Code/MinimalLib/docker/Dockerfile_CI'
+      buildContext: '.'
       tags: 'latest'
   
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,7 +9,13 @@ jobs:
   pool:
     vmImage: ubuntu-latest
   steps:
-  - template: .azure-pipelines/linux_minimal_build.yml
+  - task: Docker@2
+    displayName: 'Build MinimalLib JS bindings'
+    inputs:
+      command: build
+      Dockerfile: './Code/MinimalLib/docker/Dockerfile_CI'
+      tags: 'latest'
+  
 
 # - job: Ubuntu_x64
 #   timeoutInMinutes: 120

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,130 +15,128 @@ jobs:
       command: build
       Dockerfile: './Code/MinimalLib/docker/Dockerfile_CI'
       buildContext: '.'
-      tags: 'latest'
-  
-
-# - job: Ubuntu_x64
-#   timeoutInMinutes: 120
-#   pool:
-#     vmImage: ubuntu-20.04
-#   variables:
-#     python: python=3.8
-#     boost_version: 1.71.0
-#     compiler: gxx_linux-64
-#     number_of_cores: nproc
-#     python_name: python38
-#     cc: gcc-10
-#     cxx: g++-10
-#   steps:
-#   - template: .azure-pipelines/linux_build.yml
-# - job: Ubuntu_x64_py311
-#   timeoutInMinutes: 120
-#   pool:
-#     vmImage: ubuntu-latest
-#   variables:
-#     python: python=3.11
-#     boost_version: 1.82.0
-#     compiler: gxx_linux-64
-#     cc: gcc-10
-#     cxx: g++-10
-#     number_of_cores: nproc
-#     python_name: python311
-#   steps:
-#   - template: .azure-pipelines/linux_build_py311.yml
-# - job: macOS_x64
-#   timeoutInMinutes: 120
-#   pool:
-#     vmImage: macos-14
-#   variables:
-#     compiler: clangxx_osx-64=18.1
-#     compiler_version: 16
-#     boost_version: 1.84
-#     number_of_cores: sysctl -n hw.ncpu
-#     target_platform: 14.5
-#     python: python=3.11
-#   steps:
-#   - template: .azure-pipelines/mac_build.yml
-# - job: macOS_x64_java
-#   timeoutInMinutes: 90
-#   pool:
-#     vmImage: macos-14
-#   variables:
-#     compiler: clangxx_osx-64=18.1
-#     compiler_version: 16
-#     boost_version: 1.84
-#     number_of_cores: sysctl -n hw.ncpu
-#     target_platform: 14.5
-#   steps:
-#   - template: .azure-pipelines/mac_build_java.yml
-# - job: Windows_VS2022_x64
-#   timeoutInMinutes: 120
-#   pool:
-#     vmImage: windows-2019
-#   variables:
-#     boost_version: 1.84.0
-#     number_of_cores: '%NUMBER_OF_PROCESSORS%'
-#     python: python=3.12
-#   steps:
-#   - template: .azure-pipelines/vs_build.yml
-# - job: Windows_VS2022_x64_dll
-#   timeoutInMinutes: 120
-#   pool:
-#     vmImage: windows-2019
-#   variables:
-#     boost_version: 1.84.0
-#     number_of_cores: '%NUMBER_OF_PROCESSORS%'
-#     python: python=3.12
-#   steps:
-#   - template: .azure-pipelines/vs_build_dll.yml
-# - job: Ubuntu_x64_cartridge
-#   timeoutInMinutes: 90
-#   pool:
-#     vmImage: ubuntu-20.04
-#   variables:
-#     boost_version: 1.71.0
-#     number_of_cores: nproc
-#     compiler: gxx_linux-64
-#     cc: gcc-10
-#     cxx: g++-10
-#   steps:
-#   - template: .azure-pipelines/linux_build_cartridge.yml
-# - job: Ubuntu_x64_limitexternaldependencies
-#   timeoutInMinutes: 90
-#   pool:
-#     vmImage: ubuntu-22.04
-#   variables:
-#     python: python=3.11
-#     boost_version: 1.82.0
-#     number_of_cores: nproc
-#     compiler: gxx_linux-64
-#     cc: gcc-11
-#     cxx: g++-11
-#   steps:
-#   - template: .azure-pipelines/linux_build_limitexternal.yml
-# - job: Ubuntu_x64_java
-#   timeoutInMinutes: 90
-#   pool:
-#     vmImage: ubuntu-20.04
-#   variables:
-#     boost_version: 1.84.0
-#     number_of_cores: nproc
-#     python_name: python37
-#     compiler: gxx_linux-64
-#     cc: gcc-10
-#     cxx: g++-10
-#   steps:
-#   - template: .azure-pipelines/linux_build_java.yml
-# - job: Windows_VS2022_x64_swig
-#   timeoutInMinutes: 90
-#   pool:
-#     vmImage: windows-2019
-#   variables:
-#     boost_version: 1.84.0
-#     number_of_cores: '%NUMBER_OF_PROCESSORS%'
-#     python_name: python38
-#   steps:
-#   - template: .azure-pipelines/vs_build_swig.yml
+      tags: 'latest' 
+- job: Ubuntu_x64
+  timeoutInMinutes: 120
+  pool:
+    vmImage: ubuntu-20.04
+  variables:
+    python: python=3.8
+    boost_version: 1.71.0
+    compiler: gxx_linux-64
+    number_of_cores: nproc
+    python_name: python38
+    cc: gcc-10
+    cxx: g++-10
+  steps:
+  - template: .azure-pipelines/linux_build.yml
+- job: Ubuntu_x64_py311
+  timeoutInMinutes: 120
+  pool:
+    vmImage: ubuntu-latest
+  variables:
+    python: python=3.11
+    boost_version: 1.82.0
+    compiler: gxx_linux-64
+    cc: gcc-10
+    cxx: g++-10
+    number_of_cores: nproc
+    python_name: python311
+  steps:
+  - template: .azure-pipelines/linux_build_py311.yml
+- job: macOS_x64
+  timeoutInMinutes: 120
+  pool:
+    vmImage: macos-14
+  variables:
+    compiler: clangxx_osx-64=18.1
+    compiler_version: 16
+    boost_version: 1.84
+    number_of_cores: sysctl -n hw.ncpu
+    target_platform: 14.5
+    python: python=3.11
+  steps:
+  - template: .azure-pipelines/mac_build.yml
+- job: macOS_x64_java
+  timeoutInMinutes: 90
+  pool:
+    vmImage: macos-14
+  variables:
+    compiler: clangxx_osx-64=18.1
+    compiler_version: 16
+    boost_version: 1.84
+    number_of_cores: sysctl -n hw.ncpu
+    target_platform: 14.5
+  steps:
+  - template: .azure-pipelines/mac_build_java.yml
+- job: Windows_VS2022_x64
+  timeoutInMinutes: 120
+  pool:
+    vmImage: windows-2019
+  variables:
+    boost_version: 1.84.0
+    number_of_cores: '%NUMBER_OF_PROCESSORS%'
+    python: python=3.12
+  steps:
+  - template: .azure-pipelines/vs_build.yml
+- job: Windows_VS2022_x64_dll
+  timeoutInMinutes: 120
+  pool:
+    vmImage: windows-2019
+  variables:
+    boost_version: 1.84.0
+    number_of_cores: '%NUMBER_OF_PROCESSORS%'
+    python: python=3.12
+  steps:
+  - template: .azure-pipelines/vs_build_dll.yml
+- job: Ubuntu_x64_cartridge
+  timeoutInMinutes: 90
+  pool:
+    vmImage: ubuntu-20.04
+  variables:
+    boost_version: 1.71.0
+    number_of_cores: nproc
+    compiler: gxx_linux-64
+    cc: gcc-10
+    cxx: g++-10
+  steps:
+  - template: .azure-pipelines/linux_build_cartridge.yml
+- job: Ubuntu_x64_limitexternaldependencies
+  timeoutInMinutes: 90
+  pool:
+    vmImage: ubuntu-22.04
+  variables:
+    python: python=3.11
+    boost_version: 1.82.0
+    number_of_cores: nproc
+    compiler: gxx_linux-64
+    cc: gcc-11
+    cxx: g++-11
+  steps:
+  - template: .azure-pipelines/linux_build_limitexternal.yml
+- job: Ubuntu_x64_java
+  timeoutInMinutes: 90
+  pool:
+    vmImage: ubuntu-20.04
+  variables:
+    boost_version: 1.84.0
+    number_of_cores: nproc
+    python_name: python37
+    compiler: gxx_linux-64
+    cc: gcc-10
+    cxx: g++-10
+  steps:
+  - template: .azure-pipelines/linux_build_java.yml
+- job: Windows_VS2022_x64_swig
+  timeoutInMinutes: 90
+  pool:
+    vmImage: windows-2019
+  variables:
+    boost_version: 1.84.0
+    number_of_cores: '%NUMBER_OF_PROCESSORS%'
+    python_name: python38
+  steps:
+  - template: .azure-pipelines/vs_build_swig.yml
 
 # - job: Ubuntu_18_04_x64_fuzzer
 #  timeoutInMinutes: 90


### PR DESCRIPTION
This adds a new CI job which does a build of the minimallib docker image.

The amount of duplicated code in the new Dockerfile and the old one is not great, but the docker mechanisms for combining files are considerably more complicated and would require some refactoring. Maybe someone will have time and motivation to work on that in the future, but it doesn't seem critical