### PR TITLE
Fixes #8536

### DIFF
--- a/Code/GraphMol/Chirality.cpp
+++ b/Code/GraphMol/Chirality.cpp
@@ -2793,7 +2793,12 @@ void addStereoAnnotations(ROMol &mol, std::string absLabel, std::string orLabel,
   boost::dynamic_bitset<> doneAts(mol.getNumAtoms());
   for (const auto &sg : sgs) {
     std::string gid = std::to_string(sg.getWriteId());
-    for (const auto atom : sg.getAtoms()) {
+    std::vector<unsigned int> atomIds;
+    std::map<int, std::unique_ptr<RDKit::Chirality::WedgeInfoBase>> wedgeBonds;
+    // empty - all wedges should have been added to the mol, so this doesn't matter
+    Atropisomers::getAllAtomIdsForStereoGroup(*drawMol_, group, atomIds,
+                                              wedgeBonds);
+    for (const auto atom : atomIds) {
       if (doneAts[atom->getIdx()]) {
         BOOST_LOG(rdWarningLog) << "Warning: atom " << atom->getIdx()
                                 << " is in more than one stereogroup. Only the "

--- a/Code/GraphMol/catch_chirality.cpp
+++ b/Code/GraphMol/catch_chirality.cpp
@@ -5203,6 +5203,27 @@ TEST_CASE(
     CHECK(!m2.getBondBetweenAtoms(20, 21)->getPropIfPresent(
         common_properties::bondNote, txt));
   }
+
+  SECTION("Stereogroup annotations for atropisomers Github:#8536") {
+    auto m3 =
+      "Cc1cc([C@H](C)Cl)cc(F)c1-c1c(C)cc([C@H](C)O)cc1Cl |wU:10.10,o1:10,&1:16|"_smiles;
+    REQUIRE(m3);
+    ROMol m4(*m3);
+    CIPLabeler::assignCIPLabels(m4);
+    Chirality::addStereoAnnotations(m4);
+    //now check that all atom and bond labels including atropisomer labels are correctly set
+    std::string txt;
+    CHECK(m4.getAtomWithIdx(4)->getPropIfPresent(common_properties::atomNote, txt));
+    CHECK(txt == "(S)");
+    CHECK(m4.getAtomWithIdx(10)->getPropIfPresent(common_properties::atomNote, txt));
+    CHECK(txt == "or1"); //This is the atropisomer stereolabel check
+    CHECK(m4.getAtomWithIdx(16)->getPropIfPresent(common_properties::atomNote, txt));
+    CHECK(txt == "and1");  
+    Chirality::addStereoAnnotations(m2);
+    CHECK(m2.getBondBetweenAtoms(10, 11)->getPropIfPresent(
+        common_properties::bondNote, txt));
+    CHECK(txt == "(M)");
+  }
 }
 
 TEST_CASE("do not wedge bonds to attachment points") {


### PR DESCRIPTION
Example: Fixes https://github.com/rdkit/rdkit/issues/8536

Updates Chirality::addStereoAnnotations to use Atropisomers::getAllAtomIdsForStereoGroup() to find all atoms in stereogroup instead of stereogroup.GetAtoms(). This will allow wedged atoms that are part of chiral bonds to be included and annotated.