### PR TITLE
bump versions of SDK in MacOS CI jobs

### DIFF
--- a/.azure-pipelines/mac_build.yml
+++ b/.azure-pipelines/mac_build.yml
@@ -33,6 +33,9 @@ steps:
     export CONDA=/tmp/miniforge
     source ${CONDA}/etc/profile.d/conda.sh
     conda activate rdkit_build
+    ls -l /Library/Developer
+    ls -l /Library/Developer/CommandLineTools
+    ls -l /Library/Developer/CommandLineTools/SDKs    
     export SDKROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX$(target_platform).sdk
     export CONDA_BUILD_SYSROOT=${SDKROOT}
     export CXXFLAGS="${CXXFLAGS} -Wall -Wextra -Werror"

--- a/.azure-pipelines/mac_build.yml
+++ b/.azure-pipelines/mac_build.yml
@@ -33,6 +33,7 @@ steps:
     export CONDA=/tmp/miniforge
     source ${CONDA}/etc/profile.d/conda.sh
     conda activate rdkit_build
+    ls -l /Library
     ls -l /Library/Developer
     ls -l /Library/Developer/CommandLineTools
     ls -l /Library/Developer/CommandLineTools/SDKs    

--- a/.azure-pipelines/mac_build_java.yml
+++ b/.azure-pipelines/mac_build_java.yml
@@ -30,6 +30,7 @@ steps:
     export CONDA=/tmp/miniforge
     source ${CONDA}/etc/profile.d/conda.sh
     conda activate rdkit_build
+    ls -l /Library
     ls -l /Library/Developer
     ls -l /Library/Developer/CommandLineTools
     ls -l /Library/Developer/CommandLineTools/SDKs    

--- a/.azure-pipelines/mac_build_java.yml
+++ b/.azure-pipelines/mac_build_java.yml
@@ -30,6 +30,9 @@ steps:
     export CONDA=/tmp/miniforge
     source ${CONDA}/etc/profile.d/conda.sh
     conda activate rdkit_build
+    ls -l /Library/Developer
+    ls -l /Library/Developer/CommandLineTools
+    ls -l /Library/Developer/CommandLineTools/SDKs    
     export SDKROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX$(target_platform).sdk
     export CONDA_BUILD_SYSROOT=${SDKROOT}
     mkdir build && cd build && \

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -53,7 +53,7 @@ jobs:
     compiler_version: 16
     boost_version: 1.84
     number_of_cores: sysctl -n hw.ncpu
-    target_platform: 14.5
+    target_platform: 15.2
     python: python=3.11
   steps:
   - template: .azure-pipelines/mac_build.yml
@@ -66,7 +66,7 @@ jobs:
     compiler_version: 16
     boost_version: 1.84
     number_of_cores: sysctl -n hw.ncpu
-    target_platform: 14.5
+    target_platform: 15.2
   steps:
   - template: .azure-pipelines/mac_build_java.yml
 - job: Windows_VS2022_x64


### PR DESCRIPTION
There was some unannounced change on the Mac CI runners and jobs are intermittently failing.

At the time I wrote this, there are at least a couple of different versions of the Mac CI build images out there:
`Current image version: '20250331.1019'`
which works, and:
`Current image version: '20250414.1083'`
which doesn't work.

This PR adds some debugging info to the build script to try and figure out which SDK versions are actually installed, but since I added them the CI builds have not been sent to one of the bad images.

I'm going to merge this and hope ti at least have debugging info available the next time there is a problem.

