### PR TITLE
Protect Python DrawOptions from bad attributes.

### DIFF
--- a/Code/GraphMol/MolDraw2D/Wrap/rdMolDraw2D.cpp
+++ b/Code/GraphMol/MolDraw2D/Wrap/rdMolDraw2D.cpp
@@ -1027,7 +1027,8 @@ BOOST_PYTHON_MODULE(rdMolDraw2D) {
            "method for getting the colour of variable attachment points")
       .def("setVariableAttachmentColour", &RDKit::setVariableAttachmentColour,
            python::args("self", "tpl"),
-           "method for setting the colour of variable attachment points");
+           "method for setting the colour of variable attachment points")
+      .def("__setattr__", &safeSetattr);
   docString = "Drawer abstract base class";
   python::class_<RDKit::MolDraw2D, boost::noncopyable>(
       "MolDraw2D", docString.c_str(), python::no_init)
@@ -1474,10 +1475,9 @@ https://en.wikipedia.org/wiki/Wikipedia:Manual_of_Style/Chemistry/Structure_draw
               (python::arg("mol"), python::arg("confId") = -1),
               "Calculate the mean bond length for the molecule.");
   python::def("SetDarkMode",
-              (void (*)(RDKit::MolDrawOptions &)) & RDKit::setDarkMode,
+              (void (*)(RDKit::MolDrawOptions &))&RDKit::setDarkMode,
               python::args("d2d"), "set dark mode for a MolDrawOptions object");
-  python::def("SetDarkMode",
-              (void (*)(RDKit::MolDraw2D &)) & RDKit::setDarkMode,
+  python::def("SetDarkMode", (void (*)(RDKit::MolDraw2D &))&RDKit::setDarkMode,
               python::args("d2d"), "set dark mode for a MolDraw2D object");
   python::def("SetMonochromeMode", RDKit::setMonochromeMode_helper1,
               (python::arg("options"), python::arg("fgColour"),

--- a/Code/GraphMol/MolDraw2D/Wrap/testMolDraw2D.py
+++ b/Code/GraphMol/MolDraw2D/Wrap/testMolDraw2D.py
@@ -839,6 +839,11 @@ M  END''')
         # it's enough to check that this doesn't throw an exception
         d2d.DrawMolecule(m)
 
+    def testProtectedAttributes(self):
+        do = rdMolDraw2D.MolDrawOptions()
+        with self.assertRaises(AttributeError):
+            do.rhubarb = True
+            
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION

#### Reference Issue
No issue.


#### What does this implement/fix? Explain your changes.
Just adds @nmaeder's attribute protection to the DrawOptions object.

#### Any other comments?
clang-format seems to have had a go, as well.
