### PR TITLE
Fix potential build error under MSVC

### DIFF
--- a/Code/GraphMol/Atom.h
+++ b/Code/GraphMol/Atom.h
@@ -76,7 +76,8 @@ class RDKIT_GRAPHMOL_EXPORT Atom : public RDProps {
   friend class MolPickler;  //!< the pickler needs access to our privates
   friend class ROMol;
   friend class RWMol;
-  friend std::ostream &(::operator<<)(std::ostream &target, const Atom &at);
+  friend std::ostream &(::operator<<)(std::ostream &target,
+                                      const ::RDKit::Atom &at);
   friend int calculateImplicitValence(const Atom &, bool, bool);
 
  public:
@@ -190,12 +191,10 @@ class RDKIT_GRAPHMOL_EXPORT Atom : public RDProps {
   unsigned int getValence(ValenceType which) const;
 
   //! returns the explicit valence (including Hs) of this atom
-  [[deprecated("please use getValence(true)")]]
-  int getExplicitValence() const;
+  [[deprecated("please use getValence(true)")]] int getExplicitValence() const;
 
   //! returns the implicit valence for this Atom
-  [[deprecated("please use getValence(false)")]]
-  int getImplicitValence() const;
+  [[deprecated("please use getValence(false)")]] int getImplicitValence() const;
 
   //! returns whether the atom has a valency violation or not
   bool hasValenceViolation() const;


### PR DESCRIPTION
This is an edge case that I've hit with MSVC VC v14.29.30133 compiler.

It seems there's an ambiguity of this `friend operator<<` declaration: if the compiler has seen a `::Atom` `class` or `struct` declaration (even a forward declaration) before including this header, it seems that the VC compiler will prefer that declaration to the `RDKit::Atom` one where this declaration is made. It will trigger a build error like this one:
```
my_code.cpp
..\rdkit-Release_2024_09_5\include\rdkit\GraphMol/Atom.h(79): error C2063: 'operator <<': not a function
```

This patch seems to resolve the ambiguity and fix the issue.
