### PR TITLE
fix a logic error in needsHs

### DIFF
--- a/Code/GraphMol/AddHs.cpp
+++ b/Code/GraphMol/AddHs.cpp
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2003-2022 Greg Landrum and other RDKit contributors
+//  Copyright (C) 2003-2025 Greg Landrum and other RDKit contributors
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -1322,16 +1322,8 @@ ROMol *mergeQueryHs(const ROMol &mol, bool mergeUnmappedOnly,
 
 bool needsHs(const ROMol &mol) {
   for (const auto atom : mol.atoms()) {
-    unsigned int nHNbrs = 0;
-    for (const auto nbri :
-         boost::make_iterator_range(mol.getAtomNeighbors(atom))) {
-      const auto nbr = mol[nbri];
-      if (nbr->getAtomicNum() == 1) {
-        ++nHNbrs;
-      }
-    }
-    bool noNeighbors = false;
-    if (atom->getTotalNumHs(noNeighbors) > nHNbrs) {
+    bool includeNeighbors = false;
+    if (atom->getTotalNumHs(includeNeighbors)) {
       return true;
     }
   }

--- a/Code/GraphMol/catch_graphmol.cpp
+++ b/Code/GraphMol/catch_graphmol.cpp
@@ -1503,6 +1503,15 @@ TEST_CASE("needsHs function", "[chemistry]") {
     REQUIRE(m);
     CHECK(!MolOps::needsHs(*m));
   }
+  SECTION("edges") {
+    const std::string smiles = "[H]OC([H])[H]";
+    v2::SmilesParse::SmilesParserParams params;
+    params.removeHs = false;
+    auto m = v2::SmilesParse::MolFromSmiles(smiles, params);
+    REQUIRE(m);
+    CHECK(m->getNumAtoms() == 5);
+    CHECK(MolOps::needsHs(*m));
+  }
 }
 
 TEST_CASE(

--- a/Code/GraphMol/catch_graphmol.cpp
+++ b/Code/GraphMol/catch_graphmol.cpp
@@ -1504,13 +1504,22 @@ TEST_CASE("needsHs function", "[chemistry]") {
     CHECK(!MolOps::needsHs(*m));
   }
   SECTION("edges") {
-    const std::string smiles = "[H]OC([H])[H]";
     v2::SmilesParse::SmilesParserParams params;
     params.removeHs = false;
-    auto m = v2::SmilesParse::MolFromSmiles(smiles, params);
-    REQUIRE(m);
-    CHECK(m->getNumAtoms() == 5);
-    CHECK(MolOps::needsHs(*m));
+    {
+      const std::string smiles = "[H]OC([H])[H]";
+      auto m = v2::SmilesParse::MolFromSmiles(smiles, params);
+      REQUIRE(m);
+      CHECK(m->getNumAtoms() == 5);
+      CHECK(MolOps::needsHs(*m));
+    }
+    {
+      const std::string smiles = "C([H])([H])[H]";
+      auto m = v2::SmilesParse::MolFromSmiles(smiles, params);
+      REQUIRE(m);
+      CHECK(m->getNumAtoms() == 4);
+      CHECK(MolOps::needsHs(*m));
+    }
   }
 }
 


### PR DESCRIPTION
`needsHs()` would generate incorrect results for weird molecules with multiple graph hydrogens on a single atom, like `[H]OC([H])[H]`

The fix is easy