### PR TITLE
Feature/add descriptor max consecutive rotatable bonds

### DIFF
--- a/Code/GraphMol/Descriptors/Lipinski.h
+++ b/Code/GraphMol/Descriptors/Lipinski.h
@@ -162,6 +162,7 @@ RDKIT_DESCRIPTORS_EXPORT unsigned numUnspecifiedAtomStereoCenters(
     const ROMol &mol);
 
 //! calculates the maximum number of consecutive rotatable bonds
+RDKIT_DESCRIPTORS_EXPORT extern const std::string MaxConsecutiveRotatableBondsVersion;
 RDKIT_DESCRIPTORS_EXPORT unsigned int calcMaxConsecutiveRotatableBonds(
     const ROMol &mol, NumRotatableBondsOptions strict = Default);
 

--- a/Code/GraphMol/Descriptors/Lipinski.h
+++ b/Code/GraphMol/Descriptors/Lipinski.h
@@ -162,7 +162,11 @@ RDKIT_DESCRIPTORS_EXPORT unsigned numUnspecifiedAtomStereoCenters(
     const ROMol &mol);
 
 //! calculates the maximum number of consecutive rotatable bonds
-RDKIT_DESCRIPTORS_EXPORT unsigned int calcMaxConsecutiveRotatableBonds(const ROMol &mol);
+RDKIT_DESCRIPTORS_EXPORT unsigned int calcMaxConsecutiveRotatableBonds(
+    const ROMol &mol, NumRotatableBondsOptions strict = Default);
+
+RDKIT_DESCRIPTORS_EXPORT unsigned int calcMaxConsecutiveRotatableBonds(
+    const ROMol &mol, bool strict);
 
 //! Helper function to register the descriptors with the descriptor service
 RDKIT_DESCRIPTORS_EXPORT void registerDescriptors();

--- a/Code/GraphMol/Descriptors/Lipinski.h
+++ b/Code/GraphMol/Descriptors/Lipinski.h
@@ -161,6 +161,9 @@ RDKIT_DESCRIPTORS_EXPORT extern const std::string
 RDKIT_DESCRIPTORS_EXPORT unsigned numUnspecifiedAtomStereoCenters(
     const ROMol &mol);
 
+//! calculates the maximum number of consecutive rotatable bonds
+RDKIT_DESCRIPTORS_EXPORT unsigned int calcMaxConsecutiveRotatableBonds(const ROMol &mol);
+
 //! Helper function to register the descriptors with the descriptor service
 RDKIT_DESCRIPTORS_EXPORT void registerDescriptors();
 }  // end of namespace Descriptors

--- a/Code/GraphMol/Descriptors/Property.cpp
+++ b/Code/GraphMol/Descriptors/Property.cpp
@@ -52,6 +52,7 @@ void _registerDescriptors() {
   REGISTER_DESCRIPTOR(lipinskiHBA, calcLipinskiHBA);
   REGISTER_DESCRIPTOR(lipinskiHBD, calcLipinskiHBD);
   REGISTER_DESCRIPTOR(NumRotatableBonds, calcNumRotatableBonds);
+  REGISTER_DESCRIPTOR(MaxConsecutiveRotatableBonds, calcMaxConsecutiveRotatableBonds);
   REGISTER_DESCRIPTOR(NumHBD, calcNumHBD);
   REGISTER_DESCRIPTOR(NumHBA, calcNumHBA);
   REGISTER_DESCRIPTOR(NumHeavyAtoms, calcNumHeavyAtoms);

--- a/Code/GraphMol/Descriptors/Wrap/rdMolDescriptors.cpp
+++ b/Code/GraphMol/Descriptors/Wrap/rdMolDescriptors.cpp
@@ -1254,6 +1254,51 @@ BOOST_PYTHON_MODULE(rdMolDescriptors) {
   python::scope().attr("_CalcNumRotatableBonds_version") =
       RDKit::Descriptors::NumRotatableBondsVersion;
 
+#ifdef RDK_USE_STRICT_ROTOR_DEFINITION
+  docString =
+      "Returns the maximum number of consecutive rotatable bonds for a molecule.\\n\\n"
+      "Arguments:\\n"
+      "  mol (Mol): The molecule of interest.\\n"
+      "  strict (NumRotatableBondsOptions or bool): Controls the definition of rotatable bonds.\\n"
+      "    - If bool: `True` corresponds to `NumRotatableBondsOptions.Strict`, `False` to `NumRotatableBondsOptions.NonStrict`.\\n"
+      "    - If NumRotatableBondsOptions:\\n"
+      "      - `NonStrict`: Standard loose definition of rotatable bonds.\\n"
+      "      - `Strict`: (default) Stricter definition (e.g., excludes C-CF3, C-C(Cl)3, amide, ester bonds from being rotatable).\\n"
+      "      - `Default`: Uses `Strict` definition (reflects RDK_USE_STRICT_ROTOR_DEFINITION being defined).\\n"
+      "    - `StrictLinkages` is NOT supported and will raise an error.\\n\\n"
+      "The function identifies chains of directly connected rotatable bonds (based on the chosen 'strict' definition)\\n"
+      "and returns the length of the longest such chain. If no rotatable bonds are found, it returns 0.";
+#else
+  docString =
+      "Returns the maximum number of consecutive rotatable bonds for a molecule.\\n\\n"
+      "Arguments:\\n"
+      "  mol (Mol): The molecule of interest.\\n"
+      "  strict (NumRotatableBondsOptions or bool): Controls the definition of rotatable bonds.\\n"
+      "    - If bool: `True` corresponds to `NumRotatableBondsOptions.Strict`, `False` to `NumRotatableBondsOptions.NonStrict`.\\n"
+      "    - If NumRotatableBondsOptions:\\n"
+      "      - `NonStrict`: (default) Standard loose definition of rotatable bonds.\\n"
+      "      - `Strict`: Stricter definition (e.g., excludes C-CF3, C-C(Cl)3, amide, ester bonds from being rotatable).\\n"
+      "      - `Default`: Uses `NonStrict` definition (reflects RDK_USE_STRICT_ROTOR_DEFINITION not being defined).\\n"
+      "    - `StrictLinkages` is NOT supported and will raise an error.\\n\\n"
+      "The function identifies chains of directly connected rotatable bonds (based on the chosen 'strict' definition)\\n"
+      "and returns the length of the longest such chain. If no rotatable bonds are found, it returns 0.";
+#endif
+
+  python::def("CalcMaxConsecutiveRotatableBonds",
+              (unsigned int (*)(const RDKit::ROMol &,
+                                bool))RDKit::Descriptors::calcMaxConsecutiveRotatableBonds,
+              (python::arg("mol"), python::arg("strict")), docString.c_str());
+
+  python::def(
+      "CalcMaxConsecutiveRotatableBonds",
+      (unsigned int (*)(const RDKit::ROMol &,
+                        RDKit::Descriptors::NumRotatableBondsOptions))
+          RDKit::Descriptors::calcMaxConsecutiveRotatableBonds,
+      (python::arg("mol"), python::arg("strict") = RDKit::Descriptors::Default),
+      docString.c_str());
+  python::scope().attr("_CalcMaxConsecutiveRotatableBonds_version") =
+      RDKit::Descriptors::MaxConsecutiveRotatableBondsVersion;
+
   docString = "returns the number of rings for a molecule";
   python::def("CalcNumRings", RDKit::Descriptors::calcNumRings,
               (python::arg("mol")), docString.c_str());

--- a/Code/GraphMol/Descriptors/test.cpp
+++ b/Code/GraphMol/Descriptors/test.cpp
@@ -2216,6 +2216,35 @@ void testGithub2948() {
   BOOST_LOG(rdErrorLog) << "  done" << std::endl;
 }
 
+void testMaxConsecutiveRotatableBonds() {
+  BOOST_LOG(rdErrorLog) << "-------------------------------------" << std::endl;
+  BOOST_LOG(rdErrorLog) << "    Test calcMaxConsecutiveRotatableBonds." << std::endl;
+
+  struct TestCase {
+    std::string smiles;
+    unsigned int expected;
+  };
+  std::vector<TestCase> cases = {
+    {"CN1CCN(/N=C/c2ccc(C#N)cc2)CC1", 1},
+    {"Brc1ccc2[nH]cc(-c3ccccc3)c2c1", 1},
+    {"CCc1c(-c2ccccc2)oc(-c2ccc(O)cc2)c1-c1ccccc1", 1},
+    {"Cc1nc(NC(=O)CN2CCN(C)CC2)sc1-c1ccc2c(/C=C/c3ccccn3)n[nH]c2c1", 4},
+    {"CCN(CC)c1nc(OC)c2ccccc2n1", 2},
+    {"C1CCCCC1", 0},
+    {"CCCCCCCNCCO", 8}
+  };
+  for (const auto& tc : cases) {
+    std::unique_ptr<ROMol> mol(SmilesToMol(tc.smiles));
+    TEST_ASSERT(mol);
+    unsigned int result = calcMaxConsecutiveRotatableBonds(*mol);
+    if (result != tc.expected) {
+      std::cerr << "  failed: " << tc.smiles << " expected " << tc.expected << " got " << result << std::endl;
+    }
+    TEST_ASSERT(result == tc.expected);
+  }
+  BOOST_LOG(rdErrorLog) << "  done" << std::endl;
+}
+
 //-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
 //
 //-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
@@ -2259,4 +2288,5 @@ int main() {
 #endif
   testGithub1973();
   testGithub2948();
+  testMaxConsecutiveRotatableBonds();
 }

--- a/Code/GraphMol/Descriptors/test.cpp
+++ b/Code/GraphMol/Descriptors/test.cpp
@@ -2222,25 +2222,31 @@ void testMaxConsecutiveRotatableBonds() {
 
   struct TestCase {
     std::string smiles;
-    unsigned int expected;
+    unsigned int expected_non_strict;
+    unsigned int expected_strict;
   };
   std::vector<TestCase> cases = {
-    {"CN1CCN(/N=C/c2ccc(C#N)cc2)CC1", 1},
-    {"Brc1ccc2[nH]cc(-c3ccccc3)c2c1", 1},
-    {"CCc1c(-c2ccccc2)oc(-c2ccc(O)cc2)c1-c1ccccc1", 1},
-    {"Cc1nc(NC(=O)CN2CCN(C)CC2)sc1-c1ccc2c(/C=C/c3ccccn3)n[nH]c2c1", 4},
-    {"CCN(CC)c1nc(OC)c2ccccc2n1", 2},
-    {"C1CCCCC1", 0},
-    {"CCCCCCCNCCO", 8}
+    {"CN1CCN(/N=C/c2ccc(C#N)cc2)CC1", 1, 1},
+    {"Brc1ccc2[nH]cc(-c3ccccc3)c2c1", 1, 1},
+    {"CCc1c(-c2ccccc2)oc(-c2ccc(O)cc2)c1-c1ccccc1", 1, 1},
+    {"Cc1nc(NC(=O)CN2CCN(C)CC2)sc1-c1ccc2c(/C=C/c3ccccn3)n[nH]c2c1", 4, 2},
+    {"CCN(CC)c1nc(OC)c2ccccc2n1", 2, 2},
+    {"C1CCCCC1", 0, 0},
+    {"CCCCCCCNCCO", 8, 8}
   };
   for (const auto& tc : cases) {
     std::unique_ptr<ROMol> mol(SmilesToMol(tc.smiles));
     TEST_ASSERT(mol);
-    unsigned int result = calcMaxConsecutiveRotatableBonds(*mol);
-    if (result != tc.expected) {
-      std::cerr << "  failed: " << tc.smiles << " expected " << tc.expected << " got " << result << std::endl;
+    unsigned int result = calcMaxConsecutiveRotatableBonds(*mol, false);
+    if (result != tc.expected_non_strict) {
+      std::cerr << "  failed: " << tc.smiles << " expected " << tc.expected_non_strict << " got " << result << std::endl;
     }
-    TEST_ASSERT(result == tc.expected);
+    TEST_ASSERT(result == tc.expected_non_strict);
+    result = calcMaxConsecutiveRotatableBonds(*mol, true);
+    if (result != tc.expected_strict) {
+      std::cerr << "  failed: " << tc.smiles << " expected " << tc.expected_strict << " got " << result << std::endl;
+    }
+    TEST_ASSERT(result == tc.expected_strict);
   }
   BOOST_LOG(rdErrorLog) << "  done" << std::endl;
 }


### PR DESCRIPTION
#### Reference Issue
There is no referenced issue for this PR 

#### What does this implement/fix? Explain your changes.
It adds a new descriptor to compute the maximum number of consecutive rotatable bonds in a molecule. 
It can be a better descriptor for the flexibility of a molecule, in comparison to the raw total number of rotatable bonds.

#### Any other comments?

