### PR TITLE
Fixes #8492

### DIFF
--- a/Code/GraphMol/TautomerQuery/TautomerQuery.cpp
+++ b/Code/GraphMol/TautomerQuery/TautomerQuery.cpp
@@ -163,8 +163,15 @@ TautomerQuery *TautomerQuery::fromMol(
 
   auto templateMolecule = new RWMol(query);
   for (auto idx : modifiedAtoms) {
-    const auto atom = templateMolecule->getAtomWithIdx(idx);
+    const auto atom = query.getAtomWithIdx(idx);
     const auto queryAtom = new QueryAtom(atom->getAtomicNum());
+
+    // Forward original queries
+    if (atom->hasQuery()) {
+      auto originalAtomQuery = static_cast<const QueryAtom *>(atom)->getQuery();
+      queryAtom->setQuery(originalAtomQuery->copy());
+    }
+
     const bool updateLabel = false;
     const bool preserveProps = true;
     templateMolecule->replaceAtom(idx, queryAtom, updateLabel, preserveProps);


### PR DESCRIPTION
This fixes #8492.

The problem was that for the `modifiedAtoms`, we create fresh `QueryAtoms` and replace the `templateMolecule's` atoms with them, but we never forward the queries to these new `QueryAtoms`. This is what this PR adds: forwarding the queries to the modified and replaced atoms.

