### PR TITLE
Fixes #8527

### DIFF
--- a/Code/GraphMol/StereoGroup.cpp
+++ b/Code/GraphMol/StereoGroup.cpp
@@ -86,7 +86,7 @@ void removeAtomFromGroups(const Atom *atom, std::vector<StereoGroup> &groups) {
   // now remove any empty groups:
   groups.erase(
       std::remove_if(groups.begin(), groups.end(),
-                     [](const auto &gp) { return gp.getAtoms().empty(); }),
+                     [](const auto &gp) { return gp.getAtoms().empty() && gp.getBonds().empty(); }),
       groups.end());
 }
 

--- a/Code/GraphMol/molopstest.cpp
+++ b/Code/GraphMol/molopstest.cpp
@@ -5586,7 +5586,7 @@ void testGetMolFrags() {
     TEST_ASSERT(fragsMapping.size() == m->getNumAtoms());
 
     RDKit::SmilesWriteParams sps;
-    TEST_ASSERT(MolToCXSmiles(*frags[0], sps, SmilesWrite::CXSmilesFields::CX_ALL_BUT_COORDS) == "Cc1cccc(Cl)c1-c1c(C)cccc1I |wD:8.15,&1:8|");
+    TEST_ASSERT(MolToCXSmiles(*frags[0], sps, SmilesWrite::CXSmilesFields::CX_ALL_BUT_COORDS) == "Cc1cccc(Cl)c1-c1c(C)cccc1I |wU:7.6,&1:7|");
     TEST_ASSERT(MolToCXSmiles(*frags[1], sps, SmilesWrite::CXSmilesFields::CX_ALL_BUT_COORDS) == "Cc1cccc(F)c1-c1c(C)cccc1Cl |wU:7.6,o1:7|");
     delete m;
   }

--- a/Code/GraphMol/molopstest.cpp
+++ b/Code/GraphMol/molopstest.cpp
@@ -5572,6 +5572,24 @@ void testGetMolFrags() {
                 m->getConformer(0).getAtomPos(24).z);
     delete m;
   }
+  { //confirm bond-only stereogroups are not removed during GetmolFrags
+    std::string smiles = "Cc1cccc(Cl)c1-c1c(C)cccc1I.Cc1cccc(F)c1-c1c(C)cccc1Cl |wD:8.15,wU:23.23,o1:23,&1:8|";
+    RWMol *m = SmilesToMol(smiles);
+    TEST_ASSERT(m);
+
+    INT_VECT fragsMapping;
+    VECT_INT_VECT fragsMolAtomMapping;
+    std::vector<ROMOL_SPTR> frags =
+        MolOps::getMolFrags(*m, false, &fragsMapping, &fragsMolAtomMapping);
+
+    TEST_ASSERT(frags.size() == 2)
+    TEST_ASSERT(fragsMapping.size() == m->getNumAtoms());
+
+    RDKit::SmilesWriteParams sps;
+    TEST_ASSERT(MolToCXSmiles(*frags[0], sps, SmilesWrite::CXSmilesFields::CX_ALL_BUT_COORDS) == "Cc1cccc(Cl)c1-c1c(C)cccc1I |wD:8.15,&1:8|");
+    TEST_ASSERT(MolToCXSmiles(*frags[1], sps, SmilesWrite::CXSmilesFields::CX_ALL_BUT_COORDS) == "Cc1cccc(F)c1-c1c(C)cccc1Cl |wU:7.6,o1:7|");
+    delete m;
+  }
   BOOST_LOG(rdInfoLog) << "Finished" << std::endl;
 }
 


### PR DESCRIPTION
Fixes #8527


removeAtomFromGroup() in StereoGroups.cpp checks for empty groups and deletes them. Previously it would only check group atoms to see if the group was empty. I modified so it also checks bonds.


