### PR TITLE
Bump MaeParser version to 1.3.2

### DIFF
--- a/External/CoordGen/CMakeLists.txt
+++ b/External/CoordGen/CMakeLists.txt
@@ -14,8 +14,8 @@ if(RDK_BUILD_MAEPARSER_SUPPORT OR RDK_BUILD_COORDGEN_SUPPORT)
     endif()
 
     if(NOT EXISTS "${MAEPARSER_DIR}/MaeParser.hpp")
-        set(RELEASE_NO "1.3.1")
-        set(MD5 "cfa40e29366f4b413e4ec15f959ee139")
+        set(RELEASE_NO "1.3.2")
+        set(MD5 "40777ab2eca0142f1cd29230644fcb3a")
         downloadAndCheckMD5("https://github.com/schrodinger/maeparser/archive/v${RELEASE_NO}.tar.gz"
               "${CMAKE_CURRENT_SOURCE_DIR}/maeparser-v${RELEASE_NO}.tar.gz" ${MD5})
         execute_process(COMMAND ${CMAKE_COMMAND} -E tar zxf


### PR DESCRIPTION
Version 1.3.2 of `maeparser` can optionally be built without the `boost::iostreams` dependency.