### PR TITLE
apply query adjustments when makeAtomsGeneric is enabled

### DIFF
--- a/Code/GraphMol/AdjustQuery.cpp
+++ b/Code/GraphMol/AdjustQuery.cpp
@@ -362,6 +362,11 @@ void adjustQueryProperties(RWMol &mol, const AdjustQueryParameters *inParams) {
   QueryAtom qaTmpl;
   QueryBond qbTmpl;
 
+  std::vector<int> origAtomicNums;
+  for (const auto atom : mol.atoms()) {
+    origAtomicNums.push_back(atom->getAtomicNum());
+  }
+
   if (params.makeAtomsGeneric) {
     for (unsigned int i = 0; i < mol.getNumAtoms(); ++i) {
       if (!((params.makeAtomsGenericFlags & ADJUST_IGNORECHAINS) &&
@@ -394,7 +399,7 @@ void adjustQueryProperties(RWMol &mol, const AdjustQueryParameters *inParams) {
     // pull properties we need from the atom here, once we
     // create a query atom they may no longer be valid.
     auto nRings = ringInfo->numAtomRings(i);
-    auto atomicNum = at->getAtomicNum();
+    auto atomicNum = origAtomicNums[i];
     if (params.makeDummiesQueries && atomicNum == 0 && !at->hasQuery() &&
         !at->getIsotope()) {
       qaTmpl.setQuery(makeAtomNullQuery());

--- a/Code/GraphMol/AdjustQuery.cpp
+++ b/Code/GraphMol/AdjustQuery.cpp
@@ -363,6 +363,7 @@ void adjustQueryProperties(RWMol &mol, const AdjustQueryParameters *inParams) {
   QueryBond qbTmpl;
 
   std::vector<int> origAtomicNums;
+  origAtomicNums.reserve(mol.GetNumAtoms());
   for (const auto atom : mol.atoms()) {
     origAtomicNums.push_back(atom->getAtomicNum());
   }

--- a/Code/GraphMol/AdjustQuery.cpp
+++ b/Code/GraphMol/AdjustQuery.cpp
@@ -363,7 +363,7 @@ void adjustQueryProperties(RWMol &mol, const AdjustQueryParameters *inParams) {
   QueryBond qbTmpl;
 
   std::vector<int> origAtomicNums;
-  origAtomicNums.reserve(mol.GetNumAtoms());
+  origAtomicNums.reserve(mol.getNumAtoms());
   for (const auto atom : mol.atoms()) {
     origAtomicNums.push_back(atom->getAtomicNum());
   }

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -3891,7 +3891,7 @@ CAS<~>
     qps = Chem.AdjustQueryParameters()
     qps.makeAtomsGeneric = True
     am = Chem.AdjustQueryProperties(m, qps)
-    self.assertEqual(Chem.MolToSmarts(am), '*1-*-*-*-1-*-*')
+    self.assertEqual(Chem.MolToSmarts(am), '[D2]1-[D2]-[D2]-[D3]-1-*-*')
     qps.makeAtomsGenericFlags = Chem.ADJUST_IGNORERINGS
     am = Chem.AdjustQueryProperties(m, qps)
     self.assertEqual(Chem.MolToSmarts(am), '[#6&D2]1-[#6&D2]-[#6&D2]-[#6&D3]-1-*-*')
@@ -3915,7 +3915,7 @@ CAS<~>
     qps = Chem.AdjustQueryParameters()
     qps.makeAtomsGeneric = True
     am = Chem.AdjustQueryProperties(m, qps)
-    self.assertEqual(Chem.MolFragmentToSmarts(am, [0, 1, 2]), '*-*-*')
+    self.assertEqual(Chem.MolFragmentToSmarts(am, [3, 4, 5]), '[D3]-*-*')
 
   def testAdjustQueryPropertiesgithubIssue1474(self):
     core = Chem.MolFromSmiles('[*:1]C1N([*:2])C([*:3])O1')
@@ -6735,13 +6735,12 @@ M  END
 
     self.assertTrue((pos == pos2).all())
 
-
   def test_get_set_positions_stride(self):
     m = Chem.MolFromSmiles('CCC |(-1.29904,-0.25,;0,0.5,;1.29904,-0.25,)|')
     # to check stride walking in SetPositions
     # allocate a double size array, then slice every other element
     # numpy will mess with the striding to create the view onto the double size array
-    pos = np.zeros([6,3], np.double)[::2]
+    pos = np.zeros([6, 3], np.double)[::2]
     pos[0][1] = 1
     pos[0][2] = 2
     pos[1][0] = 3
@@ -6754,8 +6753,7 @@ M  END
     m.GetConformer(0).SetPositions(pos)
     pos2 = m.GetConformer(0).GetPositions()
 
-    self.assertTrue( (pos==pos2).all())
-
+    self.assertTrue((pos == pos2).all())
 
   def test_github3553(self):
     fileN = os.path.join(RDConfig.RDBaseDir, 'Code', 'GraphMol', 'Wrap', 'test_data',

--- a/Code/GraphMol/catch_adjustquery.cpp
+++ b/Code/GraphMol/catch_adjustquery.cpp
@@ -828,3 +828,34 @@ TEST_CASE(
     CHECK(MolToSmiles(*mol) == "*/N(=N/O)c1ccccc1");
   }
 }
+
+TEST_CASE("makeAtomsGeneric and other operations") {
+  SECTION("makeAtomsGeneric and adjustDegree") {
+    MolOps::AdjustQueryParameters ps =
+        MolOps::AdjustQueryParameters::noAdjustments();
+    ps.makeAtomsGeneric = true;
+    ps.adjustDegree = true;
+    ps.adjustDegreeFlags = MolOps::ADJUST_IGNOREDUMMIES;
+    auto q = "CN"_smiles;
+    REQUIRE(q);
+    MolOps::adjustQueryProperties(*q, &ps);
+    std::vector<std::pair<std::string, bool>> examples = {
+        {"CC", true},
+        {"CN", true},
+        {"CCC", false},
+        {"CNC", false},
+    };
+    for (const auto &tpl : examples) {
+      auto smi = tpl.first;
+      auto shouldMatch = tpl.second;
+      INFO(smi);
+      auto m = v2::SmilesParse::MolFromSmiles(smi);
+      REQUIRE(m);
+      if (shouldMatch) {
+        CHECK(!SubstructMatch(*m, *q).empty());
+      } else {
+        CHECK(SubstructMatch(*m, *q).empty());
+      }
+    }
+  }
+}

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -4,6 +4,8 @@
 - The order of combinations returned by Chem.Pharm2D.Utils.GetUniqueCombinations has changed to be in numerical order. The combinations themselves are unchanged.
 - The MaeWriter class will now throw when attempting to write an empty Mol or when there are errors during the writing (e.g. kekulization errors). Previous behavior
 was to log an error and return an empty string.
+- AdjustQueryProperties now no longer ignores additional atom adjustments when makeAtomsGeneric is enabled.
+
 
 ## Acknowledgements
 (Note: I'm no longer attempting to manually curate names. If you would like to


### PR DESCRIPTION
In current RDKit releases if you call AdjustQueryProperties() with `makeAtomsGeneric` set, the other query adjustments will not performed to the atoms:
```
In [2]: m = Chem.MolFromSmiles('C1CC1OC')

In [3]: ps = Chem.AdjustQueryParameters()

In [4]: Chem.MolToSmarts(Chem.AdjustQueryProperties(m,ps))
Out[4]: '[#6&D2]1-[#6&D2]-[#6&D3]-1-[#8]-[#6]'

In [5]: ps.makeAtomsGeneric = True

In [6]: Chem.MolToSmarts(Chem.AdjustQueryProperties(m,ps))
Out[6]: '*1-*-*-1-*-*'
```
This PR fixes that, so that we get the following:
```
In [2]: m = Chem.MolFromSmiles('C1CC1OC')

In [3]: ps = Chem.AdjustQueryParameters()

In [4]: Chem.MolToSmarts(Chem.AdjustQueryProperties(m,ps))
Out[4]: '[#6&D2]1-[#6&D2]-[#6&D3]-1-[#8]-[#6]'

In [5]: ps.makeAtomsGeneric = True

In [6]: Chem.MolToSmarts(Chem.AdjustQueryProperties(m,ps))
Out[6]: '[D2]1-[D2]-[D3]-1-*-*'
```
