### PR TITLE
add quick H-H bond removal to connectTheDots

### DIFF
--- a/Code/GraphMol/DetermineBonds/DetermineBonds.cpp
+++ b/Code/GraphMol/DetermineBonds/DetermineBonds.cpp
@@ -192,7 +192,7 @@ void determineConnectivity(RWMol &mol, bool useHueckel, int charge,
   } else if (useVdw) {
     connectivityVdW(mol, covFactor);
   } else {
-    ConnectTheDots(&mol, ctdIGNORE_H_H_CONTACTS);
+    ConnectTheDots(&mol, ctdQUICKREMOVE_H_H_CONTACTS);
   }
 }  // determineConnectivity()
 

--- a/Code/GraphMol/DetermineBonds/catch_tests.cpp
+++ b/Code/GraphMol/DetermineBonds/catch_tests.cpp
@@ -494,3 +494,18 @@ TEST_CASE(
     }
   }
 }
+
+TEST_CASE("problems with H2") {
+  SECTION("as reported") {
+    std::string xyz = R"XYZ(2
+
+H       0.0     0.0     -0.37
+H       0.0     0.0     0.37)XYZ";
+    std::unique_ptr<RWMol> m(XYZBlockToMol(xyz));
+    REQUIRE(m);
+    determineConnectivity(*m);
+    CHECK(m->getNumAtoms() == 2);
+    CHECK(m->getNumBonds() == 1);
+    CHECK(m->getBondBetweenAtoms(0, 1));
+  }
+}

--- a/Code/GraphMol/FileParsers/ProximityBonds.cpp
+++ b/Code/GraphMol/FileParsers/ProximityBonds.cpp
@@ -215,6 +215,27 @@ static void ConnectTheDots_Large(RWMol *mol, unsigned int flags) {
     unsigned int elem = atom->getAtomicNum();
     // detect multivalent Hs, which could happen with ConnectTheDots
     if (elem == 1 && atom->getDegree() > 1) {
+      // if there's an H neighbor and a non-H neighbor, remove the bond to the H
+      if (flags & ctdQUICKREMOVE_H_H_CONTACTS) {
+        Bond *bondToH = nullptr;
+        Bond *bondToNonH = nullptr;
+        for (auto bond : mol->atomBonds(atom)) {
+          if (bond->getOtherAtom(atom)->getAtomicNum() == 1) {
+            bondToH = bond;
+          } else {
+            bondToNonH = bond;
+          }
+        }
+        if (bondToH && bondToNonH) {
+          mol->removeBond(bondToH->getBeginAtomIdx(), bondToH->getEndAtomIdx());
+        }
+      }
+
+      // if we now have a degree of 1, we're done
+      if (atom->getDegree() == 1) {
+        continue;
+      }
+
       auto *atom_info = (AtomPDBResidueInfo *)(atom->getMonomerInfo());
       // cut all but shortest Bond
       RDGeom::Point3D p = conf->getAtomPos(i);

--- a/Code/GraphMol/FileParsers/ProximityBonds.h
+++ b/Code/GraphMol/FileParsers/ProximityBonds.h
@@ -14,6 +14,7 @@
 
 namespace RDKit {
 static const unsigned int ctdIGNORE_H_H_CONTACTS = 0x1;
+static const unsigned int ctdQUICKREMOVE_H_H_CONTACTS = 0x2;
 // static const unsigned int ctdALL_FLAGS = 0xFFFFFFFF;
 class AtomPDBResidueInfo;
 RDKIT_FILEPARSERS_EXPORT bool IsBlacklistedPair(Atom *beg_atom, Atom *end_atom);

--- a/Code/GraphMol/FileParsers/connectTheDots_catch.cpp
+++ b/Code/GraphMol/FileParsers/connectTheDots_catch.cpp
@@ -64,3 +64,43 @@ TEST_CASE(
     CHECK(m->getNumBonds() == 1);
   }
 }
+
+TEST_CASE("ctdQUICKREMOVE_H_H_CONTACTS mode") {
+  SECTION("H2, basics") {
+    auto m = "[H].[H] |(0.0,0.0,0.3;0.0,0.0,-0.3)|"_smiles;
+    REQUIRE(m);
+    // by default we get a bond:
+    {
+      RWMol m2(*m);
+      ConnectTheDots(&m2, 0);
+      CHECK(m2.getNumBonds() == 1);
+    }
+    {
+      RWMol m2(*m);
+      ConnectTheDots(&m2, ctdIGNORE_H_H_CONTACTS);
+      CHECK(m2.getNumBonds() == 0);
+    }
+    {
+      RWMol m2(*m);
+      ConnectTheDots(&m2, ctdQUICKREMOVE_H_H_CONTACTS);
+      CHECK(m2.getNumBonds() == 1);
+    }
+  }
+  SECTION("H2, basics") {
+    auto m = "[H].[H].[C] |(0.0,0.0,0.3;0.0,0.0,-0.3;0.0,0.0,-1.3)|"_smiles;
+    REQUIRE(m);
+    {
+      RWMol m2(*m);
+      ConnectTheDots(&m2, 0);
+      CHECK(m2.getNumBonds() == 1);
+      CHECK(m2.getBondBetweenAtoms(0, 1));
+    }
+    {
+      RWMol m2(*m);
+      ConnectTheDots(&m2, ctdQUICKREMOVE_H_H_CONTACTS);
+      CHECK(m2.getNumBonds() == 1);
+      CHECK(!m2.getBondBetweenAtoms(0, 1));
+      CHECK(m2.getBondBetweenAtoms(1, 2));
+    }
+  }
+}


### PR DESCRIPTION
Adds a mode to connectTheDots which quickly recognizes and removes H-H bonds that should not be there as part of the cleanup stage.