### PR TITLE
add StereoGroup.getBonds() to Python wrapper

### DIFF
--- a/Code/GraphMol/Wrap/StereoGroup.cpp
+++ b/Code/GraphMol/Wrap/StereoGroup.cpp
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2018 Dan Nealschneider
+//  Copyright (C) 2018-2025 Dan Nealschneider and other RDKit contributors
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -51,6 +51,13 @@ python::object getAtomsHelper(StereoGroup &sg) {
   }
   return python::tuple(res);
 }
+python::object getBondsHelper(StereoGroup &sg) {
+  python::list res;
+  for (auto bnd : sg.getBonds()) {
+    res.append(boost::ref(*bnd));
+  }
+  return python::tuple(res);
+}
 }  // namespace
 
 struct stereogroup_wrap {
@@ -67,6 +74,8 @@ struct stereogroup_wrap {
              "Returns the StereoGroupType.\n")
         .def("GetAtoms", getAtomsHelper, python::args("self"),
              "access the atoms in the StereoGroup.\n")
+        .def("GetBonds", getBondsHelper, python::args("self"),
+             "access the bonds in the StereoGroup.\n")
         .def("GetReadId", &StereoGroup::getReadId, python::args("self"),
              "return the StereoGroup's original ID.\n"
              "Note that the ID only makes sense for AND/OR groups.\n")

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -5524,6 +5524,10 @@ M  END
     # file is 1 indexed and says 5
     self.assertEqual(stereo_atoms[1].GetIdx(), 4)
 
+    # no bonds here:
+    stereo_bonds = group1.GetBonds()
+    self.assertEqual(len(stereo_bonds), 0)
+
     # make sure the atoms are connected to the parent molecule
     stereo_atoms[1].SetProp("foo", "bar")
     self.assertTrue(m.GetAtomWithIdx(4).HasProp("foo"))

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -5533,6 +5533,21 @@ M  END
       at.SetProp("foo2", "bar2")
       self.assertTrue(m.GetAtomWithIdx(at.GetIdx()).HasProp("foo2"))
 
+  def testGetEnhancedStereoAtrop(self):
+
+    m = Chem.MolFromSmiles('Cc1cccc(O)c1-c1c(C)cccc1F |wU:7.7,&1:7|')
+
+    sg = m.GetStereoGroups()
+    self.assertEqual(len(sg), 1)
+    group1 = sg[0]
+    self.assertEqual(group1.GetGroupType(), Chem.StereoGroupType.STEREO_AND)
+    stereo_atoms = group1.GetAtoms()
+    self.assertEqual(len(stereo_atoms), 0)
+
+    stereo_bonds = group1.GetBonds()
+    self.assertEqual(len(stereo_bonds), 1)
+    self.assertEqual(stereo_bonds[0].GetIdx(), 7)
+
   def testEnhancedStereoPreservesMol(self):
     """
     Check that the stereo group (and the atoms therein) preserve the lifetime


### PR DESCRIPTION
this was an oversight when we added bonds to stereo groups