### PR TITLE
Fix irritating warning when DrawMolMCHLasso compiled.

### DIFF
--- a/Code/GraphMol/MolDraw2D/DrawMolMCHLasso.cpp
+++ b/Code/GraphMol/MolDraw2D/DrawMolMCHLasso.cpp
@@ -112,8 +112,8 @@ void DrawMolMCHLasso::extractAtomColourLists(
     for (size_t i = 0U; i < colourLists.size() - 1; ++i) {
       for (size_t j = i + 1; j < colourLists.size(); ++j) {
         if (listsIntersect(colourLists[i], colourLists[j], colourAtoms)) {
-          colourLists[i].insert(colourLists[i].end(), colourLists[j].begin(),
-                                colourLists[j].end());
+          std::copy(colourLists[j].begin(), colourLists[j].end(),
+                    std::back_inserter(colourLists[i]));
           colourLists[j].clear();
           didSomething = true;
           break;

--- a/Code/GraphMol/MolDraw2D/DrawMolMCHLasso.cpp
+++ b/Code/GraphMol/MolDraw2D/DrawMolMCHLasso.cpp
@@ -112,8 +112,10 @@ void DrawMolMCHLasso::extractAtomColourLists(
     for (size_t i = 0U; i < colourLists.size() - 1; ++i) {
       for (size_t j = i + 1; j < colourLists.size(); ++j) {
         if (listsIntersect(colourLists[i], colourLists[j], colourAtoms)) {
-          std::copy(colourLists[j].begin(), colourLists[j].end(),
-                    std::back_inserter(colourLists[i]));
+          colourLists[i].reserve(colourLists[i].size() + colourLists[j].size());
+          colourLists[i].insert(colourLists[i].end(),
+                                std::make_move_iterator(colourLists[j].begin()),
+                                std::make_move_iterator(colourLists[j].end()));
           colourLists[j].clear();
           didSomething = true;
           break;


### PR DESCRIPTION

#### Reference Issue
No issue.


#### What does this implement/fix? Explain your changes.
On my Ubuntu machine using gcc 14.2.0 (from the conda env) I was getting an irritating warning from the std::vector include file when compiling DrawMolMCHLasso.cpp.  This uses a different way of copying the vector that doesn't cause the warning.

#### Any other comments?
I've checked that the lasso images don't change.
