### PR TITLE
Synthon space github8502

### DIFF
--- a/Code/GraphMol/SynthonSpaceSearch/SynthonSpace.cpp
+++ b/Code/GraphMol/SynthonSpaceSearch/SynthonSpace.cpp
@@ -268,18 +268,21 @@ void SynthonSpace::readTextFile(const std::string &inFilename,
   if (!ifs.is_open() || ifs.bad()) {
     throw std::runtime_error("Couldn't open file " + d_fileName);
   }
+  readStream(ifs, cancelled);
+}
 
+void SynthonSpace::readStream(std::istream &is, bool &cancelled) {
   int format = -1;
   std::string nextLine;
   int lineNum = 1;
   ControlCHandler::reset();
 
-  while (!ifs.eof()) {
+  while (!is.eof()) {
     if (ControlCHandler::getGotSignal()) {
       cancelled = true;
       return;
     }
-    auto nextSynthon = readSynthonLine(ifs, lineNum, format, d_fileName);
+    auto nextSynthon = readSynthonLine(is, lineNum, format, d_fileName);
     if (nextSynthon.empty()) {
       continue;
     }
@@ -500,8 +503,8 @@ void SynthonSpace::readDBFile(const std::string &inFilename,
                  d_synthonPool);
   }
 #else
-    readSynthons(0, numSynthons, fileMap.d_mappedMemory, synthonPos,
-                 d_synthonPool);
+  readSynthons(0, numSynthons, fileMap.d_mappedMemory, synthonPos,
+               d_synthonPool);
 #endif
   if (!std::is_sorted(
           d_synthonPool.begin(), d_synthonPool.end(),
@@ -525,8 +528,8 @@ void SynthonSpace::readDBFile(const std::string &inFilename,
                   d_fileMajorVersion, d_reactions);
   }
 #else
-    readReactions(0, numReactions, fileMap.d_mappedMemory, reactionPos, *this,
-                  d_fileMajorVersion, d_reactions);
+  readReactions(0, numReactions, fileMap.d_mappedMemory, reactionPos, *this,
+                d_fileMajorVersion, d_reactions);
 #endif
   if (!std::is_sorted(
           d_reactions.begin(), d_reactions.end(),

--- a/Code/GraphMol/SynthonSpaceSearch/SynthonSpace.h
+++ b/Code/GraphMol/SynthonSpaceSearch/SynthonSpace.h
@@ -264,6 +264,7 @@ class RDKIT_SYNTHONSPACESEARCH_EXPORT SynthonSpace {
    * If it receives a SIGINT, returns cancelled=true.
    */
   void readTextFile(const std::string &inFilename, bool &cancelled);
+  void readStream(std::istream &is, bool &cancelled);
 
   /*!
    * Writes to a binary DB File in our format.
@@ -383,7 +384,8 @@ RDKIT_SYNTHONSPACESEARCH_EXPORT void convertTextToDBFile(
  *
  * @return std::string
  */
-RDKIT_SYNTHONSPACESEARCH_EXPORT std::string formattedIntegerString(std::int64_t value);
+RDKIT_SYNTHONSPACESEARCH_EXPORT std::string formattedIntegerString(
+    std::int64_t value);
 
 }  // namespace SynthonSpaceSearch
 }  // namespace RDKit

--- a/Code/GraphMol/SynthonSpaceSearch/SynthonSpaceSearch_details.cpp
+++ b/Code/GraphMol/SynthonSpaceSearch/SynthonSpaceSearch_details.cpp
@@ -500,6 +500,10 @@ void buildSplitBonds(
     const std::vector<std::pair<unsigned int, unsigned int>> &bondPairs,
     const unsigned int maxBondSplits,
     std::vector<std::vector<unsigned int>> &splitBonds) {
+  if (bondPairs.size() == 1) {
+    splitBonds.push_back({bondPairs[0].first});
+    return;
+  }
   std::vector<unsigned int> nextSplits;
   splitBonds.reserve(maxBondSplits * maxBondSplits * bondPairs.size());
   for (unsigned int i = 1; i < maxBondSplits; ++i) {
@@ -537,7 +541,8 @@ std::vector<std::vector<std::unique_ptr<ROMol>>> splitMolecule(
   if (maxNumFrags < 1) {
     maxNumFrags = 1;
   }
-  maxNumFrags = std::min({maxNumFrags, MAX_CONNECTOR_NUM, query.getNumBonds()});
+  maxNumFrags =
+      std::min({maxNumFrags, MAX_CONNECTOR_NUM, query.getNumBonds() + 1});
 
   auto ringBonds = flagRingBonds(query);
 

--- a/Code/GraphMol/SynthonSpaceSearch/substructure_search_catch_tests.cpp
+++ b/Code/GraphMol/SynthonSpaceSearch/substructure_search_catch_tests.cpp
@@ -641,7 +641,8 @@ M  END)CTAB"_ctab;
     auto results1 = synthonspace.substructureSearch(xrq, mparams, params);
     CHECK(results1.getHitMolecules().size() == 5);
 #else
-    CHECK_THROWS_AS(synthonspace.substructureSearch(xrq, mparams, params), Invar::Invariant);
+    CHECK_THROWS_AS(synthonspace.substructureSearch(xrq, mparams, params),
+                    Invar::Invariant);
 #endif
   }
 
@@ -697,7 +698,31 @@ M  END)CTAB"_ctab;
     auto results1 = synthonspace.substructureSearch(xrq, mparams);
     CHECK(results1.getHitMolecules().size() == 2);
 #else
-    CHECK_THROWS_AS(synthonspace.substructureSearch(xrq, mparams), Invar::Invariant);
+    CHECK_THROWS_AS(synthonspace.substructureSearch(xrq, mparams),
+                    Invar::Invariant);
 #endif
   }
+}
+
+TEST_CASE("Fails simple test (Github 8502)") {
+  SynthonSpace space;
+  std::istringstream iss(R"(SMILES	synton_id	synton#	reaction_id
+F[1*]	277310376-742385846	0	fake-chiral
+Cl[1*]	287123986-010598048	0	fake-chiral
+OC(N)([1*])[2*]	584456271-623025187	1	fake-chiral
+OC(Br)([1*])[2*]	584456271-623025187	1	fake-chiral
+F[2*]	277310376-742385dd	2	fake-chiral
+)");
+  bool cancelled = false;
+  space.readStream(iss, cancelled);
+
+  auto mol1 = "C"_smiles;
+  REQUIRE(mol1);
+  auto res1 = space.substructureSearch(*mol1);
+  CHECK(res1.getHitMolecules().size() == 2);
+
+  auto mol2 = "CF"_smiles;
+  REQUIRE(mol2);
+  auto res2 = space.substructureSearch(*mol2);
+  CHECK(res2.getHitMolecules().size() == 2);
 }


### PR DESCRIPTION

#### Reference Issue
Fixes #8502

#### What does this implement/fix? Explain your changes.
The fragmentation code wasn't dealing with a query with only 1 bond.

#### Any other comments?
I've added a function to read a SynthonSpace from a stream, to make setting up little tests like this easier.
clang-format seems to have found a few more things to fiddle with.
