### PR TITLE
Add RascalMCES option to require complete RingInfo rings

### DIFF
--- a/Code/GraphMol/RascalMCES/RascalMCES.cpp
+++ b/Code/GraphMol/RascalMCES/RascalMCES.cpp
@@ -446,15 +446,16 @@ void buildPairs(const ROMol &mol1, const std::vector<unsigned int> &vtxLabels1,
   for (auto i = 0u; i < vtxLabels1.size(); ++i) {
     for (auto j = 0u; j < vtxLabels2.size(); ++j) {
       if (vtxLabels1[i] == vtxLabels2[j]) {
-        // opts.completeRingsOnly automatically implies opts.completeAromaticRings
-        if (opts.completeRingsOnly &&
+        // completeSmallestRings automatically implies completeAromaticRings and 
+        // ringMatchesRingsOnly
+        if (opts.completeSmallestRings &&
             !checkRings(mol1, mol1RingSmiles, i, mol2, mol2RingSmiles, j, false)) {
           continue;
         } else if (opts.completeAromaticRings &&
             !checkRings(mol1, mol1RingSmiles, i, mol2, mol2RingSmiles, j, true)) {
           continue;
         }
-        if (opts.ringMatchesRingOnly &&
+        if (!opts.completeSmallestRings && opts.ringMatchesRingOnly &&
             !checkRingMatchesRing(mol1, i, mol2, j)) {
           continue;
         }

--- a/Code/GraphMol/RascalMCES/RascalMCES.cpp
+++ b/Code/GraphMol/RascalMCES/RascalMCES.cpp
@@ -331,14 +331,15 @@ void makeLineGraph(const ROMol &mol, std::vector<std::vector<int>> &adjMatrix) {
 
 // make sure that mol1_bond in mol1 and mol2_bond in mol2 are, if aromatic, in
 // at least one ring that is the same.
-bool checkAromaticRings(const ROMol &mol1,
+bool checkRings(const ROMol &mol1,
                         std::vector<std::string> &mol1RingSmiles,
                         int mol1BondIdx, const ROMol &mol2,
                         std::vector<std::string> &mol2RingSmiles,
-                        int mol2BondIdx) {
+                        int mol2BondIdx,
+                        bool aromaticRingsMatchOnly) {
   auto mol1Bond = mol1.getBondWithIdx(mol1BondIdx);
   auto mol2Bond = mol2.getBondWithIdx(mol2BondIdx);
-  if (!mol1Bond->getIsAromatic() || !mol2Bond->getIsAromatic()) {
+  if (aromaticRingsMatchOnly && (!mol1Bond->getIsAromatic() || !mol2Bond->getIsAromatic())) {
     return true;
   }
 
@@ -445,9 +446,12 @@ void buildPairs(const ROMol &mol1, const std::vector<unsigned int> &vtxLabels1,
   for (auto i = 0u; i < vtxLabels1.size(); ++i) {
     for (auto j = 0u; j < vtxLabels2.size(); ++j) {
       if (vtxLabels1[i] == vtxLabels2[j]) {
-        if (opts.completeAromaticRings &&
-            !checkAromaticRings(mol1, mol1RingSmiles, i, mol2, mol2RingSmiles,
-                                j)) {
+        // opts.completeRingsOnly automatically implies opts.completeAromaticRings
+        if (opts.completeRingsOnly &&
+            !checkRings(mol1, mol1RingSmiles, i, mol2, mol2RingSmiles, j, false)) {
+          continue;
+        } else if (opts.completeAromaticRings &&
+            !checkRings(mol1, mol1RingSmiles, i, mol2, mol2RingSmiles, j, true)) {
           continue;
         }
         if (opts.ringMatchesRingOnly &&

--- a/Code/GraphMol/RascalMCES/RascalOptions.h
+++ b/Code/GraphMol/RascalMCES/RascalOptions.h
@@ -24,6 +24,9 @@ struct RDKIT_RASCALMCES_EXPORT RascalOptions {
       true;  // if true, partial aromatic rings won't be returned
   bool ringMatchesRingOnly =
       false;  // if true, ring bonds won't match non-ring bonds
+  bool completeRingsOnly =
+      false;  // if true, only complete rings will be returned. Implies completeAromaticRings
+              // and ringMatchesRingOnly.
   bool exactConnectionsMatch =
       false; /* if true, atoms will only match atoms if they have the same
                 number of explicit connections.  E.g. the central atom of

--- a/Code/GraphMol/RascalMCES/RascalOptions.h
+++ b/Code/GraphMol/RascalMCES/RascalOptions.h
@@ -24,9 +24,10 @@ struct RDKIT_RASCALMCES_EXPORT RascalOptions {
       true;  // if true, partial aromatic rings won't be returned
   bool ringMatchesRingOnly =
       false;  // if true, ring bonds won't match non-ring bonds
-  bool completeRingsOnly =
-      false;  // if true, only complete rings will be returned. Implies completeAromaticRings
-              // and ringMatchesRingOnly.
+  bool completeSmallestRings =
+      false;  // if true, only complete rings present in both input molecule's
+              // RingInfo will be returned. Implies completeAromaticRings and
+              // ringMatchesRingOnly.
   bool exactConnectionsMatch =
       false; /* if true, atoms will only match atoms if they have the same
                 number of explicit connections.  E.g. the central atom of

--- a/Code/GraphMol/RascalMCES/Wrap/rdRascalMCES.cpp
+++ b/Code/GraphMol/RascalMCES/Wrap/rdRascalMCES.cpp
@@ -175,7 +175,10 @@ BOOST_PYTHON_MODULE(rdRascalMCES) {
           "If True (default), partial aromatic rings won't be returned.")
       .def_readwrite("ringMatchesRingOnly",
                      &RDKit::RascalMCES::RascalOptions::ringMatchesRingOnly,
-                     "If True (default), ring bonds won't match ring bonds.")
+                     "If True (default is False), ring bonds will only match ring bonds.")
+      .def_readwrite("completeRingsOnly",
+                     &RDKit::RascalMCES::RascalOptions::completeRingsOnly,
+                     "If True (default if False), only complete rings will be returned. Implies completeAromaticRings and ringMatchesRingOnly..")
       .def_readwrite(
           "exactConnectionsMatch",
           &RDKit::RascalMCES::RascalOptions::exactConnectionsMatch,

--- a/Code/GraphMol/RascalMCES/Wrap/rdRascalMCES.cpp
+++ b/Code/GraphMol/RascalMCES/Wrap/rdRascalMCES.cpp
@@ -175,10 +175,10 @@ BOOST_PYTHON_MODULE(rdRascalMCES) {
           "If True (default), partial aromatic rings won't be returned.")
       .def_readwrite("ringMatchesRingOnly",
                      &RDKit::RascalMCES::RascalOptions::ringMatchesRingOnly,
-                     "If True (default is False), ring bonds will only match ring bonds.")
-      .def_readwrite("completeRingsOnly",
-                     &RDKit::RascalMCES::RascalOptions::completeRingsOnly,
-                     "If True (default if False), only complete rings will be returned. Implies completeAromaticRings and ringMatchesRingOnly..")
+                     "If True (default is False), ring bonds won't match non-ring bonds.")
+      .def_readwrite("completeSmallestRings",
+                     &RDKit::RascalMCES::RascalOptions::completeSmallestRings,
+                     "If True (default is False), only complete rings present in both input molecule's RingInfo will be returned. Implies completeAromaticRings and ringMatchesRingOnly.")
       .def_readwrite(
           "exactConnectionsMatch",
           &RDKit::RascalMCES::RascalOptions::exactConnectionsMatch,

--- a/Code/GraphMol/RascalMCES/Wrap/testRascalMCES.py
+++ b/Code/GraphMol/RascalMCES/Wrap/testRascalMCES.py
@@ -218,6 +218,22 @@ class TestCase(unittest.TestCase):
     mol2 = Chem.MolFromSmiles('CC12CCC3C(C1CCC2O)CCC4=C3C=CC(=C4)O')
     results = rdRascalMCES.FindMCES(mol1, mol2, opts)
     self.assertFalse(results)
+
+  def testCompleteSmallestRings(self):
+    opts = rdRascalMCES.RascalOptions()
+    opts.completeSmallestRings = True
+    opts.similarityThreshold = 0.1
+    mol1 = Chem.MolFromSmiles("CNC1CCC(C)CC1C")
+    mol2 = Chem.MolFromSmiles("CNC1CCC2CCCCCCCCCCCC1C2")
+    results = rdRascalMCES.FindMCES(mol1, mol2, opts)
+    self.assertEqual(results[0].numFragments, 1)
+    self.assertEqual(results[0].smartsString, 'CNC1CCCCC1')
+
+    # Default option; allows partial ring return
+    opts.completeSmallestRings = False
+    results = rdRascalMCES.FindMCES(mol1, mol2, opts)
+    self.assertEqual(results[0].numFragments, 1)
+    self.assertEqual(results[0].smartsString, 'CNC1CCC(-C)-CC1C')
     
     
 if __name__ == "__main__":


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

@DavidACosgrove -- your MCES implementation is awesome! For some of our use cases, it would be helpful to have an option similar to `completeAromaticRings` that requires any ring bonds in `RingInfo` to be in a complete ring in the MCS output. I added that option in this PR along with a test and a typo fix. Let me know what you think :)

#### Examples
```
# From original blogpost https://greglandrum.github.io/rdkit-blog/posts/2023-11-08-introducingrascalmces.html
def extractHighlights(res):
    bondHighlights1 = {}
    bondHighlights2 = {}
    for bondPair in res.bondMatches():
        bondHighlights1[bondPair[0]] = (1.0, 0.0, 0.0)
        bondHighlights2[bondPair[1]] = (1.0, 0.0, 0.0)
    atomHighlights1 = {}
    atomHighlights2 = {}
    for atomPair in res.atomMatches():
        atomHighlights1[atomPair[0]] = (1.0, 0.0, 0.0)
        atomHighlights2[atomPair[1]] = (1.0, 0.0, 0.0)
    return bondHighlights1, bondHighlights2, atomHighlights1, atomHighlights2

def draw_mces(mol1, mol2, options):
    results = rdRascalMCES.FindMCES(mol1, mol2, options)
    res = results[0]
    bondHighlights1, bondHighlights2, atomHighlights1, atomHighlights2 = extractHighlights(res)
    return Draw.MolsToGridImage([mol1, mol2], highlightAtomLists=[atomHighlights1, atomHighlights2], highlightBondLists=[bondHighlights1, bondHighlights2])

m1 = Chem.MolFromSmiles("CCC1NCCCC1C1CCC2CCCCC2C1")
m2 = Chem.MolFromSmiles("CCC1CCCCC1C1CCC2CCCCC2C1")
m3 = Chem.MolFromSmiles("CCC1CCCCCCC1C1CCC2CCCCC2C1")
m4 = Chem.MolFromSmiles("CCCCC1CCC2CCCCC2C1")

opts = rdRascalMCES.RascalOptions()
opts.completeSmallestRings=True
draw_mces(m1, m3, opts)
```

![image](https://github.com/user-attachments/assets/77c4b2c1-67d6-4e90-8178-ad17e6a33e11)

```
m5 = Chem.MolFromSmiles("CNC1CCC(C)CC1C")
m6 = Chem.MolFromSmiles("CNC1CCC2CCCCCCCCCCCC1C2")

# in this case, this option is equivalent to ringMatchesRingOnly
opts = rdRascalMCES.RascalOptions()
opts.similarityThreshold=0.3
opts.completeSmallestRings=True
draw_mces(m5, m6, opts)
```
![image](https://github.com/user-attachments/assets/19c71945-9fc9-4ddf-9d65-b49323dc5dd4)
```
# without completeRingsOnly option
opts = rdRascalMCES.RascalOptions()
opts.similarityThreshold=0.3
opts.completeSmallestRings=False
draw_mces(m5, m6, opts)
```
![image](https://github.com/user-attachments/assets/f9c34191-b3e1-48bd-82e3-a1ee2ce6b749)
```
m7 = Chem.MolFromSmiles("CNC1CCCCCCCCCCCCCCC1")

# this is where we differ from fmcs's completeRingsOnly -- outer ring is not matches
opts = rdRascalMCES.RascalOptions()
opts.similarityThreshold=0.3
opts.completeRingsOnly=True
draw_mecs(m6, m7, opts)
```
![image](https://github.com/user-attachments/assets/6b66fb3a-74e2-47f9-82f3-84d63e9c1684)
```
# whats returned without this option on
opts = rdRascalMCES.RascalOptions()
opts.similarityThreshold=0.3
opts.completeSmallestRings=False
draw_mces(m6, m7, opts)
```
![image](https://github.com/user-attachments/assets/93abfdcf-6076-4a02-b909-e1eaa1a7b259)

#### Any other comments?
At first I wanted to have an option similar to fMCS's `completeRingsOnly` option; but after looking at the implementation, I realized that would likely involve finding all rings and using that information when creating the modular product graph. I think that an option like this is sufficient for many of our use cases, but I'm curious what other's thoughts are.