### PR TITLE
Fix Use-of-Uninitialized-Value in ParseV3000AtomProps

### DIFF
--- a/Code/GraphMol/FileParsers/MolFileParser.cpp
+++ b/Code/GraphMol/FileParsers/MolFileParser.cpp
@@ -2211,6 +2211,12 @@ void ParseV3000AtomProps(RWMol *mol, Atom *&atom, typename T::iterator &token,
                          const T &tokens, unsigned int &line,
                          bool strictParsing) {
   PRECONDITION(mol, "bad molecule");
+  // Check if atom is initialized before proceeding
+  if (!atom) {
+    std::ostringstream errout;
+    errout << "Null atom pointer encountered on line " << line << std::endl;
+    throw FileParseException(errout.str());
+  }
   PRECONDITION(atom, "bad atom");
   std::ostringstream errout;
   while (token != tokens.end()) {


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! 
-->
#### Reference Issue
issue link: https://issues.oss-fuzz.com/issues/380569842 


#### What does this implement/fix? Explain your changes.
This PR addresses  "Use-of-Uninitialized-Value" in the ParseV3000AtomProps function. This issue was observed during fuzz testing with the rdkit:mol_data_stream_to_mol_fuzzer, where uninitialized variables were being accessed, leading to undefined behavior.

