### PR TITLE
Fix memory leaks in MolStandardize SWIG Wrapper

### DIFF
--- a/Code/GraphMol/RGroupDecomposition/RGroupFingerprintScore.cpp
+++ b/Code/GraphMol/RGroupDecomposition/RGroupFingerprintScore.cpp
@@ -62,7 +62,7 @@ void addFingerprintToRGroupData(RGroupData *rgroupData) {
     try {
       MolOps::sanitizeMol(mol);
     } catch (MolSanitizeException &) {
-      BOOST_LOG(rdWarningLog)
+      BOOST_LOG(rdDebugLog)
           << "Failed to sanitize RGroup fingerprint mol for "
           << rgroupData->smiles << std::endl;
     }

--- a/Code/JavaWrappers/MolStandardize.i
+++ b/Code/JavaWrappers/MolStandardize.i
@@ -19,6 +19,19 @@ namespace std {
 %template(PipelineLog) std::vector<RDKit::MolStandardize::PipelineLogEntry>;
 }
 
+%newobject RDKit::MolStandardize::cleanup;
+%newobject RDKit::MolStandardize::normalize;
+%newobject RDKit::MolStandardize::reionize;
+%newobject RDKit::MolStandardize::removeFragments;
+%newobject RDKit::MolStandardize::canonicalTautomer;
+%newobject RDKit::MolStandardize::tautomerParent;
+%newobject RDKit::MolStandardize::fragmentParent;
+%newobject RDKit::MolStandardize::stereoParent;
+%newobject RDKit::MolStandardize::isotopeParent;
+%newobject RDKit::MolStandardize::chargeParent;
+%newobject RDKit::MolStandardize::superParent;
+%newobject RDKit::MolStandardize::disconnectOrganometallics;
+
 %include <GraphMol/MolStandardize/MolStandardize.h>
 
 %include "enums.swg"


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! 
-->

#### What does this implement/fix? Explain your changes.

The `MolStandardize` methods that return molecules return raw pointers.  This PR wraps those using `%newobject` to prevent memory leaks. 

#### Any other comments?

Also includes a small change to RGD logging.
