### PR TITLE
fix a problem with stereogroups involving bonds and getMolFrags()

### DIFF
--- a/Code/GraphMol/MolOps.cpp
+++ b/Code/GraphMol/MolOps.cpp
@@ -725,12 +725,19 @@ std::vector<std::unique_ptr<ROMol>> getTheFrags(
             }
           }
         }
-        // doesn't seem like this should be necessary, but in case
-        // we ever need stereogroups where the atoms aren't marked
-        // with stereo...
         for (auto stereoGroup : mol.getStereoGroups()) {
+          // doesn't seem like this should be necessary, but in case
+          // we ever need stereogroups where the atoms aren't marked
+          // with stereo...
           for (auto atom : stereoGroup.getAtoms()) {
             if (atomsInFrag[atom->getIdx()]) {
+              return true;
+            }
+          }
+          // same check for stereo groups involving bonds:
+          for (auto bond : stereoGroup.getBonds()) {
+            if (atomsInFrag[bond->getBeginAtomIdx()] &&
+                atomsInFrag[bond->getEndAtomIdx()]) {
               return true;
             }
           }
@@ -776,6 +783,7 @@ std::vector<std::unique_ptr<ROMol>> getTheFrags(
       } else {
         res.emplace_back(new RWMol(mol));
         auto &frag = res.back();
+
         frag->beginBatchEdit();
         for (unsigned int idx = 0; idx < mol.getNumAtoms(); ++idx) {
           if (!atomsInFrag[idx]) {

--- a/Code/GraphMol/RWMol.cpp
+++ b/Code/GraphMol/RWMol.cpp
@@ -606,6 +606,7 @@ void RWMol::removeBond(unsigned int aid1, unsigned int aid2) {
   dp_ringInfo->reset();
 
   removeSubstanceGroupsReferencingBond(*this, idx);
+  removeBondFromGroups(bnd, d_stereo_groups);
 
   // loop over all bonds with higher indices and update their indices
   for (auto bond : bonds()) {
@@ -613,7 +614,6 @@ void RWMol::removeBond(unsigned int aid1, unsigned int aid2) {
       bond->setIdx(bond->getIdx() - 1);
     }
   }
-  bnd->setOwningMol(nullptr);
 
   auto vd1 = boost::vertex(bnd->getBeginAtomIdx(), d_graph);
   auto vd2 = boost::vertex(bnd->getEndAtomIdx(), d_graph);
@@ -733,6 +733,8 @@ void RWMol::batchRemoveBonds() {
     }
 
     removeSubstanceGroupsReferencingBond(*this, idx);
+    // Remove this bond from any stereo group
+    removeBondFromGroups(bnd, d_stereo_groups);
 
     bnd->setOwningMol(nullptr);
 

--- a/Code/GraphMol/StereoGroup.cpp
+++ b/Code/GraphMol/StereoGroup.cpp
@@ -84,10 +84,31 @@ void removeAtomFromGroups(const Atom *atom, std::vector<StereoGroup> &groups) {
     }
   }
   // now remove any empty groups:
-  groups.erase(
-      std::remove_if(groups.begin(), groups.end(),
-                     [](const auto &gp) { return gp.getAtoms().empty() && gp.getBonds().empty(); }),
-      groups.end());
+  groups.erase(std::remove_if(groups.begin(), groups.end(),
+                              [](const auto &gp) {
+                                return gp.getAtoms().empty() &&
+                                       gp.getBonds().empty();
+                              }),
+               groups.end());
+}
+
+void removeBondFromGroups(const Bond *bond, std::vector<StereoGroup> &groups) {
+  auto findBond = [bond](StereoGroup &group) {
+    return std::find(group.getBonds().begin(), group.getBonds().end(), bond);
+  };
+  for (auto &group : groups) {
+    auto bondPos = findBond(group);
+    if (bondPos != group.d_bonds.end()) {
+      group.d_bonds.erase(bondPos);
+    }
+  }
+  // now remove any empty groups:
+  groups.erase(std::remove_if(groups.begin(), groups.end(),
+                              [](const auto &gp) {
+                                return gp.getAtoms().empty() &&
+                                       gp.getBonds().empty();
+                              }),
+               groups.end());
 }
 
 void removeGroupsWithBond(const Bond *bond, std::vector<StereoGroup> &groups) {

--- a/Code/GraphMol/StereoGroup.h
+++ b/Code/GraphMol/StereoGroup.h
@@ -85,9 +85,13 @@ class RDKIT_GRAPHMOL_EXPORT StereoGroup {
   }
   friend RDKIT_GRAPHMOL_EXPORT void removeAtomFromGroups(
       const Atom *atom, std::vector<StereoGroup> &groups);
+  friend RDKIT_GRAPHMOL_EXPORT void removeBondFromGroups(
+      const Bond *bond, std::vector<StereoGroup> &groups);
 };
 RDKIT_GRAPHMOL_EXPORT void removeAtomFromGroups(
     const Atom *atom, std::vector<StereoGroup> &groups);
+RDKIT_GRAPHMOL_EXPORT void removeBondFromGroups(
+    const Bond *bond, std::vector<StereoGroup> &groups);
 RDKIT_GRAPHMOL_EXPORT void removeGroupsWithAtom(
     const Atom *atom, std::vector<StereoGroup> &groups);
 RDKIT_GRAPHMOL_EXPORT void removeGroupsWithAtoms(

--- a/Code/GraphMol/molopstest.cpp
+++ b/Code/GraphMol/molopstest.cpp
@@ -5572,8 +5572,9 @@ void testGetMolFrags() {
                 m->getConformer(0).getAtomPos(24).z);
     delete m;
   }
-  { //confirm bond-only stereogroups are not removed during GetmolFrags
-    std::string smiles = "Cc1cccc(Cl)c1-c1c(C)cccc1I.Cc1cccc(F)c1-c1c(C)cccc1Cl |wD:8.15,wU:23.23,o1:23,&1:8|";
+  {  // confirm bond-only stereogroups are not removed during GetmolFrags
+    std::string smiles =
+        "Cc1cccc(Cl)c1-c1c(C)cccc1I.Cc1cccc(F)c1-c1c(C)cccc1Cl |wD:8.15,wU:23.23,o1:23,&1:8|";
     RWMol *m = SmilesToMol(smiles);
     TEST_ASSERT(m);
 
@@ -5581,13 +5582,23 @@ void testGetMolFrags() {
     VECT_INT_VECT fragsMolAtomMapping;
     std::vector<ROMOL_SPTR> frags =
         MolOps::getMolFrags(*m, false, &fragsMapping, &fragsMolAtomMapping);
-
     TEST_ASSERT(frags.size() == 2)
     TEST_ASSERT(fragsMapping.size() == m->getNumAtoms());
 
+    for (const auto &frag : frags) {
+      TEST_ASSERT(frag->getNumAtoms() == 16);
+      TEST_ASSERT(frag->getNumBonds() == 17);
+      TEST_ASSERT(frag->getStereoGroups().size() == 1);
+      TEST_ASSERT(frag->getStereoGroups()[0].getBonds().size() == 1);
+    }
+
     RDKit::SmilesWriteParams sps;
-    TEST_ASSERT(MolToCXSmiles(*frags[0], sps, SmilesWrite::CXSmilesFields::CX_ALL_BUT_COORDS) == "Cc1cccc(Cl)c1-c1c(C)cccc1I |wU:7.6,&1:7|");
-    TEST_ASSERT(MolToCXSmiles(*frags[1], sps, SmilesWrite::CXSmilesFields::CX_ALL_BUT_COORDS) == "Cc1cccc(F)c1-c1c(C)cccc1Cl |wU:7.6,o1:7|");
+    TEST_ASSERT(MolToCXSmiles(*frags[0], sps,
+                              SmilesWrite::CXSmilesFields::CX_ALL_BUT_COORDS) ==
+                "Cc1cccc(Cl)c1-c1c(C)cccc1I |wU:7.6,&1:7|");
+    TEST_ASSERT(MolToCXSmiles(*frags[1], sps,
+                              SmilesWrite::CXSmilesFields::CX_ALL_BUT_COORDS) ==
+                "Cc1cccc(F)c1-c1c(C)cccc1Cl |wU:7.6,o1:7|");
     delete m;
   }
   BOOST_LOG(rdInfoLog) << "Finished" << std::endl;
@@ -8719,7 +8730,6 @@ int main() {
   testGithubIssue432();
   testGithubIssue443();
   testGithubIssue447();
-  testGetMolFrags();
   testGithubIssue510();
   testGithubIssue526();
   testGithubIssue539();
@@ -8764,5 +8774,6 @@ int main() {
   testGithub5099();
   testHasQueryHs();
   testIsRingFused();
+  testGetMolFrags();
   return 0;
 }


### PR DESCRIPTION
This is a continuation of #8542: empty stereogroups involving bonds were not being correctly removed from fragments.


