### PR TITLE
Explicitly wrap raw pointer into emscripten::val object with allow_raw_pointers() policy

### DIFF
--- a/Code/MinimalLib/jswrapper.cpp
+++ b/Code/MinimalLib/jswrapper.cpp
@@ -341,7 +341,7 @@ emscripten::val get_frags_helper(const JSMolBase &self,
                                  const std::string &details) {
   auto res = self.get_frags(details);
   auto obj = emscripten::val::object();
-  obj.set("molList", res.first);
+  obj.set("molList", emscripten::val(res.first, emscripten::allow_raw_pointers()));
   obj.set("mappings", res.second);
   return obj;
 }


### PR DESCRIPTION
This change in `emscripten`

https://github.com/emscripten-core/emscripten/pull/24175

has broken our MinimalLib build, and this PR restores it by wrapping the raw pointer into an `emscripten::val` constructed with `allow_raw_pointers()` policy.