### PR TITLE
Update createStereoGroup to accept bond list

### DIFF
--- a/Code/GraphMol/Wrap/StereoGroup.cpp
+++ b/Code/GraphMol/Wrap/StereoGroup.cpp
@@ -99,7 +99,8 @@ struct stereogroup_wrap {
                 "creates a StereoGroup associated with a molecule from a list "
                 "of atom Ids",
                 (python::arg("stereoGroupType"), python::arg("mol"),
-                 python::arg("atomIds"), python::arg("readId") = 0),
+                 python::arg("atomIds"), python::arg("bondIds"),
+                 python::arg("readId") = 0),
                 python::return_value_policy<
                     python::manage_new_object,
                     python::with_custodian_and_ward_postcall<0, 2>>());

--- a/Code/GraphMol/Wrap/StereoGroup.cpp
+++ b/Code/GraphMol/Wrap/StereoGroup.cpp
@@ -49,6 +49,9 @@ StereoGroup *createStereoGroup(StereoGroupType typ, ROMol &mol,
     cppBonds.push_back(mol.getBondWithIdx(v));
     ++bbeg;
   }
+  if (cppAtoms.empty() && cppBonds.empty()) {
+    throw_value_error("New StereoGroup must contain at least one atom or bond.");
+  }
   auto *sg = new StereoGroup(typ, cppAtoms, cppBonds, readId);
   return sg;
 }

--- a/Code/GraphMol/Wrap/StereoGroup.cpp
+++ b/Code/GraphMol/Wrap/StereoGroup.cpp
@@ -99,7 +99,7 @@ struct stereogroup_wrap {
                 "creates a StereoGroup associated with a molecule from a list "
                 "of atom Ids",
                 (python::arg("stereoGroupType"), python::arg("mol"),
-                 python::arg("atomIds") = [], python::arg("bondIds") = [],
+                 python::arg("atomIds") = boost::python::list(), python::arg("bondIds") = boost::python::list(),
                  python::arg("readId") = 0),
                 python::return_value_policy<
                     python::manage_new_object,

--- a/Code/GraphMol/Wrap/StereoGroup.cpp
+++ b/Code/GraphMol/Wrap/StereoGroup.cpp
@@ -40,14 +40,14 @@ StereoGroup *createStereoGroup(StereoGroupType typ, ROMol &mol,
     cppAtoms.push_back(mol.getAtomWithIdx(v));
     ++beg;
   }
-  python::stl_input_iterator<unsigned int> beg(bondIds), end;
-  while (beg != end) {
-    unsigned int v = *beg;
+  python::stl_input_iterator<unsigned int> bbeg(bondIds), bend;
+  while (bbeg != bend) {
+    unsigned int v = *bbeg;
     if (v >= mol.getNumBonds()) {
       throw_value_error("bond index exceeds mol.GetNumBonds()");
     }
     cppBonds.push_back(mol.getBondWithIdx(v));
-    ++beg;
+    ++bbeg;
   }
   auto *sg = new StereoGroup(typ, cppAtoms, cppBonds, readId);
   return sg;

--- a/Code/GraphMol/Wrap/StereoGroup.cpp
+++ b/Code/GraphMol/Wrap/StereoGroup.cpp
@@ -28,7 +28,7 @@ std::string stereoGroupClassDoc =
     "is a mix\nof diastereomers.\n";
 
 StereoGroup *createStereoGroup(StereoGroupType typ, ROMol &mol,
-                               python::object atomIds, unsigned readId) {
+                               python::object atomIds, python::object bondIds, unsigned readId) {
   std::vector<Atom *> cppAtoms;
   std::vector<Bond *> cppBonds;
   python::stl_input_iterator<unsigned int> beg(atomIds), end;
@@ -38,6 +38,15 @@ StereoGroup *createStereoGroup(StereoGroupType typ, ROMol &mol,
       throw_value_error("atom index exceeds mol.GetNumAtoms()");
     }
     cppAtoms.push_back(mol.getAtomWithIdx(v));
+    ++beg;
+  }
+  python::stl_input_iterator<unsigned int> beg(bondIds), end;
+  while (beg != end) {
+    unsigned int v = *beg;
+    if (v >= mol.getNumBonds()) {
+      throw_value_error("bond index exceeds mol.GetNumBonds()");
+    }
+    cppBonds.push_back(mol.getBondWithIdx(v));
     ++beg;
   }
   auto *sg = new StereoGroup(typ, cppAtoms, cppBonds, readId);

--- a/Code/GraphMol/Wrap/StereoGroup.cpp
+++ b/Code/GraphMol/Wrap/StereoGroup.cpp
@@ -99,7 +99,7 @@ struct stereogroup_wrap {
                 "creates a StereoGroup associated with a molecule from a list "
                 "of atom Ids",
                 (python::arg("stereoGroupType"), python::arg("mol"),
-                 python::arg("atomIds"), python::arg("bondIds"),
+                 python::arg("atomIds") = [], python::arg("bondIds") = [],
                  python::arg("readId") = 0),
                 python::return_value_policy<
                     python::manage_new_object,

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -5596,7 +5596,7 @@ M  END
     self.assertEqual(len(groups), 0)
 
     # Can add new bond-only StereoGroups
-    group1 = Chem.rdchem.CreateStereoGroup(Chem.rdchem.StereoGroupType.STEREO_ABS, m2, [], [7])
+    group1 = Chem.rdchem.CreateStereoGroup(Chem.rdchem.StereoGroupType.STEREO_ABSOLUTE, m2, [], [7])
     m2.SetStereoGroups([group1])
     self.assertEqual(len(m2.GetStereoGroups()), 1)
 
@@ -5608,7 +5608,7 @@ M  END
     self.assertEqual(len(groups), 0)
 
     # Can add new atom&bond StereoGroup
-    group1 = Chem.rdchem.CreateStereoGroup(Chem.rdchem.StereoGroupType.STEREO_ABS, m2, [13], [7])
+    group1 = Chem.rdchem.CreateStereoGroup(Chem.rdchem.StereoGroupType.STEREO_ABSOLUTE, m2, [13], [7])
     m2.SetStereoGroups([group1])
     self.assertEqual(len(m2.GetStereoGroups()), 1)
 

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -5588,6 +5588,30 @@ M  END
     m2.SetStereoGroups([group1])
     self.assertEqual(len(m2.GetStereoGroups()), 1)
 
+    #test creation of bond-only stereogroup
+    m = Chem.MolFromSmiles('Cc1cccc(F)c1-c1c(C)cc([C@H](C)O)cc1Cl |wU:7.7|')
+    m2 = Chem.RWMol(m)
+
+    groups = m2.GetStereoGroups()
+    self.assertEqual(len(groups), 0)
+
+    # Can add new bond-only StereoGroups
+    group1 = Chem.rdchem.CreateStereoGroup(Chem.rdchem.StereoGroupType.STEREO_ABS, m2, [], [7])
+    m2.SetStereoGroups([group1])
+    self.assertEqual(len(m2.GetStereoGroups()), 1)
+
+    #test creation of bond&atom stereogroup
+    m = Chem.MolFromSmiles('Cc1cccc(F)c1-c1c(C)cc([C@H](C)O)cc1Cl |wU:7.7|')
+    m2 = Chem.RWMol(m)
+
+    groups = m2.GetStereoGroups()
+    self.assertEqual(len(groups), 0)
+
+    # Can add new atom&bond StereoGroup
+    group1 = Chem.rdchem.CreateStereoGroup(Chem.rdchem.StereoGroupType.STEREO_ABS, m2, [13], [7])
+    m2.SetStereoGroups([group1])
+    self.assertEqual(len(m2.GetStereoGroups()), 1)
+
   def testSetEnhancedStereoGroupOwnershipCheck(self):
     # make sure that the object returned by CreateStereoGroup()
     # preserves the owning molecule:

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -5595,6 +5595,15 @@ M  END
     groups = m2.GetStereoGroups()
     self.assertEqual(len(groups), 0)
 
+    #Creating new StereoGroup with no atoms or bonds should not be allowed
+    try:
+      group1 = Chem.rdchem.CreateStereoGroup(Chem.rdchem.StereoGroupType.STEREO_ABSOLUTE, m2, [], [])
+    except ValueError:
+      ok = 1
+    else:
+      ok = 0
+    self.assertTrue(ok)
+      
     # Can add new bond-only StereoGroups
     group1 = Chem.rdchem.CreateStereoGroup(Chem.rdchem.StereoGroupType.STEREO_ABSOLUTE, m2, [], [7])
     m2.SetStereoGroups([group1])


### PR DESCRIPTION
Fixes #8584 

Currently, there is no way to create a StereoGroup that is bond-only, or contains bonds. I added a bond list to the createStereoGroup function to enable this.


