### PR TITLE
Add a "time out" to determineBondOrders

### DIFF
--- a/Code/GraphMol/DetermineBonds/DetermineBonds.cpp
+++ b/Code/GraphMol/DetermineBonds/DetermineBonds.cpp
@@ -13,7 +13,7 @@
 #ifdef RDK_BUILD_YAEHMOP_SUPPORT
 #include <YAeHMOP/EHTTools.h>
 #endif
-#include <iostream>
+#include <limits>
 #include <vector>
 #include <numeric>
 #include <cmath>
@@ -364,7 +364,13 @@ void addBondOrdering(RWMol &mol,
 }
 
 void determineBondOrders(RWMol &mol, int charge, bool allowChargedFragments,
-                         bool embedChiral, bool useAtomMap) {
+                         bool embedChiral, bool useAtomMap, size_t iterations) {
+  if (iterations == 0) {
+    // LazyCartesianProduct allows up to uint1024_t::max iterations,
+    // but it's unlikely we'll even get to size_t::max
+    iterations = std::numeric_limits<size_t>::max();
+  }
+
   auto numAtoms = mol.getNumAtoms();
 
   std::vector<std::vector<unsigned int>> conMat(
@@ -391,7 +397,12 @@ void determineBondOrders(RWMol &mol, int charge, bool allowChargedFragments,
   bool saturationValid = false;
 
   while (!valenceCombos.atEnd()) {
+    if (--iterations == 0) {
+      throw MaxFindBondOrdersItersExceeded();
+    }
+
     auto order = valenceCombos.next();
+
     std::vector<unsigned int> unsat;
     getUnsaturated(order, origValency, unsat);
     // checks whether the atomic connectivity is valid for the current set of
@@ -438,7 +449,7 @@ void determineBondOrders(RWMol &mol, int charge, bool allowChargedFragments,
         }
       }
 
-    } while (newBonds == true);
+    } while (newBonds);
 
     valencyValid = checkValency(order, valency);
     chargeValid = checkCharge(mol, valency, charge);
@@ -451,7 +462,6 @@ void determineBondOrders(RWMol &mol, int charge, bool allowChargedFragments,
         return;
       } else {
         int sum = std::accumulate(valency.begin(), valency.end(), 0);
-        ;
         if (sum > bestSum) {
           best = ordMat;
           bestSum = sum;
@@ -468,13 +478,13 @@ void determineBondOrders(RWMol &mol, int charge, bool allowChargedFragments,
 
 void determineBonds(RWMol &mol, bool useHueckel, int charge, double covFactor,
                     bool allowChargedFragments, bool embedChiral,
-                    bool useAtomMap, bool useVdw) {
+                    bool useAtomMap, bool useVdw, size_t maxIterations) {
   if (mol.getNumAtoms() <= 1) {
     return;
   }
   determineConnectivity(mol, useHueckel, charge, covFactor, useVdw);
   determineBondOrders(mol, charge, allowChargedFragments, embedChiral,
-                      useAtomMap);
+                      useAtomMap, maxIterations);
 }  // determineBonds()
 
 }  // namespace RDKit

--- a/Code/GraphMol/DetermineBonds/DetermineBonds.h
+++ b/Code/GraphMol/DetermineBonds/DetermineBonds.h
@@ -65,6 +65,11 @@ RDKIT_DETERMINEBONDS_EXPORT void determineConnectivity(RWMol &mol,
    sanitizeMol() when this is true
    \param useAtomMap (optional) if this is \c
    true, an atom map will be created for the molecule
+   \param maxIterations (optional) maximum number of iterations to run in the
+   bond order detection algorithm, after which a MaxFindBondOrdersItersExceeded
+   exception will be thrown. Defaults to 0 (no limit)
+
+   \throws MaxFindBondOrdersItersExceeded
  */
 RDKIT_DETERMINEBONDS_EXPORT void determineBondOrders(
     RWMol &mol, int charge = 0, bool allowChargedFragments = true,
@@ -95,6 +100,11 @@ RDKIT_DETERMINEBONDS_EXPORT void determineBondOrders(
    for the molecule
    \param useVdw (optional) if this is  \c false, the connect-the-dots method
     will be used instead of the van der Waals method
+   \param maxIterations (optional) maximum number of iterations to run in the
+   bond order detection algorithm, after which a MaxFindBondOrdersItersExceeded
+   exception will be thrown. Defaults to 0 (no limit)
+
+   \throws MaxFindBondOrdersItersExceeded
  */
 RDKIT_DETERMINEBONDS_EXPORT void determineBonds(
     RWMol &mol, bool useHueckel = false, int charge = 0, double covFactor = 1.3,

--- a/Code/GraphMol/DetermineBonds/DetermineBonds.h
+++ b/Code/GraphMol/DetermineBonds/DetermineBonds.h
@@ -14,6 +14,15 @@
 #include <GraphMol/RDKitBase.h>
 
 namespace RDKit {
+
+class RDKIT_DETERMINEBONDS_EXPORT MaxFindBondOrdersItersExceeded
+    : public std::runtime_error {
+ public:
+  explicit MaxFindBondOrdersItersExceeded()
+      : std::runtime_error(
+            "Max Iterations Exceeded in Determine Bond Orders"){};
+};
+
 // ! assigns atomic connectivity to a molecule using atomic coordinates,
 // disregarding pre-existing bonds
 /*!
@@ -59,7 +68,7 @@ RDKIT_DETERMINEBONDS_EXPORT void determineConnectivity(RWMol &mol,
  */
 RDKIT_DETERMINEBONDS_EXPORT void determineBondOrders(
     RWMol &mol, int charge = 0, bool allowChargedFragments = true,
-    bool embedChiral = true, bool useAtomMap = false);
+    bool embedChiral = true, bool useAtomMap = false, size_t maxIterations = 0);
 
 // ! assigns atomic connectivity to a molecule using atomic coordinates,
 // disregarding pre-existing bonds; it is recommended to sanitize the molecule
@@ -90,7 +99,7 @@ RDKIT_DETERMINEBONDS_EXPORT void determineBondOrders(
 RDKIT_DETERMINEBONDS_EXPORT void determineBonds(
     RWMol &mol, bool useHueckel = false, int charge = 0, double covFactor = 1.3,
     bool allowChargedFragments = true, bool embedChiral = true,
-    bool useAtomMap = false, bool useVdw = false);
+    bool useAtomMap = false, bool useVdw = false, size_t maxIterations = 0);
 
 }  // namespace RDKit
 

--- a/Code/GraphMol/DetermineBonds/Wrap/rdDetermineBonds.cpp
+++ b/Code/GraphMol/DetermineBonds/Wrap/rdDetermineBonds.cpp
@@ -100,6 +100,9 @@ Args:
       sanitizeMol() when this is true
    useAtomMap : (optional) if this is true, an atom map will be created for the
       molecule
+   maxIterations: (optional) maximum number of iterations to run in the bond order
+   determination algorithm, after which a MaxFindBondOrdersItersExceeded
+   exception will be thrown. Defaults to 0 (no limit)
 )DOC";
   python::def(
       "DetermineBondOrders", &determineBondOrdersHelper,
@@ -132,6 +135,9 @@ Args:
       molecule
    useVdw: (optional) if this is false, the connect-the-dots method
        will be used instead of the van der Waals method
+   maxIterations: (optional) maximum number of iterations to run in the bond order
+   determination algorithm, after which a MaxFindBondOrdersItersExceeded
+   exception will be thrown. Defaults to 0 (no limit)
 )DOC";
   python::def(
       "DetermineBonds", &determineBondsHelper,

--- a/Code/GraphMol/DetermineBonds/Wrap/rdDetermineBonds.cpp
+++ b/Code/GraphMol/DetermineBonds/Wrap/rdDetermineBonds.cpp
@@ -7,6 +7,7 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
+#include <string>
 
 #include <RDBoost/python.h>
 #include <GraphMol/GraphMol.h>
@@ -18,6 +19,7 @@ namespace python = boost::python;
 using namespace RDKit;
 
 namespace {
+
 void determineConnectivityHelper(ROMol &mol, bool useHueckel, int charge,
                                  double covFactor, bool useVdw) {
   auto &wmol = static_cast<RWMol &>(mol);
@@ -25,17 +27,18 @@ void determineConnectivityHelper(ROMol &mol, bool useHueckel, int charge,
 }
 void determineBondOrdersHelper(ROMol &mol, int charge,
                                bool allowChargedFragments, bool embedChiral,
-                               bool useAtomMap) {
+                               bool useAtomMap, size_t maxIterations) {
   auto &wmol = static_cast<RWMol &>(mol);
   determineBondOrders(wmol, charge, allowChargedFragments, embedChiral,
-                      useAtomMap);
+                      useAtomMap, maxIterations);
 }
 void determineBondsHelper(ROMol &mol, bool useHueckel, int charge,
                           double covFactor, bool allowChargedFragments,
-                          bool embedChiral, bool useAtomMap, bool useVdw) {
+                          bool embedChiral, bool useAtomMap, bool useVdw,
+                          size_t maxIterations) {
   auto &wmol = static_cast<RWMol &>(mol);
   determineBonds(wmol, useHueckel, charge, covFactor, allowChargedFragments,
-                 embedChiral, useAtomMap, useVdw);
+                 embedChiral, useAtomMap, useVdw, maxIterations);
 }
 bool hueckelSupportEnabled() {
 #ifdef RDK_BUILD_YAEHMOP_SUPPORT
@@ -46,19 +49,27 @@ bool hueckelSupportEnabled() {
 }
 }  // namespace
 
+void rdMaxFindBondOrdersItersExceededTranslator(
+    const RDKit::MaxFindBondOrdersItersExceeded &x) {
+  PyErr_SetString(PyExc_RuntimeError, x.what());
+}
+
 BOOST_PYTHON_MODULE(rdDetermineBonds) {
   python::scope().attr("__doc__") =
       "Module containing a C++ implementation of the xyz2mol algorithm. This is based on xyz2mol: https://github.com/jensengroup/xyz2mol";
 
+  python::register_exception_translator<RDKit::MaxFindBondOrdersItersExceeded>(
+      &rdMaxFindBondOrdersItersExceededTranslator);
+
   std::string docs;
   docs =
-      R"DOC(Assigns atomic connectivity to a molecule using atomic coordinates, 
+      R"DOC(Assigns atomic connectivity to a molecule using atomic coordinates,
 disregarding pre-existing bonds
 
 Args:
    mol : the molecule of interest; it must have a 3D conformer
    useHueckel : (optional) if this is  \c true, extended Hueckel theory
-       will be used to determine connectivity rather than the van der Waals 
+       will be used to determine connectivity rather than the van der Waals
        or connect-the-dots methods
    charge : (optional) the charge of the molecule; it must be provided if
        the Hueckel method is used and charge is non-zero
@@ -74,7 +85,7 @@ Args:
               docs.c_str());
 
   docs =
-      R"DOC(Assigns atomic connectivity to a molecule using atomic coordinates, 
+      R"DOC(Assigns atomic connectivity to a molecule using atomic coordinates,
 disregarding pre-existing bonds
 
 Args:
@@ -87,24 +98,25 @@ Args:
    embedChiral : (optional) if this is true,
       chirality information will be embedded into the molecule; the function calls
       sanitizeMol() when this is true
-   useAtomMap : (optional) if this is true, an atom map will be created for the 
+   useAtomMap : (optional) if this is true, an atom map will be created for the
       molecule
 )DOC";
   python::def(
       "DetermineBondOrders", &determineBondOrdersHelper,
       (python::arg("mol"), python::arg("charge") = 0,
        python::arg("allowChargedFragments") = true,
-       python::arg("embedChiral") = true, python::arg("useAtomMap") = false),
+       python::arg("embedChiral") = true, python::arg("useAtomMap") = false,
+       python::arg("maxIterations") = 0),
       docs.c_str());
 
   docs =
-      R"DOC(Assigns atomic connectivity to a molecule using atomic coordinates, 
+      R"DOC(Assigns atomic connectivity to a molecule using atomic coordinates,
 disregarding pre-existing bonds
 
 Args:
    mol : the molecule of interest; it must have a 3D conformer
    useHueckel : (optional) if this is true, extended Hueckel theory
-       will be used to determine connectivity rather than the van der Waals 
+       will be used to determine connectivity rather than the van der Waals
        or connect-the-dots methods
    charge : (optional) the charge of the molecule; it must be provided if
        the Hueckel method is used and charge is non-zero
@@ -116,7 +128,7 @@ Args:
    embedChiral : (optional) if this is true,
       chirality information will be embedded into the molecule; the function calls
       sanitizeMol() when this is true
-   useAtomMap : (optional) if this is true, an atom map will be created for the 
+   useAtomMap : (optional) if this is true, an atom map will be created for the
       molecule
    useVdw: (optional) if this is false, the connect-the-dots method
        will be used instead of the van der Waals method
@@ -127,7 +139,7 @@ Args:
        python::arg("charge") = 0, python::arg("covFactor") = 1.3,
        python ::arg("allowChargedFragments") = true,
        python::arg("embedChiral") = true, python::arg("useAtomMap") = false,
-       python::arg("useVdw") = false),
+       python::arg("useVdw") = false, python::arg("maxIterations") = 0),
       docs.c_str());
   python::def("hueckelEnabled", &hueckelSupportEnabled,
               "whether or not the RDKit was compiled with YAeHMOP support");

--- a/Code/GraphMol/DetermineBonds/Wrap/testDetermineBonds.py
+++ b/Code/GraphMol/DetermineBonds/Wrap/testDetermineBonds.py
@@ -96,6 +96,29 @@ class TestCase(unittest.TestCase):
           if omol.GetBondBetweenAtoms(aid1, aid2):
             self.assertIsNotNone(mol.GetBondBetweenAtoms(aid1, aid2))
 
+  def testMaxIterations(self):
+    mol = Chem.MolFromSmiles("O=[Cl+]")
+    self.assertIsNotNone(mol)
+
+    bond = mol.GetBondWithIdx(0)
+    bond.SetBondType(Chem.BondType.SINGLE)
+
+    globalCharge = 1
+    embedChiral = False
+
+    # Force a failure
+    with self.assertRaises(RuntimeError):
+      rdDetermineBonds.DetermineBondOrders(mol, charge=globalCharge, embedChiral=embedChiral,
+                                           maxIterations=1)
+
+    self.assertEqual(bond.GetBondType(), Chem.BondType.SINGLE)
+
+    # with more iterations, it should succeed
+    rdDetermineBonds.DetermineBondOrders(mol, charge=globalCharge, embedChiral=embedChiral,
+                                         maxIterations=100)
+
+    self.assertEqual(bond.GetBondType(), Chem.BondType.DOUBLE)
+
   # FIX: this is problematic...
   # def testHueckelBonds(self):
   #   testDir = os.path.join(RDConfig.RDBaseDir, 'Code', 'GraphMol', 'DetermineBonds', 'test_data',


### PR DESCRIPTION
Calling `determineBonds()` or `determineBondOrders()` on some mols may lead to an infinite loop, or at least one long enough to not make the calculation feasible or practical. This PR implements a "time out" in the form of a maximum number of iterations we'll allow the algorithm to run before throwing an exception that will stop the execution, in a similar fashion to what's implemented in CIP labeling.
