### PR TITLE
Support Ctrl+C in determineBondOrders

### DIFF
--- a/Code/GraphMol/DetermineBonds/DetermineBonds.cpp
+++ b/Code/GraphMol/DetermineBonds/DetermineBonds.cpp
@@ -25,6 +25,7 @@
 #include <boost/multiprecision/cpp_int.hpp>
 #include <RDGeneral/BoostEndInclude.h>
 #include <GraphMol/FileParsers/ProximityBonds.h>
+#include <RDGeneral/ControlCHandler.h>
 
 typedef boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS>
     Graph;
@@ -396,9 +397,16 @@ void determineBondOrders(RWMol &mol, int charge, bool allowChargedFragments,
   bool chargeValid = false;
   bool saturationValid = false;
 
+  ControlCHandler::reset();
+
   while (!valenceCombos.atEnd()) {
     if (--iterations == 0) {
       throw MaxFindBondOrdersItersExceeded();
+    }
+    if (ControlCHandler::getGotSignal()) {
+      BOOST_LOG(rdWarningLog)
+          << "Interrupted, cancelling determine Bond Orders" << std::endl;
+      return;
     }
 
     auto order = valenceCombos.next();

--- a/Code/GraphMol/DetermineBonds/Wrap/rdDetermineBonds.cpp
+++ b/Code/GraphMol/DetermineBonds/Wrap/rdDetermineBonds.cpp
@@ -12,6 +12,7 @@
 #include <RDBoost/python.h>
 #include <GraphMol/GraphMol.h>
 #include <RDBoost/Wrap.h>
+#include <RDGeneral/ControlCHandler.h>
 
 #include <GraphMol/DetermineBonds/DetermineBonds.h>
 
@@ -31,6 +32,10 @@ void determineBondOrdersHelper(ROMol &mol, int charge,
   auto &wmol = static_cast<RWMol &>(mol);
   determineBondOrders(wmol, charge, allowChargedFragments, embedChiral,
                       useAtomMap, maxIterations);
+  if (ControlCHandler::getGotSignal()) {
+    PyErr_SetString(PyExc_KeyboardInterrupt, "Determine Bond Orders cancelled");
+    boost::python::throw_error_already_set();
+  }
 }
 void determineBondsHelper(ROMol &mol, bool useHueckel, int charge,
                           double covFactor, bool allowChargedFragments,
@@ -39,6 +44,10 @@ void determineBondsHelper(ROMol &mol, bool useHueckel, int charge,
   auto &wmol = static_cast<RWMol &>(mol);
   determineBonds(wmol, useHueckel, charge, covFactor, allowChargedFragments,
                  embedChiral, useAtomMap, useVdw, maxIterations);
+  if (ControlCHandler::getGotSignal()) {
+    PyErr_SetString(PyExc_KeyboardInterrupt, "Determine Bond Orders cancelled");
+    boost::python::throw_error_already_set();
+  }
 }
 bool hueckelSupportEnabled() {
 #ifdef RDK_BUILD_YAEHMOP_SUPPORT

--- a/Code/GraphMol/DetermineBonds/catch_tests.cpp
+++ b/Code/GraphMol/DetermineBonds/catch_tests.cpp
@@ -563,7 +563,7 @@ TEST_CASE("test interrupt") {
     constexpr bool useAtomMap = false;
 
     // give the calculation a while to run (~12 s on my laptop)
-    // but still make sure it won'run forever
+    // but still make sure it won't run forever
     constexpr size_t maxIterations = 500000;
     determineBondOrders(*mol, charge, allowChargedFragments, embedChiral,
                         useAtomMap, maxIterations);

--- a/Code/GraphMol/DetermineBonds/catch_tests.cpp
+++ b/Code/GraphMol/DetermineBonds/catch_tests.cpp
@@ -13,6 +13,12 @@
 #include <algorithm>
 #include <GraphMol/Resonance.h>
 
+#ifdef RDK_TEST_MULTITHREADED
+#include <csignal>
+#include <thread>
+#include <chrono>
+#endif
+
 using namespace RDKit;
 
 TEST_CASE("Determine Connectivity") {
@@ -538,3 +544,39 @@ TEST_CASE("Time out in DetermineBondOrders()") {
 
   CHECK(bond->getBondType() == Bond::DOUBLE);
 }
+
+#ifdef RDK_TEST_MULTITHREADED
+
+using namespace std::chrono_literals;
+TEST_CASE("test interrupt") {
+  // I think this is entity 3 in https://www.rcsb.org/structure/1OL1
+  // it goes into a VERY long loop in determineBondOrders
+  auto mol =
+      "CC[C@H](C)[C@H](NC(=O)[C@H](CC(C)C)NC(O)[C@H](CCCNC(N)O)N[C@@H](O)[C@@H](N)CCCNC(N)O)C(=O)N[C@@H](CC1CCC(F)CC1)C(N)O"_smiles;
+  REQUIRE(mol);
+
+  // one thread for determineBondOrders
+  std::thread cgThread([&mol]() {
+    constexpr int charge = 0;
+    constexpr bool allowChargedFragments = true;
+    constexpr bool embedChiral = false;
+    constexpr bool useAtomMap = false;
+
+    // give the calculation a while to run (~12 s on my laptop)
+    // but still make sure it won'run forever
+    constexpr size_t maxIterations = 500000;
+    determineBondOrders(*mol, charge, allowChargedFragments, embedChiral,
+                        useAtomMap, maxIterations);
+  });
+  // another thread to raise SIGINT
+  std::thread interruptThread([]() {
+    // sleep for a bit to allow for a few iterations, but not enough to
+    // hit maxIterations and trigger the exception
+    std::this_thread::sleep_for(100ms);
+    std::raise(SIGINT);
+  });
+  cgThread.join();
+  interruptThread.join();
+}
+
+#endif


### PR DESCRIPTION
As requested by @DavidACosgrove  in PR #8548

