### PR TITLE
Fix #7112

### DIFF
--- a/Code/GraphMol/Wrap/ResonanceMolSupplier.cpp
+++ b/Code/GraphMol/Wrap/ResonanceMolSupplier.cpp
@@ -237,13 +237,13 @@ struct resmolsup_wrap {
              "Returns the number of individual conjugated groups in the "
              "molecule.\n")
         .def("GetBondConjGrpIdx",
-             (unsigned int (ResonanceMolSupplier::*)(unsigned int)) &
+             (int (ResonanceMolSupplier::*)(unsigned int)) &
                  ResonanceMolSupplier::getBondConjGrpIdx,
              python::args("self", "bi"),
              "Given a bond index, it returns the index of the conjugated group"
              "the bond belongs to, or -1 if it is not conjugated.\n")
         .def("GetAtomConjGrpIdx",
-             (unsigned int (ResonanceMolSupplier::*)(unsigned int)) &
+             (int (ResonanceMolSupplier::*)(unsigned int)) &
                  ResonanceMolSupplier::getAtomConjGrpIdx,
              python::args("self", "ai"),
              "Given an atom index, it returns the index of the conjugated group"


### PR DESCRIPTION
#### Reference Issue
Fixes #7112


#### What does this implement/fix? Explain your changes.
This PR changes the the return type of `ResonanceMolSupplier.getBondConjGrpIdx()` and `ResonanceMolSupplier.getAtomConjGrpIdx()` from `unsigned int` to `int`, so it returns the expected `-1` values for an absent resonance group instead of `2^32 - 1`. Note that on the C++ level the correct `int` is already used:

https://github.com/rdkit/rdkit/blob/c974ad42bfe6583a54787335fa5386308c96c8f8/Code/GraphMol/Resonance.h#L139-L144
