### PR TITLE
BertzCTNewVersion based on Weisfeiler-Lehman algorithm

### DIFF
--- a/rdkit/Chem/GraphDescriptors.py
+++ b/rdkit/Chem/GraphDescriptors.py
@@ -722,3 +722,342 @@ BertzCT.version = "2.0.0"
 # End block of BertzCT stuff.
 #
 # ------------------------------------------------------------------------
+"""
+************************************************************************************************
+BerzCTNewVersion: A new version of BertzCT descriptor calculation.
+Other bugs in the original BertzCT calculation have been fixed in this new version.(in Unit Test)
+There is only one examples
+
+General Mechanism: 
+Atoms progressively aggregate neighboring information to determine their chemical environment within the 
+molecular structure. Typically, distinct chemical environments are differentiated through a few rounds of iteration (often just a few steps before convergence (colors = new_colors.copy())), 
+where atoms are assigned distinct colors). The message-passing resembles that of Graph Convolutional Networks (GCNs).
+************************************************************************************************
+"""
+
+from collections import defaultdict
+from itertools import combinations
+
+
+def BertzCTNewVersion(mol):
+  if not mol or mol.GetNumAtoms() == 0:
+    return 0.0
+
+  # for different bond types, assign different weights
+  # For AROMATIC bond, I treat them as this blog does
+  BOND_WEIGHTS = {
+    Chem.BondType.SINGLE: 1.0,
+    Chem.BondType.DOUBLE: 2.0,
+    Chem.BondType.TRIPLE: 3.0,
+    Chem.BondType.AROMATIC: 1.5,
+    # special bond types
+    Chem.BondType.DATIVE: 1.2,  # dative bond
+    Chem.BondType.IONIC: 0.8,  # ionic bond
+    Chem.BondType.ZERO: 0.0  # zero bond
+  }
+
+  adj_dict = defaultdict(float)
+  for bond in mol.GetBonds():
+    start, end = sorted([bond.GetBeginAtomIdx(), bond.GetEndAtomIdx()])
+
+    # assign weights to different bond types
+    bond_type = bond.GetBondType()
+    cnt = BOND_WEIGHTS.get(bond_type, 0.0)  # default weight is 0.0
+
+    # special bond types
+    if bond_type == Chem.BondType.DATIVE:
+      # make sure the donor atom is the one with negative charge
+      donor_atom = bond.GetBeginAtom() if bond.GetBeginAtom().GetFormalCharge(
+      ) < 0 else bond.GetEndAtom()
+      if donor_atom.GetAtomicNum() in [7, 8]:  # N or O which belong to the common donor atoms
+        cnt = 1.2  # dative bond weight
+
+    adj_dict[(start, end)] += cnt
+
+  atom_neighbors = defaultdict(dict)
+  for (a, b), cnt in adj_dict.items():
+    atom_neighbors[a][b] = cnt
+    atom_neighbors[b][a] = cnt
+
+  # eta calculation
+  eta_case1 = 0.0
+  for b in atom_neighbors:
+    counts = list(atom_neighbors[b].values())
+    sum_counts = sum(counts)
+    sum_sq = sum(c * c for c in counts)
+    eta_case1 += (sum_counts**2 - sum_sq) / 2
+
+  eta_case2 = sum(k * (k - 1) / 2 for k in adj_dict.values() if k > 1)
+  eta = eta_case1 + eta_case2
+
+  # WL color refinement algorithm for atom environment feature generation
+  wl_colors = ComputeWeisfeilerLehmanSignatures(mol)
+
+  # eta_i calculation (i.e., the number of pairs of atoms with the same color in the same environment)
+  eta_i = defaultdict(float)
+  # case 1：A-B-C chain
+  for b_atom in atom_neighbors:
+    b_color = wl_colors[b_atom]
+    neighbors = list(atom_neighbors[b_atom].items())
+    for (a1, cnt1), (a2, cnt2) in combinations(neighbors, 2):
+      key = ('chain', b_color, tuple(sorted((wl_colors[a1], wl_colors[a2]))))
+      eta_i[key] += cnt1 * cnt2
+
+  # case 2：A-B loop
+  for (a, b), cnt in adj_dict.items():
+    if cnt > 1:
+      key = ('loop', tuple(sorted((wl_colors[a], wl_colors[b]))))
+      eta_i[key] += cnt * (cnt - 1) / 2
+
+  # correct term for eta_i (i.e., the number of pairs of atoms with the same color in the same
+  # environment which  leads to the overcounting of the molecular complexity)
+  entropy_term = sum(v * math.log2(v) if v > 0 else 0 for v in eta_i.values())
+  c_eta = 2 * eta * math.log2(eta) - entropy_term if eta != 0 else 0
+
+  # 计算E和C_E
+  atom_types = defaultdict(int)
+  for atom in mol.GetAtoms():
+    atom_types[atom.GetSymbol()] += 1
+  E = sum(atom_types.values())
+  entropy_term_E = sum(v * math.log2(v) for v in atom_types.values() if v > 0)
+  c_E = E * math.log2(E) - entropy_term_E if E != 0 else 0
+
+  return c_eta + c_E
+
+
+def ComputeWeisfeilerLehmanSignatures(mol, max_iter=20):
+  """Weisfeiler-Lehman color refinement algorithm is used to generate atom environment features
+    ************************************************************************************************
+    It should be noted that while there exist mathematical examples where two non-isomorphic graphs can pass the 
+    Weisfeiler-Lehman (WL) graph isomorphism test, such cases are virtually non-existent in chemical contexts, 
+    even when considering artificially synthesized bizarre molecular structures. 
+    ************************************************************************************************
+
+    So, in chemistry, especially for natural products, which lacks symmetric structures as well as strange node degrees,
+    the WL test is considered to be a reliable graph isomorphism test.
+
+    Moreover, even if some special case: Decalin:C12CCCCC1CCCC2 and Bicyclopentyl:C1(CCCC1)C2CCCC2 can't be distinguished 
+    by the WL test,see https://arxiv.org/pdf/2106.04319 For more algorithm details.
+    the BertzCT value of the two molecules are the same, (they have same catgories of eta_i, so we can take advantage of 
+    this phenomenon, making our final purpose still succeeds.)
+    """
+
+  atoms = mol.GetAtoms()
+  num_atoms = len(atoms)
+  neighbors = [sorted(n.GetIdx() for n in atom.GetNeighbors()) for atom in atoms]
+  colors = [atom.GetSymbol() for atom in atoms]
+  for _ in range(max_iter):
+    color_map = {}
+    new_colors = [None] * num_atoms
+    for a_idx in range(num_atoms):
+      neighbor_list = neighbors[a_idx]
+      neighbor_colors = sorted(colors[n] for n in neighbor_list)
+      new_color = (colors[a_idx], tuple(neighbor_colors))
+      if new_color not in color_map:
+        color_map[new_color] = len(color_map)
+      new_colors[a_idx] = color_map[new_color]
+    if new_colors == colors:
+      break
+    colors = new_colors.copy()
+  return dict(enumerate(colors))
+
+
+# this single test molecule is taxol, more examples are placed in the UnitTest file
+# other examples with different outcomes are placed in the UnitTest file
+if __name__ == "__main__":
+  import timeit
+  import rdkit
+
+  smiles = "O=C(C1=CC=CC=C1)N[C@@H](C2=CC=CC=C2)[C@H](C(O[C@@H]3C(C)=C([C@@H](OC(C)=O)C([C@@]4(C)[C@]([C@@](CO5)(OC(C)=O)[C@@]5([H])C[C@@H]4O)([H])[C@@H]6OC(C7=CC=CC=C7)=O)=O)C(C)(C)[C@@]6(O)C3)=O)O"
+
+  mol = rdkit.Chem.MolFromSmiles(smiles)
+
+  def old_version_test():
+    return BertzCT(mol)  # this is the old version
+
+  def new_version_test():
+    return BertzCTNewVersion(
+      mol)  # this is the new version (based on the Weisfeiler-Lehman color refinement algorithm)
+
+  n_runs = 5000  # number of runs for each test
+
+  # time cost comparison
+  BertzCTOldVersionTIMECOST = timeit.timeit(old_version_test, number=n_runs)
+  BertzCTNewVersionTIMECOST = timeit.timeit(new_version_test, number=n_runs)
+
+  print("old_version_TIMECOST: {:.6f} s".format(BertzCTOldVersionTIMECOST / n_runs))
+  print("new_version_TIMECOST: {:.6f} s".format(BertzCTNewVersionTIMECOST / n_runs))
+
+  C_T = BertzCTNewVersion(mol)
+  print(f"old_version_value: {C_T}")
+  print(f"new_version_value: {BertzCT(mol)}")
+
+"""
+************************************************************************************************
+BerzCTNewVersion: A new version of BertzCT descriptor calculation.
+Other bugs in the original BertzCT calculation have been fixed in this new version.(in Unit Test)
+There is only one examples
+
+General Mechanism: 
+Atoms progressively aggregate neighboring information to determine their chemical environment within the 
+molecular structure. Typically, distinct chemical environments are differentiated through a few rounds of iteration (often just a few steps before convergence (colors = new_colors.copy())), 
+where atoms are assigned distinct colors). The message-passing resembles that of Graph Convolutional Networks (GCNs).
+************************************************************************************************
+"""
+
+from collections import defaultdict
+from itertools import combinations
+
+
+def BertzCTNewVersion(mol):
+  if not mol or mol.GetNumAtoms() == 0:
+    return 0.0
+
+  # for different bond types, assign different weights
+  # For AROMATIC bond, I treat them as this blog does
+  BOND_WEIGHTS = {
+    Chem.BondType.SINGLE: 1.0,
+    Chem.BondType.DOUBLE: 2.0,
+    Chem.BondType.TRIPLE: 3.0,
+    Chem.BondType.AROMATIC: 1.5,
+    # special bond types
+    Chem.BondType.DATIVE: 1.2,  # dative bond
+    Chem.BondType.IONIC: 0.8,  # ionic bond
+    Chem.BondType.ZERO: 0.0  # zero bond
+  }
+
+  adj_dict = defaultdict(float)
+  for bond in mol.GetBonds():
+    start, end = sorted([bond.GetBeginAtomIdx(), bond.GetEndAtomIdx()])
+
+    # assign weights to different bond types
+    bond_type = bond.GetBondType()
+    cnt = BOND_WEIGHTS.get(bond_type, 0.0)  # default weight is 0.0
+
+    # special bond types
+    if bond_type == Chem.BondType.DATIVE:
+      # make sure the donor atom is the one with negative charge
+      donor_atom = bond.GetBeginAtom() if bond.GetBeginAtom().GetFormalCharge(
+      ) < 0 else bond.GetEndAtom()
+      if donor_atom.GetAtomicNum() in [7, 8]:  # N or O which belong to the common donor atoms
+        cnt = 1.2  # dative bond weight
+
+    adj_dict[(start, end)] += cnt
+
+  atom_neighbors = defaultdict(dict)
+  for (a, b), cnt in adj_dict.items():
+    atom_neighbors[a][b] = cnt
+    atom_neighbors[b][a] = cnt
+
+  # eta calculation
+  eta_case1 = 0.0
+  for b in atom_neighbors:
+    counts = list(atom_neighbors[b].values())
+    sum_counts = sum(counts)
+    sum_sq = sum(c * c for c in counts)
+    eta_case1 += (sum_counts**2 - sum_sq) / 2
+
+  eta_case2 = sum(k * (k - 1) / 2 for k in adj_dict.values() if k > 1)
+  eta = eta_case1 + eta_case2
+
+  # WL color refinement algorithm for atom environment feature generation
+  wl_colors = ComputeWeisfeilerLehmanSignatures(mol)
+
+  # eta_i calculation (i.e., the number of pairs of atoms with the same color in the same environment)
+  eta_i = defaultdict(float)
+  # case 1：A-B-C chain
+  for b_atom in atom_neighbors:
+    b_color = wl_colors[b_atom]
+    neighbors = list(atom_neighbors[b_atom].items())
+    for (a1, cnt1), (a2, cnt2) in combinations(neighbors, 2):
+      key = ('chain', b_color, tuple(sorted((wl_colors[a1], wl_colors[a2]))))
+      eta_i[key] += cnt1 * cnt2
+
+  # case 2：A-B loop
+  for (a, b), cnt in adj_dict.items():
+    if cnt > 1:
+      key = ('loop', tuple(sorted((wl_colors[a], wl_colors[b]))))
+      eta_i[key] += cnt * (cnt - 1) / 2
+
+  # correct term for eta_i (i.e., the number of pairs of atoms with the same color in the same
+  # environment which  leads to the overcounting of the molecular complexity)
+  entropy_term = sum(v * math.log2(v) if v > 0 else 0 for v in eta_i.values())
+  c_eta = 2 * eta * math.log2(eta) - entropy_term if eta != 0 else 0
+
+  # 计算E和C_E
+  atom_types = defaultdict(int)
+  for atom in mol.GetAtoms():
+    atom_types[atom.GetSymbol()] += 1
+  E = sum(atom_types.values())
+  entropy_term_E = sum(v * math.log2(v) for v in atom_types.values() if v > 0)
+  c_E = E * math.log2(E) - entropy_term_E if E != 0 else 0
+
+  return c_eta + c_E
+
+
+def ComputeWeisfeilerLehmanSignatures(mol, max_iter=20):
+  """Weisfeiler-Lehman color refinement algorithm is used to generate atom environment features
+    ************************************************************************************************
+    It should be noted that while there exist mathematical examples where two non-isomorphic graphs can pass the 
+    Weisfeiler-Lehman (WL) graph isomorphism test, such cases are virtually non-existent in chemical contexts, 
+    even when considering artificially synthesized bizarre molecular structures. 
+    ************************************************************************************************
+
+    So, in chemistry, especially for natural products, which lacks symmetric structures as well as strange node degrees,
+    the WL test is considered to be a reliable graph isomorphism test.
+
+    Moreover, even if some special case: Decalin:C12CCCCC1CCCC2 and Bicyclopentyl:C1(CCCC1)C2CCCC2 can't be distinguished 
+    by the WL test,see https://arxiv.org/pdf/2106.04319 For more algorithm details.
+    the BertzCT value of the two molecules are the same, (they have same catgories of eta_i, so we can take advantage of 
+    this phenomenon, making our final purpose still succeeds.)
+    """
+
+  atoms = mol.GetAtoms()
+  num_atoms = len(atoms)
+  neighbors = [sorted(n.GetIdx() for n in atom.GetNeighbors()) for atom in atoms]
+  colors = [atom.GetSymbol() for atom in atoms]
+  for _ in range(max_iter):
+    color_map = {}
+    new_colors = [None] * num_atoms
+    for a_idx in range(num_atoms):
+      neighbor_list = neighbors[a_idx]
+      neighbor_colors = sorted(colors[n] for n in neighbor_list)
+      new_color = (colors[a_idx], tuple(neighbor_colors))
+      if new_color not in color_map:
+        color_map[new_color] = len(color_map)
+      new_colors[a_idx] = color_map[new_color]
+    if new_colors == colors:
+      break
+    colors = new_colors.copy()
+  return dict(enumerate(colors))
+
+
+# this single test molecule is taxol, more examples are placed in the UnitTest file
+# other examples with different outcomes are placed in the UnitTest file
+if __name__ == "__main__":
+  import timeit
+  import rdkit
+
+  smiles = "O=C(C1=CC=CC=C1)N[C@@H](C2=CC=CC=C2)[C@H](C(O[C@@H]3C(C)=C([C@@H](OC(C)=O)C([C@@]4(C)[C@]([C@@](CO5)(OC(C)=O)[C@@]5([H])C[C@@H]4O)([H])[C@@H]6OC(C7=CC=CC=C7)=O)=O)C(C)(C)[C@@]6(O)C3)=O)O"
+
+  mol = rdkit.Chem.MolFromSmiles(smiles)
+
+  def old_version_test():
+    return BertzCT(mol)  # this is the old version
+
+  def new_version_test():
+    return BertzCTNewVersion(
+      mol)  # this is the new version (based on the Weisfeiler-Lehman color refinement algorithm)
+
+  n_runs = 5000  # number of runs for each test
+
+  # time cost comparison
+  BertzCTOldVersionTIMECOST = timeit.timeit(old_version_test, number=n_runs)
+  BertzCTNewVersionTIMECOST = timeit.timeit(new_version_test, number=n_runs)
+
+  print("old_version_TIMECOST: {:.6f} s".format(BertzCTOldVersionTIMECOST / n_runs))
+  print("new_version_TIMECOST: {:.6f} s".format(BertzCTNewVersionTIMECOST / n_runs))
+
+  C_T = BertzCTNewVersion(mol)
+  print(f"old_version_value: {C_T}")
+  print(f"new_version_value: {BertzCT(mol)}")


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
BerzCTNewVersion: A new version of BertzCT descriptor calculation.("yapfed")
I think this version can replace the relevant functions from previous versions, as it avoids some bug molecules of earlier version(BertzCT 2.0.0) and performs faster calculations for diterpenes and larger molecules due to O(N) grows slower((though I consider the time difference insignificant except for very large synthetic network searches). However, for comparison purposes and to solicit feedback from more experienced colleagues, instead of directly replacing the original, I've added the BertzCTNewVersion under GraphDescriptors.py. Corresponding examples are included in the unit tests, which can be deleted later. Thanks so much for help and discussion~

Other bugs in the original BertzCT calculation have been fixed in this new version.(in Unit Test)
General Mechanism: 
Atoms progressively aggregate neighboring information to determine their chemical environment within the 
molecular structure. Typically, distinct chemical environments are differentiated through a few rounds of iteration (often just a few steps before convergence (colors = new_colors.copy())), 
where atoms are assigned distinct colors). The message-passing resembles that of Graph Convolutional Networks (GCNs).
### For bug fixed, here are some examples, 1,2 I use use ”hand calculation“ to verify
1. "C1CCCCCS1" 
2. "C1CCCCCCN1"
3.  "C1=CC=CC=C1->[Cu+]" it's a simple molecule, shouldn't compute to over 1000 in the original code
![image](https://github.com/user-attachments/assets/f712c4a7-e342-465b-8308-16b23b43742f)

### A single molecule test for speed ( taxol)
![image](https://github.com/user-attachments/assets/21e13306-819a-4d5c-bcba-c274c24e4ba9)





#### Any other comments?

