### PR TITLE
Fixes #8284

### DIFF
--- a/Code/GraphMol/FileParsers/MultithreadedMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/MultithreadedMolSupplier.cpp
@@ -120,11 +120,14 @@ void MultithreadedMolSupplier::endThreads() {
     return;
   }
   df_forceStop = true;
-  d_readerThread.join();
 
+  // stop the writers before stopping the readers
+  //  otherwise there might be a deadlock
   for (auto &thread : d_writerThreads) {
     thread.join();
   }
+  d_readerThread.join();
+    
 }
 
 void MultithreadedMolSupplier::startThreads() {

--- a/Code/GraphMol/FileParsers/MultithreadedMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/MultithreadedMolSupplier.cpp
@@ -115,6 +115,11 @@ void MultithreadedMolSupplier::writer() {
     ++d_threadCounter;
     d_threadCounterMutex.unlock();
   } else {
+    // Here we need to unlock the threadCounterMutex before we setDone on the
+    //  outputQueue.  This causes a notification to the queue which may actually
+    //  have elements in it.  This notification may unblock the queue which
+    //  allows waiting threads to get their last attempt at adding to it
+    //  which will end up here and deadlock.
     d_threadCounterMutex.unlock();
     d_outputQueue->setDone();
   }

--- a/Code/GraphMol/FileParsers/MultithreadedMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/MultithreadedMolSupplier.cpp
@@ -79,7 +79,9 @@ void MultithreadedMolSupplier::reader() {
       }
     }
     auto r = std::make_tuple(record, lineNum, index);
-    if (!df_forceStop) d_inputQueue->push(r);
+    if (!df_forceStop) {
+      d_inputQueue->push(r);
+    }
   }
   d_inputQueue->setDone();
 }

--- a/Code/GraphMol/FileParsers/MultithreadedMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/MultithreadedMolSupplier.cpp
@@ -49,10 +49,6 @@ void MultithreadedMolSupplier::close() {
   df_started = false;
 }
     
-MultithreadedMolSupplier::~MultithreadedMolSupplier() {
-  close();
-}
-
 void MultithreadedMolSupplier::reader() {
   std::string record;
   unsigned int lineNum, index;

--- a/Code/GraphMol/FileParsers/MultithreadedMolSupplier.h
+++ b/Code/GraphMol/FileParsers/MultithreadedMolSupplier.h
@@ -97,6 +97,8 @@ class RDKIT_FILEPARSERS_EXPORT MultithreadedMolSupplier : public MolSupplier {
  protected:
   //! starts reader and writer threads
   void startThreads();
+  //! finalizes the reader and writer threads
+  void endThreads();
 
  private:
   //! reads lines from input stream to populate the input queue
@@ -104,8 +106,6 @@ class RDKIT_FILEPARSERS_EXPORT MultithreadedMolSupplier : public MolSupplier {
   //! parses lines from the input queue converting them to RWMol objects
   //! populating the output queue
   void writer();
-  //! finalizes the reader and writer threads
-  void endThreads();
   //! disable automatic copy constructors and assignment operators
   //! for this class and its subclasses.  They will likely be
   //! carrying around stream pointers and copying those is a recipe
@@ -129,6 +129,8 @@ class RDKIT_FILEPARSERS_EXPORT MultithreadedMolSupplier : public MolSupplier {
 
  protected:
   std::atomic<bool> df_started = false;
+  std::atomic<bool> df_forceStop = false;
+
   std::atomic<unsigned int> d_lastRecordId =
       0;                       //!< stores last extracted record id
   std::string d_lastItemText;  //!< stores last extracted record
@@ -147,6 +149,7 @@ class RDKIT_FILEPARSERS_EXPORT MultithreadedMolSupplier : public MolSupplier {
       writeCallback = nullptr;
   std::function<std::string(const std::string &, unsigned int)> readCallback =
       nullptr;
+
 };
 }  // namespace FileParsers
 }  // namespace v2

--- a/Code/GraphMol/FileParsers/MultithreadedMolSupplier.h
+++ b/Code/GraphMol/FileParsers/MultithreadedMolSupplier.h
@@ -133,6 +133,7 @@ class RDKIT_FILEPARSERS_EXPORT MultithreadedMolSupplier : public MolSupplier {
   virtual RWMol *processMoleculeRecord(const std::string &record,
                                        unsigned int lineNum) = 0;
 
+  std::mutex d_threadCounterMutex;
   std::atomic<unsigned int> d_threadCounter{1};  //!< thread counter
   std::vector<std::thread> d_writerThreads;      //!< vector writer threads
   std::thread d_readerThread;                    //!< single reader thread

--- a/Code/GraphMol/FileParsers/MultithreadedMolSupplier.h
+++ b/Code/GraphMol/FileParsers/MultithreadedMolSupplier.h
@@ -42,7 +42,11 @@ class RDKIT_FILEPARSERS_EXPORT MultithreadedMolSupplier : public MolSupplier {
   };
 
   MultithreadedMolSupplier() {}
-  ~MultithreadedMolSupplier() override;
+
+  
+  // Derived classes MUST have a destructor that calls close
+  //  to properly end threads while the instance is alive
+  virtual ~MultithreadedMolSupplier() {close();}
 
   //! shut down the supplier
   virtual void close() override;

--- a/Code/GraphMol/FileParsers/MultithreadedMolSupplier.h
+++ b/Code/GraphMol/FileParsers/MultithreadedMolSupplier.h
@@ -43,6 +43,9 @@ class RDKIT_FILEPARSERS_EXPORT MultithreadedMolSupplier : public MolSupplier {
 
   MultithreadedMolSupplier() {}
   ~MultithreadedMolSupplier() override;
+
+  //! shut down the supplier
+  virtual void close() override;
   //! pop elements from the output queue
   std::unique_ptr<RWMol> next() override;
 
@@ -95,6 +98,9 @@ class RDKIT_FILEPARSERS_EXPORT MultithreadedMolSupplier : public MolSupplier {
   }
 
  protected:
+  //! Close down any external streams
+  virtual void closeStreams() {}
+
   //! starts reader and writer threads
   void startThreads();
   //! finalizes the reader and writer threads

--- a/Code/GraphMol/FileParsers/MultithreadedSDMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/MultithreadedSDMolSupplier.cpp
@@ -56,18 +56,7 @@ void MultithreadedSDMolSupplier::initFromSettings(
   df_processPropertyLists = true;
 }
 
-MultithreadedSDMolSupplier::~MultithreadedSDMolSupplier() {
-  // end the threads and destroy all objects in the input queue
-  endThreads();
-    
-  d_inputQueue->clear();
-  if (df_started) {
-    std::tuple<RWMol *, std::string, unsigned int> r;
-    while (d_outputQueue->pop(r)) {
-      RWMol *m = std::get<0>(r);
-      delete m;
-    }
-  }
+void MultithreadedSDMolSupplier::closeStreams() {
   if (df_owner && dp_inStream) {
     delete dp_inStream;
     df_owner = false;

--- a/Code/GraphMol/FileParsers/MultithreadedSDMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/MultithreadedSDMolSupplier.cpp
@@ -57,11 +57,23 @@ void MultithreadedSDMolSupplier::initFromSettings(
 }
 
 MultithreadedSDMolSupplier::~MultithreadedSDMolSupplier() {
+  // end the threads and destroy all objects in the input queue
+  endThreads();
+    
+  d_inputQueue->clear();
+  if (df_started) {
+    std::tuple<RWMol *, std::string, unsigned int> r;
+    while (d_outputQueue->pop(r)) {
+      RWMol *m = std::get<0>(r);
+      delete m;
+    }
+  }
   if (df_owner && dp_inStream) {
     delete dp_inStream;
     df_owner = false;
     dp_inStream = nullptr;
   }
+  df_started = false; // this is in the base constructor
 }
 
 // ensures that there is a line available to be read

--- a/Code/GraphMol/FileParsers/MultithreadedSDMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/MultithreadedSDMolSupplier.cpp
@@ -132,6 +132,11 @@ bool MultithreadedSDMolSupplier::extractNextRecord(std::string &record,
       this->checkForEnd();
     }
   }
+
+  // ignore trailing new lines
+  if(record.find_first_not_of("\n\r") == std::string::npos)
+    return false;
+  
   index = d_currentRecordId;
   ++d_currentRecordId;
   return true;

--- a/Code/GraphMol/FileParsers/MultithreadedSDMolSupplier.h
+++ b/Code/GraphMol/FileParsers/MultithreadedSDMolSupplier.h
@@ -30,7 +30,6 @@ class RDKIT_FILEPARSERS_EXPORT MultithreadedSDMolSupplier
       const MolFileParserParams &parseParams = MolFileParserParams());
 
   MultithreadedSDMolSupplier();
-  ~MultithreadedSDMolSupplier() override;
   void init() override {}
 
   void checkForEnd();
@@ -46,6 +45,8 @@ class RDKIT_FILEPARSERS_EXPORT MultithreadedSDMolSupplier
   //! parses the record and returns the resulting molecule
   RWMol *processMoleculeRecord(const std::string &record,
                                unsigned int lineNum) override;
+ protected:
+    void closeStreams() override;
 
  private:
   void initFromSettings(bool takeOwnership, const Parameters &params,

--- a/Code/GraphMol/FileParsers/MultithreadedSDMolSupplier.h
+++ b/Code/GraphMol/FileParsers/MultithreadedSDMolSupplier.h
@@ -30,6 +30,7 @@ class RDKIT_FILEPARSERS_EXPORT MultithreadedSDMolSupplier
       const MolFileParserParams &parseParams = MolFileParserParams());
 
   MultithreadedSDMolSupplier();
+  virtual ~MultithreadedSDMolSupplier() {close();}
   void init() override {}
 
   void checkForEnd();

--- a/Code/GraphMol/FileParsers/MultithreadedSmilesMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/MultithreadedSmilesMolSupplier.cpp
@@ -39,12 +39,13 @@ MultithreadedSmilesMolSupplier::MultithreadedSmilesMolSupplier() {
   initFromSettings(true, d_params, d_parseParams);
 }
 
-MultithreadedSmilesMolSupplier::~MultithreadedSmilesMolSupplier() {
+void MultithreadedSmilesMolSupplier::closeStreams() {
   if (df_owner && dp_inStream) {
     delete dp_inStream;
     df_owner = false;
     dp_inStream = nullptr;
   }
+  df_started = false;  // this is in the base constructor
 }
 
 void MultithreadedSmilesMolSupplier::initFromSettings(

--- a/Code/GraphMol/FileParsers/MultithreadedSmilesMolSupplier.h
+++ b/Code/GraphMol/FileParsers/MultithreadedSmilesMolSupplier.h
@@ -28,6 +28,7 @@ class RDKIT_FILEPARSERS_EXPORT MultithreadedSmilesMolSupplier
       const Parameters &params = Parameters(),
       const SmilesMolSupplierParams &parseParams = SmilesMolSupplierParams());
   MultithreadedSmilesMolSupplier();
+  virtual ~MultithreadedSmilesMolSupplier() {close();};
 
   void init() override {}
   //! returns df_end

--- a/Code/GraphMol/FileParsers/MultithreadedSmilesMolSupplier.h
+++ b/Code/GraphMol/FileParsers/MultithreadedSmilesMolSupplier.h
@@ -28,7 +28,6 @@ class RDKIT_FILEPARSERS_EXPORT MultithreadedSmilesMolSupplier
       const Parameters &params = Parameters(),
       const SmilesMolSupplierParams &parseParams = SmilesMolSupplierParams());
   MultithreadedSmilesMolSupplier();
-  ~MultithreadedSmilesMolSupplier() override;
 
   void init() override {}
   //! returns df_end
@@ -41,6 +40,9 @@ class RDKIT_FILEPARSERS_EXPORT MultithreadedSmilesMolSupplier
   //! parses the record and returns the resulting molecule
   RWMol *processMoleculeRecord(const std::string &record,
                                unsigned int lineNum) override;
+
+ protected:
+  void closeStreams() override;
 
  private:
   void initFromSettings(

--- a/Code/GraphMol/FileParsers/testMultithreadedMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/testMultithreadedMolSupplier.cpp
@@ -395,6 +395,78 @@ void testPerformance() {
   }
 }
 
+void testThrowSDF() {
+  std::string rdbase = getenv("RDBASE");
+  std::string fname =
+      rdbase + "/Code/GraphMol/FileParsers/test_data/NCI_aids_few.sdf";
+  auto helper = [&fname](auto numToRead) {
+    v2::FileParsers::MultithreadedMolSupplier::Parameters params;
+    params.numWriterThreads = 3;
+    v2::FileParsers::MultithreadedSDMolSupplier multiSup(fname, params);
+    auto nRead = 0u;
+    while (!multiSup.atEnd()) {
+      std::unique_ptr<ROMol> mol{multiSup.next()};
+      ++nRead;
+      if (nRead >= numToRead) {
+        throw std::runtime_error("test");
+      }
+    }
+  };
+  bool ok = false;
+  try {
+    helper(0u);
+  } catch (const std::runtime_error &e) {
+    ok = true;
+  }
+  TEST_ASSERT(ok);
+  ok = false;
+  try {
+    helper(7u);
+  } catch (const std::runtime_error &e) {
+    ok = true;
+  }
+  TEST_ASSERT(ok);
+}
+
+void testThrowSmiles() {
+  std::string rdbase = getenv("RDBASE");
+  std::string fname =
+      rdbase + "/Code/GraphMol/FileParsers/test_data/first_200.tpsa.csv";
+  auto helper = [&fname](auto numToRead) {
+    v2::FileParsers::MultithreadedMolSupplier::Parameters params;
+    params.numWriterThreads = 3;
+    v2::FileParsers::SmilesMolSupplierParams smiParams;
+    smiParams.smilesColumn = 0;
+    smiParams.nameColumn = -1;
+    smiParams.delimiter = ",";
+    smiParams.titleLine = true;
+    v2::FileParsers::MultithreadedSmilesMolSupplier multiSup(fname, params,
+                                                             smiParams);
+    auto nRead = 0u;
+    while (!multiSup.atEnd()) {
+      std::unique_ptr<ROMol> mol{multiSup.next()};
+      ++nRead;
+      if (nRead >= numToRead) {
+        throw std::runtime_error("test");
+      }
+    }
+  };
+  bool ok = false;
+  try {
+    helper(0u);
+  } catch (const std::runtime_error &e) {
+    ok = true;
+  }
+  TEST_ASSERT(ok);
+  ok = false;
+  try {
+    helper(7u);
+  } catch (const std::runtime_error &e) {
+    ok = true;
+  }
+  TEST_ASSERT(ok);
+}
+
 int main() {
   RDLog::InitLogs();
 
@@ -408,6 +480,16 @@ int main() {
   BOOST_LOG(rdErrorLog) << "\n-----------------------------------------\n";
   testSDCorrectness();
   BOOST_LOG(rdErrorLog) << "Finished: testSDCorrectness()\n";
+  BOOST_LOG(rdErrorLog) << "-----------------------------------------\n\n";
+
+  BOOST_LOG(rdErrorLog) << "\n-----------------------------------------\n";
+  testThrowSDF();
+  BOOST_LOG(rdErrorLog) << "Finished: testThrowSDF()\n";
+  BOOST_LOG(rdErrorLog) << "-----------------------------------------\n\n";
+
+  BOOST_LOG(rdErrorLog) << "\n-----------------------------------------\n";
+  testThrowSmiles();
+  BOOST_LOG(rdErrorLog) << "Finished: testThrowSmiles()\n";
   BOOST_LOG(rdErrorLog) << "-----------------------------------------\n\n";
 
   /*

--- a/Code/GraphMol/Wrap/testMultithreadedMolSupplier.py
+++ b/Code/GraphMol/Wrap/testMultithreadedMolSupplier.py
@@ -134,7 +134,40 @@ class TestCase(unittest.TestCase):
       self.assertTrue(len(molNames) == i)
       self.assertTrue(sorted(confusedMolNames) == sorted(molNames))
 
+  def testMultiSmiMolSupplierThrow(self):
+    fileN = os.path.join(RDConfig.RDBaseDir, 'Code', 'GraphMol', 'FileParsers', 'test_data',
+                         'first_200.tpsa.csv')
+    # fileN = "../FileParsers/test_data/first_200.tpsa.csv"
+    smiSup = Chem.MultithreadedSmilesMolSupplier(fileN, ",", 0, -1)
+
+    def helper(smiSup):
+      i = 0
+      while not smiSup.atEnd():
+        mol = next(smiSup)
+        if (mol):
+          i += 1
+        if i >= 10:
+          raise ValueError('hi')
+
+    self.assertRaises(ValueError, helper, smiSup)
+
+  def testMultiSDMolSupplierThrow(self):
+    fileN = os.path.join(RDConfig.RDBaseDir, 'Code', 'GraphMol', 'FileParsers', 'test_data',
+                         'NCI_aids_few.sdf')
+    # fileN = "../FileParsers/test_data/NCI_aids_few.sdf"
+    sdSup = Chem.MultithreadedSDMolSupplier(fileN)
+
+    def helper(sdSup):
+      i = 0
+      while not sdSup.atEnd():
+        mol = next(sdSup)
+        if (mol):
+          i += 1
+        if i >= 10:
+          raise ValueError('hi')
+
+    self.assertRaises(ValueError, helper, sdSup)
+
 
 if __name__ == '__main__':
-  print("Testing Smiles and SD MultithreadedMolSupplier")
   unittest.main()

--- a/Code/RDGeneral/ConcurrentQueue.h
+++ b/Code/RDGeneral/ConcurrentQueue.h
@@ -65,6 +65,8 @@ void ConcurrentQueue<E>::push(const E &element) {
   std::unique_lock<std::mutex> lk(d_lock);
   //! concurrent queue is full so we wait until
   //! it is not full
+  if(d_done) return;
+  
   while (d_head + d_capacity == d_tail) {
     d_notFull.wait(lk);
   }


### PR DESCRIPTION
Fixes #8284 

The MultiThreadedMolSupplier wasn't properly clearing the input queue before ending threads.  This caused a deadlock in the inputQueue where a thread was blocking because the queue was full and couldn't properly end.

The solution was to add a df_forceStop atomic boolean (although we could probably reuse df_started) and to stop the readers when this is set and also stop the writers.

So the procedure is:

1. df_forceStop = true
2. pop items of the inputQueue
4. endThreads
6. now we can clear the input queue and output queue
8. finally close any input stream.

One issue is that we can't close the SDMolSupplier streams until the threads are shut down and destructors are called last to first, so we add a closeStreams protected virtual function that the base destructor can call.

As a cherry on top, we place all of this in the virtual "close" function overridden from MolSupplier since calling the base one would cause hangs and seg faults.

Testing code:

```
from rdkit import Chem

large_file = "/Users/brian/devel/rdkit/External/pubchem_shape/test_data/bulk.pubchem.sdf"
try:
    # this used to segfault
    for mol in Chem.MultithreadedSDMolSupplier("fakefile"):
        pass
except:
    pass

for mol in Chem.MultithreadedSDMolSupplier(large_file):
    break

suppl = Chem.MultithreadedSDMolSupplier(large_file)
it = iter(suppl)

next(it)
del suppl
while next(it):
    print("*",end="")

suppl = Chem.MultithreadedSDMolSupplier(large_file)
it = iter(suppl)

next(it)
asdf
```


