### PR TITLE
improve operator<< for stereogroups

### DIFF
--- a/Code/GraphMol/StereoGroup.cpp
+++ b/Code/GraphMol/StereoGroup.cpp
@@ -180,18 +180,20 @@ std::ostream &operator<<(std::ostream &target, const RDKit::StereoGroup &stg) {
   }
   target << " rId: " << stg.getReadId();
   target << " wId: " << stg.getWriteId();
-  target << " atoms: { ";
-  for (auto atom : stg.getAtoms()) {
-    target << atom->getIdx() << ' ';
+  if (!stg.getAtoms().empty()) {
+    target << " atoms: { ";
+    for (auto atom : stg.getAtoms()) {
+      target << atom->getIdx() << ' ';
+    }
+    target << '}';
   }
-  if (stg.getBonds().size() > 0) {
-    target << " Bonds: { ";
+  if (!stg.getBonds().empty()) {
+    target << " bonds: { ";
     for (auto bond : stg.getBonds()) {
       target << bond->getIdx() << ' ';
     }
     target << '}';
   }
-  target << '}';
 
   return target;
 }

--- a/Code/GraphMol/catch_graphmol.cpp
+++ b/Code/GraphMol/catch_graphmol.cpp
@@ -4804,3 +4804,22 @@ TEST_CASE("Github #8304: addHs should ignore queries") {
     }
   }
 }
+
+TEST_CASE("stereogroups operator<<") {
+  SECTION("atoms and bonds in one") {
+    auto m = "Oc1cccc(C)c1-c1c(C)nccc1[C@H](F)Cl |wU:8.9,&1:8,15|"_smiles;
+    REQUIRE(m);
+    REQUIRE(m->getStereoGroups().size() == 1);
+    std::ostringstream oss;
+    oss << m->getStereoGroups()[0];
+    CHECK(oss.str() == "AND rId: 0 wId: 0 atoms: { 15 } bonds: { 7 }");
+  }
+  SECTION("just bonds in one") {
+    auto m = "Oc1cccc(C)c1-c1c(C)nccc1[C@H](F)Cl |wU:8.9,&1:8|"_smiles;
+    REQUIRE(m);
+    REQUIRE(m->getStereoGroups().size() == 1);
+    std::ostringstream oss;
+    oss << m->getStereoGroups()[0];
+    CHECK(oss.str() == "AND rId: 0 wId: 0 bonds: { 7 }");
+  }
+}


### PR DESCRIPTION
small change to make capitalization consistent and only output the `Atoms` part if there are atoms.
