### PR TITLE
Feat/use draw color in drawString()

### DIFF
--- a/Code/GraphMol/MolDraw2D/DrawMolMCHCircleAndLine.cpp
+++ b/Code/GraphMol/MolDraw2D/DrawMolMCHCircleAndLine.cpp
@@ -60,6 +60,10 @@ void DrawMolMCHCircleAndLine::makeBondHighlights(
     std::vector<std::unique_ptr<DrawShape>> &bondHighlights) {
   for (auto hb : mcHighlightBondMap_) {
     auto bond_idx = hb.first;
+    if (bond_idx < 0 ||
+        static_cast<unsigned>(bond_idx) >= drawMol_->getNumBonds()) {
+      throw ValueErrorException("Bond index out of range");
+    }
     auto lineWidth = drawOptions_.bondLineWidth;
     if (!drawOptions_.fillHighlights) {
       lineWidth = getHighlightBondWidth(drawOptions_, bond_idx,
@@ -150,6 +154,11 @@ void DrawMolMCHCircleAndLine::makeBondHighlights(
 void DrawMolMCHCircleAndLine::makeAtomHighlights(
     std::vector<std::unique_ptr<DrawShape>> &atomHighlights) {
   for (auto &ha : mcHighlightAtomMap_) {
+    if (ha.first < 0 ||
+        static_cast<unsigned>(ha.first) >= drawMol_->getNumAtoms()) {
+      throw ValueErrorException("Atom index out of range");
+    }
+
     double xradius, yradius;
     Point2D centre;
     int lineWidth = getHighlightBondWidth(drawOptions_, -1, nullptr);

--- a/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
@@ -500,6 +500,7 @@ void MolDraw2D::drawPlus(const Point2D &plusPos, int plusWidth,
 // draws the string centred on cds
 void MolDraw2D::drawString(const string &str, const Point2D &cds,
                            bool rawCoords) {
+  text_drawer_->setColour(colour());
   auto draw_cds = rawCoords ? cds : getDrawCoords(cds);
   text_drawer_->drawString(str, draw_cds, MolDraw2D_detail::OrientType::N);
   //  int olw = lineWidth();
@@ -513,6 +514,7 @@ void MolDraw2D::drawString(const string &str, const Point2D &cds,
 void MolDraw2D::drawString(const std::string &str, const Point2D &cds,
                            MolDraw2D_detail::TextAlignType talign,
                            bool rawCoords) {
+  text_drawer_->setColour(colour());
   auto draw_cds = rawCoords ? cds : getDrawCoords(cds);
   text_drawer_->drawString(str, draw_cds, talign);
 }

--- a/Code/GraphMol/MolDraw2D/catch_tests.cpp
+++ b/Code/GraphMol/MolDraw2D/catch_tests.cpp
@@ -10088,7 +10088,7 @@ TEST_CASE("idx out of bounds should not cause a segfault") {
     REQUIRE_THROWS_AS(
         drawer.drawMoleculeWithHighlights(*m, "nocrash", atomCols, bondCols,
                                           atomRads, bondMults),
-        Invar::Invariant);
+        ValueErrorException);
   }
   {
     MolDraw2DSVG drawer(300, 300, -1, -1, NO_FREETYPE);
@@ -10099,7 +10099,7 @@ TEST_CASE("idx out of bounds should not cause a segfault") {
     REQUIRE_THROWS_AS(
         drawer.drawMoleculeWithHighlights(*m, "nocrash", atomCols, bondCols,
                                           atomRads, bondMults),
-        Invar::Invariant);
+        ValueErrorException);
   }
   {
     MolDraw2DSVG drawer(300, 300, -1, -1, NO_FREETYPE);
@@ -10119,7 +10119,7 @@ TEST_CASE("idx out of bounds should not cause a segfault") {
     REQUIRE_THROWS_AS(
         drawer.drawMoleculeWithHighlights(*m, "nocrash", atomCols, bondCols,
                                           atomRads, bondMults),
-        Invar::Invariant);
+        ValueErrorException);
   }
 }
 

--- a/Code/GraphMol/MolDraw2D/catch_tests.cpp
+++ b/Code/GraphMol/MolDraw2D/catch_tests.cpp
@@ -10609,3 +10609,22 @@ TEST_CASE("standard colours for highlighted atoms") {
     CHECK(match_count_hs == 1);
   }
 }
+
+TEST_CASE("drawString() uses drawColour") {
+  auto m = "CCC"_smiles;
+  REQUIRE(m);
+  MolDraw2DSVG drawer(300, 300, -1, -1, NO_FREETYPE);
+  drawer.drawMolecule(*m);
+  drawer.drawString("default Z", RDGeom::Point2D(100, 20), true);
+  drawer.setColour(DrawColour(0.3, 0.3, 1.0));
+  drawer.drawString("blue X", RDGeom::Point2D(100, 200), true);
+  drawer.finishDrawing();
+  auto text = drawer.getDrawingText();
+  std::ofstream outs("testDrawTextColour.svg");
+  outs << text;
+  outs.close();
+  // The default color:
+  CHECK(text.find("#000000' >Z</text>") != std::string::npos);
+  // The blue color:
+  CHECK(text.find("#4C4CFF' >X</text>") != std::string::npos);
+}


### PR DESCRIPTION
`MolDraw2D::drawString()` now uses the current drawing color. Previously it would always use black

This also changes the exception type that the multicolor highlighting code throws when it gets bad user input for atom/bond indices to a ValueError (previously it was a PRECONDITION)