### PR TITLE
Fix ETKDG double bond check from #8518

### DIFF
--- a/Code/GraphMol/DistGeomHelpers/Embedder.cpp
+++ b/Code/GraphMol/DistGeomHelpers/Embedder.cpp
@@ -1043,8 +1043,10 @@ void findDoubleBonds(
           if (nbr == oatm) {
             continue;
           }
-          const auto obnd = mol.getBondBetweenAtoms(atm->getIdx(), nbr->getIdx());
-          if (!obnd || (obnd->getBondType() != Bond::BondType::SINGLE && atm->getDegree() == 2)) {
+          const auto obnd =
+              mol.getBondBetweenAtoms(atm->getIdx(), nbr->getIdx());
+          if (!obnd || (obnd->getBondType() != Bond::BondType::SINGLE &&
+                        atm->getDegree() == 2)) {
             continue;
           }
           doubleBondEnds.emplace_back(nbr->getIdx(), atm->getIdx(),
@@ -1156,8 +1158,8 @@ void findChiralSets(const ROMol &mol, DistGeom::VECT_CHIRALSET &chiralCenters,
           }
         }
       }  // if block -chirality check
-    }  // if block - heavy atom check
-  }  // for loop over atoms
+    }    // if block - heavy atom check
+  }      // for loop over atoms
 
   // now do atropisomers
   for (const auto &bond : mol.bonds()) {

--- a/Code/GraphMol/DistGeomHelpers/Embedder.cpp
+++ b/Code/GraphMol/DistGeomHelpers/Embedder.cpp
@@ -1023,8 +1023,8 @@ bool embedPoints(RDGeom::PointPtrVect *positions, detail::EmbedArgs eargs,
 
   return gotCoords;
 }
-
-void findDoubleBonds(
+// export this since we are going to be testing it
+RDKIT_DISTGEOMHELPERS_EXPORT void findDoubleBonds(
     const ROMol &mol,
     std::vector<std::tuple<unsigned int, unsigned int, unsigned int>>
         &doubleBondEnds,

--- a/Code/GraphMol/DistGeomHelpers/Embedder.cpp
+++ b/Code/GraphMol/DistGeomHelpers/Embedder.cpp
@@ -1044,7 +1044,7 @@ void findDoubleBonds(
             continue;
           }
           const auto obnd = mol.getBondBetweenAtoms(atm->getIdx(), nbr->getIdx());
-          if (!obnd || obnd->getBondType() != Bond::BondType::SINGLE) {
+          if (!obnd || (obnd->getBondType() != Bond::BondType::SINGLE && atm->getDegree() == 2)) {
             continue;
           }
           doubleBondEnds.emplace_back(nbr->getIdx(), atm->getIdx(),

--- a/Code/GraphMol/DistGeomHelpers/catch_tests.cpp
+++ b/Code/GraphMol/DistGeomHelpers/catch_tests.cpp
@@ -1190,3 +1190,47 @@ TEST_CASE("allenes and cumulenes") {
     }
   }
 }
+
+namespace RDKit {
+namespace DGeomHelpers {
+namespace EmbeddingOps {
+void findDoubleBonds(
+    const ROMol &mol,
+    std::vector<std::tuple<unsigned int, unsigned int, unsigned int>>
+        &doubleBondEnds,
+    std::vector<std::pair<std::vector<unsigned int>, int>> &stereoDoubleBonds,
+    const std::map<int, RDGeom::Point3D> *coordMap);
+}
+}  // namespace DGeomHelpers
+}  // namespace RDKit
+
+TEST_CASE("FindDoubleBonds") {
+  SECTION("Allene") {
+    auto m = "C=C=C"_smiles;
+    REQUIRE(m);
+    MolOps::addHs(*m);
+    std::vector<std::tuple<unsigned int, unsigned int, unsigned int>>
+        doubleBondEnds;
+    std::vector<std::pair<std::vector<unsigned int>, int>> stereoDoubleBonds;
+    DGeomHelpers::EmbeddingOps::findDoubleBonds(*m, doubleBondEnds,
+                                                stereoDoubleBonds, nullptr);
+    // This is 4, we still have two double bonds to Hydrogens on each
+    // side that should not be linear but the C=C=C should be, so not 5.
+    CHECK(doubleBondEnds.size() == 4);
+    CHECK(stereoDoubleBonds.empty());
+  }
+  SECTION("Sulfone") {
+    auto m = "CS(=O)(=O)C"_smiles;
+    REQUIRE(m);
+    MolOps::addHs(*m);
+    std::vector<std::tuple<unsigned int, unsigned int, unsigned int>>
+        doubleBondEnds;
+    std::vector<std::pair<std::vector<unsigned int>, int>> stereoDoubleBonds;
+    DGeomHelpers::EmbeddingOps::findDoubleBonds(*m, doubleBondEnds,
+                                                stereoDoubleBonds, nullptr);
+    // We want 6 and not 4, the angle between O=S=O should not be linear
+    // (the current implementation counts it twice, hence not 5).
+    CHECK(doubleBondEnds.size() == 6);
+    CHECK(stereoDoubleBonds.empty());
+  }
+}

--- a/Code/GraphMol/DistGeomHelpers/catch_tests.cpp
+++ b/Code/GraphMol/DistGeomHelpers/catch_tests.cpp
@@ -1194,7 +1194,7 @@ TEST_CASE("allenes and cumulenes") {
 namespace RDKit {
 namespace DGeomHelpers {
 namespace EmbeddingOps {
-void findDoubleBonds(
+RDKIT_DISTGEOMHELPERS_EXPORT void findDoubleBonds(
     const ROMol &mol,
     std::vector<std::tuple<unsigned int, unsigned int, unsigned int>>
         &doubleBondEnds,


### PR DESCRIPTION
#### Reference Issue
Cleans up an oversight in #8518 

#### What does this implement/fix? Explain your changes.
Make sure that will still check angles around centers like a Sulfone, where we have two adjacent double bonds but a higher degree than two.

#### Any other comments?
Not really sure how to test this, since the function running the check is not declared in the header, is creating a details header the solution to this?
