### PR TITLE
Fixes 8327

### DIFF
--- a/Code/GraphMol/SmilesParse/SmilesWrite.cpp
+++ b/Code/GraphMol/SmilesParse/SmilesWrite.cpp
@@ -473,7 +473,8 @@ std::string MolToSmiles(const ROMol &mol, const SmilesWriteParams &params,
           static_cast<unsigned int>(params.rootedAtAtom) < mol.getNumAtoms(),
       "rootedAtAtom must be less than the number of atoms");
 
-  int rootedAtAtom = params.rootedAtAtom;
+  int rootedAtAtom;
+  std::vector<int> fragsRootedAtAtom;
   std::vector<std::vector<int>> fragsMolAtomMapping;
   auto mols =
       MolOps::getMolFrags(mol, false, nullptr, &fragsMolAtomMapping, false);
@@ -488,6 +489,13 @@ std::string MolToSmiles(const ROMol &mol, const SmilesWriteParams &params,
     for (auto aidx : atsInFrag) {
       atsPresent.set(aidx);
     }
+
+    rootedAtAtom = -1;
+    if (params.rootedAtAtom >= 0 && atsPresent[params.rootedAtAtom]) {
+        rootedAtAtom = params.rootedAtAtom - atsPresent.find_first();
+    }
+    fragsRootedAtAtom.push_back(rootedAtAtom);
+
     for (const auto bnd : mol.bonds()) {
       if (atsPresent[bnd->getBeginAtomIdx()] &&
           atsPresent[bnd->getEndAtomIdx()]) {
@@ -573,6 +581,7 @@ std::string MolToSmiles(const ROMol &mol, const SmilesWriteParams &params,
     std::cout << "----------------------------" << std::endl;
 #endif
 
+    rootedAtAtom = fragsRootedAtAtom[fragIdx];
     if (params.doRandom && rootedAtAtom == -1) {
       // need to find a random atom id between 0 and mol.getNumAtoms()
       // exclusively


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! 
-->
#### Reference Issue
Fixes 8327

#### What does this implement/fix? Explain your changes.
This applies rootedAtAtom correctly for multiple fragments

```python
from rdkit import Chem

smiles = "[C:1][C:2].[N:3]([C:4])=[O:5]"
mol = Chem.MolFromSmiles(smiles)
for i in range(5):
    print(f"Starting at atom {i + 1}: {Chem.MolToSmiles(mol, rootedAtAtom=i)}")
```
```
Starting at atom 1: [C:1][C:2].[N:3]([C:4])=[O:5]
Starting at atom 2: [C:2][C:1].[N:3]([C:4])=[O:5]
Starting at atom 3: [C:1][C:2].[N:3]([C:4])=[O:5]
Starting at atom 4: [C:1][C:2].[C:4][N:3]=[O:5]
Starting at atom 5: [C:1][C:2].[O:5]=[N:3][C:4]
```
