### PR TITLE
Speed up GetProp Python keyerrors

### DIFF
--- a/Code/GraphMol/Wrap/Atom.cpp
+++ b/Code/GraphMol/Wrap/Atom.cpp
@@ -330,7 +330,8 @@ struct atom_wrapper {
             "  RETURNS: a string\n\n"
             "  NOTE:\n"
             "    - If the property has not been set, a KeyError exception "
-            "will be raised.\n")
+            "will be raised.\n",
+            boost::python::return_value_policy<return_pyobject_passthrough>())
 
         .def("SetIntProp", AtomSetProp<int>,
              (python::arg("self"), python::arg("key"), python::arg("val")),

--- a/Code/GraphMol/Wrap/Atom.cpp
+++ b/Code/GraphMol/Wrap/Atom.cpp
@@ -355,7 +355,8 @@ struct atom_wrapper {
              "  RETURNS: an int\n\n"
              "  NOTE:\n"
              "    - If the property has not been set, a KeyError exception "
-             "will be raised.\n")
+             "will be raised.\n",
+             boost::python::return_value_policy<return_pyobject_passthrough>())
 
         .def("GetUnsignedProp", GetProp<Atom, unsigned>,
              python::args("self", "key"),
@@ -366,8 +367,8 @@ struct atom_wrapper {
              "  RETURNS: an integer (Python has no unsigned type)\n\n"
              "  NOTE:\n"
              "    - If the property has not been set, a KeyError exception "
-             "will be raised.\n")
-
+             "will be raised.\n",
+             boost::python::return_value_policy<return_pyobject_passthrough>())
         .def("SetDoubleProp", AtomSetProp<double>,
              (python::arg("self"), python::arg("key"), python::arg("val")),
              "Sets an atomic property\n\n"
@@ -383,7 +384,8 @@ struct atom_wrapper {
              "  RETURNS: a double\n\n"
              "  NOTE:\n"
              "    - If the property has not been set, a KeyError exception "
-             "will be raised.\n")
+             "will be raised.\n",
+             boost::python::return_value_policy<return_pyobject_passthrough>())
 
         .def("SetBoolProp", AtomSetProp<bool>,
              (python::arg("self"), python::arg("key"), python::arg("val")),
@@ -399,7 +401,8 @@ struct atom_wrapper {
              "  RETURNS: a bool\n\n"
              "  NOTE:\n"
              "    - If the property has not been set, a KeyError exception "
-             "will be raised.\n")
+             "will be raised.\n",
+             boost::python::return_value_policy<return_pyobject_passthrough>())
 
         .def("SetExplicitBitVectProp", AtomSetProp<ExplicitBitVect>,
              (python::arg("self"), python::arg("key"), python::arg("val")),
@@ -418,7 +421,8 @@ struct atom_wrapper {
              "  RETURNS: an ExplicitBitVect \n\n"
              "  NOTE:\n"
              "    - If the property has not been set, a KeyError exception "
-             "will be raised.\n")
+             "will be raised.\n",
+             boost::python::return_value_policy<return_pyobject_passthrough>())
 
         .def("HasProp", AtomHasProp, python::args("self", "key"),
              "Queries a Atom to see if a particular property has been "

--- a/Code/GraphMol/Wrap/Bond.cpp
+++ b/Code/GraphMol/Wrap/Bond.cpp
@@ -207,7 +207,8 @@ struct bond_wrapper {
             "  RETURNS: a string\n\n"
             "  NOTE:\n"
             "    - If the property has not been set, a KeyError exception "
-            "will be raised.\n")
+            "will be raised.\n",
+            boost::python::return_value_policy<return_pyobject_passthrough>())
         .def("SetIntProp", BondSetProp<int>,
              (python::arg("self"), python::arg("key"), python::arg("val")),
              "Sets a bond property\n\n"

--- a/Code/GraphMol/Wrap/Bond.cpp
+++ b/Code/GraphMol/Wrap/Bond.cpp
@@ -230,7 +230,8 @@ struct bond_wrapper {
              "  RETURNS: an int\n\n"
              "  NOTE:\n"
              "    - If the property has not been set, a KeyError exception "
-             "will be raised.\n")
+             "will be raised.\n",
+             boost::python::return_value_policy<return_pyobject_passthrough>())
 
         .def("GetUnsignedProp", GetProp<Bond, unsigned int>,
              python::args("self", "key"),
@@ -241,7 +242,8 @@ struct bond_wrapper {
              "  RETURNS: an int (Python has no unsigned type)\n\n"
              "  NOTE:\n"
              "    - If the property has not been set, a KeyError exception "
-             "will be raised.\n")
+             "will be raised.\n",
+             boost::python::return_value_policy<return_pyobject_passthrough>())
 
         .def("SetDoubleProp", BondSetProp<double>,
              (python::arg("self"), python::arg("key"), python::arg("val")),
@@ -258,7 +260,8 @@ struct bond_wrapper {
              "  RETURNS: a double\n\n"
              "  NOTE:\n"
              "    - If the property has not been set, a KeyError exception "
-             "will be raised.\n")
+             "will be raised.\n",
+             boost::python::return_value_policy<return_pyobject_passthrough>())
 
         .def("SetBoolProp", BondSetProp<bool>,
              (python::arg("self"), python::arg("key"), python::arg("val")),
@@ -274,7 +277,8 @@ struct bond_wrapper {
              "  RETURNS: a boolean\n\n"
              "  NOTE:\n"
              "    - If the property has not been set, a KeyError exception "
-             "will be raised.\n")
+             "will be raised.\n",
+             boost::python::return_value_policy<return_pyobject_passthrough>())
 
         .def("HasProp", BondHasProp, python::args("self", "key"),
              "Queries a Bond to see if a particular property has been "

--- a/Code/GraphMol/Wrap/Conformer.cpp
+++ b/Code/GraphMol/Wrap/Conformer.cpp
@@ -232,7 +232,8 @@ struct conformer_wrapper {
             "  RETURNS: a string\n\n"
             "  NOTE:\n"
             "    - If the property has not been set, a KeyError exception "
-            "will be raised.\n")
+            "will be raised.\n",
+            boost::python::return_value_policy<return_pyobject_passthrough>())
         .def("GetDoubleProp", GetProp<Conformer, double>,
              python::args("self", "key"),
              "Returns the double value of the property if possible.\n\n"

--- a/Code/GraphMol/Wrap/Mol.cpp
+++ b/Code/GraphMol/Wrap/Mol.cpp
@@ -172,9 +172,9 @@ void setSubstructMatchFinalCheck(SubstructMatchParameters &ps,
 
 class ReadWriteMol : public RWMol {
  public:
-  ReadWriteMol() {};
+  ReadWriteMol(){};
   ReadWriteMol(const ROMol &m, bool quickCopy = false, int confId = -1)
-      : RWMol(m, quickCopy, confId) {};
+      : RWMol(m, quickCopy, confId){};
 
   void RemoveAtom(unsigned int idx) { removeAtom(idx); };
   void RemoveBond(unsigned int idx1, unsigned int idx2) {
@@ -699,8 +699,8 @@ struct mol_wrapper {
             "    - autoConvert: if True attempt to convert the property into a python object\n\n"
             "  RETURNS: a string\n\n"
             "  NOTE:\n"
-            "    - If the property has not been set, a KeyError exception "
-            "will be raised.\n")
+            "    - If the property has not been set, a KeyError exception will be raised.\n",
+            boost::python::return_value_policy<return_pyobject_passthrough>())
         .def("GetDoubleProp", GetProp<ROMol, double>,
              python::args("self", "key"),
              "Returns the double value of the property if possible.\n\n"

--- a/Code/GraphMol/Wrap/Mol.cpp
+++ b/Code/GraphMol/Wrap/Mol.cpp
@@ -709,7 +709,8 @@ struct mol_wrapper {
              "  RETURNS: a double\n\n"
              "  NOTE:\n"
              "    - If the property has not been set, a KeyError exception "
-             "will be raised.\n")
+             "will be raised.\n",
+             boost::python::return_value_policy<return_pyobject_passthrough>())
         .def("GetIntProp", GetProp<ROMol, int>, python::args("self", "key"),
              "Returns the integer value of the property if possible.\n\n"
              "  ARGUMENTS:\n"
@@ -717,7 +718,8 @@ struct mol_wrapper {
              "  RETURNS: an integer\n\n"
              "  NOTE:\n"
              "    - If the property has not been set, a KeyError exception "
-             "will be raised.\n")
+             "will be raised.\n",
+             boost::python::return_value_policy<return_pyobject_passthrough>())
         .def("GetUnsignedProp", GetProp<ROMol, unsigned int>,
              python::args("self", "key"),
              "Returns the unsigned int value of the property if possible.\n\n"
@@ -726,7 +728,8 @@ struct mol_wrapper {
              "  RETURNS: an unsigned integer\n\n"
              "  NOTE:\n"
              "    - If the property has not been set, a KeyError exception "
-             "will be raised.\n")
+             "will be raised.\n",
+             boost::python::return_value_policy<return_pyobject_passthrough>())
         .def("GetBoolProp", GetProp<ROMol, bool>, python::args("self", "key"),
              "Returns the Bool value of the property if possible.\n\n"
              "  ARGUMENTS:\n"
@@ -734,7 +737,8 @@ struct mol_wrapper {
              "  RETURNS: a bool\n\n"
              "  NOTE:\n"
              "    - If the property has not been set, a KeyError exception "
-             "will be raised.\n")
+             "will be raised.\n",
+             boost::python::return_value_policy<return_pyobject_passthrough>())
         .def("ClearProp", MolClearProp<ROMol>, python::args("self", "key"),
              "Removes a property from the molecule.\n\n"
              "  ARGUMENTS:\n"

--- a/Code/GraphMol/Wrap/SubstanceGroup.cpp
+++ b/Code/GraphMol/Wrap/SubstanceGroup.cpp
@@ -256,7 +256,8 @@ struct sgroup_wrap {
             "  RETURNS: a string\n\n"
             "  NOTE:\n"
             "    - If the property has not been set, a KeyError exception "
-            "will be raised.\n")
+            "will be raised.\n",
+            boost::python::return_value_policy<return_pyobject_passthrough>())
         .def("GetIntProp",
              (int(RDProps::*)(const std::string &) const) &
                  SubstanceGroup::getProp<int>,

--- a/Code/GraphMol/Wrap/props.hpp
+++ b/Code/GraphMol/Wrap/props.hpp
@@ -96,25 +96,23 @@ boost::python::dict GetPropsAsDict(const T &obj, bool includePrivate,
         case RDTypeTag::DoubleTag:
           dict[rdvalue.key] = from_rdvalue<double>(rdvalue.val);
           break;
-        case RDTypeTag::StringTag:
-          {
-            auto value = from_rdvalue<std::string>(rdvalue.val);
-            if (autoConvertStrings) {
-              // Auto convert strings to ints and double if possible
-              int ivalue;
-              if (boost::conversion::try_lexical_convert(value, ivalue)) {
-                dict[rdvalue.key] = ivalue;
-                break;
-              }
-              double dvalue;
-              if (boost::conversion::try_lexical_convert(value, dvalue)) {
-                dict[rdvalue.key] = dvalue;
-                break;
-              }
+        case RDTypeTag::StringTag: {
+          auto value = from_rdvalue<std::string>(rdvalue.val);
+          if (autoConvertStrings) {
+            // Auto convert strings to ints and double if possible
+            int ivalue;
+            if (boost::conversion::try_lexical_convert(value, ivalue)) {
+              dict[rdvalue.key] = ivalue;
+              break;
             }
-            dict[rdvalue.key] = value;
+            double dvalue;
+            if (boost::conversion::try_lexical_convert(value, dvalue)) {
+              dict[rdvalue.key] = dvalue;
+              break;
+            }
           }
-          break;
+          dict[rdvalue.key] = value;
+        } break;
         case RDTypeTag::FloatTag:
           dict[rdvalue.key] = from_rdvalue<float>(rdvalue.val);
           break;
@@ -199,64 +197,76 @@ python::object autoConvertString(const RDOb *ob, const std::string &key) {
 
   return python::object();
 }
+
+static PyObject *rawPy(python::object &&pyobj) {
+  Py_INCREF(pyobj.ptr());
+  return pyobj.ptr();
+}
+
+template <class T>
+PyObject *rawPy(T &&thing) {
+  return rawPy(python::object(thing));
+}
+
 template <class RDOb>
-python::object GetPyProp(const RDOb *obj, const std::string &key,
-                         bool autoConvert) {
+PyObject *GetPyProp(const RDOb *obj, const std::string &key, bool autoConvert) {
+  python::object pobj;
   if (!autoConvert) {
-    return python::object(GetProp<RDOb, std::string>(obj, key));
+    std::string res;
+    if (obj->getPropIfPresent(key, res)) {
+      return rawPy(res);
+    } else {
+      PyErr_SetString(PyExc_KeyError, key.c_str());
+      return nullptr;
+    }
   } else {
-    auto &data = obj->getDict().getData();
+    const auto &data = obj->getDict().getData();
     for (auto &rdvalue : data) {
       if (rdvalue.key == key) {
         try {
           const auto tag = rdvalue.val.getTag();
           switch (tag) {
             case RDTypeTag::IntTag:
-              return python::object(from_rdvalue<int>(rdvalue.val));
+              return rawPy(from_rdvalue<int>(rdvalue.val));
 
             case RDTypeTag::DoubleTag:
-              return python::object(from_rdvalue<double>(rdvalue.val));
+              return rawPy(from_rdvalue<double>(rdvalue.val));
 
             case RDTypeTag::StringTag:
               if (autoConvert) {
-                return autoConvertString(obj, rdvalue.key);
+                pobj = autoConvertString(obj, rdvalue.key);
               }
-              return python::object(from_rdvalue<std::string>(rdvalue.val));
-
+              return rawPy(from_rdvalue<std::string>(rdvalue.val));
             case RDTypeTag::FloatTag:
-              return python::object(from_rdvalue<float>(rdvalue.val));
+              return rawPy(from_rdvalue<float>(rdvalue.val));
               break;
             case RDTypeTag::BoolTag:
-              return python::object(from_rdvalue<bool>(rdvalue.val));
+              return rawPy(from_rdvalue<bool>(rdvalue.val));
               break;
             case RDTypeTag::UnsignedIntTag:
-              return python::object(from_rdvalue<unsigned int>(rdvalue.val));
+              return rawPy(from_rdvalue<unsigned int>(rdvalue.val));
               break;
             case RDTypeTag::AnyTag:
               // we skip these for now
               break;
             case RDTypeTag::VecDoubleTag:
-              return python::object(
-                  from_rdvalue<std::vector<double>>(rdvalue.val));
+              return rawPy(from_rdvalue<std::vector<double>>(rdvalue.val));
               break;
             case RDTypeTag::VecFloatTag:
-              return python::object(
-                  from_rdvalue<std::vector<float>>(rdvalue.val));
+              return rawPy(from_rdvalue<std::vector<float>>(rdvalue.val));
               break;
             case RDTypeTag::VecIntTag:
-              return python::object(
-                  from_rdvalue<std::vector<int>>(rdvalue.val));
+              return rawPy(from_rdvalue<std::vector<int>>(rdvalue.val));
               break;
             case RDTypeTag::VecUnsignedIntTag:
-              return python::object(
+              return rawPy(
                   from_rdvalue<std::vector<unsigned int>>(rdvalue.val));
               break;
             case RDTypeTag::VecStringTag:
-              return python::object(
-                  from_rdvalue<std::vector<std::string>>(rdvalue.val));
+              return rawPy(from_rdvalue<std::vector<std::string>>(rdvalue.val));
               break;
             case RDTypeTag::EmptyTag:
-              return boost::python::object();
+              return Py_None;
               break;
             default:
               std::string message =
@@ -264,7 +274,7 @@ python::object GetPyProp(const RDOb *obj, const std::string &key,
                       "Unhandled property type encountered for property: ") +
                   rdvalue.key;
               UNDER_CONSTRUCTION(message.c_str());
-              return boost::python::object();
+              return Py_None;
           }
         } catch (std::bad_any_cast &) {
           // C++ datatypes can really be anything, this just captures
@@ -273,14 +283,33 @@ python::object GetPyProp(const RDOb *obj, const std::string &key,
               std::string("Unhandled type conversion occured for property: ") +
               rdvalue.key;
           UNDER_CONSTRUCTION(message.c_str());
-          return boost::python::object();
+          return Py_None;
         }
       }
     }
   }
   PyErr_SetString(PyExc_KeyError, key.c_str());
-  throw python::error_already_set();
+  return nullptr;
 }
+
+// Return policy for functions that directly return a PyObject* and
+// are fully responsible for setting the Python error state.
+struct return_pyobject_passthrough {
+  template <class T>
+  struct apply {
+    struct type {
+      static bool convertible() { return true; }
+
+      PyObject *operator()(PyObject *inner) const { return inner; }
+#ifndef BOOST_PYTHON_NO_PY_SIGNATURES
+      PyTypeObject const *get_pytype() const {
+        return boost::python::converter::expected_pytype_for_arg<
+            T>::get_pytype();
+      }
+#endif
+    };
+  };
+};
 
 template <class RDOb>
 int MolHasProp(const RDOb &mol, const std::string &key) {


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

A common pattern _in Python_ for checking for the presence or absence of a key is:

```
    try:
       return mol.GetProp('mykey')
    except KeyError:
       return None
```

Shockingly, this is really slow with boost python objects! I was recently profiling a workflow and 90% of the time or more was spent in failed GetProp calls (mostly on bonds, some on atoms or mols).

I sped up the workflow by protecting the calls using HasProp. But I think this is a silly trap we've set for our users.

The problem comes because boost::python uses a C++ exception to indicate that there is already a Python exception set. In C++, exceptions are slow - they require unrolling a stack. In Python, exceptions are about the same speed as any other control flow!

This commit speeds up GetProp failures by circumventing the boost throw_exception_already_set() mechanism. I based `return_pyobject_passthrough` on `return_none` in boost::python's return_arg.hpp https://github.com/boostorg/python/blob/3e7be69e1e405e1d5ddd232c69c024ee441592c5/include/boost/python/return_arg.hpp#L36. It was really annoying to figure out the right incantation here.

In my testing, this speeds up failed GetProp substantially:

* Factor of 1000x on Mac
* Factor of 40x on Linux

For 100,000 Mol.GetProp calls, before this commit:

|   |  Mac  | Linux |
| - | ----- | ----- |
| Present prop | 0.03s | 0.02s |
| Missing prop | 30s | 0.82s |

(after this commit missing and present properties aer about the same duration)