### PR TITLE
Avoid a segfault in CoordGen when a double bond has stereo spec but no stereo atoms

### DIFF
--- a/Code/GraphMol/Depictor/catch_tests.cpp
+++ b/Code/GraphMol/Depictor/catch_tests.cpp
@@ -2337,3 +2337,19 @@ M  END)CTAB"_ctab;
   CHECK_THAT(ctd.x, Catch::Matchers::WithinAbs(0.0, 1.0e-4));
   CHECK_THAT(ctd.y, Catch::Matchers::WithinAbs(0.0, 1.0e-4));
 }
+
+#ifdef RDK_BUILD_COORDGEN_SUPPORT
+TEST_CASE("CoordGen should not segfault when bond has stereo spec but no stereo atoms") {
+  auto m = "C=C1C=CC(=O)CC1"_smiles;
+  REQUIRE(m);
+  CHECK(m->getNumBonds() == 8);
+  auto b = m->getBondWithIdx(0);
+  CHECK(b->getBondType() == Bond::DOUBLE);
+  b->setStereo(Bond::STEREOZ);
+  CHECK(b->getStereoAtoms().empty());
+  RDDepict::preferCoordGen = true;
+  RDDepict::compute2DCoords(*m);
+  RDDepict::preferCoordGen = false;
+  CHECK(m->getNumConformers() == 1);
+}
+#endif

--- a/External/CoordGen/CoordGen.h
+++ b/External/CoordGen/CoordGen.h
@@ -154,17 +154,19 @@ unsigned int addCoords(T &mol, const CoordGenParams *params = nullptr) {
     auto obnd = *bndit;
     if (obnd->getBondType() != Bond::DOUBLE ||
         obnd->getStereo() <= Bond::STEREOANY ||
-        obnd->getStereo() > Bond::STEREOTRANS)
+        obnd->getStereo() > Bond::STEREOTRANS ||
+        obnd->getStereoAtoms().size() < 2) {
       continue;
+    }
 
     sketcherMinimizerBondStereoInfo sinfo;
-    sinfo.atom1 = ats[obnd->getStereoAtoms()[0]];
-    sinfo.atom2 = ats[obnd->getStereoAtoms()[1]];
+    sinfo.atom1 = ats.at(obnd->getStereoAtoms().at(0));
+    sinfo.atom2 = ats.at(obnd->getStereoAtoms().at(1));
     sinfo.stereo = (obnd->getStereo() == Bond::STEREOZ ||
                     obnd->getStereo() == Bond::STEREOCIS)
                        ? sketcherMinimizerBondStereoInfo::cis
                        : sketcherMinimizerBondStereoInfo::trans;
-    auto bnd = bnds[obnd->getIdx()];
+    auto bnd = bnds.at(obnd->getIdx());
     bnd->setStereoChemistry(sinfo);
     bnd->setAbsoluteStereoFromStereoInfo();
   }

--- a/External/CoordGen/CoordGen.h
+++ b/External/CoordGen/CoordGen.h
@@ -160,13 +160,13 @@ unsigned int addCoords(T &mol, const CoordGenParams *params = nullptr) {
     }
 
     sketcherMinimizerBondStereoInfo sinfo;
-    sinfo.atom1 = ats.at(obnd->getStereoAtoms().at(0));
-    sinfo.atom2 = ats.at(obnd->getStereoAtoms().at(1));
+    sinfo.atom1 = ats[obnd->getStereoAtoms()[0]];
+    sinfo.atom2 = ats[obnd->getStereoAtoms()[1]];
     sinfo.stereo = (obnd->getStereo() == Bond::STEREOZ ||
                     obnd->getStereo() == Bond::STEREOCIS)
                        ? sketcherMinimizerBondStereoInfo::cis
                        : sketcherMinimizerBondStereoInfo::trans;
-    auto bnd = bnds.at(obnd->getIdx());
+    auto bnd = bnds[obnd->getIdx()];
     bnd->setStereoChemistry(sinfo);
     bnd->setAbsoluteStereoFromStereoInfo();
   }


### PR DESCRIPTION
This was originally reported by @sroughley.
When a double bond has a stereo spec but no stereo atoms, CoordGen segfaults as it attempts to access elements at indices 0 and 1 in an empty vector.
```
$ cat ~/py/crashes_coordgen.py
from rdkit import Chem
from rdkit.Chem import rdDepictor

m = Chem.MolFromSmiles("C=C1C=CC(=O)CC1")
m.GetBondWithIdx(0).SetStereo(Chem.BondStereo.STEREOZ)
print(list(m.GetBondWithIdx(0).GetStereoAtoms()))
rdDepictor.SetPreferCoordGen(True)
rdDepictor.Compute2DCoords(m)

$ python ~/py/crashes_coordgen.py
[]
Segmentation fault
```
This PR prevents this and adds a unit test.