### PR TITLE
Fix the way carbon is handed in cleanupOrganometallics()

### DIFF
--- a/Code/GraphMol/FileParsers/Mol2FileParser.cpp
+++ b/Code/GraphMol/FileParsers/Mol2FileParser.cpp
@@ -951,6 +951,10 @@ std::unique_ptr<RWMol> MolFromMol2DataStream(std::istream &inStream,
     MolOps::cleanUp(*res);
 
     try {
+      // when we sanitize for mol2, we skip the cleanup organometallic step since it's
+      // not really compatible with the semantics of mol2 files
+      constexpr auto sanitizeFlags = MolOps::SanitizeFlags::SANITIZE_ALL ^
+                            MolOps::SanitizeFlags::SANITIZE_CLEANUP_ORGANOMETALLICS;
       if (params.removeHs) {
         // Bond stereo detection must happen before H removal, or
         // else we might be removing stereogenic H atoms in double
@@ -961,11 +965,15 @@ std::unique_ptr<RWMol> MolFromMol2DataStream(std::istream &inStream,
         // rings in bond stereo detection, and another in
         // sanitization's SSSR symmetrization).
         unsigned int failedOp = 0;
-        MolOps::sanitizeMol(*res, failedOp, MolOps::SANITIZE_CLEANUP);
+        MolOps::sanitizeMol(*res, failedOp, MolOps::SanitizeFlags::SANITIZE_CLEANUP);
         MolOps::detectBondStereochemistry(*res);
-        MolOps::removeHs(*res);
+        MolOps::RemoveHsParameters rhp;
+        bool sanitize = false;
+        MolOps::removeHs(*res, rhp, sanitize);
+        MolOps::sanitizeMol(*res, failedOp, sanitizeFlags);
       } else {
-        MolOps::sanitizeMol(*res);
+        unsigned int failedOp;
+        MolOps::sanitizeMol(*res, failedOp, sanitizeFlags);
         MolOps::detectBondStereochemistry(*res);
       }
 

--- a/Code/GraphMol/FileParsers/file_parsers_catch.cpp
+++ b/Code/GraphMol/FileParsers/file_parsers_catch.cpp
@@ -1838,6 +1838,8 @@ GASTEIGER
     CHECK(mol->getNumAtoms() == 2);
   }
   SECTION("_mol2 failure") {
+    // this one checks that the C-Na bond is not automatically converted
+    // to dative when parsing Mol2 files
     auto mol = R"DATA(@<TRIPOS>MOLECULE
 UNK
 6 5 0 0 0

--- a/Code/GraphMol/MolOps.cpp
+++ b/Code/GraphMol/MolOps.cpp
@@ -213,7 +213,7 @@ bool isHypervalentNonMetal(Atom *atom) {
   //  We have a special case in here for aromatic atoms where the explicit
   //  valence matches the max allowed and the degree is 4. This is there for
   //  cases like cyclopentadienyl - metal systems. We need this special case
-  //  because the explicit on the C atoms there ends up being 4
+  //  because the explicit valence on the C atoms there ends up being 4
   const auto &otherValens =
       PeriodicTable::getTable()->getValenceList(effAtomicNum);
   auto maxV = otherValens.back();

--- a/Code/GraphMol/MolOps.cpp
+++ b/Code/GraphMol/MolOps.cpp
@@ -194,7 +194,8 @@ bool isHypervalentNonMetal(Atom *atom) {
   if (isMetal(atom)) {
     return false;
   }
-  auto ev = atom->calcExplicitValence(false);
+  atom->updatePropertyCache(false);
+  int ev = atom->getValence(Atom::ValenceType::EXPLICIT);
   // Check the explicit valence of the non-metal against the allowed
   // valences of the atom, adjusted by its formal charge.  This means that
   // N+ is treated the same as C, O+ the same as N.  This allows for,
@@ -207,14 +208,17 @@ bool isHypervalentNonMetal(Atom *atom) {
   if (effAtomicNum <= 0) {
     return false;
   }
-  // atom is a non-metal, so if its atomic number is > 2, it should
-  // obey the octet rule (2*ev <= 8).  If it doesn't, don't set the bond to
-  // dative, so the molecule is later flagged as having bad valence.
-  // [CH4]-[Na] being a case in point, line 1800 of
-  // FileParsers/file_parsers_catch.cpp.
+  // atom is a non-metal. If its explicit valence is greater than the
+  // maximum allowed valence then it is hypervalent.
+  //  We have a special case in here for aromatic atoms where the explicit
+  //  valence matches the max allowed and the degree is 4. This is there for
+  //  cases like cyclopentadienyl - metal systems. We need this special case
+  //  because the explicit on the C atoms there ends up being 4
   const auto &otherValens =
       PeriodicTable::getTable()->getValenceList(effAtomicNum);
-  if (otherValens.back() > 0 && ev > otherValens.back()) {
+  auto maxV = otherValens.back();
+  if (maxV > 0 && (ev > maxV || (ev == maxV && atom->getIsAromatic() &&
+                                 atom->getTotalDegree() == 4))) {
     return true;
   }
 

--- a/Code/GraphMol/MolOps.cpp
+++ b/Code/GraphMol/MolOps.cpp
@@ -214,7 +214,7 @@ bool isHypervalentNonMetal(Atom *atom) {
   // FileParsers/file_parsers_catch.cpp.
   const auto &otherValens =
       PeriodicTable::getTable()->getValenceList(effAtomicNum);
-  if (otherValens.back() > 0 && ev > otherValens.back() && ev <= 4) {
+  if (otherValens.back() > 0 && ev > otherValens.back()) {
     return true;
   }
 

--- a/Code/GraphMol/catch_molops.cpp
+++ b/Code/GraphMol/catch_molops.cpp
@@ -336,4 +336,83 @@ TEST_CASE("cleanuporganometallics and carbon") {
       }
     }
   }
+  SECTION("github #8312") {
+    std::string mb = R"CTAB(
+  ChemDraw03012503262D
+
+  0  0  0     0  0              0 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 21 24 0 0 0
+M  V30 BEGIN ATOM
+M  V30 1 C -1.822529 0.405221 0.000000 0 VAL=5
+M  V30 2 C -1.822529 -0.419779 0.000000 0 VAL=5
+M  V30 3 C -1.239167 -1.003142 0.000000 0
+M  V30 4 C -0.414167 -1.003142 0.000000 0
+M  V30 5 C 0.169196 -0.419779 0.000000 0 VAL=5
+M  V30 6 C 0.169196 0.405221 0.000000 0 VAL=5
+M  V30 7 C -0.414167 0.988584 0.000000 0
+M  V30 8 C -1.239167 0.988584 0.000000 0
+M  V30 9 Pt 1.335541 -0.028481 0.000000 0 VAL=6
+M  V30 10 C 1.697726 0.712766 0.000000 0
+M  V30 11 C 1.796387 -0.712766 0.000000 0
+M  V30 12 H 2.520757 0.769729 0.000000 0
+M  V30 13 H 1.236879 1.397051 0.000000 0
+M  V30 14 H 2.059910 1.454013 0.000000 0
+M  V30 15 H 2.619419 -0.655803 0.000000 0
+M  V30 16 H 1.434203 -1.454013 0.000000 0
+M  V30 17 H 2.257234 -1.397051 0.000000 0
+M  V30 18 H -2.619419 0.618747 0.000000 0
+M  V30 19 H -2.619419 -0.633305 0.000000 0
+M  V30 20 H 0.382722 1.202110 0.000000 0
+M  V30 21 H 0.581696 -1.134250 0.000000 0
+M  V30 END ATOM
+M  V30 BEGIN BOND
+M  V30 1 2 1 2
+M  V30 2 1 2 3
+M  V30 3 1 3 4
+M  V30 4 1 4 5
+M  V30 5 2 5 6
+M  V30 6 1 6 7
+M  V30 7 1 7 8
+M  V30 8 1 8 1
+M  V30 9 1 9 10
+M  V30 10 1 9 11
+M  V30 11 1 10 12
+M  V30 12 1 10 13
+M  V30 13 1 10 14
+M  V30 14 1 11 15
+M  V30 15 1 11 16
+M  V30 16 1 11 17
+M  V30 17 1 9 6
+M  V30 18 1 9 5
+M  V30 19 1 9 1
+M  V30 20 1 9 2
+M  V30 21 1 1 18
+M  V30 22 1 2 19
+M  V30 23 1 6 20
+M  V30 24 1 5 21
+M  V30 END BOND
+M  V30 END CTAB
+M  END)CTAB";
+    auto mol = v2::FileParsers::MolFromMolBlock(mb);
+    REQUIRE(mol);
+    REQUIRE(mol->getBondBetweenAtoms(5, 8));
+    CHECK(mol->getBondBetweenAtoms(5, 8)->getBondType() ==
+          Bond::BondType::DATIVE);
+    REQUIRE(mol->getBondBetweenAtoms(4, 8));
+    CHECK(mol->getBondBetweenAtoms(4, 8)->getBondType() ==
+          Bond::BondType::DATIVE);
+    REQUIRE(mol->getBondBetweenAtoms(0, 8));
+    CHECK(mol->getBondBetweenAtoms(0, 8)->getBondType() ==
+          Bond::BondType::DATIVE);
+    REQUIRE(mol->getBondBetweenAtoms(1, 8));
+    CHECK(mol->getBondBetweenAtoms(1, 8)->getBondType() ==
+          Bond::BondType::DATIVE);
+    REQUIRE(mol->getBondBetweenAtoms(9, 8));
+    CHECK(mol->getBondBetweenAtoms(9, 8)->getBondType() ==
+          Bond::BondType::SINGLE);
+    REQUIRE(mol->getBondBetweenAtoms(10, 8));
+    CHECK(mol->getBondBetweenAtoms(10, 8)->getBondType() ==
+          Bond::BondType::SINGLE);
+  }
 }


### PR DESCRIPTION
In the current master the logic in `cleanupOrganometallics()` for converting single bonds from hypervalent atoms to metals into dative bonds essentially doesn't work for carbon.

For example, eta-3 propene represented with the SMILES `[CH2-]1-[CH]2=[CH2]3.[Fe]123`:
![image](https://github.com/user-attachments/assets/27798feb-9118-46c9-8537-f93e1de6a139)
Should be converted to:
![image](https://github.com/user-attachments/assets/029aa79a-8e06-4f93-8578-55b2d16b6573)

Even worse is the handling of this: `[cH]12[cH]3[cH]4[cH]5[cH]6[cH]17.[Fe]234567`, which ends up losing the aromatic bonds:
![image](https://github.com/user-attachments/assets/dfb6f28d-4cef-473e-839d-b1cf41729ccc)
It should be converted to:
![image](https://github.com/user-attachments/assets/a3f93d32-974d-4342-b8b2-cfaa93e0edb7)

This fixes that problem.

There's also a change to disable `cleanupOrganometallics()` when parsing mol2 files. Given the semantics encoded by the atoms types on those files, this kind of cleanup operation doesn't really make sense for them.

Fixes #8312 