### PR TITLE
Fix SynthonSpace build when RDK_USE_BOOST_SERIALIZATION is not defined

### DIFF
--- a/Code/GraphMol/SynthonSpaceSearch/SynthonSpace.cpp
+++ b/Code/GraphMol/SynthonSpaceSearch/SynthonSpace.cpp
@@ -146,9 +146,8 @@ SearchResults SynthonSpace::substructureSearch(
         std::get<GeneralizedSubstruct::ExtendedQueryMol::TautomerBundle_T>(
             query.xqmol),
         matchParams, params);
-  }
 #endif
-  else {
+  } else {
     UNDER_CONSTRUCTION("unrecognized type in ExtendedQueryMol");
   }
   return SearchResults();


### PR DESCRIPTION
Small PR to fix the `SynthonSpace.cpp` build when `RDK_USE_BOOST_SERIALIZATION` is not defined (currently it fails due to curly bracket mismatches).