### PR TITLE
Make assignCIPLabels Ctrl+c interruptable

### DIFF
--- a/Code/GraphMol/CIPLabeler/Wrap/rdCIPLabeler.cpp
+++ b/Code/GraphMol/CIPLabeler/Wrap/rdCIPLabeler.cpp
@@ -16,6 +16,7 @@
 #include <GraphMol/RDKitBase.h>
 #include <GraphMol/CIPLabeler/CIPLabeler.h>
 #include <GraphMol/FileParsers/FileParsers.h>
+#include "RDGeneral/ControlCHandler.h"
 
 namespace python = boost::python;
 using RDKit::CIPLabeler::assignCIPLabels;
@@ -41,6 +42,10 @@ void assignCIPLabelsWrapHelper(RDKit::ROMol &mol,
   }
 
   assignCIPLabels(mol, atoms, bonds, maxRecursiveIterations);
+  if (RDKit::ControlCHandler::getGotSignal()) {
+    PyErr_SetString(PyExc_KeyboardInterrupt, "Assign CIP labels cancelled");
+    boost::python::throw_error_already_set();
+  }
 }
 
 BOOST_PYTHON_MODULE(rdCIPLabeler) {

--- a/Code/GraphMol/CIPLabeler/rules/SequenceRule.cpp
+++ b/Code/GraphMol/CIPLabeler/rules/SequenceRule.cpp
@@ -8,6 +8,7 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
+#include "RDGeneral/ControlCHandler.h"
 
 #include "SequenceRule.h"
 
@@ -51,6 +52,9 @@ const Sort *SequenceRule::getSorter() const {
 int SequenceRule::recursiveCompare(const Edge *a, const Edge *b) const {
   if (!CIPLabeler_detail::decrementRemainingCallCountAndCheck()) {
     throw MaxIterationsExceeded();
+  }
+  if (ControlCHandler::getGotSignal()) {
+    throw ControlCCaught();
   }
 
   int cmp = compare(a, b);

--- a/Code/RDGeneral/ControlCHandler.h
+++ b/Code/RDGeneral/ControlCHandler.h
@@ -17,6 +17,13 @@
 #include <RDGeneral/export.h>
 
 namespace RDKit {
+
+class ControlCCaught : public std::runtime_error {
+ public:
+  explicit ControlCCaught()
+      : std::runtime_error("The process was interrupted with Ctrl+c"){};
+};
+
 //! This class catches a control-C/SIGINT and sets the flag d_gotSignal
 //! if one is received.  It is intended to be used inside a long
 //! C++ calculation called from Python which intercepts the signal

--- a/Code/RDGeneral/ControlCHandler.h
+++ b/Code/RDGeneral/ControlCHandler.h
@@ -13,6 +13,7 @@
 
 #include <atomic>
 #include <csignal>
+#include <stdexcept>
 
 #include <RDGeneral/export.h>
 
@@ -21,7 +22,7 @@ namespace RDKit {
 class ControlCCaught : public std::runtime_error {
  public:
   explicit ControlCCaught()
-      : std::runtime_error("The process was interrupted with Ctrl+c"){};
+      : std::runtime_error("The process was interrupted with Ctrl+c") {};
 };
 
 //! This class catches a control-C/SIGINT and sets the flag d_gotSignal


### PR DESCRIPTION
This allows interrupting `assignCIPLabels`, which is nice if you forgot passing a value for `maxRecursiveIterations`.