### PR TITLE
Make Cartridge @= operator coordinate agnostic

### DIFF
--- a/Code/PgSQL/rdkit/adapter.cpp
+++ b/Code/PgSQL/rdkit/adapter.cpp
@@ -610,8 +610,9 @@ extern "C" int molcmp(CROMol i, CROMol a) {
     smi1 = MolToSmiles(*im, useChirality);
     smi2 = MolToSmiles(*am, useChirality);
   } else {
-    smi1 = MolToCXSmiles(*im);
-    smi2 = MolToCXSmiles(*am);
+    RDKit::SmilesWriteParams sps;
+    smi1 = MolToCXSmiles(*im, sps, SmilesWrite::CXSmilesFields::CX_ALL_BUT_COORDS);
+    smi2 = MolToCXSmiles(*am, sps, SmilesWrite::CXSmilesFields::CX_ALL_BUT_COORDS);
   }
   return smi1 == smi2 ? 0 : (smi1 < smi2 ? -1 : 1);
 }

--- a/Code/PgSQL/rdkit/expected/rdkit-91.out
+++ b/Code/PgSQL/rdkit/expected/rdkit-91.out
@@ -734,6 +734,7 @@ select 'CC(F)Cl'::mol@='CC(F)Cl'::mol;
 
 set rdkit.do_chiral_sss=false;
 -- Enhanced stereo
+-- Includes Issue# 8465: Demonstrate that modification of molecule coords does not impact identity
 set rdkit.do_chiral_sss=false;
 set rdkit.do_enhanced_stereo_sss=false; /* has no effect when do_chiral_sss is false */
 select 'C[C@@H](O)[C@@H](C)F |&1:1,3,r|'::mol@>'C[C@@H](O)[C@@H](C)F |o1:1,3,r|'::mol;
@@ -784,6 +785,12 @@ select 'C[C@@H](O)[C@@H](C)F |&1:1,3,r|'::mol@>'C[C@H](O)[C@H](C)F'::mol;
  t
 (1 row)
 
+select 'c1ccccc1 |(7.8993,-8.9847,;8.6138,-8.5722,;8.6138,-7.7472,;7.8993,-7.3347,;7.1848,-7.7472,;7.1848,-8.5722,)|'::mol@='c1ccccc1 |(10.3733,-8.9847,;11.0877,-8.5722,;11.0877,-7.7472,;10.3733,-7.3347,;9.6588,-7.7472,;9.6588,-8.5722,)|'::mol;
+ ?column? 
+----------
+ t
+(1 row)
+
 set rdkit.do_enhanced_stereo_sss=true; /* has no effect when do_chiral_sss is false */
 select 'C[C@@H](O)[C@@H](C)F |&1:1,3,r|'::mol@>'C[C@@H](O)[C@@H](C)F |o1:1,3,r|'::mol;
  ?column? 
@@ -828,6 +835,12 @@ select 'C[C@@H](O)[C@@H](C)F |o1:1,3,r|'::mol@>'C[C@H](O)[C@H](C)F'::mol;
 (1 row)
 
 select 'C[C@@H](O)[C@@H](C)F |&1:1,3,r|'::mol@>'C[C@H](O)[C@H](C)F'::mol;
+ ?column? 
+----------
+ t
+(1 row)
+
+select 'c1ccccc1 |(7.8993,-8.9847,;8.6138,-8.5722,;8.6138,-7.7472,;7.8993,-7.3347,;7.1848,-7.7472,;7.1848,-8.5722,)|'::mol@='c1ccccc1 |(10.3733,-8.9847,;11.0877,-8.5722,;11.0877,-7.7472,;10.3733,-7.3347,;9.6588,-7.7472,;9.6588,-8.5722,)|'::mol;
  ?column? 
 ----------
  t
@@ -883,6 +896,12 @@ select 'C[C@@H](O)[C@@H](C)F |&1:1,3,r|'::mol@>'C[C@H](O)[C@H](C)F'::mol;
  f
 (1 row)
 
+select 'c1ccccc1 |(7.8993,-8.9847,;8.6138,-8.5722,;8.6138,-7.7472,;7.8993,-7.3347,;7.1848,-7.7472,;7.1848,-8.5722,)|'::mol@='c1ccccc1 |(10.3733,-8.9847,;11.0877,-8.5722,;11.0877,-7.7472,;10.3733,-7.3347,;9.6588,-7.7472,;9.6588,-8.5722,)|'::mol;
+ ?column? 
+----------
+ t
+(1 row)
+
 set rdkit.do_enhanced_stereo_sss=true; /* now we expect to see an effect */
 select 'C[C@@H](O)[C@@H](C)F |&1:1,3,r|'::mol@>'C[C@@H](O)[C@@H](C)F |o1:1,3,r|'::mol;
  ?column? 
@@ -927,6 +946,12 @@ select 'C[C@@H](O)[C@@H](C)F |o1:1,3,r|'::mol@>'C[C@H](O)[C@H](C)F'::mol;
 (1 row)
 
 select 'C[C@@H](O)[C@@H](C)F |&1:1,3,r|'::mol@>'C[C@H](O)[C@H](C)F'::mol;
+ ?column? 
+----------
+ t
+(1 row)
+
+select 'c1ccccc1 |(7.8993,-8.9847,;8.6138,-8.5722,;8.6138,-7.7472,;7.8993,-7.3347,;7.1848,-7.7472,;7.1848,-8.5722,)|'::mol@='c1ccccc1 |(10.3733,-8.9847,;11.0877,-8.5722,;11.0877,-7.7472,;10.3733,-7.3347,;9.6588,-7.7472,;9.6588,-8.5722,)|'::mol;
  ?column? 
 ----------
  t

--- a/Code/PgSQL/rdkit/sql/rdkit-91.sql
+++ b/Code/PgSQL/rdkit/sql/rdkit-91.sql
@@ -246,6 +246,7 @@ select 'CC(F)Cl'::mol@='CC(F)Cl'::mol;
 set rdkit.do_chiral_sss=false;
 
 -- Enhanced stereo
+-- Includes Issue# 8465: Demonstrate that modification of molecule coords does not impact identity
 set rdkit.do_chiral_sss=false;
 set rdkit.do_enhanced_stereo_sss=false; /* has no effect when do_chiral_sss is false */
 select 'C[C@@H](O)[C@@H](C)F |&1:1,3,r|'::mol@>'C[C@@H](O)[C@@H](C)F |o1:1,3,r|'::mol;
@@ -256,6 +257,7 @@ select 'C[C@@H](O)[C@@H](C)F |o1:1,3,r|'::mol@>'C[C@@H](O)[C@@H](C)F'::mol;
 select 'C[C@@H](O)[C@@H](C)F |&1:1,3,r|'::mol@>'C[C@@H](O)[C@@H](C)F'::mol;
 select 'C[C@@H](O)[C@@H](C)F |o1:1,3,r|'::mol@>'C[C@H](O)[C@H](C)F'::mol;
 select 'C[C@@H](O)[C@@H](C)F |&1:1,3,r|'::mol@>'C[C@H](O)[C@H](C)F'::mol;
+select 'c1ccccc1 |(7.8993,-8.9847,;8.6138,-8.5722,;8.6138,-7.7472,;7.8993,-7.3347,;7.1848,-7.7472,;7.1848,-8.5722,)|'::mol@='c1ccccc1 |(10.3733,-8.9847,;11.0877,-8.5722,;11.0877,-7.7472,;10.3733,-7.3347,;9.6588,-7.7472,;9.6588,-8.5722,)|'::mol;
 set rdkit.do_enhanced_stereo_sss=true; /* has no effect when do_chiral_sss is false */
 select 'C[C@@H](O)[C@@H](C)F |&1:1,3,r|'::mol@>'C[C@@H](O)[C@@H](C)F |o1:1,3,r|'::mol;
 select 'C[C@@H](O)[C@@H](C)F |o1:1,3,r|'::mol@>'C[C@@H](O)[C@@H](C)F |&1:1,3,r|'::mol;
@@ -265,6 +267,7 @@ select 'C[C@@H](O)[C@@H](C)F |o1:1,3,r|'::mol@>'C[C@@H](O)[C@@H](C)F'::mol;
 select 'C[C@@H](O)[C@@H](C)F |&1:1,3,r|'::mol@>'C[C@@H](O)[C@@H](C)F'::mol;
 select 'C[C@@H](O)[C@@H](C)F |o1:1,3,r|'::mol@>'C[C@H](O)[C@H](C)F'::mol;
 select 'C[C@@H](O)[C@@H](C)F |&1:1,3,r|'::mol@>'C[C@H](O)[C@H](C)F'::mol;
+select 'c1ccccc1 |(7.8993,-8.9847,;8.6138,-8.5722,;8.6138,-7.7472,;7.8993,-7.3347,;7.1848,-7.7472,;7.1848,-8.5722,)|'::mol@='c1ccccc1 |(10.3733,-8.9847,;11.0877,-8.5722,;11.0877,-7.7472,;10.3733,-7.3347,;9.6588,-7.7472,;9.6588,-8.5722,)|'::mol;
 set rdkit.do_chiral_sss=true;
 set rdkit.do_enhanced_stereo_sss=false;
 select 'C[C@@H](O)[C@@H](C)F |&1:1,3,r|'::mol@>'C[C@@H](O)[C@@H](C)F |o1:1,3,r|'::mol;
@@ -275,6 +278,7 @@ select 'C[C@@H](O)[C@@H](C)F |o1:1,3,r|'::mol@>'C[C@@H](O)[C@@H](C)F'::mol;
 select 'C[C@@H](O)[C@@H](C)F |&1:1,3,r|'::mol@>'C[C@@H](O)[C@@H](C)F'::mol;
 select 'C[C@@H](O)[C@@H](C)F |o1:1,3,r|'::mol@>'C[C@H](O)[C@H](C)F'::mol;
 select 'C[C@@H](O)[C@@H](C)F |&1:1,3,r|'::mol@>'C[C@H](O)[C@H](C)F'::mol;
+select 'c1ccccc1 |(7.8993,-8.9847,;8.6138,-8.5722,;8.6138,-7.7472,;7.8993,-7.3347,;7.1848,-7.7472,;7.1848,-8.5722,)|'::mol@='c1ccccc1 |(10.3733,-8.9847,;11.0877,-8.5722,;11.0877,-7.7472,;10.3733,-7.3347,;9.6588,-7.7472,;9.6588,-8.5722,)|'::mol;
 set rdkit.do_enhanced_stereo_sss=true; /* now we expect to see an effect */
 select 'C[C@@H](O)[C@@H](C)F |&1:1,3,r|'::mol@>'C[C@@H](O)[C@@H](C)F |o1:1,3,r|'::mol;
 select 'C[C@@H](O)[C@@H](C)F |o1:1,3,r|'::mol@>'C[C@@H](O)[C@@H](C)F |&1:1,3,r|'::mol;
@@ -284,6 +288,7 @@ select 'C[C@@H](O)[C@@H](C)F |o1:1,3,r|'::mol@>'C[C@@H](O)[C@@H](C)F'::mol;
 select 'C[C@@H](O)[C@@H](C)F |&1:1,3,r|'::mol@>'C[C@@H](O)[C@@H](C)F'::mol;
 select 'C[C@@H](O)[C@@H](C)F |o1:1,3,r|'::mol@>'C[C@H](O)[C@H](C)F'::mol;
 select 'C[C@@H](O)[C@@H](C)F |&1:1,3,r|'::mol@>'C[C@H](O)[C@H](C)F'::mol;
+select 'c1ccccc1 |(7.8993,-8.9847,;8.6138,-8.5722,;8.6138,-7.7472,;7.8993,-7.3347,;7.1848,-7.7472,;7.1848,-8.5722,)|'::mol@='c1ccccc1 |(10.3733,-8.9847,;11.0877,-8.5722,;11.0877,-7.7472,;10.3733,-7.3347,;9.6588,-7.7472,;9.6588,-8.5722,)|'::mol;
 
 set rdkit.do_chiral_sss=false;
 set rdkit.do_enhanced_stereo_sss=false;


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! 
 #-->
Fixes Issue #8465 

Modifies behavior of @= operator in the cartridge to ignore coordinates when comparing CXSmiles. This is needed becuase the existing implementation will evaluate identical molecules as different if one or more atoms has a different position than the reference molecule.


