### PR TITLE
Fixes #8308

### DIFF
--- a/Code/GraphMol/MolDraw2D/MolDraw2DUtils.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DUtils.cpp
@@ -343,6 +343,14 @@ void contourAndDrawGrid(MolDraw2D &drawer, const double *grid,
     for (size_t i = 0; i < nX - 1; ++i) {
       for (size_t j = 0; j < nY - 1; ++j) {
         auto gridV = grid[i * nY + j];
+        auto threshTest = gridV;
+        if (params.fillThreholdIsFraction) {
+          threshTest /= delta;
+        }
+        if (params.useFillThreshold &&
+            fabs(threshTest) < params.fillThreshold) {
+          continue;
+        }
         auto fracV = (gridV - minV) / delta;
         if (params.colourMap.size() > 2) {
           // need to find how fractionally far we are from zero, not the min

--- a/Code/GraphMol/MolDraw2D/MolDraw2DUtils.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DUtils.cpp
@@ -344,7 +344,7 @@ void contourAndDrawGrid(MolDraw2D &drawer, const double *grid,
       for (size_t j = 0; j < nY - 1; ++j) {
         auto gridV = grid[i * nY + j];
         auto threshTest = gridV;
-        if (params.fillThreholdIsFraction) {
+        if (params.fillThresholdIsFraction) {
           threshTest /= delta;
         }
         if (params.useFillThreshold &&

--- a/Code/GraphMol/MolDraw2D/MolDraw2DUtils.h
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DUtils.h
@@ -103,6 +103,11 @@ struct ContourParams {
   double isovalScaleForQuantization =
       1e6;  // scaling factor used to convert isovalues to ints when forming the
             // continuous lines
+  bool useFillThreshold =
+      false;  // use a magnitude threshold to determine if a grid box is filled
+  double fillThreshold = 0.01;  // magnitude threshold for filling grid boxes
+  bool fillThreholdIsFraction = true;  // if true, the fill threshold is a
+                                       // fraction of the range of the data
 };
 
 //! Generates and draws contours for data on a grid

--- a/Code/GraphMol/MolDraw2D/MolDraw2DUtils.h
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DUtils.h
@@ -106,8 +106,8 @@ struct ContourParams {
   bool useFillThreshold =
       false;  // use a magnitude threshold to determine if a grid box is filled
   double fillThreshold = 0.01;  // magnitude threshold for filling grid boxes
-  bool fillThreholdIsFraction = true;  // if true, the fill threshold is a
-                                       // fraction of the range of the data
+  bool fillThresholdIsFraction = true;  // if true, the fill threshold is a
+                                        // fraction of the range of the data
 };
 
 //! Generates and draws contours for data on a grid

--- a/Code/GraphMol/MolDraw2D/Wrap/rdMolDraw2D.cpp
+++ b/Code/GraphMol/MolDraw2D/Wrap/rdMolDraw2D.cpp
@@ -1021,7 +1021,7 @@ BOOST_PYTHON_MODULE(rdMolDraw2D) {
           "standardColoursForHighlightedAtoms",
           &RDKit::MolDrawOptions::standardColoursForHighlightedAtoms,
           "If true, highlighted hetero atoms are drawn in standard colours"
-              " rather than black.  Default=False")
+          " rather than black.  Default=False")
       .def("getVariableAttachmentColour", &RDKit::getVariableAttachmentColour,
            python::args("self"),
            "method for getting the colour of variable attachment points")
@@ -1330,6 +1330,17 @@ BOOST_PYTHON_MODULE(rdMolDraw2D) {
           "isovalScaleForQuantization",
           &RDKit::MolDraw2DUtils::ContourParams::isovalScaleForQuantization,
           "scaling factor used to convert isovalues to ints when forming the continuous lines")
+      .def_readwrite(
+          "useFillThreshold",
+          &RDKit::MolDraw2DUtils::ContourParams::useFillThreshold,
+          "use a magnitude threshold to determine if a grid point is filled")
+      .def_readwrite(
+          "fillThreshold", &RDKit::MolDraw2DUtils::ContourParams::fillThreshold,
+          "magnitude threshold to determine if a grid point is filled")
+      .def_readwrite(
+          "fillThresholdIsFraction",
+          &RDKit::MolDraw2DUtils::ContourParams::fillThreholdIsFraction,
+          "if true, fillThreshold is a fraction of the range of the data")
       .def("setContourColour", &RDKit::setContourColour,
            (python::arg("self"), python::arg("colour")))
       .def("setColourMap", &RDKit::setColoursHelper,
@@ -1463,9 +1474,10 @@ https://en.wikipedia.org/wiki/Wikipedia:Manual_of_Style/Chemistry/Structure_draw
               (python::arg("mol"), python::arg("confId") = -1),
               "Calculate the mean bond length for the molecule.");
   python::def("SetDarkMode",
-              (void (*)(RDKit::MolDrawOptions &))&RDKit::setDarkMode,
+              (void (*)(RDKit::MolDrawOptions &)) & RDKit::setDarkMode,
               python::args("d2d"), "set dark mode for a MolDrawOptions object");
-  python::def("SetDarkMode", (void (*)(RDKit::MolDraw2D &))&RDKit::setDarkMode,
+  python::def("SetDarkMode",
+              (void (*)(RDKit::MolDraw2D &)) & RDKit::setDarkMode,
               python::args("d2d"), "set dark mode for a MolDraw2D object");
   python::def("SetMonochromeMode", RDKit::setMonochromeMode_helper1,
               (python::arg("options"), python::arg("fgColour"),

--- a/Code/GraphMol/MolDraw2D/Wrap/rdMolDraw2D.cpp
+++ b/Code/GraphMol/MolDraw2D/Wrap/rdMolDraw2D.cpp
@@ -1339,7 +1339,7 @@ BOOST_PYTHON_MODULE(rdMolDraw2D) {
           "magnitude threshold to determine if a grid point is filled")
       .def_readwrite(
           "fillThresholdIsFraction",
-          &RDKit::MolDraw2DUtils::ContourParams::fillThreholdIsFraction,
+          &RDKit::MolDraw2DUtils::ContourParams::fillThresholdIsFraction,
           "if true, fillThreshold is a fraction of the range of the data")
       .def("setContourColour", &RDKit::setContourColour,
            (python::arg("self"), python::arg("colour")))

--- a/Code/GraphMol/MolDraw2D/catch_tests.cpp
+++ b/Code/GraphMol/MolDraw2D/catch_tests.cpp
@@ -62,6 +62,8 @@ const std::map<std::string, std::hash_result_t> SVG_HASHES = {
     {"contourMol_3.svg", 2579392727U},
     {"contourMol_4.svg", 2914799663U},
     {"contourMol_5.svg", 3792684719U},
+    {"contourMol_6.svg", 1743220181U},
+    {"contourMol_7.svg", 2221193310U},
     {"testDativeBonds_1.svg", 3550231997U},
     {"testDativeBonds_2.svg", 2510476717U},
     {"testDativeBonds_3.svg", 1742381275U},
@@ -790,6 +792,67 @@ TEST_CASE("contour data", "[drawing][conrec]") {
     outs << text;
     outs.close();
     check_file_hash("contourMol_5.svg");
+  }
+
+  SECTION("Threshold testing") {
+    MolDraw2DUtils::prepareMolForDrawing(*m1);
+
+    const auto conf = m1->getConformer();
+    std::vector<Point2D> cents(conf.getNumAtoms());
+    std::vector<double> weights(conf.getNumAtoms());
+    std::vector<double> widths(conf.getNumAtoms());
+    for (size_t i = 0; i < conf.getNumAtoms(); ++i) {
+      cents[i] = Point2D(conf.getAtomPos(i).x, conf.getAtomPos(i).y);
+      weights[i] = i % 2 ? 4 : 1;
+      widths[i] = 0.4 * PeriodicTable::getTable()->getRcovalent(
+                            m1->getAtomWithIdx(i)->getAtomicNum());
+    }
+
+    std::vector<double> levels;
+    MolDraw2DUtils::ContourParams cps;
+    cps.fillGrid = true;
+    cps.colourMap = {
+        DrawColour(1.0, 1.0, 1.0),
+        DrawColour(0.5, 1.0, 0.5),
+        DrawColour(0.0, 1.0, 0.0),
+    };
+
+    cps.useFillThreshold = true;
+
+    {
+      MolDraw2DSVG drawer(250, 250, -1, -1, NO_FREETYPE);
+      drawer.drawOptions().padding = 0.1;
+      drawer.clearDrawing();
+      MolDraw2DUtils::contourAndDrawGaussians(drawer, cents, weights, widths,
+                                              10, levels, cps, m1.get());
+
+      drawer.drawOptions().clearBackground = false;
+      drawer.drawMolecule(*m1);
+      drawer.finishDrawing();
+      std::string text = drawer.getDrawingText();
+      std::ofstream outs("contourMol_6.svg");
+      outs << text;
+      outs.close();
+      check_file_hash("contourMol_6.svg");
+    }
+
+    cps.fillThreholdIsFraction = false;
+    {
+      MolDraw2DSVG drawer(250, 250, -1, -1, NO_FREETYPE);
+      drawer.drawOptions().padding = 0.1;
+      drawer.clearDrawing();
+      MolDraw2DUtils::contourAndDrawGaussians(drawer, cents, weights, widths,
+                                              10, levels, cps, m1.get());
+
+      drawer.drawOptions().clearBackground = false;
+      drawer.drawMolecule(*m1);
+      drawer.finishDrawing();
+      std::string text = drawer.getDrawingText();
+      std::ofstream outs("contourMol_7.svg");
+      outs << text;
+      outs.close();
+      check_file_hash("contourMol_7.svg");
+    }
   }
 }
 

--- a/Code/GraphMol/MolDraw2D/catch_tests.cpp
+++ b/Code/GraphMol/MolDraw2D/catch_tests.cpp
@@ -836,7 +836,7 @@ TEST_CASE("contour data", "[drawing][conrec]") {
       check_file_hash("contourMol_6.svg");
     }
 
-    cps.fillThreholdIsFraction = false;
+    cps.fillThresholdIsFraction = false;
     {
       MolDraw2DSVG drawer(250, 250, -1, -1, NO_FREETYPE);
       drawer.drawOptions().padding = 0.1;

--- a/rdkit/Chem/Draw/SimilarityMaps.py
+++ b/rdkit/Chem/Draw/SimilarityMaps.py
@@ -129,7 +129,9 @@ def GetStandardizedWeights(weights):
 
 def GetSimilarityMapFromWeights(mol, weights, draw2d, colorMap=None, scale=-1, size=(250, 250),
                                 sigma=None, coordScale=1.5, step=0.01, colors='k', contourLines=10,
-                                alpha=0.5, **kwargs):
+                                alpha=0.5, gridResolution=0.1, extraGridPadding=0.5,
+                                useFillThreshold=False, fillThreshold=0.01,
+                                fillThresholdIsFraction=True, **kwargs):
   """
     Generates the similarity map for a molecule given the atomic weights.
 
@@ -148,6 +150,11 @@ def GetSimilarityMapFromWeights(mol, weights, draw2d, colorMap=None, scale=-1, s
       contourLines -- if integer number N: N contour lines are drawn
                       if list(numbers): contour lines at these numbers are drawn
       alpha -- the alpha blending value for the contour lines
+      gridResolution -- the resolution of the grid
+      extraGridPadding -- the extra padding of the grid
+      useFillThreshold -- use a magnitude threshold to determine if a grid box is filled
+      fillThreshold -- the magnitude threshold for filling grid boxes
+      fillThresholdIsFraction -- if True, the fillThreshold is a fraction of the data range
       kwargs -- additional arguments for drawing
     """
   if mol.GetNumAtoms() < 2:
@@ -178,8 +185,11 @@ def GetSimilarityMapFromWeights(mol, weights, draw2d, colorMap=None, scale=-1, s
   draw2d.ClearDrawing()
   ps = Draw.ContourParams()
   ps.fillGrid = True
-  ps.gridResolution = 0.1
-  ps.extraGridPadding = 0.5
+  ps.gridResolution = gridResolution
+  ps.extraGridPadding = extraGridPadding
+  ps.useFillThreshold = useFillThreshold
+  ps.fillThreshold = fillThreshold
+  ps.fillThresholdIsFraction = fillThresholdIsFraction
 
   if colorMap is not None:
     if cm is not None and isinstance(colorMap, type(cm.Blues)):


### PR DESCRIPTION
Here's what we used to get (and what the defaults still generate) with a color-gradient heatmap:
![image](https://github.com/user-attachments/assets/86ca0420-cb82-49f0-a0b0-300a7eea9ad6)
Using the new option (which disables the filling of small-magnitude boxes) we get:
![image](https://github.com/user-attachments/assets/56fec9c5-0bf2-444e-91a8-0ba7bd2a3ae8)


This also exposes a couple of more parameters in `GetSimilarityMapFromWeights()`