### PR TITLE
Expose reading/writing PNG metadata to CFFI and MinimalLib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,7 @@ option(RDK_BUILD_CPP_TESTS "build the c++ tests (disabing can speed up builds" O
 option(RDK_USE_FLEXBISON "use flex/bison, if available, to build the SMILES/SMARTS/SLN parsers" OFF)
 option(RDK_TEST_COVERAGE "Use G(L)COV to compute test coverage" OFF)
 option(RDK_USE_BOOST_SERIALIZATION "Use the boost serialization library if available" ON)
+option(RDK_USE_BOOST_PROGRAM_OPTIONS "Use the boost program options library if available" ON)
 option(RDK_USE_BOOST_STACKTRACE "use boost::stacktrace to do more verbose invariant output (linux only)" ON)
 option(RDK_BUILD_TEST_GZIP "Build the gzip'd stream test" OFF)
 option(RDK_OPTIMIZE_POPCNT "Use SSE4.2 popcount instruction while compiling." ON)

--- a/Code/GraphMol/FileParsers/CMakeLists.txt
+++ b/Code/GraphMol/FileParsers/CMakeLists.txt
@@ -1,3 +1,11 @@
+
+
+if(NOT RDK_USE_BOOST_IOSTREAMS)
+    find_package(ZLIB)
+    set(STANDALONE_ZLIB_LIBRARY ${ZLIB_LIBRARIES})
+    add_definitions("-DRDK_USE_STANDALONE_ZLIB")
+endif(NOT RDK_USE_BOOST_IOSTREAMS)
+
 if(RDK_BUILD_MAEPARSER_SUPPORT)
     include_directories(${maeparser_INCLUDE_DIRS})
     set(maesupplier MaeMolSupplier.cpp MaeWriter.cpp)
@@ -23,7 +31,10 @@ rdkit_library(FileParsers
     MultithreadedMolSupplier.cpp
     MultithreadedSmilesMolSupplier.cpp
     MultithreadedSDMolSupplier.cpp
-    LINK_LIBRARIES GenericGroups Depictor SmilesParse ChemTransforms GraphMol ${RDK_MAEPARSER_LIBS})
+    LINK_LIBRARIES GenericGroups Depictor SmilesParse ChemTransforms GraphMol ${RDK_MAEPARSER_LIBS} ${STANDALONE_ZLIB_LIBRARY})
+if(STANDALONE_ZLIB_LIBRARY)
+    target_include_directories(FileParsers PRIVATE ${ZLIB_INCLUDE_DIRS})
+endif(STANDALONE_ZLIB_LIBRARY)
 target_compile_definitions(FileParsers PRIVATE RDKIT_FILEPARSERS_BUILD)
 
 rdkit_headers(CDXMLParser.h

--- a/Code/GraphMol/FileParsers/PNGParser.h
+++ b/Code/GraphMol/FileParsers/PNGParser.h
@@ -16,6 +16,7 @@
 #include <GraphMol/RDKitBase.h>
 #include <GraphMol/SmilesParse/SmilesParse.h>
 #include <GraphMol/SmilesParse/SmilesWrite.h>
+#include <GraphMol/MolPickler.h>
 
 #include <boost/format.hpp>
 
@@ -31,6 +32,24 @@ RDKIT_FILEPARSERS_EXPORT extern const std::string smilesTag;
 RDKIT_FILEPARSERS_EXPORT extern const std::string molTag;
 RDKIT_FILEPARSERS_EXPORT extern const std::string pklTag;
 }  // namespace PNGData
+
+struct RDKIT_FILEPARSERS_EXPORT PNGMetadataParams {
+  //! include molecule pickle
+  bool includePkl = true;
+  //! include CXSMILES for the molecule
+  bool includeSmiles = true;
+  //! include molblock for the molecule
+  bool includeMol = false;
+  //! choose properties to be included in the pickle
+  unsigned int propertyFlags = MolPickler::getDefaultPickleProperties();
+  //! choose SmilesWriteParams for the CXSMILES string
+  SmilesWriteParams smilesWriteParams = SmilesWriteParams();
+  //! choose CXSMILES fields to be included in the CXSMILES string
+  std::uint32_t cxSmilesFlags = SmilesWrite::CXSmilesFields::CX_ALL;
+  //! choose what to do with bond dirs in the CXSMILES string
+  RestoreBondDirOption restoreBondDirs =
+      RestoreBondDirOption::RestoreBondDirOptionClear;
+};
 
 //! \name metadata to/from PNG
 //! @{
@@ -164,14 +183,33 @@ inline std::vector<std::unique_ptr<ROMol>> PNGStringToMols(
 
   \param mol            the molecule to add
   \param iStream        the stream to read from
+  \param params         instance of PNGMetadataParams
+
+*/
+RDKIT_FILEPARSERS_EXPORT std::string addMolToPNGStream(
+    const ROMol &mol, std::istream &iStream, const PNGMetadataParams &params);
+
+//! \brief adds metadata for an ROMol to the data from a PNG stream.
+//! The modified PNG data is returned.
+/*!
+
+  \param mol            the molecule to add
+  \param iStream        the stream to read from
   \param includePkl     include a molecule pickle
   \param includeSmiles  include CXSMILES for the molecule
   \param includeMol     include a mol block for the molecule
 
 */
-RDKIT_FILEPARSERS_EXPORT std::string addMolToPNGStream(
-    const ROMol &mol, std::istream &iStream, bool includePkl = true,
-    bool includeSmiles = true, bool includeMol = false);
+inline std::string addMolToPNGStream(const ROMol &mol, std::istream &iStream,
+                                     bool includePkl = true,
+                                     bool includeSmiles = true,
+                                     bool includeMol = false) {
+  PNGMetadataParams params;
+  params.includePkl = includePkl;
+  params.includeSmiles = includeSmiles;
+  params.includeMol = includeMol;
+  return addMolToPNGStream(mol, iStream, params);
+}
 
 //! \brief adds metadata for an ROMol to a PNG string.
 //! The modified PNG data is returned.
@@ -185,6 +223,17 @@ inline std::string addMolToPNGString(const ROMol &mol,
   return addMolToPNGStream(mol, inStream, includePkl, includeSmiles,
                            includeMol);
 }
+
+//! \brief adds metadata for an ROMol to a PNG string.
+//! The modified PNG data is returned.
+//! See \c addMolToPNGStream() for more details.
+inline std::string addMolToPNGString(const ROMol &mol,
+                                     const std::string &pngString,
+                                     const PNGMetadataParams &params) {
+  std::stringstream inStream(pngString);
+  return addMolToPNGStream(mol, inStream, params);
+}
+
 //! \brief adds metadata for an ROMol to the data from a PNG file.
 //! The modified PNG data is returned.
 //! See \c addMolToPNGStream() for more details.
@@ -195,6 +244,15 @@ inline std::string addMolToPNGFile(const ROMol &mol, const std::string &fname,
   std::ifstream inStream(fname.c_str(), std::ios::binary);
   return addMolToPNGStream(mol, inStream, includePkl, includeSmiles,
                            includeMol);
+}
+
+//! \brief adds metadata for an ROMol to the data from a PNG file.
+//! The modified PNG data is returned.
+//! See \c addMolToPNGStream() for more details.
+inline std::string addMolToPNGFile(const ROMol &mol, const std::string &fname,
+                                   const PNGMetadataParams &params) {
+  std::ifstream inStream(fname.c_str(), std::ios::binary);
+  return addMolToPNGStream(mol, inStream, params);
 }
 //! @}
 

--- a/Code/GraphMol/FileParsers/file_parsers_catch.cpp
+++ b/Code/GraphMol/FileParsers/file_parsers_catch.cpp
@@ -31,6 +31,7 @@
 #include <GraphMol/FileParsers/MolFileStereochem.h>
 #include <GraphMol/FileParsers/MolWriters.h>
 #include <GraphMol/MonomerInfo.h>
+#include <GraphMol/Depictor/RDDepictor.h>
 #include <GraphMol/test_fixtures.h>
 #include <RDGeneral/FileParseException.h>
 #include <boost/algorithm/string.hpp>
@@ -2751,6 +2752,216 @@ TEST_CASE("write molecule to PNG", "[writer][PNG]") {
     REQUIRE(mol);
     CHECK(mol->getNumAtoms() == 29);
     CHECK(mol->getNumConformers() == 1);
+  }
+  SECTION("use PKL") {
+    std::string fname =
+        rdbase +
+        "/Code/GraphMol/FileParsers/test_data/colchicine.no_metadata.png";
+    auto colchicine =
+        "COc1cc2c(c(OC)c1OC)-c1ccc(OC)c(=O)cc1[C@@H](NC(C)=O)CC2"_smiles;
+    REQUIRE(colchicine);
+    RDDepict::compute2DCoords(*colchicine);
+    CHECK(colchicine->getNumConformers() == 1);
+    static const std::string propertyName("property");
+    static const std::string propertyValue("value");
+    colchicine->setProp<std::string>(propertyName, propertyValue);
+    PNGMetadataParams params;
+    params.includePkl = true;
+    params.includeSmiles = false;
+    params.includeMol = false;
+    {
+      std::ifstream strm(fname, std::ios::in | std::ios::binary);
+      params.propertyFlags = PicklerOps::PropertyPickleOptions::NoProps;
+      auto pngString = addMolToPNGStream(*colchicine, strm, params);
+      // read it back out
+      std::unique_ptr<ROMol> mol(PNGStringToMol(pngString));
+      REQUIRE(mol);
+      CHECK(mol->getNumAtoms() == 29);
+      CHECK(mol->getNumConformers() == 1);
+      CHECK(!mol->hasProp(propertyName));
+    }
+    {
+      std::ifstream strm(fname, std::ios::in | std::ios::binary);
+      params.propertyFlags = PicklerOps::PropertyPickleOptions::AllProps;
+      auto pngString = addMolToPNGStream(*colchicine, strm, params);
+      // read it back out
+      std::unique_ptr<ROMol> mol(PNGStringToMol(pngString));
+      REQUIRE(mol);
+      CHECK(mol->getNumAtoms() == 29);
+      CHECK(mol->getNumConformers() == 1);
+      CHECK(mol->hasProp(propertyName));
+      CHECK(mol->getProp<std::string>(propertyName) == propertyValue);
+    }
+    {
+      std::ifstream strm(fname, std::ios::in | std::ios::binary);
+      params.includePkl = false;
+      params.includeSmiles = true;
+      params.cxSmilesFlags = SmilesWrite::CXSmilesFields::CX_ALL_BUT_COORDS;
+      auto pngString = addMolToPNGStream(*colchicine, strm, params);
+      // read it back out
+      std::unique_ptr<ROMol> mol(PNGStringToMol(pngString));
+      REQUIRE(mol);
+      CHECK(mol->getNumAtoms() == 29);
+      CHECK(mol->getNumConformers() == 0);
+      CHECK(!mol->hasProp(propertyName));
+    }
+  }
+  SECTION("use original wedging") {
+    std::string fname =
+        rdbase +
+        "/Code/GraphMol/FileParsers/test_data/colchicine.no_metadata.png";
+    auto colchicineUnusualWedging =
+        R"CTAB(
+     RDKit          2D
+
+ 29 31  0  0  0  0  0  0  0  0999 V2000
+    6.4602    1.0300    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    5.3062    1.9883    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0
+    3.8993    1.4680    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    2.7453    2.4262    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    1.3384    1.9059    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    1.0856    0.4273    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    2.2396   -0.5309    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    1.9868   -2.0094    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0
+    3.1408   -2.9677    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    3.6465   -0.0106    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    4.8005   -0.9688    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0
+    4.5477   -2.4474    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -0.2280   -0.2968    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    0.1857   -1.7387    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -0.6836   -2.9611    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -2.1813   -3.0436    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -2.7569   -4.4288    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0
+   -4.2442   -4.6230    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -3.1797   -1.9240    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -4.6215   -2.3378    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0
+   -2.9268   -0.4455    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -1.6132    0.2787    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -2.0269    1.7205    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -3.5055    1.9733    0.0000 N   0  0  0  0  0  0  0  0  0  0  0  0
+   -4.0258    3.3802    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -5.5043    3.6330    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -3.0675    4.5342    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0
+   -1.1576    2.9429    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    0.3401    3.0254    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+  1  2  1  0
+  2  3  1  0
+  3  4  2  0
+  4  5  1  0
+  5  6  2  0
+  6  7  1  0
+  7  8  1  0
+  8  9  1  0
+  7 10  2  0
+ 10 11  1  0
+ 11 12  1  0
+  6 13  1  0
+ 13 14  2  0
+ 14 15  1  0
+ 15 16  2  0
+ 16 17  1  0
+ 17 18  1  0
+ 16 19  1  0
+ 19 20  2  0
+ 19 21  1  0
+ 21 22  2  0
+ 23 22  1  1
+ 23 24  1  0
+ 24 25  1  0
+ 25 26  1  0
+ 25 27  2  0
+ 23 28  1  0
+ 28 29  1  0
+ 10  3  1  0
+ 22 13  1  0
+ 29  5  1  0
+M  END
+)CTAB"_ctab;
+    REQUIRE(colchicineUnusualWedging);
+    CHECK(colchicineUnusualWedging->getNumConformers() == 1);
+    SmilesWriteParams ps;
+    CHECK(MolToCXSmiles(*colchicineUnusualWedging).find("wU:22.24|") !=
+          std::string::npos);
+    CHECK(MolToCXSmiles(*colchicineUnusualWedging, ps, SmilesWrite::CX_ALL,
+                        RestoreBondDirOptionTrue)
+              .find("wU:22.23|") != std::string::npos);
+    PNGMetadataParams params;
+    params.includePkl = true;
+    params.includeSmiles = true;
+    params.includeMol = true;
+    params.propertyFlags = PicklerOps::PropertyPickleOptions::AtomProps |
+                           PicklerOps::PropertyPickleOptions::BondProps;
+    {
+      std::ifstream strm(fname, std::ios::in | std::ios::binary);
+      auto pngString =
+          addMolToPNGStream(*colchicineUnusualWedging, strm, params);
+      // read it back out
+      std::unique_ptr<ROMol> mol(PNGStringToMol(pngString));
+      REQUIRE(mol);
+      CHECK(mol->getNumAtoms() == 29);
+      CHECK(mol->getNumConformers() == 1);
+      CHECK(
+          MolToCXSmiles(*mol, ps, SmilesWrite::CX_ALL, RestoreBondDirOptionTrue)
+              .find("wU:22.23|") != std::string::npos);
+      auto metadata = PNGStringToMetadata(pngString);
+      auto smilesFound = false;
+      auto ctabFound = false;
+      auto pklFound = false;
+      for (const auto &[key, value] : metadata) {
+        if (key.substr(0, 6) == "SMILES") {
+          smilesFound = true;
+          CHECK(value.find("wU:22.24|") != std::string::npos);
+        } else if (key.substr(0, 3) == "MOL") {
+          ctabFound = true;
+          CHECK(value.find(" 23 24  1  1") != std::string::npos);
+        } else if (key.substr(0, 8) == "rdkitPKL") {
+          pklFound = true;
+          RWMol molFromPkl(value);
+          CHECK(MolToMolBlock(molFromPkl).find(" 23 24  1  1") !=
+                std::string::npos);
+          Chirality::reapplyMolBlockWedging(molFromPkl);
+          CHECK(MolToMolBlock(molFromPkl).find(" 23 22  1  1") !=
+                std::string::npos);
+        }
+      }
+      CHECK((smilesFound && ctabFound && pklFound));
+    }
+    {
+      params.restoreBondDirs = RestoreBondDirOptionTrue;
+      std::ifstream strm(fname, std::ios::in | std::ios::binary);
+      auto pngString =
+          addMolToPNGStream(*colchicineUnusualWedging, strm, params);
+      // read it back out
+      std::unique_ptr<ROMol> mol(PNGStringToMol(pngString));
+      REQUIRE(mol);
+      CHECK(mol->getNumAtoms() == 29);
+      CHECK(mol->getNumConformers() == 1);
+      CHECK(
+          MolToCXSmiles(*mol, ps, SmilesWrite::CX_ALL, RestoreBondDirOptionTrue)
+              .find("wU:22.23|") != std::string::npos);
+      auto metadata = PNGStringToMetadata(pngString);
+      auto smilesFound = false;
+      auto ctabFound = false;
+      auto pklFound = false;
+      for (const auto &[key, value] : metadata) {
+        if (key.substr(0, 6) == "SMILES") {
+          smilesFound = true;
+          CHECK(value.find("wU:22.23|") != std::string::npos);
+        } else if (key.substr(0, 3) == "MOL") {
+          ctabFound = true;
+          CHECK(value.find(" 23 22  1  1") != std::string::npos);
+        } else if (key.substr(0, 8) == "rdkitPKL") {
+          pklFound = true;
+          RWMol molFromPkl(value);
+          CHECK(MolToMolBlock(molFromPkl).find(" 23 24  1  1") !=
+                std::string::npos);
+          Chirality::reapplyMolBlockWedging(molFromPkl);
+          CHECK(MolToMolBlock(molFromPkl).find(" 23 22  1  1") !=
+                std::string::npos);
+        }
+      }
+      CHECK((smilesFound && ctabFound && pklFound));
+    }
   }
 }
 TEST_CASE("multiple molecules in the PNG", "[writer][PNG]") {

--- a/Code/GraphMol/RGroupDecomposition/CMakeLists.txt
+++ b/Code/GraphMol/RGroupDecomposition/CMakeLists.txt
@@ -25,10 +25,12 @@ rdkit_test(testRGroupDecompInternals testRGroupInternals.cpp
 rdkit_catch_test(rgroupCatchTests catch_rgd.cpp 
   LINK_LIBRARIES RGroupDecomposition)
 
-find_package(Boost ${RDK_BOOST_VERSION} COMPONENTS program_options CONFIG)
-if(RDK_BUILD_CPP_TESTS AND Boost_FOUND)
+if(RDK_USE_BOOST_PROGRAM_OPTIONS)
+  find_package(Boost ${RDK_BOOST_VERSION} COMPONENTS program_options CONFIG)
+endif()
+if(RDK_BUILD_CPP_TESTS AND (Boost_FOUND OR NOT RDK_USE_BOOST_PROGRAM_OPTIONS))
   add_executable(gaExample GaExample.cpp)
-  if(NOT Boost_USE_STATIC_LIBS)
+  if(RDK_USE_BOOST_PROGRAM_OPTIONS AND NOT Boost_USE_STATIC_LIBS)
     target_compile_definitions(gaExample PUBLIC -DBOOST_PROGRAM_OPTIONS_DYN_LINK)
   endif()
   target_link_libraries(gaExample RGroupDecomposition ${Boost_PROGRAM_OPTIONS_LIBRARY})

--- a/Code/GraphMol/RGroupDecomposition/GaExample.cpp
+++ b/Code/GraphMol/RGroupDecomposition/GaExample.cpp
@@ -14,24 +14,48 @@
 #include <string>
 #include <vector>
 #include <memory>
+#include <variant>
+#include <map>
 
 #include <GraphMol/SmilesParse/SmilesParse.h>
 #include <GraphMol/SmilesParse/SmilesWrite.h>
 #include <GraphMol/FileParsers/MolWriters.h>
 #include <GraphMol/RGroupDecomposition/RGroupDecomp.h>
 
+#ifdef RDK_USE_BOOST_PROGRAM_OPTIONS
 #include <boost/program_options.hpp>
+#endif
 
 using namespace std;
 using namespace RDKit;
+#ifdef RDK_USE_BOOST_PROGRAM_OPTIONS
 using namespace boost::program_options;
 namespace options = boost::program_options;
+#else
+namespace {
+class Option {
+ public:
+  Option(): d_option(std::string()) {}
+  template<typename T>
+  Option(const T o): d_option(o) {}
+  template<>
+  Option(const char *o): d_option(o) {}
+  template<typename T>
+  T as() const {
+    return std::get<T>(d_option);
+  }
+ private:
+  std::variant<std::string, int> d_option;
+};
+} // end anonymous namespace
+#endif
 
 // Example systems based on Brian's MultipleCores notebook for profiling
 int main(int argc, char *argv[]) {
   RDLog::InitLogs();
   boost::logging::disable_logs("rdApp.debug");
 
+#ifdef RDK_USE_BOOST_PROGRAM_OPTIONS
   options_description desc("Allowed options");
   desc.add_options()("help", "Help message")(
       "dataset", options::value<std::string>()->default_value("rg-easy"),
@@ -59,6 +83,18 @@ int main(int argc, char *argv[]) {
     cerr << desc << endl;
     return 0;
   }
+#else
+  std::map<std::string, Option> vm;
+  vm.emplace("dataset", "rg-easy");
+  vm.emplace("maximumOperations", -1);
+  vm.emplace("populationSize", -1);
+  vm.emplace("numberOperationsWithoutImprovement", -1);
+  vm.emplace("randomSeed", -1);
+  vm.emplace("matchingStrategy", "GA");
+  vm.emplace("numberRuns", 1);
+  vm.emplace("start", 0);
+  vm.emplace("batch", 10000000);
+#endif
 
   auto dataset = vm["dataset"].as<std::string>();
   std::string rdBase(getenv("RDBASE"));

--- a/Code/GraphMol/Wrap/rdmolfiles.cpp
+++ b/Code/GraphMol/Wrap/rdmolfiles.cpp
@@ -539,12 +539,34 @@ ROMol *MolFromPNGString(python::object png, python::object pyParams) {
   return newM;
 }
 
+python::object addMolToPNGFileHelperParams(const ROMol &mol,
+                                           python::object fname,
+                                           const PNGMetadataParams &params) {
+  std::string cstr = python::extract<std::string>(fname);
+
+  auto res = addMolToPNGFile(mol, cstr, params);
+
+  python::object retval = python::object(
+      python::handle<>(PyBytes_FromStringAndSize(res.c_str(), res.length())));
+  return retval;
+}
+
 python::object addMolToPNGFileHelper(const ROMol &mol, python::object fname,
                                      bool includePkl, bool includeSmiles,
                                      bool includeMol) {
-  std::string cstr = python::extract<std::string>(fname);
+  PNGMetadataParams params;
+  params.includePkl = includePkl;
+  params.includeSmiles = includeSmiles;
+  params.includeMol = includeMol;
+  return addMolToPNGFileHelperParams(mol, fname, params);
+}
 
-  auto res = addMolToPNGFile(mol, cstr, includePkl, includeSmiles, includeMol);
+python::object addMolToPNGStringHelperParams(const ROMol &mol,
+                                             python::object png,
+                                             const PNGMetadataParams &params) {
+  std::string cstr = python::extract<std::string>(png);
+
+  auto res = addMolToPNGString(mol, cstr, params);
 
   python::object retval = python::object(
       python::handle<>(PyBytes_FromStringAndSize(res.c_str(), res.length())));
@@ -554,14 +576,11 @@ python::object addMolToPNGFileHelper(const ROMol &mol, python::object fname,
 python::object addMolToPNGStringHelper(const ROMol &mol, python::object png,
                                        bool includePkl, bool includeSmiles,
                                        bool includeMol) {
-  std::string cstr = python::extract<std::string>(png);
-
-  auto res =
-      addMolToPNGString(mol, cstr, includePkl, includeSmiles, includeMol);
-
-  python::object retval = python::object(
-      python::handle<>(PyBytes_FromStringAndSize(res.c_str(), res.length())));
-  return retval;
+  PNGMetadataParams params;
+  params.includePkl = includePkl;
+  params.includeSmiles = includeSmiles;
+  params.includeMol = includeMol;
+  return addMolToPNGStringHelperParams(mol, png, params);
 }
 
 python::object addMetadataToPNGFileHelper(python::dict pymetadata,
@@ -679,31 +698,41 @@ python::tuple MolsFromCDXML(python::object cdxml, bool sanitize,
 }
 
 namespace {
-python::dict translateMetadata(
-    const std::vector<std::pair<std::string, std::string>> &metadata) {
-  python::dict res;
-  for (const auto &pr : metadata) {
+PyObject *translateMetadata(
+    const std::vector<std::pair<std::string, std::string>> &metadata,
+    bool asList) {
+  std::unique_ptr<python::dict> resAsDict;
+  std::unique_ptr<python::list> resAsList;
+  if (asList) {
+    resAsList.reset(new python::list());
+  } else {
+    resAsDict.reset(new python::dict());
+  }
+  for (const auto &[key, value] : metadata) {
     // keys are safe to extract:
-    std::string key = pr.first;
     // but values may include binary, so we convert them directly to bytes:
     python::object val = python::object(python::handle<>(
-        PyBytes_FromStringAndSize(pr.second.c_str(), pr.second.length())));
-    res[key] = val;
+        PyBytes_FromStringAndSize(value.c_str(), value.length())));
+    if (asList) {
+      resAsList->append(python::make_tuple(key, val));
+    } else {
+      (*resAsDict)[key] = val;
+    }
   }
-  return res;
+  return (asList ? resAsList.release()->ptr() : resAsDict.release()->ptr());
 }
 
 }  // namespace
-python::dict MetadataFromPNGFile(python::object fname) {
+PyObject *MetadataFromPNGFile(python::object fname, bool asList) {
   std::string cstr = python::extract<std::string>(fname);
   auto metadata = PNGFileToMetadata(cstr);
-  return translateMetadata(metadata);
+  return translateMetadata(metadata, asList);
 }
 
-python::dict MetadataFromPNGString(python::object png) {
+PyObject *MetadataFromPNGString(python::object png, bool asList) {
   std::string cstr = python::extract<std::string>(png);
   auto metadata = PNGStringToMetadata(cstr);
-  return translateMetadata(metadata);
+  return translateMetadata(metadata, asList);
 }
 
 void CanonicalizeEnhancedStereo(ROMol &mol) {
@@ -2315,6 +2344,28 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
       "returns a list of SMILES generated using the randomSmiles algorithm");
 
 #ifdef RDK_USE_BOOST_IOSTREAMS
+  python::class_<RDKit::PNGMetadataParams, boost::noncopyable>(
+      "PNGMetadataParams",
+      "Parameters controlling metadata included in PNG images")
+      .def_readwrite("includePkl", &RDKit::PNGMetadataParams::includePkl,
+                     "toggles inclusion of molecule pickle (default=True)")
+      .def_readwrite("includeSmiles", &RDKit::PNGMetadataParams::includeSmiles,
+                     "toggles inclusion of molecule CXSMILES (default=True)")
+      .def_readwrite("includeMol", &RDKit::PNGMetadataParams::includeMol,
+                     "toggles inclusion of molecule molblock (default=False)")
+      .def_readwrite(
+          "propertyFlags", &RDKit::PNGMetadataParams::propertyFlags,
+          "choose properties to be included in the pickle (default=rdkit.Chem.rdchem.PropertyPickleOptions.NoProps)")
+      .def_readwrite(
+          "smilesWriteParams", &RDKit::PNGMetadataParams::smilesWriteParams,
+          "choose SmilesWriteParams for the CXSMILES string (default=rdkit.Chem.rdmolfiles.SmilesWriteParams())")
+      .def_readwrite(
+          "cxSmilesFlags", &RDKit::PNGMetadataParams::cxSmilesFlags,
+          "choose CXSMILES fields to be included in the CXSMILES string (default=rdkit.Chem.rdmolfiles.CXSmilesFields.CX_ALL)")
+      .def_readwrite(
+          "restoreBondDirs", &RDKit::PNGMetadataParams::restoreBondDirs,
+          "choose what to do with bond dirs in the CXSMILES string (default=rdkit.Chem.rdmolfiles.RestoreBondDirOption.RestoreBondDirOptionClear)");
+
   docString =
       R"DOC(Construct a molecule from metadata in a PNG string.
 
@@ -2434,6 +2485,24 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
       docString.c_str());
 
   docString =
+      R"DOC(Adds molecular metadata to PNG data read from a file.
+
+     ARGUMENTS:
+
+       - mol: the molecule
+
+       - filename: the PNG filename
+
+       - params: an instance of PNGMetadataParams
+
+     RETURNS:
+       the updated PNG data)DOC";
+  python::def(
+      "MolMetadataToPNGFile", addMolToPNGFileHelperParams,
+      (python::arg("mol"), python::arg("filename"), python::arg("params")),
+      docString.c_str());
+
+  docString =
       R"DOC(Adds molecular metadata to a PNG string.
 
      ARGUMENTS:
@@ -2455,6 +2524,23 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
       (python::arg("mol"), python::arg("png"), python::arg("includePkl") = true,
        python::arg("includeSmiles") = true, python::arg("includeMol") = false),
       docString.c_str());
+
+  docString =
+      R"DOC(Adds molecular metadata to a PNG string.
+
+     ARGUMENTS:
+
+       - mol: the molecule
+
+       - png: the PNG string
+
+       - params: an instance of PNGMetadataParams
+
+     RETURNS:
+       the updated PNG data)DOC";
+  python::def("MolMetadataToPNGString", addMolToPNGStringHelperParams,
+              (python::arg("mol"), python::arg("png"), python::arg("params")),
+              docString.c_str());
 
   docString =
       R"DOC(Adds metadata to PNG data read from a file.
@@ -2488,14 +2574,18 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
               (python::arg("metadata"), python::arg("png")), docString.c_str());
 
   python::def("MetadataFromPNGFile", MetadataFromPNGFile,
-              (python::arg("filename")),
+              (python::arg("filename"), python::arg("asList") = false),
               "Returns a dict with all metadata from the PNG file. Keys are "
-              "strings, values are bytes.");
+              "strings, values are bytes. "
+              "If asList is True, a list of (key, value) tuples is returned; "
+              "this enables retrieving multiple values sharing the same key.");
 
   python::def("MetadataFromPNGString", MetadataFromPNGString,
-              (python::arg("png")),
+              (python::arg("png"), python::arg("asList") = false),
               "Returns a dict with all metadata from the PNG string. Keys are "
-              "strings, values are bytes.");
+              "strings, values are bytes. "
+              "If asList is True, a list of (key, value) tuples is returned; "
+              "this enables retrieving multiple values sharing the same key.");
 #endif
 /********************************************************
  * MolSupplier stuff

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -6640,19 +6640,92 @@ M  END
 
     with open(fileN, 'rb') as inf:
       d = inf.read()
-    mol = Chem.MolFromSmiles("COc1cc2c(c(OC)c1OC)-c1ccc(OC)c(=O)cc1[C@@H](NC(C)=O)CC2")
+    mol = Chem.MolFromSmiles('COc1cc2c(c(OC)c1OC)-c1ccc(OC)c(=O)cc1[C@@H](NC(C)=O)CC2')
+    mol.SetProp('property', 'value')
     self.assertIsNotNone(mol)
     self.assertEqual(mol.GetNumAtoms(), 29)
 
     nd = Chem.MolMetadataToPNGString(mol, d)
-    mol = Chem.MolFromPNGString(nd)
-    self.assertIsNotNone(mol)
-    self.assertEqual(mol.GetNumAtoms(), 29)
+    molFromPNG = Chem.MolFromPNGString(nd)
+    self.assertIsNotNone(molFromPNG)
+    self.assertEqual(molFromPNG.GetNumAtoms(), 29)
+    self.assertTrue(molFromPNG.HasProp('property'))
+    rdkit.Chem.rdDepictor.Compute2DCoords(mol)
+    self.assertEqual(mol.GetNumConformers(), 1)
 
-    nd = Chem.MolMetadataToPNGFile(mol, fileN)
-    mol = Chem.MolFromPNGString(nd)
-    self.assertIsNotNone(mol)
-    self.assertEqual(mol.GetNumAtoms(), 29)
+    nd = Chem.MolMetadataToPNGString(mol, d, includePkl=False)
+    molFromPNG = Chem.MolFromPNGString(nd)
+    self.assertIsNotNone(molFromPNG)
+    self.assertEqual(molFromPNG.GetNumAtoms(), 29)
+    self.assertEqual(molFromPNG.GetNumConformers(), 1)
+    self.assertFalse(molFromPNG.HasProp('property'))
+    nd = Chem.MolMetadataToPNGString(mol, d, includePkl=True)
+    molFromPNG = Chem.MolFromPNGString(nd)
+    self.assertIsNotNone(molFromPNG)
+    self.assertEqual(molFromPNG.GetNumAtoms(), 29)
+    self.assertEqual(molFromPNG.GetNumConformers(), 1)
+    self.assertTrue(molFromPNG.HasProp('property'))
+    params = Chem.PNGMetadataParams()
+    params.includePkl = False
+    params.cxSmilesFlags = Chem.CXSmilesFields.CX_ALL_BUT_COORDS
+    nd = Chem.MolMetadataToPNGString(mol, d, params)
+    molFromPNG = Chem.MolFromPNGString(nd)
+    self.assertIsNotNone(molFromPNG)
+    self.assertEqual(molFromPNG.GetNumAtoms(), 29)
+    self.assertEqual(molFromPNG.GetNumConformers(), 0)
+    self.assertFalse(molFromPNG.HasProp('property'))
+    params.includePkl = True
+    params.propertyFlags = Chem.PropertyPickleOptions.NoProps
+    nd = Chem.MolMetadataToPNGString(mol, d, params)
+    molFromPNG = Chem.MolFromPNGString(nd)
+    self.assertIsNotNone(molFromPNG)
+    self.assertEqual(molFromPNG.GetNumAtoms(), 29)
+    self.assertEqual(molFromPNG.GetNumConformers(), 1)
+    self.assertFalse(molFromPNG.HasProp('property'))
+    params.propertyFlags = Chem.PropertyPickleOptions.AllProps
+    nd = Chem.MolMetadataToPNGString(mol, d, params)
+    molFromPNG = Chem.MolFromPNGString(nd)
+    self.assertIsNotNone(molFromPNG)
+    self.assertEqual(molFromPNG.GetNumAtoms(), 29)
+    self.assertEqual(molFromPNG.GetNumConformers(), 1)
+    self.assertTrue(molFromPNG.HasProp('property'))
+
+    nd = Chem.MolMetadataToPNGFile(mol, fileN, includePkl=False)
+    molFromPNG = Chem.MolFromPNGString(nd)
+    self.assertIsNotNone(molFromPNG)
+    self.assertEqual(molFromPNG.GetNumAtoms(), 29)
+    self.assertEqual(molFromPNG.GetNumConformers(), 1)
+    self.assertFalse(molFromPNG.HasProp('property'))
+    nd = Chem.MolMetadataToPNGFile(mol, fileN, includePkl=True)
+    molFromPNG = Chem.MolFromPNGString(nd)
+    self.assertIsNotNone(molFromPNG)
+    self.assertEqual(molFromPNG.GetNumAtoms(), 29)
+    self.assertEqual(molFromPNG.GetNumConformers(), 1)
+    self.assertTrue(molFromPNG.HasProp('property'))
+    params = Chem.PNGMetadataParams()
+    params.includePkl = False
+    params.cxSmilesFlags = Chem.CXSmilesFields.CX_ALL_BUT_COORDS
+    nd = Chem.MolMetadataToPNGFile(mol, fileN, params)
+    molFromPNG = Chem.MolFromPNGString(nd)
+    self.assertIsNotNone(molFromPNG)
+    self.assertEqual(molFromPNG.GetNumAtoms(), 29)
+    self.assertEqual(molFromPNG.GetNumConformers(), 0)
+    self.assertFalse(molFromPNG.HasProp('property'))
+    params.includePkl = True
+    params.propertyFlags = Chem.PropertyPickleOptions.NoProps
+    nd = Chem.MolMetadataToPNGFile(mol, fileN, params)
+    molFromPNG = Chem.MolFromPNGString(nd)
+    self.assertIsNotNone(molFromPNG)
+    self.assertEqual(molFromPNG.GetNumAtoms(), 29)
+    self.assertEqual(molFromPNG.GetNumConformers(), 1)
+    self.assertFalse(molFromPNG.HasProp('property'))
+    params.propertyFlags = Chem.PropertyPickleOptions.AllProps
+    nd = Chem.MolMetadataToPNGFile(mol, fileN, params)
+    molFromPNG = Chem.MolFromPNGString(nd)
+    self.assertIsNotNone(molFromPNG)
+    self.assertEqual(molFromPNG.GetNumAtoms(), 29)
+    self.assertEqual(molFromPNG.GetNumConformers(), 1)
+    self.assertTrue(molFromPNG.HasProp('property'))
 
   @unittest.skipUnless(hasattr(Chem, 'MolFromPNGFile'), "RDKit not built with iostreams support")
   def testMolsFromPNG(self):
@@ -6672,6 +6745,7 @@ M  END
     with open(fileN, 'rb') as inf:
       d = inf.read()
     mol = Chem.MolFromPNGString(d)
+    self.assertIsNotNone(mol)
     nd = Chem.MolMetadataToPNGString(mol, d)
     vals = {'foo': '1', 'bar': '2'}
     nd = Chem.AddMetadataToPNGString(vals, nd)
@@ -6680,6 +6754,20 @@ M  END
     self.assertEqual(nvals['foo'], b'1')
     self.assertTrue('bar' in nvals)
     self.assertEqual(nvals['bar'], b'2')
+
+    with open(fileN, 'rb') as inf:
+      d = inf.read()
+    mol = Chem.MolFromPNGString(d)
+    self.assertIsNotNone(mol)
+    nd = Chem.MolMetadataToPNGString(mol, d)
+    nd = Chem.AddMetadataToPNGString(vals, nd)
+    vals2 = {'foo': '3', 'bar': '4'}
+    nd = Chem.AddMetadataToPNGString(vals2, nd)
+    nvals = Chem.MetadataFromPNGString(nd, asList=True)
+    self.assertEqual(len(nvals), 7)
+    self.assertEqual([k.split()[0] for k, _ in nvals], ['SMILES', 'rdkitPKL', 'SMILES', 'foo', 'bar', 'foo', 'bar'])
+    self.assertEqual([v.decode() for k, v in nvals if k == 'foo'], ['1', '3'])
+    self.assertEqual([v.decode() for k, v in nvals if k == 'bar'], ['2', '4'])
 
     nd = Chem.AddMetadataToPNGFile(vals, fileN)
     nvals = Chem.MetadataFromPNGString(nd)

--- a/Code/MinimalLib/JSONParsers.cpp
+++ b/Code/MinimalLib/JSONParsers.cpp
@@ -99,5 +99,24 @@ void updateRemoveHsParametersFromJSON(MolOps::RemoveHsParameters &ps,
   }
 }
 
+void updatePNGMetadataParamsFromJSON(PNGMetadataParams &params,
+                                     const char *details_json) {
+  if (details_json && strlen(details_json)) {
+    boost::property_tree::ptree pt;
+    std::istringstream ss;
+    ss.str(details_json);
+    boost::property_tree::read_json(ss, pt);
+    params.includePkl = pt.get("includePkl", params.includePkl);
+    params.includeSmiles = pt.get("includeSmiles", params.includeSmiles);
+    params.includeMol = pt.get("includeMol", params.includeMol);
+    updatePropertyPickleOptionsFromJSON(params.propertyFlags, details_json);
+    updateSmilesWriteParamsFromJSON(params.smilesWriteParams, details_json);
+    unsigned int restoreBondDirs = params.restoreBondDirs;
+    updateCXSmilesFieldsFromJSON(params.cxSmilesFlags, restoreBondDirs,
+                                 details_json);
+    params.restoreBondDirs =
+        RestoreBondDirOption::_from_integral(restoreBondDirs);
+  }
+}
 }  // end namespace MinimalLib
 }  // end namespace RDKit

--- a/Code/MinimalLib/JSONParsers.h
+++ b/Code/MinimalLib/JSONParsers.h
@@ -25,5 +25,7 @@ void updateSanitizeFlagsFromJSON(unsigned int &sanitizeFlags,
 void updateRemoveHsParametersFromJSON(MolOps::RemoveHsParameters &ps,
                                       bool &sanitize, const char *details_json);
 
+void updatePNGMetadataParamsFromJSON(PNGMetadataParams &params,
+                                     const char *details_json);
 }  // end namespace MinimalLib
 }  // end namespace RDKit

--- a/Code/MinimalLib/cffiwrapper.h
+++ b/Code/MinimalLib/cffiwrapper.h
@@ -161,6 +161,23 @@ RDKIT_RDKITCFFI_EXPORT short disable_logger(const char *log_name);
 RDKIT_RDKITCFFI_EXPORT short use_legacy_stereo_perception(short value);
 RDKIT_RDKITCFFI_EXPORT short allow_non_tetrahedral_chirality(short value);
 
+// PNG metadata
+RDKIT_RDKITCFFI_EXPORT short add_mol_to_png_blob(char **png_blob,
+                                                 size_t *png_blob_sz,
+                                                 const char *mpkl,
+                                                 size_t mpkl_size,
+                                                 const char *details_json);
+RDKIT_RDKITCFFI_EXPORT short get_mol_from_png_blob(const char *png_blob,
+                                                   size_t png_blob_sz,
+                                                   char **mpkl, size_t *mpkl_sz,
+                                                   const char *details_json);
+RDKIT_RDKITCFFI_EXPORT short get_mols_from_png_blob(const char *png_blob,
+                                                    size_t png_blob_sz,
+                                                    char ***mpkl_array,
+                                                    size_t **mpkl_sz_array,
+                                                    const char *details_json);
+RDKIT_RDKITCFFI_EXPORT void free_mol_array(char ***pkl_array,
+                                           size_t **pkl_sz_array);
 // logging
 RDKIT_RDKITCFFI_EXPORT void *set_log_tee(const char *log_name);
 RDKIT_RDKITCFFI_EXPORT void *set_log_capture(const char *log_name);

--- a/Code/MinimalLib/minilib.h
+++ b/Code/MinimalLib/minilib.h
@@ -30,6 +30,7 @@ class JSMolBase {
   virtual ~JSMolBase(){};
   virtual const RDKit::RWMol &get() const = 0;
   virtual RDKit::RWMol &get() = 0;
+  virtual void reset(RDKit::RWMol *other) = 0;
   std::string get_smiles() const;
   std::string get_smiles(const std::string &details) const;
   std::string get_cxsmiles() const;
@@ -117,6 +118,7 @@ class JSMolBase {
       "instead")]] bool
   is_valid() const;
   int has_coords() const;
+  const RDGeom::POINT3D_VECT &get_coords() const;
 
   std::string get_stereo_tags();
   std::string get_aromatic_form() const;
@@ -163,6 +165,12 @@ class JSMolBase {
   unsigned int get_num_atoms(bool heavyOnly) const;
   unsigned int get_num_atoms() const { return get_num_atoms(false); };
   unsigned int get_num_bonds() const;
+  std::string add_to_png_blob(const std::string &pngString,
+                              const std::string &details) const;
+  std::string combine_with(const JSMolBase &other, const std::string &details);
+  std::string combine_with(const JSMolBase &other) {
+    return combine_with(other, "{}");
+  }
 #ifdef RDK_BUILD_MINIMAL_LIB_MMPA
   std::pair<JSMolList *, JSMolList *> get_mmpa_frags(
       unsigned int minCuts, unsigned int maxCuts,
@@ -193,6 +201,10 @@ class JSMol : public JSMolBase {
     checkNotNull();
     return *d_mol.get();
   }
+  void reset(RDKit::RWMol *other) {
+    PRECONDITION(other, "other cannot be null");
+    d_mol.reset(other);
+  }
 
  private:
   void checkNotNull() const { CHECK_INVARIANT(d_mol, "d_mol cannot be null"); }
@@ -218,6 +230,14 @@ class JSMolShared : public JSMolBase {
   }
   const RDKit::ROMOL_SPTR &get_sptr() const { return d_mol; }
   RDKit::ROMOL_SPTR &get_sptr() { return d_mol; }
+  void reset(RDKit::RWMol *other) {
+    PRECONDITION(other, "other cannot be null");
+    d_mol.reset(other);
+  }
+  void reset_sptr(const RDKit::ROMOL_SPTR &other) {
+    PRECONDITION(other, "other cannot be null");
+    d_mol = other;
+  }
 
  private:
   void checkNotNull() const { CHECK_INVARIANT(d_mol, "d_mol cannot be null"); }
@@ -351,6 +371,10 @@ bool enable_logging(const std::string &logName);
 bool disable_logging(const std::string &logName);
 JSLog *set_log_tee(const std::string &log_name);
 JSLog *set_log_capture(const std::string &log_name);
+JSMolBase *get_mol_from_png_blob(const std::string &pngString,
+                                 const std::string &details);
+JSMolList *get_mols_from_png_blob(const std::string &pngString,
+                                  const std::string &details);
 #ifdef RDK_BUILD_MINIMAL_LIB_MCS
 std::string get_mcs_as_json(const JSMolList &mols,
                             const std::string &details_json);

--- a/Code/MinimalLib/tests/tests.js
+++ b/Code/MinimalLib/tests/tests.js
@@ -2803,6 +2803,21 @@ function captureStdoutStderr(stdoutCallback, optStderrCallback) {
     };
 }
 
+function captureStdoutStderr(stdoutCallback, optStderrCallback) {
+    if (!stdoutCallback) {
+        return null;
+    }
+    const stderrCallback = optStderrCallback || stdoutCallback;
+    const origStdoutWrite = process.stdout.write;
+    const origStderrWrite = process.stderr.write;
+    process.stdout.write = (chunk) => stdoutCallback(chunk);
+    process.stderr.write = (chunk) => stderrCallback(chunk);
+    return () => {
+        process.stdout.write = origStdoutWrite;
+        process.stderr.write = origStderrWrite;
+    };
+}
+
 function test_capture_logs() {
     const PENTAVALENT_CARBON = 'CC(C)(C)(C)C';
     const PENTAVALENT_CARBON_VALENCE_ERROR = 'Explicit valence for atom # 1 C, 5, is greater than permitted';
@@ -3750,6 +3765,398 @@ M  END
     mol.delete();
 }
 
+function test_png_metadata() {
+    const PNG_COLCHICINE_NO_METADATA = "/../../GraphMol/FileParsers/test_data/colchicine.no_metadata.png";
+    const PNG_COLCHICINE_WITH_METADATA = "/../../GraphMol/FileParsers/test_data/colchicine.png";
+    const PNG_PENICILLIN_METADATA = "penicillin_metadata.png";
+    const PNG_PENICILLIN_AMOXICILLIN_METADATA = "penicillin_amoxicillin_metadata.png";
+    const PNG_COLCHICINE_AMOXICILLIN_METADATA = "colchicine_amoxicillin_metadata.png";
+    const BENZYLPENICILLIN_SMI = "CC1([C@@H](N2[C@H](S1)[C@@H](C2=O)NC(=O)Cc3ccccc3)C(=O)O)C";
+    const BENZYLPENICILLIN_CAN_SMI = "CC1(C)S[C@@H]2[C@H](NC(=O)Cc3ccccc3)C(=O)N2[C@H]1C(=O)O";
+    const AMOXICILLIN_SMI = "O=C(O)[C@@H]2N3C(=O)[C@@H](NC(=O)[C@@H](c1ccc(O)cc1)N)[C@H]3SC2(C)C";
+    const AMOXICILLIN_CAN_SMI = "CC1(C)S[C@@H]2[C@H](NC(=O)[C@H](N)c3ccc(O)cc3)C(=O)N2[C@H]1C(=O)O";
+    let mol;
+    let mols;
+    let molSan;
+    const png_no_metadata_buf = fs.readFileSync(__dirname + PNG_COLCHICINE_NO_METADATA);
+    const png_no_metadata_blob = new Uint8Array(png_no_metadata_buf.length);
+    const png_no_metadata_blob2 = new Uint8Array(png_no_metadata_buf.length);
+    png_no_metadata_buf.copy(png_no_metadata_blob);
+    png_no_metadata_buf.copy(png_no_metadata_blob2);
+    const png_with_metadata_buf = fs.readFileSync(__dirname + PNG_COLCHICINE_WITH_METADATA);
+    const png_with_metadata_blob = new Uint8Array(png_with_metadata_buf.length);
+    png_with_metadata_buf.copy(png_with_metadata_blob);
+    assert(!RDKitModule.get_mol_from_png_blob(png_no_metadata_blob));
+    assert(!RDKitModule.get_mols_from_png_blob(png_no_metadata_blob));
+    let penicillin = RDKitModule.get_mol(BENZYLPENICILLIN_SMI);
+    assert(penicillin);
+    assert(penicillin.set_new_coords());
+    let png_penicillin_metadata_blob = penicillin.add_to_png_blob(png_no_metadata_blob,
+        "{\"includePkl\":false,\"includeSmiles\":true,\"includeMol\":true}");
+    penicillin.delete();
+    assert(png_penicillin_metadata_blob);
+    fs.writeFileSync(PNG_PENICILLIN_METADATA, png_penicillin_metadata_blob);
+    penicillin = RDKitModule.get_mol_from_png_blob(png_penicillin_metadata_blob);
+    assert(penicillin);
+    assert.equal(penicillin.has_coords(), 2);
+    penicillin.delete();
+    RDKitModule.enable_logging()
+    mol = RDKitModule.get_mol_from_png_blob(png_with_metadata_blob);
+    assert(mol);
+    assert.equal(mol.has_coords(), 2);
+    mol.delete();
+    mols = RDKitModule.get_mols_from_png_blob(png_with_metadata_blob);
+    assert(!mols);
+    mols = RDKitModule.get_mols_from_png_blob(png_with_metadata_blob,
+        JSON.stringify({ includePkl: true, includeSmiles: true }));
+    assert(!mols);
+    mols = RDKitModule.get_mols_from_png_blob(
+        png_with_metadata_blob, JSON.stringify({ includeSmiles: true }));
+    assert(mols);
+    assert.equal(mols.size(), 1);
+    mol = mols.next();
+    assert.equal(mol.has_coords(), 2);
+    mol.delete();
+    mols.delete();
+    assert(!RDKitModule.get_mol_from_png_blob(png_penicillin_metadata_blob,
+        "{\"includePkl\":true,\"includeSmiles\":false,\"includeMol\":false}"));
+    penicillin = RDKitModule.get_mol_from_png_blob(png_penicillin_metadata_blob,
+        "{\"includePkl\":false,\"includeSmiles\":false,\"includeMol\":true,\"sanitize\":false,\"removeHs\":false,\"assignStereo\":false,\"fastFindRings\":false}");
+    assert(penicillin);
+    assert.equal(penicillin.has_coords(), 2);
+    smi = penicillin.get_smiles();
+    assert.notEqual(smi, BENZYLPENICILLIN_CAN_SMI);
+    molSan = RDKitModule.get_mol(smi)
+    assert.equal(molSan.get_smiles(), BENZYLPENICILLIN_CAN_SMI);
+    molSan.delete();
+    penicillin.delete();
+    assert(!RDKitModule.get_mol_from_png_blob(png_no_metadata_blob2));
+    penicillin = RDKitModule.get_mol(BENZYLPENICILLIN_SMI);
+    assert(penicillin);
+    let amoxicillin = RDKitModule.get_mol(AMOXICILLIN_SMI);
+    assert(amoxicillin);
+    assert(amoxicillin.set_new_coords());
+    png_penicillin_metadata_blob = penicillin.add_to_png_blob(png_no_metadata_blob2,
+        "{\"includePkl\":false,\"includeMol\":true,\"CX_ALL_BUT_COORDS\":true}");
+    assert(png_penicillin_metadata_blob);
+    let png_penicillin_amoxicillin_metadata_blob = amoxicillin.add_to_png_blob(png_penicillin_metadata_blob,
+        "{\"includePkl\":false,\"includeMol\":true,\"CX_ALL_BUT_COORDS\":true}");
+    assert(png_penicillin_amoxicillin_metadata_blob);
+    fs.writeFileSync(PNG_PENICILLIN_AMOXICILLIN_METADATA, png_penicillin_amoxicillin_metadata_blob);
+    mol = RDKitModule.get_mol_from_png_blob(png_penicillin_amoxicillin_metadata_blob,
+        "{\"sanitize\":false,\"removeHs\":false,\"assignStereo\":false,\"fastFindRings\":false}");
+    assert(mol);
+    assert(!mol.has_coords());
+    smi = mol.get_smiles();
+    assert.equal(smi, BENZYLPENICILLIN_CAN_SMI);
+    mol.delete();
+    assert(!RDKitModule.get_mol_from_png_blob(png_penicillin_amoxicillin_metadata_blob,
+        "{\"includePkl\":false,\"includeSmiles\":false,\"includeMol\":false}"));
+    mol = RDKitModule.get_mol_from_png_blob(png_penicillin_amoxicillin_metadata_blob,
+        "{\"includePkl\":true,\"includeSmiles\":false,\"includeMol\":true}");
+    assert(mol);
+    assert.equal(mol.has_coords(), 2);
+    smi = mol.get_smiles();
+    assert.equal(smi, BENZYLPENICILLIN_CAN_SMI);
+    mol.delete();
+    mols = RDKitModule.get_mols_from_png_blob(png_penicillin_amoxicillin_metadata_blob);
+    assert(!mols);
+    mols = RDKitModule.get_mols_from_png_blob(
+        png_penicillin_amoxicillin_metadata_blob, JSON.stringify({ includeSmiles: true }));
+    assert(mols);
+    assert.equal(mols.size(), 2);
+    mol = mols.at(0);
+    assert(!mol.has_coords());
+    smi = mol.get_smiles();
+    assert.equal(smi, BENZYLPENICILLIN_CAN_SMI);
+    assert(mol.get_morgan_fp());
+    mol.delete();
+    mol = mols.at(1);
+    assert(!mol.has_coords());
+    smi = mol.get_smiles();
+    assert.equal(smi, AMOXICILLIN_CAN_SMI);
+    assert(mol.get_morgan_fp());
+    mol.delete();
+    mols.delete();
+    mols = RDKitModule.get_mols_from_png_blob(png_penicillin_amoxicillin_metadata_blob, JSON.stringify({
+        includePkl: false, includeMol: true, sanitize: false, removeHs: false, assignStereo: false, fastFindRings: false
+    }));
+    assert(mols);
+    assert.equal(mols.size(), 2);
+    mol = mols.at(0);
+    assert(mol.has_coords());
+    smi = mol.get_smiles();
+    assert.notEqual(smi, BENZYLPENICILLIN_CAN_SMI);
+    molSan = RDKitModule.get_mol(smi)
+    assert.equal(molSan.get_smiles(), BENZYLPENICILLIN_CAN_SMI);
+    molSan.delete();
+    mol.delete();
+    mol = mols.at(1);
+    assert(mol.has_coords());
+    smi = mol.get_smiles();
+    assert.notEqual(smi, AMOXICILLIN_CAN_SMI);
+    molSan = RDKitModule.get_mol(smi)
+    assert.equal(molSan.get_smiles(), AMOXICILLIN_CAN_SMI);
+    molSan.delete();
+    mol.delete();
+    mols.delete();
+    let png_colchicine_amoxicillin_metadata_blob = amoxicillin.add_to_png_blob(
+        png_with_metadata_blob, JSON.stringify({ includeMol: true, CX_ALL_BUT_COORDS:true }));
+    assert(png_colchicine_amoxicillin_metadata_blob);
+    fs.writeFileSync(PNG_COLCHICINE_AMOXICILLIN_METADATA, png_colchicine_amoxicillin_metadata_blob);
+    mols = RDKitModule.get_mols_from_png_blob(png_colchicine_amoxicillin_metadata_blob,
+        "{\"includePkl\":false,\"includeMol\":true}");
+    assert.equal(mols.size(), 1);
+    mol = mols.at(0);
+    assert.equal(mol.has_coords(), 2);
+    mol.delete();
+    mols.delete();
+    mols = RDKitModule.get_mols_from_png_blob(png_colchicine_amoxicillin_metadata_blob,
+        "{\"includeSmiles\":true}");
+    assert.equal(mols.size(), 2);
+    assert.equal(mols.at(0).has_coords(), 2);
+    assert(!mols.at(1).has_coords());
+    mols.delete();
+    penicillin.delete();
+    amoxicillin.delete();
+
+    const colchicine = RDKitModule.get_mol('COc1cc2c(c(OC)c1OC)-c1ccc(OC)c(=O)cc1[C@@H](NC(C)=O)CC2');
+    assert(colchicine);
+    png_no_metadata_buf.copy(png_no_metadata_blob);
+    let png_colchicine_metadata_blob;
+    png_colchicine_metadata_blob = colchicine.add_to_png_blob(png_no_metadata_blob);
+    mol = RDKitModule.get_mol_from_png_blob(png_colchicine_metadata_blob);
+    assert(mol);
+    assert.equal(mol.get_num_atoms(), 29);
+    assert(!mol.has_coords());
+    mol.delete();
+    // use SMILES
+    png_colchicine_metadata_blob = colchicine.add_to_png_blob(png_no_metadata_blob,
+        JSON.stringify({ includePkl: false }));
+    mol = RDKitModule.get_mol_from_png_blob(png_colchicine_metadata_blob);
+    assert(mol);
+    assert.equal(mol.get_num_atoms(), 29);
+    assert(!mol.has_coords());
+    mol.delete();
+    // use MOL
+    png_colchicine_metadata_blob = colchicine.add_to_png_blob(png_no_metadata_blob,
+        JSON.stringify({ includePkl: false, includeSmiles: false, includeMol: true }));
+    mol = RDKitModule.get_mol_from_png_blob(png_colchicine_metadata_blob);
+    assert(mol);
+    assert.equal(mol.get_num_atoms(), 29);
+    assert.equal(mol.has_coords(), 2);
+    mol.delete();
+    // use PKL
+    colchicine.set_new_coords();
+    assert.equal(colchicine.has_coords(), 2);
+    const PROPERTY_NAME = 'property';
+    const PROPERTY_VALUE = 'value';
+    colchicine.set_prop(PROPERTY_NAME, PROPERTY_VALUE);
+    png_colchicine_metadata_blob = colchicine.add_to_png_blob(png_no_metadata_blob, JSON.stringify({
+        includePkl: true, includeSmiles: false, includeMol: false, propertyFlags: { NoProps: true }
+    }));
+    mol = RDKitModule.get_mol_from_png_blob(png_colchicine_metadata_blob);
+    assert(mol);
+    assert.equal(mol.get_num_atoms(), 29);
+    assert.equal(mol.has_coords(), 2);
+    assert(!mol.has_prop(PROPERTY_NAME));
+    mol.delete();
+    png_colchicine_metadata_blob = colchicine.add_to_png_blob(png_no_metadata_blob, JSON.stringify({
+        includePkl: true, includeSmiles: false, includeMol: false, propertyFlags: { AllProps: true }
+    }));
+    mol = RDKitModule.get_mol_from_png_blob(png_colchicine_metadata_blob);
+    assert(mol);
+    assert.equal(mol.get_num_atoms(), 29);
+    assert.equal(mol.has_coords(), 2);
+    assert(mol.has_prop(PROPERTY_NAME));
+    assert(mol.get_prop(PROPERTY_NAME) == PROPERTY_VALUE);
+    mol.delete();
+    png_colchicine_metadata_blob = colchicine.add_to_png_blob(png_no_metadata_blob, JSON.stringify({
+        includePkl: false, includeSmiles: true, includeMol: false,
+        propertyFlags: { NoProps: true }, CX_ALL_BUT_COORDS: true
+    }));
+    mol = RDKitModule.get_mol_from_png_blob(png_colchicine_metadata_blob);
+    assert(mol);
+    assert.equal(mol.get_num_atoms(), 29);
+    assert(!mol.has_coords());
+    assert(!mol.has_prop(PROPERTY_NAME));
+    mol.delete();
+    // use original wedging
+    const colchicineUnusualWedging = RDKitModule.get_mol(`
+     RDKit          2D
+
+ 29 31  0  0  0  0  0  0  0  0999 V2000
+    6.4602    1.0300    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    5.3062    1.9883    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0
+    3.8993    1.4680    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    2.7453    2.4262    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    1.3384    1.9059    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    1.0856    0.4273    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    2.2396   -0.5309    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    1.9868   -2.0094    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0
+    3.1408   -2.9677    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    3.6465   -0.0106    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    4.8005   -0.9688    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0
+    4.5477   -2.4474    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -0.2280   -0.2968    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    0.1857   -1.7387    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -0.6836   -2.9611    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -2.1813   -3.0436    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -2.7569   -4.4288    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0
+   -4.2442   -4.6230    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -3.1797   -1.9240    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -4.6215   -2.3378    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0
+   -2.9268   -0.4455    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -1.6132    0.2787    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -2.0269    1.7205    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -3.5055    1.9733    0.0000 N   0  0  0  0  0  0  0  0  0  0  0  0
+   -4.0258    3.3802    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -5.5043    3.6330    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -3.0675    4.5342    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0
+   -1.1576    2.9429    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    0.3401    3.0254    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+  1  2  1  0
+  2  3  1  0
+  3  4  2  0
+  4  5  1  0
+  5  6  2  0
+  6  7  1  0
+  7  8  1  0
+  8  9  1  0
+  7 10  2  0
+ 10 11  1  0
+ 11 12  1  0
+  6 13  1  0
+ 13 14  2  0
+ 14 15  1  0
+ 15 16  2  0
+ 16 17  1  0
+ 17 18  1  0
+ 16 19  1  0
+ 19 20  2  0
+ 19 21  1  0
+ 21 22  2  0
+ 23 22  1  1
+ 23 24  1  0
+ 24 25  1  0
+ 25 26  1  0
+ 25 27  2  0
+ 23 28  1  0
+ 28 29  1  0
+ 10  3  1  0
+ 22 13  1  0
+ 29  5  1  0
+M  END
+`);
+    assert(colchicineUnusualWedging);
+    assert.equal(colchicineUnusualWedging.has_coords(), 2);
+    assert(colchicineUnusualWedging.get_cxsmiles().includes('wU:22.24|'));
+    assert(colchicineUnusualWedging.get_cxsmiles(JSON.stringify({ CX_ALL: true, restoreBondDirOption: 'RestoreBondDirOptionTrue' })).includes('wU:22.23|'));
+    png_colchicine_metadata_blob = colchicineUnusualWedging.add_to_png_blob(png_no_metadata_blob, JSON.stringify({
+        includePkl: true, includeSmiles: true, includeMol: true,
+        propertyFlags: { AtomProps: true, BondProps: true }
+    }));
+    mol = RDKitModule.get_mol_from_png_blob(png_colchicine_metadata_blob);
+    // the mol is restored from pickle, so it will retain
+    // original molblock wedging
+    assert(mol);
+    assert.equal(mol.get_num_atoms(), 29);
+    assert.equal(mol.has_coords(), 2);
+    assert(mol.get_cxsmiles(JSON.stringify({ CX_ALL: true, restoreBondDirOption: 'RestoreBondDirOptionTrue' })).includes('wU:22.23|'));
+    assert(mol.get_cxsmiles(JSON.stringify({ CX_ALL: true, restoreBondDirOption: 'RestoreBondDirOptionClear' })).includes('wU:22.24|'));
+    assert(mol.get_molblock().includes(' 23 24  1  1'));
+    assert(mol.get_molblock(JSON.stringify({ useMolBlockWedging: true })).includes(' 23 22  1  1'));
+    mol.delete();
+    // the mol is restored from CXSMILES, so it will not retain
+    // original molblock wedging, as it was not stored in the CXSMILES string
+    png_colchicine_metadata_blob = colchicineUnusualWedging.add_to_png_blob(png_no_metadata_blob, JSON.stringify({
+        includePkl: false, includeSmiles: true, includeMol: true,
+        propertyFlags: { AtomProps: true, BondProps: true }
+    }));
+    mol = RDKitModule.get_mol_from_png_blob(png_colchicine_metadata_blob);
+    assert(mol);
+    assert.equal(mol.get_num_atoms(), 29);
+    assert.equal(mol.has_coords(), 2);
+    assert(mol.get_cxsmiles(JSON.stringify({ CX_ALL: true, restoreBondDirOption: 'RestoreBondDirOptionTrue' })).includes('wU:22.24|'));
+    assert(mol.get_cxsmiles(JSON.stringify({ CX_ALL: true, restoreBondDirOption: 'RestoreBondDirOptionClear' })).includes('wU:22.24|'));
+    assert(mol.get_molblock().includes(' 23 24  1  1'));
+    assert(mol.get_molblock(JSON.stringify({ useMolBlockWedging: true })).includes(' 23 24  1  1'));
+    mol.delete();
+    // the mol is restored from CXSMILES, but restoreBondDirOption was set
+    // to 'RestoreBondDirOptionTrue', so it will not retain
+    // original molblock wedging, as it was stored in the CXSMILES string
+    png_colchicine_metadata_blob = colchicineUnusualWedging.add_to_png_blob(png_no_metadata_blob, JSON.stringify({
+        includePkl: false, includeSmiles: true, includeMol: true,
+        propertyFlags: { AtomProps: true, BondProps: true },
+        restoreBondDirOption: 'RestoreBondDirOptionTrue'
+    }));
+    mol = RDKitModule.get_mol_from_png_blob(png_colchicine_metadata_blob);
+    assert(mol);
+    assert.equal(mol.get_num_atoms(), 29);
+    assert.equal(mol.has_coords(), 2);
+    assert(mol.get_cxsmiles(JSON.stringify({ CX_ALL: true, restoreBondDirOption: 'RestoreBondDirOptionTrue' })).includes('wU:22.23|'));
+    assert(mol.get_cxsmiles(JSON.stringify({ CX_ALL: true, restoreBondDirOption: 'RestoreBondDirOptionClear' })).includes('wU:22.24|'));
+    assert(mol.get_molblock().includes(' 23 22  1  1'));
+    assert(mol.get_molblock(JSON.stringify({ useMolBlockWedging: true })).includes(' 23 22  1  1'));
+    mol.delete();
+    colchicineUnusualWedging.delete();
+}
+
+function test_combine_with() {
+    {
+        var mol = RDKitModule.get_mol("CC");
+        assert(mol);
+        var other = RDKitModule.get_mol("NCC");
+        assert(other);
+        assert(!mol.combine_with(other));
+        assert.equal(mol.get_num_atoms(), 5);
+        assert(mol.get_smiles() === "CC.CCN");
+        mol.delete();
+        other.delete();
+    }
+    {
+        var mol = RDKitModule.get_mol("C1CC1 |(0.866025,0,;-0.433013,0.75,;-0.433013,-0.75,)|");
+        var mol_copy = RDKitModule.get_mol_copy(mol);
+        assert(mol);
+        var other = RDKitModule.get_mol("C1CNC1 |(-1.06066,0,;0,-1.06066,;1.06066,0,;0,1.06066,)|");
+        assert(other);
+        assert(!mol.combine_with(other, JSON.stringify({offset: [4.0, 0.0, 0.0]})));
+        assert.equal(mol.get_num_atoms(), 7);
+        assert(mol.get_smiles() === "C1CC1.C1CNC1");
+        assert(mol.get_molblock().includes("    4.0000"));
+        mol.delete();
+        assert(!mol_copy.combine_with(other, JSON.stringify({offset: [9.0, 0.0, 0.0]})));
+        assert.equal(mol_copy.get_num_atoms(), 7);
+        assert(mol_copy.get_smiles() === "C1CC1.C1CNC1");
+        assert(mol_copy.get_molblock().includes("    9.0000"));
+        mol_copy.delete();
+        other.delete();
+    }
+}
+
+function test_get_coords() {
+    {
+        var mol = RDKitModule.get_mol("C1CC1 |(0.866025,0,;-0.433013,0.75,;-0.433013,-0.75,)|");
+        assert(mol);
+        assert.equal(mol.has_coords(), 2);
+        var pos = mol.get_coords();
+        assert(Array.isArray(pos));
+        assert(pos.length === mol.get_num_atoms());
+        assert(pos.every((xyz) => Array.isArray(xyz) && xyz.length === 3 && xyz.every((c) => typeof c === "number")));
+        assert(JSON.stringify(pos) === "[[0.866025,0,0],[-0.433013,0.75,0],[-0.433013,-0.75,0]]");
+        mol.delete();
+    }
+    {
+        var mol = RDKitModule.get_mol("C1CC1");
+        assert(mol);
+        assert(!mol.has_coords());
+        var pos = mol.get_coords();
+        assert(Array.isArray(pos));
+        assert(!pos.length);
+        mol.delete();
+    }
+}
+
 initRDKitModule().then(function(instance) {
     var done = {};
     const waitAllTestsFinished = () => {
@@ -3844,6 +4251,9 @@ initRDKitModule().then(function(instance) {
     test_pickle();
     test_remove_hs_details();
     test_get_mol_remove_hs();
+    test_png_metadata();
+    test_combine_with();
+    test_get_coords();
 
     waitAllTestsFinished().then(() =>
         console.log("Tests finished successfully")

--- a/External/CoordGen/CMakeLists.txt
+++ b/External/CoordGen/CMakeLists.txt
@@ -21,9 +21,15 @@ if(RDK_BUILD_MAEPARSER_SUPPORT OR RDK_BUILD_COORDGEN_SUPPORT)
         execute_process(COMMAND ${CMAKE_COMMAND} -E tar zxf
           ${CMAKE_CURRENT_SOURCE_DIR}/maeparser-v${RELEASE_NO}.tar.gz
           WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
-        file(RENAME "maeparser-${RELEASE_NO}" "${MAEPARSER_DIR}")
+        execute_process(COMMAND ${CMAKE_COMMAND} -E rename "maeparser-${RELEASE_NO}" "${MAEPARSER_DIR}"
+          WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+        set(REMOVE_BOOST_IOSTREAMS_DEP_PATCH_COMMIT "d04fa00602bfd19d0222bf54c819b3029cbc85e8.diff")
+        set(REMOVE_BOOST_IOSTREAMS_DEP_PATCH_MD5 "b8e648bad20cf6fc285d5840430476c9")
+        downloadAndCheckMD5("https://github.com/schrodinger/maeparser/commit/${REMOVE_BOOST_IOSTREAMS_DEP_PATCH_COMMIT}"
+              "${MAEPARSER_DIR}/${REMOVE_BOOST_IOSTREAMS_DEP_PATCH_COMMIT}" ${REMOVE_BOOST_IOSTREAMS_DEP_PATCH_MD5})
+        execute_process(COMMAND git --git-dir= apply ${REMOVE_BOOST_IOSTREAMS_DEP_PATCH_COMMIT}
+          WORKING_DIRECTORY ${MAEPARSER_DIR})
         patchCoordGenMaeExportHeaders("MAEPARSER" "${MAEPARSER_DIR}/MaeParserConfig.hpp")
-
     else()
       message("-- Found MAEParser source in ${MAEPARSER_DIR}")
     endif()


### PR DESCRIPTION
This is the long-due PR to enable reading/writing PNG metadata from CFFI and MinimalLib (presented at RDKit UGMs 2023/2024).

- expose reading/writing PNG metadata to CFFI and MinimalLib
- add relevant CFFI and MinimalLib unit tests
- add `RDK_USE_BOOST_PROGRAM_OPTIONS` CMake option
- enable using standalone `zlib` in the absence of `boost::iostreams` for parsing PNG files
- enable linking against `maeparser` in the absence of `boost::iostreams` also on Windows
- enable building RDKit in the absence of `boost::program_options`
