### PR TITLE
Add missing default values to docker-compose configuration

### DIFF
--- a/Code/MinimalLib/docker/docker_compose_build_minimallib.yml
+++ b/Code/MinimalLib/docker/docker_compose_build_minimallib.yml
@@ -31,9 +31,9 @@ services:
     environment:
       - NETWORK_MODE=${NETWORK_MODE:-bridge}
       - NETWORK=${NETWORK:-rdkit_network}
-    network_mode: ${NETWORK_MODE}
+    network_mode: ${NETWORK_MODE:-bridge}
     build:
-      network: ${NETWORK}
+      network: ${NETWORK:-rdkit_network}
       context: .
       dockerfile: Dockerfile_1_deps
     image: rdkit-minimallib-deps:latest
@@ -43,11 +43,11 @@ services:
       - NETWORK_MODE=${NETWORK_MODE:-bridge}
       - NETWORK=${NETWORK:-rdkit_network}
       - GET_SRC=${GET_SRC:-clone_from_github}
-    network_mode: ${NETWORK_MODE}
+    network_mode: ${NETWORK_MODE:-bridge}
     build:
-      network: ${NETWORK}
+      network: ${NETWORK:-rdkit_network}
       context: ../../..
-      dockerfile: ./Code/MinimalLib/docker/Dockerfile_2_rdkit_${GET_SRC}
+      dockerfile: ./Code/MinimalLib/docker/Dockerfile_2_rdkit_${GET_SRC:-clone_from_github}
     image: rdkit-minimallib-rdkit-src:latest
     depends_on:
       - rdkit_deps
@@ -56,9 +56,9 @@ services:
     environment:
       - NETWORK_MODE=${NETWORK_MODE:-bridge}
       - NETWORK=${NETWORK:-rdkit_network}
-    network_mode: ${NETWORK_MODE}
+    network_mode: ${NETWORK_MODE:-bridge}
     build:
-      network: ${NETWORK}
+      network: ${NETWORK:-rdkit_network}
       context: .
       dockerfile: Dockerfile_3_rdkit_build
     image: rdkit-minimallib:latest

--- a/Code/MinimalLib/docker/docker_compose_build_minimallib.yml
+++ b/Code/MinimalLib/docker/docker_compose_build_minimallib.yml
@@ -30,10 +30,8 @@ services:
   rdkit_deps:
     environment:
       - NETWORK_MODE=${NETWORK_MODE:-bridge}
-      - NETWORK=${NETWORK:-rdkit_network}
     network_mode: ${NETWORK_MODE:-bridge}
     build:
-      network: ${NETWORK:-rdkit_network}
       context: .
       dockerfile: Dockerfile_1_deps
     image: rdkit-minimallib-deps:latest
@@ -41,11 +39,9 @@ services:
   rdkit_get_src:
     environment:
       - NETWORK_MODE=${NETWORK_MODE:-bridge}
-      - NETWORK=${NETWORK:-rdkit_network}
       - GET_SRC=${GET_SRC:-clone_from_github}
     network_mode: ${NETWORK_MODE:-bridge}
     build:
-      network: ${NETWORK:-rdkit_network}
       context: ../../..
       dockerfile: ./Code/MinimalLib/docker/Dockerfile_2_rdkit_${GET_SRC:-clone_from_github}
     image: rdkit-minimallib-rdkit-src:latest
@@ -55,10 +51,8 @@ services:
   rdkit_build:
     environment:
       - NETWORK_MODE=${NETWORK_MODE:-bridge}
-      - NETWORK=${NETWORK:-rdkit_network}
     network_mode: ${NETWORK_MODE:-bridge}
     build:
-      network: ${NETWORK:-rdkit_network}
       context: .
       dockerfile: Dockerfile_3_rdkit_build
     image: rdkit-minimallib:latest


### PR DESCRIPTION
The current `Code/MinimalLib/docker/docker_compose_build_minimallib.yml` file is missing defaults for variables in case an `.env` file does not exist; this PR fixes that.