### PR TITLE
Change from pointers to C-style arrays to vectors

### DIFF
--- a/Code/GraphMol/hanoitest.cpp
+++ b/Code/GraphMol/hanoitest.cpp
@@ -258,9 +258,9 @@ void test3() {
     std::vector<int> count(atoms.size());
     int *order = (int *)malloc(atoms.size() * sizeof(int));
     int activeset;
-    int *next = (int *)malloc(atoms.size() * sizeof(int));
-    int *changed = (int *)malloc(atoms.size() * sizeof(int));
-    memset(changed, 1, atoms.size() * sizeof(int));
+    std::vector<int> next(atoms.size());
+    std::vector<int> changed(atoms.size());
+    memset(changed.data(), 1, atoms.size() * sizeof(int));
     char *touched = (char *)malloc(atoms.size() * sizeof(char));
     memset(touched, 0, atoms.size() * sizeof(char));
 
@@ -298,9 +298,6 @@ void test3() {
     TEST_ASSERT(count[order[7]] == 1);
 
     delete m;
-    free(order);
-    free(next);
-    free(changed);
     free(touched);
   }
   {
@@ -316,9 +313,9 @@ void test3() {
     std::vector<int> count(atoms.size());
     int *order = (int *)malloc(atoms.size() * sizeof(int));
     int activeset;
-    int *next = (int *)malloc(atoms.size() * sizeof(int));
-    int *changed = (int *)malloc(atoms.size() * sizeof(int));
-    memset(changed, 1, atoms.size() * sizeof(int));
+    std::vector<int> next(atoms.size());
+    std::vector<int> changed(atoms.size());
+    memset(changed.data(), 1, atoms.size() * sizeof(int));
     char *touched = (char *)malloc(atoms.size() * sizeof(char));
     memset(touched, 0, atoms.size() * sizeof(char));
 
@@ -348,9 +345,6 @@ void test3() {
     TEST_ASSERT(count[order[5]] == 3);
     TEST_ASSERT(count[order[6]] == 0);
     delete m;
-    free(order);
-    free(next);
-    free(changed);
     free(touched);
   }
   BOOST_LOG(rdInfoLog) << "Done" << std::endl;
@@ -457,9 +451,9 @@ void test4() {
     std::vector<int> count(atoms.size());
     int *order = (int *)malloc(atoms.size() * sizeof(int));
     int activeset;
-    int *next = (int *)malloc(atoms.size() * sizeof(int));
-    int *changed = (int *)malloc(atoms.size() * sizeof(int));
-    memset(changed, 1, atoms.size() * sizeof(int));
+    std::vector<int> next(atoms.size());
+    std::vector<int> changed(atoms.size());
+    memset(changed.data(), 1, atoms.size() * sizeof(int));
     char *touched = (char *)malloc(atoms.size() * sizeof(char));
     memset(touched, 0, atoms.size() * sizeof(char));
 
@@ -505,9 +499,6 @@ void test4() {
       }
     }
     delete m;
-    free(order);
-    free(next);
-    free(changed);
     free(touched);
   }
 
@@ -523,9 +514,9 @@ void test4() {
     std::vector<int> count(atoms.size());
     int *order = (int *)malloc(atoms.size() * sizeof(int));
     int activeset;
-    int *next = (int *)malloc(atoms.size() * sizeof(int));
-    int *changed = (int *)malloc(atoms.size() * sizeof(int));
-    memset(changed, 1, atoms.size() * sizeof(int));
+    std::vector<int> next(atoms.size());
+    std::vector<int> changed(atoms.size());
+    memset(changed.data(), 1, atoms.size() * sizeof(int));
     char *touched = (char *)malloc(atoms.size() * sizeof(char));
     memset(touched, 0, atoms.size() * sizeof(char));
 
@@ -558,9 +549,6 @@ void test4() {
       }
     }
     delete m;
-    free(order);
-    free(next);
-    free(changed);
     free(touched);
   }
 
@@ -576,9 +564,9 @@ void test4() {
     std::vector<int> count(atoms.size());
     int *order = (int *)malloc(atoms.size() * sizeof(int));
     int activeset;
-    int *next = (int *)malloc(atoms.size() * sizeof(int));
-    int *changed = (int *)malloc(atoms.size() * sizeof(int));
-    memset(changed, 1, atoms.size() * sizeof(int));
+    std::vector<int> next(atoms.size());
+    std::vector<int> changed(atoms.size());
+    memset(changed.data(), 1, atoms.size() * sizeof(int));
     char *touched = (char *)malloc(atoms.size() * sizeof(char));
     memset(touched, 0, atoms.size() * sizeof(char));
 
@@ -626,9 +614,6 @@ void test4() {
     TEST_ASSERT(order[9] == 1 && count[1] == 1);
 
     delete m;
-    free(order);
-    free(next);
-    free(changed);
     free(touched);
   }
 
@@ -651,9 +636,9 @@ void test5() {
     std::vector<int> count(atoms.size());
     int *order = (int *)malloc(atoms.size() * sizeof(int));
     int activeset;
-    int *next = (int *)malloc(atoms.size() * sizeof(int));
-    int *changed = (int *)malloc(atoms.size() * sizeof(int));
-    memset(changed, 1, atoms.size() * sizeof(int));
+    std::vector<int> next(atoms.size());
+    std::vector<int> changed(atoms.size());
+    memset(changed.data(), 1, atoms.size() * sizeof(int));
     char *touched = (char *)malloc(atoms.size() * sizeof(char));
     memset(touched, 0, atoms.size() * sizeof(char));
 
@@ -703,9 +688,6 @@ void test5() {
       TEST_ASSERT(count[order[i]] == 1);
     }
     delete m;
-    free(order);
-    free(next);
-    free(changed);
     free(touched);
   }
   BOOST_LOG(rdInfoLog) << "Done" << std::endl;

--- a/Code/GraphMol/hanoitest.cpp
+++ b/Code/GraphMol/hanoitest.cpp
@@ -83,14 +83,13 @@ void hs1(const std::vector<std::vector<int>> &vects) {
     for (unsigned int j = 0; j < vect.size(); ++j) {
       indices[j] = j;
     }
-    int *count = (int *)malloc(vect.size() * sizeof(int));
+    std::vector<int> count(vect.size());
     int *changed = (int *)malloc(vect.size() * sizeof(int));
     memset(changed, 1, vect.size() * sizeof(int));
-    RDKit::hanoisort(indices, vect.size(), count, changed, icmp);
+    RDKit::hanoisort(indices, vect.size(), count.data(), changed, icmp);
     for (unsigned int j = 1; j < vect.size(); ++j) {
       TEST_ASSERT(data[indices[j]] >= data[indices[j - 1]]);
     }
-    free(count);
     free(indices);
     free(changed);
   }
@@ -217,10 +216,10 @@ void test2() {
     atomcomparefunctor ftor(&atoms.front());
 
     int *data = &indices.front();
-    int *count = (int *)malloc(atoms.size() * sizeof(int));
+    std::vector<int> count(atoms.size());
     int *changed = (int *)malloc(atoms.size() * sizeof(int));
     memset(changed, 1, atoms.size() * sizeof(int));
-    RDKit::hanoisort(data, atoms.size(), count, changed, ftor);
+    RDKit::hanoisort(data, atoms.size(), count.data(), changed, ftor);
 
     for (unsigned int i = 0; i < m->getNumAtoms(); ++i) {
       // std::cerr<<indices[i]<<" "<<" index: "<<atoms[indices[i]].index<<"
@@ -239,7 +238,6 @@ void test2() {
       }
     }
     delete m;
-    free(count);
     free(changed);
   }
   BOOST_LOG(rdInfoLog) << "Done" << std::endl;
@@ -257,7 +255,7 @@ void test3() {
     atomcomparefunctor ftor(&atoms.front());
 
     RDKit::Canon::canon_atom *data = &atoms.front();
-    int *count = (int *)malloc(atoms.size() * sizeof(int));
+    std::vector<int> count(atoms.size());
     int *order = (int *)malloc(atoms.size() * sizeof(int));
     int activeset;
     int *next = (int *)malloc(atoms.size() * sizeof(int));
@@ -300,7 +298,6 @@ void test3() {
     TEST_ASSERT(count[order[7]] == 1);
 
     delete m;
-    free(count);
     free(order);
     free(next);
     free(changed);
@@ -316,7 +313,7 @@ void test3() {
     atomcomparefunctor2 ftor(&atoms.front());
 
     RDKit::Canon::canon_atom *data = &atoms.front();
-    int *count = (int *)malloc(atoms.size() * sizeof(int));
+    std::vector<int> count(atoms.size());
     int *order = (int *)malloc(atoms.size() * sizeof(int));
     int activeset;
     int *next = (int *)malloc(atoms.size() * sizeof(int));
@@ -351,7 +348,6 @@ void test3() {
     TEST_ASSERT(count[order[5]] == 3);
     TEST_ASSERT(count[order[6]] == 0);
     delete m;
-    free(count);
     free(order);
     free(next);
     free(changed);
@@ -458,7 +454,7 @@ void test4() {
     initCanonAtoms(*m, atoms, true);
     atomcomparefunctor3 ftor(&atoms.front(), *m);
     RDKit::Canon::canon_atom *data = &atoms.front();
-    int *count = (int *)malloc(atoms.size() * sizeof(int));
+    std::vector<int> count(atoms.size());
     int *order = (int *)malloc(atoms.size() * sizeof(int));
     int activeset;
     int *next = (int *)malloc(atoms.size() * sizeof(int));
@@ -509,7 +505,6 @@ void test4() {
       }
     }
     delete m;
-    free(count);
     free(order);
     free(next);
     free(changed);
@@ -525,7 +520,7 @@ void test4() {
     atomcomparefunctor3 ftor(&atoms.front(), *m);
 
     RDKit::Canon::canon_atom *data = &atoms.front();
-    int *count = (int *)malloc(atoms.size() * sizeof(int));
+    std::vector<int> count(atoms.size());
     int *order = (int *)malloc(atoms.size() * sizeof(int));
     int activeset;
     int *next = (int *)malloc(atoms.size() * sizeof(int));
@@ -563,7 +558,6 @@ void test4() {
       }
     }
     delete m;
-    free(count);
     free(order);
     free(next);
     free(changed);
@@ -579,7 +573,7 @@ void test4() {
     atomcomparefunctor3 ftor(&atoms.front(), *m);
 
     RDKit::Canon::canon_atom *data = &atoms.front();
-    int *count = (int *)malloc(atoms.size() * sizeof(int));
+    std::vector<int> count(atoms.size());
     int *order = (int *)malloc(atoms.size() * sizeof(int));
     int activeset;
     int *next = (int *)malloc(atoms.size() * sizeof(int));
@@ -632,7 +626,6 @@ void test4() {
     TEST_ASSERT(order[9] == 1 && count[1] == 1);
 
     delete m;
-    free(count);
     free(order);
     free(next);
     free(changed);
@@ -655,7 +648,7 @@ void test5() {
     atomcomparefunctor3 ftor(&atoms.front(), *m);
 
     RDKit::Canon::canon_atom *data = &atoms.front();
-    int *count = (int *)malloc(atoms.size() * sizeof(int));
+    std::vector<int> count(atoms.size());
     int *order = (int *)malloc(atoms.size() * sizeof(int));
     int activeset;
     int *next = (int *)malloc(atoms.size() * sizeof(int));
@@ -710,7 +703,6 @@ void test5() {
       TEST_ASSERT(count[order[i]] == 1);
     }
     delete m;
-    free(count);
     free(order);
     free(next);
     free(changed);

--- a/Code/GraphMol/hanoitest.cpp
+++ b/Code/GraphMol/hanoitest.cpp
@@ -298,6 +298,7 @@ void test3() {
     TEST_ASSERT(count[order[7]] == 1);
 
     delete m;
+    free(order);
     free(touched);
   }
   {
@@ -345,6 +346,7 @@ void test3() {
     TEST_ASSERT(count[order[5]] == 3);
     TEST_ASSERT(count[order[6]] == 0);
     delete m;
+    free(order);
     free(touched);
   }
   BOOST_LOG(rdInfoLog) << "Done" << std::endl;
@@ -499,6 +501,7 @@ void test4() {
       }
     }
     delete m;
+    free(order);
     free(touched);
   }
 
@@ -549,6 +552,7 @@ void test4() {
       }
     }
     delete m;
+    free(order);
     free(touched);
   }
 
@@ -614,6 +618,7 @@ void test4() {
     TEST_ASSERT(order[9] == 1 && count[1] == 1);
 
     delete m;
+    free(order);
     free(touched);
   }
 
@@ -688,6 +693,7 @@ void test5() {
       TEST_ASSERT(count[order[i]] == 1);
     }
     delete m;
+    free(order);
     free(touched);
   }
   BOOST_LOG(rdInfoLog) << "Done" << std::endl;

--- a/Code/GraphMol/hanoitest.cpp
+++ b/Code/GraphMol/hanoitest.cpp
@@ -18,6 +18,7 @@
 #include <GraphMol/SmilesParse/SmilesWrite.h>
 #include <GraphMol/FileParsers/FileParsers.h>
 
+#include <algorithm>
 #include <iostream>
 #include <vector>
 #include <random>
@@ -260,9 +261,9 @@ void test3() {
     int activeset;
     std::vector<int> next(atoms.size());
     std::vector<int> changed(atoms.size());
-    memset(changed.data(), 1, atoms.size() * sizeof(int));
-    char *touched = (char *)malloc(atoms.size() * sizeof(char));
-    memset(touched, 0, atoms.size() * sizeof(char));
+    std::fill(changed.begin(), changed.end(), 1);
+    std::vector<char> touched(atoms.size());
+    std::fill(touched.begin(), touched.end(), 0);
 
     RDKit::Canon::CreateSinglePartition(atoms.size(), order, count, data);
     RDKit::Canon::ActivatePartitions(atoms.size(), order, count, activeset,
@@ -299,7 +300,6 @@ void test3() {
 
     delete m;
     free(order);
-    free(touched);
   }
   {
     // this time with smarter invariants
@@ -316,9 +316,9 @@ void test3() {
     int activeset;
     std::vector<int> next(atoms.size());
     std::vector<int> changed(atoms.size());
-    memset(changed.data(), 1, atoms.size() * sizeof(int));
-    char *touched = (char *)malloc(atoms.size() * sizeof(char));
-    memset(touched, 0, atoms.size() * sizeof(char));
+    std::fill(changed.begin(), changed.end(), 1);
+    std::vector<char> touched(atoms.size());
+    std::fill(touched.begin(), touched.end(), 0);
 
     RDKit::Canon::CreateSinglePartition(atoms.size(), order, count, data);
     RDKit::Canon::ActivatePartitions(atoms.size(), order, count, activeset,
@@ -347,7 +347,6 @@ void test3() {
     TEST_ASSERT(count[order[6]] == 0);
     delete m;
     free(order);
-    free(touched);
   }
   BOOST_LOG(rdInfoLog) << "Done" << std::endl;
 };
@@ -455,9 +454,9 @@ void test4() {
     int activeset;
     std::vector<int> next(atoms.size());
     std::vector<int> changed(atoms.size());
-    memset(changed.data(), 1, atoms.size() * sizeof(int));
-    char *touched = (char *)malloc(atoms.size() * sizeof(char));
-    memset(touched, 0, atoms.size() * sizeof(char));
+    std::fill(changed.begin(), changed.end(), 1);
+    std::vector<char> touched(atoms.size());
+    std::fill(touched.begin(), touched.end(), 0);
 
     RDKit::Canon::CreateSinglePartition(atoms.size(), order, count, data);
     RDKit::Canon::ActivatePartitions(atoms.size(), order, count, activeset,
@@ -502,7 +501,6 @@ void test4() {
     }
     delete m;
     free(order);
-    free(touched);
   }
 
   {
@@ -519,9 +517,9 @@ void test4() {
     int activeset;
     std::vector<int> next(atoms.size());
     std::vector<int> changed(atoms.size());
-    memset(changed.data(), 1, atoms.size() * sizeof(int));
-    char *touched = (char *)malloc(atoms.size() * sizeof(char));
-    memset(touched, 0, atoms.size() * sizeof(char));
+    std::fill(changed.begin(), changed.end(), 1);
+    std::vector<char> touched(atoms.size());
+    std::fill(touched.begin(), touched.end(), 0);
 
     RDKit::Canon::CreateSinglePartition(atoms.size(), order, count, data);
     RDKit::Canon::ActivatePartitions(atoms.size(), order, count, activeset,
@@ -553,7 +551,6 @@ void test4() {
     }
     delete m;
     free(order);
-    free(touched);
   }
 
   {
@@ -570,9 +567,9 @@ void test4() {
     int activeset;
     std::vector<int> next(atoms.size());
     std::vector<int> changed(atoms.size());
-    memset(changed.data(), 1, atoms.size() * sizeof(int));
-    char *touched = (char *)malloc(atoms.size() * sizeof(char));
-    memset(touched, 0, atoms.size() * sizeof(char));
+    std::fill(changed.begin(), changed.end(), 1);
+    std::vector<char> touched(atoms.size());
+    std::fill(touched.begin(), touched.end(), 0);
 
     RDKit::Canon::CreateSinglePartition(atoms.size(), order, count, data);
     RDKit::Canon::ActivatePartitions(atoms.size(), order, count, activeset,
@@ -619,7 +616,6 @@ void test4() {
 
     delete m;
     free(order);
-    free(touched);
   }
 
   BOOST_LOG(rdInfoLog) << "Done" << std::endl;
@@ -643,9 +639,9 @@ void test5() {
     int activeset;
     std::vector<int> next(atoms.size());
     std::vector<int> changed(atoms.size());
-    memset(changed.data(), 1, atoms.size() * sizeof(int));
-    char *touched = (char *)malloc(atoms.size() * sizeof(char));
-    memset(touched, 0, atoms.size() * sizeof(char));
+    std::fill(changed.begin(), changed.end(), 1);
+    std::vector<char> touched(atoms.size());
+    std::fill(touched.begin(), touched.end(), 0);
 
     RDKit::Canon::CreateSinglePartition(atoms.size(), order, count, data);
     RDKit::Canon::ActivatePartitions(atoms.size(), order, count, activeset,
@@ -694,7 +690,6 @@ void test5() {
     }
     delete m;
     free(order);
-    free(touched);
   }
   BOOST_LOG(rdInfoLog) << "Done" << std::endl;
 };

--- a/Code/GraphMol/new_canon.cpp
+++ b/Code/GraphMol/new_canon.cpp
@@ -19,6 +19,7 @@
 #include <cstring>
 #include <iostream>
 #include <cassert>
+#include <vector>
 // #define VERBOSE_CANON 1
 
 namespace RDKit {
@@ -780,8 +781,9 @@ void rankMolAtoms(const ROMol &mol, std::vector<unsigned int> &res,
   ftor.df_useNonStereoRanks = useNonStereoRanks;
   ftor.df_useChiralPresence = includeChiralPresence;
 
-  auto order = std::make_unique<int[]>(mol.getNumAtoms());
-  detail::rankWithFunctor(ftor, breakTies, order.get(), true, includeChirality);
+  std::vector<int> order(mol.getNumAtoms());
+  detail::rankWithFunctor(ftor, breakTies, order.data(), true,
+                          includeChirality);
 
   for (unsigned int i = 0; i < mol.getNumAtoms(); ++i) {
     res[order[i]] = atoms[order[i]].index;
@@ -829,8 +831,8 @@ void rankFragmentAtoms(const ROMol &mol, std::vector<unsigned int> &res,
   ftor.df_useChiralityRings = includeChirality;
   ftor.df_useChiralPresence = includeChiralPresence;
 
-  auto order = std::make_unique<int[]>(mol.getNumAtoms());
-  detail::rankWithFunctor(ftor, breakTies, order.get(), true, includeChirality,
+  std::vector<int> order(mol.getNumAtoms());
+  detail::rankWithFunctor(ftor, breakTies, order.data(), true, includeChirality,
                           &atomsInPlay, &bondsInPlay);
 
   for (unsigned int i = 0; i < mol.getNumAtoms(); ++i) {
@@ -858,8 +860,8 @@ void chiralRankMolAtoms(const ROMol &mol, std::vector<unsigned int> &res) {
   detail::initChiralCanonAtoms(mol, atoms);
   ChiralAtomCompareFunctor ftor(&atoms.front(), mol);
 
-  auto order = std::make_unique<int[]>(mol.getNumAtoms());
-  detail::rankWithFunctor(ftor, false, order.get());
+  std::vector<int> order(mol.getNumAtoms());
+  detail::rankWithFunctor(ftor, false, order.data());
 
   for (unsigned int i = 0; i < mol.getNumAtoms(); ++i) {
     res[order[i]] = atoms[order[i]].index;

--- a/Code/GraphMol/new_canon.h
+++ b/Code/GraphMol/new_canon.h
@@ -692,7 +692,7 @@ class RDKIT_GRAPHMOL_EXPORT ChiralAtomCompareFunctor {
 
 template <typename CompareFunc>
 void RefinePartitions(const ROMol &mol, canon_atom *atoms, CompareFunc compar,
-                      int mode, int *order, int *count, int &activeset,
+                      int mode, int *order, std::vector<int>& count, int &activeset,
                       int *next, int *changed, char *touchedPartitions) {
   unsigned int nAtoms = mol.getNumAtoms();
   int partition;
@@ -734,7 +734,7 @@ void RefinePartitions(const ROMol &mol, canon_atom *atoms, CompareFunc compar,
     //   std::cerr<<order[ii]+1<<" count: "<<count[order[ii]]<<" index:
     //   "<<atoms[order[ii]].index<<std::endl;
     // }
-    hanoisort(start, len, count, changed, compar);
+    hanoisort(start, len, count.data(), changed, compar);
     // std::cerr<<"*_*_*_*_*_*_*_*_*_*_*_*_*_*_*_*"<<std::endl;
     // std::cerr<<"  result:";
     // for(unsigned int ii=0;ii<nAtoms;++ii){
@@ -789,7 +789,7 @@ void RefinePartitions(const ROMol &mol, canon_atom *atoms, CompareFunc compar,
 
 template <typename CompareFunc>
 void BreakTies(const ROMol &mol, canon_atom *atoms, CompareFunc compar,
-               int mode, int *order, int *count, int &activeset, int *next,
+               int mode, int *order, std::vector<int>& count, int &activeset, int *next,
                int *changed, char *touchedPartitions) {
   unsigned int nAtoms = mol.getNumAtoms();
   int partition;
@@ -840,11 +840,11 @@ void BreakTies(const ROMol &mol, canon_atom *atoms, CompareFunc compar,
 }  // end of BreakTies()
 
 RDKIT_GRAPHMOL_EXPORT void CreateSinglePartition(unsigned int nAtoms,
-                                                 int *order, int *count,
+                                                 int *order, std::vector<int>& count,
                                                  canon_atom *atoms);
 
 RDKIT_GRAPHMOL_EXPORT void ActivatePartitions(unsigned int nAtoms, int *order,
-                                              int *count, int &activeset,
+                                              std::vector<int>& count, int &activeset,
                                               int *next, int *changed);
 
 //! Note that atom maps on dummy atoms will always be used
@@ -905,3 +905,4 @@ void rankWithFunctor(T &ftor, bool breakTies, int *order,
 
 }  // namespace Canon
 }  // namespace RDKit
+

--- a/Code/GraphMol/new_canon.h
+++ b/Code/GraphMol/new_canon.h
@@ -692,8 +692,9 @@ class RDKIT_GRAPHMOL_EXPORT ChiralAtomCompareFunctor {
 
 template <typename CompareFunc>
 void RefinePartitions(const ROMol &mol, canon_atom *atoms, CompareFunc compar,
-                      int mode, int *order, std::vector<int>& count, int &activeset,
-                      int *next, int *changed, char *touchedPartitions) {
+                      int mode, int *order, std::vector<int> &count,
+                      int &activeset, std::vector<int> &next,
+                      std::vector<int> &changed, char *touchedPartitions) {
   unsigned int nAtoms = mol.getNumAtoms();
   int partition;
   int symclass = 0;
@@ -734,7 +735,7 @@ void RefinePartitions(const ROMol &mol, canon_atom *atoms, CompareFunc compar,
     //   std::cerr<<order[ii]+1<<" count: "<<count[order[ii]]<<" index:
     //   "<<atoms[order[ii]].index<<std::endl;
     // }
-    hanoisort(start, len, count.data(), changed, compar);
+    hanoisort(start, len, count.data(), changed.data(), compar);
     // std::cerr<<"*_*_*_*_*_*_*_*_*_*_*_*_*_*_*_*"<<std::endl;
     // std::cerr<<"  result:";
     // for(unsigned int ii=0;ii<nAtoms;++ii){
@@ -789,8 +790,9 @@ void RefinePartitions(const ROMol &mol, canon_atom *atoms, CompareFunc compar,
 
 template <typename CompareFunc>
 void BreakTies(const ROMol &mol, canon_atom *atoms, CompareFunc compar,
-               int mode, int *order, std::vector<int>& count, int &activeset, int *next,
-               int *changed, char *touchedPartitions) {
+               int mode, int *order, std::vector<int> &count, int &activeset,
+               std::vector<int> &next, std::vector<int> &changed,
+               char *touchedPartitions) {
   unsigned int nAtoms = mol.getNumAtoms();
   int partition;
   int offset;
@@ -840,12 +842,15 @@ void BreakTies(const ROMol &mol, canon_atom *atoms, CompareFunc compar,
 }  // end of BreakTies()
 
 RDKIT_GRAPHMOL_EXPORT void CreateSinglePartition(unsigned int nAtoms,
-                                                 int *order, std::vector<int>& count,
+                                                 int *order,
+                                                 std::vector<int> &count,
                                                  canon_atom *atoms);
 
 RDKIT_GRAPHMOL_EXPORT void ActivatePartitions(unsigned int nAtoms, int *order,
-                                              std::vector<int>& count, int &activeset,
-                                              int *next, int *changed);
+                                              std::vector<int> &count,
+                                              int &activeset,
+                                              std::vector<int> &next,
+                                              std::vector<int> &changed);
 
 //! Note that atom maps on dummy atoms will always be used
 RDKIT_GRAPHMOL_EXPORT void rankMolAtoms(
@@ -905,4 +910,3 @@ void rankWithFunctor(T &ftor, bool breakTies, int *order,
 
 }  // namespace Canon
 }  // namespace RDKit
-

--- a/Code/GraphMol/new_canon.h
+++ b/Code/GraphMol/new_canon.h
@@ -694,7 +694,7 @@ template <typename CompareFunc>
 void RefinePartitions(const ROMol &mol, canon_atom *atoms, CompareFunc compar,
                       int mode, int *order, std::vector<int> &count,
                       int &activeset, std::vector<int> &next,
-                      std::vector<int> &changed, char *touchedPartitions) {
+                      std::vector<int> &changed, std::vector<char>& touchedPartitions) {
   unsigned int nAtoms = mol.getNumAtoms();
   int partition;
   int symclass = 0;
@@ -792,7 +792,7 @@ template <typename CompareFunc>
 void BreakTies(const ROMol &mol, canon_atom *atoms, CompareFunc compar,
                int mode, int *order, std::vector<int> &count, int &activeset,
                std::vector<int> &next, std::vector<int> &changed,
-               char *touchedPartitions) {
+               std::vector<char>& touchedPartitions) {
   unsigned int nAtoms = mol.getNumAtoms();
   int partition;
   int offset;
@@ -910,3 +910,4 @@ void rankWithFunctor(T &ftor, bool breakTies, int *order,
 
 }  // namespace Canon
 }  // namespace RDKit
+

--- a/Code/GraphMol/new_canon.h
+++ b/Code/GraphMol/new_canon.h
@@ -694,7 +694,8 @@ template <typename CompareFunc>
 void RefinePartitions(const ROMol &mol, canon_atom *atoms, CompareFunc compar,
                       int mode, int *order, std::vector<int> &count,
                       int &activeset, std::vector<int> &next,
-                      std::vector<int> &changed, std::vector<char>& touchedPartitions) {
+                      std::vector<int> &changed,
+                      std::vector<char> &touchedPartitions) {
   unsigned int nAtoms = mol.getNumAtoms();
   int partition;
   int symclass = 0;
@@ -792,7 +793,7 @@ template <typename CompareFunc>
 void BreakTies(const ROMol &mol, canon_atom *atoms, CompareFunc compar,
                int mode, int *order, std::vector<int> &count, int &activeset,
                std::vector<int> &next, std::vector<int> &changed,
-               std::vector<char>& touchedPartitions) {
+               std::vector<char> &touchedPartitions) {
   unsigned int nAtoms = mol.getNumAtoms();
   int partition;
   int offset;
@@ -910,4 +911,3 @@ void rankWithFunctor(T &ftor, bool breakTies, int *order,
 
 }  // namespace Canon
 }  // namespace RDKit
-


### PR DESCRIPTION
#### What does this implement/fix?
This moves away from C-style arrays (```std::make_unique<int[]>(n);```) to ```std::vectors```.

#### Other comments:
- I did not manage to use arrays and have opted for vectors instead. Maybe this can be improved!
- ```struct canon_atom``` could in principle also be changed from  ```std::unique_ptr<int[]> nbrIds;``` to a vector, but would impact more files.