### PR TITLE
add correct export to SynthonSpace.h

### DIFF
--- a/Code/GraphMol/SynthonSpaceSearch/SynthonSpace.h
+++ b/Code/GraphMol/SynthonSpaceSearch/SynthonSpace.h
@@ -383,7 +383,7 @@ RDKIT_SYNTHONSPACESEARCH_EXPORT void convertTextToDBFile(
  *
  * @return std::string
  */
-std::string formattedIntegerString(std::int64_t value);
+RDKIT_SYNTHONSPACESEARCH_EXPORT std::string formattedIntegerString(std::int64_t value);
 
 }  // namespace SynthonSpaceSearch
 }  // namespace RDKit


### PR DESCRIPTION
I'm not sure how the win64 DLL CI builds worked, but this definitely broke the conda-forge builds