### PR TITLE
add function to overwrite __setattr__ to only accept valid arguments

### DIFF
--- a/Code/GraphMol/DistGeomHelpers/Wrap/rdDistGeom.cpp
+++ b/Code/GraphMol/DistGeomHelpers/Wrap/rdDistGeom.cpp
@@ -578,7 +578,8 @@ BOOST_PYTHON_MODULE(rdDistGeom) {
           &PyEmbedParameters::symmetrizeConjugatedTerminalGroupsForPruning,
           "symmetrize terminal conjugated groups for RMSD pruning")
       .def("SetCoordMap", &PyEmbedParameters::setCoordMap, python::args("self"),
-           "sets the coordmap to be used");
+           "sets the coordmap to be used")
+      .def("__setattr__", &safeSetattr);
 
   docString =
       "Use distance geometry to obtain multiple sets of \n\

--- a/Code/GraphMol/DistGeomHelpers/Wrap/testDistGeom.py
+++ b/Code/GraphMol/DistGeomHelpers/Wrap/testDistGeom.py
@@ -1,7 +1,6 @@
 import copy
 import math
 import os
-import pickle
 import unittest
 
 import numpy
@@ -730,6 +729,17 @@ class TestCase(unittest.TestCase):
     ps.symmetrizeConjugatedTerminalGroupsForPruning = False
     cids = rdDistGeom.EmbedMultipleConfs(mol, 50, ps)
     self.assertGreater(len(cids), 1)
+  
+  def testSetattr(self):
+    mol = Chem.MolFromSmiles("CCC")
+    bm = rdDistGeom.GetMoleculeBoundsMatrix(mol)
+    ps = rdDistGeom.EmbedParameters()
+    ps.randomSeed = 0xc0ffee
+    ps.SetBoundsMat(bm)
+    with self.assertRaises(AttributeError):
+      ps.wrongName=1234
+    with self.assertRaises(AttributeError):
+      ps.wrongName(1234)
 
 
 if __name__ == '__main__':

--- a/Code/RDBoost/Wrap.cpp
+++ b/Code/RDBoost/Wrap.cpp
@@ -48,6 +48,20 @@ void translate_key_error(KeyErrorException const &e) {
   throw_key_error(e.key());
 }
 
+void safeSetattr(python::object self, std::string const &name,
+                 python::object const &value) {
+  python::object cls = self.attr("__class__");
+  if (!PyObject_HasAttrString(cls.ptr(), name.c_str())) {
+    PyErr_Format(PyExc_AttributeError, "Cannot set unknown attribute '%s'",
+                 name.c_str());
+    python::throw_error_already_set();
+  }
+  python::object builtin = python::import("builtins");
+  python::object objectType = builtin.attr("object");
+  python::object setattrFunc = objectType.attr("__setattr__");
+  setattrFunc(self, name, value);
+}
+
 #ifdef INVARIANT_EXCEPTION_METHOD
 // A helper function for dealing with errors. Throw a Python RuntimeError
 void throw_runtime_error(const std::string err) {

--- a/Code/RDBoost/Wrap.h
+++ b/Code/RDBoost/Wrap.h
@@ -45,6 +45,21 @@ RDKIT_RDBOOST_EXPORT void translate_index_error(IndexErrorException const &e);
 RDKIT_RDBOOST_EXPORT void translate_value_error(ValueErrorException const &e);
 RDKIT_RDBOOST_EXPORT void translate_key_error(KeyErrorException const &e);
 
+//! \brief Safely set an attribute on a Python-wrapped object
+/*!
+  Reimplements Python's `__setattr__` to disallow assignment to attributes
+  that are not explicitly defined on the C++ class. This simulates the
+  behavior of `__slots__`.
+
+  \param self   Python object instance
+  \param name   Name of the attribute to set
+  \param value  Value to assign to the attribute
+
+  \throws AttributeError if the attribute does not exist
+  \throws Python error if assignment fails
+*/
+RDKIT_RDBOOST_EXPORT void safeSetattr(python::object self, std::string const &name, python::object const &value);
+
 #ifdef INVARIANT_EXCEPTION_METHOD
 RDKIT_RDBOOST_EXPORT void throw_runtime_error(
     const std::string err);  //!< construct and throw a \c ValueError


### PR DESCRIPTION
Allows to overwrite __setattr__ for python classes from within c++.
This to raise errors in case a class attribute is misspelled.
