### PR TITLE
Make MaeWriter to throw on errors.

### DIFF
--- a/Code/GraphMol/FileParsers/FileWriters.h
+++ b/Code/GraphMol/FileParsers/FileWriters.h
@@ -14,7 +14,6 @@
 #include <RDGeneral/types.h>
 #include <GraphMol/RDKitBase.h>
 #include <string>
-#include <iostream>
 
 namespace RDKit {
 

--- a/Code/GraphMol/FileParsers/MaeWriter.cpp
+++ b/Code/GraphMol/FileParsers/MaeWriter.cpp
@@ -212,12 +212,6 @@ void setPropertyValue(mae::IndexedBlock &block, const std::string &propName,
   property->set(idx, value);
 }
 
-class UnsupportedBondException : public std::runtime_error {
- public:
-  UnsupportedBondException(const char *msg) : std::runtime_error(msg) {}
-  UnsupportedBondException(const std::string &msg) : std::runtime_error(msg) {}
-};
-
 int bondTypeToOrder(const Bond &bond) {
   switch (bond.getBondType()) {
     case Bond::BondType::SINGLE:
@@ -230,7 +224,7 @@ int bondTypeToOrder(const Bond &bond) {
     case Bond::BondType::DATIVE:
       return 0;
     default:
-      throw UnsupportedBondException(
+      throw FileParseException(
           "Bond " + std::to_string(bond.getIdx()) +
           " has a type that is not supported by maeparser.");
   }
@@ -498,17 +492,13 @@ void mapBonds(const ROMol &mol, const STR_VECT &propNames,
 std::shared_ptr<mae::Block> _MolToMaeCtBlock(const ROMol &mol, int confId,
                                              const STR_VECT &propNames) {
   if (mol.getNumAtoms() == 0) {
-    BOOST_LOG(rdErrorLog)
-        << "ERROR: molecules without atoms cannot be exported to Maestro files.\n";
-    return nullptr;
+    throw FileParseException(
+        "molecules without atoms cannot be exported to Maestro files.\n");
   }
 
   RWMol tmpMol(mol);
-  if (!MolOps::KekulizeIfPossible(tmpMol)) {
-    BOOST_LOG(rdErrorLog)
-        << "ERROR: the mol cannot be kekulized, and will not be written to the output file.\n";
-    return nullptr;
-  }
+  MolOps::Kekulize(tmpMol);
+
   if (mol.getNumConformers() == 0) {
     // make sure there's at least one conformer we can write
     RDDepict::compute2DCoords(tmpMol);
@@ -523,15 +513,7 @@ std::shared_ptr<mae::Block> _MolToMaeCtBlock(const ROMol &mol, int confId,
   mapAtoms(tmpMol, propNames, confId, *indexedBlockMap);
 
   if (mol.getNumBonds() > 0) {
-    try {
-      mapBonds(tmpMol, propNames, *indexedBlockMap);
-
-    } catch (const UnsupportedBondException &exc) {
-      BOOST_LOG(rdErrorLog)
-          << "ERROR: " << exc.what()
-          << " The mol will not be written to the output file.\n";
-      return nullptr;
-    }
+    mapBonds(tmpMol, propNames, *indexedBlockMap);
   }
 
   stBlock->setIndexedBlockMap(indexedBlockMap);
@@ -608,23 +590,19 @@ void MaeWriter::write(const ROMol &mol, int confId) {
 
   auto block = _MolToMaeCtBlock(mol, confId, d_props);
 
-  if (block != nullptr) {
-    if (!dp_writer) {
-      open();
-    }
-
-    block->write(*dp_ostream);
-    ++d_molid;
+  if (!dp_writer) {
+    open();
   }
+
+  block->write(*dp_ostream);
+  ++d_molid;
 }
 
 std::string MaeWriter::getText(const ROMol &mol, int confId,
                                const STR_VECT &propNames) {
   std::stringstream sstr;
   auto block = _MolToMaeCtBlock(mol, confId, propNames);
-  if (block != nullptr) {
-    block->write(sstr);
-  }
+  block->write(sstr);
 
   return sstr.str();
 }

--- a/Code/GraphMol/FileParsers/MaeWriter.cpp
+++ b/Code/GraphMol/FileParsers/MaeWriter.cpp
@@ -224,7 +224,7 @@ int bondTypeToOrder(const Bond &bond) {
     case Bond::BondType::DATIVE:
       return 0;
     default:
-      throw FileParseException(
+      throw ValueErrorException(
           "Bond " + std::to_string(bond.getIdx()) +
           " has a type that is not supported by maeparser.");
   }
@@ -492,7 +492,7 @@ void mapBonds(const ROMol &mol, const STR_VECT &propNames,
 std::shared_ptr<mae::Block> _MolToMaeCtBlock(const ROMol &mol, int confId,
                                              const STR_VECT &propNames) {
   if (mol.getNumAtoms() == 0) {
-    throw FileParseException(
+    throw ValueErrorException(
         "molecules without atoms cannot be exported to Maestro files.\n");
   }
 

--- a/Code/GraphMol/FileParsers/PDBWriter.cpp
+++ b/Code/GraphMol/FileParsers/PDBWriter.cpp
@@ -266,14 +266,13 @@ std::string MolToPDBBody(const ROMol &mol, const Conformer *conf,
 }
 
 std::string MolToPDBBlock(const ROMol &imol, int confId, unsigned int flavor) {
-  ROMol mol(imol);
-  auto &trwmol = static_cast<RWMol &>(mol);
-  MolOps::Kekulize(trwmol);
+  RWMol rwmol(imol);
+  MolOps::Kekulize(rwmol);
   Utils::LocaleSwitcher ls;
 
   std::string res;
   std::string name;
-  if (mol.getPropIfPresent(common_properties::_Name, name)) {
+  if (rwmol.getPropIfPresent(common_properties::_Name, name)) {
     if (!name.empty()) {
       res += "COMPND    ";
       res += name;
@@ -286,26 +285,27 @@ std::string MolToPDBBlock(const ROMol &imol, int confId, unsigned int flavor) {
   unsigned int conect_count = 0;
 
   const Conformer *conf;
-  if (confId < 0 && mol.getNumConformers() > 1) {
-    int count = mol.getNumConformers();
+  if (confId < 0 && rwmol.getNumConformers() > 1) {
+    int count = rwmol.getNumConformers();
     for (confId = 0; confId < count; confId++) {
-      conf = &(mol.getConformer(confId));
+      conf = &(rwmol.getConformer(confId));
       std::stringstream ss;
       ss << "MODEL     ";
       ss << std::setw(4) << (confId + 1);
       ss << "\n";
       res += ss.str();
       res +=
-          MolToPDBBody(mol, conf, flavor, atm_count, ter_count, conect_count);
+          MolToPDBBody(rwmol, conf, flavor, atm_count, ter_count, conect_count);
       res += "ENDMDL\n";
     }
   } else {
-    if (confId < 0 && mol.getNumConformers() == 0) {
+    if (confId < 0 && rwmol.getNumConformers() == 0) {
       conf = nullptr;
     } else {
-      conf = &(mol.getConformer(confId));
+      conf = &(rwmol.getConformer(confId));
     }
-    res += MolToPDBBody(mol, conf, flavor, atm_count, ter_count, conect_count);
+    res +=
+        MolToPDBBody(rwmol, conf, flavor, atm_count, ter_count, conect_count);
   }
 
   if (flavor & 16) {

--- a/Code/GraphMol/FileParsers/file_parsers_catch.cpp
+++ b/Code/GraphMol/FileParsers/file_parsers_catch.cpp
@@ -6454,7 +6454,7 @@ TEST_CASE("MaeWriter basic testing", "[mae][MaeWriter][writer]") {
 TEST_CASE("MaeWriter edge case testing", "[mae][MaeWriter][writer][bug]") {
   SECTION("No atoms") {
     ROMol m;
-    CHECK_THROWS_AS(RDKit::MaeWriter::getText(m), FileParseException);
+    CHECK_THROWS_AS(RDKit::MaeWriter::getText(m), ValueErrorException);
   }
 
   SECTION("No bonds") {
@@ -6488,7 +6488,7 @@ TEST_CASE("MaeWriter edge case testing", "[mae][MaeWriter][writer][bug]") {
 
     m->getBondWithIdx(0)->setBondType(Bond::DATIVEONE);
 
-    CHECK_THROWS_AS(RDKit::MaeWriter::getText(*m), FileParseException);
+    CHECK_THROWS_AS(RDKit::MaeWriter::getText(*m), ValueErrorException);
   }
 }
 

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -2,6 +2,8 @@
 (Changes relative to Release_2024.09.1)
 ## Backwards incompatible changes
 - The order of combinations returned by Chem.Pharm2D.Utils.GetUniqueCombinations has changed to be in numerical order. The combinations themselves are unchanged.
+- The MaeWriter class will now throw when attempting to write an empty Mol or when there are errors during the writing (e.g. kekulization errors). Previous behavior
+was to log an error and return an empty string.
 
 ## Acknowledgements
 (Note: I'm no longer attempting to manually curate names. If you would like to


### PR DESCRIPTION
`MaeWriter` didn't throw on errors, it was just returning an empty string when an error happened. We have now decided that it should throw, instead.

The change in `PdbWriter` avoids an unnecessary downcast from `ROMol` to `RWMol`.