### PR TITLE
Bump maeparser to 1.3.3 (fixes #8525)

### DIFF
--- a/External/CoordGen/CMakeLists.txt
+++ b/External/CoordGen/CMakeLists.txt
@@ -14,8 +14,8 @@ if(RDK_BUILD_MAEPARSER_SUPPORT OR RDK_BUILD_COORDGEN_SUPPORT)
     endif()
 
     if(NOT EXISTS "${MAEPARSER_DIR}/MaeParser.hpp")
-        set(RELEASE_NO "1.3.2")
-        set(MD5 "40777ab2eca0142f1cd29230644fcb3a")
+        set(RELEASE_NO "1.3.3")
+        set(MD5 "c43dfb89c495512f695ce018b32ac749")
         downloadAndCheckMD5("https://github.com/schrodinger/maeparser/archive/v${RELEASE_NO}.tar.gz"
               "${CMAKE_CURRENT_SOURCE_DIR}/maeparser-v${RELEASE_NO}.tar.gz" ${MD5})
         execute_process(COMMAND ${CMAKE_COMMAND} -E tar zxf


### PR DESCRIPTION
This updates the maeparser dependency to v1.3.3. The new version fixes issue #8525.