### PR TITLE
Another mem leak fix to the InChI conversion

### DIFF
--- a/External/INCHI-API/inchi.cpp
+++ b/External/INCHI-API/inchi.cpp
@@ -1367,6 +1367,7 @@ RWMol *InchiToMol(const std::string &inchi, ExtraInchiReturnValues &rv,
             BOOST_LOG(rdErrorLog) << "illegal bond type ("
                                   << (unsigned int)inchiAtom->bond_type[b]
                                   << ") in InChI" << std::endl;
+            FreeStructFromINCHI(&inchiOutput);
             delete m;
             return nullptr;
           }


### PR DESCRIPTION
I missed this one in #8276. It leaks about 40 kb of data from the InChI structure when there's an illegal bond type.
