### PR TITLE
Fix build under gcc-14

### DIFF
--- a/Code/GraphMol/SynthonSpaceSearch/SynthonSpaceSearcher.cpp
+++ b/Code/GraphMol/SynthonSpaceSearch/SynthonSpaceSearcher.cpp
@@ -40,9 +40,9 @@ SynthonSpaceSearcher::SynthonSpaceSearcher(
       // work on all platforms.
       if (d_params.randomSeed == -1) {
         std::random_device rd;
-        d_randGen = std::make_unique<boost::mt19937>(rd());
+        d_randGen = std::make_unique<std::mt19937>(rd());
       } else {
-        d_randGen = std::make_unique<boost::mt19937>(d_params.randomSeed);
+        d_randGen = std::make_unique<std::mt19937>(d_params.randomSeed);
       }
     }
   }

--- a/Code/GraphMol/SynthonSpaceSearch/SynthonSpaceSearcher.h
+++ b/Code/GraphMol/SynthonSpaceSearch/SynthonSpaceSearcher.h
@@ -16,8 +16,7 @@
 #define SYNTHONSPACESEARCHER_H
 
 #include <chrono>
-
-#include <boost/random.hpp>
+#include <random>
 
 #include <RDGeneral/export.h>
 #include <GraphMol/SynthonSpaceSearch/SynthonSpace.h>
@@ -70,7 +69,7 @@ class SynthonSpaceSearcher {
       const std::vector<size_t> &synthNums) const;
 
  private:
-  std::unique_ptr<boost::mt19937> d_randGen;
+  std::unique_ptr<std::mt19937> d_randGen;
 
   const ROMol &d_query;
   const SynthonSpaceSearchParams &d_params;


### PR DESCRIPTION
The build is currently failing under gcc 14 :
```
In file included from /opt/gcc-14/include/c++/14.2.0/bits/random.h:35,
                 from /opt/gcc-14/include/c++/14.2.0/random:48,
                 from /tmp/rdkit_builder/rdkit/Code/GraphMol/SynthonSpaceSearch/SynthonSpaceSearcher.cpp:11:
/opt/gcc-14/include/c++/14.2.0/bits/uniform_int_dist.h: In instantiation of ‘std::uniform_int_distribution<_IntType>::result_type std::uniform_int_distribution<_IntType>::operator()(_UniformRandomBitGenerator&, const param_type&) [with _UniformRandomBitGenerator = boost::random::mersenne_twister_engine<unsigned int, 32, 624, 397, 31, 2567483615, 11, 4294967295, 7, 2636928640, 15, 4022730752, 18, 1812433253>; _IntType = long unsigned int; result_type = long unsigned int]’:
/opt/gcc-14/include/c++/14.2.0/bits/stl_algo.h:3758:35:   required from ‘void std::shuffle(_RAIter, _RAIter, _UGenerator&&) [with _RAIter = __gnu_cxx::__normal_iterator<unique_ptr<RDKit::SynthonSpaceSearch::SynthonSpaceHitSet>*, vector<unique_ptr<RDKit::SynthonSpaceSearch::SynthonSpaceHitSet> > >; _UGenerator = boost::random::mersenne_twister_engine<unsigned int, 32, 624, 397, 31, 2567483615, 11, 4294967295, 7, 2636928640, 15, 4022730752, 18, 1812433253>&]’
 3758 |         std::iter_swap(__i, __first + __d(__g, __p_type(0, __i - __first)));
      |                                       ~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/tmp/rdkit_builder/rdkit/Code/GraphMol/SynthonSpaceSearch/SynthonSpaceSearcher.cpp:303:17:   required from here
  303 |     std::shuffle(hitsets.begin(), hitsets.end(), *d_randGen);
      |     ~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/opt/gcc-14/include/c++/14.2.0/bits/uniform_int_dist.h:295:71: error: call to non-‘constexpr’ function ‘static boost::random::mersenne_twister_engine<UIntType, w, n, m, r, a, u, d, s, b, t, c, l, f>::result_type boost::random::mersenne_twister_engine<UIntType, w, n, m, r, a, u, d, s, b, t, c, l, f>::min() [with UIntType = unsigned int; long unsigned int w = 32; long unsigned int n = 624; long unsigned int m = 397; long unsigned int r = 31; UIntType a = 2567483615; long unsigned int u = 11; UIntType d = 4294967295; long unsigned int s = 7; UIntType b = 2636928640; long unsigned int t = 15; UIntType c = 4022730752; long unsigned int l = 18; UIntType f = 1812433253; result_type = unsigned int]’
  295 |         constexpr __uctype __urngmin = _UniformRandomBitGenerator::min();

```

This patch switches the Synthon Space Searcher to use `std::mt19937` instead of `boost:mt19937`, which fixes the issue.
