### PR TITLE
Fixes #8304

### DIFF
--- a/Code/GraphMol/MolOps.h
+++ b/Code/GraphMol/MolOps.h
@@ -257,9 +257,11 @@ inline void addHs(RWMol &mol, bool explicitOnly = false, bool addCoords = false,
 //! coordinates based on the geometry of the neighbor.
 /*!
     NOTE: this sets appropriate coordinates in all of the molecule's
-   conformers. \param mol       the molecule the atoms belong to \param idx
-   index of the terminal atom whose coordinates are set \param otherIdx  index
-   of the bonded neighbor atom
+   conformers.
+
+   \param mol       the molecule the atoms belong to
+   \param idx index of the terminal atom whose coordinates are set
+   \param otherIdx  index of the bonded neighbor atom
 */
 
 RDKIT_GRAPHMOL_EXPORT void setTerminalAtomCoords(ROMol &mol, unsigned int idx,
@@ -272,8 +274,9 @@ RDKIT_GRAPHMOL_EXPORT void setTerminalAtomCoords(ROMol &mol, unsigned int idx,
    removed
     \param updateExplicitCount  (optional) If this is \c true, when explicit
    Hs are removed from the graph, the heavy atom to which they are bound will
-   have its counter of explicit Hs increased. \param sanitize:  (optional) If
-   this is \c true, the final molecule will be sanitized
+   have its counter of explicit Hs increased.
+    \param sanitize:  (optional) If this is \c true, the final molecule will be
+   sanitized
 
     \return the new molecule
 

--- a/Code/GraphMol/MolOps.h
+++ b/Code/GraphMol/MolOps.h
@@ -240,7 +240,7 @@ inline ROMol *addHs(const ROMol &mol, bool explicitOnly = false,
                     bool addResidueInfo = false) {
   AddHsParameters ps{explicitOnly, addCoords, addResidueInfo};
   std::unique_ptr<RWMol> res{new RWMol(mol)};
-  addHs(res.get(), ps, onlyOnAtoms);
+  addHs(*res, ps, onlyOnAtoms);
   return static_cast<ROMol *>(res.release());
 }
 //! \overload

--- a/Code/GraphMol/MolOps.h
+++ b/Code/GraphMol/MolOps.h
@@ -192,9 +192,10 @@ RDKIT_GRAPHMOL_EXPORT unsigned int getMolFragsWithQuery(
 
 struct RDKIT_GRAPHMOL_EXPORT AddHsParameters {
   bool explicitOnly = false;   /**< only add explicit Hs */
-  bool addCoords = false;      /**< add coordinates to the Hs */
+  bool addCoords = false;      /**< add coordinates for the Hs */
   bool addResidueInfo = false; /**< add residue info to the Hs */
-  bool skipQueries = false;    /**< do not add Hs to query atoms */
+  bool skipQueries =
+      false; /**< do not add Hs to query atoms or atoms with query bonds */
 };
 //! adds Hs to a molecule as explicit Atoms
 /*!

--- a/Code/GraphMol/MolOps.h
+++ b/Code/GraphMol/MolOps.h
@@ -239,9 +239,9 @@ inline ROMol *addHs(const ROMol &mol, bool explicitOnly = false,
                     const UINT_VECT *onlyOnAtoms = nullptr,
                     bool addResidueInfo = false) {
   AddHsParameters ps{explicitOnly, addCoords, addResidueInfo};
-  RWMol *res = new RWMol(mol);
-  addHs(*res, ps, onlyOnAtoms);
-  return static_cast<ROMol *>(res);
+  std::unique_ptr<RWMol> res{new RWMol(mol)};
+  addHs(res.get(), ps, onlyOnAtoms);
+  return static_cast<ROMol *>(res.release());
 }
 //! \overload
 /// modifies the molecule in place

--- a/Code/GraphMol/MolOps.h
+++ b/Code/GraphMol/MolOps.h
@@ -190,6 +190,27 @@ RDKIT_GRAPHMOL_EXPORT unsigned int getMolFragsWithQuery(
 //! \name Dealing with hydrogens
 //{@
 
+struct RDKIT_GRAPHMOL_EXPORT AddHsParameters {
+  bool explicitOnly = false;   /**< only add explicit Hs */
+  bool addCoords = false;      /**< add coordinates to the Hs */
+  bool addResidueInfo = false; /**< add residue info to the Hs */
+  bool skipQueries = false;    /**< do not add Hs to query atoms */
+};
+//! adds Hs to a molecule as explicit Atoms
+/*!
+    \param mol          the molecule to add Hs to
+    \param params       parameters controlling which Hs are added.
+    \param onlyOnAtoms   (optional) if provided, this should be a vector of
+                IDs of the atoms that will be considered for H addition.
+
+    <b>Notes:</b>
+       - it makes no sense to use the \c addCoords option if the molecule's
+   heavy atoms don't already have coordinates.
+       - the molecule is modified
+ */
+RDKIT_GRAPHMOL_EXPORT void addHs(RWMol &mol, const AddHsParameters &params,
+                                 const UINT_VECT *onlyOnAtoms = nullptr);
+
 //! returns a copy of a molecule with hydrogens added in as explicit Atoms
 /*!
     \param mol          the molecule to add Hs to
@@ -212,25 +233,32 @@ RDKIT_GRAPHMOL_EXPORT unsigned int getMolFragsWithQuery(
        - the caller is responsible for <tt>delete</tt>ing the pointer this
    returns.
  */
-RDKIT_GRAPHMOL_EXPORT ROMol *addHs(const ROMol &mol, bool explicitOnly = false,
-                                   bool addCoords = false,
-                                   const UINT_VECT *onlyOnAtoms = nullptr,
-                                   bool addResidueInfo = false);
+inline ROMol *addHs(const ROMol &mol, bool explicitOnly = false,
+                    bool addCoords = false,
+                    const UINT_VECT *onlyOnAtoms = nullptr,
+                    bool addResidueInfo = false) {
+  AddHsParameters ps{explicitOnly, addCoords, addResidueInfo};
+  RWMol *res = new RWMol(mol);
+  addHs(*res, ps, onlyOnAtoms);
+  return static_cast<ROMol *>(res);
+}
 //! \overload
 /// modifies the molecule in place
-RDKIT_GRAPHMOL_EXPORT void addHs(RWMol &mol, bool explicitOnly = false,
-                                 bool addCoords = false,
-                                 const UINT_VECT *onlyOnAtoms = nullptr,
-                                 bool addResidueInfo = false);
+inline void addHs(RWMol &mol, bool explicitOnly = false, bool addCoords = false,
+                  const UINT_VECT *onlyOnAtoms = nullptr,
+                  bool addResidueInfo = false) {
+  AddHsParameters ps{explicitOnly, addCoords, addResidueInfo};
+  addHs(mol, ps, onlyOnAtoms);
+}
 
 //! Sets Cartesian coordinates for a terminal atom.
 //! Useful for growing an atom off a molecule with sensible
 //! coordinates based on the geometry of the neighbor.
 /*!
-    NOTE: this sets appropriate coordinates in all of the molecule's conformers.
-    \param mol       the molecule the atoms belong to
-    \param idx       index of the terminal atom whose coordinates are set
-    \param otherIdx  index of the bonded neighbor atom
+    NOTE: this sets appropriate coordinates in all of the molecule's
+   conformers. \param mol       the molecule the atoms belong to \param idx
+   index of the terminal atom whose coordinates are set \param otherIdx  index
+   of the bonded neighbor atom
 */
 
 RDKIT_GRAPHMOL_EXPORT void setTerminalAtomCoords(ROMol &mol, unsigned int idx,
@@ -241,13 +269,10 @@ RDKIT_GRAPHMOL_EXPORT void setTerminalAtomCoords(ROMol &mol, unsigned int idx,
     \param mol          the molecule to remove Hs from
     \param implicitOnly if this \c true, only implicit Hs will be
    removed
-    \param updateExplicitCount  (optional) If this is \c true, when explicit Hs
-   are removed
-         from the graph, the heavy atom to which they are bound will have its
-   counter of
-         explicit Hs increased.
-    \param sanitize:  (optional) If this is \c true, the final molecule will be
-   sanitized
+    \param updateExplicitCount  (optional) If this is \c true, when explicit
+   Hs are removed from the graph, the heavy atom to which they are bound will
+   have its counter of explicit Hs increased. \param sanitize:  (optional) If
+   this is \c true, the final molecule will be sanitized
 
     \return the new molecule
 
@@ -286,8 +311,8 @@ struct RDKIT_GRAPHMOL_EXPORT RemoveHsParameters {
   bool removeIsotopes = false; /**< hydrogens with non-default isotopes */
   bool removeAndTrackIsotopes = false; /**< removes hydrogens with non-default
    isotopes and keeps track of the heavy atom the isotopes were attached to in
-   the private _isotopicHs atom property, so they are re-added by AddHs() as the
-   original isotopes if possible*/
+   the private _isotopicHs atom property, so they are re-added by AddHs() as
+   the original isotopes if possible*/
   bool removeDummyNeighbors =
       false; /**< hydrogens with at least one dummy-atom neighbor */
   bool removeDefiningBondStereo =
@@ -368,8 +393,9 @@ RDKIT_GRAPHMOL_EXPORT void mergeQueryHs(RWMol &mol,
 
 
   \param mol the molecule to check for query Hs from
-  \return std::pair  if pair.first is true if the molecule has query hydrogens,
-  if pair.second is true, the queryHs cannot be removed my mergeQueryHs
+  \return std::pair  if pair.first is true if the molecule has query
+  hydrogens, if pair.second is true, the queryHs cannot be removed my
+  mergeQueryHs
 */
 RDKIT_GRAPHMOL_EXPORT std::pair<bool, bool> hasQueryHs(const ROMol &mol);
 
@@ -388,8 +414,8 @@ typedef enum {
 
   Note that some of the options here are either directly contradictory or make
   no sense when combined with each other. We generally assume that client code
-  is doing something sensible and don't attempt to detect possible conflicts or
-  problems.
+  is doing something sensible and don't attempt to detect possible conflicts
+  or problems.
 
 */
 struct RDKIT_GRAPHMOL_EXPORT AdjustQueryParameters {
@@ -422,8 +448,8 @@ struct RDKIT_GRAPHMOL_EXPORT AdjustQueryParameters {
   std::uint32_t adjustRingChainFlags = ADJUST_IGNORENONE;
 
   bool useStereoCareForBonds =
-      false; /**< remove stereochemistry info from double bonds that do not have
-                the stereoCare property set */
+      false; /**< remove stereochemistry info from double bonds that do not
+                have the stereoCare property set */
 
   bool adjustConjugatedFiveRings =
       false; /**< sets bond queries in conjugated five-rings to
@@ -438,8 +464,8 @@ struct RDKIT_GRAPHMOL_EXPORT AdjustQueryParameters {
                 degree one neighbors to SINGLE|AROMATIC */
 
   bool adjustSingleBondsBetweenAromaticAtoms =
-      false; /**<  sets non-ring single bonds between two aromatic or conjugated
-                atoms to SINGLE|AROMATIC */
+      false; /**<  sets non-ring single bonds between two aromatic or
+                conjugated atoms to SINGLE|AROMATIC */
 
   //! \brief returns an AdjustQueryParameters object with all adjustments
   //! disabled
@@ -661,12 +687,12 @@ RDKIT_GRAPHMOL_EXPORT void cleanUp(RWMol &mol);
 //! organometallic species before valence is perceived
 /*!
 
-    \b Note that this function is experimental and may either change in behavior
-   or be replaced with something else in future releases.
+    \b Note that this function is experimental and may either change in
+   behavior or be replaced with something else in future releases.
 
     Currently this:
-     - replaces single bonds between "hypervalent" organic atoms and metals with
-       dative bonds (this is following an IUPAC recommendation:
+     - replaces single bonds between "hypervalent" organic atoms and metals
+   with dative bonds (this is following an IUPAC recommendation:
        https://iupac.qmul.ac.uk/tetrapyrrole/TP8.html)
 
    \param mol    the molecule of interest
@@ -763,8 +789,8 @@ RDKIT_GRAPHMOL_EXPORT void setHybridization(ROMol &mol);
   \param res used to return the vector of rings. Each entry is a vector with
       atom indices.  This information is also stored in the molecule's
       RingInfo structure, so this argument is optional (see overload)
-  \param includeDativeBonds - determines whether or not dative bonds are used in
-      the ring finding.
+  \param includeDativeBonds - determines whether or not dative bonds are used
+  in the ring finding.
 
   \return number of smallest rings found
 
@@ -835,8 +861,8 @@ RDKIT_GRAPHMOL_EXPORT void findRingFamilies(const ROMol &mol);
   \param res used to return the vector of rings. Each entry is a vector with
       atom indices.  This information is also stored in the molecule's
       RingInfo structure, so this argument is optional (see overload)
-  \param includeDativeBonds - determines whether or not dative bonds are used in
-      the ring finding.
+  \param includeDativeBonds - determines whether or not dative bonds are used
+  in the ring finding.
 
   \return the total number of rings = (new rings + old SSSRs)
 
@@ -1012,7 +1038,8 @@ class Hybridizations {
   std::vector<int> d_hybridizations;
 };
 
-//! removes bogus chirality markers (e.g. tetrahedral flags on non-sp3 centers):
+//! removes bogus chirality markers (e.g. tetrahedral flags on non-sp3
+//! centers):
 RDKIT_GRAPHMOL_EXPORT void cleanupChirality(RWMol &mol);
 
 //! removes bogus atropisomeric markers (e.g. those without sp2 begin and end
@@ -1183,8 +1210,8 @@ RDKIT_GRAPHMOL_EXPORT bool needsHs(const ROMol &mol);
  * ferrocene) is to use a dummy atom with a dative bond to the iron atom with
  * the bond labelled with the atoms involved in the organic end of the bond.
  * Another way is to have explicit dative bonds from the atoms of the haptic
- * group to the metal atom.  This function converts the former representation to
- * the latter.
+ * group to the metal atom.  This function converts the former representation
+ * to the latter.
  */
 RDKIT_GRAPHMOL_EXPORT ROMol *hapticBondsToDative(const ROMol &mol);
 
@@ -1197,10 +1224,10 @@ RDKIT_GRAPHMOL_EXPORT void hapticBondsToDative(RWMol &mol);
  * @param mol the molecule of interest
  *
  * Does the reverse of hapticBondsToDative.  If there are multiple contiguous
- * atoms attached by dative bonds to an atom (probably a metal atom), the dative
- * bonds will be replaced by a dummy atom in their centre attached to the
- * (metal) atom by a dative bond, which is labelled with ENDPTS of the atoms
- * that had the original dative bonds.
+ * atoms attached by dative bonds to an atom (probably a metal atom), the
+ * dative bonds will be replaced by a dummy atom in their centre attached to
+ * the (metal) atom by a dative bond, which is labelled with ENDPTS of the
+ * atoms that had the original dative bonds.
  */
 RDKIT_GRAPHMOL_EXPORT ROMol *dativeBondsToHaptic(const ROMol &mol);
 
@@ -1237,8 +1264,8 @@ RDKIT_GRAPHMOL_EXPORT double getExactMolWt(const ROMol &mol,
   \param separateIsotopes  if true, isotopes will show up separately in the
      formula. So C[13CH2]O will give the formula: C[13C]H6O
   \param abbreviateHIsotopes  if true, 2H and 3H will be represented as
-     D and T instead of [2H] and [3H]. This only applies if \c separateIsotopes
-     is true
+     D and T instead of [2H] and [3H]. This only applies if \c
+  separateIsotopes is true
 
   \return the formula as a string
 */
@@ -1296,8 +1323,8 @@ namespace details {
 /*!
  *
  * @param mol the molecule of interest
- * @param atomIdx the index of the atom to which the attachment point should be
- *       added
+ * @param atomIdx the index of the atom to which the attachment point should
+ * be added
  * @param val the attachment point value. Should be 1 or 2
  * @param addAsQueries if true, the dummy atoms will be added as null queries
  *       (i.e. they will match any atom in a substructure search)

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -489,6 +489,23 @@ class TestCase(unittest.TestCase):
     self.assertEqual(m.GetAtomWithIdx(2).GetDegree(), 4)
     self.assertEqual(m.GetAtomWithIdx(1).GetDegree(), 2)
 
+    # AddHsParameters
+    params = Chem.AddHsParameters()
+    params.skipQueries = True
+    m = Chem.MolFromSmiles('CC')
+    self.assertIsNotNone(m)
+    nm = Chem.AddHs(m)
+    self.assertEqual(nm.GetNumAtoms(), 8)
+    nm = Chem.AddHs(m, params)
+    self.assertEqual(nm.GetNumAtoms(), 8)
+
+    m = Chem.MolFromSmarts('[CH3][CH3]')
+    self.assertIsNotNone(m)
+    nm = Chem.AddHs(m)
+    self.assertEqual(nm.GetNumAtoms(), 8)
+    nm = Chem.AddHs(m, params)
+    self.assertEqual(nm.GetNumAtoms(), 2)
+
   def test15Neighbors(self):
     m = Chem.MolFromSmiles('CC(=O)[OH]')
     self.assertTrue(m.GetNumAtoms() == 4)
@@ -6735,13 +6752,12 @@ M  END
 
     self.assertTrue((pos == pos2).all())
 
-
   def test_get_set_positions_stride(self):
     m = Chem.MolFromSmiles('CCC |(-1.29904,-0.25,;0,0.5,;1.29904,-0.25,)|')
     # to check stride walking in SetPositions
     # allocate a double size array, then slice every other element
     # numpy will mess with the striding to create the view onto the double size array
-    pos = np.zeros([6,3], np.double)[::2]
+    pos = np.zeros([6, 3], np.double)[::2]
     pos[0][1] = 1
     pos[0][2] = 2
     pos[1][0] = 3
@@ -6754,8 +6770,7 @@ M  END
     m.GetConformer(0).SetPositions(pos)
     pos2 = m.GetConformer(0).GetPositions()
 
-    self.assertTrue( (pos==pos2).all())
-
+    self.assertTrue((pos == pos2).all())
 
   def test_github3553(self):
     fileN = os.path.join(RDConfig.RDBaseDir, 'Code', 'GraphMol', 'Wrap', 'test_data',

--- a/Code/GraphMol/catch_graphmol.cpp
+++ b/Code/GraphMol/catch_graphmol.cpp
@@ -4894,19 +4894,51 @@ TEST_CASE("Github #8304: addHs should ignore queries") {
     REQUIRE(m1);
     MolOps::addHs(*m1);
     CHECK(m1->getNumAtoms() == 8);
-    auto m2 = "CC"_smarts;
-    REQUIRE(m2);
-    m2->updatePropertyCache(false);
-    MolOps::addHs(*m2);
-    CHECK(m2->getNumAtoms() == 2);
+    std::vector<std::tuple<std::string, unsigned int, unsigned int>> data = {
+        {"CC", 2, 2},
+        {"[CH3]C", 5, 2},
+        {"[CH3][CH3]", 8, 2},
+    };
+    for (const auto &[sma, def, noq] : data) {
+      INFO(sma);
+      auto m2 = v2::SmilesParse::MolFromSmarts(sma);
+      REQUIRE(m2);
+      m2->updatePropertyCache(false);
+      // by default we addHs:
+      {
+        RWMol m3(*m2);
+        MolOps::addHs(m3);
+        CHECK(m3.getNumAtoms() == def);
+      }
+      // but we can change that:
+      MolOps::AddHsParameters ps;
+      ps.skipQueries = true;
+      {
+        RWMol m3(*m2);
+        MolOps::addHs(m3, ps);
+        CHECK(m3.getNumAtoms() == noq);
+      }
+    }
   }
-  SECTION("queryBonds") {
+  SECTION("queryBonds make their atoms queries") {
     auto m1 = "CC"_smiles;
     REQUIRE(m1);
     auto qb = v2::SmilesParse::BondFromSmarts("!@");
     REQUIRE(qb);
     m1->replaceBond(0, qb.get());
-    MolOps::addHs(*m1);
-    CHECK(m1->getNumAtoms() == 2);
+    // by default we addHs:
+    {
+      RWMol m2(*m1);
+      MolOps::addHs(m2);
+      CHECK(m2.getNumAtoms() == 8);
+    }
+    // but we can change that:
+    MolOps::AddHsParameters ps;
+    ps.skipQueries = true;
+    {
+      RWMol m2(*m1);
+      MolOps::addHs(m2, ps);
+      CHECK(m2.getNumAtoms() == 2);
+    }
   }
 }

--- a/Code/GraphMol/catch_graphmol.cpp
+++ b/Code/GraphMol/catch_graphmol.cpp
@@ -4887,3 +4887,26 @@ TEST_CASE("Github #7873: monomer info segfaults and mem leaks", "[PDB]") {
     CHECK(was_deleted == true);
   }
 }
+
+TEST_CASE("Github #8304: addHs should ignore queries") {
+  SECTION("queryAtoms") {
+    auto m1 = "CC"_smiles;
+    REQUIRE(m1);
+    MolOps::addHs(*m1);
+    CHECK(m1->getNumAtoms() == 8);
+    auto m2 = "CC"_smarts;
+    REQUIRE(m2);
+    m2->updatePropertyCache(false);
+    MolOps::addHs(*m2);
+    CHECK(m2->getNumAtoms() == 2);
+  }
+  SECTION("queryBonds") {
+    auto m1 = "CC"_smiles;
+    REQUIRE(m1);
+    auto qb = v2::SmilesParse::BondFromSmarts("!@");
+    REQUIRE(qb);
+    m1->replaceBond(0, qb.get());
+    MolOps::addHs(*m1);
+    CHECK(m1->getNumAtoms() == 2);
+  }
+}


### PR DESCRIPTION
This does not change the default behavior of the code, but instead introduces a new option to AddHs that allows adding Hs to query atoms to be toggled off.

Rather than adding YA parameter to the standard AddHs call, I introduced an `AddHsParameters` struct and put the new option there.
