### PR TITLE
cartridge: expose sanitize options to mol_from_ctab

### DIFF
--- a/Code/PgSQL/rdkit/expected/rdkit-91.out
+++ b/Code/PgSQL/rdkit/expected/rdkit-91.out
@@ -1096,7 +1096,7 @@ select 'c1ccc[nH]1'::mol@>qmol_from_ctab('query
 M  END') as match;
  match 
 -------
- t
+ f
 (1 row)
 
 select 'c1cccn1C'::mol@>qmol_from_ctab('query
@@ -1139,9 +1139,9 @@ select mol_to_smarts(qmol_from_ctab('query
   3  4  1  0  0  0  0
   1  6  1  0  0  0  0
 M  END'));
-          mol_to_smarts          
----------------------------------
- [#7&!H0]1:[#6]:[#6]:[#6]:[#6]:1
+           mol_to_smarts           
+-----------------------------------
+ [#7]1(:[#6]:[#6]:[#6]:[#6]:1)-[H]
 (1 row)
 
 select mol_to_smarts(qmol_from_ctab('query
@@ -1161,9 +1161,9 @@ select mol_to_smarts(qmol_from_ctab('query
   3  4  4  0  0  0  0
   1  6  1  0  0  0  0
 M  END'));
-          mol_to_smarts          
----------------------------------
- [#7&!H0]1:[#6]:[#6]:[#6]:[#6]:1
+           mol_to_smarts           
+-----------------------------------
+ [#7]1(:[#6]:[#6]:[#6]:[#6]:1)-[H]
 (1 row)
 
 select mol_to_smarts(qmol_from_ctab('Boronate acid/ester(aryl)
@@ -1580,6 +1580,143 @@ M  END'));
  M  V30 END BOND                           +
  M  V30 END CTAB                           +
  M  END                                    +
+ 
+(1 row)
+
+-- sanitization and Hs: do not sanitize, removing Hs has no effect
+select mol_to_smiles(mol_from_ctab('
+     RDKit          2D
+
+  0  0  0  0  0  0  0  0  0  0999 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 3 2 0 0 0
+M  V30 BEGIN ATOM
+M  V30 1 C 0.000000 0.000000 0.000000 0
+M  V30 2 F 1.299038 0.750000 0.000000 0
+M  V30 3 H 2.598076 -0.000000 0.000000 0
+M  V30 END ATOM
+M  V30 BEGIN BOND
+M  V30 1 1 1 2
+M  V30 2 1 2 3
+M  V30 END BOND
+M  V30 END CTAB
+M  END
+',false,false,true));
+ mol_to_smiles 
+---------------
+ [H]FC
+(1 row)
+
+-- sanitization and Hs: do not sanitize, do not remove Hs
+select mol_to_smiles(mol_from_ctab('
+     RDKit          2D
+
+  0  0  0  0  0  0  0  0  0  0999 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 3 2 0 0 0
+M  V30 BEGIN ATOM
+M  V30 1 C 0.000000 0.000000 0.000000 0
+M  V30 2 F 1.299038 0.750000 0.000000 0
+M  V30 3 H 2.598076 -0.000000 0.000000 0
+M  V30 END ATOM
+M  V30 BEGIN BOND
+M  V30 1 1 1 2
+M  V30 2 1 2 3
+M  V30 END BOND
+M  V30 END CTAB
+M  END
+',false,false,false));
+ mol_to_smiles 
+---------------
+ [H]FC
+(1 row)
+
+-- sanitization and Hs: sanitize, do not remove Hs
+select mol_to_smiles(mol_from_ctab('
+     RDKit          2D
+
+  0  0  0  0  0  0  0  0  0  0999 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 3 2 0 0 0
+M  V30 BEGIN ATOM
+M  V30 1 C 0.000000 0.000000 0.000000 0
+M  V30 2 O 1.299038 0.750000 0.000000 0
+M  V30 3 H 2.598076 -0.000000 0.000000 0
+M  V30 END ATOM
+M  V30 BEGIN BOND
+M  V30 1 1 1 2
+M  V30 2 1 2 3
+M  V30 END BOND
+M  V30 END CTAB
+M  END
+',false,true,false));
+ mol_to_smiles 
+---------------
+ [H]OC
+(1 row)
+
+-- sanitization and Hs: default is to sanitize and remove Hs
+select mol_to_smiles(mol_from_ctab('
+     RDKit          2D
+
+  0  0  0  0  0  0  0  0  0  0999 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 3 2 0 0 0
+M  V30 BEGIN ATOM
+M  V30 1 C 0.000000 0.000000 0.000000 0
+M  V30 2 O 1.299038 0.750000 0.000000 0
+M  V30 3 H 2.598076 -0.000000 0.000000 0
+M  V30 END ATOM
+M  V30 BEGIN BOND
+M  V30 1 1 1 2
+M  V30 2 1 2 3
+M  V30 END BOND
+M  V30 END CTAB
+M  END
+',false));
+ mol_to_smiles 
+---------------
+ CO
+(1 row)
+
+-- sanitization and Hs: sanitize, do not remove Hs, input coords manipulated
+select mol_to_v3kctab(mol_from_ctab('
+     RDKit          2D
+
+  0  0  0  0  0  0  0  0  0  0999 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 3 2 0 0 0
+M  V30 BEGIN ATOM
+M  V30 1 C 0.000000 0.000000 0.000000 0
+M  V30 2 O 1.000000 0.500000 0.000000 0
+M  V30 3 H 2.598076 -0.000000 0.000000 0
+M  V30 END ATOM
+M  V30 BEGIN BOND
+M  V30 1 1 1 2
+M  V30 2 1 2 3
+M  V30 END BOND
+M  V30 END CTAB
+M  END
+',false,true,false));
+              mol_to_v3kctab              
+------------------------------------------
+                                         +
+      RDKit          2D                  +
+                                         +
+   0  0  0  0  0  0  0  0  0  0999 V3000 +
+ M  V30 BEGIN CTAB                       +
+ M  V30 COUNTS 3 2 0 0 0                 +
+ M  V30 BEGIN ATOM                       +
+ M  V30 1 C 0.000000 0.000000 0.000000 0 +
+ M  V30 2 O 1.299038 0.750000 0.000000 0 +
+ M  V30 3 H 2.598076 -0.000000 0.000000 0+
+ M  V30 END ATOM                         +
+ M  V30 BEGIN BOND                       +
+ M  V30 1 1 1 2                          +
+ M  V30 2 1 2 3                          +
+ M  V30 END BOND                         +
+ M  V30 END CTAB                         +
+ M  END                                  +
  
 (1 row)
 

--- a/Code/PgSQL/rdkit/expected/rdkit-91.out
+++ b/Code/PgSQL/rdkit/expected/rdkit-91.out
@@ -1096,7 +1096,7 @@ select 'c1ccc[nH]1'::mol@>qmol_from_ctab('query
 M  END') as match;
  match 
 -------
- f
+ t
 (1 row)
 
 select 'c1cccn1C'::mol@>qmol_from_ctab('query
@@ -1139,9 +1139,9 @@ select mol_to_smarts(qmol_from_ctab('query
   3  4  1  0  0  0  0
   1  6  1  0  0  0  0
 M  END'));
-           mol_to_smarts           
------------------------------------
- [#7]1(:[#6]:[#6]:[#6]:[#6]:1)-[H]
+          mol_to_smarts          
+---------------------------------
+ [#7&!H0]1:[#6]:[#6]:[#6]:[#6]:1
 (1 row)
 
 select mol_to_smarts(qmol_from_ctab('query
@@ -1161,9 +1161,9 @@ select mol_to_smarts(qmol_from_ctab('query
   3  4  4  0  0  0  0
   1  6  1  0  0  0  0
 M  END'));
-           mol_to_smarts           
------------------------------------
- [#7]1(:[#6]:[#6]:[#6]:[#6]:1)-[H]
+          mol_to_smarts          
+---------------------------------
+ [#7&!H0]1:[#6]:[#6]:[#6]:[#6]:1
 (1 row)
 
 select mol_to_smarts(qmol_from_ctab('Boronate acid/ester(aryl)

--- a/Code/PgSQL/rdkit/rdkit.control
+++ b/Code/PgSQL/rdkit/rdkit.control
@@ -1,4 +1,4 @@
 comment = 'Cheminformatics functionality for PostgreSQL.'
-default_version = '4.6.1'
+default_version = '4.7.0'
 module_pathname = '$libdir/rdkit'
 relocatable = true

--- a/Code/PgSQL/rdkit/rdkit.h
+++ b/Code/PgSQL/rdkit/rdkit.h
@@ -126,7 +126,7 @@ char *makeMolBlob(CROMol data, int *len);
 CROMol parseMolText(char *data, bool asSmarts, bool warnOnFail, bool asQuery,
                     bool sanitize);
 CROMol parseMolCTAB(char *data, bool keepConformer, bool warnOnFail,
-                    bool asQuery);
+                    bool asQuery, bool sanitize, bool removeHs);
 char *makeMolText(CROMol data, int *len, bool asSmarts, bool cxSmiles,
                   bool isomeric);
 char *makeCtabText(CROMol data, int *len, bool createDepictionIfMissing,

--- a/Code/PgSQL/rdkit/rdkit.sql.in
+++ b/Code/PgSQL/rdkit/rdkit.sql.in
@@ -225,7 +225,7 @@ RETURNS NULL ON NULL INPUT;
 CREATE CAST (text as mol) WITH FUNCTION mol_from_smiles(text) AS IMPLICIT;
 CREATE CAST (varchar as mol) WITH FUNCTION mol_from_smiles(text) AS IMPLICIT;
 
-CREATE OR REPLACE FUNCTION mol_from_ctab(cstring,bool default false, bool default true, bool default true)
+CREATE OR REPLACE FUNCTION mol_from_ctab(ctab cstring,keep_conformer bool default false, sanitize bool default true, remove_hs bool default true)
 RETURNS mol
 PARALLEL SAFE
 AS 'MODULE_PATHNAME'
@@ -300,7 +300,7 @@ PARALLEL SAFE
 AS 'MODULE_PATHNAME'
 LANGUAGE C STRICT IMMUTABLE;
 
-CREATE OR REPLACE FUNCTION mol_to_ctab(mol,bool default true, bool default false)
+CREATE OR REPLACE FUNCTION mol_to_ctab(mol mol,bool default true, bool default false)
 RETURNS cstring
 PARALLEL SAFE
 AS 'MODULE_PATHNAME'
@@ -340,7 +340,7 @@ PARALLEL SAFE
 AS 'MODULE_PATHNAME', 'mol_from_smarts'
 LANGUAGE C STRICT IMMUTABLE;
 
-CREATE OR REPLACE FUNCTION qmol_from_ctab(cstring,bool default false, bool default false, bool default true)
+CREATE OR REPLACE FUNCTION qmol_from_ctab(ctab cstring,keep_conformer bool default false, sanitize bool default true, remove_hs bool default true)
 RETURNS qmol
 PARALLEL SAFE
 AS 'MODULE_PATHNAME'

--- a/Code/PgSQL/rdkit/rdkit.sql.in
+++ b/Code/PgSQL/rdkit/rdkit.sql.in
@@ -225,7 +225,7 @@ RETURNS NULL ON NULL INPUT;
 CREATE CAST (text as mol) WITH FUNCTION mol_from_smiles(text) AS IMPLICIT;
 CREATE CAST (varchar as mol) WITH FUNCTION mol_from_smiles(text) AS IMPLICIT;
 
-CREATE OR REPLACE FUNCTION mol_from_ctab(cstring,bool default false)
+CREATE OR REPLACE FUNCTION mol_from_ctab(cstring,bool default false, bool default true, bool default true)
 RETURNS mol
 PARALLEL SAFE
 AS 'MODULE_PATHNAME'
@@ -340,7 +340,7 @@ PARALLEL SAFE
 AS 'MODULE_PATHNAME', 'mol_from_smarts'
 LANGUAGE C STRICT IMMUTABLE;
 
-CREATE OR REPLACE FUNCTION qmol_from_ctab(cstring,bool default false)
+CREATE OR REPLACE FUNCTION qmol_from_ctab(cstring,bool default false, bool default false, bool default true)
 RETURNS qmol
 PARALLEL SAFE
 AS 'MODULE_PATHNAME'

--- a/Code/PgSQL/rdkit/rdkit.sql.in
+++ b/Code/PgSQL/rdkit/rdkit.sql.in
@@ -340,7 +340,7 @@ PARALLEL SAFE
 AS 'MODULE_PATHNAME', 'mol_from_smarts'
 LANGUAGE C STRICT IMMUTABLE;
 
-CREATE OR REPLACE FUNCTION qmol_from_ctab(ctab cstring,keep_conformer bool default false, sanitize bool default true, remove_hs bool default true)
+CREATE OR REPLACE FUNCTION qmol_from_ctab(ctab cstring,keep_conformer bool default false, merge_hs bool default true)
 RETURNS qmol
 PARALLEL SAFE
 AS 'MODULE_PATHNAME'

--- a/Code/PgSQL/rdkit/rdkit_io.c
+++ b/Code/PgSQL/rdkit/rdkit_io.c
@@ -112,10 +112,15 @@ PG_FUNCTION_INFO_V1(mol_from_ctab);
 Datum mol_from_ctab(PG_FUNCTION_ARGS) {
   char *data = PG_GETARG_CSTRING(0);
   bool keepConformer = PG_GETARG_BOOL(1);
+  bool sanitize =  PG_GETARG_BOOL(2);
+  bool removeHs =  PG_GETARG_BOOL(3);
   CROMol mol;
   Mol *res;
 
-  mol = parseMolCTAB(data, keepConformer, true, false);
+  
+  bool warnOnFail =  true;
+  bool asQuery =  false;
+  mol = parseMolCTAB(data, keepConformer, warnOnFail, asQuery, sanitize, removeHs);
   if (!mol) {
     PG_RETURN_NULL();
   }
@@ -130,10 +135,14 @@ PG_FUNCTION_INFO_V1(qmol_from_ctab);
 Datum qmol_from_ctab(PG_FUNCTION_ARGS) {
   char *data = PG_GETARG_CSTRING(0);
   bool keepConformer = PG_GETARG_BOOL(1);
+  bool removeHs =  PG_GETARG_BOOL(2);
   CROMol mol;
   Mol *res;
 
-  mol = parseMolCTAB(data, keepConformer, true, true);
+  bool warnOnFail =  true;
+  bool asQuery =  true;
+  bool sanitize = false;
+  mol = parseMolCTAB(data, keepConformer, warnOnFail, asQuery, sanitize, removeHs);
   if (!mol) {
     PG_RETURN_NULL();
   }

--- a/Code/PgSQL/rdkit/sql/rdkit-91.sql
+++ b/Code/PgSQL/rdkit/sql/rdkit-91.sql
@@ -547,3 +547,100 @@ M  V30 3 1 4 5 ENDPTS=(3 1 2 3) ATTACH=ANY
 M  V30 END BOND
 M  V30 END CTAB
 M  END'));
+
+-- sanitization and Hs: do not sanitize, removing Hs has no effect
+select mol_to_smiles(mol_from_ctab('
+     RDKit          2D
+
+  0  0  0  0  0  0  0  0  0  0999 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 3 2 0 0 0
+M  V30 BEGIN ATOM
+M  V30 1 C 0.000000 0.000000 0.000000 0
+M  V30 2 F 1.299038 0.750000 0.000000 0
+M  V30 3 H 2.598076 -0.000000 0.000000 0
+M  V30 END ATOM
+M  V30 BEGIN BOND
+M  V30 1 1 1 2
+M  V30 2 1 2 3
+M  V30 END BOND
+M  V30 END CTAB
+M  END
+',false,false,true));
+-- sanitization and Hs: do not sanitize, do not remove Hs
+select mol_to_smiles(mol_from_ctab('
+     RDKit          2D
+
+  0  0  0  0  0  0  0  0  0  0999 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 3 2 0 0 0
+M  V30 BEGIN ATOM
+M  V30 1 C 0.000000 0.000000 0.000000 0
+M  V30 2 F 1.299038 0.750000 0.000000 0
+M  V30 3 H 2.598076 -0.000000 0.000000 0
+M  V30 END ATOM
+M  V30 BEGIN BOND
+M  V30 1 1 1 2
+M  V30 2 1 2 3
+M  V30 END BOND
+M  V30 END CTAB
+M  END
+',false,false,false));
+-- sanitization and Hs: sanitize, do not remove Hs
+select mol_to_smiles(mol_from_ctab('
+     RDKit          2D
+
+  0  0  0  0  0  0  0  0  0  0999 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 3 2 0 0 0
+M  V30 BEGIN ATOM
+M  V30 1 C 0.000000 0.000000 0.000000 0
+M  V30 2 O 1.299038 0.750000 0.000000 0
+M  V30 3 H 2.598076 -0.000000 0.000000 0
+M  V30 END ATOM
+M  V30 BEGIN BOND
+M  V30 1 1 1 2
+M  V30 2 1 2 3
+M  V30 END BOND
+M  V30 END CTAB
+M  END
+',false,true,false));
+-- sanitization and Hs: default is to sanitize and remove Hs
+select mol_to_smiles(mol_from_ctab('
+     RDKit          2D
+
+  0  0  0  0  0  0  0  0  0  0999 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 3 2 0 0 0
+M  V30 BEGIN ATOM
+M  V30 1 C 0.000000 0.000000 0.000000 0
+M  V30 2 O 1.299038 0.750000 0.000000 0
+M  V30 3 H 2.598076 -0.000000 0.000000 0
+M  V30 END ATOM
+M  V30 BEGIN BOND
+M  V30 1 1 1 2
+M  V30 2 1 2 3
+M  V30 END BOND
+M  V30 END CTAB
+M  END
+',false));
+-- sanitization and Hs: sanitize, do not remove Hs, input coords manipulated
+select mol_to_v3kctab(mol_from_ctab('
+     RDKit          2D
+
+  0  0  0  0  0  0  0  0  0  0999 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 3 2 0 0 0
+M  V30 BEGIN ATOM
+M  V30 1 C 0.000000 0.000000 0.000000 0
+M  V30 2 O 1.000000 0.500000 0.000000 0
+M  V30 3 H 2.598076 -0.000000 0.000000 0
+M  V30 END ATOM
+M  V30 BEGIN BOND
+M  V30 1 1 1 2
+M  V30 2 1 2 3
+M  V30 END BOND
+M  V30 END CTAB
+M  END
+',false,true,false));
+

--- a/Code/PgSQL/rdkit/update_sql/rdkit--4.4.0--4.5.0.sql.in
+++ b/Code/PgSQL/rdkit/update_sql/rdkit--4.4.0--4.5.0.sql.in
@@ -1,4 +1,4 @@
-DROP FUNCTION mol_to_smiles(mol);
+DROP FUNCTION IF EXISTS mol_to_smiles(mol);
 
 CREATE OR REPLACE FUNCTION mol_to_smiles(mol, isomeric bool DEFAULT true)
 RETURNS cstring
@@ -6,7 +6,7 @@ PARALLEL SAFE
 AS 'MODULE_PATHNAME'
 LANGUAGE C STRICT IMMUTABLE;
 
-DROP FUNCTION mol_to_cxsmiles(mol);
+DROP FUNCTION IF EXISTS mol_to_cxsmiles(mol);
 
 CREATE OR REPLACE FUNCTION mol_to_cxsmiles(mol, isomeric bool DEFAULT true)
 RETURNS cstring

--- a/Code/PgSQL/rdkit/update_sql/rdkit--4.4.0--4.5.0.sql.in
+++ b/Code/PgSQL/rdkit/update_sql/rdkit--4.4.0--4.5.0.sql.in
@@ -1,8 +1,12 @@
+DROP FUNCTION mol_to_smiles(mol);
+
 CREATE OR REPLACE FUNCTION mol_to_smiles(mol, isomeric bool DEFAULT true)
 RETURNS cstring
 PARALLEL SAFE
 AS 'MODULE_PATHNAME'
 LANGUAGE C STRICT IMMUTABLE;
+
+DROP FUNCTION mol_to_cxsmiles(mol);
 
 CREATE OR REPLACE FUNCTION mol_to_cxsmiles(mol, isomeric bool DEFAULT true)
 RETURNS cstring

--- a/Code/PgSQL/rdkit/update_sql/rdkit--4.6.1--4.7.0.sql.in
+++ b/Code/PgSQL/rdkit/update_sql/rdkit--4.6.1--4.7.0.sql.in
@@ -1,6 +1,6 @@
 DROP FUNCTION mol_from_ctab(cstring,bool);
 
-CREATE OR REPLACE FUNCTION mol_from_ctab(cstring,bool default false, bool default true, bool default true)
+CREATE OR REPLACE FUNCTION mol_from_ctab(ctab cstring,keep_conformer bool default false, sanitize bool default true, remove_hs bool default true)
 RETURNS mol
 PARALLEL SAFE
 AS 'MODULE_PATHNAME'
@@ -8,7 +8,7 @@ LANGUAGE C STRICT IMMUTABLE;
 
 DROP FUNCTION qmol_from_ctab(cstring,bool);
 
-CREATE OR REPLACE FUNCTION qmol_from_ctab(cstring,bool default false, bool default false, bool default true)
+CREATE OR REPLACE FUNCTION qmol_from_ctab(ctab cstring,keep_conformer bool default false, sanitize bool default true, remove_hs bool default true)
 RETURNS qmol
 PARALLEL SAFE
 AS 'MODULE_PATHNAME'

--- a/Code/PgSQL/rdkit/update_sql/rdkit--4.6.1--4.7.0.sql.in
+++ b/Code/PgSQL/rdkit/update_sql/rdkit--4.6.1--4.7.0.sql.in
@@ -8,7 +8,7 @@ LANGUAGE C STRICT IMMUTABLE;
 
 DROP FUNCTION qmol_from_ctab(cstring,bool);
 
-CREATE OR REPLACE FUNCTION qmol_from_ctab(ctab cstring,keep_conformer bool default false, sanitize bool default true, remove_hs bool default true)
+CREATE OR REPLACE FUNCTION qmol_from_ctab(ctab cstring,keep_conformer bool default false, merge_hs bool default true)
 RETURNS qmol
 PARALLEL SAFE
 AS 'MODULE_PATHNAME'

--- a/Code/PgSQL/rdkit/update_sql/rdkit--4.6.1--4.7.0.sql.in
+++ b/Code/PgSQL/rdkit/update_sql/rdkit--4.6.1--4.7.0.sql.in
@@ -1,0 +1,15 @@
+DROP FUNCTION mol_from_ctab(cstring,bool);
+
+CREATE OR REPLACE FUNCTION mol_from_ctab(cstring,bool default false, bool default true, bool default true)
+RETURNS mol
+PARALLEL SAFE
+AS 'MODULE_PATHNAME'
+LANGUAGE C STRICT IMMUTABLE;
+
+DROP FUNCTION qmol_from_ctab(cstring,bool);
+
+CREATE OR REPLACE FUNCTION qmol_from_ctab(cstring,bool default false, bool default false, bool default true)
+RETURNS qmol
+PARALLEL SAFE
+AS 'MODULE_PATHNAME'
+LANGUAGE C STRICT IMMUTABLE;

--- a/Code/PgSQL/rdkit/update_sql/rdkit--4.6.1--4.7.0.sql.in
+++ b/Code/PgSQL/rdkit/update_sql/rdkit--4.6.1--4.7.0.sql.in
@@ -1,4 +1,4 @@
-DROP FUNCTION mol_from_ctab(cstring,bool);
+DROP FUNCTION IF EXISTS mol_from_ctab(cstring,bool);
 
 CREATE OR REPLACE FUNCTION mol_from_ctab(ctab cstring,keep_conformer bool default false, sanitize bool default true, remove_hs bool default true)
 RETURNS mol
@@ -6,7 +6,7 @@ PARALLEL SAFE
 AS 'MODULE_PATHNAME'
 LANGUAGE C STRICT IMMUTABLE;
 
-DROP FUNCTION qmol_from_ctab(cstring,bool);
+DROP FUNCTION IF EXISTS qmol_from_ctab(cstring,bool);
 
 CREATE OR REPLACE FUNCTION qmol_from_ctab(ctab cstring,keep_conformer bool default false, merge_hs bool default true)
 RETURNS qmol


### PR DESCRIPTION
This adds the sanitize and removeHs options to `mol_from_ctab()`
It also documents the names of the arguments, something that should be done for all the functions in the cartridge (but that's a separate PR)