### PR TITLE
Fix indexing of heavy atoms in PubChemShape

### DIFF
--- a/External/pubchem_shape/PubChemShape.cpp
+++ b/External/pubchem_shape/PubChemShape.cpp
@@ -292,6 +292,7 @@ ShapeInput PrepareConformer(const ROMol &mol, int confId, bool useColors) {
       res.coord[j * 3] = pos.x;
       res.coord[(j * 3) + 1] = pos.y;
       res.coord[(j * 3) + 2] = pos.z;
+      ++j;
     }
   }
 

--- a/External/pubchem_shape/PubChemShape.cpp
+++ b/External/pubchem_shape/PubChemShape.cpp
@@ -283,15 +283,15 @@ ShapeInput PrepareConformer(const ROMol &mol, int confId, bool useColors) {
   res.shift = {-ave.x, -ave.y, -ave.z};
   res.coord.resize(nAlignmentAtoms * 3);
 
-  for (unsigned i = 0; i < nAtoms; ++i) {
+  for (unsigned i = 0, j = 0; i < nAtoms; ++i) {
     // use only non-H for alignment
     if (mol.getAtomWithIdx(i)->getAtomicNum() > 1) {
       RDGeom::Point3D pos = conformer.getAtomPos(i);
       pos -= ave;
 
-      res.coord[i * 3] = pos.x;
-      res.coord[(i * 3) + 1] = pos.y;
-      res.coord[(i * 3) + 2] = pos.z;
+      res.coord[j * 3] = pos.x;
+      res.coord[(j * 3) + 1] = pos.y;
+      res.coord[(j * 3) + 2] = pos.z;
     }
   }
 

--- a/External/pubchem_shape/PubChemShape.hpp
+++ b/External/pubchem_shape/PubChemShape.hpp
@@ -2,6 +2,9 @@
 #include <map>
 #include <vector>
 
+#ifndef RDKIT_PUBCHEMSHAPE_GUARD
+#define RDKIT_PUBCHEMSHAPE_GUARD
+
 //! The input for the pubchem shape alignment code
 struct RDKIT_PUBCHEMSHAPE_EXPORT ShapeInput {
   std::vector<float> coord;
@@ -66,3 +69,5 @@ RDKIT_PUBCHEMSHAPE_EXPORT std::pair<double, double> AlignMolecule(
     int refConfId = -1, int fitConfId = -1, bool useColors = true,
     double opt_param = 1.0, unsigned int max_preiters = 10u,
     unsigned int max_postiters = 30u);
+
+#endif

--- a/External/pubchem_shape/test.cpp
+++ b/External/pubchem_shape/test.cpp
@@ -278,7 +278,7 @@ TEST_CASE("Github #8096") {
     REQUIRE(m2);
     std::vector<float> matrix(12, 0.0);
     auto [nbr_st, nbr_ct] = AlignMolecule(*m1, *m2, matrix);
-    CHECK_THAT(nbr_st, Catch::Matchers::WithinAbs(0.940, 0.005));
-    CHECK_THAT(nbr_ct, Catch::Matchers::WithinAbs(0.902, 0.005));
+    CHECK_THAT(nbr_st, Catch::Matchers::WithinAbs(1.0, 0.005));
+    CHECK_THAT(nbr_ct, Catch::Matchers::WithinAbs(1.0, 0.005));
   }
 }


### PR DESCRIPTION

#### Reference Issue
Fixes #8416 

#### What does this implement/fix? Explain your changes.
The loop was going over all atoms, but only updating coords for non-H atoms so gaps could be left in the array and values written over the end of the vector.

#### Any other comments?
I couldn't find a simple test that crashed it, so haven't added one.  However the test "Github #8096" now gives Tanimoto scores of 1.0 for shape and colour which I think is correct since the deuterium shouldn't be affecting things at all.  Previously, it caused an extra coordinate in the array which was left at its default value of 0.0, 0.0, 0.0 (atom index 4).
It is not impossible that whatever was done to fix #8096 didn't get to the root of the problem, or there were 2 problems.
