### PR TITLE
A few mem fixes in tests

### DIFF
--- a/Code/GraphMol/FileParsers/testMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/testMolSupplier.cpp
@@ -2817,7 +2817,7 @@ void testGitHub2881() {
     bool sanitize = false;
     bool takeOwnership = true;
     MaeMolSupplier suppl(iss, takeOwnership, sanitize);
-    auto mol = suppl.next();
+    std::unique_ptr<ROMol> mol(suppl.next());
     TEST_ASSERT(mol);
     TEST_ASSERT(mol->getNumAtoms() == 15);
     TEST_ASSERT(mol->getNumBonds() == 17);

--- a/Code/GraphMol/FileParsers/testMolWriter.cpp
+++ b/Code/GraphMol/FileParsers/testMolWriter.cpp
@@ -1647,7 +1647,7 @@ void testMolFileGithub8265() {
       conf->setAtomPos(0, pos);
       auto mbV2K = MolToMolBlock(*m);
       TEST_ASSERT(mbV2K.find("M  V30") != std::string::npos);
-      MolBlockToMol(mbV2K);
+      TEST_ASSERT(v2::FileParsers::MolFromMolBlock(mbV2K));
       try {
         MolToV2KMolBlock(*m);
         TEST_ASSERT(0);
@@ -1664,7 +1664,7 @@ void testMolFileGithub8265() {
       conf->setAtomPos(0, pos);
       auto mbV2k = MolToMolBlock(*m);
       TEST_ASSERT(mbV2k.find("M  V30") == std::string::npos);
-      MolBlockToMol(mbV2k);
+      TEST_ASSERT(v2::FileParsers::MolFromMolBlock(mbV2k));
     }
 
     {
@@ -1672,7 +1672,7 @@ void testMolFileGithub8265() {
       conf->setAtomPos(0, pos);
       auto mbV2k = MolToMolBlock(*m);
       TEST_ASSERT(mbV2k.find("M  V30") != std::string::npos);
-      MolBlockToMol(mbV2k);
+      TEST_ASSERT(v2::FileParsers::MolFromMolBlock(mbV2k));
       try {
         MolToV2KMolBlock(*m);
         TEST_ASSERT(0);
@@ -1689,7 +1689,7 @@ void testMolFileGithub8265() {
       conf->setAtomPos(0, pos);
       auto mbV2k = MolToMolBlock(*m);
       TEST_ASSERT(mbV2k.find("M  V30") == std::string::npos);
-      MolBlockToMol(mbV2k);
+      TEST_ASSERT(v2::FileParsers::MolFromMolBlock(mbV2k));
     }
   }
   BOOST_LOG(rdInfoLog) << "Finished\n";

--- a/Code/GraphMol/FileParsers/v2_suppliers_catch.cpp
+++ b/Code/GraphMol/FileParsers/v2_suppliers_catch.cpp
@@ -115,8 +115,8 @@ TEST_CASE("MaeMolSupplier") {
     std::string fName = getenv("RDBASE");
     fName += "/Code/GraphMol/FileParsers/test_data/props_test.mae";
 
-    MaeMolSupplier maesup(fName);
-    std::unique_ptr<ROMol> nmol(maesup.next());
+    FileParsers::MaeMolSupplier maesup(fName);
+    auto nmol(maesup.next());
     TEST_ASSERT(nmol);
   }
 }
@@ -171,10 +171,10 @@ TEST_CASE("TestParsingInvalidChiralityLabelsWithMaeMolSupplier") {
       (boost::format(maeblock_template) % invalid_chirality_label).str();
 
   auto iss = std::make_unique<std::istringstream>(maeblock);
-  constexpr bool sanitize = false;
   constexpr bool takeOwnership = true;
+  constexpr FileParsers::MaeMolSupplierParams params{.sanitize = false};
 
-  MaeMolSupplier suppl(iss.release(), takeOwnership, sanitize);
+  FileParsers::MaeMolSupplier suppl(iss.release(), takeOwnership, params);
   auto mol = suppl.next();
 
   REQUIRE(mol);

--- a/Code/GraphMol/catch_chirality.cpp
+++ b/Code/GraphMol/catch_chirality.cpp
@@ -6133,7 +6133,7 @@ $$$$
     pathName += "/Code/GraphMol/test_data/Github8323.sdf";
     SDMolSupplier suppl(pathName);
     while (!suppl.atEnd()) {
-      auto mol = suppl.next();
+      std::unique_ptr<ROMol> mol(suppl.next());
       REQUIRE(mol);
       auto &sgs = mol->getStereoGroups();
       REQUIRE(sgs.size() == 1);

--- a/Code/GraphMol/querytest.cpp
+++ b/Code/GraphMol/querytest.cpp
@@ -416,8 +416,9 @@ void testQueryQueryMatches() {
   {
     QueryAtom a1;
     std::string excStr;
+    std::unique_ptr<ATOM_EQUALS_QUERY> q(makeAtomNumQuery(7));
     try {
-      a1.expandQuery(makeAtomNumQuery(7), Queries::COMPOSITE_OR);
+      a1.expandQuery(q.get(), Queries::COMPOSITE_OR);
     } catch (std::exception &e) {
       excStr = e.what();
     }


### PR DESCRIPTION
I ran asan on tests again. Besides finding https://github.com/rdkit/rdkit/issues/8520, there's just some minor leaks in tests.

Special mention to the two issues in  `Code/GraphMol/FileParsers/v2_suppliers_catch.cpp`, which weren't using the "v2" API at all.