### PR TITLE
Replacing core GraphMol data structures with RDMol

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -496,7 +496,7 @@ if (RDK_TEST_COVERAGE)
  message("")
 
  INCLUDE(CodeCoverage)
- SET(CMAKE_CXX_FLAGS "-g -O0 -fprofile-arcs -ftest-coverage")
+ SET(CMAKE_CXX_FLAGS "-g -O0 -fprofile-arcs -ftest-coverage -wno-return-type")
  SET(CMAKE_C_FLAGS "-g -O0 -fprofile-arcs -ftest-coverage")
  message("== setup_target_for_coverage(${PROJECT_NAME}_coverage test coverage)")
  setup_target_for_coverage(${PROJECT_NAME}_coverage ctest coverage)

--- a/Code/GraphMol/Atom.cpp
+++ b/Code/GraphMol/Atom.cpp
@@ -10,6 +10,7 @@
 #include <cmath>
 
 #include "ROMol.h"
+#include "RDMol.h"
 #include "Atom.h"
 #include "PeriodicTable.h"
 #include "SanitException.h"
@@ -20,9 +21,24 @@
 #include <RDGeneral/RDLog.h>
 #include <RDGeneral/types.h>
 #include <RDGeneral/Dict.h>
+#include <GraphMol/rdmol_throw.h>
 
 namespace RDKit {
 
+bool isAromaticAtom(ConstRDMolAtom atom) {
+  if (atom.data().getIsAromatic()) {
+    return true;
+  }
+  auto [begin, end] = atom.mol().getAtomBonds(atom.index());
+  for (; begin != end; ++begin) {
+    const auto &bond = atom.mol().getBond(*begin);
+    if (bond.getIsAromatic() ||
+        bond.getBondType() == Bond::BondType::AROMATIC) {
+      return true;
+    }
+  }
+  return false;
+}
 bool isAromaticAtom(const Atom &atom) {
   if (atom.getIsAromatic()) {
     return true;
@@ -179,46 +195,21 @@ bool isEarlyAtom(int atomicNum) {
   return ((unsigned int)atomicNum < 119) && table[atomicNum];
 }
 
-Atom::Atom() : RDProps() {
-  d_atomicNum = 0;
-  initAtom();
+Atom::Atom() {
+  dp_dataMol = new RDMol();
+  dp_dataMol->addAtom();
+  dp_owningMol = nullptr;
 }
 
-Atom::Atom(unsigned int num) : RDProps() {
-  d_atomicNum = num;
-  initAtom();
+Atom::Atom(unsigned int num): Atom() { setAtomicNum(num); }
+
+Atom::Atom(const std::string &what) : Atom() {
+  setAtomicNum(PeriodicTable::getTable()->getAtomicNumber(what));
 };
 
-Atom::Atom(const std::string &what) : RDProps() {
-  d_atomicNum = PeriodicTable::getTable()->getAtomicNumber(what);
-  initAtom();
-};
-
-void Atom::initFromOther(const Atom &other) {
-  RDProps::operator=(other);
-  // NOTE: we do *not* copy ownership!
-  dp_mol = nullptr;
-  d_atomicNum = other.d_atomicNum;
-  d_index = 0;
-  d_formalCharge = other.d_formalCharge;
-  df_noImplicit = other.df_noImplicit;
-  df_isAromatic = other.df_isAromatic;
-  d_numExplicitHs = other.d_numExplicitHs;
-  d_numRadicalElectrons = other.d_numRadicalElectrons;
-  d_isotope = other.d_isotope;
-  // d_pos = other.d_pos;
-  d_chiralTag = other.d_chiralTag;
-  d_hybrid = other.d_hybrid;
-  d_implicitValence = other.d_implicitValence;
-  d_explicitValence = other.d_explicitValence;
-  if (other.dp_monomerInfo) {
-    dp_monomerInfo = other.dp_monomerInfo->copy();
-  } else {
-    dp_monomerInfo = nullptr;
-  }
+Atom::Atom(const Atom &other): Atom() {
+  initFromOther(other);
 }
-
-Atom::Atom(const Atom &other) : RDProps() { initFromOther(other); }
 
 Atom &Atom::operator=(const Atom &other) {
   if (this == &other) {
@@ -228,426 +219,284 @@ Atom &Atom::operator=(const Atom &other) {
   return *this;
 }
 
-void Atom::initAtom() {
-  df_isAromatic = false;
-  df_noImplicit = false;
-  d_numExplicitHs = 0;
-  d_numRadicalElectrons = 0;
-  d_formalCharge = 0;
-  d_index = 0;
-  d_isotope = 0;
-  d_chiralTag = CHI_UNSPECIFIED;
-  d_hybrid = UNSPECIFIED;
-  dp_mol = nullptr;
-  dp_monomerInfo = nullptr;
-
-  d_implicitValence = -1;
-  d_explicitValence = -1;
+Atom::Atom(Atom &&other) {
+  dp_dataMol = other.dp_dataMol;
+  dp_owningMol = other.dp_owningMol;
+  d_index = other.d_index;
+  other.dp_dataMol = nullptr;
+  other.dp_owningMol = nullptr;
+  other.d_index = 0;
 }
 
-Atom::~Atom() { delete dp_monomerInfo; }
+Atom &Atom::operator=(Atom &&other) {
+  if (this == &other) {
+    return *this;
+  }
+  if (dp_dataMol != dp_owningMol) {
+    delete dp_dataMol;
+  }
+  dp_dataMol = other.dp_dataMol;
+  dp_owningMol = other.dp_owningMol;
+  d_index = other.d_index;
+  other.dp_dataMol = nullptr;
+  other.dp_owningMol = nullptr;
+  return *this;
+}
+
+void Atom::initFromOther(const Atom &other, const bool preserveProps) {
+  dp_dataMol->getAtom(d_index) = other.dp_dataMol->getAtom(other.d_index);
+  if (!preserveProps) {
+    dp_dataMol->clearSingleAtomAllProps(d_index);
+    for (auto it = other.dp_dataMol->beginProps(true, RDMol::Scope::ATOM,
+                                                other.d_index),
+              end = other.dp_dataMol->endProps();
+         it != end; ++it) {
+      dp_dataMol->copySingleProp(*it, d_index, *other.dp_dataMol, *it,
+                                 other.d_index, RDMol::Scope::ATOM);
+    }
+  }
+  const auto &otherMonomerInfo = other.dp_dataMol->monomerInfo;
+  if (auto it = otherMonomerInfo.find(other.d_index); it != otherMonomerInfo.end()) {
+    AtomMonomerInfo* monomerInfo = it->second.get();
+    auto monomerInfoCopy = std::unique_ptr<AtomMonomerInfo>(monomerInfo->copy());
+    dp_dataMol->monomerInfo[d_index] = std::move(monomerInfoCopy);
+  } else {
+    // If the atom doesn't have monomer info, remove it from the copy. Useful in
+    // the case of replacement, where atomMonomerInfo should now not exist.
+    dp_dataMol->monomerInfo.erase(d_index);
+  }
+}
+
+Atom::~Atom() {
+  if (dp_dataMol != dp_owningMol) {
+    delete dp_dataMol;
+  }
+}
 
 Atom *Atom::copy() const {
   auto *res = new Atom(*this);
   return res;
 }
 
-void Atom::setOwningMol(ROMol *other) {
-  // NOTE: this operation does not update the topology of the owning
-  // molecule (i.e. this atom is not added to the graph).  Only
-  // molecules can add atoms to themselves.
-  dp_mol = other;
+int Atom::getAtomicNum() const {
+  return dp_dataMol->getAtom(d_index).getAtomicNum();
 }
-
+void Atom::setAtomicNum(int newNum) {
+  dp_dataMol->getAtom(d_index).setAtomicNum(newNum);
+}
 std::string Atom::getSymbol() const {
-  std::string res;
-  // handle dummies differently:
-  if (d_atomicNum != 0 ||
-      !getPropIfPresent<std::string>(common_properties::dummyLabel, res)) {
-    res = PeriodicTable::getTable()->getElementSymbol(d_atomicNum);
+  int atomicNum = getAtomicNum();
+  if (atomicNum == 0) {
+    // handle dummies differently:
+    std::string res;
+    dp_dataMol->getAtomPropIfPresent<std::string>(
+        common_properties::dummyLabelToken, d_index, res);
+    return res;
   }
-  return res;
+  return PeriodicTable::getTable()->getElementSymbol(atomicNum);
 }
-
+ROMol &Atom::getOwningMol() const {
+  PRECONDITION(dp_owningMol != nullptr, "no owner");
+  return dp_owningMol->asROMol();
+}
 unsigned int Atom::getDegree() const {
-  return dp_mol ? getOwningMol().getAtomDegree(this) : 0;
+  return dp_owningMol ? dp_owningMol->getAtomDegree(d_index) : 0;
 }
-
 unsigned int Atom::getTotalDegree() const {
-  unsigned int res = this->getTotalNumHs(false) + this->getDegree();
-  return res;
+  return getTotalNumHs(false) + getDegree();
 }
-
-//
-//  If includeNeighbors is set, we'll loop over our neighbors
-//   and include any of them that are Hs in the count here
-//
 unsigned int Atom::getTotalNumHs(bool includeNeighbors) const {
-  int res = getNumExplicitHs() + getNumImplicitHs();
-  if (includeNeighbors && dp_mol) {
-    auto nbrs = dp_mol->atomNeighbors(this);
-    res += std::count_if(nbrs.begin(), nbrs.end(), [](const auto nbr) {
-      return (nbr->getAtomicNum() == 1);
-    });
-  }
-  return res;
+  // Support for isolated Atoms by using data mol, instead of owning mol.
+  return dp_dataMol->getTotalNumHs(d_index, includeNeighbors);
 }
-
+unsigned int Atom::getTotalValence() const {
+  return getExplicitValence() + getImplicitValence();
+}
 unsigned int Atom::getNumImplicitHs() const {
-  if (df_noImplicit) {
-    return 0;
-  }
-
-  PRECONDITION(d_implicitValence > -1,
-               "getNumImplicitHs() called without preceding call to "
-               "calcImplicitValence()");
-  return getValence(ValenceType::IMPLICIT);
-}
-
-int Atom::getExplicitValence() const {
-  return getValence(ValenceType::EXPLICIT);
-}
-
-int Atom::getImplicitValence() const {
-  return getValence(ValenceType::IMPLICIT);
+  return dp_dataMol->getAtom(d_index).getNumImplicitHs();
 }
 
 unsigned int Atom::getValence(ValenceType which) const {
-  if (!dp_mol) {
+  if (!dp_owningMol) {
     return 0;
   }
-  PRECONDITION(
-      (which == ValenceType::IMPLICIT || d_explicitValence > -1),
-      "getValence(ValenceType::EXPLICIT) called without call to calcExplicitValence()");
-  PRECONDITION(
-      (which == ValenceType::EXPLICIT || df_noImplicit ||
-       d_implicitValence > -1),
-      "getValence(ValenceType::IMPLICIT) called without call to calcImplicitValence()");
-  if (which == ValenceType::EXPLICIT) {
-    return d_explicitValence;
-  } else {
-    return df_noImplicit ? 0 : d_implicitValence;
-  }
+  const uint32_t valence = dp_dataMol->getAtom(d_index).getValence(which);
+  return valence == AtomData::unsetValenceVal ? (unsigned int)-1 : valence;
 }
 
-unsigned int Atom::getTotalValence() const {
-  return getValence(ValenceType::EXPLICIT) + getValence(ValenceType::IMPLICIT);
+int Atom::getExplicitValence() const {
+  const uint32_t explicitValence =
+      dp_dataMol->getAtom(d_index).getExplicitValence();
+  return explicitValence == AtomData::unsetValenceVal ? -1 : explicitValence;
 }
-
-namespace {
-
-bool canBeHypervalent(const Atom &atom, unsigned int effectiveAtomicNum) {
-  return (effectiveAtomicNum > 16 &&
-          (atom.getAtomicNum() == 15 || atom.getAtomicNum() == 16)) ||
-         (effectiveAtomicNum > 34 &&
-          (atom.getAtomicNum() == 33 || atom.getAtomicNum() == 34));
+int Atom::getImplicitValence() const {
+  // RDMol returns a uint32_t, but we want to return -1 for the default value
+  const uint32_t implicitValence =
+      dp_dataMol->getAtom(d_index).getImplicitValence();
+  return implicitValence == AtomData::unsetValenceVal ? -1 : implicitValence;
 }
-
-int calculateExplicitValence(const Atom &atom, bool strict, bool checkIt) {
-  // FIX: contributions of bonds to valence are being done at best
-  // approximately
-  double accum = 0;
-  for (const auto bnd : atom.getOwningMol().atomBonds(&atom)) {
-    accum += bnd->getValenceContrib(&atom);
-  }
-  accum += atom.getNumExplicitHs();
-
-  const auto &ovalens =
-      PeriodicTable::getTable()->getValenceList(atom.getAtomicNum());
-  // if we start with an atom that doesn't have specified valences, we stick
-  // with that. otherwise we will use the effective valence
-  unsigned int effectiveAtomicNum = atom.getAtomicNum();
-  if (ovalens.size() > 1 || ovalens[0] != -1) {
-    effectiveAtomicNum = getEffectiveAtomicNum(atom, checkIt);
-  }
-  unsigned int dv =
-      PeriodicTable::getTable()->getDefaultValence(effectiveAtomicNum);
-  const auto &valens =
-      PeriodicTable::getTable()->getValenceList(effectiveAtomicNum);
-  if (accum > dv && isAromaticAtom(atom)) {
-    // this needs some explanation : if the atom is aromatic and
-    // accum > dv we assume that no hydrogen can be added
-    // to this atom.  We set x = (v + chr) such that x is the
-    // closest possible integer to "accum" but less than
-    // "accum".
-    //
-    // "v" here is one of the allowed valences. For example:
-    //    sulfur here : O=c1ccs(=O)cc1
-    //    nitrogen here : c1cccn1C
-
-    int pval = dv;
-    for (auto val : valens) {
-      if (val == -1) {
-        break;
-      }
-      if (val > accum) {
-        break;
-      } else {
-        pval = val;
-      }
-    }
-    // if we're within 1.5 of the allowed valence, go ahead and take it.
-    // this reflects things like the N in c1cccn1C, which starts with
-    // accum of 4, but which can be kekulized to C1=CC=CN1C, where
-    // the valence is 3 or the bridging N in c1ccn2cncc2c1, which starts
-    // with a valence of 4.5, but can be happily kekulized down to a valence
-    // of 3
-    if (accum - pval <= 1.5) {
-      accum = pval;
-    }
-  }
-  // despite promising to not to blame it on him - this a trick Greg
-  // came up with: if we have a bond order sum of x.5 (i.e. 1.5, 2.5
-  // etc) we would like it to round to the higher integer value --
-  // 2.5 to 3 instead of 2 -- so we will add 0.1 to accum.
-  // this plays a role in the number of hydrogen that are implicitly
-  // added. This will only happen when the accum is a non-integer
-  // value and less than the default valence (otherwise the above if
-  // statement should have caught it). An example of where this can
-  // happen is the following smiles:
-  //    C1ccccC1
-  // Daylight accepts this smiles and we should be able to Kekulize
-  // correctly.
-  accum += 0.1;
-
-  auto res = static_cast<int>(std::round(accum));
-
-  if (strict || checkIt) {
-    int maxValence = valens.back();
-    int offset = 0;
-    // we have to include a special case here for negatively charged P, S, As,
-    // and Se, which all support "hypervalent" forms, but which can be
-    // isoelectronic to Cl/Ar or Br/Kr, which do not support hypervalent forms.
-    if (canBeHypervalent(atom, effectiveAtomicNum)) {
-      maxValence = ovalens.back();
-      offset -= atom.getFormalCharge();
-    }
-    // we have historically accepted two-coordinate [H-] as a valid atom. This
-    // is highly questionable, but changing it requires some thought. For now we
-    // will just keep accepting it
-    if (atom.getAtomicNum() == 1 && atom.getFormalCharge() == -1) {
-      maxValence = 2;
-    }
-    // maxValence == -1 signifies that we'll take anything at the high end
-    if (maxValence >= 0 && ovalens.back() >= 0 && (res + offset) > maxValence) {
-      // the explicit valence is greater than any
-      // allowed valence for the atoms
-
-      if (strict) {
-        // raise an error
-        std::ostringstream errout;
-        errout << "Explicit valence for atom # " << atom.getIdx() << " "
-               << PeriodicTable::getTable()->getElementSymbol(
-                      atom.getAtomicNum())
-               << ", " << res << ", is greater than permitted";
-        std::string msg = errout.str();
-        BOOST_LOG(rdErrorLog) << msg << std::endl;
-        throw AtomValenceException(msg, atom.getIdx());
-      } else {
-        return -1;
-      }
-    }
-  }
-  return res;
+unsigned int Atom::getNumRadicalElectrons() const {
+  return dp_dataMol->getAtom(d_index).getNumRadicalElectrons();
 }
-}  // namespace
-
-// NOTE: this uses the explicitValence, so it will call
-// calculateExplicitValence if it is not set on the given atom
-int calculateImplicitValence(const Atom &atom, bool strict, bool checkIt) {
-  if (atom.df_noImplicit) {
-    return 0;
-  }
-  auto explicitValence = atom.d_explicitValence;
-  if (explicitValence == -1) {
-    explicitValence = calculateExplicitValence(atom, strict, checkIt);
-  }
-  // special cases
-  auto atomicNum = atom.d_atomicNum;
-  if (atomicNum == 0) {
-    return 0;
-  }
-  for (const auto bnd : atom.getOwningMol().atomBonds(&atom)) {
-    if (QueryOps::hasComplexBondTypeQuery(*bnd)) {
-      return 0;
-    }
-  }
-
-  auto formalCharge = atom.d_formalCharge;
-  auto numRadicalElectrons = atom.d_numRadicalElectrons;
-  if (explicitValence == 0 && numRadicalElectrons == 0 && atomicNum == 1) {
-    if (formalCharge == 1 || formalCharge == -1) {
-      return 0;
-    } else if (formalCharge == 0) {
-      return 1;
-    } else {
-      if (strict) {
-        std::ostringstream errout;
-        errout << "Unreasonable formal charge on atom # " << atom.getIdx()
-               << ".";
-        std::string msg = errout.str();
-        BOOST_LOG(rdErrorLog) << msg << std::endl;
-        throw AtomValenceException(msg, atom.getIdx());
-      } else if (checkIt) {
-        return -1;
-      } else {
-        return 0;
-      }
-    }
-  }
-  int explicitPlusRadV = atom.d_explicitValence + atom.d_numRadicalElectrons;
-
-  const auto &ovalens =
-      PeriodicTable::getTable()->getValenceList(atom.d_atomicNum);
-  // if we start with an atom that doesn't have specified valences, we stick
-  // with that. otherwise we will use the effective valence for the rest of
-  // this.
-  unsigned int effectiveAtomicNum = atom.d_atomicNum;
-  if (ovalens.size() > 1 || ovalens[0] != -1) {
-    effectiveAtomicNum = getEffectiveAtomicNum(atom, checkIt);
-  }
-  if (effectiveAtomicNum == 0) {
-    return 0;
-  }
-
-  // this is basically the difference between the allowed valence of
-  // the atom and the explicit valence already specified - tells how
-  // many Hs to add
-  //
-
-  // The d-block and f-block of the periodic table (i.e. transition metals,
-  // lanthanoids and actinoids) have no default valence.
-  int dv = PeriodicTable::getTable()->getDefaultValence(effectiveAtomicNum);
-  if (dv == -1) {
-    return 0;
-  }
-
-  // here is how we are going to deal with the possibility of
-  // multiple valences
-  // - check the explicit valence "ev"
-  // - if it is already equal to one of the allowed valences for the
-  //    atom return 0
-  // - otherwise take return difference between next larger allowed
-  //   valence and "ev"
-  // if "ev" is greater than all allowed valences for the atom raise an
-  // exception
-  // finally aromatic cases are dealt with differently - these atoms are allowed
-  // only default valences
-
-  // we have to include a special case here for negatively charged P, S, As,
-  // and Se, which all support "hypervalent" forms, but which can be
-  // isoelectronic to Cl/Ar or Br/Kr, which do not support hypervalent forms.
-  if (canBeHypervalent(atom, effectiveAtomicNum)) {
-    effectiveAtomicNum = atomicNum;
-    explicitPlusRadV -= atom.d_formalCharge;
-  }
-  const auto &valens =
-      PeriodicTable::getTable()->getValenceList(effectiveAtomicNum);
-
-  int res = 0;
-  // if we have an aromatic case treat it differently
-  if (isAromaticAtom(atom)) {
-    if (explicitPlusRadV <= dv) {
-      res = dv - explicitPlusRadV;
-    } else {
-      // As we assume when finding the explicitPlusRadValence if we are
-      // aromatic we should not be adding any hydrogen and already
-      // be at an accepted valence state,
-
-      // FIX: this is just ERROR checking and probably moot - the
-      // explicitPlusRadValence function called above should assure us that
-      // we satisfy one of the accepted valence states for the
-      // atom. The only diff I can think of is in the way we handle
-      // formal charge here vs the explicit valence function.
-      bool satis = false;
-      for (auto vi = valens.begin(); vi != valens.end() && *vi > 0; ++vi) {
-        if (explicitPlusRadV == *vi) {
-          satis = true;
-          break;
-        }
-      }
-      if (!satis && (strict || checkIt)) {
-        if (strict) {
-          std::ostringstream errout;
-          errout << "Explicit valence for aromatic atom # " << atom.getIdx()
-                 << " not equal to any accepted valence\n";
-          std::string msg = errout.str();
-          BOOST_LOG(rdErrorLog) << msg << std::endl;
-          throw AtomValenceException(msg, atom.getIdx());
-        } else {
-          return -1;
-        }
-      }
-      res = 0;
-    }
-  } else {
-    // non-aromatic case we are allowed to have non default valences
-    // and be able to add hydrogens
-    res = -1;
-    for (auto vi = valens.begin(); vi != valens.end() && *vi >= 0; ++vi) {
-      int tot = *vi;
-      if (explicitPlusRadV <= tot) {
-        res = tot - explicitPlusRadV;
-        break;
-      }
-    }
-    if (res < 0) {
-      if ((strict || checkIt) && valens.back() != -1 && ovalens.back() > 0) {
-        // this means that the explicit valence is greater than any
-        // allowed valence for the atoms
-        if (strict) {
-          // raise an error
-          std::ostringstream errout;
-          errout << "Explicit valence for atom # " << atom.getIdx() << " "
-                 << PeriodicTable::getTable()->getElementSymbol(atomicNum)
-                 << " greater than permitted";
-          std::string msg = errout.str();
-          BOOST_LOG(rdErrorLog) << msg << std::endl;
-          throw AtomValenceException(msg, atom.getIdx());
-        } else {
-          return -1;
-        }
-      } else {
-        res = 0;
-      }
-    }
-  }
-  return res;
+void Atom::setNumRadicalElectrons(unsigned int num) {
+  dp_dataMol->getAtom(d_index).setNumRadicalElectrons(num);
 }
-
-int Atom::calcExplicitValence(bool strict) {
-  bool checkIt = false;
-  d_explicitValence = calculateExplicitValence(*this, strict, checkIt);
-  return d_explicitValence;
+int Atom::getFormalCharge() const {
+  return dp_dataMol->getAtom(d_index).getFormalCharge();
 }
-
-int Atom::calcImplicitValence(bool strict) {
-  if (d_explicitValence == -1) {
-    calcExplicitValence(strict);
-  }
-  bool checkIt = false;
-  d_implicitValence = calculateImplicitValence(*this, strict, checkIt);
-  return d_implicitValence;
+void Atom::setFormalCharge(int what) {
+  dp_dataMol->getAtom(d_index).setFormalCharge(what);
 }
-
-void Atom::setMonomerInfo(AtomMonomerInfo *info) {
-  delete dp_monomerInfo;
-  dp_monomerInfo = info;
+void Atom::setNoImplicit(bool what) {
+  dp_dataMol->getAtom(d_index).setNoImplicit(what);
 }
-
-void Atom::setIsotope(unsigned int what) { d_isotope = what; }
-
+bool Atom::getNoImplicit() const {
+  return dp_dataMol->getAtom(d_index).getNoImplicit();
+}
+void Atom::setNumExplicitHs(unsigned int what) {
+  dp_dataMol->getAtom(d_index).setNumExplicitHs(what);
+}
+unsigned int Atom::getNumExplicitHs() const {
+  return dp_dataMol->getAtom(d_index).getNumExplicitHs();
+}
+void Atom::setIsAromatic(bool what) {
+  dp_dataMol->getAtom(d_index).setIsAromatic(what);
+}
+bool Atom::getIsAromatic() const {
+  return dp_dataMol->getAtom(d_index).getIsAromatic();
+}
 double Atom::getMass() const {
-  if (d_isotope) {
-    double res =
-        PeriodicTable::getTable()->getMassForIsotope(d_atomicNum, d_isotope);
-    if (d_atomicNum != 0 && res == 0.0) {
-      res = d_isotope;
+  return dp_dataMol->getAtom(d_index).getMass();
+}
+void Atom::setIsotope(unsigned int what) {
+  dp_dataMol->getAtom(d_index).setIsotope(what);
+}
+unsigned int Atom::getIsotope() const {
+  return dp_dataMol->getAtom(d_index).getIsotope();
+}
+void Atom::setChiralTag(ChiralType what) {
+  dp_dataMol->getAtom(d_index).setChiralTag(
+      static_cast<RDKit::AtomEnums::ChiralType>(what));
+}
+bool Atom::invertChirality() {
+  return dp_dataMol->invertAtomChirality(d_index);
+}
+Atom::ChiralType Atom::getChiralTag() const {
+  return static_cast<ChiralType>(dp_dataMol->getAtom(d_index).getChiralTag());
+}
+void Atom::setHybridization(HybridizationType what) {
+  dp_dataMol->getAtom(d_index).setHybridization(
+      static_cast<RDKit::AtomEnums::HybridizationType>(what));
+}
+Atom::HybridizationType Atom::getHybridization() const {
+  return static_cast<HybridizationType>(
+      dp_dataMol->getAtom(d_index).getHybridization());
+}
+
+void Atom::setQuery(QUERYATOM_QUERY* what) {
+  //  Atoms don't have complex queries so this has to fail
+  PRECONDITION(0, "plain atoms have no Query");
+}
+Atom::QUERYATOM_QUERY* Atom::getQuery() const { return nullptr; }
+void Atom::expandQuery(
+    QUERYATOM_QUERY* what,
+    Queries::CompositeQueryType how,
+    bool maintainOrder) {
+  PRECONDITION(0, "plain atoms have no Query");
+}
+bool Atom::Match(Atom const* what) const {
+  PRECONDITION(what, "bad query atom");
+  bool res = getAtomicNum() == what->getAtomicNum();
+
+  // special dummy--dummy match case:
+  //   [*] matches [*],[1*],[2*],etc.
+  //   [1*] only matches [*] and [1*]
+  if (res) {
+    if (hasOwningMol() && what->hasOwningMol() &&
+        this->getOwningMol().getRingInfo()->isInitialized() &&
+        what->getOwningMol().getRingInfo()->isInitialized() &&
+        this->getOwningMol().getRingInfo()->numAtomRings(d_index) >
+            what->getOwningMol().getRingInfo()->numAtomRings(what->d_index)) {
+      res = false;
+    } else if (!this->getAtomicNum()) {
+      // this is the new behavior, based on the isotopes:
+      int tgt = this->getIsotope();
+      int test = what->getIsotope();
+      if (tgt && test && tgt != test) {
+        res = false;
+      }
+    } else {
+      // standard atom-atom match: The general rule here is that if this atom
+      // has a property that
+      // deviates from the default, then the other atom should match that value.
+      if ((this->getFormalCharge() &&
+           this->getFormalCharge() != what->getFormalCharge()) ||
+          (this->getIsotope() && this->getIsotope() != what->getIsotope()) ||
+          (this->getNumRadicalElectrons() &&
+           this->getNumRadicalElectrons() != what->getNumRadicalElectrons())) {
+        res = false;
+      }
     }
-    return res;
-  } else {
-    return PeriodicTable::getTable()->getAtomicWeight(d_atomicNum);
   }
+  return res;
+}
+int Atom::getPerturbationOrder(const INT_LIST &probe) const {
+  PRECONDITION(
+      dp_owningMol != nullptr,
+      "perturbation order not defined for atoms not associated with molecules");
+  const size_t numBonds = dp_owningMol->getAtomDegree(d_index);
+  PRECONDITION(numBonds == probe.size(), "size mismatch");
+
+  auto [beginBonds, endBonds] = dp_owningMol->getAtomBonds(d_index);
+
+  std::vector<int> copy(probe.begin(), probe.end());
+
+  // The bond list on the atom should be sorted, but check just in case.
+  bool isSorted = true;
+  for (size_t i = 0; numBonds > 0 && i < numBonds - 1; ++i) {
+    isSorted = isSorted && (beginBonds[i] < beginBonds[i + 1]);
+  }
+
+  if (isSorted) {
+    // This is effectively selection sort, which minimizes the number of swaps,
+    // so we can just count the number of swaps here.
+    int nSwaps = 0;
+    for (size_t desti = 0, n = copy.size(); desti < n; ++desti) {
+      size_t besti = desti;
+      for (size_t srci = desti + 1; srci < n; ++srci) {
+        if (copy[srci] < copy[besti]) {
+          besti = srci;
+        }
+      }
+      if (besti != desti) {
+        ++nSwaps;
+        std::swap(copy[besti], copy[desti]);
+      }
+    }
+    return nSwaps;
+  }
+
+  std::vector<int> bondsCopy(beginBonds, endBonds);
+  int nSwaps = static_cast<int>(countSwapsToInterconvert(bondsCopy, copy));
+  return nSwaps;
+}
+void Atom::updatePropertyCache(bool strict) {
+  calcExplicitValence(strict);
+  calcImplicitValence(strict);
+}
+
+bool Atom::needsUpdatePropertyCache() const {
+  return dp_dataMol->getAtom(d_index).needsUpdatePropertyCache();
+}
+int Atom::calcExplicitValence(bool strict) {
+  PRECONDITION(dp_owningMol,
+               "calcExplicitValence requires an owning molecule");
+  return dp_owningMol->calcExplicitValence(d_index, strict);
+}
+int Atom::calcImplicitValence(bool strict) {
+  PRECONDITION(dp_owningMol,
+               "calcImplicitValence requires an owning molecule");
+  return dp_owningMol->calcImplicitValence(d_index, strict);
 }
 
 bool Atom::hasValenceViolation() const {
@@ -677,7 +526,7 @@ bool Atom::hasValenceViolation() const {
     //   1. the formal charge is larger than the atomic number
     //   2. the formal charge moves us to a different row of the periodic table
     if (getFormalCharge() > getAtomicNum() ||
-        PeriodicTable::getTable()->getRow(d_atomicNum) !=
+        PeriodicTable::getTable()->getRow(getAtomicNum()) !=
             PeriodicTable::getTable()->getRow(effectiveAtomicNum)) {
       return true;
     }
@@ -685,244 +534,88 @@ bool Atom::hasValenceViolation() const {
 
   bool strict = false;
   bool checkIt = true;
-  if (calculateExplicitValence(*this, strict, checkIt) == -1 ||
-      calculateImplicitValence(*this, strict, checkIt) == -1) {
+  try {
+    dp_dataMol->calcExplicitValence(getIdx(), /*strict=*/true);
+    dp_dataMol->calcImplicitValence(getIdx(), /*strict=*/true);
+  } catch (AtomValenceException) {
     return true;
   }
   return false;
 }
 
-void Atom::setQuery(Atom::QUERYATOM_QUERY *) {
-  //  Atoms don't have complex queries so this has to fail
-  PRECONDITION(0, "plain atoms have no Query");
+int Atom::getExplicitValencePrivate() const {
+  PRECONDITION(dp_dataMol,
+               "valence not defined for atoms not associated with molecules");
+  return dp_dataMol->getAtom(d_index).explicitValence;
 }
-Atom::QUERYATOM_QUERY *Atom::getQuery() const { return nullptr; };
-void Atom::expandQuery(Atom::QUERYATOM_QUERY *, Queries::CompositeQueryType,
-                       bool) {
-  PRECONDITION(0, "plain atoms have no Query");
-}
-
-bool Atom::Match(Atom const *what) const {
-  PRECONDITION(what, "bad query atom");
-  bool res = getAtomicNum() == what->getAtomicNum();
-
-  // special dummy--dummy match case:
-  //   [*] matches [*],[1*],[2*],etc.
-  //   [1*] only matches [*] and [1*]
-  if (res) {
-    if (!this->getAtomicNum()) {
-      // this is the new behavior, based on the isotopes:
-      int tgt = this->getIsotope();
-      int test = what->getIsotope();
-      if (tgt && test && tgt != test) {
-        res = false;
-      }
-    } else {
-      // standard atom-atom match: The general rule here is that if this atom
-      // has a property that
-      // deviates from the default, then the other atom should match that value.
-      if ((this->getFormalCharge() &&
-           this->getFormalCharge() != what->getFormalCharge()) ||
-          (this->getIsotope() && this->getIsotope() != what->getIsotope()) ||
-          (this->getNumRadicalElectrons() &&
-           this->getNumRadicalElectrons() != what->getNumRadicalElectrons())) {
-        res = false;
-      }
-    }
-  }
-  return res;
-}
-void Atom::updatePropertyCache(bool strict) {
-  calcExplicitValence(strict);
-  calcImplicitValence(strict);
+int Atom::getImplicitValencePrivate() const {
+  PRECONDITION(dp_dataMol,
+               "valence not defined for atoms not associated with molecules");
+  return dp_dataMol->getAtom(d_index).implicitValence;
 }
 
-bool Atom::needsUpdatePropertyCache() const {
-  return !(this->d_explicitValence >= 0 &&
-           (this->df_noImplicit || this->d_implicitValence >= 0));
-}
-
-// returns the number of swaps required to convert the ordering
-// of the probe list to match the order of our incoming bonds:
-//
-//  e.g. if our incoming bond order is: [0,1,2,3]:
-//   getPerturbationOrder([1,0,2,3]) = 1
-//   getPerturbationOrder([1,2,3,0]) = 3
-//   getPerturbationOrder([1,2,0,3]) = 2
-int Atom::getPerturbationOrder(const INT_LIST &probe) const {
-  INT_LIST ref;
-  for (const auto bnd : getOwningMol().atomBonds(this)) {
-    ref.push_back(bnd->getIdx());
-  }
-  return static_cast<int>(countSwapsToInterconvert(probe, ref));
-}
-
-static const unsigned char octahedral_invert[31] = {
-    0,   //  0 -> 0
-    2,   //  1 -> 2
-    1,   //  2 -> 1
-    16,  //  3 -> 16
-    14,  //  4 -> 14
-    15,  //  5 -> 15
-    18,  //  6 -> 18
-    17,  //  7 -> 17
-    10,  //  8 -> 10
-    11,  //  9 -> 11
-    8,   // 10 -> 8
-    9,   // 11 -> 9
-    13,  // 12 -> 13
-    12,  // 13 -> 12
-    4,   // 14 -> 4
-    5,   // 15 -> 5
-    3,   // 16 -> 3
-    7,   // 17 -> 7
-    6,   // 18 -> 6
-    24,  // 19 -> 24
-    23,  // 20 -> 23
-    22,  // 21 -> 22
-    21,  // 22 -> 21
-    20,  // 23 -> 20
-    19,  // 24 -> 19
-    30,  // 25 -> 30
-    29,  // 26 -> 29
-    28,  // 27 -> 28
-    27,  // 28 -> 27
-    26,  // 29 -> 26
-    25   // 30 -> 25
-};
-
-static const unsigned char trigonalbipyramidal_invert[21] = {
-    0,   //  0 -> 0
-    2,   //  1 -> 2
-    1,   //  2 -> 1
-    4,   //  3 -> 4
-    3,   //  4 -> 3
-    6,   //  5 -> 6
-    5,   //  6 -> 5
-    8,   //  7 -> 8
-    7,   //  8 -> 7
-    11,  //  9 -> 11
-    12,  // 10 -> 12
-    9,   // 11 -> 9
-    10,  // 12 -> 10
-    14,  // 13 -> 14
-    13,  // 14 -> 13
-    20,  // 15 -> 20
-    19,  // 16 -> 19
-    18,  // 17 -> 28
-    17,  // 18 -> 17
-    16,  // 19 -> 16
-    15   // 20 -> 15
-};
-
-bool Atom::invertChirality() {
-  unsigned int perm;
-  switch (getChiralTag()) {
-    case CHI_TETRAHEDRAL_CW:
-      setChiralTag(CHI_TETRAHEDRAL_CCW);
-      return true;
-    case CHI_TETRAHEDRAL_CCW:
-      setChiralTag(CHI_TETRAHEDRAL_CW);
-      return true;
-    case CHI_TETRAHEDRAL:
-      if (getPropIfPresent(common_properties::_chiralPermutation, perm)) {
-        if (perm == 1) {
-          perm = 2;
-        } else if (perm == 2) {
-          perm = 1;
-        } else {
-          perm = 0;
-        }
-        setProp(common_properties::_chiralPermutation, perm);
-        return perm != 0;
-      }
-      break;
-    case CHI_TRIGONALBIPYRAMIDAL:
-      if (getPropIfPresent(common_properties::_chiralPermutation, perm)) {
-        perm = (perm <= 20) ? trigonalbipyramidal_invert[perm] : 0;
-        setProp(common_properties::_chiralPermutation, perm);
-        return perm != 0;
-      }
-      break;
-    case CHI_OCTAHEDRAL:
-      if (getPropIfPresent(common_properties::_chiralPermutation, perm)) {
-        perm = (perm <= 30) ? octahedral_invert[perm] : 0;
-        setProp(common_properties::_chiralPermutation, perm);
-        return perm != 0;
-      }
-      break;
-    default:
-      break;
-  }
-  return false;
-}
-
-void setAtomRLabel(Atom *atm, int rlabel) {
-  PRECONDITION(atm, "bad atom");
+void setAtomRLabel(Atom *atom, int rlabel) {
+  PRECONDITION(atom, "bad atom");
   // rlabel ==> n2 => 0..99
   PRECONDITION(rlabel >= 0 && rlabel < 100,
                "rlabel out of range for MDL files");
-  if (rlabel) {
-    atm->setProp(common_properties::_MolFileRLabel,
-                 static_cast<unsigned int>(rlabel));
-  } else {
-    atm->clearProp(common_properties::_MolFileRLabel);
+  uint32_t *prop = atom->getRDMol().getAtomPropArrayIfPresent<uint32_t>(
+        common_properties::_MolFileRLabelToken);
+  // Default of zero indicates no RLabel
+  if (rlabel != 0 && prop == nullptr) {
+    prop = atom->getRDMol().addAtomProp<uint32_t>(common_properties::_MolFileRLabelToken, 0);
+  } else if (prop != nullptr) {
+    // TODO: Consider removing prop if will now be all zeros
+  }
+  if (prop != nullptr) {
+    prop[atom->getIdx()] = static_cast<uint32_t>(rlabel);
   }
 }
 //! Gets the atom's RLabel
 int getAtomRLabel(const Atom *atom) {
   PRECONDITION(atom, "bad atom");
-  unsigned int rlabel = 0;
-  atom->getPropIfPresent(common_properties::_MolFileRLabel, rlabel);
-  return static_cast<int>(rlabel);
+  const uint32_t *prop =
+      atom->getDataRDMol().getAtomPropArrayIfPresent<uint32_t>(
+      common_properties::_MolFileRLabelToken);
+  return (prop != nullptr) ? prop[atom->getIdx()] : 0;
+}
+
+void setAtomStringProp(Atom* atom, const PropToken& token, const std::string& value) {
+  PRECONDITION(atom, "bad atom");
+  atom->getDataRDMol().setSingleAtomProp<PropToken>(token, atom->getIdx(),
+                                                    PropToken(value), false, true);
+}
+
+std::string getAtomStringProp(const Atom* atom, const PropToken& token) {
+  PRECONDITION(atom, "bad atom");
+  PropToken prop;
+  bool found = atom->getDataRDMol().getAtomPropIfPresent<PropToken>(
+      token, atom->getIdx(), prop);
+  return found ? prop.getString() : std::string();
 }
 
 void setAtomAlias(Atom *atom, const std::string &alias) {
-  PRECONDITION(atom, "bad atom");
-  if (alias != "") {
-    atom->setProp(common_properties::molFileAlias, alias);
-  } else {
-    atom->clearProp(common_properties::molFileAlias);
-  }
+  setAtomStringProp(atom, common_properties::molFileAliasToken, alias);
 }
 
 std::string getAtomAlias(const Atom *atom) {
-  PRECONDITION(atom, "bad atom");
-  std::string alias;
-  atom->getPropIfPresent(common_properties::molFileAlias, alias);
-  return alias;
+  return getAtomStringProp(atom, common_properties::molFileAliasToken);
 }
 
 void setAtomValue(Atom *atom, const std::string &value) {
-  PRECONDITION(atom, "bad atom");
-  if (value != "") {
-    atom->setProp(common_properties::molFileValue, value);
-  } else {
-    atom->clearProp(common_properties::molFileValue);
-  }
+  setAtomStringProp(atom, common_properties::molFileValueToken, value);
 }
 
 std::string getAtomValue(const Atom *atom) {
-  PRECONDITION(atom, "bad atom");
-  std::string value;
-  atom->getPropIfPresent(common_properties::molFileValue, value);
-  return value;
+  return getAtomStringProp(atom, common_properties::molFileValueToken);
 }
 
 void setSupplementalSmilesLabel(Atom *atom, const std::string &label) {
-  PRECONDITION(atom, "bad atom");
-  if (label != "") {
-    atom->setProp(common_properties::_supplementalSmilesLabel, label);
-  } else {
-    atom->clearProp(common_properties::_supplementalSmilesLabel);
-  }
+  setAtomStringProp(atom, common_properties::_supplementalSmilesLabelToken, label);
 }
 
 std::string getSupplementalSmilesLabel(const Atom *atom) {
-  PRECONDITION(atom, "bad atom");
-  std::string label;
-  atom->getPropIfPresent(common_properties::_supplementalSmilesLabel, label);
-  return label;
+  return getAtomStringProp(atom, common_properties::_supplementalSmilesLabelToken);
 }
 
 unsigned int numPiElectrons(const Atom &atom) {
@@ -1001,14 +694,16 @@ std::ostream &operator<<(std::ostream &target, const RDKit::Atom &at) {
   target << " chg: " << at.getFormalCharge();
   target << "  deg: " << at.getDegree();
   target << " exp: ";
-  target << (at.d_explicitValence >= 0 ? std::to_string(at.d_explicitValence)
+  target << (at.getExplicitValencePrivate() >= 0
+                 ? std::to_string(at.getExplicitValencePrivate())
                                        : "N/A");
 
   target << " imp: ";
-  if (at.df_noImplicit) {
+  if (at.getNoImplicit()) {
     target << "0";
   } else {
-    target << (at.d_implicitValence >= 0 ? std::to_string(at.d_implicitValence)
+    target << (at.getImplicitValencePrivate() >= 0
+                   ? std::to_string(at.getImplicitValencePrivate())
                                          : "N/A");
   }
   target << " hyb: " << hybridizationToString(at.getHybridization());
@@ -1048,3 +743,109 @@ std::ostream &operator<<(std::ostream &target, const RDKit::Atom &at) {
   }
   return target;
 };
+
+namespace RDKit {
+
+AtomMonomerInfo * Atom::getMonomerInfo() {
+  auto found = dp_dataMol->monomerInfo.find(d_index);
+  if (found != dp_dataMol->monomerInfo.end()) {
+    return found->second.get();
+  }
+  return nullptr;
+}
+
+const AtomMonomerInfo * Atom::getMonomerInfo() const {
+  const auto found = dp_dataMol->monomerInfo.find(d_index);
+  if (found != dp_dataMol->monomerInfo.end()) {
+    return found->second.get();
+  }
+  return nullptr;
+}
+
+void Atom::setMonomerInfo(AtomMonomerInfo *info) {
+  dp_dataMol->monomerInfo[d_index].reset(info);
+}
+
+void Atom::setAtomMapNum(int mapno, bool strict) {
+  PRECONDITION(
+      !strict || (mapno >= 0 && mapno < 1000),
+      "atom map number out of range [0..1000], use strict=false to override");
+  const uint32_t idx = getIdx();
+  if (mapno != 0) {
+    dp_dataMol->setSingleAtomProp(common_properties::molAtomMapNumberToken, idx, mapno, false, true);
+  } else if (dp_dataMol->hasAtomProp(common_properties::molAtomMapNumberToken, idx)) {
+    dp_dataMol->clearSingleAtomProp(common_properties::molAtomMapNumberToken, idx);
+  }
+}
+
+int Atom::getAtomMapNum() const {
+  int mapno = 0;
+  dp_dataMol->getAtomPropIfPresent(common_properties::molAtomMapNumberToken,
+                                   getIdx(), mapno);
+  return mapno;
+}
+
+STR_VECT Atom::getPropList(bool includePrivate, bool includeComputed) const {
+  return dp_dataMol->getPropList(includePrivate, includeComputed,
+                                 RDMol::Scope::ATOM, d_index);
+}
+
+
+bool Atom::hasProp(const std::string &key) const {
+  return dp_dataMol->hasAtomProp(PropToken(key), getIdx());
+}
+
+void Atom::clearProp(const std::string &key) const {
+  dp_dataMol->clearSingleAtomProp(PropToken(key), getIdx());
+}
+
+void Atom::clearComputedProps() const {
+  dp_dataMol->clearSingleAtomAllProps(getIdx(), true);
+}
+
+void Atom::updateProps(const RDProps &source, bool preserveExisting) {
+  if (!preserveExisting) {
+    clear();
+  }
+  std::vector<std::string> computedPropList;
+  source.getPropIfPresent<std::vector<std::string>>(
+      RDKit::detail::computedPropName, computedPropList);
+  const STR_VECT keys = source.getPropList();
+  for (const auto &key : keys) {
+    if (key == RDKit::detail::computedPropName) {
+      continue;
+    }
+    const RDValue &val = source.getPropRDValue(key);
+    bool isComputed =
+        std::find(computedPropList.begin(), computedPropList.end(), key) !=
+        computedPropList.end();
+    getDataRDMol().setSingleAtomProp(PropToken(key), getIdx(), val, isComputed, true);
+  }
+}
+
+void Atom::updateProps(const Atom &source, bool preserveExisting) {
+  if (!preserveExisting) {
+    clear();
+  }
+  for (auto it = source.dp_dataMol->beginProps(true, RDMol::Scope::ATOM,
+                                               source.d_index),
+            end = source.dp_dataMol->endProps();
+       it != end; ++it) {
+    dp_dataMol->copySingleProp(*it, d_index, *source.dp_dataMol, *it,
+                               source.d_index, RDMol::Scope::ATOM);
+  }
+}
+
+void Atom::clear() { dp_dataMol->clearSingleAtomAllProps(getIdx(), false); }
+
+void Atom::setOwningMol(ROMol *other) {
+  setOwningMol(&other->asRDMol());
+}
+
+void Atom::setOwningMol(RDKit::RDMol *other) {
+  PRECONDITION(dp_owningMol == nullptr || dp_owningMol == other,
+               "setOwningMol called twice");
+  dp_owningMol = other;
+}
+
+}  // namespace RDKit

--- a/Code/GraphMol/Atom.h
+++ b/Code/GraphMol/Atom.h
@@ -25,6 +25,9 @@
 #include <RDGeneral/types.h>
 #include <RDGeneral/RDProps.h>
 #include <GraphMol/details.h>
+#include <GraphMol/RDMol.h>
+#include <GraphMol/rdmol_throw.h>
+#include "GraphMolEnums.h"
 
 namespace RDKit {
 class Atom;
@@ -37,6 +40,7 @@ namespace RDKit {
 class ROMol;
 class RWMol;
 class AtomMonomerInfo;
+class ConstRDMolAtom;
 
 //! The class for representing atoms
 /*!
@@ -72,49 +76,80 @@ class AtomMonomerInfo;
   at the *end* of the list of other bonds.
 
 */
-class RDKIT_GRAPHMOL_EXPORT Atom : public RDProps {
-  friend class MolPickler;  //!< the pickler needs access to our privates
+class RDKIT_GRAPHMOL_EXPORT Atom {
+  friend class RDMol;
   friend class ROMol;
   friend class RWMol;
-  friend std::ostream &(::operator<<)(std::ostream &target,
-                                      const ::RDKit::Atom &at);
-  friend int calculateImplicitValence(const Atom &, bool, bool);
+  friend class MolPickler;
+  friend std::ostream &(::operator<<)(std::ostream &target, const Atom &at);
+
+  // When an atom is created on its own, it owns dp_dataMol to store its data
+  // and dp_owningMol is nullptr. Calling setOwningMol will set dp_owningMol,
+  // but as before, this does not actually insert the Atom's data into the
+  // owning RDMol, so dp_dataMol will continue keeping the data until
+  // ROMol::addAtom copies the data and frees dp_dataMol, setting dp_dataMol
+  // to be equal to dp_owningMol, to indicate that dp_dataMol is no longer
+  // owned by this Atom, and setting d_index accordingly.
+  //
+  // The 3 states are:
+  // 1) dp_owningMol == nullptr: dp_dataMol owned by this & no owning mol
+  // 2) else if dp_dataMol != dp_owningMol: dp_dataMol owned by this
+  // 3) dp_dataMol == dp_owningMol: dp_owningMol owns this
+  //
+  // This is necessary for compatibility with previous workflows that would
+  // call setOwningMol and separately ROMol::addAtom.
+  RDMol *dp_dataMol = nullptr;
+  RDMol *dp_owningMol = nullptr;
+  atomindex_t d_index = 0;
+
+ protected:
+  Atom(RDMol *mol, atomindex_t atomIndex)
+      : dp_dataMol(mol), dp_owningMol(mol), d_index(atomIndex) {}
 
  public:
   // FIX: grn...
   typedef Queries::Query<int, Atom const *, true> QUERYATOM_QUERY;
+  //typedef Queries::Query<int, ConstRDMolAtom, true> QUERYATOM_QUERY;
 
   //! store hybridization
-  typedef enum {
-    UNSPECIFIED = 0,  //!< hybridization that hasn't been specified
-    S,
-    SP,
-    SP2,
-    SP3,
-    SP2D,
-    SP3D,
-    SP3D2,
-    OTHER  //!< unrecognized hybridization
-  } HybridizationType;
+  enum HybridizationType {
+    //!< hybridization that hasn't been specified
+    UNSPECIFIED = AtomEnums::HybridizationType::UNSPECIFIED,
+    S = AtomEnums::HybridizationType::S,
+    SP = AtomEnums::HybridizationType::SP,
+    SP2 = AtomEnums::HybridizationType::SP2,
+    SP3 = AtomEnums::HybridizationType::SP3,
+    SP2D = AtomEnums::HybridizationType::SP2D,
+    SP3D = AtomEnums::HybridizationType::SP3D,
+    SP3D2 = AtomEnums::HybridizationType::SP3D2,
+    OTHER = AtomEnums::HybridizationType::OTHER //!< unrecognized hybridization
+  };
 
   //! store type of chirality
-  typedef enum {
-    CHI_UNSPECIFIED = 0,  //!< chirality that hasn't been specified
-    CHI_TETRAHEDRAL_CW,   //!< tetrahedral: clockwise rotation (SMILES \@\@)
-    CHI_TETRAHEDRAL_CCW,  //!< tetrahedral: counter-clockwise rotation (SMILES
-                          //\@)
-    CHI_OTHER,            //!< some unrecognized type of chirality
-    CHI_TETRAHEDRAL,      //!< tetrahedral, use permutation flag
-    CHI_ALLENE,           //!< allene, use permutation flag
-    CHI_SQUAREPLANAR,     //!< square planar, use permutation flag
-    CHI_TRIGONALBIPYRAMIDAL,  //!< trigonal bipyramidal, use permutation flag
-    CHI_OCTAHEDRAL            //!< octahedral, use permutation flag
-  } ChiralType;
-
-  enum class ValenceType : std::uint8_t {
-    IMPLICIT = 0,
-    EXPLICIT
+  enum ChiralType {
+    //!< chirality that hasn't been specified
+    CHI_UNSPECIFIED = AtomEnums::ChiralType::CHI_UNSPECIFIED,
+    //!< tetrahedral: clockwise rotation (SMILES \@\@)
+    CHI_TETRAHEDRAL_CW = AtomEnums::ChiralType::CHI_TETRAHEDRAL_CW,
+    //!< tetrahedral: counter-clockwise rotation (SMILES \@)
+    CHI_TETRAHEDRAL_CCW = AtomEnums::ChiralType::CHI_TETRAHEDRAL_CCW,
+    //!< some unrecognized type of chirality
+    CHI_OTHER = AtomEnums::ChiralType::CHI_OTHER,
+    //!< tetrahedral, use permutation flag
+    CHI_TETRAHEDRAL = AtomEnums::ChiralType::CHI_TETRAHEDRAL,
+    //!< allene, use permutation flag
+    CHI_ALLENE = AtomEnums::ChiralType::CHI_ALLENE,
+    //!< square planar, use permutation flag
+    CHI_SQUAREPLANAR = AtomEnums::ChiralType::CHI_SQUAREPLANAR,
+    //!< trigonal bipyramidal, use permutation flag
+    CHI_TRIGONALBIPYRAMIDAL = AtomEnums::ChiralType::CHI_TRIGONALBIPYRAMIDAL,
+    //!< octahedral, use permutation flag
+    CHI_OCTAHEDRAL = AtomEnums::ChiralType::CHI_OCTAHEDRAL
   };
+
+  // A "using" statement works for ValenceType, because it's an enum class,
+  // so needs ValenceType::IMPLICIT instead of just IMPLICIT, for example.
+  using ValenceType = AtomData::ValenceType;
 
   Atom();
   //! construct an Atom with a particular atomic number
@@ -126,8 +161,12 @@ class RDKIT_GRAPHMOL_EXPORT Atom : public RDProps {
   Atom &operator=(const Atom &other);
   // NOTE: the move methods are somewhat fraught for atoms associated with
   // molecules since the molecule will still be pointing to the original object
-  Atom(Atom &&other) = default;
-  Atom &operator=(Atom &&other) = default;
+  Atom(Atom && other);
+  Atom& operator=(Atom&& other);
+
+ private:
+  void initFromOther(const Atom &other, bool preserveProps = false);
+ public:
 
   virtual ~Atom();
 
@@ -137,26 +176,58 @@ class RDKIT_GRAPHMOL_EXPORT Atom : public RDProps {
   */
   virtual Atom *copy() const;
 
+  //! makes a copy of this Atom and returns a pointer to it.
+  //! FIXME: Should this be private or deleted?
+  /*!
+    <b>Note:</b> the caller is responsible for <tt>delete</tt>ing the result
+  */
+  //virtual Atom *copy() const;
+
   //! returns our atomic number
-  int getAtomicNum() const { return d_atomicNum; }
+  int getAtomicNum() const;
   //! sets our atomic number
-  void setAtomicNum(int newNum) { d_atomicNum = newNum; }
+  void setAtomicNum(int newNum);
 
   //! returns our symbol (determined by our atomic number)
   std::string getSymbol() const;
 
   //! returns whether or not this instance belongs to a molecule
-  bool hasOwningMol() const { return dp_mol != nullptr; }
+  bool hasOwningMol() const { return dp_owningMol != nullptr; }
 
   //! returns a reference to the ROMol that owns this instance
-  ROMol &getOwningMol() const {
-    PRECONDITION(dp_mol, "no owner");
-    return *dp_mol;
+  ROMol &getOwningMol() const;
+
+  //! returns a reference to the RDMol that owns this instance
+  const RDMol &getRDMol() const {
+    PRECONDITION(dp_owningMol, "no owner");
+    return *dp_owningMol;
   }
+  //! overload
+  RDMol &getRDMol() {
+    PRECONDITION(dp_owningMol, "no owner");
+    return *dp_owningMol;
+  }
+
+ protected:
+  //! returns a reference to the RDMol that contains the data for this atom,
+  //! for internal use only
+  const RDMol &getDataRDMol() const {
+    return *dp_dataMol;
+  }
+  //! overload
+  RDMol &getDataRDMol() {
+    return *dp_dataMol;
+  }
+  friend int getAtomRLabel(const Atom *atom);
+  friend std::string getAtomStringProp(const Atom *atom, const PropToken &token);
+  friend void setAtomStringProp(Atom *atom, const PropToken &token,
+                                const std::string &value);
+ public:
 
   //! returns our index within the ROMol
   unsigned int getIdx() const { return d_index; }
   //! sets our index within the ROMol
+  //! FIXME: Should this be private or deleted?
   /*!
     <b>Notes:</b>
       - this makes no sense if we do not have an owning molecule
@@ -164,10 +235,12 @@ class RDKIT_GRAPHMOL_EXPORT Atom : public RDProps {
   */
   void setIdx(unsigned int index) { d_index = index; }
   //! overload
+  //! FIXME: Should this be private or deleted?
   template <class U>
   void setIdx(const U index) {
     setIdx(rdcast<unsigned int>(index));
   }
+
   //! returns the explicit degree of the Atom (number of bonded
   //!   neighbors in the graph)
   unsigned int getDegree() const;
@@ -191,38 +264,40 @@ class RDKIT_GRAPHMOL_EXPORT Atom : public RDProps {
   unsigned int getValence(ValenceType which) const;
 
   //! returns the explicit valence (including Hs) of this atom
-  [[deprecated("please use getValence(true)")]] int getExplicitValence() const;
+  [[deprecated("please use getValence(ValenceType::EXPLICIT)")]]
+  int getExplicitValence() const;
 
   //! returns the implicit valence for this Atom
-  [[deprecated("please use getValence(false)")]] int getImplicitValence() const;
+  [[deprecated("please use getValence(ValenceType::IMPLICIT)")]]
+  int getImplicitValence() const;
 
   //! returns whether the atom has a valency violation or not
   bool hasValenceViolation() const;
 
   //! returns the number of radical electrons for this Atom
-  unsigned int getNumRadicalElectrons() const { return d_numRadicalElectrons; }
-  void setNumRadicalElectrons(unsigned int num) { d_numRadicalElectrons = num; }
+  unsigned int getNumRadicalElectrons() const;
+  void setNumRadicalElectrons(unsigned int num);
 
   //! returns the formal charge of this atom
-  int getFormalCharge() const { return d_formalCharge; }
+  int getFormalCharge() const;
   //! set's the formal charge of this atom
-  void setFormalCharge(int what) { d_formalCharge = what; }
+  void setFormalCharge(int what);
 
   //! \brief sets our \c noImplicit flag, indicating whether or not
   //!  we are allowed to have implicit Hs
-  void setNoImplicit(bool what) { df_noImplicit = what; }
+  void setNoImplicit(bool what);
   //! returns the \c noImplicit flag
-  bool getNoImplicit() const { return df_noImplicit; }
+  bool getNoImplicit() const;
 
   //! sets our number of explicit Hs
-  void setNumExplicitHs(unsigned int what) { d_numExplicitHs = what; }
+  void setNumExplicitHs(unsigned int what);
   //! returns our number of explicit Hs
-  unsigned int getNumExplicitHs() const { return d_numExplicitHs; }
+  unsigned int getNumExplicitHs() const;
 
   //! sets our \c isAromatic flag, indicating whether or not we are aromatic
-  void setIsAromatic(bool what) { df_isAromatic = what; }
+  void setIsAromatic(bool what);
   //! returns our \c isAromatic flag
-  bool getIsAromatic() const { return df_isAromatic; }
+  bool getIsAromatic() const;
 
   //! returns our mass
   double getMass() const;
@@ -230,23 +305,19 @@ class RDKIT_GRAPHMOL_EXPORT Atom : public RDProps {
   //! sets our isotope number
   void setIsotope(unsigned int what);
   //! returns our isotope number
-  unsigned int getIsotope() const { return d_isotope; }
+  unsigned int getIsotope() const;
 
   //! sets our \c chiralTag
-  void setChiralTag(ChiralType what) { d_chiralTag = what; }
+  void setChiralTag(ChiralType what);
   //! inverts our \c chiralTag, returns whether or not a change was made
   bool invertChirality();
   //! returns our \c chiralTag
-  ChiralType getChiralTag() const {
-    return static_cast<ChiralType>(d_chiralTag);
-  }
+  ChiralType getChiralTag() const;
 
   //! sets our hybridization
-  void setHybridization(HybridizationType what) { d_hybrid = what; }
+  void setHybridization(HybridizationType what);
   //! returns our hybridization
-  HybridizationType getHybridization() const {
-    return static_cast<HybridizationType>(d_hybrid);
-  }
+  HybridizationType getHybridization() const;
 
   // ------------------------------------
   // Some words of explanation before getting down into
@@ -360,62 +431,157 @@ class RDKIT_GRAPHMOL_EXPORT Atom : public RDProps {
   */
   int calcImplicitValence(bool strict = true);
 
-  AtomMonomerInfo *getMonomerInfo() { return dp_monomerInfo; }
-  const AtomMonomerInfo *getMonomerInfo() const { return dp_monomerInfo; }
+  AtomMonomerInfo *getMonomerInfo();
+  const AtomMonomerInfo *getMonomerInfo() const;
   //! takes ownership of the pointer
   void setMonomerInfo(AtomMonomerInfo *info);
 
   //! Set the atom map Number of the atom
-  void setAtomMapNum(int mapno, bool strict = true) {
-    PRECONDITION(
-        !strict || (mapno >= 0 && mapno < 1000),
-        "atom map number out of range [0..1000], use strict=false to override");
-    if (mapno) {
-      setProp(common_properties::molAtomMapNumber, mapno);
-    } else if (hasProp(common_properties::molAtomMapNumber)) {
-      clearProp(common_properties::molAtomMapNumber);
-    }
-  }
+  void setAtomMapNum(int mapno, bool strict = true);
   //! Gets the atom map Number of the atom, if no atom map exists, 0 is
   //! returned.
-  int getAtomMapNum() const {
-    int mapno = 0;
-    getPropIfPresent(common_properties::molAtomMapNumber, mapno);
-    return mapno;
+  int getAtomMapNum() const;
+
+  //! returns a list with the names of our \c properties
+  STR_VECT getPropList(bool includePrivate = true,
+                       bool includeComputed = true) const;
+
+  //! sets a \c property value
+  /*!
+    \param key the name under which the \c property should be stored.
+    If a \c property is already stored under this name, it will be
+    replaced.
+    \param val the value to be stored
+    \param computed (optional) allows the \c property to be flagged
+    \c computed.
+
+    <b>Notes:</b>
+    - This must be allowed on a const Atom for backward compatibility,
+    but DO NOT call this while this atom might be being modified in another
+    thread, NOR while any properties on the same molecule might be being read or
+    written.
+  */
+  //! \overload
+  template <typename T>
+  void setProp(const std::string &key, T val, bool computed = false) const {
+    // Continue support for mixed-type cases like:
+    // atom0->setProp("a", 1.7); atom1->setProp("a", 123);
+    // If there is a type mismatch, this option will convert to RDValue
+    dp_dataMol->setSingleAtomProp(PropToken(key), getIdx(), val, computed, true);
+  }
+  void setProp(const std::string &key, const char *val,
+               bool computed = false) const {
+    std::string sv(val);
+    // Continue support for mixed-type cases like:
+    // atom0->setProp("a", 1.7); atom1->setProp("a", 123);
+    // If there is a type mismatch, this option will convert to RDValue
+    dp_dataMol->setSingleAtomProp(PropToken(key), getIdx(), sv, computed, true);
   }
 
+  //! allows retrieval of a particular property value
+  /*!
+    \param key the name under which the \c property should be stored.
+    If a \c property is already stored under this name, it will be
+    replaced.
+    \param res a reference to the storage location for the value.
+
+    <b>Notes:</b>
+    - if no \c property with name \c key exists, a KeyErrorException will be
+    thrown.
+    - the \c boost::lexical_cast machinery is used to attempt type
+    conversions.
+    If this fails, a \c boost::bad_lexical_cast exception will be thrown.
+  */
+  //! \overload
+  template <typename T>
+  void getProp(const std::string &key, T &res) const {
+    bool found = dp_dataMol->getAtomPropIfPresent(PropToken(key), getIdx(), res);
+    if (!found) {
+      throw KeyErrorException(key);
+    }
+  }
+
+  //! \overload
+  template <typename T>
+  T getProp(const std::string &key) const {
+    return dp_dataMol->getAtomProp<T>(PropToken(key), getIdx());
+  }
+
+  //! returns whether or not we have a \c property with name \c key
+  //!  and assigns the value if we do
+  //! \overload
+  template <typename T>
+  bool getPropIfPresent(const std::string &key, T &res) const {
+    return dp_dataMol->getAtomPropIfPresent(PropToken(key), getIdx(), res);
+  }
+
+  //! \overload
+  bool hasProp(const std::string &key) const;
+
+  //! clears the value of a \c property
+  /*!
+    <b>Notes:</b>
+    - if no \c property with name \c key exists, a KeyErrorException
+    will be thrown.
+    - if the \c property is marked as \c computed, it will also be removed
+    from our list of \c computedProperties
+
+    <b>Notes:</b>
+    - This must be allowed on a const Atom for backward compatibility,
+    but DO NOT call this while this atom might be being modified in another
+    thread, NOR while any properties on the same molecule might be being read or
+    written.
+  */
+  //! \overload
+  void clearProp(const std::string &key) const;
+
+  //! clears all of our \c computed \c properties
+  /*!
+    <b>Notes:</b>
+    - This must be allowed on a const Atom for backward compatibility,
+    but DO NOT call this while this atom might be being modified in another
+    thread, NOR while any properties on the same molecule might be being read or
+    written.
+  */
+  void clearComputedProps() const;
+
+  //! update the properties from another
+  /*
+    \param source    Source to update the properties from
+    \param preserve  Existing If true keep existing data, else override from
+    the source
+  */
+  void updateProps(const Atom& source, bool preserveExisting = false);
+  void updateProps(const RDProps& source, bool preserveExisting = false);
+
+  //! Clears all properties of this Atom, but leaves everything else
+  void clear();
+  Dict &getDict() {
+    raiseNonImplementedFunction("GetDict");
+    Dict dict;
+    return dict;
+  }
+  const Dict &getDict() const {
+    raiseNonImplementedFunction("GetDict");
+    Dict dict;
+    return dict;
+  }
  protected:
   //! sets our owning molecule
   void setOwningMol(ROMol *other);
-  //! sets our owning molecule
+  //! \overload
   void setOwningMol(ROMol &other) { setOwningMol(&other); }
+  //! \overload
+  void setOwningMol(RDMol* other);
 
-  bool df_isAromatic;
-  bool df_noImplicit;
-  std::uint8_t d_numExplicitHs;
-  std::int8_t d_formalCharge;
-  std::uint8_t d_atomicNum;
-  // NOTE that these cannot be signed, they are calculated using
-  // a lazy scheme and are initialized to -1 to indicate that the
-  // calculation has not yet been done.
-  std::int8_t d_implicitValence, d_explicitValence;
-  std::uint8_t d_numRadicalElectrons;
-  std::uint8_t d_chiralTag;
-  std::uint8_t d_hybrid;
-
-  std::uint16_t d_isotope;
-  atomindex_t d_index;
-
-  ROMol *dp_mol;
-  AtomMonomerInfo *dp_monomerInfo;
-  void initAtom();
-  void initFromOther(const Atom &other);
+  int getExplicitValencePrivate() const;
+  int getImplicitValencePrivate() const;
 };
 
 //! Set the atom's MDL integer RLabel
 ///  Setting to 0 clears the rlabel.  Rlabel must be in the range [0..99]
-RDKIT_GRAPHMOL_EXPORT void setAtomRLabel(Atom *atm, int rlabel);
-RDKIT_GRAPHMOL_EXPORT int getAtomRLabel(const Atom *atm);
+RDKIT_GRAPHMOL_EXPORT void setAtomRLabel(Atom *atom, int rlabel);
+RDKIT_GRAPHMOL_EXPORT int getAtomRLabel(const Atom *atom);
 
 //! Set the atom's MDL atom alias
 ///  Setting to an empty string clears the alias
@@ -434,10 +600,11 @@ RDKIT_GRAPHMOL_EXPORT void setSupplementalSmilesLabel(Atom *atom,
                                                       const std::string &label);
 RDKIT_GRAPHMOL_EXPORT std::string getSupplementalSmilesLabel(const Atom *atom);
 
-//! returns true if the atom is to the left of C
-RDKIT_GRAPHMOL_EXPORT bool isEarlyAtom(int atomicNum);
 //! returns true if the atom is aromatic or has an aromatic bond
 RDKIT_GRAPHMOL_EXPORT bool isAromaticAtom(const Atom &atom);
+//! overload
+RDKIT_GRAPHMOL_EXPORT bool isAromaticAtom(ConstRDMolAtom atom);
+
 //! returns the number of pi electrons on the atom
 RDKIT_GRAPHMOL_EXPORT unsigned int numPiElectrons(const Atom &atom);
 };  // namespace RDKit

--- a/Code/GraphMol/Bond.cpp
+++ b/Code/GraphMol/Bond.cpp
@@ -15,115 +15,110 @@
 
 namespace RDKit {
 
-Bond::Bond() : RDProps() { initBond(); };
+void Bond::initFromOther(const Bond &other, const bool preserveProps) {
+  auto& newBondInfo = dp_dataMol->getBond(d_index);
+  newBondInfo = other.dp_dataMol->getBond(other.d_index);
 
-Bond::Bond(BondType bT) : RDProps() {
-  initBond();
-  d_bondType = bT;
-};
-
-Bond::Bond(const Bond &other) : RDProps(other) {
-  // NOTE: we do *not* copy ownership!
-  dp_mol = nullptr;
-  d_bondType = other.d_bondType;
-  d_beginAtomIdx = other.d_beginAtomIdx;
-  d_endAtomIdx = other.d_endAtomIdx;
-  d_dirTag = other.d_dirTag;
-  d_stereo = other.d_stereo;
-  if (other.dp_stereoAtoms) {
-    dp_stereoAtoms = new INT_VECT(*other.dp_stereoAtoms);
-  } else {
-    dp_stereoAtoms = nullptr;
+  if (!preserveProps) {
+    dp_dataMol->clearSingleBondAllProps(d_index);
+    for (auto it = other.dp_dataMol->beginProps(true, RDMol::Scope::BOND,
+                                                other.d_index),
+              end = other.dp_dataMol->endProps();
+         it != end; ++it) {
+      dp_dataMol->copySingleProp(*it, d_index, *other.dp_dataMol, *it,
+                                 other.d_index, RDMol::Scope::BOND);
+    }
   }
-  df_isAromatic = other.df_isAromatic;
-  df_isConjugated = other.df_isConjugated;
-  d_index = other.d_index;
+
+  // These may come from compat data
+  const atomindex_t *stereoAtoms = other.dp_dataMol->getBondStereoAtoms(other.d_index);
+  if (stereoAtoms != nullptr && stereoAtoms[0] != atomindex_t(-1) && stereoAtoms[1] != atomindex_t(-1)) {
+    // Don't check the atom indices if this is a Bond outside a molecule
+    dp_dataMol->setBondStereoAtoms(d_index, stereoAtoms[0], stereoAtoms[1],
+                                   dp_dataMol->getNumAtoms() != 0);
+  } else {
+    dp_dataMol->clearBondStereoAtoms(d_index);
+  }
 }
 
-Bond::~Bond() { delete dp_stereoAtoms; }
+Bond::Bond() {
+  dp_dataMol = new RDMol();
+  dp_dataMol->addUnconnectedBond();
+  dp_owningMol = nullptr;
+};
 
-Bond &Bond::operator=(const Bond &other) {
+Bond::Bond(BondType bT): Bond() {
+  setBondType(bT);
+}
+
+Bond::Bond(const Bond& other): Bond() {
+  initFromOther(other);
+}
+
+Bond& Bond::operator=(const Bond &other) {
   if (this == &other) {
     return *this;
   }
-  dp_mol = other.dp_mol;
-  d_bondType = other.d_bondType;
-  d_beginAtomIdx = other.d_beginAtomIdx;
-  d_endAtomIdx = other.d_endAtomIdx;
-  d_dirTag = other.d_dirTag;
-  delete dp_stereoAtoms;
-  if (other.dp_stereoAtoms) {
-    dp_stereoAtoms = new INT_VECT(*other.dp_stereoAtoms);
-  } else {
-    dp_stereoAtoms = nullptr;
-  }
-  df_isAromatic = other.df_isAromatic;
-  df_isConjugated = other.df_isConjugated;
-  d_index = other.d_index;
-  d_props = other.d_props;
+  *this = Bond(other);
+  return *this;
+}
 
+Bond::Bond(Bond &&o) noexcept {
+  dp_dataMol = o.dp_dataMol;
+  dp_owningMol = o.dp_owningMol;
+  d_index = o.d_index;
+  o.dp_dataMol = nullptr;
+  o.dp_owningMol = nullptr;
+}
+
+Bond &Bond::operator=(Bond &&o) noexcept {
+  if (this == &o) {
+    return *this;
+  }
+  if (dp_dataMol != dp_owningMol) {
+    delete dp_dataMol;
+  }
+  dp_dataMol = o.dp_dataMol;
+  dp_owningMol = o.dp_owningMol;
+  d_index = o.d_index;
+  o.dp_dataMol = nullptr;
+  o.dp_owningMol = nullptr;
   return *this;
 }
 
 Bond *Bond::copy() const {
-  auto *res = new Bond(*this);
-  return res;
+  auto *bond = new Bond(*this);
+  return bond;
+}
+
+ROMol &Bond::getOwningMol() const {
+  PRECONDITION(dp_owningMol != nullptr, "no owner");
+  return dp_owningMol->asROMol();
 }
 
 void Bond::setOwningMol(ROMol *other) {
-  // FIX: doesn't update topology
-  dp_mol = other;
+  setOwningMol(&other->asRDMol());
 }
 
-unsigned int Bond::getOtherAtomIdx(const unsigned int thisIdx) const {
-  PRECONDITION(d_beginAtomIdx == thisIdx || d_endAtomIdx == thisIdx,
-               "bad index");
-  if (d_beginAtomIdx == thisIdx) {
-    return d_endAtomIdx;
-  } else if (d_endAtomIdx == thisIdx) {
-    return d_beginAtomIdx;
+void Bond::setOwningMol(RDMol* other) {
+  PRECONDITION(dp_owningMol == nullptr || dp_owningMol == other,
+               "setOwningMol called twice");
+  dp_owningMol = other;
+}
+
+Bond::~Bond() {
+  if (dp_dataMol != dp_owningMol) {
+    delete dp_dataMol;
   }
-  // we cannot actually get down here
-  return 0;
 }
 
-void Bond::setBeginAtomIdx(unsigned int what) {
-  if (dp_mol) {
-    URANGE_CHECK(what, getOwningMol().getNumAtoms());
-  }
-  d_beginAtomIdx = what;
-};
-
-void Bond::setEndAtomIdx(unsigned int what) {
-  if (dp_mol) {
-    URANGE_CHECK(what, getOwningMol().getNumAtoms());
-  }
-  d_endAtomIdx = what;
-};
-
-void Bond::setBeginAtom(Atom *at) {
-  PRECONDITION(dp_mol != nullptr, "no owning molecule for bond");
-  setBeginAtomIdx(at->getIdx());
+Bond::BondType Bond::getBondType() const {
+  return static_cast<BondType>(dp_dataMol->getBond(d_index).getBondType());
 }
-void Bond::setEndAtom(Atom *at) {
-  PRECONDITION(dp_mol != nullptr, "no owning molecule for bond");
-  setEndAtomIdx(at->getIdx());
+void Bond::setBondType(BondType bT) {
+  dp_dataMol->getBond(d_index).setBondType(
+      static_cast<RDKit::BondEnums::BondType>(bT));
 }
-
-Atom *Bond::getBeginAtom() const {
-  PRECONDITION(dp_mol != nullptr, "no owning molecule for bond");
-  return dp_mol->getAtomWithIdx(d_beginAtomIdx);
-};
-Atom *Bond::getEndAtom() const {
-  PRECONDITION(dp_mol != nullptr, "no owning molecule for bond");
-  return dp_mol->getAtomWithIdx(d_endAtomIdx);
-};
-Atom *Bond::getOtherAtom(Atom const *what) const {
-  PRECONDITION(dp_mol != nullptr, "no owning molecule for bond");
-
-  return dp_mol->getAtomWithIdx(getOtherAtomIdx(what->getIdx()));
-};
-
 double Bond::getBondTypeAsDouble() const {
   double res;
   switch (getBondType()) {
@@ -182,23 +177,63 @@ double Bond::getBondTypeAsDouble() const {
   }
   return res;
 }
-
-double Bond::getValenceContrib(const Atom *atom) const {
-  if (atom != getBeginAtom() && atom != getEndAtom()) {
-    return 0.0;
-  }
-  double res;
-  if ((getBondType() == DATIVE || getBondType() == DATIVEONE) &&
-      atom->getIdx() != getEndAtomIdx()) {
-    res = 0.0;
-  } else {
-    res = getBondTypeAsDouble();
-  }
-
-  return res;
+double Bond::getValenceContrib(const Atom* atom) const {
+  return 0.5 * dp_dataMol->getBond(d_index).getTwiceValenceContrib(atom->getIdx());
 }
-
-void Bond::setQuery(QUERYBOND_QUERY *) {
+void Bond::setIsAromatic(bool what) {
+  dp_dataMol->getBond(d_index).setIsAromatic(what);
+}
+bool Bond::getIsAromatic() const {
+  return dp_dataMol->getBond(d_index).getIsAromatic();
+}
+void Bond::setIsConjugated(bool what) {
+  dp_dataMol->getBond(d_index).setIsConjugated(what);
+}
+bool Bond::getIsConjugated() const {
+  return dp_dataMol->getBond(d_index).getIsConjugated();
+}
+unsigned int Bond::getBeginAtomIdx() const {
+  return dp_dataMol->getBond(d_index).getBeginAtomIdx();
+}
+unsigned int Bond::getEndAtomIdx() const {
+  return dp_dataMol->getBond(d_index).getEndAtomIdx();
+}
+unsigned int Bond::getOtherAtomIdx(unsigned int thisIdx) const {
+  return dp_dataMol->getBond(d_index).getOtherAtomIdx(thisIdx);
+}
+void Bond::setBeginAtomIdx(unsigned int what) {
+  if (dp_owningMol) {
+    URANGE_CHECK(what, getOwningMol().getNumAtoms());
+  }
+  dp_dataMol->getBond(d_index).setBeginAtomIdx(what);
+}
+void Bond::setEndAtomIdx(unsigned int what) {
+  if (dp_owningMol) {
+    URANGE_CHECK(what, getOwningMol().getNumAtoms());
+  }
+  dp_dataMol->getBond(d_index).setEndAtomIdx(what);
+}
+void Bond::setBeginAtom(Atom* at) {
+  PRECONDITION(dp_owningMol != nullptr, "no owning molecule for bond");
+  // TODO: Should this assert that at is from the same molecule?
+  dp_dataMol->getBond(d_index).setBeginAtomIdx(at->getIdx());
+}
+void Bond::setEndAtom(Atom* at) {
+  PRECONDITION(dp_owningMol != nullptr, "no owning molecule for bond");
+  // TODO: Should this assert that at is from the same molecule?
+  dp_dataMol->getBond(d_index).setEndAtomIdx(at->getIdx());
+}
+Atom* Bond::getBeginAtom() const {
+  PRECONDITION(dp_owningMol, "no owning molecule for bond");
+  return dp_owningMol->asROMol().getAtomWithIdx(
+      dp_dataMol->getBond(d_index).getBeginAtomIdx());
+}
+Atom* Bond::getEndAtom() const {
+  PRECONDITION(dp_owningMol, "no owning molecule for bond");
+  return dp_owningMol->asROMol().getAtomWithIdx(
+      dp_dataMol->getBond(d_index).getEndAtomIdx());
+}
+void Bond::setQuery(QUERYBOND_QUERY* what) {
   //  Bonds don't have queries at the moment because I have not
   //  yet figured out what a good base query should be.
   //  It would be nice to be able to do substructure searches
@@ -206,13 +241,15 @@ void Bond::setQuery(QUERYBOND_QUERY *) {
   //  issue resolved ASAP.
   PRECONDITION(0, "plain bonds have no Query");
 }
-
-Bond::QUERYBOND_QUERY *Bond::getQuery() const {
+Bond::QUERYBOND_QUERY* Bond::getQuery() const {
   PRECONDITION(0, "plain bonds have no Query");
   return nullptr;
-};
-
-bool Bond::Match(Bond const *what) const {
+}
+void Bond::expandQuery(QUERYBOND_QUERY* what, Queries::CompositeQueryType how,
+                       bool maintainOrder) {
+  PRECONDITION(0, "plain bonds have no query");
+}
+bool Bond::Match(Bond const* what) const {
   bool res;
   if (getBondType() == Bond::UNSPECIFIED ||
       what->getBondType() == Bond::UNSPECIFIED) {
@@ -221,26 +258,21 @@ bool Bond::Match(Bond const *what) const {
     res = getBondType() == what->getBondType();
   }
   return res;
-};
-
-void Bond::expandQuery(Bond::QUERYBOND_QUERY *, Queries::CompositeQueryType,
-                       bool) {
-  PRECONDITION(0, "plain bonds have no query");
-};
-
-void Bond::initBond() {
-  d_bondType = UNSPECIFIED;
-  d_dirTag = NONE;
-  d_stereo = STEREONONE;
-  dp_mol = nullptr;
-  d_beginAtomIdx = 0;
-  d_endAtomIdx = 0;
-  df_isAromatic = 0;
-  d_index = 0;
-  df_isConjugated = 0;
-  dp_stereoAtoms = nullptr;
-};
-
+}
+void Bond::setBondDir(BondDir what) {
+  dp_dataMol->getBond(d_index).setBondDir(
+      static_cast<BondEnums::BondDir>(what));
+}
+Bond::BondDir Bond::getBondDir() const {
+  return static_cast<BondDir>(dp_dataMol->getBond(d_index).getBondDir());
+}
+void Bond::setStereo(BondStereo what) {
+  dp_dataMol->getBond(d_index).setStereo(
+      static_cast<BondEnums::BondStereo>(what));
+}
+Bond::BondStereo Bond::getStereo() const {
+  return static_cast<BondStereo>(dp_dataMol->getBond(d_index).getStereo());
+}
 void Bond::setStereoAtoms(unsigned int bgnIdx, unsigned int endIdx) {
   PRECONDITION(
       getOwningMol().getBondBetweenAtoms(getBeginAtomIdx(), bgnIdx) != nullptr,
@@ -249,67 +281,27 @@ void Bond::setStereoAtoms(unsigned int bgnIdx, unsigned int endIdx) {
       getOwningMol().getBondBetweenAtoms(getEndAtomIdx(), endIdx) != nullptr,
       "endIdx not connected to end atom of bond");
 
-  auto &atoms = getStereoAtoms();
-  atoms.clear();
-  atoms.push_back(bgnIdx);
-  atoms.push_back(endIdx);
-};
-
-uint8_t getTwiceBondType(const Bond &b) {
-  switch (b.getBondType()) {
-    case Bond::UNSPECIFIED:
-    case Bond::IONIC:
-    case Bond::ZERO:
-      return 0;
-      break;
-    case Bond::SINGLE:
-      return 2;
-      break;
-    case Bond::DOUBLE:
-      return 4;
-      break;
-    case Bond::TRIPLE:
-      return 6;
-      break;
-    case Bond::QUADRUPLE:
-      return 8;
-      break;
-    case Bond::QUINTUPLE:
-      return 10;
-      break;
-    case Bond::HEXTUPLE:
-      return 12;
-      break;
-    case Bond::ONEANDAHALF:
-      return 3;
-      break;
-    case Bond::TWOANDAHALF:
-      return 5;
-      break;
-    case Bond::THREEANDAHALF:
-      return 7;
-      break;
-    case Bond::FOURANDAHALF:
-      return 9;
-      break;
-    case Bond::FIVEANDAHALF:
-      return 11;
-      break;
-    case Bond::AROMATIC:
-      return 3;
-      break;
-    case Bond::DATIVEONE:
-      return 2;
-      break;  // FIX: this should probably be different
-    case Bond::DATIVE:
-      return 2;
-      break;  // FIX: again probably wrong
-    case Bond::HYDROGEN:
-      return 0;
-      break;
-    default:
-      UNDER_CONSTRUCTION("Bad bond type");
+  BondData &bond = dp_dataMol->getBond(d_index);
+  bond.stereoAtoms[0] = bgnIdx;
+  bond.stereoAtoms[1] = endIdx;
+  if (dp_dataMol->hasCompatibilityData()) {
+    auto *compatStereo = dp_dataMol->getBondStereoAtomsCompat(d_index);
+    CHECK_INVARIANT(compatStereo, "No stereo atoms in compatibility data");
+    compatStereo->clear();
+    compatStereo->push_back(bgnIdx);
+    compatStereo->push_back(endIdx);
   }
+}
+const INT_VECT& Bond::getStereoAtoms() const {
+  return *dp_dataMol->getBondStereoAtomsCompat(d_index);
+}
+INT_VECT& Bond::getStereoAtoms() {
+  return *dp_dataMol->getBondStereoAtomsCompat(d_index);
+}
+void Bond::updatePropertyCache(bool strict) { (void)strict; }
+
+uint8_t getTwiceBondType(Bond::BondType type) {
+  return getTwiceBondType(static_cast<BondEnums::BondType>(type));
 }
 
 bool Bond::invertChirality() {
@@ -325,6 +317,68 @@ bool Bond::invertChirality() {
       break;
   }
   return false;
+}
+
+uint8_t getTwiceBondType(const Bond &b) {
+  return getTwiceBondType(b.getBondType());
+}
+
+Atom * Bond::getOtherAtom(Atom const *what) const {
+  PRECONDITION(what != nullptr, "null input Atom");
+  PRECONDITION(dp_owningMol != nullptr, "no owning molecule for bond");
+  return dp_owningMol->getAtomCompat(getOtherAtomIdx(what->getIdx()));
+}
+
+STR_VECT Bond::getPropList(bool includePrivate, bool includeComputed) const {
+  return dp_dataMol->getPropList(includePrivate, includeComputed, RDMol::Scope::BOND, d_index);
+}
+
+bool Bond::hasProp(const std::string &key) const{
+  return dp_dataMol->hasBondProp(PropToken(key), getIdx());
+}
+
+void Bond::clearProp(const std::string &key) const {
+  dp_dataMol->clearSingleBondProp(PropToken(key), getIdx());
+}
+void Bond::clearComputedProps() const {
+  dp_dataMol->clearSingleBondAllProps(getIdx(), true);
+}
+
+void Bond::updateProps(const RDProps &source, bool preserveExisting) {
+  if (!preserveExisting) {
+    clear();
+  }
+  std::vector<std::string> computedPropList;
+  source.getPropIfPresent<std::vector<std::string>>(
+      RDKit::detail::computedPropName, computedPropList);
+  const STR_VECT keys = source.getPropList();
+  for (const auto &key : keys) {
+    if (key == RDKit::detail::computedPropName) {
+      continue;
+    }
+    const RDValue &val = source.getPropRDValue(key);
+    bool isComputed =
+        std::find(computedPropList.begin(), computedPropList.end(), key) !=
+        computedPropList.end();
+    getDataRDMol().setSingleBondProp(PropToken(key), getIdx(), val, isComputed, true);
+  }
+}
+
+void Bond::updateProps(const Bond &source, bool preserveExisting) {
+  if (!preserveExisting) {
+    clear();
+  }
+  for (auto it = source.dp_dataMol->beginProps(true, RDMol::Scope::BOND,
+                                               source.d_index),
+            end = source.dp_dataMol->endProps();
+       it != end; ++it) {
+    dp_dataMol->copySingleProp(*it, d_index, *source.dp_dataMol, *it,
+                               source.d_index, RDMol::Scope::BOND);
+  }
+}
+
+void Bond::clear() {
+  dp_dataMol->clearSingleBondAllProps(getIdx(), false);
 }
 
 };  // namespace RDKit

--- a/Code/GraphMol/Bond.h
+++ b/Code/GraphMol/Bond.h
@@ -21,11 +21,16 @@
 #include <RDGeneral/types.h>
 #include <RDGeneral/RDProps.h>
 #include <GraphMol/details.h>
+#include <GraphMol/RDMol.h>
+#include <GraphMol/rdmol_throw.h>
+
+#include "GraphMolEnums.h"
 
 namespace RDKit {
 class ROMol;
 class RWMol;
 class Atom;
+class ConstRDMolBond;
 
 //! class for representing a bond
 /*!
@@ -44,108 +49,107 @@ class Atom;
           clients who need to store extra data on Bond objects.
 
 */
-class RDKIT_GRAPHMOL_EXPORT Bond : public RDProps {
-  friend class RWMol;
+class RDKIT_GRAPHMOL_EXPORT Bond {
   friend class ROMol;
+  friend class RWMol;
+  friend class RDMol;
+
+  // When a bond is created on its own, it owns dp_dataMol to store its data
+  // and dp_owningMol is nullptr. Calling setOwningMol will set dp_owningMol,
+  // but as before, this does not actually insert the Bond's data into the
+  // owning RDMol, so dp_dataMol will continue keeping the data until
+  // ROMol::addBond copies the data and frees dp_dataMol, setting dp_dataMol
+  // to be equal to dp_owningMol, to indicate that dp_dataMol is no longer
+  // owned by this Bond, and setting d_index accordingly.
+  //
+  // The 3 states are:
+  // 1) dp_owningMol == nullptr: dp_dataMol owned by this & no owning mol
+  // 2) else if dp_dataMol != dp_owningMol: dp_dataMol owned by this
+  // 3) dp_dataMol == dp_owningMol: dp_owningMol owns this
+  //
+  // This is necessary for compatibility with previous workflows that would
+  // call setOwningMol and separately ROMol::addBond.
+  RDMol *dp_dataMol = nullptr;
+  RDMol *dp_owningMol = nullptr;
+  uint32_t d_index = 0;
+
+ protected:
+  Bond(RDMol *mol, uint32_t bondIndex)
+      : dp_dataMol(mol), dp_owningMol(mol), d_index(bondIndex) {}
 
  public:
   // FIX: grn...
   typedef Queries::Query<int, Bond const *, true> QUERYBOND_QUERY;
+  //typedef Queries::Query<int, ConstRDMolBond, true> QUERYBOND_QUERY;
 
   //! the type of Bond
-  typedef enum {
-    UNSPECIFIED = 0,
-    SINGLE,
-    DOUBLE,
-    TRIPLE,
-    QUADRUPLE,
-    QUINTUPLE,
-    HEXTUPLE,
-    ONEANDAHALF,
-    TWOANDAHALF,
-    THREEANDAHALF,
-    FOURANDAHALF,
-    FIVEANDAHALF,
-    AROMATIC,
-    IONIC,
-    HYDROGEN,
-    THREECENTER,
-    DATIVEONE,  //!< one-electron dative (e.g. from a C in a Cp ring to a metal)
-    DATIVE,     //!< standard two-electron dative
-    DATIVEL,    //!< standard two-electron dative
-    DATIVER,    //!< standard two-electron dative
-    OTHER,
-    ZERO  //!< Zero-order bond (from
+  enum BondType {
+    UNSPECIFIED = BondEnums::BondType::UNSPECIFIED,
+    SINGLE = BondEnums::BondType::SINGLE,
+    DOUBLE = BondEnums::BondType::DOUBLE,
+    TRIPLE = BondEnums::BondType::TRIPLE,
+    QUADRUPLE = BondEnums::BondType::QUADRUPLE,
+    QUINTUPLE = BondEnums::BondType::QUINTUPLE,
+    HEXTUPLE = BondEnums::BondType::HEXTUPLE,
+    ONEANDAHALF = BondEnums::BondType::ONEANDAHALF,
+    TWOANDAHALF = BondEnums::BondType::TWOANDAHALF,
+    THREEANDAHALF = BondEnums::BondType::THREEANDAHALF,
+    FOURANDAHALF = BondEnums::BondType::FOURANDAHALF,
+    FIVEANDAHALF = BondEnums::BondType::FIVEANDAHALF,
+    AROMATIC = BondEnums::BondType::AROMATIC,
+    IONIC = BondEnums::BondType::IONIC,
+    HYDROGEN = BondEnums::BondType::HYDROGEN,
+    THREECENTER = BondEnums::BondType::THREECENTER,
+    //!< one-electron dative (e.g. from a C in a Cp ring to a metal)
+    DATIVEONE = BondEnums::BondType::DATIVEONE,
+    DATIVE = BondEnums::BondType::DATIVE,    //!< standard two-electron dative
+    DATIVEL = BondEnums::BondType::DATIVEL,  //!< standard two-electron dative
+    DATIVER = BondEnums::BondType::DATIVER,  //!< standard two-electron dative
+    OTHER = BondEnums::BondType::OTHER,
+    ZERO = BondEnums::BondType::ZERO  //!< Zero-order bond (from
     // http://pubs.acs.org/doi/abs/10.1021/ci200488k)
-  } BondType;
+  };
 
   //! the bond's direction (for chirality)
-  typedef enum {
-    NONE = 0,    //!< no special style
-    BEGINWEDGE,  //!< wedged: narrow at begin
-    BEGINDASH,   //!< dashed: narrow at begin
+  enum BondDir {
+    NONE = BondEnums::BondDir::NONE,              //!< no special style
+    BEGINWEDGE = BondEnums::BondDir::BEGINWEDGE,  //!< wedged: narrow at begin
+    BEGINDASH = BondEnums::BondDir::BEGINDASH,    //!< dashed: narrow at begin
     // FIX: this may not really be adequate
-    ENDDOWNRIGHT,  //!< for cis/trans
-    ENDUPRIGHT,    //!<  ditto
-    EITHERDOUBLE,  //!< a "crossed" double bond
-    UNKNOWN,       //!< intentionally unspecified stereochemistry
-  } BondDir;
+    ENDDOWNRIGHT = BondEnums::BondDir::ENDDOWNRIGHT,  //!< for cis/trans
+    ENDUPRIGHT = BondEnums::BondDir::ENDUPRIGHT,      //!<  ditto
+    //!< a "crossed" double bond
+    EITHERDOUBLE = BondEnums::BondDir::EITHERDOUBLE,
+    //!< intentionally unspecified stereochemistry
+    UNKNOWN = BondEnums::BondDir::UNKNOWN,
+  };
 
   //! the nature of the bond's stereochem (for cis/trans)
-  typedef enum {     // stereochemistry of double bonds
-    STEREONONE = 0,  // no special style
-    STEREOANY,       // intentionally unspecified
+  enum BondStereo {  // stereochemistry of double bonds
+    STEREONONE = BondEnums::BondStereo::STEREONONE,         // no special style
+    STEREOANY = BondEnums::BondStereo::STEREOANY,           // intentionally unspecified
     // -- Put any true specifications about this point so
     // that we can do comparisons like if(bond->getStereo()>Bond::STEREOANY)
-    STEREOZ,         // Z double bond
-    STEREOE,         // E double bond
-    STEREOCIS,       // cis double bond
-    STEREOTRANS,     // trans double bond
-    STEREOATROPCW,   //  atropisomer clockwise rotation
-    STEREOATROPCCW,  //  atropisomer counter clockwise rotation
-  } BondStereo;
+    STEREOZ = BondEnums::BondStereo::STEREOZ,               // Z double bond
+    STEREOE = BondEnums::BondStereo::STEREOE,               // E double bond
+    STEREOCIS = BondEnums::BondStereo::STEREOCIS,           // cis double bond
+    STEREOTRANS = BondEnums::BondStereo::STEREOTRANS,       // trans double bond
+    STEREOATROPCW = BondEnums::BondStereo::STEREOATROPCW,   // cis double bond
+    STEREOATROPCCW = BondEnums::BondStereo::STEREOATROPCCW  // trans double bond
+  };
 
   Bond();
   //! construct with a particular BondType
   explicit Bond(BondType bT);
   Bond(const Bond &other);
+
   virtual ~Bond();
   Bond &operator=(const Bond &other);
 
-  Bond(Bond &&o) noexcept : RDProps(std::move(o)) {
-    df_isAromatic = o.df_isAromatic;
-    df_isConjugated = o.df_isConjugated;
-    d_bondType = o.d_bondType;
-    d_dirTag = o.d_dirTag;
-    d_stereo = o.d_stereo;
-    d_index = o.d_index;
-    d_beginAtomIdx = o.d_beginAtomIdx;
-    d_endAtomIdx = o.d_endAtomIdx;
-    // NOTE: this is somewhat fraught for bonds associated with molecules since
-    // the molecule will still be pointing to the original object
-    dp_mol = std::exchange(o.dp_mol, nullptr);
-    dp_stereoAtoms = std::exchange(o.dp_stereoAtoms, nullptr);
-  }
-  Bond &operator=(Bond &&o) noexcept {
-    if (this == &o) {
-      return *this;
-    }
-    RDProps::operator=(std::move(o));
-    df_isAromatic = o.df_isAromatic;
-    df_isConjugated = o.df_isConjugated;
-    d_bondType = o.d_bondType;
-    d_dirTag = o.d_dirTag;
-    d_stereo = o.d_stereo;
-    d_index = o.d_index;
-    d_beginAtomIdx = o.d_beginAtomIdx;
-    d_endAtomIdx = o.d_endAtomIdx;
-    // NOTE: this is somewhat fraught for bonds associated with molecules since
-    // the molecule will still be pointing to the original object
-    delete dp_stereoAtoms;
-    dp_mol = std::exchange(o.dp_mol, nullptr);
-    dp_stereoAtoms = std::exchange(o.dp_stereoAtoms, nullptr);
-    return *this;
-  }
+  // NOTE: the move methods are somewhat fraught for bonds associated with
+  // molecules since the molecule will still be pointing to the original object
+  Bond(Bond &&o) noexcept;
+  Bond &operator=(Bond &&o) noexcept;
 
   //! returns a copy
   /*!
@@ -154,10 +158,59 @@ class RDKIT_GRAPHMOL_EXPORT Bond : public RDProps {
   */
   virtual Bond *copy() const;
 
+  //! returns whether or not this instance belongs to a molecule
+  bool hasOwningMol() const { return dp_owningMol != nullptr; }
+
+  //! returns a reference to the ROMol that owns this instance
+  ROMol &getOwningMol() const;
+
+  //! returns a reference to the RDMol that owns this instance
+  const RDMol &getRDMol() const {
+    PRECONDITION(dp_owningMol, "no owner");
+    return *dp_owningMol;
+  }
+  //! overload
+  RDMol &getRDMol() {
+    PRECONDITION(dp_owningMol, "no owner");
+    return *dp_owningMol;
+  }
+
+ protected:
+  //! returns a reference to the RDMol that contains the data for this bond,
+  //! for internal use only
+  const RDMol &getDataRDMol() const {
+    return *dp_dataMol;
+  }
+  //! overload
+  RDMol &getDataRDMol() {
+    return *dp_dataMol;
+  }
+ public:
+
+  //! sets our owning molecule
+  void setOwningMol(ROMol *other);
+  //! \overload
+  void setOwningMol(ROMol &other) { setOwningMol(&other); }
+  //! \overload
+  void setOwningMol(RDMol *other);
+
+  // inverts the chirality of an atropisomer
+  bool invertChirality();
+
+  //! returns our index within the ROMol
+  unsigned int getIdx() const { return d_index; }
+  //! sets our index within the ROMol
+  /*!
+    <b>Notes:</b>
+      - this makes no sense if we do not have an owning molecule
+      - the index should be <tt>< this->getOwningMol()->getNumBonds()</tt>
+  */
+  void setIdx(unsigned int index) {d_index = index;}
+
   //! returns our \c bondType
-  BondType getBondType() const { return static_cast<BondType>(d_bondType); }
+  BondType getBondType() const;
   //! sets our \c bondType
-  void setBondType(BondType bT) { d_bondType = bT; }
+  void setBondType(BondType bT);
   //! \brief returns our \c bondType as a double
   //!   (e.g. SINGLE->1.0, AROMATIC->1.5, etc.)
   double getBondTypeAsDouble() const;
@@ -170,59 +223,28 @@ class RDKIT_GRAPHMOL_EXPORT Bond : public RDProps {
   virtual double getValenceContrib(const Atom *at) const;
 
   //! sets our \c isAromatic flag
-  void setIsAromatic(bool what) { df_isAromatic = what; }
+  void setIsAromatic(bool what);
   //! returns the status of our \c isAromatic flag
-  bool getIsAromatic() const { return df_isAromatic; }
+  bool getIsAromatic() const;
 
   //! sets our \c isConjugated flag
-  void setIsConjugated(bool what) { df_isConjugated = what; }
+  void setIsConjugated(bool what);
   //! returns the status of our \c isConjugated flag
-  bool getIsConjugated() const { return df_isConjugated; }
-
-  //! returns whether or not this instance belongs to a molecule
-  bool hasOwningMol() const { return dp_mol != nullptr; }
-
-  //! returns a reference to the ROMol that owns this instance
-  ROMol &getOwningMol() const {
-    PRECONDITION(dp_mol, "no owner");
-    return *dp_mol;
-  }
-  //! sets our owning molecule
-  void setOwningMol(ROMol *other);
-  //! sets our owning molecule
-  void setOwningMol(ROMol &other) { setOwningMol(&other); }
-
-  // inverts the chirality of an atropisomer
-  bool invertChirality();
-
-  //! returns our index within the ROMol
-  /*!
-    <b>Notes:</b>
-      - this makes no sense if we do not have an owning molecule
-
-  */
-  unsigned int getIdx() const { return d_index; }
-  //! sets our index within the ROMol
-  /*!
-    <b>Notes:</b>
-      - this makes no sense if we do not have an owning molecule
-      - the index should be <tt>< this->getOwningMol()->getNumBonds()</tt>
-  */
-  void setIdx(unsigned int index) { d_index = index; }
+  bool getIsConjugated() const;
 
   //! returns the index of our begin Atom
   /*!
     <b>Notes:</b>
       - this makes no sense if we do not have an owning molecule
   */
-  unsigned int getBeginAtomIdx() const { return d_beginAtomIdx; }
+  unsigned int getBeginAtomIdx() const;
 
   //! returns the index of our end Atom
   /*!
     <b>Notes:</b>
       - this makes no sense if we do not have an owning molecule
   */
-  unsigned int getEndAtomIdx() const { return d_endAtomIdx; }
+  unsigned int getEndAtomIdx() const;
 
   //! given the index of one Atom, returns the index of the other
   /*!
@@ -306,9 +328,9 @@ class RDKIT_GRAPHMOL_EXPORT Bond : public RDProps {
   virtual bool Match(Bond const *what) const;
 
   //! sets our direction
-  void setBondDir(BondDir what) { d_dirTag = what; }
+  void setBondDir(BondDir what);
   //! returns our direction
-  BondDir getBondDir() const { return static_cast<BondDir>(d_dirTag); }
+  BondDir getBondDir() const;
 
   //! sets our stereo code
   /*!
@@ -322,15 +344,9 @@ class RDKIT_GRAPHMOL_EXPORT Bond : public RDProps {
         - MolOps::findPotentialStereoBonds can be used to set
           getStereoAtoms before setting CIS/TRANS
   */
-  void setStereo(BondStereo what) {
-    PRECONDITION(((what != STEREOCIS && what != STEREOTRANS) ||
-                  getStereoAtoms().size() == 2),
-                 "Stereo atoms should be specified before specifying CIS/TRANS "
-                 "bond stereochemistry")
-    d_stereo = what;
-  }
+  void setStereo(BondStereo what);
   //! returns our stereo code
-  BondStereo getStereo() const { return static_cast<BondStereo>(d_stereo); }
+  BondStereo getStereo() const;
 
   //! sets the atoms to be considered as reference points for bond stereo
   /*!
@@ -347,43 +363,144 @@ class RDKIT_GRAPHMOL_EXPORT Bond : public RDProps {
   void setStereoAtoms(unsigned int bgnIdx, unsigned int endIdx);
 
   //! returns the indices of our stereo atoms
-  const INT_VECT &getStereoAtoms() const {
-    if (!dp_stereoAtoms) {
-      const_cast<Bond *>(this)->dp_stereoAtoms = new INT_VECT();
-    }
-    return *dp_stereoAtoms;
-  }
+  const INT_VECT &getStereoAtoms() const;
   //! \overload
-  INT_VECT &getStereoAtoms() {
-    if (!dp_stereoAtoms) {
-      dp_stereoAtoms = new INT_VECT();
-    }
-    return *dp_stereoAtoms;
-  }
+  INT_VECT &getStereoAtoms();
 
   //! calculates any of our lazy \c properties
   /*!
     <b>Notes:</b>
       - requires an owning molecule
   */
-  void updatePropertyCache(bool strict = true) { (void)strict; }
+  void updatePropertyCache(bool strict = true);
 
- protected:
-  //! sets our owning molecule
-  /// void setOwningMol(ROMol *other);
-  //! sets our owning molecule
-  /// void setOwningMol(ROMol &other) { setOwningMol(&other); }
-  ROMol *dp_mol;
-  INT_VECT *dp_stereoAtoms;
-  atomindex_t d_index;
-  atomindex_t d_beginAtomIdx, d_endAtomIdx;
-  bool df_isAromatic;
-  bool df_isConjugated;
-  std::uint8_t d_bondType;
-  std::uint8_t d_dirTag;
-  std::uint8_t d_stereo;
+  //! returns a list with the names of our \c properties
+  STR_VECT getPropList(bool includePrivate = true,
+                       bool includeComputed = true) const;
 
-  void initBond();
+  //! sets a \c property value
+  /*!
+    \param key the name under which the \c property should be stored.
+    If a \c property is already stored under this name, it will be
+    replaced.
+    \param val the value to be stored
+    \param computed (optional) allows the \c property to be flagged
+    \c computed.
+
+    <b>Notes:</b>
+    - This must be allowed on a const Bond for backward compatibility,
+    but DO NOT call this while this bond might be being modified in another
+    thread, NOR while any properties on the same molecule might be being read or
+    written.
+  */
+
+  //! \overload
+  template <typename T>
+  void setProp(const std::string &key, T val, bool computed = false) const {
+    // Continue support for mixed-type cases like:
+    // bond0->setProp("a", 1.7); bond1->setProp("a", 123);
+    // If there is a type mismatch, this option will convert to RDValue
+    dp_dataMol->setSingleBondProp(PropToken(key), getIdx(), val, computed, true);
+  }
+  void setProp(const std::string &key, const char *val,
+               bool computed = false) const {
+    std::string sv(val);
+    // Continue support for mixed-type cases like:
+    // bond0->setProp("a", 1.7); bond1->setProp("a", 123);
+    // If there is a type mismatch, this option will convert to RDValue
+    dp_dataMol->setSingleBondProp(PropToken(key), getIdx(), sv, computed, true);
+  }
+
+  //! allows retrieval of a particular property value
+  /*!
+    \param key the name under which the \c property should be stored.
+    If a \c property is already stored under this name, it will be
+    replaced.
+    \param res a reference to the storage location for the value.
+
+    <b>Notes:</b>
+    - if no \c property with name \c key exists, a KeyErrorException will be
+    thrown.
+    - the \c boost::lexical_cast machinery is used to attempt type
+    conversions.
+    If this fails, a \c boost::bad_lexical_cast exception will be thrown.
+  */
+  //! \overload
+  template <typename T>
+  void getProp(const std::string &key, T &res) const {
+    bool found = dp_dataMol->getBondPropIfPresent(PropToken(key), getIdx(), res);
+    if (!found) {
+      throw KeyErrorException(key);
+    }
+  }
+
+  //! \overload
+  template <typename T>
+  T getProp(const std::string &key) const {
+    return dp_dataMol->getBondProp<T>(PropToken(key), getIdx());
+  }
+
+  //! returns whether or not we have a \c property with name \c key
+  //!  and assigns the value if we do
+  //! \overload
+  template <typename T>
+  bool getPropIfPresent(const std::string &key, T &res) const {
+    return dp_dataMol->getBondPropIfPresent(PropToken(key), getIdx(), res);
+  }
+
+  //! \overload
+  bool hasProp(const std::string &key) const;
+
+  //! clears the value of a \c property
+  /*!
+    <b>Notes:</b>
+    - if no \c property with name \c key exists, a KeyErrorException
+    will be thrown.
+    - if the \c property is marked as \c computed, it will also be removed
+    from our list of \c computedProperties
+
+    <b>Notes:</b>
+    - This must be allowed on a const Bond for backward compatibility,
+    but DO NOT call this while this bond might be being modified in another
+    thread, NOR while any properties on the same molecule might be being read or
+    written.
+  */
+  //! \overload
+  void clearProp(const std::string &key) const;
+
+  //! clears all of our \c computed \c properties
+  /*!
+    <b>Notes:</b>
+    - This must be allowed on a const Bond for backward compatibility,
+    but DO NOT call this while this bond might be being modified in another
+    thread, NOR while any properties on the same molecule might be being read or
+    written.
+  */
+  void clearComputedProps() const;
+
+  //! update the properties from another
+  /*
+    \param source    Source to update the properties from
+    \param preserve  Existing If true keep existing data, else override from
+    the source
+  */
+  void updateProps(const Bond& source, bool preserveExisting = false);
+  void updateProps(const RDProps& source, bool preserveExisting = false);
+
+  //! Clears all properties of this Bond, but leaves everything else
+  void clear();
+  Dict &getDict() {
+    raiseNonImplementedFunction("GetDict");
+    Dict dict;
+    return dict;
+  }
+  const Dict &getDict() const {
+    raiseNonImplementedFunction("GetDict");
+    Dict dict;
+    return dict;
+  }
+ private:
+  void initFromOther(const Bond& other, bool preserveProps = false);
 };
 
 inline bool isDative(const Bond &bond) {
@@ -405,6 +522,7 @@ inline bool canHaveDirection(const Bond &bond) {
 
 //! returns twice the \c bondType
 //! (e.g. SINGLE->2, AROMATIC->3, etc.)
+RDKIT_GRAPHMOL_EXPORT extern uint8_t getTwiceBondType(RDKit::Bond::BondType b);
 RDKIT_GRAPHMOL_EXPORT extern uint8_t getTwiceBondType(const RDKit::Bond &b);
 
 };  // namespace RDKit

--- a/Code/GraphMol/CMakeLists.txt
+++ b/Code/GraphMol/CMakeLists.txt
@@ -1,6 +1,6 @@
 rdkit_library(GraphMol
         Atom.cpp QueryAtom.cpp QueryBond.cpp Bond.cpp
-        MolOps.cpp FindRings.cpp ROMol.cpp RWMol.cpp PeriodicTable.cpp
+        MolOps.cpp FindRings.cpp RDMol.cpp ROMol.cpp RWMol.cpp PeriodicTable.cpp
         atomic_data.cpp QueryOps.cpp MolPickler.cpp Canon.cpp
         AtomIterators.cpp BondIterators.cpp Aromaticity.cpp Kekulize.cpp
         ConjugHybrid.cpp AddHs.cpp
@@ -30,6 +30,8 @@ rdkit_headers(Atom.h
         Conformer.h
         details.h
         GraphMol.h
+        GraphMolEnums.h
+        GraphMolFwd.h
         MolOps.h
         MolPickler.h
         PeriodicTable.h
@@ -41,6 +43,7 @@ rdkit_headers(Atom.h
         Resonance.h
         RingInfo.h
         Rings.h
+        RDMol.h
         ROMol.h
         RWMol.h
         SanitException.h
@@ -203,3 +206,14 @@ rdkit_catch_test(tableTestsCatch catch_periodictable.cpp
 rdkit_catch_test(molopsTestsCatch catch_molops.cpp
         LINK_LIBRARIES FileParsers SmilesParse GraphMol)
 
+rdkit_catch_test(rdmolTestsCatch catch_rdmol.cpp
+        LINK_LIBRARIES SmilesParse GraphMol)
+
+rdkit_catch_test(romolcompatTestsCatch catch_romol_compat.cpp
+        LINK_LIBRARIES SmilesParse GraphMol)
+
+rdkit_catch_test(rwmolcompatTestsCatch catch_rwmol_compat.cpp
+        LINK_LIBRARIES SmilesParse GraphMol)
+
+rdkit_catch_test(stereoGroupsTestCatch catch_stereo_groups.cpp
+        LINK_LIBRARIES SmilesParse GraphMol)

--- a/Code/GraphMol/ChemReactions/ReactionRunner.cpp
+++ b/Code/GraphMol/ChemReactions/ReactionRunner.cpp
@@ -425,7 +425,7 @@ RWMOL_SPTR convertTemplateToMol(const ROMOL_SPTR prodTemplateSptr) {
 
     // copy properties over:
     bool preserveExisting = true;
-    newB->updateProps(*static_cast<const RDProps *>(oldB), preserveExisting);
+    newB->updateProps(*oldB, preserveExisting);
   }
   return RWMOL_SPTR(res);
 }  // end of convertTemplateToMol()

--- a/Code/GraphMol/ChemTransforms/MolFragmenter.cpp
+++ b/Code/GraphMol/ChemTransforms/MolFragmenter.cpp
@@ -329,8 +329,8 @@ void fragmentOnSomeBonds(
     return;
   }
 
-  std::uint64_t state = (0x1L << maxToCut) - 1;
-  std::uint64_t stop = 0x1L << bondIndices.size();
+  std::uint64_t state = (std::uint64_t(1) << maxToCut) - 1;
+  std::uint64_t stop = std::uint64_t(1) << bondIndices.size();
   std::vector<unsigned int> fragmentHere(maxToCut);
   std::vector<std::pair<unsigned int, unsigned int>> *dummyLabelsHere = nullptr;
   if (dummyLabels) {
@@ -344,7 +344,7 @@ void fragmentOnSomeBonds(
   while (state < stop) {
     unsigned int nSeen = 0;
     for (unsigned int i = 0; i < bondIndices.size() && nSeen < maxToCut; ++i) {
-      if (state & (0x1L << i)) {
+      if (state & (std::uint64_t(1) << i)) {
         fragmentHere[nSeen] = bondIndices[i];
         if (dummyLabelsHere) {
           (*dummyLabelsHere)[nSeen] = (*dummyLabels)[i];

--- a/Code/GraphMol/Chirality.h
+++ b/Code/GraphMol/Chirality.h
@@ -19,11 +19,16 @@
 #include <boost/dynamic_bitset.hpp>
 #include <limits>
 
+#include "MolOps.h"
+
 namespace RDKit {
 class Atom;
+class AtomData;
 class Bond;
+class BondData;
 class ROMol;
 class Conformer;
+class RingInfoCache;
 
 namespace Chirality {
 
@@ -54,6 +59,19 @@ RDKIT_GRAPHMOL_EXPORT extern bool
     useLegacyStereoPerception;  //!< Toggle usage of the legacy stereo
                                 //!< perception code
 
+typedef INT_VECT CIP_ENTRY;
+typedef std::vector<CIP_ENTRY> CIP_ENTRY_VECT;
+
+struct CIPRanksTempData {
+  INT_VECT invars;
+  CIP_ENTRY_VECT cipEntries;
+  std::vector<unsigned int> counts;
+  std::vector<unsigned int> updatedNbrIdxs;
+};
+
+typedef std::pair<int, int> INT_PAIR;
+typedef std::vector<INT_PAIR> INT_PAIR_VECT;
+
 /// @cond
 /*!
   \param mol the molecule to be altered
@@ -65,10 +83,11 @@ RDKIT_GRAPHMOL_EXPORT extern bool
        CIP ranking.
 
 */
-RDKIT_GRAPHMOL_EXPORT void assignAtomCIPRanks(const ROMol &mol,
+RDKIT_GRAPHMOL_EXPORT void assignAtomCIPRanks(ROMol &mol,
                                               UINT_VECT &ranks);
 
 RDKIT_GRAPHMOL_EXPORT bool hasStereoBondDir(const Bond *bond);
+RDKIT_GRAPHMOL_EXPORT bool hasStereoBondDir(const BondData &bond);
 
 /**
  *  Returns the first neighboring bond that can be found which has a stereo
@@ -184,6 +203,7 @@ RDKIT_GRAPHMOL_EXPORT INT_VECT findStereoAtoms(const Bond *bond);
 //! \name Non-tetrahedral stereochemistry
 //! @{
 RDKIT_GRAPHMOL_EXPORT bool hasNonTetrahedralStereo(const Atom *center);
+RDKIT_GRAPHMOL_EXPORT bool hasNonTetrahedralStereo(const AtomData &center);
 RDKIT_GRAPHMOL_EXPORT Bond *getChiralAcrossBond(const Atom *center,
                                                 const Bond *qry);
 RDKIT_GRAPHMOL_EXPORT Bond *getChiralAcrossBond(const Atom *center,

--- a/Code/GraphMol/Conformer.h
+++ b/Code/GraphMol/Conformer.h
@@ -11,6 +11,8 @@
 #ifndef _RD_CONFORMER_H
 #define _RD_CONFORMER_H
 
+#include <GraphMol/RDMol.h>
+
 #include <Geometry/point.h>
 #include <RDGeneral/types.h>
 #include <boost/smart_ptr.hpp>
@@ -46,6 +48,8 @@ class RDKIT_GRAPHMOL_EXPORT ConformerException : public std::exception {
 class RDKIT_GRAPHMOL_EXPORT Conformer : public RDProps {
  public:
   friend class ROMol;
+  // CompatibilityData needs private access for setOwningMol
+  friend class RDMol::CompatibilityData;
 
   //! Constructor
   Conformer() = default;

--- a/Code/GraphMol/FMCS/Test/testFMCS.cpp
+++ b/Code/GraphMol/FMCS/Test/testFMCS.cpp
@@ -547,7 +547,7 @@ std::string testChEMBL_Txt(const char *test, double th = 1.0,
   std::cout << "MCS : " << res.SmartsString << " " << res.NumAtoms << " atoms, "
             << res.NumBonds << " bonds\n";
   printTime();
-  fprintf(fres, "%s;%lu;%.1f;%.4f;%u;%u;%s;", test, mols.size(), th, sec,
+  fprintf(fres, "%s;%zu;%.1f;%.4f;%u;%u;%s;", test, mols.size(), th, sec,
           res.NumAtoms, res.NumBonds, res.SmartsString.c_str());
 
   p.BondTyper = MCSBondCompareOrderExact;
@@ -1229,7 +1229,7 @@ void testFileSDF_RandomSet_SMI(
       printTime();
       std::cout << n << " MCS: " << res.SmartsString << " " << res.NumAtoms
                 << " atoms, " << res.NumBonds << " bonds\n";
-      fprintf(fcsv, "%u;%lu;%s;%.3f;%u;%u;%s;", n, mols.size(),
+      fprintf(fcsv, "%u;%zu;%s;%.3f;%u;%u;%s;", n, mols.size(),
               res.isCompleted() ? " " : "TIMEOUT", t, res.NumAtoms,
               res.NumBonds, res.SmartsString.c_str());
     }
@@ -1241,7 +1241,7 @@ void testFileSDF_RandomSet_SMI(
       printTime();
       std::cout << n << " MCS: " << res.SmartsString << " " << res.NumAtoms
                 << " atoms, " << res.NumBonds << " bonds\n";
-      fprintf(fcsv, "%u;%lu;%s;%.3f;%u;%u;%s\n", n, mols.size(),
+      fprintf(fcsv, "%u;%zu;%s;%.3f;%u;%u;%s\n", n, mols.size(),
               res.isCompleted() ? " " : "TIMEOUT", t, res.NumAtoms,
               res.NumBonds, res.SmartsString.c_str());
       p.BondTyper = MCSBondCompareOrder;
@@ -1347,7 +1347,7 @@ void testFileSDF_RandomSet(const char *test = "chembl13-10000-random-pairs.sdf",
         printTime();
         std::cout << n << " MCS: " << res.SmartsString << " " << res.NumAtoms
                   << " atoms, " << res.NumBonds << " bonds\n";
-        fprintf(fcsv, "%u;%lu;%s;%.5f;%u;%u;%s;", n, mols.size(),
+        fprintf(fcsv, "%u;%zu;%s;%.5f;%u;%u;%s;", n, mols.size(),
                 res.isCompleted() ? " " : "TIMEOUT", t, res.NumAtoms,
                 res.NumBonds, res.SmartsString.c_str());
       }
@@ -1400,7 +1400,7 @@ void testFileSDF_RandomSet(const char *test = "chembl13-10000-random-pairs.sdf",
       printTime();
       std::cout << n << " MCS: " << res.SmartsString << " " << res.NumAtoms
                 << " atoms, " << res.NumBonds << " bonds\n";
-      fprintf(fcsv, "%u;%lu;%s;%.5f;%u;%u;%s;", n, mols.size(),
+      fprintf(fcsv, "%u;%zu;%s;%.5f;%u;%u;%s;", n, mols.size(),
               res.isCompleted() ? " " : "TIMEOUT", t, res.NumAtoms,
               res.NumBonds, res.SmartsString.c_str());
     }
@@ -1489,7 +1489,7 @@ void testFileSDF_RandomSet(const char *test = "chembl13-10000-random-pairs.sdf",
       std::cout << n << " MCS: " << res.SmartsString << " " << res.NumAtoms
                 << " atoms, " << res.NumBonds << " bonds\n";
       if (res.NumBonds >= SizeOfBigMCS_ForBigRandomTests && res.isCompleted()) {
-        fprintf(fcsv, "%u;%lu;%s;%.5f;%u;%u;%s;", n, mols.size(),
+        fprintf(fcsv, "%u;%zu;%s;%.5f;%u;%u;%s;", n, mols.size(),
                 res.isCompleted() ? " " : "TIMEOUT", t, res.NumAtoms,
                 res.NumBonds, res.SmartsString.c_str());
         fprintf(fcmd,

--- a/Code/GraphMol/FileParsers/MaeWriter.cpp
+++ b/Code/GraphMol/FileParsers/MaeWriter.cpp
@@ -312,8 +312,9 @@ void mapMolProperties(const ROMol &mol, const STR_VECT &propNames,
   };
 
   int fake_idx = 0;
-  copyProperties(mol, propNames, fake_idx, boolSetter, intSetter, realSetter,
-                 stringSetter);
+  raiseNonImplementedDetail("Properties");
+  //copyProperties(mol, propNames, fake_idx, boolSetter, intSetter, realSetter,
+  //               stringSetter);
 }
 void mapAtom(
     const Conformer &conformer, const Atom &atom, const STR_VECT &propNames,
@@ -368,8 +369,10 @@ void mapAtom(
   }
 
   // Custom properties
-  copyProperties(atom, propNames, idx, boolSetter, intSetter, realSetter,
-                 stringSetter);
+  raiseNonImplementedDetail("Properties");
+
+  // copyProperties(atom, propNames, idx, boolSetter, intSetter, realSetter,
+   //              stringSetter);
 }
 
 void mapAtoms(const ROMol &mol, const STR_VECT &propNames, int confId,
@@ -442,8 +445,9 @@ void mapBond(
   }
 
   // Custom properties
-  copyProperties(bond, propNames, idx, boolSetter, intSetter, realSetter,
-                 stringSetter);
+  raiseNonImplementedDetail("Properties");
+  //copyProperties(bond, propNames, idx, boolSetter, intSetter, realSetter,
+   //              stringSetter);
 }
 
 void mapBonds(const ROMol &mol, const STR_VECT &propNames,

--- a/Code/GraphMol/FileParsers/file_parsers_catch.cpp
+++ b/Code/GraphMol/FileParsers/file_parsers_catch.cpp
@@ -35,7 +35,7 @@
 #include <GraphMol/test_fixtures.h>
 #include <RDGeneral/FileParseException.h>
 #include <boost/algorithm/string.hpp>
-
+#include <GraphMol/rdmol_throw.h>
 using namespace RDKit;
 
 TEST_CASE("Basic SVG Parsing", "[SVG][reader]") {
@@ -6097,7 +6097,7 @@ TEST_CASE("MaeWriter basic testing", "[mae][MaeWriter][writer]") {
   auto mol = "C1CCC(*)CC1"_smiles;
   REQUIRE(mol);
 
-  auto add_some_props = [](RDProps &obj, const std::string &prefix) {
+  auto add_some_props = [](auto &obj, const std::string &prefix) {
     obj.setProp(prefix + "_bool_prop", false);
     obj.setProp(prefix + "_int_prop", 42);
     obj.setProp(prefix + "_real_prop", 3.141592);
@@ -6337,6 +6337,8 @@ TEST_CASE("MaeWriter basic testing", "[mae][MaeWriter][writer]") {
 
     REQUIRE(MolToSmiles(*roundtrip_mol) == "*C1CCCCC1");
 
+    raiseNonImplementedFunction("mol rdprop conversion");
+    /*
     {
       INFO("Checking mol properties");
       check_roundtripped_properties(*mol, *roundtrip_mol);
@@ -6348,6 +6350,7 @@ TEST_CASE("MaeWriter basic testing", "[mae][MaeWriter][writer]") {
                                       *roundtrip_mol->getAtomWithIdx(i));
       }
     }
+     */
     // Maeparser does not parse bond properties, so don't check them.
   }
   SECTION("Check reverse roundtrip") {

--- a/Code/GraphMol/FindRings.cpp
+++ b/Code/GraphMol/FindRings.cpp
@@ -7,8 +7,10 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
+#include <GraphMol/rdmol_throw.h>
 #include <GraphMol/RDKitBase.h>
 #include <GraphMol/Rings.h>
+#include <GraphMol/RDMol.h>
 #include <RDGeneral/RDLog.h>
 #include <RDGeneral/Exceptions.h>
 
@@ -139,6 +141,44 @@ void pickD2Nodes(const ROMol &tMol, INT_VECT &d2nodes, const INT_VECT &currFrag,
       break;
     } else {
       markUselessD2s(root, tMol, forb, atomDegrees, activeBonds);
+    }
+  }
+}
+
+void markUselessD2s(uint32_t rootAtomIndex, const RDMol &tMol,
+                    boost::dynamic_bitset<> &forb, const INT_VECT &atomDegrees,
+                    const boost::dynamic_bitset<> &activeBonds) {
+  // recursive function to mark any degree 2 nodes that are already represented
+  // by root for the purpose of finding smallest rings.
+  auto [beg, end] = tMol.getAtomBonds(rootAtomIndex);
+  for (; beg != end; ++beg) {
+    const uint32_t bondIndex = *beg;
+    if (!activeBonds[bondIndex]) {
+      continue;
+    }
+    const BondData &bond = tMol.getBond(bondIndex);
+    const uint32_t oIdx = bond.getOtherAtomIdx(rootAtomIndex);
+    if (!forb[oIdx] && atomDegrees[oIdx] == 2) {
+      forb.set(oIdx);
+      markUselessD2s(oIdx, tMol, forb, atomDegrees, activeBonds);
+    }
+  }
+}
+
+void pickD2Nodes(const RDMol &tMol, INT_VECT &d2nodes,
+                 const uint32_t *currFragBegin, const uint32_t *currFragEnd,
+                 const INT_VECT &atomDegrees,
+                 const boost::dynamic_bitset<> &activeBonds) {
+  d2nodes.resize(0);
+
+  // forb contains all d2 nodes, not just the ones we want to keep
+  boost::dynamic_bitset<> forb(tMol.getNumAtoms());
+  for (auto it = currFragBegin; it != currFragEnd; ++it) {
+    const uint32_t axci = *it;
+    if (atomDegrees[axci] == 2 && !forb[axci]) {
+      d2nodes.push_back(axci);
+      forb.set(axci);
+      markUselessD2s(axci, tMol, forb, atomDegrees, activeBonds);
     }
   }
 }
@@ -550,6 +590,8 @@ void findRingsD3Node(const ROMol &tMol, VECT_INT_VECT &res,
   }  // end of found less than 3 smallest ring for the degree 3 node
 }
 
+// This function was unused
+#if 0
 int greatestComFac(long curfac, long nfac) {
   long small;
   long large;
@@ -571,6 +613,7 @@ int greatestComFac(long curfac, long nfac) {
   // By here nLarge will hold the largest common factor, so just return it
   return large;
 }
+#endif
 
 /******************************************************************************
  * SUMMARY:
@@ -600,6 +643,25 @@ void trimBonds(unsigned int cand, const ROMol &tMol, INT_SET &changed,
       changed.insert(oIdx);
     }
     activeBonds[bond->getIdx()] = 0;
+    atomDegrees[oIdx] -= 1;
+    atomDegrees[cand] -= 1;
+  }
+}
+void trimBonds(const uint32_t cand, const RDMol &tMol, std::vector<uint32_t> &changed,
+               INT_VECT &atomDegrees, boost::dynamic_bitset<> &activeBonds) {
+  auto [beg, end] = tMol.getAtomBonds(cand);
+  for (; beg != end; ++beg) {
+    const uint32_t bondIndex = *beg;
+    if (!activeBonds[bondIndex]) {
+      continue;
+    }
+    const BondData &bond = tMol.getBond(bondIndex);
+    const uint32_t oIdx = bond.getOtherAtomIdx(cand);
+    if (atomDegrees[oIdx] <= 2) {
+      changed.push_back(oIdx);
+      std::push_heap(changed.begin(), changed.end(), std::greater());
+    }
+    activeBonds.reset(bondIndex);
     atomDegrees[oIdx] -= 1;
     atomDegrees[cand] -= 1;
   }
@@ -1000,7 +1062,7 @@ int findSSSR(const ROMol &mol, VECT_INT_VECT &res, bool includeDativeBonds) {
       // for this fix to apply we have to have at least one non-ring bond
       // that terminates in ring atoms. Find those bonds:
       std::vector<const Bond *> possibleBonds;
-      for (unsigned int i = 0; i < nbnds; ++i) {
+      for (unsigned int i = 0; i < mol.getNumBonds(); ++i) {
         if (!ringBonds[i]) {
           const Bond *bnd = mol.getBondWithIdx(i);
           if (ringAtoms[bnd->getBeginAtomIdx()] &&
@@ -1019,7 +1081,7 @@ int findSSSR(const ROMol &mol, VECT_INT_VECT &res, bool includeDativeBonds) {
         }
         possibleBonds.clear();
         // check if we need to repeat the process:
-        for (unsigned int i = 0; i < nbnds; ++i) {
+        for (unsigned int i = 0; i < mol.getNumBonds(); ++i) {
           if (!ringBonds[i]) {
             const Bond *bnd = mol.getBondWithIdx(i);
             if (!deadBonds[bnd->getIdx()] &&
@@ -1235,6 +1297,181 @@ void fastFindRings(const ROMol &mol) {
   }
 
   FindRings::storeRingsInfo(mol, res);
+}
+void fastFindRings(const RDMol &mol, RingInfoCache& rings) {
+  std::vector<uint32_t> &ringBegins = rings.ringBegins;
+  std::vector<uint32_t> &atomsInRings = rings.atomsInRings;
+  std::vector<uint32_t> &bondsInRings = rings.bondsInRings;
+  ringBegins.resize(0);
+  atomsInRings.resize(0);
+  bondsInRings.resize(0);
+
+  uint32_t numAtoms = mol.getNumAtoms();
+  uint32_t numBonds = mol.getNumBonds();
+
+  // atomVisited:
+  // 0 = unvisited
+  // 1 = atom in traversalStack
+  // 2 = atom fully visited
+  INT_VECT &atomVisited = rings.tempPerAtomInts;
+  atomVisited.resize(0);
+  atomVisited.resize(numAtoms, 0);
+
+  std::vector<uint32_t> &atomRingCounts = rings.atomMembershipBegins;
+  std::vector<uint32_t> &bondRingCounts = rings.bondMembershipBegins;
+  atomRingCounts.resize(numAtoms);
+  bondRingCounts.resize(numBonds);
+  //struct RingStackEntry {
+  //  uint32_t atomIndex;
+  //  uint32_t atomNeighborIndex;
+  //};
+  // first is atomIndex, second is atomNeighborIndex
+  std::vector<std::pair<int,int>> &traversalStack = rings.tempPerAtomPairs;
+
+  // First, mark all atoms with degree less than 2 as unvisitable.
+  for (uint32_t i = 0; i < numAtoms; ++i) {
+    if (mol.getAtomDegree(i) < 2) {
+      atomVisited[i] = 2;
+    }
+  }
+
+  for (uint32_t i = 0; i < numAtoms; ++i) {
+    if (atomVisited[i] != 0) {
+      continue;
+    }
+    atomVisited[i] = 1;
+    traversalStack.resize(1);
+    traversalStack[0] = std::make_pair(i, 0);
+    while (traversalStack.size() != 0) {
+      auto [atomIndex, atomNeighborIndex] = traversalStack.back();
+      uint32_t edgeIndex = mol.getAtomBondStarts()[atomIndex] + atomNeighborIndex;
+      const uint32_t endEdgeIndex = mol.getAtomBondStarts()[atomIndex + 1];
+      uint32_t nbrAtomIndex = mol.getOtherAtomIndices()[edgeIndex];
+      //uint32_t bondIndex = mol.getBondDataIndices()[edgeIndex];
+
+      if (atomVisited[nbrAtomIndex] == 0) {
+        // Unvisited atom, so recurse
+        atomVisited[nbrAtomIndex] = 1;
+        traversalStack.push_back(std::make_pair(nbrAtomIndex, 0));
+        continue;
+      }
+
+      if (atomVisited[nbrAtomIndex] == 1 && traversalStack.size() >= 3 &&
+          nbrAtomIndex != traversalStack[traversalStack.size() - 2].first) {
+        // Atom already in the traversal stack, but not the previous 2,
+        // so we have a cycle.
+        assert(traversalStack.back().first == atomIndex);
+        ringBegins.push_back(atomsInRings.size());
+        atomsInRings.push_back(atomIndex);
+        // FIXME: Double-check the order of the bonds in the rings matches the original code!!!
+        uint32_t bondIndex = mol.getBondDataIndices()[edgeIndex];
+        bondsInRings.push_back(bondIndex);
+        ++atomRingCounts[atomIndex];
+        ++bondRingCounts[bondIndex];
+        size_t i; 
+        for (i = traversalStack.size() - 2;
+             traversalStack[i].first != nbrAtomIndex; --i) {
+          auto [ringAtomIndex, ringNeighborIndex] = traversalStack[i];
+          atomsInRings.push_back(ringAtomIndex);
+          uint32_t ringEdgeIndex =
+              mol.getAtomBondStarts()[ringAtomIndex] + ringNeighborIndex;
+          uint32_t ringBondIndex = mol.getBondDataIndices()[ringEdgeIndex];
+          bondsInRings.push_back(ringBondIndex);
+          ++atomRingCounts[ringAtomIndex];
+          ++bondRingCounts[ringBondIndex];
+          // This shouldn't loop forever, but we can double-check in a debug
+          // build.
+          assert(i > 1 || traversalStack[0].first == nbrAtomIndex);
+        }
+        atomsInRings.push_back(nbrAtomIndex);
+        uint32_t ringEdgeIndex =
+            mol.getAtomBondStarts()[nbrAtomIndex] + traversalStack[i].second;
+        uint32_t ringBondIndex = mol.getBondDataIndices()[ringEdgeIndex];
+        bondsInRings.push_back(ringBondIndex);
+        ++atomRingCounts[nbrAtomIndex];
+        ++bondRingCounts[ringBondIndex];
+      }
+
+      // Pick the next available edge, possibly up the stack.
+      ++edgeIndex;
+      if (edgeIndex != endEdgeIndex) {
+        ++traversalStack.back().second;
+      } else {
+        while (true) {
+          traversalStack.pop_back();
+          if (traversalStack.size() == 0) {
+            break;
+          }
+          std::pair<int,int> &pair = traversalStack.back();
+          auto [atomIndex, atomNeighborIndex] = pair; 
+          const uint32_t numNeighbors = mol.getAtomDegree(atomIndex);
+          ++atomNeighborIndex;
+          if (atomNeighborIndex != numNeighbors) {
+            // Found an edge
+            pair.second = atomNeighborIndex;
+            break;
+          }
+        }
+      }
+    }
+    atomVisited[i] = 2;
+  }
+  const size_t numRings = ringBegins.size();
+  ringBegins.push_back(atomsInRings.size());
+
+  // Record the rings that each atom and bond are in, using
+  // atomRingCounts and bondRingCounts to preallocate,
+  // and then iterate through, filling the final arrays in.
+  assert(atomsInRings.size() == bondsInRings.size());
+  uint32_t sum = 0;
+  for (uint32_t i = 0; i < numAtoms; ++i) {
+    uint32_t newSum = sum + atomRingCounts[i];
+    atomRingCounts[i] = sum;
+    sum = newSum;
+  }
+  assert(sum == atomsInRings.size());
+  sum = 0;
+  for (uint32_t i = 0; i < numBonds; ++i) {
+    uint32_t newSum = sum + bondRingCounts[i];
+    bondRingCounts[i] = sum;
+    sum = newSum;
+  }
+  assert(sum == bondsInRings.size());
+
+  // Fill in the atom-to-ring and bond-to-ring mappings
+  std::vector<uint32_t> &atomMemberships = rings.atomMemberships;
+  std::vector<uint32_t> &bondMemberships = rings.bondMemberships;
+  atomMemberships.resize(atomsInRings.size());
+  bondMemberships.resize(bondsInRings.size());
+  for (size_t ring = 0; ring < numRings; ++ring) {
+    uint32_t ringBegin = ringBegins[ring];
+    uint32_t ringEnd = ringBegins[ring+1];
+    for (; ringBegin < ringEnd; ++ringBegin) {
+      uint32_t atom = atomsInRings[ringBegin];
+      uint32_t destIndex = atomRingCounts[atom];
+      atomMemberships[destIndex] = ring;
+      atomRingCounts[atom] = destIndex + 1;
+
+      uint32_t bond = bondsInRings[ringBegin];
+      destIndex = bondRingCounts[bond];
+      bondMemberships[destIndex] = ring;
+      bondRingCounts[bond] = destIndex + 1;
+    }
+  }
+  // atomRingCounts and bondRingCounts effectively got shifted over by
+  // the incrementing, so add back the 0 at the beginning.
+  atomRingCounts.push_back(0);
+  memmove(atomRingCounts.data() + 1, atomRingCounts.data(),
+          sizeof(uint32_t) * (atomRingCounts.size() - 1));
+  atomRingCounts[0] = 0;
+
+  bondRingCounts.push_back(0);
+  memmove(bondRingCounts.data() + 1, bondRingCounts.data(),
+          sizeof(uint32_t) * (bondRingCounts.size() - 1));
+  bondRingCounts[0] = 0;
+
+  rings.isInit = true;
+  rings.findRingType = FIND_RING_TYPE_FAST;
 }
 
 #ifdef RDK_USE_URF

--- a/Code/GraphMol/GraphMolEnums.h
+++ b/Code/GraphMol/GraphMolEnums.h
@@ -1,0 +1,102 @@
+//
+//  Copyright (C) 2025 NVIDIA Corporation & Affiliates and other RDKit contributors
+//
+//   @@ All Rights Reserved @@
+//  This file is part of the RDKit.
+//  The contents are covered by the terms of the BSD license
+//  which is included in the file license.txt, found at the root
+//  of the RDKit source tree.
+//
+#pragma once
+
+#include <RDGeneral/export.h>
+
+namespace RDKit {
+
+namespace AtomEnums {
+//! store hybridization
+enum HybridizationType {
+  UNSPECIFIED = 0,  //!< hybridization that hasn't been specified
+  S,
+  SP,
+  SP2,
+  SP3,
+  SP2D,
+  SP3D,
+  SP3D2,
+  OTHER  //!< unrecognized hybridization
+};
+
+//! store type of chirality
+enum ChiralType {
+  CHI_UNSPECIFIED = 0,      //!< chirality that hasn't been specified
+  CHI_TETRAHEDRAL_CW,       //!< tetrahedral: clockwise rotation (SMILES \@\@)
+  CHI_TETRAHEDRAL_CCW,      //!< tetrahedral: counter-clockwise rotation (SMILES \@)
+  CHI_OTHER,                //!< some unrecognized type of chirality
+  CHI_TETRAHEDRAL,          //!< tetrahedral, use permutation flag
+  CHI_ALLENE,               //!< allene, use permutation flag
+  CHI_SQUAREPLANAR,         //!< square planar, use permutation flag
+  CHI_TRIGONALBIPYRAMIDAL,  //!< trigonal bipyramidal, use permutation flag
+  CHI_OCTAHEDRAL            //!< octahedral, use permutation flag
+};
+}  // namespace AtomEnums
+
+namespace BondEnums {
+//! the type of Bond
+enum BondType {
+  UNSPECIFIED = 0,
+  SINGLE,
+  DOUBLE,
+  TRIPLE,
+  QUADRUPLE,
+  QUINTUPLE,
+  HEXTUPLE,
+  ONEANDAHALF,
+  TWOANDAHALF,
+  THREEANDAHALF,
+  FOURANDAHALF,
+  FIVEANDAHALF,
+  AROMATIC,
+  IONIC,
+  HYDROGEN,
+  THREECENTER,
+  DATIVEONE,  //!< one-electron dative (e.g. from a C in a Cp ring to a metal)
+  DATIVE,     //!< standard two-electron dative
+  DATIVEL,    //!< standard two-electron dative
+  DATIVER,    //!< standard two-electron dative
+  OTHER,
+  ZERO  //!< Zero-order bond (from
+  // http://pubs.acs.org/doi/abs/10.1021/ci200488k)
+};
+
+//! the bond's direction (for chirality)
+enum BondDir {
+  NONE = 0,    //!< no special style
+  BEGINWEDGE,  //!< wedged: narrow at begin
+  BEGINDASH,   //!< dashed: narrow at begin
+  // FIX: this may not really be adequate
+  ENDDOWNRIGHT,  //!< for cis/trans
+  ENDUPRIGHT,    //!<  ditto
+  EITHERDOUBLE,  //!< a "crossed" double bond
+  UNKNOWN,       //!< intentionally unspecified stereochemistry
+};
+
+//! the nature of the bond's stereochem (for cis/trans)
+enum BondStereo {  // stereochemistry of double bonds
+  STEREONONE = 0,  // no special style
+  STEREOANY,       // intentionally unspecified
+  // -- Put any true specifications about this point so
+  // that we can do comparisons like if(bond->getStereo()>BondStereo::STEREOANY)
+  STEREOZ,         // Z double bond
+  STEREOE,         // E double bond
+  STEREOCIS,       // cis double bond
+  STEREOTRANS,     // trans double bond
+  STEREOATROPCW,   //  atropisomer clockwise rotation
+  STEREOATROPCCW,  //  atropisomer counter clockwise rotation
+};
+}  // namespace BondEnums
+
+//! returns true if the atom is to the left of C
+RDKIT_GRAPHMOL_EXPORT bool isEarlyAtom(int atomicNum);
+
+}  // namespace RDKit

--- a/Code/GraphMol/GraphMolFwd.h
+++ b/Code/GraphMol/GraphMolFwd.h
@@ -1,0 +1,25 @@
+//
+//  Copyright (C) 2025 NVIDIA Corporation & Affiliates and other RDKit contributors
+//
+//   @@ All Rights Reserved @@
+//  This file is part of the RDKit.
+//  The contents are covered by the terms of the BSD license
+//  which is included in the file license.txt, found at the root
+//  of the RDKit source tree.
+//
+#pragma once
+
+namespace RDKit {
+
+class RDMol;
+class AtomData;
+class BondData;
+class RingInfoCache;
+struct PropertyType;
+class PropToken;
+namespace detail {
+class BitSetWrapper;
+}
+
+
+}  // namespace RDKit

--- a/Code/GraphMol/MolDraw2D/DrawMol.cpp
+++ b/Code/GraphMol/MolDraw2D/DrawMol.cpp
@@ -2582,7 +2582,7 @@ double DrawMol::getNoteStartAngle(const Atom *atom) const {
   }
   const Point2D &at_cds = atCds_[atom->getIdx()];
   std::vector<Point2D> bond_vecs;
-  for (auto nbr : make_iterator_range(drawMol_->getAtomNeighbors(atom))) {
+  for (auto nbr : boost::make_iterator_range(drawMol_->getAtomNeighbors(atom))) {
     // If the nbr has the same coords as atom, bond_vec comes out as NaN, NaN
     // (issue 6559), so use a short arbitrary vector instead.
     Point2D bond_vec;
@@ -3279,7 +3279,7 @@ void DrawMol::doubleBondTerminal(Atom *at1, Atom *at2, double offset,
     Point2D l2 = l2s.directionVector(l2f);
     l2f = l2s + l2 * 2.0 * bl;
     Point2D ip;
-    for (auto nbr : make_iterator_range(drawMol_->getAtomNeighbors(at2))) {
+    for (auto nbr : boost::make_iterator_range(drawMol_->getAtomNeighbors(at2))) {
       auto nbr_cds = atCds_[nbr];
       if (doLinesIntersect(l1s, l1f, at2_cds, nbr_cds, &ip)) {
         l1f = ip;
@@ -3756,7 +3756,7 @@ bool isLinearAtom(const Atom &atom, const std::vector<Point2D> &atCds) {
     Point2D const &at1_cds = atCds[atom.getIdx()];
     ROMol const &mol = atom.getOwningMol();
     int i = 0;
-    for (auto nbr : make_iterator_range(mol.getAtomNeighbors(&atom))) {
+    for (auto nbr : boost::make_iterator_range(mol.getAtomNeighbors(&atom))) {
       Point2D bond_vec = at1_cds.directionVector(atCds[nbr]);
       bond_vec.normalize();
       bond_vecs[i] = bond_vec;

--- a/Code/GraphMol/MolOps.cpp
+++ b/Code/GraphMol/MolOps.cpp
@@ -15,6 +15,7 @@
 #include <GraphMol/PeriodicTable.h>
 #include <GraphMol/Chirality.h>
 #include <GraphMol/RDKitQueries.h>
+#include <GraphMol/RDMol.h>
 
 #include <vector>
 #include <algorithm>
@@ -824,10 +825,13 @@ std::vector<ROMOL_SPTR> getMolFrags(const ROMol &mol, bool sanitizeFrags,
 }
 
 unsigned int getMolFrags(const ROMol &mol, INT_VECT &mapping) {
-  unsigned int natms = mol.getNumAtoms();
-  mapping.resize(natms);
-  return natms ? boost::connected_components(mol.getTopology(), &mapping[0])
-               : 0;
+  const uint32_t numAtoms = mol.getNumAtoms();
+  // Resize to zero first, so that the entire array is initialized to -1 next.
+  mapping.resize(0);
+  mapping.resize(numAtoms, uint32_t(-1));
+  // The reinterpret_cast is only valid if the size of the integers is the same.
+  static_assert(sizeof(mapping[0]) == sizeof(uint32_t));
+  return getMolFrags(mol.asRDMol(), reinterpret_cast<uint32_t *>(mapping.data()));
 };
 
 unsigned int getMolFrags(const ROMol &mol, VECT_INT_VECT &frags) {
@@ -860,6 +864,48 @@ unsigned int getMolFrags(const ROMol &mol,
                          copyConformers);
   return rdcast<unsigned int>(molFrags.size());
 }
+
+namespace {
+static void getMolFragsHelper(const RDMol &mol, uint32_t componentIndex,
+                              uint32_t *mapping, atomindex_t atomIndex) {
+  auto [beginNeighbors, endNeighbors] = mol.getAtomNeighbors(atomIndex);
+  for (; beginNeighbors != endNeighbors; ++beginNeighbors) {
+    const uint32_t neighbor = *beginNeighbors;
+    if (mapping[neighbor] == uint32_t(-1)) {
+      mapping[neighbor] = componentIndex;
+      getMolFragsHelper(mol, componentIndex, mapping, neighbor);
+    }
+  }
+}
+}  // namespace
+
+uint32_t getMolFrags(const RDMol &mol, uint32_t* mapping) {
+  const uint32_t numAtoms = mol.getNumAtoms();
+  uint32_t numComponents = 0;
+  for (uint32_t atomIndex = 0; atomIndex < numAtoms; ++atomIndex) {
+    if (mapping[atomIndex] != uint32_t(-1)) {
+      continue;
+    }
+    mapping[atomIndex] = numComponents;
+    auto [beginNeighbors, endNeighbors] = mol.getAtomNeighbors(atomIndex);
+    for (; beginNeighbors != endNeighbors; ++beginNeighbors) {
+      const uint32_t neighbor = *beginNeighbors;
+      if (mapping[neighbor] == uint32_t(-1)) {
+        mapping[neighbor] = numComponents;
+        getMolFragsHelper(mol, numComponents, mapping, neighbor);
+      }
+    }
+    ++numComponents;
+  }
+  return uint32_t(numComponents);
+}
+uint32_t getMolFrags(const RDMol &mol, std::vector<uint32_t> &mapping) {
+  const uint32_t numAtoms = mol.getNumAtoms();
+  // Resize to zero first, so that the entire array is initialized to -1 next.
+  mapping.resize(0);
+  mapping.resize(numAtoms, uint32_t(-1));
+  return getMolFrags(mol, mapping.data());
+};
 
 namespace {
 template <typename T>

--- a/Code/GraphMol/MolOps.h
+++ b/Code/GraphMol/MolOps.h
@@ -11,6 +11,9 @@
 #ifndef RD_MOL_OPS_H
 #define RD_MOL_OPS_H
 
+#include <GraphMol/Atom.h> // Needed for Atom::HybridizationType
+#include <GraphMol/RWMol.h>
+
 #include <vector>
 #include <map>
 #include <list>
@@ -22,17 +25,24 @@
 #include <RDGeneral/BetterEnums.h>
 #include "SanitException.h"
 #include <RDGeneral/FileParseException.h>
+#include "details.h"
 
 RDKIT_GRAPHMOL_EXPORT extern const int ci_LOCAL_INF;
 namespace RDKit {
 class ROMol;
 class RWMol;
+class RDMol;
+class RingInfoCache;
 class Atom;
 class Bond;
 class Conformer;
 typedef std::vector<double> INVAR_VECT;
 typedef INVAR_VECT::iterator INVAR_VECT_I;
 typedef INVAR_VECT::const_iterator INVAR_VECT_CI;
+
+namespace Chirality {
+struct ChiralityTempData;
+}
 
 //! \brief Groups a variety of molecular query and transformation operations.
 namespace MolOps {
@@ -50,12 +60,16 @@ namespace MolOps {
    \return the number of electrons
 */
 RDKIT_GRAPHMOL_EXPORT int countAtomElec(const Atom *at);
+RDKIT_GRAPHMOL_EXPORT int countAtomElec(const RDMol &mol,
+                                        const atomindex_t atomIndex);
 
 //! sums up all atomic formal charges and returns the result
 RDKIT_GRAPHMOL_EXPORT int getFormalCharge(const ROMol &mol);
 
 //! returns whether or not the given Atom is involved in a conjugated bond
 RDKIT_GRAPHMOL_EXPORT bool atomHasConjugatedBond(const Atom *at);
+RDKIT_GRAPHMOL_EXPORT bool atomHasConjugatedBond(const RDMol &mol,
+                                                 const atomindex_t atomIndex);
 
 //! find fragments (disconnected components of the molecular graph)
 /*!
@@ -83,6 +97,34 @@ RDKIT_GRAPHMOL_EXPORT unsigned int getMolFrags(const ROMol &mol,
 */
 RDKIT_GRAPHMOL_EXPORT unsigned int getMolFrags(
     const ROMol &mol, std::vector<std::vector<int>> &frags);
+
+//! find fragments (disconnected components of the molecular graph)
+/*!
+
+  \param mol     the molecule of interest
+  \param mapping used to return the mapping of Atoms->fragments.
+     \c mapping must be pre-allocated to <tt>mol->getNumAtoms()</tt> long
+     and on return, it will contain the fragment assignment for each Atom
+
+  \return the number of fragments found.
+
+*/
+RDKIT_GRAPHMOL_EXPORT uint32_t getMolFrags(const RDMol &mol,
+                                           uint32_t *mapping);
+
+//! find fragments (disconnected components of the molecular graph)
+/*!
+
+  \param mol     the molecule of interest
+  \param mapping used to return the mapping of Atoms->fragments.
+     On return \c mapping will be <tt>mol->getNumAtoms()</tt> long
+     and will contain the fragment assignment for each Atom
+
+  \return the number of fragments found.
+
+*/
+RDKIT_GRAPHMOL_EXPORT uint32_t getMolFrags(const RDMol &mol,
+                                               std::vector<uint32_t> &mapping);
 
 //! splits a molecule into its component fragments
 /// (disconnected components of the molecular graph)
@@ -267,6 +309,11 @@ inline void addHs(RWMol &mol, bool explicitOnly = false, bool addCoords = false,
 RDKIT_GRAPHMOL_EXPORT void setTerminalAtomCoords(ROMol &mol, unsigned int idx,
                                                  unsigned int otherIdx);
 
+struct RDKIT_GRAPHMOL_EXPORT SanitizeTemp {
+  std::vector<uint64_t> hydrogenIsotopeMap;
+  std::vector<uint64_t> bitSet0;
+};
+
 //! returns a copy of a molecule with hydrogens removed
 /*!
     \param mol          the molecule to remove Hs from
@@ -307,6 +354,10 @@ RDKIT_GRAPHMOL_EXPORT ROMol *removeHs(const ROMol &mol, bool implicitOnly,
 RDKIT_GRAPHMOL_EXPORT void removeHs(RWMol &mol, bool implicitOnly,
                                     bool updateExplicitCount = false,
                                     bool sanitize = true);
+RDKIT_GRAPHMOL_EXPORT void removeHs(RDMol &mol, MolOps::SanitizeTemp &temp,
+                                    bool implicitOnly = false,
+                                    bool updateExplicitCount = false,
+                                    bool sanitize = true);
 struct RDKIT_GRAPHMOL_EXPORT RemoveHsParameters {
   bool removeDegreeZero = false;    /**< hydrogens that have no bonds */
   bool removeHigherDegrees = false; /**< hydrogens with two (or more) bonds */
@@ -343,6 +394,9 @@ struct RDKIT_GRAPHMOL_EXPORT RemoveHsParameters {
 RDKIT_GRAPHMOL_EXPORT void removeHs(
     RWMol &mol, const RemoveHsParameters &ps = RemoveHsParameters(),
     bool sanitize = true);
+RDKIT_GRAPHMOL_EXPORT void removeHs(RDMol &mol, const RemoveHsParameters &ps,
+                                    MolOps::SanitizeTemp &temp,
+                                    bool sanitize = true);
 //! \overload
 /// The caller owns the pointer this returns
 RDKIT_GRAPHMOL_EXPORT ROMol *removeHs(
@@ -845,6 +899,8 @@ RDKIT_GRAPHMOL_EXPORT int findSSSR(const ROMol &mol,
   return values >0
 */
 RDKIT_GRAPHMOL_EXPORT void fastFindRings(const ROMol &mol);
+RDKIT_GRAPHMOL_EXPORT void fastFindRings(const RDMol &mol,
+                                         RingInfoCache &rings);
 
 RDKIT_GRAPHMOL_EXPORT void findRingFamilies(const ROMol &mol);
 
@@ -1119,6 +1175,7 @@ RDKIT_GRAPHMOL_EXPORT void clearDirFlags(ROMol &mol,
 //! Assign CIS/TRANS bond stereochemistry tags based on neighboring
 //! directions
 RDKIT_GRAPHMOL_EXPORT void setBondStereoFromDirections(ROMol &mol);
+RDKIT_GRAPHMOL_EXPORT void setBondStereoFromDirections(RDMol &mol);
 
 //! Assign stereochemistry tags to atoms and bonds.
 /*!
@@ -1152,6 +1209,9 @@ RDKIT_GRAPHMOL_EXPORT void setBondStereoFromDirections(ROMol &mol);
 RDKIT_GRAPHMOL_EXPORT void assignStereochemistry(
     ROMol &mol, bool cleanIt = false, bool force = false,
     bool flagPossibleStereoCenters = false);
+RDKIT_GRAPHMOL_EXPORT void assignStereochemistry(
+    RDMol &mol, Chirality::ChiralityTempData &temp, bool cleanIt = false,
+    bool force = false, bool flagPossibleStereoCenters = false);
 //! Removes all stereochemistry information from atoms (i.e. R/S) and bonds
 /// i.e. Z/E)
 /*!

--- a/Code/GraphMol/MolPickler.cpp
+++ b/Code/GraphMol/MolPickler.cpp
@@ -11,6 +11,7 @@
 #include <GraphMol/RDKitQueries.h>
 #include <GraphMol/MolPickler.h>
 #include <GraphMol/QueryOps.h>
+#include <GraphMol/rdmol_throw.h>
 #include <GraphMol/MonomerInfo.h>
 #include <GraphMol/StereoGroup.h>
 #include <GraphMol/SubstanceGroup.h>
@@ -1258,6 +1259,8 @@ void MolPickler::_pickle(const ROMol *mol, std::ostream &ss,
   }
 
   if (propertyFlags & PicklerOps::MolProps) {
+    raiseNonImplementedDetail("Cast atom to property");
+    /*
     std::stringstream tss;
     _pickleProperties(tss, *mol, propertyFlags);
     if (!tss.str().empty()) {
@@ -1265,9 +1268,12 @@ void MolPickler::_pickle(const ROMol *mol, std::ostream &ss,
       write_sstream_to_stream(ss, tss);
       streamWrite(ss, ENDPROPS);
     }
+     */
   }
 
   if (propertyFlags & PicklerOps::AtomProps) {
+    raiseNonImplementedDetail("Cast atom to property");
+    /*
     std::stringstream tss;
     bool anyWritten = false;
     for (const auto atom : mol->atoms()) {
@@ -1278,9 +1284,12 @@ void MolPickler::_pickle(const ROMol *mol, std::ostream &ss,
       write_sstream_to_stream(ss, tss);
       streamWrite(ss, ENDPROPS);
     }
+     */
   }
 
   if (propertyFlags & PicklerOps::BondProps) {
+    raiseNonImplementedDetail("Cast atom to property");
+    /*
     std::stringstream tss;
     bool anyWritten = false;
     for (const auto bond : mol->bonds()) {
@@ -1291,6 +1300,7 @@ void MolPickler::_pickle(const ROMol *mol, std::ostream &ss,
       write_sstream_to_stream(ss, tss);
       streamWrite(ss, ENDPROPS);
     }
+    */
   }
   streamWrite(ss, ENDMOL);
 }
@@ -1457,6 +1467,8 @@ void MolPickler::_depickle(std::istream &ss, ROMol *mol, int version,
   }
 
   while (tag != ENDMOL) {
+    raiseNonImplementedDetail("Cast atom to property");
+    /*
     if (tag == BEGINPROPS) {
       int32_t blkSize = 0;
       if (version >= 13000) {
@@ -1502,6 +1514,7 @@ void MolPickler::_depickle(std::istream &ss, ROMol *mol, int version,
     } else {
       break;  // break to tag != ENDMOL
     }
+     */
     if (tag != ENDPROPS) {
       throw MolPicklerException("Bad pickle format: ENDPROPS tag not found.");
     }
@@ -1585,13 +1598,15 @@ int32_t MolPickler::_pickleAtomData(std::ostream &tss, const Atom *atom) {
     propFlags |= 1 << 4;
     streamWrite(tss, tmpChar);
   }
-  if (atom->d_explicitValence > 0) {
-    tmpChar = static_cast<char>(atom->d_explicitValence);
+
+  const AtomData &atomData = atom->getRDMol().getAtom(atom->getIdx());
+  if (atomData.explicitValence > 0) {
+    tmpChar = static_cast<char>(atomData.explicitValence);
     propFlags |= 1 << 5;
     streamWrite(tss, tmpChar);
   }
-  if (atom->d_implicitValence > 0) {
-    tmpChar = static_cast<char>(atom->d_implicitValence);
+  if (atomData.implicitValence > 0) {
+    tmpChar = static_cast<char>(atomData.implicitValence);
     propFlags |= 1 << 6;
     streamWrite(tss, tmpChar);
   }
@@ -1655,22 +1670,23 @@ void MolPickler::_unpickleAtomData(std::istream &ss, Atom *atom, int version) {
   } else {
     tmpChar = 0;
   }
-  atom->d_explicitValence = tmpChar;
+  AtomData &atomData = atom->getDataRDMol().getAtom(atom->getIdx());
+  atomData.explicitValence = tmpChar;
 
   if (propFlags & (1 << 6)) {
     streamRead(ss, tmpChar, version);
   } else {
     tmpChar = 0;
   }
-  atom->d_implicitValence = tmpChar;
+  atomData.implicitValence = tmpChar;
   if (propFlags & (1 << 7)) {
     streamReadPositiveChar(ss, tmpChar, version);
   } else {
     tmpChar = 0;
   }
-  atom->d_numRadicalElectrons = static_cast<unsigned int>(tmpChar);
+  atomData.numRadicalElectrons = static_cast<unsigned int>(tmpChar);
 
-  atom->d_isotope = 0;
+  atomData.isotope = 0;
   if (propFlags & (1 << 8)) {
     unsigned int tmpuint;
     streamRead(ss, tmpuint, version);
@@ -1878,12 +1894,13 @@ Atom *MolPickler::_addAtomFromPickle(std::istream &ss, ROMol *mol,
       streamRead(ss, tmpChar, version);
       atom->setNumExplicitHs(static_cast<int>(tmpChar));
       streamRead(ss, tmpChar, version);
-      atom->d_explicitValence = tmpChar;
+      AtomData& data = atom->dp_dataMol->getAtom(atom->getIdx());
+      data.explicitValence = tmpChar;
       streamRead(ss, tmpChar, version);
-      atom->d_implicitValence = tmpChar;
+      data.implicitValence = tmpChar;
       if (version > 6000) {
         streamRead(ss, tmpChar, version);
-        atom->d_numRadicalElectrons = static_cast<unsigned int>(tmpChar);
+        data.numRadicalElectrons = static_cast<unsigned int>(tmpChar);
       }
     } else {
       _unpickleAtomData(ss, atom, version);

--- a/Code/GraphMol/QueryAtom.cpp
+++ b/Code/GraphMol/QueryAtom.cpp
@@ -14,55 +14,26 @@
 
 namespace RDKit {
 
-QueryAtom::~QueryAtom() {
-  delete dp_query;
-  dp_query = nullptr;
-};
-
 Atom *QueryAtom::copy() const {
   auto *res = new QueryAtom(*this);
   return static_cast<Atom *>(res);
+}
+
+void QueryAtom::setQuery(QUERYATOM_QUERY *what) {
+  dp_query.reset(what);
+  getDataRDMol().setAtomQueryCompat(getIdx(), what);
+  PRECONDITION(getDataRDMol().getAtomQuery(getIdx()) != nullptr,
+               "Missing new query");
 }
 
 void QueryAtom::expandQuery(QUERYATOM_QUERY *what,
                             Queries::CompositeQueryType how,
                             bool maintainOrder) {
   PRECONDITION(dp_query, "Can't expand empty query");
-  bool thisIsNullQuery = dp_query->getDescription() == "AtomNull";
-  bool otherIsNullQuery = what->getDescription() == "AtomNull";
-
-  if (thisIsNullQuery || otherIsNullQuery) {
-    mergeNullQueries(dp_query, thisIsNullQuery, what, otherIsNullQuery, how);
-    delete what;
-    return;
-  }
-
-  QUERYATOM_QUERY *origQ = dp_query;
-  std::string descrip;
-  switch (how) {
-    case Queries::COMPOSITE_AND:
-      dp_query = new ATOM_AND_QUERY;
-      descrip = "AtomAnd";
-      break;
-    case Queries::COMPOSITE_OR:
-      dp_query = new ATOM_OR_QUERY;
-      descrip = "AtomOr";
-      break;
-    case Queries::COMPOSITE_XOR:
-      dp_query = new ATOM_XOR_QUERY;
-      descrip = "AtomXor";
-      break;
-    default:
-      UNDER_CONSTRUCTION("unrecognized combination query");
-  }
-  dp_query->setDescription(descrip);
-  if (maintainOrder) {
-    dp_query->addChild(QUERYATOM_QUERY::CHILD_TYPE(origQ));
-    dp_query->addChild(QUERYATOM_QUERY::CHILD_TYPE(what));
-  } else {
-    dp_query->addChild(QUERYATOM_QUERY::CHILD_TYPE(what));
-    dp_query->addChild(QUERYATOM_QUERY::CHILD_TYPE(origQ));
-  }
+  std::unique_ptr<QUERYATOM_QUERY> origPtr(std::move(dp_query));
+  std::unique_ptr<QUERYATOM_QUERY> whatPtr(what);
+  QueryOps::expandQuery(origPtr, std::move(whatPtr), how, maintainOrder);
+  setQuery(origPtr.release());
 }
 
 namespace {
@@ -189,7 +160,7 @@ bool QueryAtom::QueryMatch(QueryAtom const *what) const {
   if (!what->hasQuery()) {
     return dp_query->Match(what);
   } else {
-    return queriesMatch(dp_query, what->getQuery());
+    return queriesMatch(dp_query.get(), what->getQuery());
   }
 }
 

--- a/Code/GraphMol/QueryOps.cpp
+++ b/Code/GraphMol/QueryOps.cpp
@@ -8,6 +8,7 @@
 //  of the RDKit source tree.
 //
 #include "QueryOps.h"
+#include "RDMol.h"
 #include <algorithm>
 #include <RDGeneral/types.h>
 #include <GraphMol/QueryAtom.h>
@@ -15,77 +16,92 @@
 #include <boost/dynamic_bitset.hpp>
 #include <boost/algorithm/string.hpp>
 
+#include <Query/NullQueryAlgebra.h>
+
 namespace RDKit {
 
 // common general queries
 
 int queryIsAtomBridgehead(Atom const *at) {
-  // at least three ring bonds, all ring bonds in a ring which shares at
+  return queryIsAtomBridgeheadInternal(at->getRDMol(), at->getIdx(),
+                                       at->getRDMol().getRingInfo()) ? 1 : 0;
+}
+bool queryIsAtomBridgeheadInternal(const RDMol &mol, atomindex_t atomIndex,
+                           const RingInfoCache &rings) {
+  // at least three ring bonds, at least one ring bond in a ring which shares at
   // least two bonds with another ring involving this atom
   //
   // We can't just go with "at least three ring bonds shared between multiple
   // rings" because of structures like CC12CCN(CC1)C2 where there are only two
   // SSSRs
-  PRECONDITION(at, "no atom");
-  if (at->getDegree() < 3) {
-    return 0;
+  PRECONDITION(atomIndex < mol.getNumAtoms(), "no atom");
+  uint32_t atomDegree = mol.getAtomDegree(atomIndex);
+  if (atomDegree < 3) {
+    return false;
   }
-  const auto &mol = at->getOwningMol();
-  const auto ri = mol.getRingInfo();
-  if (!ri || !ri->isInitialized()) {
-    return 0;
+  if (!rings.isInitialized()) {
+    // FIXME: Should there be some sort of warning here?
+    return false;
   }
-  // track which ring bonds involve this atom
-  boost::dynamic_bitset<> atomRingBonds(mol.getNumBonds());
-  for (const auto bnd : mol.atomBonds(at)) {
-    if (ri->numBondRings(bnd->getIdx())) {
-      atomRingBonds.set(bnd->getIdx());
+  // track which bonds involve this atom
+  auto [beginBonds, endBonds] = mol.getAtomBonds(atomIndex);
+  size_t numAtomRingBonds = 0;
+  for (; beginBonds != endBonds; ++beginBonds) {
+    const uint32_t bondIndex = *beginBonds;
+    if (rings.numBondRings(bondIndex)) {
+      ++numAtomRingBonds;
     }
   }
-  if (atomRingBonds.count() < 3) {
-    return 0;
+  if (numAtomRingBonds < 3) {
+    return false;
   }
 
-  boost::dynamic_bitset<> bondsInRingI(mol.getNumBonds());
-  boost::dynamic_bitset<> ringsOverlap(ri->numRings());
-  for (unsigned int i = 0; i < ri->bondRings().size(); ++i) {
-    bondsInRingI.reset();
-    bool atomInRingI = false;
-    for (const auto bidx : ri->bondRings()[i]) {
-      bondsInRingI.set(bidx);
-      if (atomRingBonds[bidx]) {
-        atomInRingI = true;
-      }
+  // Check all pairs of rings that contain this atom.
+  const uint32_t beginAtomRings = rings.atomMembershipBegins[atomIndex];
+  const uint32_t endAtomRings = rings.atomMembershipBegins[atomIndex+1];
+  boost::dynamic_bitset<> bondsInRing(mol.getNumBonds());
+  for (uint32_t atomRingIndexI = beginAtomRings;
+       atomRingIndexI != endAtomRings; ++atomRingIndexI) {
+    const uint32_t ringIndexI = rings.atomMemberships[atomRingIndexI];
+
+    bondsInRing.reset();
+    uint32_t beginBondRingI = rings.ringBegins[ringIndexI];
+    const uint32_t endBondRingI = rings.ringBegins[ringIndexI+1];
+    for (; beginBondRingI != endBondRingI; ++beginBondRingI) {
+      const uint32_t bondIndex = rings.bondsInRings[beginBondRingI];
+      bondsInRing.set(bondIndex);
     }
-    if (!atomInRingI) {
-      continue;
-    }
-    for (unsigned int j = i + 1; j < ri->bondRings().size(); ++j) {
-      unsigned int overlap = 0;
-      bool atomInRingJ = false;
-      for (const auto bidx : ri->bondRings()[j]) {
-        if (atomRingBonds[bidx]) {
-          atomInRingJ = true;
-        }
-        if (bondsInRingI[bidx]) {
+
+    for (uint32_t atomRingIndexJ = atomRingIndexI + 1;
+         atomRingIndexJ != endAtomRings; ++atomRingIndexJ) {
+      const uint32_t ringIndexJ = rings.atomMemberships[atomRingIndexJ];
+
+      uint32_t overlap = 0;
+      uint32_t beginBondRingJ = rings.ringBegins[ringIndexJ];
+      const uint32_t endBondRingJ = rings.ringBegins[ringIndexJ + 1];
+      for (; beginBondRingJ != endBondRingJ; ++beginBondRingJ) {
+        const uint32_t bondIndex = rings.bondsInRings[beginBondRingJ];
+        if (bondsInRing[bondIndex]) {
           ++overlap;
-        }
-        if (overlap >= 2 && atomInRingJ) {
-          // we have two rings containing the atom which share at least two
-          // bonds:
-          ringsOverlap.set(i);
-          ringsOverlap.set(j);
-          break;
+          if (overlap >= 2) {
+            // we have two rings containing the atom which share at least two
+            // bonds:
+            return true;
+          }
         }
       }
-    }
-    if (!ringsOverlap[i]) {
-      return 0;
     }
   }
-  return 1;
+  return false;
 }
 
+//! returns a Query for matching atoms with a particular number of ring bonds
+ATOM_EQUALS_QUERY2 *makeAtomRingBondCountQuery2(int what) {
+  ATOM_EQUALS_QUERY2 *res = new AtomRingQuery2(what);
+  res->setDescription("AtomRingBondCount");
+  res->setDataFunc(queryAtomRingBondCount2);
+  return res;
+};
 //! returns a Query for matching atoms with a particular number of ring bonds
 ATOM_EQUALS_QUERY *makeAtomRingBondCountQuery(int what) {
   ATOM_EQUALS_QUERY *res = new AtomRingQuery(what);
@@ -94,140 +110,108 @@ ATOM_EQUALS_QUERY *makeAtomRingBondCountQuery(int what) {
   return res;
 };
 
+template <bool isBond, bool newVersion>
+using ParamType = std::conditional_t<isBond,
+      std::conditional_t<newVersion, ConstRDMolBond, Bond const *>,
+      std::conditional_t<newVersion, ConstRDMolAtom, Atom const *>>;
+template <bool isBond, bool newVersion>
+using EqualsType = std::conditional_t<isBond,
+    std::conditional_t<newVersion, BOND_EQUALS_QUERY2, BOND_EQUALS_QUERY>,
+    std::conditional_t<newVersion, ATOM_EQUALS_QUERY2, ATOM_EQUALS_QUERY>>;
+
+template <bool isBond, bool newVersion>
+using DataFuncPtrType = int (*)(ParamType<isBond, newVersion>);
+
+template <bool isBond, bool newVersion, int tgt>
+int queryIsInRingOfSizeTmpl(ParamType<isBond, newVersion> at) {
+  if constexpr (isBond) {
+    if constexpr (newVersion) {
+      return queryBondIsInRingOfSize2<tgt>(at);
+    } else {
+      return queryBondIsInRingOfSize<tgt>(at);
+    }
+  } else {
+    if constexpr (newVersion) {
+      return queryAtomIsInRingOfSize2<tgt>(at);
+    } else {
+      return queryAtomIsInRingOfSize<tgt>(at);
+    }
+  }
+}
+
+template <bool isBond, bool newVersion>
+DataFuncPtrType<isBond, newVersion> getQueryIsInRingOfSizeTmpl(int tgt) {
+  switch (tgt) {
+    case 3:  return queryIsInRingOfSizeTmpl<isBond, newVersion, 3>;
+    case 4:  return queryIsInRingOfSizeTmpl<isBond, newVersion, 4>;
+    case 5:  return queryIsInRingOfSizeTmpl<isBond, newVersion, 5>;
+    case 6:  return queryIsInRingOfSizeTmpl<isBond, newVersion, 6>;
+    case 7:  return queryIsInRingOfSizeTmpl<isBond, newVersion, 7>;
+    case 8:  return queryIsInRingOfSizeTmpl<isBond, newVersion, 8>;
+    case 9:  return queryIsInRingOfSizeTmpl<isBond, newVersion, 9>;
+    case 10: return queryIsInRingOfSizeTmpl<isBond, newVersion, 10>;
+    case 11: return queryIsInRingOfSizeTmpl<isBond, newVersion, 11>;
+    case 12: return queryIsInRingOfSizeTmpl<isBond, newVersion, 12>;
+    case 13: return queryIsInRingOfSizeTmpl<isBond, newVersion, 13>;
+    case 14: return queryIsInRingOfSizeTmpl<isBond, newVersion, 14>;
+    case 15: return queryIsInRingOfSizeTmpl<isBond, newVersion, 15>;
+    case 16: return queryIsInRingOfSizeTmpl<isBond, newVersion, 16>;
+    case 17: return queryIsInRingOfSizeTmpl<isBond, newVersion, 17>;
+    case 18: return queryIsInRingOfSizeTmpl<isBond, newVersion, 18>;
+    case 19: return queryIsInRingOfSizeTmpl<isBond, newVersion, 19>;
+    case 20: return queryIsInRingOfSizeTmpl<isBond, newVersion, 20>;
+  }
+  return nullptr;
+}
+
+template <bool isBond, bool newVersion>
+EqualsType<isBond, newVersion> *makeInRingOfSizeQueryTmpl(int tgt) {
+  RANGE_CHECK(3, tgt, 20);
+  auto *res = new EqualsType<isBond, newVersion>;
+  res->setVal(tgt);
+
+  auto *dataFunc = getQueryIsInRingOfSizeTmpl<isBond, newVersion>(tgt);
+  if (dataFunc != nullptr) {
+    res->setDataFunc(dataFunc);
+  }
+
+  res->setDescription(isBond ? "BondRingSize" : "AtomRingSize");
+  return res;
+}
+
+ATOM_EQUALS_QUERY2 *makeAtomInRingOfSizeQuery2(int tgt) {
+  return makeInRingOfSizeQueryTmpl<false, true>(tgt);
+}
 ATOM_EQUALS_QUERY *makeAtomInRingOfSizeQuery(int tgt) {
-  RANGE_CHECK(3, tgt, 20);
-  auto *res = new ATOM_EQUALS_QUERY;
-  res->setVal(tgt);
-  switch (tgt) {
-    case 3:
-      res->setDataFunc(queryAtomIsInRingOfSize<3>);
-      break;
-    case 4:
-      res->setDataFunc(queryAtomIsInRingOfSize<4>);
-      break;
-    case 5:
-      res->setDataFunc(queryAtomIsInRingOfSize<5>);
-      break;
-    case 6:
-      res->setDataFunc(queryAtomIsInRingOfSize<6>);
-      break;
-    case 7:
-      res->setDataFunc(queryAtomIsInRingOfSize<7>);
-      break;
-    case 8:
-      res->setDataFunc(queryAtomIsInRingOfSize<8>);
-      break;
-    case 9:
-      res->setDataFunc(queryAtomIsInRingOfSize<9>);
-      break;
-    case 10:
-      res->setDataFunc(queryAtomIsInRingOfSize<10>);
-      break;
-    case 11:
-      res->setDataFunc(queryAtomIsInRingOfSize<11>);
-      break;
-    case 12:
-      res->setDataFunc(queryAtomIsInRingOfSize<12>);
-      break;
-    case 13:
-      res->setDataFunc(queryAtomIsInRingOfSize<13>);
-      break;
-    case 14:
-      res->setDataFunc(queryAtomIsInRingOfSize<14>);
-      break;
-    case 15:
-      res->setDataFunc(queryAtomIsInRingOfSize<15>);
-      break;
-    case 16:
-      res->setDataFunc(queryAtomIsInRingOfSize<16>);
-      break;
-    case 17:
-      res->setDataFunc(queryAtomIsInRingOfSize<17>);
-      break;
-    case 18:
-      res->setDataFunc(queryAtomIsInRingOfSize<18>);
-      break;
-    case 19:
-      res->setDataFunc(queryAtomIsInRingOfSize<19>);
-      break;
-    case 20:
-      res->setDataFunc(queryAtomIsInRingOfSize<20>);
-      break;
-  }
-
-  res->setDescription("AtomRingSize");
-  return res;
+  return makeInRingOfSizeQueryTmpl<false, false>(tgt);
 }
 
+BOND_EQUALS_QUERY2 *makeBondInRingOfSizeQuery2(int tgt) {
+  return makeInRingOfSizeQueryTmpl<true, true>(tgt);
+}
 BOND_EQUALS_QUERY *makeBondInRingOfSizeQuery(int tgt) {
-  RANGE_CHECK(3, tgt, 20);
-  auto *res = new BOND_EQUALS_QUERY;
-  res->setVal(tgt);
-  switch (tgt) {
-    case 3:
-      res->setDataFunc(queryBondIsInRingOfSize<3>);
-      break;
-    case 4:
-      res->setDataFunc(queryBondIsInRingOfSize<4>);
-      break;
-    case 5:
-      res->setDataFunc(queryBondIsInRingOfSize<5>);
-      break;
-    case 6:
-      res->setDataFunc(queryBondIsInRingOfSize<6>);
-      break;
-    case 7:
-      res->setDataFunc(queryBondIsInRingOfSize<7>);
-      break;
-    case 8:
-      res->setDataFunc(queryBondIsInRingOfSize<8>);
-      break;
-    case 9:
-      res->setDataFunc(queryBondIsInRingOfSize<9>);
-      break;
-    case 10:
-      res->setDataFunc(queryBondIsInRingOfSize<10>);
-      break;
-    case 11:
-      res->setDataFunc(queryBondIsInRingOfSize<11>);
-      break;
-    case 12:
-      res->setDataFunc(queryBondIsInRingOfSize<12>);
-      break;
-    case 13:
-      res->setDataFunc(queryBondIsInRingOfSize<13>);
-      break;
-    case 14:
-      res->setDataFunc(queryBondIsInRingOfSize<14>);
-      break;
-    case 15:
-      res->setDataFunc(queryBondIsInRingOfSize<15>);
-      break;
-    case 16:
-      res->setDataFunc(queryBondIsInRingOfSize<16>);
-      break;
-    case 17:
-      res->setDataFunc(queryBondIsInRingOfSize<17>);
-      break;
-    case 18:
-      res->setDataFunc(queryBondIsInRingOfSize<18>);
-      break;
-    case 19:
-      res->setDataFunc(queryBondIsInRingOfSize<19>);
-      break;
-    case 20:
-      res->setDataFunc(queryBondIsInRingOfSize<20>);
-      break;
-  }
-  res->setDescription("BondRingSize");
-  return res;
+  return makeInRingOfSizeQueryTmpl<true, false>(tgt);
 }
 
+ATOM_EQUALS_QUERY2 *makeAtomMinRingSizeQuery2(int tgt) {
+  auto *res = new ATOM_EQUALS_QUERY2;
+  res->setVal(tgt);
+  res->setDataFunc(queryAtomMinRingSize2);
+  res->setDescription("AtomMinRingSize");
+  return res;
+}
 ATOM_EQUALS_QUERY *makeAtomMinRingSizeQuery(int tgt) {
   auto *res = new ATOM_EQUALS_QUERY;
   res->setVal(tgt);
   res->setDataFunc(queryAtomMinRingSize);
   res->setDescription("AtomMinRingSize");
+  return res;
+}
+BOND_EQUALS_QUERY2 *makeBondMinRingSizeQuery2(int tgt) {
+  auto *res = new BOND_EQUALS_QUERY2;
+  res->setVal(tgt);
+  res->setDataFunc(queryBondMinRingSize2);
+  res->setDescription("BondMinRingSize");
   return res;
 }
 BOND_EQUALS_QUERY *makeBondMinRingSizeQuery(int tgt) {
@@ -238,6 +222,16 @@ BOND_EQUALS_QUERY *makeBondMinRingSizeQuery(int tgt) {
   return res;
 }
 
+unsigned int queryAtomBondProduct2(ConstRDMolAtom at) {
+  auto [beg, end] = at.mol().getAtomBonds(at.index());
+  unsigned int prod = 1;
+  while (beg != end) {
+    prod *= static_cast<unsigned int>(
+        firstThousandPrimes[at.mol().getBond(*beg).getBondType()]);
+    ++beg;
+  }
+  return prod;
+}
 unsigned int queryAtomBondProduct(Atom const *at) {
   ROMol::OEDGE_ITER beg, end;
   boost::tie(beg, end) = at->getOwningMol().getAtomBonds(at);
@@ -246,6 +240,19 @@ unsigned int queryAtomBondProduct(Atom const *at) {
     prod *= static_cast<unsigned int>(
         firstThousandPrimes[at->getOwningMol()[*beg]->getBondType()]);
     ++beg;
+  }
+  return prod;
+}
+unsigned int queryAtomAllBondProduct2(ConstRDMolAtom at) {
+  auto [beg, end] = at.mol().getAtomBonds(at.index());
+  unsigned int prod = 1;
+  while (beg != end) {
+    prod *= static_cast<unsigned int>(
+        firstThousandPrimes[at.mol().getBond(*beg).getBondType()]);
+    ++beg;
+  }
+  for (unsigned int i = 0, n = at.mol().getTotalNumHs(at.index()); i < n; i++) {
+    prod *= static_cast<unsigned int>(firstThousandPrimes[Bond::SINGLE]);
   }
   return prod;
 }
@@ -265,10 +272,22 @@ unsigned int queryAtomAllBondProduct(Atom const *at) {
   return prod;
 }
 
+ATOM_EQUALS_QUERY2 *makeAtomImplicitValenceQuery2(int what) {
+  auto *res =
+      makeAtomSimpleQuery2<ATOM_EQUALS_QUERY2>(what, queryAtomImplicitValence2);
+  res->setDescription("AtomImplicitValence");
+  return res;
+}
 ATOM_EQUALS_QUERY *makeAtomImplicitValenceQuery(int what) {
   auto *res =
       makeAtomSimpleQuery<ATOM_EQUALS_QUERY>(what, queryAtomImplicitValence);
   res->setDescription("AtomImplicitValence");
+  return res;
+}
+ATOM_EQUALS_QUERY2 *makeAtomExplicitValenceQuery2(int what) {
+  auto *res =
+      makeAtomSimpleQuery2<ATOM_EQUALS_QUERY2>(what, queryAtomExplicitValence2);
+  res->setDescription("AtomExplicitValence");
   return res;
 }
 ATOM_EQUALS_QUERY *makeAtomExplicitValenceQuery(int what) {
@@ -278,6 +297,12 @@ ATOM_EQUALS_QUERY *makeAtomExplicitValenceQuery(int what) {
   return res;
 }
 
+ATOM_EQUALS_QUERY2 *makeAtomTotalValenceQuery2(int what) {
+  auto *res =
+      makeAtomSimpleQuery2<ATOM_EQUALS_QUERY2>(what, queryAtomTotalValence2);
+  res->setDescription("AtomTotalValence");
+  return res;
+}
 ATOM_EQUALS_QUERY *makeAtomTotalValenceQuery(int what) {
   auto *res =
       makeAtomSimpleQuery<ATOM_EQUALS_QUERY>(what, queryAtomTotalValence);
@@ -285,14 +310,28 @@ ATOM_EQUALS_QUERY *makeAtomTotalValenceQuery(int what) {
   return res;
 }
 
+ATOM_EQUALS_QUERY2 *makeAtomNumQuery2(int what) {
+  return makeAtomSimpleQuery2<ATOM_EQUALS_QUERY2>(what, queryAtomNum2,
+                                                  "AtomAtomicNum");
+}
 ATOM_EQUALS_QUERY *makeAtomNumQuery(int what) {
   return makeAtomSimpleQuery<ATOM_EQUALS_QUERY>(what, queryAtomNum,
                                                 "AtomAtomicNum");
 }
 
+ATOM_EQUALS_QUERY2 *makeAtomTypeQuery2(int num, int aromatic) {
+  return makeAtomSimpleQuery2<ATOM_EQUALS_QUERY2>(makeAtomType(num, aromatic),
+                                                  queryAtomType2, "AtomType");
+}
 ATOM_EQUALS_QUERY *makeAtomTypeQuery(int num, int aromatic) {
   return makeAtomSimpleQuery<ATOM_EQUALS_QUERY>(makeAtomType(num, aromatic),
                                                 queryAtomType, "AtomType");
+}
+ATOM_EQUALS_QUERY2 *makeAtomExplicitDegreeQuery2(int what) {
+  auto *res =
+      makeAtomSimpleQuery2<ATOM_EQUALS_QUERY2>(what, queryAtomExplicitDegree2);
+  res->setDescription("AtomExplicitDegree");
+  return res;
 }
 ATOM_EQUALS_QUERY *makeAtomExplicitDegreeQuery(int what) {
   auto *res =
@@ -301,6 +340,12 @@ ATOM_EQUALS_QUERY *makeAtomExplicitDegreeQuery(int what) {
   return res;
 }
 
+ATOM_EQUALS_QUERY2 *makeAtomTotalDegreeQuery2(int what) {
+  auto *res =
+      makeAtomSimpleQuery2<ATOM_EQUALS_QUERY2>(what, queryAtomTotalDegree2);
+  res->setDescription("AtomTotalDegree");
+  return res;
+}
 ATOM_EQUALS_QUERY *makeAtomTotalDegreeQuery(int what) {
   auto *res =
       makeAtomSimpleQuery<ATOM_EQUALS_QUERY>(what, queryAtomTotalDegree);
@@ -308,6 +353,12 @@ ATOM_EQUALS_QUERY *makeAtomTotalDegreeQuery(int what) {
   return res;
 }
 
+ATOM_EQUALS_QUERY2 *makeAtomHeavyAtomDegreeQuery2(int what) {
+  auto *res =
+      makeAtomSimpleQuery2<ATOM_EQUALS_QUERY2>(what, queryAtomHeavyAtomDegree2);
+  res->setDescription("AtomHeavyAtomDegree");
+  return res;
+}
 ATOM_EQUALS_QUERY *makeAtomHeavyAtomDegreeQuery(int what) {
   auto *res =
       makeAtomSimpleQuery<ATOM_EQUALS_QUERY>(what, queryAtomHeavyAtomDegree);
@@ -315,15 +366,32 @@ ATOM_EQUALS_QUERY *makeAtomHeavyAtomDegreeQuery(int what) {
   return res;
 }
 
+ATOM_EQUALS_QUERY2 *makeAtomHCountQuery2(int what) {
+  auto *res = makeAtomSimpleQuery2<ATOM_EQUALS_QUERY2>(what, queryAtomHCount2);
+  res->setDescription("AtomHCount");
+  return res;
+}
 ATOM_EQUALS_QUERY *makeAtomHCountQuery(int what) {
   auto *res = makeAtomSimpleQuery<ATOM_EQUALS_QUERY>(what, queryAtomHCount);
   res->setDescription("AtomHCount");
+  return res;
+}
+ATOM_EQUALS_QUERY2 *makeAtomImplicitHCountQuery2(int what) {
+  auto *res =
+      makeAtomSimpleQuery2<ATOM_EQUALS_QUERY2>(what, queryAtomImplicitHCount2);
+  res->setDescription("AtomImplicitHCount");
   return res;
 }
 ATOM_EQUALS_QUERY *makeAtomImplicitHCountQuery(int what) {
   auto *res =
       makeAtomSimpleQuery<ATOM_EQUALS_QUERY>(what, queryAtomImplicitHCount);
   res->setDescription("AtomImplicitHCount");
+  return res;
+}
+ATOM_EQUALS_QUERY2 *makeAtomHasImplicitHQuery2() {
+  auto *res =
+      makeAtomSimpleQuery2<ATOM_EQUALS_QUERY2>(true, queryAtomHasImplicitH2);
+  res->setDescription("AtomHasImplicitH");
   return res;
 }
 ATOM_EQUALS_QUERY *makeAtomHasImplicitHQuery() {
@@ -333,18 +401,34 @@ ATOM_EQUALS_QUERY *makeAtomHasImplicitHQuery() {
   return res;
 }
 
+ATOM_EQUALS_QUERY2 *makeAtomAromaticQuery2() {
+  auto *res = makeAtomSimpleQuery2<ATOM_EQUALS_QUERY2>(true, queryAtomAromatic2);
+  res->setDescription("AtomIsAromatic");
+  return res;
+}
 ATOM_EQUALS_QUERY *makeAtomAromaticQuery() {
   auto *res = makeAtomSimpleQuery<ATOM_EQUALS_QUERY>(true, queryAtomAromatic);
   res->setDescription("AtomIsAromatic");
   return res;
 }
 
+ATOM_EQUALS_QUERY2 *makeAtomAliphaticQuery2() {
+  auto *res = makeAtomSimpleQuery2<ATOM_EQUALS_QUERY2>(true, queryAtomAliphatic2);
+  res->setDescription("AtomIsAliphatic");
+  return res;
+}
 ATOM_EQUALS_QUERY *makeAtomAliphaticQuery() {
   auto *res = makeAtomSimpleQuery<ATOM_EQUALS_QUERY>(true, queryAtomAliphatic);
   res->setDescription("AtomIsAliphatic");
   return res;
 }
 
+ATOM_EQUALS_QUERY2 *makeAtomUnsaturatedQuery2() {
+  auto *res =
+      makeAtomSimpleQuery2<ATOM_EQUALS_QUERY2>(true, queryAtomUnsaturated2);
+  res->setDescription("AtomUnsaturated");
+  return res;
+}
 ATOM_EQUALS_QUERY *makeAtomUnsaturatedQuery() {
   auto *res =
       makeAtomSimpleQuery<ATOM_EQUALS_QUERY>(true, queryAtomUnsaturated);
@@ -352,6 +436,12 @@ ATOM_EQUALS_QUERY *makeAtomUnsaturatedQuery() {
   return res;
 }
 
+ATOM_EQUALS_QUERY2 *makeAtomMassQuery2(int what) {
+  auto *res = makeAtomSimpleQuery2<ATOM_EQUALS_QUERY2>(
+      massIntegerConversionFactor * what, queryAtomMass2);
+  res->setDescription("AtomMass");
+  return res;
+}
 ATOM_EQUALS_QUERY *makeAtomMassQuery(int what) {
   auto *res = makeAtomSimpleQuery<ATOM_EQUALS_QUERY>(
       massIntegerConversionFactor * what, queryAtomMass);
@@ -359,12 +449,23 @@ ATOM_EQUALS_QUERY *makeAtomMassQuery(int what) {
   return res;
 }
 
+ATOM_EQUALS_QUERY2 *makeAtomIsotopeQuery2(int what) {
+  auto *res = makeAtomSimpleQuery2<ATOM_EQUALS_QUERY2>(what, queryAtomIsotope2);
+  res->setDescription("AtomIsotope");
+  return res;
+}
 ATOM_EQUALS_QUERY *makeAtomIsotopeQuery(int what) {
   auto *res = makeAtomSimpleQuery<ATOM_EQUALS_QUERY>(what, queryAtomIsotope);
   res->setDescription("AtomIsotope");
   return res;
 }
 
+ATOM_EQUALS_QUERY2 *makeAtomFormalChargeQuery2(int what) {
+  auto *res =
+      makeAtomSimpleQuery2<ATOM_EQUALS_QUERY2>(what, queryAtomFormalCharge2);
+  res->setDescription("AtomFormalCharge");
+  return res;
+}
 ATOM_EQUALS_QUERY *makeAtomFormalChargeQuery(int what) {
   auto *res =
       makeAtomSimpleQuery<ATOM_EQUALS_QUERY>(what, queryAtomFormalCharge);
@@ -372,6 +473,12 @@ ATOM_EQUALS_QUERY *makeAtomFormalChargeQuery(int what) {
   return res;
 }
 
+ATOM_EQUALS_QUERY2 *makeAtomNegativeFormalChargeQuery2(int what) {
+  auto *res = makeAtomSimpleQuery2<ATOM_EQUALS_QUERY2>(
+      what, queryAtomNegativeFormalCharge2);
+  res->setDescription("AtomNegativeFormalCharge");
+  return res;
+}
 ATOM_EQUALS_QUERY *makeAtomNegativeFormalChargeQuery(int what) {
   auto *res = makeAtomSimpleQuery<ATOM_EQUALS_QUERY>(
       what, queryAtomNegativeFormalCharge);
@@ -379,6 +486,12 @@ ATOM_EQUALS_QUERY *makeAtomNegativeFormalChargeQuery(int what) {
   return res;
 }
 
+ATOM_EQUALS_QUERY2 *makeAtomHybridizationQuery2(int what) {
+  auto *res =
+      makeAtomSimpleQuery2<ATOM_EQUALS_QUERY2>(what, queryAtomHybridization2);
+  res->setDescription("AtomHybridization");
+  return res;
+}
 ATOM_EQUALS_QUERY *makeAtomHybridizationQuery(int what) {
   auto *res =
       makeAtomSimpleQuery<ATOM_EQUALS_QUERY>(what, queryAtomHybridization);
@@ -386,6 +499,12 @@ ATOM_EQUALS_QUERY *makeAtomHybridizationQuery(int what) {
   return res;
 }
 
+ATOM_EQUALS_QUERY2 *makeAtomNumRadicalElectronsQuery2(int what) {
+  auto *res = makeAtomSimpleQuery2<ATOM_EQUALS_QUERY2>(
+      what, queryAtomNumRadicalElectrons2);
+  res->setDescription("AtomNumRadicalElectrons");
+  return res;
+}
 ATOM_EQUALS_QUERY *makeAtomNumRadicalElectronsQuery(int what) {
   auto *res = makeAtomSimpleQuery<ATOM_EQUALS_QUERY>(
       what, queryAtomNumRadicalElectrons);
@@ -393,6 +512,12 @@ ATOM_EQUALS_QUERY *makeAtomNumRadicalElectronsQuery(int what) {
   return res;
 }
 
+ATOM_EQUALS_QUERY2 *makeAtomHasChiralTagQuery2() {
+  auto *res =
+      makeAtomSimpleQuery2<ATOM_EQUALS_QUERY2>(true, queryAtomHasChiralTag2);
+  res->setDescription("AtomHasChiralTag");
+  return res;
+}
 ATOM_EQUALS_QUERY *makeAtomHasChiralTagQuery() {
   auto *res =
       makeAtomSimpleQuery<ATOM_EQUALS_QUERY>(true, queryAtomHasChiralTag);
@@ -400,6 +525,12 @@ ATOM_EQUALS_QUERY *makeAtomHasChiralTagQuery() {
   return res;
 }
 
+ATOM_EQUALS_QUERY2 *makeAtomMissingChiralTagQuery2() {
+  auto *res =
+      makeAtomSimpleQuery2<ATOM_EQUALS_QUERY2>(true, queryAtomMissingChiralTag2);
+  res->setDescription("AtomMissingChiralTag");
+  return res;
+}
 ATOM_EQUALS_QUERY *makeAtomMissingChiralTagQuery() {
   auto *res =
       makeAtomSimpleQuery<ATOM_EQUALS_QUERY>(true, queryAtomMissingChiralTag);
@@ -407,12 +538,23 @@ ATOM_EQUALS_QUERY *makeAtomMissingChiralTagQuery() {
   return res;
 }
 
+ATOM_EQUALS_QUERY2 *makeAtomInRingQuery2() {
+  auto *res = makeAtomSimpleQuery2<ATOM_EQUALS_QUERY2>(true, queryIsAtomInRing2);
+  res->setDescription("AtomInRing");
+  return res;
+}
 ATOM_EQUALS_QUERY *makeAtomInRingQuery() {
   auto *res = makeAtomSimpleQuery<ATOM_EQUALS_QUERY>(true, queryIsAtomInRing);
   res->setDescription("AtomInRing");
   return res;
 }
 
+ATOM_EQUALS_QUERY2 *makeAtomIsBridgeheadQuery2() {
+  auto *res =
+      makeAtomSimpleQuery2<ATOM_EQUALS_QUERY2>(true, queryIsAtomBridgehead2);
+  res->setDescription("AtomIsBridgehead");
+  return res;
+}
 ATOM_EQUALS_QUERY *makeAtomIsBridgeheadQuery() {
   auto *res =
       makeAtomSimpleQuery<ATOM_EQUALS_QUERY>(true, queryIsAtomBridgehead);
@@ -420,6 +562,17 @@ ATOM_EQUALS_QUERY *makeAtomIsBridgeheadQuery() {
   return res;
 }
 
+ATOM_OR_QUERY2 *makeQAtomQuery2() {
+  auto *res = new ATOM_OR_QUERY2;
+  res->setDescription("AtomOr");
+  res->setTypeLabel("Q");
+  res->setNegation(true);
+  res->addChild(Queries::Query<int, ConstRDMolAtom, true>::CHILD_TYPE(
+      makeAtomNumQuery2(6)));
+  res->addChild(Queries::Query<int, ConstRDMolAtom, true>::CHILD_TYPE(
+      makeAtomNumQuery2(1)));
+  return res;
+}
 ATOM_OR_QUERY *makeQAtomQuery() {
   auto *res = new ATOM_OR_QUERY;
   res->setDescription("AtomOr");
@@ -431,10 +584,22 @@ ATOM_OR_QUERY *makeQAtomQuery() {
       Queries::Query<int, Atom const *, true>::CHILD_TYPE(makeAtomNumQuery(1)));
   return res;
 }
+ATOM_EQUALS_QUERY2 *makeQHAtomQuery2() {
+  ATOM_EQUALS_QUERY2 *res = makeAtomNumQuery2(6);
+  res->setNegation(true);
+  res->setTypeLabel("QH");
+  return res;
+}
 ATOM_EQUALS_QUERY *makeQHAtomQuery() {
   ATOM_EQUALS_QUERY *res = makeAtomNumQuery(6);
   res->setNegation(true);
   res->setTypeLabel("QH");
+  return res;
+}
+ATOM_EQUALS_QUERY2 *makeAAtomQuery2() {
+  ATOM_EQUALS_QUERY2 *res = makeAtomNumQuery2(1);
+  res->setNegation(true);
+  res->setTypeLabel("A");
   return res;
 }
 ATOM_EQUALS_QUERY *makeAAtomQuery() {
@@ -443,27 +608,55 @@ ATOM_EQUALS_QUERY *makeAAtomQuery() {
   res->setTypeLabel("A");
   return res;
 }
+ATOM_NULL_QUERY2 *makeAHAtomQuery2() {
+  auto *res = makeAtomNullQuery2();
+  res->setTypeLabel("AH");
+  return res;
+}
 ATOM_NULL_QUERY *makeAHAtomQuery() {
   auto *res = makeAtomNullQuery();
   res->setTypeLabel("AH");
   return res;
 }
 
+template <bool newVersion, size_t count>
+void addAtomNumQueries(
+    std::conditional_t<newVersion, ATOM_OR_QUERY2, ATOM_OR_QUERY> *res,
+    const std::array<int, count> &nums) {
+  for (size_t i = 0; i < count; ++i) {
+    if constexpr (newVersion) {
+      res->addChild(
+          typename Queries::Query<int, ParamType<false, newVersion>, true>::CHILD_TYPE(
+              makeAtomNumQuery2(nums[i])));
+    } else {
+      res->addChild(
+          typename Queries::Query<int, ParamType<false, newVersion>, true>::CHILD_TYPE(
+              makeAtomNumQuery(nums[i])));
+    }
+  }
+}
+
+ATOM_OR_QUERY2 *makeXAtomQuery2() {
+  auto *res = new ATOM_OR_QUERY2;
+  res->setDescription("AtomOr");
+  const std::array nums = {9, 17, 35, 53, 85};
+  addAtomNumQueries<true>(res, nums);
+  res->setTypeLabel("X");
+  return res;
+}
 ATOM_OR_QUERY *makeXAtomQuery() {
   auto *res = new ATOM_OR_QUERY;
   res->setDescription("AtomOr");
-  res->addChild(
-      Queries::Query<int, Atom const *, true>::CHILD_TYPE(makeAtomNumQuery(9)));
-  res->addChild(Queries::Query<int, Atom const *, true>::CHILD_TYPE(
-      makeAtomNumQuery(17)));
-  res->addChild(Queries::Query<int, Atom const *, true>::CHILD_TYPE(
-      makeAtomNumQuery(35)));
-  res->addChild(Queries::Query<int, Atom const *, true>::CHILD_TYPE(
-      makeAtomNumQuery(53)));
-  res->addChild(Queries::Query<int, Atom const *, true>::CHILD_TYPE(
-      makeAtomNumQuery(85)));
+  const std::array nums = {9, 17, 35, 53, 85};
+  addAtomNumQueries<false>(res, nums);
   res->setTypeLabel("X");
-
+  return res;
+}
+ATOM_OR_QUERY2 *makeXHAtomQuery2() {
+  ATOM_OR_QUERY2 *res = makeXAtomQuery2();
+  res->addChild(
+      Queries::Query<int, ConstRDMolAtom, true>::CHILD_TYPE(makeAtomNumQuery2(1)));
+  res->setTypeLabel("XH");
   return res;
 }
 ATOM_OR_QUERY *makeXHAtomQuery() {
@@ -474,6 +667,18 @@ ATOM_OR_QUERY *makeXHAtomQuery() {
   return res;
 }
 
+ATOM_OR_QUERY2 *makeMAtomQuery2() {
+  // using the definition from Marvin Sketch, which produces the following
+  // SMARTS:
+  // !#1!#2!#5!#6!#7!#8!#9!#10!#14!#15!#16!#17!#18!#33!#34!#35!#36!#52!#53!#54!#85!#86
+  // We expanded this with !#0 as part of #6106
+  // it's easier to define what isn't a metal than what is. :-)
+  ATOM_OR_QUERY2 *res = makeMHAtomQuery2();
+  res->addChild(
+      Queries::Query<int, ConstRDMolAtom, true>::CHILD_TYPE(makeAtomNumQuery2(1)));
+  res->setTypeLabel("M");
+  return res;
+}
 ATOM_OR_QUERY *makeMAtomQuery() {
   // using the definition from Marvin Sketch, which produces the following
   // SMARTS:
@@ -484,7 +689,22 @@ ATOM_OR_QUERY *makeMAtomQuery() {
   res->addChild(
       Queries::Query<int, Atom const *, true>::CHILD_TYPE(makeAtomNumQuery(1)));
   res->setTypeLabel("M");
-
+  return res;
+}
+ATOM_OR_QUERY2 *makeMHAtomQuery2() {
+  // using the definition from Marvin Sketch, which produces the following
+  // SMARTS:
+  // !#2!#5!#6!#7!#8!#9!#10!#14!#15!#16!#17!#18!#33!#34!#35!#36!#52!#53!#54!#85!#86
+  // We expanded this with !#0 as part of #6106
+  // it's easier to define what isn't a metal than what is. :-)
+  auto *res = new ATOM_OR_QUERY2;
+  res->setDescription("AtomOr");
+  res->setNegation(true);
+  const std::array nums = {
+      0, 2, 5, 6, 7, 8, 9, 10, 14, 15, 16, 17, 18, 33, 34, 35, 36, 52, 53, 54, 85, 86
+  };
+  addAtomNumQueries<true>(res, nums);
+  res->setTypeLabel("MH");
   return res;
 }
 ATOM_OR_QUERY *makeMHAtomQuery() {
@@ -496,61 +716,31 @@ ATOM_OR_QUERY *makeMHAtomQuery() {
   auto *res = new ATOM_OR_QUERY;
   res->setDescription("AtomOr");
   res->setNegation(true);
-  res->addChild(
-      Queries::Query<int, Atom const *, true>::CHILD_TYPE(makeAtomNumQuery(0)));
-  res->addChild(
-      Queries::Query<int, Atom const *, true>::CHILD_TYPE(makeAtomNumQuery(2)));
-  res->addChild(
-      Queries::Query<int, Atom const *, true>::CHILD_TYPE(makeAtomNumQuery(5)));
-  res->addChild(
-      Queries::Query<int, Atom const *, true>::CHILD_TYPE(makeAtomNumQuery(6)));
-  res->addChild(
-      Queries::Query<int, Atom const *, true>::CHILD_TYPE(makeAtomNumQuery(7)));
-  res->addChild(
-      Queries::Query<int, Atom const *, true>::CHILD_TYPE(makeAtomNumQuery(8)));
-  res->addChild(
-      Queries::Query<int, Atom const *, true>::CHILD_TYPE(makeAtomNumQuery(9)));
-  res->addChild(Queries::Query<int, Atom const *, true>::CHILD_TYPE(
-      makeAtomNumQuery(10)));
-  res->addChild(Queries::Query<int, Atom const *, true>::CHILD_TYPE(
-      makeAtomNumQuery(14)));
-  res->addChild(Queries::Query<int, Atom const *, true>::CHILD_TYPE(
-      makeAtomNumQuery(15)));
-  res->addChild(Queries::Query<int, Atom const *, true>::CHILD_TYPE(
-      makeAtomNumQuery(16)));
-  res->addChild(Queries::Query<int, Atom const *, true>::CHILD_TYPE(
-      makeAtomNumQuery(17)));
-  res->addChild(Queries::Query<int, Atom const *, true>::CHILD_TYPE(
-      makeAtomNumQuery(18)));
-  res->addChild(Queries::Query<int, Atom const *, true>::CHILD_TYPE(
-      makeAtomNumQuery(33)));
-  res->addChild(Queries::Query<int, Atom const *, true>::CHILD_TYPE(
-      makeAtomNumQuery(34)));
-  res->addChild(Queries::Query<int, Atom const *, true>::CHILD_TYPE(
-      makeAtomNumQuery(35)));
-  res->addChild(Queries::Query<int, Atom const *, true>::CHILD_TYPE(
-      makeAtomNumQuery(36)));
-  res->addChild(Queries::Query<int, Atom const *, true>::CHILD_TYPE(
-      makeAtomNumQuery(52)));
-  res->addChild(Queries::Query<int, Atom const *, true>::CHILD_TYPE(
-      makeAtomNumQuery(53)));
-  res->addChild(Queries::Query<int, Atom const *, true>::CHILD_TYPE(
-      makeAtomNumQuery(54)));
-  res->addChild(Queries::Query<int, Atom const *, true>::CHILD_TYPE(
-      makeAtomNumQuery(85)));
-  res->addChild(Queries::Query<int, Atom const *, true>::CHILD_TYPE(
-      makeAtomNumQuery(86)));
+  const std::array nums = {
+      0, 2, 5, 6, 7, 8, 9, 10, 14, 15, 16, 17, 18, 33, 34, 35, 36, 52, 53, 54, 85, 86
+  };
+  addAtomNumQueries<false>(res, nums);
   res->setTypeLabel("MH");
   return res;
 }
 
+ATOM_EQUALS_QUERY2 *makeAtomInNRingsQuery2(int what) {
+  auto *res = makeAtomSimpleQuery2<ATOM_EQUALS_QUERY2>(what, queryIsAtomInNRings2);
+  res->setDescription("AtomInNRings");
+  return res;
+}
 ATOM_EQUALS_QUERY *makeAtomInNRingsQuery(int what) {
-  ATOM_EQUALS_QUERY *res;
-  res = makeAtomSimpleQuery<ATOM_EQUALS_QUERY>(what, queryIsAtomInNRings);
+  auto *res = makeAtomSimpleQuery<ATOM_EQUALS_QUERY>(what, queryIsAtomInNRings);
   res->setDescription("AtomInNRings");
   return res;
 }
 
+ATOM_EQUALS_QUERY2 *makeAtomHasRingBondQuery2() {
+  auto *res =
+      makeAtomSimpleQuery2<ATOM_EQUALS_QUERY2>(true, queryAtomHasRingBond2);
+  res->setDescription("AtomHasRingBond");
+  return res;
+}
 ATOM_EQUALS_QUERY *makeAtomHasRingBondQuery() {
   auto *res =
       makeAtomSimpleQuery<ATOM_EQUALS_QUERY>(true, queryAtomHasRingBond);
@@ -558,6 +748,12 @@ ATOM_EQUALS_QUERY *makeAtomHasRingBondQuery() {
   return res;
 }
 
+ATOM_EQUALS_QUERY2 *makeAtomNumHeteroatomNbrsQuery2(int what) {
+  auto *res =
+      makeAtomSimpleQuery2<ATOM_EQUALS_QUERY2>(what, queryAtomNumHeteroatomNbrs2);
+  res->setDescription("AtomNumHeteroatomNeighbors");
+  return res;
+}
 ATOM_EQUALS_QUERY *makeAtomNumHeteroatomNbrsQuery(int what) {
   auto *res =
       makeAtomSimpleQuery<ATOM_EQUALS_QUERY>(what, queryAtomNumHeteroatomNbrs);
@@ -565,10 +761,22 @@ ATOM_EQUALS_QUERY *makeAtomNumHeteroatomNbrsQuery(int what) {
   return res;
 }
 
+ATOM_EQUALS_QUERY2 *makeAtomHasHeteroatomNbrsQuery2() {
+  auto *res =
+      makeAtomSimpleQuery2<ATOM_EQUALS_QUERY2>(true, queryAtomHasHeteroatomNbrs2);
+  res->setDescription("AtomHasHeteroatomNeighbors");
+  return res;
+}
 ATOM_EQUALS_QUERY *makeAtomHasHeteroatomNbrsQuery() {
   auto *res =
       makeAtomSimpleQuery<ATOM_EQUALS_QUERY>(true, queryAtomHasHeteroatomNbrs);
   res->setDescription("AtomHasHeteroatomNeighbors");
+  return res;
+}
+ATOM_EQUALS_QUERY2 *makeAtomNumAliphaticHeteroatomNbrsQuery2(int what) {
+  auto *res = makeAtomSimpleQuery2<ATOM_EQUALS_QUERY2>(
+      what, queryAtomNumAliphaticHeteroatomNbrs2);
+  res->setDescription("AtomNumAliphaticHeteroatomNeighbors");
   return res;
 }
 ATOM_EQUALS_QUERY *makeAtomNumAliphaticHeteroatomNbrsQuery(int what) {
@@ -578,6 +786,12 @@ ATOM_EQUALS_QUERY *makeAtomNumAliphaticHeteroatomNbrsQuery(int what) {
   return res;
 }
 
+ATOM_EQUALS_QUERY2 *makeAtomHasAliphaticHeteroatomNbrsQuery2() {
+  auto *res = makeAtomSimpleQuery2<ATOM_EQUALS_QUERY2>(
+      true, queryAtomHasAliphaticHeteroatomNbrs2);
+  res->setDescription("AtomHasAliphaticHeteroatomNeighbors");
+  return res;
+}
 ATOM_EQUALS_QUERY *makeAtomHasAliphaticHeteroatomNbrsQuery() {
   auto *res = makeAtomSimpleQuery<ATOM_EQUALS_QUERY>(
       true, queryAtomHasAliphaticHeteroatomNbrs);
@@ -585,6 +799,12 @@ ATOM_EQUALS_QUERY *makeAtomHasAliphaticHeteroatomNbrsQuery() {
   return res;
 }
 
+ATOM_EQUALS_QUERY2 *makeAtomNonHydrogenDegreeQuery2(int what) {
+  auto *res =
+      makeAtomSimpleQuery2<ATOM_EQUALS_QUERY2>(what, queryAtomNonHydrogenDegree2);
+  res->setDescription("AtomNonHydrogenDegree");
+  return res;
+}
 ATOM_EQUALS_QUERY *makeAtomNonHydrogenDegreeQuery(int what) {
   auto *res =
       makeAtomSimpleQuery<ATOM_EQUALS_QUERY>(what, queryAtomNonHydrogenDegree);
@@ -592,6 +812,14 @@ ATOM_EQUALS_QUERY *makeAtomNonHydrogenDegreeQuery(int what) {
   return res;
 }
 
+BOND_EQUALS_QUERY2 *makeBondOrderEqualsQuery2(Bond::BondType what) {
+  auto *res = new BOND_EQUALS_QUERY2;
+  res->setVal(what);
+  res->setDataFunc(queryBondOrder2);
+  res->setDescription("BondOrder");
+  res->setTypeLabel("BondOrder");
+  return res;
+}
 BOND_EQUALS_QUERY *makeBondOrderEqualsQuery(Bond::BondType what) {
   auto *res = new BOND_EQUALS_QUERY;
   res->setVal(what);
@@ -601,6 +829,14 @@ BOND_EQUALS_QUERY *makeBondOrderEqualsQuery(Bond::BondType what) {
   return res;
 }
 
+RDKIT_GRAPHMOL_EXPORT BOND_EQUALS_QUERY2 *makeSingleOrAromaticBondQuery2() {
+  auto *res = new BOND_EQUALS_QUERY2;
+  res->setVal(true);
+  res->setDataFunc(queryBondIsSingleOrAromatic2);
+  res->setDescription("SingleOrAromaticBond");
+  res->setTypeLabel("BondOrder");
+  return res;
+};
 RDKIT_GRAPHMOL_EXPORT BOND_EQUALS_QUERY *makeSingleOrAromaticBondQuery() {
   auto *res = new BOND_EQUALS_QUERY;
   res->setVal(true);
@@ -610,6 +846,14 @@ RDKIT_GRAPHMOL_EXPORT BOND_EQUALS_QUERY *makeSingleOrAromaticBondQuery() {
   return res;
 };
 
+RDKIT_GRAPHMOL_EXPORT BOND_EQUALS_QUERY2 *makeDoubleOrAromaticBondQuery2() {
+  auto *res = new BOND_EQUALS_QUERY2;
+  res->setVal(true);
+  res->setDataFunc(queryBondIsDoubleOrAromatic2);
+  res->setDescription("DoubleOrAromaticBond");
+  res->setTypeLabel("BondOrder");
+  return res;
+};
 RDKIT_GRAPHMOL_EXPORT BOND_EQUALS_QUERY *makeDoubleOrAromaticBondQuery() {
   auto *res = new BOND_EQUALS_QUERY;
   res->setVal(true);
@@ -619,6 +863,14 @@ RDKIT_GRAPHMOL_EXPORT BOND_EQUALS_QUERY *makeDoubleOrAromaticBondQuery() {
   return res;
 };
 
+RDKIT_GRAPHMOL_EXPORT BOND_EQUALS_QUERY2 *makeSingleOrDoubleBondQuery2() {
+  auto *res = new BOND_EQUALS_QUERY2;
+  res->setVal(true);
+  res->setDataFunc(queryBondIsSingleOrDouble2);
+  res->setDescription("SingleOrDoubleBond");
+  res->setTypeLabel("BondOrder");
+  return res;
+};
 RDKIT_GRAPHMOL_EXPORT BOND_EQUALS_QUERY *makeSingleOrDoubleBondQuery() {
   auto *res = new BOND_EQUALS_QUERY;
   res->setVal(true);
@@ -628,6 +880,15 @@ RDKIT_GRAPHMOL_EXPORT BOND_EQUALS_QUERY *makeSingleOrDoubleBondQuery() {
   return res;
 };
 
+RDKIT_GRAPHMOL_EXPORT BOND_EQUALS_QUERY2 *
+makeSingleOrDoubleOrAromaticBondQuery2() {
+  auto *res = new BOND_EQUALS_QUERY2;
+  res->setVal(true);
+  res->setDataFunc(queryBondIsSingleOrDoubleOrAromatic2);
+  res->setDescription("SingleOrDoubleOrAromaticBond");
+  res->setTypeLabel("BondOrder");
+  return res;
+};
 RDKIT_GRAPHMOL_EXPORT BOND_EQUALS_QUERY *
 makeSingleOrDoubleOrAromaticBondQuery() {
   auto *res = new BOND_EQUALS_QUERY;
@@ -639,14 +900,15 @@ makeSingleOrDoubleOrAromaticBondQuery() {
 };
 
 namespace QueryOps {
+namespace {
 // we don't use these anymore but we need to keep them around for backwards
 // compatibility with pickled queries. There's no reason to update this list.
 const std::vector<std::string> bondOrderQueryFunctions{
     std::string("BondOrder"), std::string("SingleOrAromaticBond"),
     std::string("DoubleOrAromaticBond"), std::string("SingleOrDoubleBond"),
     std::string("SingleOrDoubleOrAromaticBond")};
-RDKIT_GRAPHMOL_EXPORT bool hasBondTypeQuery(
-    const Queries::Query<int, Bond const *, true> &qry) {
+template <typename BondType>
+bool hasBondTypeQueryHelper(const Queries::Query<int, BondType, true> &qry) {
   const auto df = qry.getDescription();
   const auto dt = qry.getTypeLabel();
   // is this a bond order query?
@@ -664,10 +926,21 @@ RDKIT_GRAPHMOL_EXPORT bool hasBondTypeQuery(
   }
   return false;
 }
+}  // namespace
+
+RDKIT_GRAPHMOL_EXPORT bool hasBondTypeQuery(
+    const Queries::Query<int, Bond const *, true> &qry) {
+  return hasBondTypeQueryHelper(qry);
+}
+RDKIT_GRAPHMOL_EXPORT bool hasBondTypeQuery(
+    const Queries::Query<int, ConstRDMolBond, true> &qry) {
+  return hasBondTypeQueryHelper(qry);
+}
 
 namespace {
+template <typename BondType>
 bool hasComplexBondTypeQueryHelper(
-    const Queries::Query<int, Bond const *, true> &qry, bool seenBondOrder) {
+    const Queries::Query<int, BondType, true> &qry, bool seenBondOrder) {
   const auto df = qry.getDescription();
   bool isBondOrder = (df == "BondOrder");
   // is this a bond order query?
@@ -694,8 +967,19 @@ RDKIT_GRAPHMOL_EXPORT bool hasComplexBondTypeQuery(
     const Queries::Query<int, Bond const *, true> &qry) {
   return hasComplexBondTypeQueryHelper(qry, false);
 }
+RDKIT_GRAPHMOL_EXPORT bool hasComplexBondTypeQuery(
+    const Queries::Query<int, ConstRDMolBond, true> &qry) {
+  return hasComplexBondTypeQueryHelper(qry, false);
+}
 }  // namespace QueryOps
 
+BOND_EQUALS_QUERY2 *makeBondDirEqualsQuery2(Bond::BondDir what) {
+  auto *res = new BOND_EQUALS_QUERY2;
+  res->setVal(what);
+  res->setDataFunc(queryBondDir2);
+  res->setDescription("BondDir");
+  return res;
+}
 BOND_EQUALS_QUERY *makeBondDirEqualsQuery(Bond::BondDir what) {
   auto *res = new BOND_EQUALS_QUERY;
   res->setVal(what);
@@ -704,6 +988,13 @@ BOND_EQUALS_QUERY *makeBondDirEqualsQuery(Bond::BondDir what) {
   return res;
 }
 
+BOND_EQUALS_QUERY2 *makeBondHasStereoQuery2() {
+  auto *res = new BOND_EQUALS_QUERY2;
+  res->setVal(true);
+  res->setDataFunc(queryBondHasStereo2);
+  res->setDescription("BondStereo");
+  return res;
+}
 BOND_EQUALS_QUERY *makeBondHasStereoQuery() {
   auto *res = new BOND_EQUALS_QUERY;
   res->setVal(true);
@@ -712,6 +1003,13 @@ BOND_EQUALS_QUERY *makeBondHasStereoQuery() {
   return res;
 }
 
+BOND_EQUALS_QUERY2 *makeBondIsInRingQuery2() {
+  auto *res = new BOND_EQUALS_QUERY2;
+  res->setVal(true);
+  res->setDataFunc(queryIsBondInRing2);
+  res->setDescription("BondInRing");
+  return res;
+}
 BOND_EQUALS_QUERY *makeBondIsInRingQuery() {
   auto *res = new BOND_EQUALS_QUERY;
   res->setVal(true);
@@ -720,6 +1018,13 @@ BOND_EQUALS_QUERY *makeBondIsInRingQuery() {
   return res;
 }
 
+BOND_EQUALS_QUERY2 *makeBondInNRingsQuery2(int what) {
+  auto *res = new BOND_EQUALS_QUERY2;
+  res->setVal(what);
+  res->setDataFunc(queryIsBondInNRings2);
+  res->setDescription("BondInNRings");
+  return res;
+}
 BOND_EQUALS_QUERY *makeBondInNRingsQuery(int what) {
   auto *res = new BOND_EQUALS_QUERY;
   res->setVal(what);
@@ -728,6 +1033,13 @@ BOND_EQUALS_QUERY *makeBondInNRingsQuery(int what) {
   return res;
 }
 
+BOND_NULL_QUERY2 *makeBondNullQuery2() {
+  auto *res = new BOND_NULL_QUERY2;
+  res->setDataFunc(nullDataFun);
+  res->setMatchFunc(nullQueryFun);
+  res->setDescription("BondNull");
+  return res;
+}
 BOND_NULL_QUERY *makeBondNullQuery() {
   auto *res = new BOND_NULL_QUERY;
   res->setDataFunc(nullDataFun);
@@ -736,6 +1048,13 @@ BOND_NULL_QUERY *makeBondNullQuery() {
   return res;
 }
 
+ATOM_NULL_QUERY2 *makeAtomNullQuery2() {
+  auto *res = new ATOM_NULL_QUERY2;
+  res->setDataFunc(nullDataFun);
+  res->setMatchFunc(nullQueryFun);
+  res->setDescription("AtomNull");
+  return res;
+}
 ATOM_NULL_QUERY *makeAtomNullQuery() {
   auto *res = new ATOM_NULL_QUERY;
   res->setDataFunc(nullDataFun);
@@ -744,6 +1063,29 @@ ATOM_NULL_QUERY *makeAtomNullQuery() {
   return res;
 }
 
+void convertComplexNameToQuery2(RDMolAtom atom, std::string_view symb) {
+  if (symb == "Q") {
+    atom.mol().setAtomQuery(atom.index(), std::unique_ptr<RDMol::QUERYATOM_QUERY>(makeQAtomQuery2()));
+  } else if (symb == "QH") {
+    atom.mol().setAtomQuery(atom.index(), std::unique_ptr<RDMol::QUERYATOM_QUERY>(makeQHAtomQuery2()));
+  } else if (symb == "A") {
+    atom.mol().setAtomQuery(atom.index(), std::unique_ptr<RDMol::QUERYATOM_QUERY>(makeAAtomQuery2()));
+  } else if (symb == "AH") {
+    atom.mol().setAtomQuery(atom.index(), std::unique_ptr<RDMol::QUERYATOM_QUERY>(makeAHAtomQuery2()));
+  } else if (symb == "X") {
+    atom.mol().setAtomQuery(atom.index(), std::unique_ptr<RDMol::QUERYATOM_QUERY>(makeXAtomQuery2()));
+  } else if (symb == "XH") {
+    atom.mol().setAtomQuery(atom.index(), std::unique_ptr<RDMol::QUERYATOM_QUERY>(makeXHAtomQuery2()));
+  } else if (symb == "M") {
+    atom.mol().setAtomQuery(atom.index(), std::unique_ptr<RDMol::QUERYATOM_QUERY>(makeMAtomQuery2()));
+  } else if (symb == "MH") {
+    atom.mol().setAtomQuery(atom.index(), std::unique_ptr<RDMol::QUERYATOM_QUERY>(makeMHAtomQuery2()));
+  } else {
+    // we control what this function gets called with, so we should never land
+    // here
+    ASSERT_INVARIANT(0, "bad complex query symbol");
+  }
+}
 void convertComplexNameToQuery(Atom *query, std::string_view symb) {
   if (symb == "Q") {
     query->setQuery(makeQAtomQuery());
@@ -768,16 +1110,17 @@ void convertComplexNameToQuery(Atom *query, std::string_view symb) {
   }
 }
 
-bool isComplexQuery(const Bond *b) {
-  PRECONDITION(b, "bad bond");
-  if (!b->hasQuery()) {
+namespace {
+template<typename QUERY_T>
+bool _complexBondQueryHelper(const QUERY_T* query) {
+  if (query == nullptr) {
     return false;
   }
   // negated things are always complex:
-  if (b->getQuery()->getNegation()) {
+  if (query->getNegation()) {
     return true;
   }
-  std::string descr = b->getQuery()->getDescription();
+  std::string descr = query->getDescription();
   if (descr == "BondOrder" || descr == "SingleOrAromaticBond") {
     return false;
   }
@@ -787,16 +1130,17 @@ bool isComplexQuery(const Bond *b) {
   if (descr == "BondOr") {
     // detect the types of queries that appear for unspecified bonds in
     // SMARTS:
-    if (b->getQuery()->endChildren() - b->getQuery()->beginChildren() == 2) {
-      for (auto child = b->getQuery()->beginChildren();
-           child != b->getQuery()->endChildren(); ++child) {
+    if (query->endChildren() - query->beginChildren() == 2) {
+      for (auto child = query->beginChildren(); child != query->endChildren();
+           ++child) {
         if ((*child)->getDescription() != "BondOrder" ||
             (*child)->getNegation()) {
           return true;
         }
-        if (static_cast<BOND_EQUALS_QUERY *>(child->get())->getVal() !=
+        using BOND_EQUALS_QUERY_TYPE = Queries::EqualityQuery<int, typename QUERY_T::DATA_FUNC_ARG_TYPE, true>;
+        if (static_cast<BOND_EQUALS_QUERY_TYPE *>(child->get())->getVal() !=
                 Bond::SINGLE &&
-            static_cast<BOND_EQUALS_QUERY *>(child->get())->getVal() !=
+            static_cast<BOND_EQUALS_QUERY_TYPE *>(child->get())->getVal() !=
                 Bond::AROMATIC) {
           return true;
         }
@@ -807,36 +1151,22 @@ bool isComplexQuery(const Bond *b) {
 
   return true;
 }
+}  // namespace
 
-namespace {
-bool _complexQueryHelper(Atom::QUERYATOM_QUERY const *query, bool &hasAtNum) {
-  if (!query) {
+bool isComplexQuery(ConstRDMolBond b) {
+  PRECONDITION(b.index() < b.mol().getNumBonds(), "bad bond");
+  const auto* query = b.mol().getBondQuery(b.index());
+  return _complexBondQueryHelper(query);
+}
+bool isComplexQuery(const Bond *b) {
+  PRECONDITION(b, "bad bond");
+  if (!b->hasQuery()) {
     return false;
   }
-  if (query->getNegation()) {
-    return true;
-  }
-  std::string descr = query->getDescription();
-  // std::cerr<<" |"<<descr;
-  if (descr == "AtomAtomicNum" || descr == "AtomType") {
-    hasAtNum = true;
-    return false;
-  }
-  if (descr == "AtomOr" || descr == "AtomXor") {
-    return true;
-  }
-  if (descr == "AtomAnd") {
-    auto childIt = query->beginChildren();
-    while (childIt != query->endChildren()) {
-      if (_complexQueryHelper(childIt->get(), hasAtNum)) {
-        return true;
-      }
-      ++childIt;
-    }
-  }
-  return false;
+  return _complexBondQueryHelper(b->getQuery());
 }
 
+namespace {
 template <typename T>
 bool _atomListQueryHelper(const T query, bool ignoreNegation) {
   PRECONDITION(query, "no query");
@@ -858,33 +1188,47 @@ bool _atomListQueryHelper(const T query, bool ignoreNegation) {
   }
   return false;
 }
-}  // namespace
-bool isAtomListQuery(const Atom *a) {
-  PRECONDITION(a, "bad atom");
-  if (!a->hasQuery()) {
+
+template <typename QUERY_T>
+bool _isAtomListQuery(const QUERY_T *query) {
+  if (query == nullptr) {
     return false;
   }
-  if (a->getQuery()->getDescription() == "AtomOr") {
-    for (const auto &child : boost::make_iterator_range(
-             a->getQuery()->beginChildren(), a->getQuery()->endChildren())) {
+  if (query->getDescription() == "AtomOr") {
+    for (const auto &child : boost::make_iterator_range(query->beginChildren(),
+                                                        query->endChildren())) {
       if (!_atomListQueryHelper(child, false)) {
         return false;
       }
     }
     return true;
-  } else if (a->getQuery()->getNegation() &&
-             _atomListQueryHelper(a->getQuery(), true)) {
+  } else if (query->getNegation() && _atomListQueryHelper(query, true)) {
     // this was github #5930: negated list queries containing a single atom were
     // being lost on output
     return true;
   }
   return false;
 }
+}  // namespace
+bool isAtomListQuery(ConstRDMolAtom a) {
+  PRECONDITION(a.index() < a.mol().getNumAtoms(), "bad atom");
+  const auto *query = a.mol().getAtomQuery(a.index());
+  return _isAtomListQuery(query);
+}
+bool isAtomListQuery(const Atom *a) {
+  PRECONDITION(a, "bad atom");
+  if (!a->hasQuery()) {
+    return false;
+  }
+  return _isAtomListQuery(a->getQuery());
+}
 
-void getAtomListQueryVals(const Atom::QUERYATOM_QUERY *q,
-                          std::vector<int> &vals) {
+namespace {
+template <typename QUERY_T>
+void _getAtomListQueryValsHelper(const QUERY_T *q, std::vector<int> &vals) {
   // list queries are series of nested ors of AtomAtomicNum queries
   PRECONDITION(q, "bad query");
+  using ATOM_EQUALS_QUERY_TYPE = Queries::EqualityQuery<int, typename QUERY_T::DATA_FUNC_ARG_TYPE, true>;
   auto descr = q->getDescription();
   if (descr == "AtomOr") {
     for (const auto &child :
@@ -897,11 +1241,11 @@ void getAtomListQueryVals(const Atom::QUERYATOM_QUERY *q,
       }
       // we don't allow negation of any children of the query:
       if (descr == "AtomOr") {
-        getAtomListQueryVals(child.get(), vals);
+        _getAtomListQueryValsHelper(child.get(), vals);
       } else if (descr == "AtomAtomicNum") {
-        vals.push_back(static_cast<ATOM_EQUALS_QUERY *>(child.get())->getVal());
+        vals.push_back(static_cast<ATOM_EQUALS_QUERY_TYPE *>(child.get())->getVal());
       } else if (descr == "AtomType") {
-        auto v = static_cast<ATOM_EQUALS_QUERY *>(child.get())->getVal();
+        auto v = static_cast<ATOM_EQUALS_QUERY_TYPE *>(child.get())->getVal();
         // aromatic AtomType queries add 1000 to the atomic number;
         // correct for that:
         if (v >= 1000) {
@@ -911,9 +1255,9 @@ void getAtomListQueryVals(const Atom::QUERYATOM_QUERY *q,
       }
     }
   } else if (descr == "AtomAtomicNum") {
-    vals.push_back(static_cast<const ATOM_EQUALS_QUERY *>(q)->getVal());
+    vals.push_back(static_cast<const ATOM_EQUALS_QUERY_TYPE *>(q)->getVal());
   } else if (descr == "AtomType") {
-    auto v = static_cast<const ATOM_EQUALS_QUERY *>(q)->getVal();
+    auto v = static_cast<const ATOM_EQUALS_QUERY_TYPE *>(q)->getVal();
     // aromatic AtomType queries add 1000 to the atomic number;
     // correct for that:
     if (v >= 1000) {
@@ -924,18 +1268,58 @@ void getAtomListQueryVals(const Atom::QUERYATOM_QUERY *q,
     CHECK_INVARIANT(0, "bad query type");
   }
 }
+}  // namespace
 
-bool isComplexQuery(const Atom *a) {
-  PRECONDITION(a, "bad atom");
-  if (!a->hasQuery()) {
+void getAtomListQueryVals(const RDMol::QUERYATOM_QUERY *q,
+                          std::vector<int> &vals) {
+  _getAtomListQueryValsHelper(q, vals);
+}
+void getAtomListQueryVals(const Atom::QUERYATOM_QUERY *q,
+                          std::vector<int> &vals) {
+  _getAtomListQueryValsHelper(q, vals);
+}
+
+namespace {
+template <typename QUERY_T>
+bool _complexQueryHelper(const QUERY_T *query, bool &hasAtNum) {
+  if (!query) {
+    return false;
+  }
+  if (query->getNegation()) {
+    return true;
+  }
+  const std::string &descr = query->getDescription();
+  // std::cerr<<" |"<<descr;
+  if (descr == "AtomAtomicNum" || descr == "AtomType") {
+    hasAtNum = true;
+    return false;
+  }
+  if (descr == "AtomOr" || descr == "AtomXor") {
+    return true;
+  }
+  if (descr == "AtomAnd") {
+    auto childIt = query->beginChildren();
+    while (childIt != query->endChildren()) {
+      if (_complexQueryHelper(childIt->get(), hasAtNum)) {
+        return true;
+      }
+      ++childIt;
+    }
+  }
+  return false;
+}
+
+template <typename QUERY_T>
+bool _isComplexQuery(const QUERY_T *query) {
+  if (query == nullptr) {
     return false;
   }
   // std::cerr<<"\n"<<a->getIdx();
   // negated things are always complex:
-  if (a->getQuery()->getNegation()) {
+  if (query->getNegation()) {
     return true;
   }
-  std::string descr = a->getQuery()->getDescription();
+  const std::string &descr = query->getDescription();
   // std::cerr<<" "<<descr;
   if (descr == "AtomNull" || descr == "AtomAtomicNum" || descr == "AtomType") {
     return false;
@@ -945,7 +1329,7 @@ bool isComplexQuery(const Atom *a) {
   }
   if (descr == "AtomAnd") {
     bool hasAtNum = false;
-    if (_complexQueryHelper(a->getQuery(), hasAtNum)) {
+    if (_complexQueryHelper(query, hasAtNum)) {
       return true;
     }
     return !hasAtNum;
@@ -953,54 +1337,84 @@ bool isComplexQuery(const Atom *a) {
 
   return true;
 }
+}  // namespace
+bool isComplexQuery(ConstRDMolAtom a) {
+  PRECONDITION(a.index() < a.mol().getNumAtoms(), "bad atom");
+  const auto *query = a.mol().getAtomQuery(a.index());
+  return _isComplexQuery(query);
+}
+bool isComplexQuery(const Atom *a) {
+  PRECONDITION(a, "bad atom");
+  if (!a->hasQuery()) {
+    return false;
+  }
+  return _isComplexQuery(a->getQuery());
+}
+
+namespace {
+template <typename QUERY_T, typename ATOM_T>
+bool _isAtomAromatic(const QUERY_T *query, const ATOM_T &atom, const bool isAromaticDataMember) {
+  if (query == nullptr) {
+    return isAromaticAtom(atom);
+  }
+  const std::string &descr = query->getDescription();
+  if (descr == "AtomAtomicNum") {
+    return isAromaticDataMember;
+  }
+  if (descr == "AtomIsAromatic") {
+    return !query->getNegation();
+  }
+  if (descr == "AtomIsAliphatic") {
+    return query->getNegation();
+  }
+  if (descr == "AtomType") {
+    using ATOM_EQUALS_QUERY_TYPE =
+        Queries::EqualityQuery<int, typename QUERY_T::DATA_FUNC_ARG_TYPE, true>;
+    bool res = getAtomTypeIsAromatic(
+        static_cast<const ATOM_EQUALS_QUERY_TYPE *>(query)->getVal());
+    if (query->getNegation()) {
+      res = !res;
+    }
+    return res;
+  }
+  if (descr == "AtomAnd") {
+    auto childIt = query->beginChildren();
+    if ((*childIt)->getDescription() == "AtomAtomicNum") {
+      if (query->getNegation()) {
+        return false;
+      } else if ((*(childIt + 1))->getDescription() == "AtomIsAliphatic") {
+        return false;
+      } else if ((*(childIt + 1))->getDescription() == "AtomIsAromatic") {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+}  // namespace
+bool isAtomAromatic(ConstRDMolAtom a) {
+  PRECONDITION(a.index() < a.mol().getNumAtoms(), "bad atom");
+  const auto *query = a.mol().getAtomQuery(a.index());
+  return _isAtomAromatic(query, a, a.data().getIsAromatic());
+}
 bool isAtomAromatic(const Atom *a) {
   PRECONDITION(a, "bad atom");
   bool res = false;
   if (!a->hasQuery()) {
-    res = isAromaticAtom(*a);
-  } else {
-    std::string descr = a->getQuery()->getDescription();
-    if (descr == "AtomAtomicNum") {
-      res = a->getIsAromatic();
-    } else if (descr == "AtomIsAromatic") {
-      res = true;
-      if (a->getQuery()->getNegation()) {
-        res = !res;
-      }
-    } else if (descr == "AtomIsAliphatic") {
-      res = false;
-      if (a->getQuery()->getNegation()) {
-        res = !res;
-      }
-    } else if (descr == "AtomType") {
-      res = getAtomTypeIsAromatic(
-          static_cast<ATOM_EQUALS_QUERY *>(a->getQuery())->getVal());
-      if (a->getQuery()->getNegation()) {
-        res = !res;
-      }
-    } else if (descr == "AtomAnd") {
-      auto childIt = a->getQuery()->beginChildren();
-      if ((*childIt)->getDescription() == "AtomAtomicNum") {
-        if (a->getQuery()->getNegation()) {
-          res = false;
-        } else if ((*(childIt + 1))->getDescription() == "AtomIsAliphatic") {
-          res = false;
-        } else if ((*(childIt + 1))->getDescription() == "AtomIsAromatic") {
-          res = true;
-        }
-      }
-    }
+    return isAromaticAtom(*a);
   }
-  return res;
+  return _isAtomAromatic(a->getQuery(), *a, a->getIsAromatic());
 }
 
 namespace QueryOps {
 namespace {
-void completeQueryAndChildren(Atom::QUERYATOM_QUERY *query, Atom *tgt,
+template <typename QUERY_T, typename ATOM_T>
+void completeQueryAndChildren(QUERY_T *query, ATOM_T tgt,
                               unsigned int magicVal) {
   PRECONDITION(query, "no query");
-  PRECONDITION(tgt, "no atom");
-  auto eqQuery = dynamic_cast<ATOM_EQUALS_QUERY *>(query);
+  using ATOM_EQUALS_QUERY_TYPE = Queries::EqualityQuery<int, typename QUERY_T::DATA_FUNC_ARG_TYPE, true>;
+  auto eqQuery = dynamic_cast<ATOM_EQUALS_QUERY_TYPE *>(query);
   if (eqQuery) {
     if (static_cast<unsigned int>(eqQuery->getVal()) == magicVal) {
       int tgtVal = eqQuery->getDataFunc()(tgt);
@@ -1013,6 +1427,16 @@ void completeQueryAndChildren(Atom::QUERYATOM_QUERY *query, Atom *tgt,
   }
 }
 }  // namespace
+void completeMolQueries(RDMol *mol, unsigned int magicVal) {
+  PRECONDITION(mol, "bad molecule");
+  for (size_t atomIndex = 0, numAtoms = mol->getNumAtoms();
+       atomIndex < numAtoms; ++atomIndex) {
+    if (mol->hasAtomQuery(atomIndex)) {
+      completeQueryAndChildren(mol->getAtomQuery(atomIndex),
+                               ConstRDMolAtom(mol, atomIndex), magicVal);
+    }
+  }
+}
 void completeMolQueries(RWMol *mol, unsigned int magicVal) {
   PRECONDITION(mol, "bad molecule");
   for (auto atom : mol->atoms()) {
@@ -1022,6 +1446,47 @@ void completeMolQueries(RWMol *mol, unsigned int magicVal) {
   }
 }
 
+void replaceAtomWithQueryAtom(RDMol *mol, atomindex_t atomIndex) {
+  PRECONDITION(mol, "bad molecule");
+  PRECONDITION(atomIndex < mol->getNumAtoms(), "bad atom");
+  if (mol->hasAtomQuery(atomIndex)) {
+    return;
+  }
+
+  // This is based on the QueryAtom constructor that accepts (const Atom &)
+  auto &atom = mol->getAtom(atomIndex);
+  std::unique_ptr<RDMol::QUERYATOM_QUERY> query(makeAtomNumQuery2(atom.getAtomicNum()));
+  if (atom.getIsotope()) {
+    std::unique_ptr<RDMol::QUERYATOM_QUERY> newQuery(
+        makeAtomIsotopeQuery2(atom.getIsotope()));
+    expandQuery(query, std::move(newQuery),
+                      Queries::CompositeQueryType::COMPOSITE_AND);
+  }
+  if (atom.getFormalCharge()) {
+    std::unique_ptr<RDMol::QUERYATOM_QUERY> newQuery(
+        makeAtomFormalChargeQuery2(atom.getFormalCharge()));
+    expandQuery(query, std::move(newQuery),
+                      Queries::CompositeQueryType::COMPOSITE_AND);
+  }
+  if (atom.getNumRadicalElectrons()) {
+    std::unique_ptr<RDMol::QUERYATOM_QUERY> newQuery(
+        makeAtomNumRadicalElectronsQuery2(atom.getNumRadicalElectrons()));
+    expandQuery(query, std::move(newQuery),
+        Queries::CompositeQueryType::COMPOSITE_AND);
+  }
+
+  // This is based on the original replaceAtomWithQueryAtom
+  bool massQueryPropValue = false;
+  bool hasMassQueryProp = mol->getAtomPropIfPresent(
+      common_properties::_hasMassQueryToken, atomIndex, massQueryPropValue);
+  if (hasMassQueryProp) {
+    std::unique_ptr<RDMol::QUERYATOM_QUERY> newQuery(
+        makeAtomMassQuery2(static_cast<int>(atom.getMass())));
+    expandQuery(query, std::move(newQuery),
+                Queries::CompositeQueryType::COMPOSITE_AND);
+  }
+  mol->setAtomQuery(atomIndex, std::move(query));
+}
 Atom *replaceAtomWithQueryAtom(RWMol *mol, Atom *atom) {
   PRECONDITION(mol, "bad molecule");
   PRECONDITION(atom, "bad atom");
@@ -1039,6 +1504,80 @@ Atom *replaceAtomWithQueryAtom(RWMol *mol, Atom *atom) {
   return mol->getAtomWithIdx(idx);
 }
 
+static const std::unordered_map<std::string,
+    std::pair<DataFuncPtrType<false, false>, DataFuncPtrType<false, true>>>
+    atom_descr_to_func = {
+        {"AtomRingBondCount", {queryAtomRingBondCount, queryAtomRingBondCount2}},
+        {"AtomHasRingBond", {queryAtomHasRingBond, queryAtomHasRingBond2}},
+        {"AtomRingSize", {nullptr, nullptr}},
+        {"AtomMinRingSize", {queryAtomMinRingSize, queryAtomMinRingSize2}},
+        {"AtomImplicitValence", {queryAtomImplicitValence, queryAtomImplicitValence2}},
+        {"AtomTotalValence", {queryAtomTotalValence, queryAtomTotalValence2}},
+        {"AtomAtomicNum", {queryAtomNum, queryAtomNum2}},
+        {"AtomExplicitDegree", {queryAtomExplicitDegree, queryAtomExplicitDegree2}},
+        {"AtomTotalDegree", {queryAtomTotalDegree, queryAtomTotalDegree2}},
+        {"AtomHeavyAtomDegree", {queryAtomHeavyAtomDegree, queryAtomHeavyAtomDegree2}},
+        {"AtomHCount", {queryAtomHCount, queryAtomHCount2}},
+        {"AtomImplicitHCount", {queryAtomImplicitHCount, queryAtomImplicitHCount2}},
+        {"AtomHasImplicitH", {queryAtomHasImplicitH, queryAtomHasImplicitH2}},
+        {"AtomIsAromatic", {queryAtomAromatic, queryAtomAromatic2}},
+        {"AtomIsAliphatic", {queryAtomAliphatic, queryAtomAliphatic2}},
+        {"AtomUnsaturated", {queryAtomUnsaturated, queryAtomUnsaturated2}},
+        {"AtomMass", {queryAtomMass, queryAtomMass2}},
+        {"AtomIsotope", {queryAtomIsotope, queryAtomIsotope2}},
+        {"AtomFormalCharge", {queryAtomFormalCharge, queryAtomFormalCharge2}},
+        {"AtomNegativeFormalCharge", {queryAtomNegativeFormalCharge, queryAtomNegativeFormalCharge2}},
+        {"AtomHybridization", {queryAtomHybridization, queryAtomHybridization2}},
+        {"AtomInRing", {queryIsAtomInRing, queryIsAtomInRing2}},
+        {"AtomInNRings", {queryIsAtomInNRings, queryIsAtomInNRings2}},
+        {"AtomHasHeteroatomNeighbors", {queryAtomHasHeteroatomNbrs, queryAtomHasHeteroatomNbrs2}},
+        {"AtomNumHeteroatomNeighbors", {queryAtomNumHeteroatomNbrs, queryAtomNumHeteroatomNbrs2}},
+        {"AtomNonHydrogenDegree", {queryAtomNonHydrogenDegree, queryAtomNonHydrogenDegree2}},
+        {"AtomHasAliphaticHeteroatomNeighbors", {queryAtomHasAliphaticHeteroatomNbrs, queryAtomHasAliphaticHeteroatomNbrs2}},
+        {"AtomNumAliphaticHeteroatomNeighbors", {queryAtomNumAliphaticHeteroatomNbrs, queryAtomNumAliphaticHeteroatomNbrs2}},
+        {"AtomNull", {nullDataFun, nullDataFun}},
+        {"AtomType", {queryAtomType, queryAtomType2}},
+        {"AtomNumRadicalElectrons", {queryAtomNumRadicalElectrons, queryAtomNumRadicalElectrons2}},
+        {"RecursiveStructure", {nullptr, nullptr}},
+        {"AtomAnd", {nullptr, nullptr}},
+        {"AtomOr", {nullptr, nullptr}},
+        {"AtomXor", {nullptr, nullptr}},
+        {"HasProp", {nullptr, nullptr}},
+        {"HasPropWithValue", {nullptr, nullptr}},
+};
+
+void finalizeQueryFromDescription(
+    Queries::Query<int, ConstRDMolAtom, true> *query, ConstRDMolAtom) {
+  std::string descr = query->getDescription();
+
+  if (boost::starts_with(descr, "range_")) {
+    descr = descr.substr(6);
+  } else if (boost::starts_with(descr, "less_")) {
+    descr = descr.substr(5);
+  } else if (boost::starts_with(descr, "greater_")) {
+    descr = descr.substr(8);
+  }
+
+  auto it = atom_descr_to_func.find(descr);
+  if (it != atom_descr_to_func.end()) {
+    if (it->second.second != nullptr) {
+      query->setDataFunc(it->second.second);
+      if (descr == "AtomNull") {
+        query->setMatchFunc(nullQueryFun);
+      }
+    } else if (descr == "AtomRingSize") {
+      auto *dataFunc = getQueryIsInRingOfSizeTmpl<false, true>(
+          static_cast<ATOM_EQUALS_QUERY2 *>(query)->getVal());
+      query->setDataFunc(dataFunc);
+    } else {
+      // don't need to do anything here because the classes
+      // automatically have everything set
+    }
+  } else {
+    throw ValueErrorException("Do not know how to finalize query: '" + descr +
+                              "'");
+  }
+}
 void finalizeQueryFromDescription(
     Queries::Query<int, Atom const *, true> *query, Atom const *) {
   std::string descr = query->getDescription();
@@ -1051,120 +1590,89 @@ void finalizeQueryFromDescription(
     descr = descr.substr(8);
   }
 
-  Queries::Query<int, Atom const *, true> *tmpQuery;
-  if (descr == "AtomRingBondCount") {
-    query->setDataFunc(queryAtomRingBondCount);
-  } else if (descr == "AtomHasRingBond") {
-    query->setDataFunc(queryAtomHasRingBond);
-  } else if (descr == "AtomRingSize") {
-    tmpQuery = makeAtomInRingOfSizeQuery(
-        static_cast<ATOM_EQUALS_QUERY *>(query)->getVal());
-    query->setDataFunc(tmpQuery->getDataFunc());
-    delete tmpQuery;
-  } else if (descr == "AtomMinRingSize") {
-    query->setDataFunc(queryAtomMinRingSize);
-  } else if (descr == "AtomImplicitValence") {
-    query->setDataFunc(queryAtomImplicitValence);
-  } else if (descr == "AtomTotalValence") {
-    query->setDataFunc(queryAtomTotalValence);
-  } else if (descr == "AtomAtomicNum") {
-    query->setDataFunc(queryAtomNum);
-  } else if (descr == "AtomExplicitDegree") {
-    query->setDataFunc(queryAtomExplicitDegree);
-  } else if (descr == "AtomTotalDegree") {
-    query->setDataFunc(queryAtomTotalDegree);
-  } else if (descr == "AtomHeavyAtomDegree") {
-    query->setDataFunc(queryAtomHeavyAtomDegree);
-  } else if (descr == "AtomHCount") {
-    query->setDataFunc(queryAtomHCount);
-  } else if (descr == "AtomImplicitHCount") {
-    query->setDataFunc(queryAtomImplicitHCount);
-  } else if (descr == "AtomHasImplicitH") {
-    query->setDataFunc(queryAtomHasImplicitH);
-  } else if (descr == "AtomIsAromatic") {
-    query->setDataFunc(queryAtomAromatic);
-  } else if (descr == "AtomIsAliphatic") {
-    query->setDataFunc(queryAtomAliphatic);
-  } else if (descr == "AtomUnsaturated") {
-    query->setDataFunc(queryAtomUnsaturated);
-  } else if (descr == "AtomMass") {
-    query->setDataFunc(queryAtomMass);
-  } else if (descr == "AtomIsotope") {
-    query->setDataFunc(queryAtomIsotope);
-  } else if (descr == "AtomFormalCharge") {
-    query->setDataFunc(queryAtomFormalCharge);
-  } else if (descr == "AtomNegativeFormalCharge") {
-    query->setDataFunc(queryAtomNegativeFormalCharge);
-  } else if (descr == "AtomHybridization") {
-    query->setDataFunc(queryAtomHybridization);
-  } else if (descr == "AtomInRing") {
-    query->setDataFunc(queryIsAtomInRing);
-  } else if (descr == "AtomInNRings") {
-    query->setDataFunc(queryIsAtomInNRings);
-  } else if (descr == "AtomHasHeteroatomNeighbors") {
-    query->setDataFunc(queryAtomHasHeteroatomNbrs);
-  } else if (descr == "AtomNumHeteroatomNeighbors") {
-    query->setDataFunc(queryAtomNumHeteroatomNbrs);
-  } else if (descr == "AtomNonHydrogenDegree") {
-    query->setDataFunc(queryAtomNonHydrogenDegree);
-  } else if (descr == "AtomHasAliphaticHeteroatomNeighbors") {
-    query->setDataFunc(queryAtomHasAliphaticHeteroatomNbrs);
-  } else if (descr == "AtomNumAliphaticHeteroatomNeighbors") {
-    query->setDataFunc(queryAtomNumAliphaticHeteroatomNbrs);
-  } else if (descr == "AtomNull") {
-    query->setDataFunc(nullDataFun);
-    query->setMatchFunc(nullQueryFun);
-  } else if (descr == "AtomType") {
-    query->setDataFunc(queryAtomType);
-  } else if (descr == "AtomNumRadicalElectrons") {
-    query->setDataFunc(queryAtomNumRadicalElectrons);
-  } else if (descr == "AtomInNRings" || descr == "RecursiveStructure") {
-    // don't need to do anything here because the classes
-    // automatically have everything set
-  } else if (descr == "AtomAnd" || descr == "AtomOr" || descr == "AtomXor" ||
-             descr == "HasProp" || descr == "HasPropWithValue") {
-    // don't need to do anything here because the classes
-    // automatically have everything set
+  auto it = atom_descr_to_func.find(descr);
+  if (it != atom_descr_to_func.end()) {
+    if (it->second.first != nullptr) {
+      query->setDataFunc(it->second.first);
+      if (descr == "AtomNull") {
+        query->setMatchFunc(nullQueryFun);
+      }
+    } else if (descr == "AtomRingSize") {
+      auto *dataFunc = getQueryIsInRingOfSizeTmpl<false, false>(
+          static_cast<ATOM_EQUALS_QUERY *>(query)->getVal());
+      query->setDataFunc(dataFunc);
+    } else {
+      // don't need to do anything here because the classes
+      // automatically have everything set
+    }
   } else {
     throw ValueErrorException("Do not know how to finalize query: '" + descr +
                               "'");
   }
 }
 
+static const std::unordered_map<std::string,
+    std::pair<DataFuncPtrType<true, false>, DataFuncPtrType<true, true>>>
+    bond_descr_to_func = {
+        {"BondRingSize", {nullptr, nullptr}},
+        {"BondMinRingSize", {queryBondMinRingSize, queryBondMinRingSize2}},
+        {"BondOrder", {queryBondOrder, queryBondOrder2}},
+        {"BondDir", {queryBondDir, queryBondDir2}},
+        {"BondInRing", {queryIsBondInRing, queryIsBondInRing2}},
+        {"BondInNRings", {queryIsBondInNRings, queryIsBondInNRings2}},
+        {"SingleOrAromaticBond", {queryBondIsSingleOrAromatic, queryBondIsSingleOrAromatic2}},
+        {"SingleOrDoubleBond", {queryBondIsSingleOrDouble, queryBondIsSingleOrDouble2}},
+        {"DoubleOrAromaticBond", {queryBondIsDoubleOrAromatic, queryBondIsDoubleOrAromatic2}},
+        {"SingleOrDoubleOrAromaticBond", {queryBondIsSingleOrDoubleOrAromatic, queryBondIsSingleOrDoubleOrAromatic2}},
+        {"BondNull", {nullDataFun, nullDataFun}},
+        {"BondAnd", {nullptr, nullptr}},
+        {"BondOr", {nullptr, nullptr}},
+        {"BondXor", {nullptr, nullptr}},
+        {"HasProp", {nullptr, nullptr}},
+        {"HasPropWithValue", {nullptr, nullptr}},
+};
+
+void finalizeQueryFromDescription(
+    Queries::Query<int, ConstRDMolBond, true> *query, ConstRDMolBond) {
+  const std::string &descr = query->getDescription();
+  auto it = bond_descr_to_func.find(descr);
+  if (it != bond_descr_to_func.end()) {
+    if (it->second.second != nullptr) {
+      query->setDataFunc(it->second.second);
+      if (descr == "BondNull") {
+        query->setMatchFunc(nullQueryFun);
+      }
+    } else if (descr == "BondRingSize") {
+      auto *dataFunc = getQueryIsInRingOfSizeTmpl<true, true>(
+          static_cast<BOND_EQUALS_QUERY2 *>(query)->getVal());
+      query->setDataFunc(dataFunc);
+    } else {
+      // don't need to do anything here because the classes
+      // automatically have everything set
+    }
+  } else {
+    throw ValueErrorException("Do not know how to finalize query: '" + descr +
+                              "'");
+  }
+}
 void finalizeQueryFromDescription(
     Queries::Query<int, Bond const *, true> *query, Bond const *) {
-  std::string descr = query->getDescription();
-  Queries::Query<int, Bond const *, true> *tmpQuery;
-  if (descr == "BondRingSize") {
-    tmpQuery = makeBondInRingOfSizeQuery(
-        static_cast<BOND_EQUALS_QUERY *>(query)->getVal());
-    query->setDataFunc(tmpQuery->getDataFunc());
-    delete tmpQuery;
-  } else if (descr == "BondMinRingSize") {
-    query->setDataFunc(queryBondMinRingSize);
-  } else if (descr == "BondOrder") {
-    query->setDataFunc(queryBondOrder);
-  } else if (descr == "BondDir") {
-    query->setDataFunc(queryBondDir);
-  } else if (descr == "BondInRing") {
-    query->setDataFunc(queryIsBondInRing);
-  } else if (descr == "BondInNRings") {
-    query->setDataFunc(queryIsBondInNRings);
-  } else if (descr == "SingleOrAromaticBond") {
-    query->setDataFunc(queryBondIsSingleOrAromatic);
-  } else if (descr == "SingleOrDoubleBond") {
-    query->setDataFunc(queryBondIsSingleOrDouble);
-  } else if (descr == "DoubleOrAromaticBond") {
-    query->setDataFunc(queryBondIsDoubleOrAromatic);
-  } else if (descr == "SingleOrDoubleOrAromaticBond") {
-    query->setDataFunc(queryBondIsSingleOrDoubleOrAromatic);
-  } else if (descr == "BondNull") {
-    query->setDataFunc(nullDataFun);
-    query->setMatchFunc(nullQueryFun);
-  } else if (descr == "BondAnd" || descr == "BondOr" || descr == "BondXor" ||
-             descr == "HasProp" || descr == "HasPropWithValue") {
-    // don't need to do anything here because the classes
-    // automatically have everything set
+  const std::string &descr = query->getDescription();
+  auto it = bond_descr_to_func.find(descr);
+  if (it != bond_descr_to_func.end()) {
+    if (it->second.first != nullptr) {
+      query->setDataFunc(it->second.first);
+      if (descr == "BondNull") {
+        query->setMatchFunc(nullQueryFun);
+      }
+    } else if (descr == "BondRingSize") {
+      auto *dataFunc = getQueryIsInRingOfSizeTmpl<true, false>(
+          static_cast<BOND_EQUALS_QUERY *>(query)->getVal());
+      query->setDataFunc(dataFunc);
+    } else {
+      // don't need to do anything here because the classes
+      // automatically have everything set
+    }
   } else {
     throw ValueErrorException("Do not know how to finalize query: '" + descr +
                               "'");

--- a/Code/GraphMol/QueryOps.h
+++ b/Code/GraphMol/QueryOps.h
@@ -18,6 +18,7 @@
 #define RD_QUERY_OPS_H
 
 #include <GraphMol/RDKitBase.h>
+#include <GraphMol/RDMol.h>
 #include <Query/QueryObjects.h>
 #include <Query/Query.h>
 #include <DataStructs/BitVects.h>
@@ -29,58 +30,111 @@
 #endif
 
 namespace RDKit {
+class RDMol;
+class RingInfoCache;
+
+typedef Queries::Query<bool, ConstRDMolAtom, true> ATOM_BOOL_QUERY2;
+typedef Queries::Query<bool, ConstRDMolBond, true> BOND_BOOL_QUERY2;
 typedef Queries::Query<bool, Atom const *, true> ATOM_BOOL_QUERY;
 typedef Queries::Query<bool, Bond const *, true> BOND_BOOL_QUERY;
 
+typedef Queries::AndQuery<int, ConstRDMolAtom, true> ATOM_AND_QUERY2;
+typedef Queries::AndQuery<int, ConstRDMolBond, true> BOND_AND_QUERY2;
 typedef Queries::AndQuery<int, Atom const *, true> ATOM_AND_QUERY;
 typedef Queries::AndQuery<int, Bond const *, true> BOND_AND_QUERY;
 
+typedef Queries::OrQuery<int, ConstRDMolAtom, true> ATOM_OR_QUERY2;
+typedef Queries::OrQuery<int, ConstRDMolBond, true> BOND_OR_QUERY2;
 typedef Queries::OrQuery<int, Atom const *, true> ATOM_OR_QUERY;
 typedef Queries::OrQuery<int, Bond const *, true> BOND_OR_QUERY;
 
+typedef Queries::XOrQuery<int, ConstRDMolAtom, true> ATOM_XOR_QUERY2;
+typedef Queries::XOrQuery<int, ConstRDMolBond, true> BOND_XOR_QUERY2;
 typedef Queries::XOrQuery<int, Atom const *, true> ATOM_XOR_QUERY;
 typedef Queries::XOrQuery<int, Bond const *, true> BOND_XOR_QUERY;
 
+typedef Queries::EqualityQuery<int, ConstRDMolAtom, true> ATOM_EQUALS_QUERY2;
+typedef Queries::EqualityQuery<int, ConstRDMolBond, true> BOND_EQUALS_QUERY2;
 typedef Queries::EqualityQuery<int, Atom const *, true> ATOM_EQUALS_QUERY;
 typedef Queries::EqualityQuery<int, Bond const *, true> BOND_EQUALS_QUERY;
 
+typedef Queries::GreaterQuery<int, ConstRDMolAtom, true> ATOM_GREATER_QUERY2;
+typedef Queries::GreaterQuery<int, ConstRDMolBond, true> BOND_GREATER_QUERY2;
 typedef Queries::GreaterQuery<int, Atom const *, true> ATOM_GREATER_QUERY;
 typedef Queries::GreaterQuery<int, Bond const *, true> BOND_GREATER_QUERY;
 
+typedef Queries::GreaterEqualQuery<int, ConstRDMolAtom, true>
+    ATOM_GREATEREQUAL_QUERY2;
+typedef Queries::GreaterEqualQuery<int, ConstRDMolBond, true>
+    BOND_GREATEREQUAL_QUERY2;
 typedef Queries::GreaterEqualQuery<int, Atom const *, true>
     ATOM_GREATEREQUAL_QUERY;
 typedef Queries::GreaterEqualQuery<int, Bond const *, true>
     BOND_GREATEREQUAL_QUERY;
 
+typedef Queries::LessQuery<int, ConstRDMolAtom, true> ATOM_LESS_QUERY2;
+typedef Queries::LessQuery<int, ConstRDMolBond, true> BOND_LESS_QUERY2;
 typedef Queries::LessQuery<int, Atom const *, true> ATOM_LESS_QUERY;
 typedef Queries::LessQuery<int, Bond const *, true> BOND_LESS_QUERY;
 
+typedef Queries::LessEqualQuery<int, ConstRDMolAtom, true> ATOM_LESSEQUAL_QUERY2;
+typedef Queries::LessEqualQuery<int, ConstRDMolBond, true> BOND_LESSEQUAL_QUERY2;
 typedef Queries::LessEqualQuery<int, Atom const *, true> ATOM_LESSEQUAL_QUERY;
 typedef Queries::LessEqualQuery<int, Bond const *, true> BOND_LESSEQUAL_QUERY;
 
+typedef Queries::RangeQuery<int, ConstRDMolAtom, true> ATOM_RANGE_QUERY2;
+typedef Queries::RangeQuery<int, ConstRDMolBond, true> BOND_RANGE_QUERY2;
 typedef Queries::RangeQuery<int, Atom const *, true> ATOM_RANGE_QUERY;
 typedef Queries::RangeQuery<int, Bond const *, true> BOND_RANGE_QUERY;
 
+typedef Queries::SetQuery<int, ConstRDMolAtom, true> ATOM_SET_QUERY2;
+typedef Queries::SetQuery<int, ConstRDMolBond, true> BOND_SET_QUERY2;
 typedef Queries::SetQuery<int, Atom const *, true> ATOM_SET_QUERY;
 typedef Queries::SetQuery<int, Bond const *, true> BOND_SET_QUERY;
 
-typedef Queries::Query<int, Bond const *, true> BOND_NULL_QUERY;
+typedef Queries::Query<int, ConstRDMolAtom, true> ATOM_NULL_QUERY2;
+typedef Queries::Query<int, ConstRDMolBond, true> BOND_NULL_QUERY2;
 typedef Queries::Query<int, Atom const *, true> ATOM_NULL_QUERY;
+typedef Queries::Query<int, Bond const *, true> BOND_NULL_QUERY;
 
 // -------------------------------------------------
 // common atom queries
 
+static inline int queryAtomAromatic2(ConstRDMolAtom at) {
+  return at.data().getIsAromatic();
+};
 static inline int queryAtomAromatic(Atom const *at) {
   return at->getIsAromatic();
+};
+static inline int queryAtomAliphatic2(ConstRDMolAtom at) {
+  return !(at.data().getIsAromatic());
 };
 static inline int queryAtomAliphatic(Atom const *at) {
   return !(at->getIsAromatic());
 };
+static inline int queryAtomExplicitDegree2(ConstRDMolAtom at) {
+  return at.mol().getAtomDegree(at.index());
+};
 static inline int queryAtomExplicitDegree(Atom const *at) {
   return at->getDegree();
 };
+static inline int queryAtomTotalDegree2(ConstRDMolAtom at) {
+  return at.mol().getAtomTotalDegree(at.index());
+};
 static inline int queryAtomTotalDegree(Atom const *at) {
   return at->getTotalDegree();
+};
+//! D and T are treated as "non-hydrogen" here
+static inline int queryAtomNonHydrogenDegree2(ConstRDMolAtom at) {
+  int res = 0;
+  for (const auto nbri :
+       boost::make_iterator_range(at.mol().getAtomNeighbors(at.index()))) {
+    const auto nbr = at.mol().getAtom(nbri);
+    if (nbr.getAtomicNum() != 1 || nbr.getIsotope() > 1) {
+      res++;
+    }
+  }
+  return res;
 };
 //! D and T are treated as "non-hydrogen" here
 static inline int queryAtomNonHydrogenDegree(Atom const *at) {
@@ -96,6 +150,19 @@ static inline int queryAtomNonHydrogenDegree(Atom const *at) {
   return res;
 };
 //! D and T are not treated as heavy atoms here
+static inline int queryAtomHeavyAtomDegree2(ConstRDMolAtom at) {
+  int heavyDegree = 0;
+  for (const auto nbri :
+       boost::make_iterator_range(at.mol().getAtomNeighbors(at.index()))) {
+    const auto nbr = at.mol().getAtom(nbri);
+    if (nbr.getAtomicNum() > 1) {
+      heavyDegree++;
+    }
+  }
+
+  return heavyDegree;
+};
+//! D and T are not treated as heavy atoms here
 static inline int queryAtomHeavyAtomDegree(Atom const *at) {
   int heavyDegree = 0;
   for (const auto nbri :
@@ -108,27 +175,53 @@ static inline int queryAtomHeavyAtomDegree(Atom const *at) {
 
   return heavyDegree;
 };
+static inline int queryAtomHCount2(ConstRDMolAtom at) {
+  return at.mol().getTotalNumHs(at.index(), true);
+};
 static inline int queryAtomHCount(Atom const *at) {
   return at->getTotalNumHs(true);
+};
+static inline int queryAtomImplicitHCount2(ConstRDMolAtom at) {
+  return at.mol().getTotalNumHs(at.index(), false);
 };
 static inline int queryAtomImplicitHCount(Atom const *at) {
   return at->getTotalNumHs(false);
 };
+static inline int queryAtomHasImplicitH2(ConstRDMolAtom at) {
+  return int(at.mol().getTotalNumHs(at.index(), false) > 0);
+};
 static inline int queryAtomHasImplicitH(Atom const *at) {
   return int(at->getTotalNumHs(false) > 0);
+};
+static inline int queryAtomImplicitValence2(ConstRDMolAtom at) {
+  return at.data().getImplicitValence();
 };
 static inline int queryAtomImplicitValence(Atom const *at) {
   return at->getValence(Atom::ValenceType::IMPLICIT);
 };
+static inline int queryAtomExplicitValence2(ConstRDMolAtom at) {
+  const AtomData &data = at.data();
+  return data.getExplicitValence() - data.getNumExplicitHs();
+};
 static inline int queryAtomExplicitValence(Atom const *at) {
   return at->getValence(Atom::ValenceType::EXPLICIT) - at->getNumExplicitHs();
+};
+static inline int queryAtomTotalValence2(ConstRDMolAtom at) {
+  return at.data().getTotalValence();
 };
 static inline int queryAtomTotalValence(Atom const *at) {
   return at->getTotalValence();
 };
+static inline int queryAtomUnsaturated2(ConstRDMolAtom at) {
+  const AtomData &data = at.data();
+  return at.mol().getAtomTotalDegree(at.index()) < data.getTotalValence();
+};
 static inline int queryAtomUnsaturated(Atom const *at) {
   return at->getTotalDegree() < at->getTotalValence();
 };
+static inline int queryAtomNum2(ConstRDMolAtom at) {
+  return at.data().getAtomicNum();
+}
 static inline int queryAtomNum(Atom const *at) { return at->getAtomicNum(); }
 static inline int makeAtomType(int atomic_num, bool aromatic) {
   return atomic_num + 1000 * static_cast<int>(aromatic);
@@ -150,37 +243,82 @@ static inline int getAtomTypeAtomicNum(int val) {
   return val;
 }
 
+static inline int queryAtomType2(ConstRDMolAtom at) {
+  const AtomData &data = at.data();
+  return makeAtomType(data.getAtomicNum(), data.getIsAromatic());
+};
 static inline int queryAtomType(Atom const *at) {
   return makeAtomType(at->getAtomicNum(), at->getIsAromatic());
 };
 const int massIntegerConversionFactor = 1000;
+static inline int queryAtomMass2(ConstRDMolAtom at) {
+  return static_cast<int>(std::round(massIntegerConversionFactor * at.data().getMass()));
+};
 static inline int queryAtomMass(Atom const *at) {
   return static_cast<int>(
       std::round(massIntegerConversionFactor * at->getMass()));
 };
+static inline int queryAtomIsotope2(ConstRDMolAtom at) {
+  return static_cast<int>(at.data().getIsotope());
+};
 static inline int queryAtomIsotope(Atom const *at) {
   return static_cast<int>(at->getIsotope());
+};
+static inline int queryAtomFormalCharge2(ConstRDMolAtom at) {
+  return static_cast<int>(at.data().getFormalCharge());
 };
 static inline int queryAtomFormalCharge(Atom const *at) {
   return static_cast<int>(at->getFormalCharge());
 };
+static inline int queryAtomNegativeFormalCharge2(ConstRDMolAtom at) {
+  return static_cast<int>(-1 * at.data().getFormalCharge());
+};
 static inline int queryAtomNegativeFormalCharge(Atom const *at) {
   return static_cast<int>(-1 * at->getFormalCharge());
+};
+static inline int queryAtomHybridization2(ConstRDMolAtom at) {
+  return at.data().getHybridization();
 };
 static inline int queryAtomHybridization(Atom const *at) {
   return at->getHybridization();
 };
+static inline int queryAtomNumRadicalElectrons2(ConstRDMolAtom at) {
+  return at.data().getNumRadicalElectrons();
+};
 static inline int queryAtomNumRadicalElectrons(Atom const *at) {
   return at->getNumRadicalElectrons();
 };
+static inline int queryAtomHasChiralTag2(ConstRDMolAtom at) {
+  return at.data().getChiralTag() != Atom::CHI_UNSPECIFIED;
+};
 static inline int queryAtomHasChiralTag(Atom const *at) {
   return at->getChiralTag() != Atom::CHI_UNSPECIFIED;
+};
+static inline int queryAtomMissingChiralTag2(ConstRDMolAtom at) {
+  if (at.data().getChiralTag() != Atom::CHI_UNSPECIFIED) {
+    return false;
+  }
+  bool value = false;
+  bool present = at.mol().getAtomPropIfPresent(
+      common_properties::_ChiralityPossibleToken, at.index(), value);
+  return present && value;
 };
 static inline int queryAtomMissingChiralTag(Atom const *at) {
   return at->getChiralTag() == Atom::CHI_UNSPECIFIED &&
          at->hasProp(common_properties::_ChiralityPossible);
 };
 
+static inline int queryAtomHasHeteroatomNbrs2(ConstRDMolAtom at) {
+  auto [nbrIdx, endNbrs] = at.mol().getAtomNeighbors(at.index());
+  while (nbrIdx != endNbrs) {
+    const AtomData& nbr = at.mol().getAtom(*nbrIdx);
+    if (nbr.getAtomicNum() != 6 && nbr.getAtomicNum() != 1) {
+      return 1;
+    }
+    ++nbrIdx;
+  }
+  return 0;
+};
 static inline int queryAtomHasHeteroatomNbrs(Atom const *at) {
   ROMol::ADJ_ITER nbrIdx, endNbrs;
   boost::tie(nbrIdx, endNbrs) = at->getOwningMol().getAtomNeighbors(at);
@@ -194,6 +332,18 @@ static inline int queryAtomHasHeteroatomNbrs(Atom const *at) {
   return 0;
 };
 
+static inline int queryAtomNumHeteroatomNbrs2(ConstRDMolAtom at) {
+  int res = 0;
+  auto [nbrIdx, endNbrs] = at.mol().getAtomNeighbors(at.index());
+  while (nbrIdx != endNbrs) {
+    const AtomData& nbr = at.mol().getAtom(*nbrIdx);
+    if (nbr.getAtomicNum() != 6 && nbr.getAtomicNum() != 1) {
+      ++res;
+    }
+    ++nbrIdx;
+  }
+  return res;
+};
 static inline int queryAtomNumHeteroatomNbrs(Atom const *at) {
   int res = 0;
   ROMol::ADJ_ITER nbrIdx, endNbrs;
@@ -208,6 +358,18 @@ static inline int queryAtomNumHeteroatomNbrs(Atom const *at) {
   return res;
 };
 
+static inline int queryAtomHasAliphaticHeteroatomNbrs2(ConstRDMolAtom at) {
+  auto [nbrIdx, endNbrs] = at.mol().getAtomNeighbors(at.index());
+  while (nbrIdx != endNbrs) {
+    const AtomData &nbr = at.mol().getAtom(*nbrIdx);
+    if ((!nbr.getIsAromatic()) && nbr.getAtomicNum() != 6 &&
+        nbr.getAtomicNum() != 1) {
+      return 1;
+    }
+    ++nbrIdx;
+  }
+  return 0;
+};
 static inline int queryAtomHasAliphaticHeteroatomNbrs(Atom const *at) {
   ROMol::ADJ_ITER nbrIdx, endNbrs;
   boost::tie(nbrIdx, endNbrs) = at->getOwningMol().getAtomNeighbors(at);
@@ -222,6 +384,19 @@ static inline int queryAtomHasAliphaticHeteroatomNbrs(Atom const *at) {
   return 0;
 };
 
+static inline int queryAtomNumAliphaticHeteroatomNbrs2(ConstRDMolAtom at) {
+  int res = 0;
+  auto [nbrIdx, endNbrs] = at.mol().getAtomNeighbors(at.index());
+  while (nbrIdx != endNbrs) {
+    const AtomData &nbr = at.mol().getAtom(*nbrIdx);
+    if ((!nbr.getIsAromatic()) && nbr.getAtomicNum() != 6 &&
+        nbr.getAtomicNum() != 1) {
+      ++res;
+    }
+    ++nbrIdx;
+  }
+  return res;
+};
 static inline int queryAtomNumAliphaticHeteroatomNbrs(Atom const *at) {
   int res = 0;
   ROMol::ADJ_ITER nbrIdx, endNbrs;
@@ -237,37 +412,69 @@ static inline int queryAtomNumAliphaticHeteroatomNbrs(Atom const *at) {
   return res;
 };
 
+RDKIT_GRAPHMOL_EXPORT unsigned int queryAtomBondProduct2(ConstRDMolAtom at);
 RDKIT_GRAPHMOL_EXPORT unsigned int queryAtomBondProduct(Atom const *at);
+RDKIT_GRAPHMOL_EXPORT unsigned int queryAtomAllBondProduct2(ConstRDMolAtom at);
 RDKIT_GRAPHMOL_EXPORT unsigned int queryAtomAllBondProduct(Atom const *at);
 
 // -------------------------------------------------
 // common bond queries
 
+static inline int queryBondOrder2(ConstRDMolBond bond) {
+  return static_cast<int>(bond.data().getBondType());
+};
 static inline int queryBondOrder(Bond const *bond) {
   return static_cast<int>(bond->getBondType());
+};
+static inline int queryBondIsSingleOrAromatic2(ConstRDMolBond bond) {
+  auto type = bond.data().getBondType();
+  return static_cast<int>(type == Bond::SINGLE || type == Bond::AROMATIC);
 };
 static inline int queryBondIsSingleOrAromatic(Bond const *bond) {
   return static_cast<int>(bond->getBondType() == Bond::SINGLE ||
                           bond->getBondType() == Bond::AROMATIC);
 };
+static inline int queryBondIsDoubleOrAromatic2(ConstRDMolBond bond) {
+  auto type = bond.data().getBondType();
+  return static_cast<int>(type == Bond::DOUBLE || type == Bond::AROMATIC);
+};
 static inline int queryBondIsDoubleOrAromatic(Bond const *bond) {
   return static_cast<int>(bond->getBondType() == Bond::DOUBLE ||
                           bond->getBondType() == Bond::AROMATIC);
 };
+static inline int queryBondIsSingleOrDouble2(ConstRDMolBond bond) {
+  auto type = bond.data().getBondType();
+  return static_cast<int>(type == Bond::SINGLE || type == Bond::DOUBLE);
+};
 static inline int queryBondIsSingleOrDouble(Bond const *bond) {
   return static_cast<int>(bond->getBondType() == Bond::SINGLE ||
                           bond->getBondType() == Bond::DOUBLE);
+};
+static inline int queryBondIsSingleOrDoubleOrAromatic2(ConstRDMolBond bond) {
+  auto type = bond.data().getBondType();
+  return static_cast<int>(type == Bond::SINGLE ||
+                          type == Bond::DOUBLE ||
+                          type == Bond::AROMATIC);
 };
 static inline int queryBondIsSingleOrDoubleOrAromatic(Bond const *bond) {
   return static_cast<int>(bond->getBondType() == Bond::SINGLE ||
                           bond->getBondType() == Bond::DOUBLE ||
                           bond->getBondType() == Bond::AROMATIC);
 };
+static inline int queryBondDir2(ConstRDMolBond bond) {
+  return static_cast<int>(bond.data().getBondDir());
+};
 static inline int queryBondDir(Bond const *bond) {
   return static_cast<int>(bond->getBondDir());
 };
+static inline int queryIsBondInNRings2(ConstRDMolBond at) {
+  return at.mol().getRingInfo().numBondRings(at.index());
+};
 static inline int queryIsBondInNRings(Bond const *at) {
   return at->getOwningMol().getRingInfo()->numBondRings(at->getIdx());
+};
+static inline int queryBondHasStereo2(ConstRDMolBond bnd) {
+  return bnd.data().getStereo() > Bond::STEREONONE;
 };
 static inline int queryBondHasStereo(Bond const *bnd) {
   return bnd->getStereo() > Bond::STEREONONE;
@@ -276,11 +483,28 @@ static inline int queryBondHasStereo(Bond const *bnd) {
 // -------------------------------------------------
 // ring queries
 
+static inline int queryIsAtomInNRings2(ConstRDMolAtom at) {
+  return at.mol().getRingInfo().numAtomRings(at.index());
+};
 static inline int queryIsAtomInNRings(Atom const *at) {
   return at->getOwningMol().getRingInfo()->numAtomRings(at->getIdx());
 };
+static inline int queryIsAtomInRing2(ConstRDMolAtom at) {
+  return at.mol().getRingInfo().numAtomRings(at.index()) != 0;
+};
 static inline int queryIsAtomInRing(Atom const *at) {
   return at->getOwningMol().getRingInfo()->numAtomRings(at->getIdx()) != 0;
+};
+static inline int queryAtomHasRingBond2(ConstRDMolAtom at) {
+  auto [begin, end] = at.mol().getAtomBonds(at.index());
+  while (begin != end) {
+    unsigned int bondIdx = *begin;
+    if (at.mol().getRingInfo().numBondRings(bondIdx)) {
+      return 1;
+    }
+    ++begin;
+  }
+  return 0;
 };
 static inline int queryAtomHasRingBond(Atom const *at) {
   ROMol::OBOND_ITER_PAIR atomBonds = at->getOwningMol().getAtomBonds(at);
@@ -294,18 +518,44 @@ static inline int queryAtomHasRingBond(Atom const *at) {
   }
   return 0;
 };
+RDKIT_GRAPHMOL_EXPORT bool queryIsAtomBridgeheadInternal(const RDMol &mol, atomindex_t atomIndex, const RingInfoCache &rings);
+static inline int queryIsAtomBridgehead2(ConstRDMolAtom at) {
+  return queryIsAtomBridgeheadInternal(at.mol(), at.index(), at.mol().getRingInfo()) ? 1 : 0;
+}
 RDKIT_GRAPHMOL_EXPORT int queryIsAtomBridgehead(Atom const *at);
 
+static inline int queryIsBondInRing2(ConstRDMolBond bond) {
+  return bond.mol().getRingInfo().numBondRings(bond.index()) != 0;
+};
 static inline int queryIsBondInRing(Bond const *bond) {
   return bond->getOwningMol().getRingInfo()->numBondRings(bond->getIdx()) != 0;
 };
+static inline int queryAtomMinRingSize2(ConstRDMolAtom at) {
+  return at.mol().getRingInfo().minAtomRingSize(at.index());
+};
 static inline int queryAtomMinRingSize(Atom const *at) {
   return at->getOwningMol().getRingInfo()->minAtomRingSize(at->getIdx());
+};
+static inline int queryBondMinRingSize2(ConstRDMolBond bond) {
+  return bond.mol().getRingInfo().minBondRingSize(bond.index());
 };
 static inline int queryBondMinRingSize(Bond const *bond) {
   return bond->getOwningMol().getRingInfo()->minBondRingSize(bond->getIdx());
 };
 
+static inline int queryAtomRingBondCount2(ConstRDMolAtom at) {
+  // EFF: cache this result
+  int res = 0;
+  auto [begin, end] = at.mol().getAtomBonds(at.index());
+  while (begin != end) {
+    unsigned int bondIdx = *begin;
+    if (at.mol().getRingInfo().numBondRings(bondIdx)) {
+      res++;
+    }
+    ++begin;
+  }
+  return res;
+}
 static inline int queryAtomRingBondCount(Atom const *at) {
   // EFF: cache this result
   int res = 0;
@@ -322,8 +572,24 @@ static inline int queryAtomRingBondCount(Atom const *at) {
 }
 
 template <int tgt>
+int queryAtomIsInRingOfSize2(ConstRDMolAtom at) {
+  if (at.mol().getRingInfo().isAtomInRingOfSize(at.index(), tgt)) {
+    return tgt;
+  } else {
+    return 0;
+  }
+};
+template <int tgt>
 int queryAtomIsInRingOfSize(Atom const *at) {
   if (at->getOwningMol().getRingInfo()->isAtomInRingOfSize(at->getIdx(), tgt)) {
+    return tgt;
+  } else {
+    return 0;
+  }
+};
+template <int tgt>
+int queryBondIsInRingOfSize2(ConstRDMolBond bond) {
+  if (bond.mol().getRingInfo().isBondInRingOfSize(bond.index(), tgt)) {
     return tgt;
   } else {
     return 0;
@@ -340,6 +606,15 @@ int queryBondIsInRingOfSize(Bond const *bond) {
 };
 
 template <class T>
+T *makeAtomSimpleQuery2(int what, int func(ConstRDMolAtom),
+                       const std::string &description = "Atom Simple") {
+  T *res = new T;
+  res->setVal(what);
+  res->setDataFunc(func);
+  res->setDescription(description);
+  return res;
+}
+template <class T>
 T *makeAtomSimpleQuery(int what, int func(Atom const *),
                        const std::string &description = "Atom Simple") {
   T *res = new T;
@@ -349,6 +624,15 @@ T *makeAtomSimpleQuery(int what, int func(Atom const *),
   return res;
 }
 
+static inline ATOM_RANGE_QUERY2 *makeAtomRangeQuery2(
+    int lower, int upper, bool lowerOpen, bool upperOpen,
+    int func(ConstRDMolAtom), const std::string &description = "Atom Range") {
+  ATOM_RANGE_QUERY2 *res = new ATOM_RANGE_QUERY2(lower, upper);
+  res->setDataFunc(func);
+  res->setDescription(description);
+  res->setEndsOpen(lowerOpen, upperOpen);
+  return res;
+}
 static inline ATOM_RANGE_QUERY *makeAtomRangeQuery(
     int lower, int upper, bool lowerOpen, bool upperOpen,
     int func(Atom const *), const std::string &description = "Atom Range") {
@@ -361,12 +645,25 @@ static inline ATOM_RANGE_QUERY *makeAtomRangeQuery(
 
 //! returns a Query for matching atomic number
 template <class T>
+T *makeAtomNumQuery2(int what, const std::string &descr) {
+  return makeAtomSimpleQuery2<T>(what, queryAtomNum2, descr);
+}
+//! returns a Query for matching atomic number
+template <class T>
 T *makeAtomNumQuery(int what, const std::string &descr) {
   return makeAtomSimpleQuery<T>(what, queryAtomNum, descr);
 }
 //! \overload
+RDKIT_GRAPHMOL_EXPORT ATOM_EQUALS_QUERY2 *makeAtomNumQuery2(int what);
+//! \overload
 RDKIT_GRAPHMOL_EXPORT ATOM_EQUALS_QUERY *makeAtomNumQuery(int what);
 
+//! returns a Query for matching atomic number and aromaticity
+template <class T>
+T *makeAtomTypeQuery2(int num, int aromatic, const std::string &descr) {
+  return makeAtomSimpleQuery2<T>(makeAtomType(num, aromatic), queryAtomType2,
+                                descr);
+}
 //! returns a Query for matching atomic number and aromaticity
 template <class T>
 T *makeAtomTypeQuery(int num, int aromatic, const std::string &descr) {
@@ -374,97 +671,183 @@ T *makeAtomTypeQuery(int num, int aromatic, const std::string &descr) {
                                 descr);
 }
 //! \overload
+RDKIT_GRAPHMOL_EXPORT ATOM_EQUALS_QUERY2 *makeAtomTypeQuery2(int num,
+                                                             int aromatic);
+//! \overload
 RDKIT_GRAPHMOL_EXPORT ATOM_EQUALS_QUERY *makeAtomTypeQuery(int num,
                                                            int aromatic);
 
+//! returns a Query for matching implicit valence
+template <class T>
+T *makeAtomImplicitValenceQuery2(int what, const std::string &descr) {
+  return makeAtomSimpleQuery2<T>(what, queryAtomImplicitValence2, descr);
+}
 //! returns a Query for matching implicit valence
 template <class T>
 T *makeAtomImplicitValenceQuery(int what, const std::string &descr) {
   return makeAtomSimpleQuery<T>(what, queryAtomImplicitValence, descr);
 }
 //! \overload
+RDKIT_GRAPHMOL_EXPORT ATOM_EQUALS_QUERY2 *makeAtomImplicitValenceQuery2(int what);
+//! \overload
 RDKIT_GRAPHMOL_EXPORT ATOM_EQUALS_QUERY *makeAtomImplicitValenceQuery(int what);
 
+//! returns a Query for matching explicit valence
+template <class T>
+T *makeAtomExplicitValenceQuery2(int what, const std::string &descr) {
+  return makeAtomSimpleQuery2<T>(what, queryAtomExplicitValence2, descr);
+}
 //! returns a Query for matching explicit valence
 template <class T>
 T *makeAtomExplicitValenceQuery(int what, const std::string &descr) {
   return makeAtomSimpleQuery<T>(what, queryAtomExplicitValence, descr);
 }
 //! \overload
+RDKIT_GRAPHMOL_EXPORT ATOM_EQUALS_QUERY2 *makeAtomExplicitValenceQuery2(int what);
+//! \overload
 RDKIT_GRAPHMOL_EXPORT ATOM_EQUALS_QUERY *makeAtomExplicitValenceQuery(int what);
 
+//! returns a Query for matching total valence
+template <class T>
+T *makeAtomTotalValenceQuery2(int what, const std::string &descr) {
+  return makeAtomSimpleQuery2<T>(what, queryAtomTotalValence2, descr);
+}
 //! returns a Query for matching total valence
 template <class T>
 T *makeAtomTotalValenceQuery(int what, const std::string &descr) {
   return makeAtomSimpleQuery<T>(what, queryAtomTotalValence, descr);
 }
 //! \overload
+RDKIT_GRAPHMOL_EXPORT ATOM_EQUALS_QUERY2 *makeAtomTotalValenceQuery2(int what);
+//! \overload
 RDKIT_GRAPHMOL_EXPORT ATOM_EQUALS_QUERY *makeAtomTotalValenceQuery(int what);
 
+//! returns a Query for matching explicit degree
+template <class T>
+T *makeAtomExplicitDegreeQuery2(int what, const std::string &descr) {
+  return makeAtomSimpleQuery2<T>(what, queryAtomExplicitDegree2, descr);
+}
 //! returns a Query for matching explicit degree
 template <class T>
 T *makeAtomExplicitDegreeQuery(int what, const std::string &descr) {
   return makeAtomSimpleQuery<T>(what, queryAtomExplicitDegree, descr);
 }
 //! \overload
+RDKIT_GRAPHMOL_EXPORT ATOM_EQUALS_QUERY2 *makeAtomExplicitDegreeQuery2(int what);
+//! \overload
 RDKIT_GRAPHMOL_EXPORT ATOM_EQUALS_QUERY *makeAtomExplicitDegreeQuery(int what);
 
+//! returns a Query for matching atomic degree
+template <class T>
+T *makeAtomTotalDegreeQuery2(int what, const std::string &descr) {
+  return makeAtomSimpleQuery2<T>(what, queryAtomTotalDegree2, descr);
+}
 //! returns a Query for matching atomic degree
 template <class T>
 T *makeAtomTotalDegreeQuery(int what, const std::string &descr) {
   return makeAtomSimpleQuery<T>(what, queryAtomTotalDegree, descr);
 }
 //! \overload
+RDKIT_GRAPHMOL_EXPORT ATOM_EQUALS_QUERY2 *makeAtomTotalDegreeQuery2(int what);
+//! \overload
 RDKIT_GRAPHMOL_EXPORT ATOM_EQUALS_QUERY *makeAtomTotalDegreeQuery(int what);
 
+//! returns a Query for matching heavy atom degree
+template <class T>
+T *makeAtomHeavyAtomDegreeQuery2(int what, const std::string &descr) {
+  return makeAtomSimpleQuery2<T>(what, queryAtomHeavyAtomDegree2, descr);
+}
 //! returns a Query for matching heavy atom degree
 template <class T>
 T *makeAtomHeavyAtomDegreeQuery(int what, const std::string &descr) {
   return makeAtomSimpleQuery<T>(what, queryAtomHeavyAtomDegree, descr);
 }
 //! \overload
+RDKIT_GRAPHMOL_EXPORT ATOM_EQUALS_QUERY2 *makeAtomHeavyAtomDegreeQuery2(int what);
+//! \overload
 RDKIT_GRAPHMOL_EXPORT ATOM_EQUALS_QUERY *makeAtomHeavyAtomDegreeQuery(int what);
 
+//! returns a Query for matching hydrogen count
+template <class T>
+T *makeAtomHCountQuery2(int what, const std::string &descr) {
+  return makeAtomSimpleQuery2<T>(what, queryAtomHCount2, descr);
+}
 //! returns a Query for matching hydrogen count
 template <class T>
 T *makeAtomHCountQuery(int what, const std::string &descr) {
   return makeAtomSimpleQuery<T>(what, queryAtomHCount, descr);
 }
 //! \overload
+RDKIT_GRAPHMOL_EXPORT ATOM_EQUALS_QUERY2 *makeAtomHCountQuery2(int what);
+//! \overload
 RDKIT_GRAPHMOL_EXPORT ATOM_EQUALS_QUERY *makeAtomHCountQuery(int what);
 
+//! returns a Query for matching ring atoms
+template <class T>
+T *makeAtomHasImplicitHQuery2(const std::string &descr) {
+  return makeAtomSimpleQuery2<T>(true, queryAtomHasImplicitH2, descr);
+}
 //! returns a Query for matching ring atoms
 template <class T>
 T *makeAtomHasImplicitHQuery(const std::string &descr) {
   return makeAtomSimpleQuery<T>(true, queryAtomHasImplicitH, descr);
 }
 //! \overload
+RDKIT_GRAPHMOL_EXPORT ATOM_EQUALS_QUERY2 *makeAtomHasImplicitHQuery2();
+//! \overload
 RDKIT_GRAPHMOL_EXPORT ATOM_EQUALS_QUERY *makeAtomHasImplicitHQuery();
 
+//! returns a Query for matching implicit hydrogen count
+template <class T>
+T *makeAtomImplicitHCountQuery2(int what, const std::string &descr) {
+  return makeAtomSimpleQuery2<T>(what, queryAtomImplicitHCount2, descr);
+}
 //! returns a Query for matching implicit hydrogen count
 template <class T>
 T *makeAtomImplicitHCountQuery(int what, const std::string &descr) {
   return makeAtomSimpleQuery<T>(what, queryAtomImplicitHCount, descr);
 }
 //! \overload
+RDKIT_GRAPHMOL_EXPORT ATOM_EQUALS_QUERY2 *makeAtomImplicitHCountQuery2(int what);
+//! \overload
 RDKIT_GRAPHMOL_EXPORT ATOM_EQUALS_QUERY *makeAtomImplicitHCountQuery(int what);
 
+//! returns a Query for matching the \c isAromatic flag
+template <class T>
+T *makeAtomAromaticQuery2(const std::string &descr) {
+  return makeAtomSimpleQuery2<T>(true, queryAtomAromatic2, descr);
+}
 //! returns a Query for matching the \c isAromatic flag
 template <class T>
 T *makeAtomAromaticQuery(const std::string &descr) {
   return makeAtomSimpleQuery<T>(true, queryAtomAromatic, descr);
 }
 //! \overload
+RDKIT_GRAPHMOL_EXPORT ATOM_EQUALS_QUERY2 *makeAtomAromaticQuery2();
+//! \overload
 RDKIT_GRAPHMOL_EXPORT ATOM_EQUALS_QUERY *makeAtomAromaticQuery();
 
+//! returns a Query for matching aliphatic atoms
+template <class T>
+T *makeAtomAliphaticQuery2(const std::string &descr) {
+  return makeAtomSimpleQuery2<T>(true, queryAtomAliphatic2, descr);
+}
 //! returns a Query for matching aliphatic atoms
 template <class T>
 T *makeAtomAliphaticQuery(const std::string &descr) {
   return makeAtomSimpleQuery<T>(true, queryAtomAliphatic, descr);
 }
 //! \overload
+RDKIT_GRAPHMOL_EXPORT ATOM_EQUALS_QUERY2 *makeAtomAliphaticQuery2();
+//! \overload
 RDKIT_GRAPHMOL_EXPORT ATOM_EQUALS_QUERY *makeAtomAliphaticQuery();
 
+//! returns a Query for matching atoms with a particular mass
+template <class T>
+T *makeAtomMassQuery2(int what, const std::string &descr) {
+  return makeAtomSimpleQuery2<T>(massIntegerConversionFactor * what,
+                                queryAtomMass2, descr);
+}
 //! returns a Query for matching atoms with a particular mass
 template <class T>
 T *makeAtomMassQuery(int what, const std::string &descr) {
@@ -472,24 +855,46 @@ T *makeAtomMassQuery(int what, const std::string &descr) {
                                 queryAtomMass, descr);
 }
 //! \overload
+RDKIT_GRAPHMOL_EXPORT ATOM_EQUALS_QUERY2 *makeAtomMassQuery2(int what);
+//! \overload
 RDKIT_GRAPHMOL_EXPORT ATOM_EQUALS_QUERY *makeAtomMassQuery(int what);
 
+//! returns a Query for matching atoms with a particular isotope
+template <class T>
+T *makeAtomIsotopeQuery2(int what, const std::string &descr) {
+  return makeAtomSimpleQuery2<T>(what, queryAtomIsotope2, descr);
+}
 //! returns a Query for matching atoms with a particular isotope
 template <class T>
 T *makeAtomIsotopeQuery(int what, const std::string &descr) {
   return makeAtomSimpleQuery<T>(what, queryAtomIsotope, descr);
 }
 //! \overload
+RDKIT_GRAPHMOL_EXPORT ATOM_EQUALS_QUERY2 *makeAtomIsotopeQuery2(int what);
+//! \overload
 RDKIT_GRAPHMOL_EXPORT ATOM_EQUALS_QUERY *makeAtomIsotopeQuery(int what);
 
+//! returns a Query for matching formal charge
+template <class T>
+T *makeAtomFormalChargeQuery2(int what, const std::string &descr) {
+  return makeAtomSimpleQuery2<T>(what, queryAtomFormalCharge2, descr);
+}
 //! returns a Query for matching formal charge
 template <class T>
 T *makeAtomFormalChargeQuery(int what, const std::string &descr) {
   return makeAtomSimpleQuery<T>(what, queryAtomFormalCharge, descr);
 }
 //! \overload
+RDKIT_GRAPHMOL_EXPORT ATOM_EQUALS_QUERY2 *makeAtomFormalChargeQuery2(int what);
+//! \overload
 RDKIT_GRAPHMOL_EXPORT ATOM_EQUALS_QUERY *makeAtomFormalChargeQuery(int what);
 
+//! returns a Query for matching negative formal charges (i.e. a query val of 1
+//! matches a formal charge of -1)
+template <class T>
+T *makeAtomNegativeFormalChargeQuery2(int what, const std::string &descr) {
+  return makeAtomSimpleQuery2<T>(what, queryAtomNegativeFormalCharge2, descr);
+}
 //! returns a Query for matching negative formal charges (i.e. a query val of 1
 //! matches a formal charge of -1)
 template <class T>
@@ -497,22 +902,40 @@ T *makeAtomNegativeFormalChargeQuery(int what, const std::string &descr) {
   return makeAtomSimpleQuery<T>(what, queryAtomNegativeFormalCharge, descr);
 }
 //! \overload
+RDKIT_GRAPHMOL_EXPORT ATOM_EQUALS_QUERY2 *makeAtomNegativeFormalChargeQuery2(
+    int what);
+//! \overload
 RDKIT_GRAPHMOL_EXPORT ATOM_EQUALS_QUERY *makeAtomNegativeFormalChargeQuery(
     int what);
 
+//! returns a Query for matching hybridization
+template <class T>
+T *makeAtomHybridizationQuery2(int what, const std::string &descr) {
+  return makeAtomSimpleQuery2<T>(what, queryAtomHybridization2, descr);
+}
 //! returns a Query for matching hybridization
 template <class T>
 T *makeAtomHybridizationQuery(int what, const std::string &descr) {
   return makeAtomSimpleQuery<T>(what, queryAtomHybridization, descr);
 }
 //! \overload
+RDKIT_GRAPHMOL_EXPORT ATOM_EQUALS_QUERY2 *makeAtomHybridizationQuery2(int what);
+//! \overload
 RDKIT_GRAPHMOL_EXPORT ATOM_EQUALS_QUERY *makeAtomHybridizationQuery(int what);
 
+//! returns a Query for matching the number of radical electrons
+template <class T>
+T *makeAtomNumRadicalElectronsQuery2(int what, const std::string &descr) {
+  return makeAtomSimpleQuery2<T>(what, queryAtomNumRadicalElectrons2, descr);
+}
 //! returns a Query for matching the number of radical electrons
 template <class T>
 T *makeAtomNumRadicalElectronsQuery(int what, const std::string &descr) {
   return makeAtomSimpleQuery<T>(what, queryAtomNumRadicalElectrons, descr);
 }
+//! \overload
+RDKIT_GRAPHMOL_EXPORT ATOM_EQUALS_QUERY2 *makeAtomNumRadicalElectronsQuery2(
+    int what);
 //! \overload
 RDKIT_GRAPHMOL_EXPORT ATOM_EQUALS_QUERY *makeAtomNumRadicalElectronsQuery(
     int what);
@@ -520,12 +943,26 @@ RDKIT_GRAPHMOL_EXPORT ATOM_EQUALS_QUERY *makeAtomNumRadicalElectronsQuery(
 //! returns a Query for matching whether or not chirality has been set on the
 //! atom
 template <class T>
+T *makeAtomHasChiralTagQuery2(const std::string &descr) {
+  return makeAtomSimpleQuery2<T>(true, queryAtomHasChiralTag2, descr);
+}
+//! returns a Query for matching whether or not chirality has been set on the
+//! atom
+template <class T>
 T *makeAtomHasChiralTagQuery(const std::string &descr) {
   return makeAtomSimpleQuery<T>(true, queryAtomHasChiralTag, descr);
 }
 //! \overloadquery
+RDKIT_GRAPHMOL_EXPORT ATOM_EQUALS_QUERY2 *makeAtomHasChiralTagQuery2();
+//! \overloadquery
 RDKIT_GRAPHMOL_EXPORT ATOM_EQUALS_QUERY *makeAtomHasChiralTagQuery();
 
+//! returns a Query for matching whether or not a potentially chiral atom is
+//! missing a chiral tag
+template <class T>
+T *makeAtomMissingChiralTagQuery2(const std::string &descr) {
+  return makeAtomSimpleQuery2<T>(true, queryAtomMissingChiralTag2, descr);
+}
 //! returns a Query for matching whether or not a potentially chiral atom is
 //! missing a chiral tag
 template <class T>
@@ -533,65 +970,120 @@ T *makeAtomMissingChiralTagQuery(const std::string &descr) {
   return makeAtomSimpleQuery<T>(true, queryAtomMissingChiralTag, descr);
 }
 //! \overloadquery
+RDKIT_GRAPHMOL_EXPORT ATOM_EQUALS_QUERY2 *makeAtomMissingChiralTagQuery2();
+//! \overloadquery
 RDKIT_GRAPHMOL_EXPORT ATOM_EQUALS_QUERY *makeAtomMissingChiralTagQuery();
 
+//! returns a Query for matching atoms with unsaturation:
+template <class T>
+T *makeAtomUnsaturatedQuery2(const std::string &descr) {
+  return makeAtomSimpleQuery2<T>(true, queryAtomUnsaturated2, descr);
+}
 //! returns a Query for matching atoms with unsaturation:
 template <class T>
 T *makeAtomUnsaturatedQuery(const std::string &descr) {
   return makeAtomSimpleQuery<T>(true, queryAtomUnsaturated, descr);
 }
 //! \overload
+RDKIT_GRAPHMOL_EXPORT ATOM_EQUALS_QUERY2 *makeAtomUnsaturatedQuery2();
+//! \overload
 RDKIT_GRAPHMOL_EXPORT ATOM_EQUALS_QUERY *makeAtomUnsaturatedQuery();
 
+//! returns a Query for matching ring atoms
+template <class T>
+T *makeAtomInRingQuery2(const std::string &descr) {
+  return makeAtomSimpleQuery2<T>(true, queryIsAtomInRing2, descr);
+}
 //! returns a Query for matching ring atoms
 template <class T>
 T *makeAtomInRingQuery(const std::string &descr) {
   return makeAtomSimpleQuery<T>(true, queryIsAtomInRing, descr);
 }
 //! \overload
+RDKIT_GRAPHMOL_EXPORT ATOM_EQUALS_QUERY2 *makeAtomInRingQuery2();
+//! \overload
 RDKIT_GRAPHMOL_EXPORT ATOM_EQUALS_QUERY *makeAtomInRingQuery();
 
+//! returns a Query for matching atoms in a particular number of rings
+template <class T>
+T *makeAtomInNRingsQuery2(int what, const std::string &descr) {
+  return makeAtomSimpleQuery2<T>(what, queryIsAtomInNRings2, descr);
+}
 //! returns a Query for matching atoms in a particular number of rings
 template <class T>
 T *makeAtomInNRingsQuery(int what, const std::string &descr) {
   return makeAtomSimpleQuery<T>(what, queryIsAtomInNRings, descr);
 }
 //! \overload
+RDKIT_GRAPHMOL_EXPORT ATOM_EQUALS_QUERY2 *makeAtomInNRingsQuery2(int what);
+//! \overload
 RDKIT_GRAPHMOL_EXPORT ATOM_EQUALS_QUERY *makeAtomInNRingsQuery(int what);
 
 //! returns a Query for matching atoms in rings of a particular size
+RDKIT_GRAPHMOL_EXPORT ATOM_EQUALS_QUERY2 *makeAtomInRingOfSizeQuery2(int tgt);
+//! returns a Query for matching atoms in rings of a particular size
 RDKIT_GRAPHMOL_EXPORT ATOM_EQUALS_QUERY *makeAtomInRingOfSizeQuery(int tgt);
 
+//! returns a Query for matching an atom's minimum ring size
+template <class T>
+T *makeAtomMinRingSizeQuery2(int tgt, const std::string &descr) {
+  return makeAtomSimpleQuery2<T>(tgt, queryAtomMinRingSize2, descr);
+}
 //! returns a Query for matching an atom's minimum ring size
 template <class T>
 T *makeAtomMinRingSizeQuery(int tgt, const std::string &descr) {
   return makeAtomSimpleQuery<T>(tgt, queryAtomMinRingSize, descr);
 }
 //! \overload
+RDKIT_GRAPHMOL_EXPORT ATOM_EQUALS_QUERY2 *makeAtomMinRingSizeQuery2(int tgt);
+//! \overload
 RDKIT_GRAPHMOL_EXPORT ATOM_EQUALS_QUERY *makeAtomMinRingSizeQuery(int tgt);
 
+//! returns a Query for matching atoms with a particular number of ring bonds
+template <class T>
+T *makeAtomRingBondCountQuery2(int what, const std::string &descr) {
+  return makeAtomSimpleQuery2<T>(what, queryAtomRingBondCount2, descr);
+}
 //! returns a Query for matching atoms with a particular number of ring bonds
 template <class T>
 T *makeAtomRingBondCountQuery(int what, const std::string &descr) {
   return makeAtomSimpleQuery<T>(what, queryAtomRingBondCount, descr);
 }
 //! \overload
+RDKIT_GRAPHMOL_EXPORT ATOM_EQUALS_QUERY2 *makeAtomRingBondCountQuery2(int what);
+//! \overload
 RDKIT_GRAPHMOL_EXPORT ATOM_EQUALS_QUERY *makeAtomRingBondCountQuery(int what);
 
 //! returns a Query for matching generic A atoms (heavy atoms)
+RDKIT_GRAPHMOL_EXPORT ATOM_EQUALS_QUERY2 *makeAAtomQuery2();
+//! returns a Query for matching generic A atoms (heavy atoms)
 RDKIT_GRAPHMOL_EXPORT ATOM_EQUALS_QUERY *makeAAtomQuery();
+//! returns a Query for matching generic AH atoms (any atom)
+RDKIT_GRAPHMOL_EXPORT ATOM_NULL_QUERY2 *makeAHAtomQuery2();
 //! returns a Query for matching generic AH atoms (any atom)
 RDKIT_GRAPHMOL_EXPORT ATOM_NULL_QUERY *makeAHAtomQuery();
 //! returns a Query for matching generic Q atoms (heteroatoms)
+RDKIT_GRAPHMOL_EXPORT ATOM_OR_QUERY2 *makeQAtomQuery2();
+//! returns a Query for matching generic Q atoms (heteroatoms)
 RDKIT_GRAPHMOL_EXPORT ATOM_OR_QUERY *makeQAtomQuery();
+//! returns a Query for matching generic QH atoms (heteroatom or H)
+RDKIT_GRAPHMOL_EXPORT ATOM_EQUALS_QUERY2 *makeQHAtomQuery2();
 //! returns a Query for matching generic QH atoms (heteroatom or H)
 RDKIT_GRAPHMOL_EXPORT ATOM_EQUALS_QUERY *makeQHAtomQuery();
 //! returns a Query for matching generic X atoms (halogens)
+RDKIT_GRAPHMOL_EXPORT ATOM_OR_QUERY2 *makeXAtomQuery2();
+//! returns a Query for matching generic X atoms (halogens)
 RDKIT_GRAPHMOL_EXPORT ATOM_OR_QUERY *makeXAtomQuery();
+//! returns a Query for matching generic XH atoms (halogen or H)
+RDKIT_GRAPHMOL_EXPORT ATOM_OR_QUERY2 *makeXHAtomQuery2();
 //! returns a Query for matching generic XH atoms (halogen or H)
 RDKIT_GRAPHMOL_EXPORT ATOM_OR_QUERY *makeXHAtomQuery();
 //! returns a Query for matching generic M atoms (metals)
+RDKIT_GRAPHMOL_EXPORT ATOM_OR_QUERY2 *makeMAtomQuery2();
+//! returns a Query for matching generic M atoms (metals)
 RDKIT_GRAPHMOL_EXPORT ATOM_OR_QUERY *makeMAtomQuery();
+//! returns a Query for matching generic MH atoms (metals or H)
+RDKIT_GRAPHMOL_EXPORT ATOM_OR_QUERY2 *makeMHAtomQuery2();
 //! returns a Query for matching generic MH atoms (metals or H)
 RDKIT_GRAPHMOL_EXPORT ATOM_OR_QUERY *makeMHAtomQuery();
 
@@ -599,34 +1091,64 @@ RDKIT_GRAPHMOL_EXPORT ATOM_OR_QUERY *makeMHAtomQuery();
 // CXSMILES
 const std::vector<std::string> complexQueries = {"A", "AH", "Q", "QH",
                                                  "X", "XH", "M", "MH"};
+RDKIT_GRAPHMOL_EXPORT void convertComplexNameToQuery2(RDMolAtom query,
+                                                     std::string_view symb);
 RDKIT_GRAPHMOL_EXPORT void convertComplexNameToQuery(Atom *query,
                                                      std::string_view symb);
 
+//! returns a Query for matching atoms that have ring bonds
+template <class T>
+T *makeAtomHasRingBondQuery2(const std::string &descr) {
+  return makeAtomSimpleQuery2<T>(1, queryAtomHasRingBond2, descr);
+}
 //! returns a Query for matching atoms that have ring bonds
 template <class T>
 T *makeAtomHasRingBondQuery(const std::string &descr) {
   return makeAtomSimpleQuery<T>(1, queryAtomHasRingBond, descr);
 }
 //! \overload
+RDKIT_GRAPHMOL_EXPORT ATOM_EQUALS_QUERY2 *makeAtomHasRingBondQuery2();
+//! \overload
 RDKIT_GRAPHMOL_EXPORT ATOM_EQUALS_QUERY *makeAtomHasRingBondQuery();
 
+//! returns a Query for matching the number of heteroatom neighbors
+template <class T>
+T *makeAtomNumHeteroatomNbrsQuery2(int what, const std::string &descr) {
+  return makeAtomSimpleQuery2<T>(what, queryAtomNumHeteroatomNbrs2, descr);
+}
 //! returns a Query for matching the number of heteroatom neighbors
 template <class T>
 T *makeAtomNumHeteroatomNbrsQuery(int what, const std::string &descr) {
   return makeAtomSimpleQuery<T>(what, queryAtomNumHeteroatomNbrs, descr);
 }
 //! \overload
+RDKIT_GRAPHMOL_EXPORT ATOM_EQUALS_QUERY2 *makeAtomNumHeteroatomNbrsQuery2(
+    int what);
+//! \overload
 RDKIT_GRAPHMOL_EXPORT ATOM_EQUALS_QUERY *makeAtomNumHeteroatomNbrsQuery(
     int what);
 
+//! returns a Query for matching atoms that have heteroatom neighbors
+template <class T>
+T *makeAtomHasHeteroatomNbrsQuery2(const std::string &descr) {
+  return makeAtomSimpleQuery2<T>(1, queryAtomHasHeteroatomNbrs2, descr);
+}
 //! returns a Query for matching atoms that have heteroatom neighbors
 template <class T>
 T *makeAtomHasHeteroatomNbrsQuery(const std::string &descr) {
   return makeAtomSimpleQuery<T>(1, queryAtomHasHeteroatomNbrs, descr);
 }
 //! \overload
+RDKIT_GRAPHMOL_EXPORT ATOM_EQUALS_QUERY2 *makeAtomHasHeteroatomNbrsQuery2();
+//! \overload
 RDKIT_GRAPHMOL_EXPORT ATOM_EQUALS_QUERY *makeAtomHasHeteroatomNbrsQuery();
 
+//! returns a Query for matching the number of aliphatic heteroatom neighbors
+template <class T>
+T *makeAtomNumAliphaticHeteroatomNbrsQuery2(int what, const std::string &descr) {
+  return makeAtomSimpleQuery2<T>(what, queryAtomNumAliphaticHeteroatomNbrs2,
+                                descr);
+}
 //! returns a Query for matching the number of aliphatic heteroatom neighbors
 template <class T>
 T *makeAtomNumAliphaticHeteroatomNbrsQuery(int what, const std::string &descr) {
@@ -634,67 +1156,126 @@ T *makeAtomNumAliphaticHeteroatomNbrsQuery(int what, const std::string &descr) {
                                 descr);
 }
 //! \overload
+RDKIT_GRAPHMOL_EXPORT ATOM_EQUALS_QUERY2 *
+makeAtomNumAliphaticHeteroatomNbrsQuery2(int what);
+//! \overload
 RDKIT_GRAPHMOL_EXPORT ATOM_EQUALS_QUERY *
 makeAtomNumAliphaticHeteroatomNbrsQuery(int what);
 
+//! returns a Query for matching atoms that have heteroatom neighbors
+template <class T>
+T *makeAtomHasAliphaticHeteroatomNbrsQuery2(const std::string &descr) {
+  return makeAtomSimpleQuery2<T>(1, queryAtomHasAliphaticHeteroatomNbrs2, descr);
+}
 //! returns a Query for matching atoms that have heteroatom neighbors
 template <class T>
 T *makeAtomHasAliphaticHeteroatomNbrsQuery(const std::string &descr) {
   return makeAtomSimpleQuery<T>(1, queryAtomHasAliphaticHeteroatomNbrs, descr);
 }
 //! \overload
+RDKIT_GRAPHMOL_EXPORT ATOM_EQUALS_QUERY2 *
+makeAtomHasAliphaticHeteroatomNbrsQuery2();
+//! \overload
 RDKIT_GRAPHMOL_EXPORT ATOM_EQUALS_QUERY *
 makeAtomHasAliphaticHeteroatomNbrsQuery();
 
+//! returns a Query for matching the number of non-hydrogen neighbors
+template <class T>
+T *makeAtomNonHydrogenDegreeQuery2(int what, const std::string &descr) {
+  return makeAtomSimpleQuery2<T>(what, queryAtomNonHydrogenDegree2, descr);
+}
 //! returns a Query for matching the number of non-hydrogen neighbors
 template <class T>
 T *makeAtomNonHydrogenDegreeQuery(int what, const std::string &descr) {
   return makeAtomSimpleQuery<T>(what, queryAtomNonHydrogenDegree, descr);
 }
 //! \overload
+RDKIT_GRAPHMOL_EXPORT ATOM_EQUALS_QUERY2 *makeAtomNonHydrogenDegreeQuery2(
+    int what);
+//! \overload
 RDKIT_GRAPHMOL_EXPORT ATOM_EQUALS_QUERY *makeAtomNonHydrogenDegreeQuery(
     int what);
 
+//! returns a Query for matching bridgehead atoms
+template <class T>
+T *makeAtomIsBridgeheadQuery2(const std::string &descr) {
+  return makeAtomSimpleQuery2<T>(true, queryIsAtomBridgehead2, descr);
+}
 //! returns a Query for matching bridgehead atoms
 template <class T>
 T *makeAtomIsBridgeheadQuery(const std::string &descr) {
   return makeAtomSimpleQuery<T>(true, queryIsAtomBridgehead, descr);
 }
 //! \overload
+RDKIT_GRAPHMOL_EXPORT ATOM_EQUALS_QUERY2 *makeAtomIsBridgeheadQuery2();
+//! \overload
 RDKIT_GRAPHMOL_EXPORT ATOM_EQUALS_QUERY *makeAtomIsBridgeheadQuery();
 
+//! returns a Query for matching bond orders
+RDKIT_GRAPHMOL_EXPORT BOND_EQUALS_QUERY2 *makeBondOrderEqualsQuery2(
+    BondEnums::BondType what);
 //! returns a Query for matching bond orders
 RDKIT_GRAPHMOL_EXPORT BOND_EQUALS_QUERY *makeBondOrderEqualsQuery(
     Bond::BondType what);
 //! returns a Query for unspecified SMARTS bonds
+RDKIT_GRAPHMOL_EXPORT BOND_EQUALS_QUERY2 *makeSingleOrAromaticBondQuery2();
+//! returns a Query for unspecified SMARTS bonds
 RDKIT_GRAPHMOL_EXPORT BOND_EQUALS_QUERY *makeSingleOrAromaticBondQuery();
 //! returns a Query for double|aromatic bonds
+RDKIT_GRAPHMOL_EXPORT BOND_EQUALS_QUERY2 *makeDoubleOrAromaticBondQuery2();
+//! returns a Query for single|double bonds
 RDKIT_GRAPHMOL_EXPORT BOND_EQUALS_QUERY *makeDoubleOrAromaticBondQuery();
 //! returns a Query for single|double bonds
+RDKIT_GRAPHMOL_EXPORT BOND_EQUALS_QUERY2 *makeSingleOrDoubleBondQuery2();
+//! returns a Query for tautomeric bonds
 RDKIT_GRAPHMOL_EXPORT BOND_EQUALS_QUERY *makeSingleOrDoubleBondQuery();
+//! returns a Query for tautomeric bonds
+RDKIT_GRAPHMOL_EXPORT BOND_EQUALS_QUERY2 *
+makeSingleOrDoubleOrAromaticBondQuery2();
 //! returns a Query for tautomeric bonds
 RDKIT_GRAPHMOL_EXPORT BOND_EQUALS_QUERY *
 makeSingleOrDoubleOrAromaticBondQuery();
 
 //! returns a Query for matching bond directions
+RDKIT_GRAPHMOL_EXPORT BOND_EQUALS_QUERY2 *makeBondDirEqualsQuery2(
+    BondEnums::BondDir what);
+//! returns a Query for matching bond directions
 RDKIT_GRAPHMOL_EXPORT BOND_EQUALS_QUERY *makeBondDirEqualsQuery(
     Bond::BondDir what);
 //! returns a Query for matching bonds with stereo set
+RDKIT_GRAPHMOL_EXPORT BOND_EQUALS_QUERY2 *makeBondHasStereoQuery2();
+//! returns a Query for matching bonds with stereo set
 RDKIT_GRAPHMOL_EXPORT BOND_EQUALS_QUERY *makeBondHasStereoQuery();
+//! returns a Query for matching ring bonds
+RDKIT_GRAPHMOL_EXPORT BOND_EQUALS_QUERY2 *makeBondIsInRingQuery2();
 //! returns a Query for matching ring bonds
 RDKIT_GRAPHMOL_EXPORT BOND_EQUALS_QUERY *makeBondIsInRingQuery();
 //! returns a Query for matching bonds in rings of a particular size
+RDKIT_GRAPHMOL_EXPORT BOND_EQUALS_QUERY2 *makeBondInRingOfSizeQuery2(int what);
+//! returns a Query for matching bonds in rings of a particular size
 RDKIT_GRAPHMOL_EXPORT BOND_EQUALS_QUERY *makeBondInRingOfSizeQuery(int what);
 //! returns a Query for matching a bond's minimum ring size
+RDKIT_GRAPHMOL_EXPORT BOND_EQUALS_QUERY2 *makeBondMinRingSizeQuery2(int what);
+//! returns a Query for matching a bond's minimum ring size
 RDKIT_GRAPHMOL_EXPORT BOND_EQUALS_QUERY *makeBondMinRingSizeQuery(int what);
+//! returns a Query for matching bonds in a particular number of rings
+RDKIT_GRAPHMOL_EXPORT BOND_EQUALS_QUERY2 *makeBondInNRingsQuery2(int tgt);
 //! returns a Query for matching bonds in a particular number of rings
 RDKIT_GRAPHMOL_EXPORT BOND_EQUALS_QUERY *makeBondInNRingsQuery(int tgt);
 
 //! returns a Query for matching any bond
+RDKIT_GRAPHMOL_EXPORT BOND_NULL_QUERY2 *makeBondNullQuery2();
+//! returns a Query for matching any bond
 RDKIT_GRAPHMOL_EXPORT BOND_NULL_QUERY *makeBondNullQuery();
+//! returns a Query for matching any atom
+RDKIT_GRAPHMOL_EXPORT ATOM_NULL_QUERY2 *makeAtomNullQuery2();
 //! returns a Query for matching any atom
 RDKIT_GRAPHMOL_EXPORT ATOM_NULL_QUERY *makeAtomNullQuery();
 
+static inline int queryAtomRingMembership2(ConstRDMolAtom at) {
+  return static_cast<int>(
+      at.mol().getRingInfo().numAtomRings(at.index()));
+}
 static inline int queryAtomRingMembership(Atom const *at) {
   return static_cast<int>(
       at->getOwningMol().getRingInfo()->numAtomRings(at->getIdx()));
@@ -705,23 +1286,37 @@ static inline int queryAtomRingMembership(Atom const *at) {
 // that differs only by const/volatile (c4301), then generates
 // incorrect code if we don't do this... so let's do it.
 typedef Atom const *ConstAtomPtr;
+class AtomRingQuery;
+class AtomRingQuery2;
 
-class RDKIT_GRAPHMOL_EXPORT AtomRingQuery
-    : public Queries::EqualityQuery<int, ConstAtomPtr, true> {
+template <bool newVersion>
+class AtomRingQueryBase : public Queries::EqualityQuery<int,
+    std::conditional_t<newVersion, ConstRDMolAtom, ConstAtomPtr>, true> {
+  using DataFuncArgType =
+      std::conditional_t<newVersion, ConstRDMolAtom, ConstAtomPtr>;
+
  public:
-  AtomRingQuery() : Queries::EqualityQuery<int, ConstAtomPtr, true>(-1) {
+  AtomRingQueryBase() : Queries::EqualityQuery<int, DataFuncArgType, true>(-1) {
     // default is to just do a number of rings query:
     this->setDescription("AtomInNRings");
-    this->setDataFunc(queryAtomRingMembership);
+    if constexpr (newVersion) {
+      this->setDataFunc(queryAtomRingMembership2);
+    } else {
+      this->setDataFunc(queryAtomRingMembership);
+    }
   }
-  explicit AtomRingQuery(int v)
-      : Queries::EqualityQuery<int, ConstAtomPtr, true>(v) {
+  explicit AtomRingQueryBase(int v)
+      : Queries::EqualityQuery<int, DataFuncArgType, true>(v) {
     // default is to just do a number of rings query:
     this->setDescription("AtomInNRings");
-    this->setDataFunc(queryAtomRingMembership);
+    if constexpr (newVersion) {
+      this->setDataFunc(queryAtomRingMembership2);
+    } else {
+      this->setDataFunc(queryAtomRingMembership);
+    }
   }
 
-  bool Match(const ConstAtomPtr what) const override {
+  bool Match(const DataFuncArgType what) const override {
     int v = this->TypeConvert(what, Queries::Int2Type<true>());
     bool res;
     if (this->d_val < 0) {
@@ -736,14 +1331,82 @@ class RDKIT_GRAPHMOL_EXPORT AtomRingQuery
   }
 
   //! returns a copy of this query
-  Queries::Query<int, ConstAtomPtr, true> *copy() const override {
-    AtomRingQuery *res = new AtomRingQuery(this->d_val);
-    res->setNegation(getNegation());
+  Queries::Query<int, DataFuncArgType, true> *copy() const override {
+    using RingQueryType = std::conditional_t<newVersion, AtomRingQuery2, AtomRingQuery>;
+    RingQueryType *res = new RingQueryType(this->d_val);
+    res->setNegation(this->getNegation());
     res->setTol(this->getTol());
     res->d_description = this->d_description;
     res->d_dataFunc = this->d_dataFunc;
     return res;
   }
+};
+class RDKIT_GRAPHMOL_EXPORT AtomRingQuery2 : public AtomRingQueryBase<true> {
+ public:
+    using AtomRingQueryBase::AtomRingQueryBase;
+};
+class RDKIT_GRAPHMOL_EXPORT AtomRingQuery : public AtomRingQueryBase<false> {
+ public:
+    using AtomRingQueryBase::AtomRingQueryBase;
+};
+
+//! allows use of recursive structure queries (e.g. recursive SMARTS)
+class RDKIT_GRAPHMOL_EXPORT RecursiveStructureQuery2
+    : public Queries::SetQuery<int, ConstRDMolAtom, true> {
+ public:
+    RecursiveStructureQuery2() : Queries::SetQuery<int, ConstRDMolAtom, true>() {
+    setDataFunc(getAtIdx);
+    setDescription("RecursiveStructure");
+  }
+  //! initialize from an RDMol pointer
+  /*!
+    <b>Notes</b>
+      - this takes over ownership of the pointer
+  */
+  RecursiveStructureQuery2(RDMol *query, unsigned int serialNumber = 0)
+      : Queries::SetQuery<int, ConstRDMolAtom, true>(),
+        d_serialNumber(serialNumber) {
+    setQueryMol(query);
+    setDataFunc(getAtIdx);
+    setDescription("RecursiveStructure");
+  }
+  //! returns the index of an atom
+  static inline int getAtIdx(ConstRDMolAtom at) {
+    PRECONDITION(at.index() < at.mol().getNumAtoms(), "bad atom argument");
+    return at.index();
+  }
+
+  //! sets the molecule we'll use recursively
+  /*!
+    <b>Notes</b>
+      - this takes over ownership of the pointer
+  */
+  void setQueryMol(RDMol *query) { dp_queryMol.reset(query); }
+  //! returns a pointer to our query molecule
+  RDMol const *getQueryMol() const { return dp_queryMol.get(); }
+
+  //! returns a copy of this query
+  Queries::Query<int, ConstRDMolAtom, true> *copy() const override {
+    RecursiveStructureQuery2 *res = new RecursiveStructureQuery2();
+    res->dp_queryMol.reset(new RDMol(*dp_queryMol, true));
+
+    std::set<int>::const_iterator i;
+    for (i = d_set.begin(); i != d_set.end(); i++) {
+      res->insert(*i);
+    }
+    res->setNegation(getNegation());
+    res->d_description = d_description;
+    res->d_serialNumber = d_serialNumber;
+    return res;
+  }
+  unsigned int getSerialNumber() const { return d_serialNumber; }
+
+#ifdef RDK_BUILD_THREADSAFE_SSS
+  std::mutex d_mutex;
+#endif
+ private:
+  std::unique_ptr<const RDMol> dp_queryMol;
+  unsigned int d_serialNumber{0};
 };
 
 //! allows use of recursive structure queries (e.g. recursive SMARTS)
@@ -819,7 +1482,7 @@ typedef Bond const *ConstBondPtr;
 // ! Query whether an atom has a property
 template <class TargetPtr>
 class HasPropQuery : public Queries::EqualityQuery<int, TargetPtr, true> {
-  std::string propname;
+  PropToken propname;
 
  public:
   HasPropQuery() : Queries::EqualityQuery<int, TargetPtr, true>(), propname() {
@@ -831,9 +1494,21 @@ class HasPropQuery : public Queries::EqualityQuery<int, TargetPtr, true> {
     this->setDescription("HasProp");
     this->setDataFunc(nullptr);
   }
+  explicit HasPropQuery(PropToken v)
+      : Queries::EqualityQuery<int, TargetPtr, true>(), propname(std::move(v)) {
+    this->setDescription("HasProp");
+    this->setDataFunc(nullptr);
+  }
 
   bool Match(const TargetPtr what) const override {
-    bool res = what->hasProp(propname);
+    bool res;
+    if constexpr (std::is_same_v<TargetPtr, ConstRDMolAtom>) {
+      res = what.mol().hasAtomProp(propname, what.index());
+    } else if constexpr (std::is_same_v<TargetPtr, ConstRDMolBond>) {
+      res = what.mol().hasBondProp(propname, what.index());
+    } else {
+      res = what->hasProp(propname.getString());
+    }
     if (this->getNegation()) {
       res = !res;
     }
@@ -848,13 +1523,21 @@ class HasPropQuery : public Queries::EqualityQuery<int, TargetPtr, true> {
     return res;
   }
 
-  const std::string &getPropName() const { return propname; }
+  const std::string &getPropName() const { return propname.getString(); }
 };
 
+typedef Queries::EqualityQuery<int, ConstRDMolAtom, true> ATOM_PROP_QUERY2;
+typedef Queries::EqualityQuery<int, ConstRDMolBond, true> BOND_PROP_QUERY2;
 typedef Queries::EqualityQuery<int, Atom const *, true> ATOM_PROP_QUERY;
 typedef Queries::EqualityQuery<int, Bond const *, true> BOND_PROP_QUERY;
 
-//! returns a Query for matching atoms that have a particular property
+//! returns a Query for matching atoms or bonds that have a particular property
+template <class Target>
+Queries::EqualityQuery<int, Target, true> *makeHasPropQuery2(
+    const std::string &property) {
+  return new HasPropQuery<Target>(property);
+}
+//! returns a Query for matching atoms or bonds that have a particular property
 template <class Target>
 Queries::EqualityQuery<int, const Target *, true> *makeHasPropQuery(
     const std::string &property) {
@@ -874,7 +1557,7 @@ template <class TargetPtr, class T>
 class HasPropWithValueQuery
     : public HasPropWithValueQueryBase,
       public Queries::EqualityQuery<int, TargetPtr, true> {
-  std::string propname;
+  PropToken propname;
   T val;
   double tolerance{0.0};
 
@@ -887,7 +1570,7 @@ class HasPropWithValueQuery
   }
 
   PairHolder getPair() const override {
-    return PairHolder(Dict::Pair(propname, val));
+    return PairHolder(Dict::Pair(propname.getString(), val));
   }
 
   double getTolerance() const override { return tolerance; }
@@ -904,12 +1587,25 @@ class HasPropWithValueQuery
   }
 
   bool Match(const TargetPtr what) const override {
-    bool res = what->hasProp(propname);
+    bool res;
+    if constexpr (std::is_same_v<TargetPtr, ConstRDMolAtom>) {
+      res = what.mol().hasAtomProp(propname, what.index());
+    } else if constexpr (std::is_same_v<TargetPtr, ConstRDMolBond>) {
+      res = what.mol().hasBondProp(propname, what.index());
+    } else {
+      res = what->hasProp(propname.getString());
+    }
     if (res) {
       try {
-        T atom_val = what->template getProp<T>(propname);
-        res = Queries::queryCmp(atom_val, this->val,
-                                static_cast<T>(this->tolerance)) == 0;
+        T atom_val;
+        if constexpr (std::is_same_v<TargetPtr, ConstRDMolAtom>) {
+          atom_val = what.mol().template getAtomPropValue<T>(propname, what.index());
+        } else if constexpr (std::is_same_v<TargetPtr, ConstRDMolBond>) {
+          atom_val = what.mol().template getBondPropValue<T>(propname, what.index());
+        } else {
+          atom_val = what->template getProp<T>(propname.getString());
+        }
+        res = Queries::queryCmp(atom_val, this->val, static_cast<T>(this->tolerance)) == 0;
       } catch (KeyErrorException &) {
         res = false;
       } catch (std::bad_any_cast &) {
@@ -938,8 +1634,8 @@ class HasPropWithValueQuery
 
   //! returns a copy of this query
   Queries::Query<int, TargetPtr, true> *copy() const override {
-    HasPropWithValueQuery *res =
-        new HasPropWithValueQuery(this->propname, this->val, this->tolerance);
+    HasPropWithValueQuery *res = new HasPropWithValueQuery(
+        this->propname.getString(), this->val, this->tolerance);
     res->setNegation(this->getNegation());
     res->d_description = this->d_description;
     return res;
@@ -950,8 +1646,8 @@ template <class TargetPtr>
 class HasPropWithValueQuery<TargetPtr, std::string>
     : public HasPropWithValueQueryBase,
       public Queries::EqualityQuery<int, TargetPtr, true> {
-  std::string propname;
-  std::string val;
+  PropToken propname;
+  PropToken val;
 
  public:
   HasPropWithValueQuery()
@@ -971,17 +1667,32 @@ class HasPropWithValueQuery<TargetPtr, std::string>
   }
 
   PairHolder getPair() const override {
-    return PairHolder(Dict::Pair(propname, val));
+    return PairHolder(Dict::Pair(propname.getString(), val));
   }
 
   double getTolerance() const override { return 0.0; }
 
   bool Match(const TargetPtr what) const override {
-    bool res = what->hasProp(propname);
+    bool res;
+    if constexpr (std::is_same_v<TargetPtr, ConstRDMolAtom>) {
+      res = what.mol().hasAtomProp(propname, what.index());
+    } else if constexpr (std::is_same_v<TargetPtr, ConstRDMolBond>) {
+      res = what.mol().hasBondProp(propname, what.index());
+    } else {
+      res = what->hasProp(propname.getString());
+    }
     if (res) {
       try {
-        std::string atom_val = what->template getProp<std::string>(propname);
-        res = atom_val == this->val;
+        if constexpr (std::is_same_v<TargetPtr, ConstRDMolAtom>) {
+          PropToken token = what.mol().template getAtomProp<PropToken>(propname, what.index());
+          res = token == this->val;
+        } else if constexpr (std::is_same_v<TargetPtr, ConstRDMolBond>) {
+          PropToken token = what.mol().template getBondProp<PropToken>(propname, what.index());
+          res = token == this->val;
+        } else {
+          std::string atom_val = what->template getProp<std::string>(propname.getString());
+          res = atom_val == this->val.getString();
+        }
       } catch (KeyErrorException &) {
         res = false;
       } catch (std::bad_any_cast &) {
@@ -1011,8 +1722,8 @@ class HasPropWithValueQuery<TargetPtr, std::string>
   //! returns a copy of this query
   Queries::Query<int, TargetPtr, true> *copy() const override {
     HasPropWithValueQuery<TargetPtr, std::string> *res =
-        new HasPropWithValueQuery<TargetPtr, std::string>(this->propname,
-                                                          this->val);
+        new HasPropWithValueQuery<TargetPtr, std::string>(this->propname.getString(),
+                                                          this->val.getString());
     res->setNegation(this->getNegation());
     res->d_description = this->d_description;
     return res;
@@ -1023,7 +1734,7 @@ template <class TargetPtr>
 class HasPropWithValueQuery<TargetPtr, ExplicitBitVect>
     : public HasPropWithValueQueryBase,
       public Queries::EqualityQuery<int, TargetPtr, true> {
-  std::string propname;
+  PropToken propname;
   ExplicitBitVect val;
   double tol{0.0};
 
@@ -1045,17 +1756,24 @@ class HasPropWithValueQuery<TargetPtr, ExplicitBitVect>
   }
 
   PairHolder getPair() const override {
-    return PairHolder(Dict::Pair(propname, val));
+    return PairHolder(Dict::Pair(propname.getString(), val));
   }
 
   double getTolerance() const override { return tol; }
 
   bool Match(const TargetPtr what) const override {
-    bool res = what->hasProp(propname);
+    bool res;
+    if constexpr (std::is_same_v<TargetPtr, ConstRDMolAtom>) {
+      res = what.mol().hasAtomProp(propname, what.index());
+    } else if constexpr (std::is_same_v<TargetPtr, ConstRDMolBond>) {
+      res = what.mol().hasBondProp(propname, what.index());
+    } else {
+      res = what->hasProp(propname.getString());
+    }
     if (res) {
       try {
         const ExplicitBitVect &bv =
-            what->template getProp<const ExplicitBitVect &>(propname);
+            what->template getProp<const ExplicitBitVect &>(propname.getString());
         const double tani = TanimotoSimilarity(val, bv);
         res = (1.0 - tani) <= tol;
       } catch (KeyErrorException &) {
@@ -1088,7 +1806,7 @@ class HasPropWithValueQuery<TargetPtr, ExplicitBitVect>
   Queries::Query<int, TargetPtr, true> *copy() const override {
     HasPropWithValueQuery<TargetPtr, ExplicitBitVect> *res =
         new HasPropWithValueQuery<TargetPtr, ExplicitBitVect>(
-            this->propname, this->val, this->tol);
+            this->propname.getString(), this->val, this->tol);
     res->setNegation(this->getNegation());
     res->d_description = this->d_description;
     return res;
@@ -1109,19 +1827,32 @@ Queries::EqualityQuery<int, const Target *, true> *makePropQuery(
       propname, val, tolerance);
 }
 
+RDKIT_GRAPHMOL_EXPORT bool isComplexQuery(ConstRDMolBond b);
 RDKIT_GRAPHMOL_EXPORT bool isComplexQuery(const Bond *b);
+RDKIT_GRAPHMOL_EXPORT bool isComplexQuery(ConstRDMolAtom a);
 RDKIT_GRAPHMOL_EXPORT bool isComplexQuery(const Atom *a);
+RDKIT_GRAPHMOL_EXPORT bool isAtomAromatic(ConstRDMolAtom a);
 RDKIT_GRAPHMOL_EXPORT bool isAtomAromatic(const Atom *a);
+RDKIT_GRAPHMOL_EXPORT bool isAtomListQuery(ConstRDMolAtom a);
 RDKIT_GRAPHMOL_EXPORT bool isAtomListQuery(const Atom *a);
+RDKIT_GRAPHMOL_EXPORT void getAtomListQueryVals(const RDMol::QUERYATOM_QUERY *q,
+                                                std::vector<int> &vals);
 RDKIT_GRAPHMOL_EXPORT void getAtomListQueryVals(const Atom::QUERYATOM_QUERY *q,
                                                 std::vector<int> &vals);
 
-// Checks if an atom is dummy or not.
-// 1. A dummy non-query atom (e.g., "*" in SMILES) is defined by its zero atomic
-//    number. This rule breaks for query atoms because a COMPOSITE_OR query atom
-//    also has a zero atomic number (#6349).
-// 2. A dummy query atom (e.g., "*" in SMARTS) is defined by its explicit
-//    description: "AtomNull".
+//! Checks if an atom is dummy or not.
+//! 1. A dummy non-query atom (e.g., "*" in SMILES) is defined by its zero atomic
+//!    number. This rule breaks for query atoms because a COMPOSITE_OR query atom
+//!    also has a zero atomic number (#6349).
+//! 2. A dummy query atom (e.g., "*" in SMARTS) is defined by its explicit
+//!    description: "AtomNull".
+inline bool isAtomDummy(ConstRDMolAtom a) {
+  return (!a.mol().hasAtomQuery(a.index()) && a.data().getAtomicNum() == 0) ||
+         (a.mol().hasAtomQuery(a.index()) &&
+          !a.mol().getAtomQuery(a.index())->getNegation() &&
+          a.mol().getAtomQuery(a.index())->getDescription() == "AtomNull");
+}
+//! \overload
 inline bool isAtomDummy(const Atom *a) {
   return (!a->hasQuery() && a->getAtomicNum() == 0) ||
          (a->hasQuery() && !a->getQuery()->getNegation() &&
@@ -1130,32 +1861,111 @@ inline bool isAtomDummy(const Atom *a) {
 
 namespace QueryOps {
 RDKIT_GRAPHMOL_EXPORT void completeMolQueries(
+    RDMol *mol, unsigned int magicVal = 0xDEADBEEF);
+RDKIT_GRAPHMOL_EXPORT void completeMolQueries(
     RWMol *mol, unsigned int magicVal = 0xDEADBEEF);
-// Replaces the given atom in the molecule with a QueryAtom that is otherwise
-// a copy of the given atom.  Returns a pointer to that atom.
-// if the atom already has a query, nothing will be changed
+
+template <typename DataFuncArgType>
+void expandQuery(
+    std::unique_ptr<Queries::Query<int, DataFuncArgType, true>> &firstQuery,
+    std::unique_ptr<Queries::Query<int, DataFuncArgType, true>> newQuery,
+    Queries::CompositeQueryType how = Queries::COMPOSITE_AND,
+    bool maintainOrder = true) {
+  constexpr bool isAtom = std::is_same_v<DataFuncArgType, const Atom *> ||
+                          std::is_same_v<DataFuncArgType, ConstRDMolAtom>;
+  constexpr const char *nullString = isAtom ? "AtomNull" : "BondNull";
+  bool thisIsNullQuery = firstQuery->getDescription() == nullString;
+  bool otherIsNullQuery = newQuery->getDescription() == nullString;
+
+  if (thisIsNullQuery || otherIsNullQuery) {
+    auto *query1 = firstQuery.release();
+    auto *query2 = newQuery.release();
+    mergeNullQueries(query1, thisIsNullQuery, query2, otherIsNullQuery, how);
+    delete query2;
+    firstQuery.reset(query1);
+    return;
+  }
+
+  auto *origQ = firstQuery.release();
+  std::string descrip;
+  switch (how) {
+    case Queries::COMPOSITE_AND:
+      firstQuery.reset(new Queries::AndQuery<int, DataFuncArgType, true>);
+      descrip = isAtom ? "AtomAnd" : "BondAnd";
+      break;
+    case Queries::COMPOSITE_OR:
+      firstQuery.reset(new Queries::OrQuery<int, DataFuncArgType, true>);
+      descrip = isAtom ? "AtomOr" : "BondOr";
+      break;
+    case Queries::COMPOSITE_XOR:
+      firstQuery.reset(new Queries::XOrQuery<int, DataFuncArgType, true>);
+      descrip = isAtom ? "AtomXor" : "BondXor";
+      break;
+    default:
+      UNDER_CONSTRUCTION("unrecognized combination query");
+  }
+  firstQuery->setDescription(descrip);
+  using CHILD_TYPE = typename Queries::Query<int, DataFuncArgType, true>::CHILD_TYPE;
+  if (maintainOrder) {
+    firstQuery->addChild(CHILD_TYPE(origQ));
+    firstQuery->addChild(CHILD_TYPE(newQuery.release()));
+  } else {
+    firstQuery->addChild(CHILD_TYPE(newQuery.release()));
+    firstQuery->addChild(CHILD_TYPE(origQ));
+  }
+}
+
+//! Adds the default Query to the given atom in mol.
+//! If the atom already has a query, nothing will be changed.
+RDKIT_GRAPHMOL_EXPORT void replaceAtomWithQueryAtom(RDMol *mol,
+                                                    atomindex_t atomIndex);
+//! Replaces the given atom in the molecule with a QueryAtom that is otherwise
+//! a copy of the given atom.  Returns a pointer to that atom.
+//! if the atom already has a query, nothing will be changed
 RDKIT_GRAPHMOL_EXPORT Atom *replaceAtomWithQueryAtom(RWMol *mol, Atom *atom);
 
 RDKIT_GRAPHMOL_EXPORT void finalizeQueryFromDescription(
+    Queries::Query<int, ConstRDMolAtom, true> *query, ConstRDMolAtom owner);
+RDKIT_GRAPHMOL_EXPORT void finalizeQueryFromDescription(
     Queries::Query<int, Atom const *, true> *query, Atom const *owner);
+RDKIT_GRAPHMOL_EXPORT void finalizeQueryFromDescription(
+    Queries::Query<int, ConstRDMolBond, true> *query, ConstRDMolBond owner);
 RDKIT_GRAPHMOL_EXPORT void finalizeQueryFromDescription(
     Queries::Query<int, Bond const *, true> *query, Bond const *owner);
 
 RDKIT_GRAPHMOL_EXPORT bool hasBondTypeQuery(
     const Queries::Query<int, Bond const *, true> &qry);
+RDKIT_GRAPHMOL_EXPORT bool hasBondTypeQuery(
+    const Queries::Query<int, ConstRDMolBond, true> &qry);
 inline bool hasBondTypeQuery(const Bond &bond) {
   if (!bond.hasQuery()) {
     return false;
   }
   return hasBondTypeQuery(*bond.getQuery());
 }
+inline bool hasBondTypeQuery(ConstRDMolBond bond) {
+  auto *query = bond.mol().getBondQuery(bond.index());
+  if (query == nullptr) {
+    return false;
+  }
+  return hasBondTypeQuery(*query);
+}
 RDKIT_GRAPHMOL_EXPORT bool hasComplexBondTypeQuery(
     const Queries::Query<int, Bond const *, true> &qry);
+RDKIT_GRAPHMOL_EXPORT bool hasComplexBondTypeQuery(
+    const Queries::Query<int, ConstRDMolBond, true> &qry);
 inline bool hasComplexBondTypeQuery(const Bond &bond) {
   if (!bond.hasQuery()) {
     return false;
   }
   return hasComplexBondTypeQuery(*bond.getQuery());
+}
+inline bool hasComplexBondTypeQuery(ConstRDMolBond bond) {
+  auto *query = bond.mol().getBondQuery(bond.index());
+  if (query == nullptr) {
+    return false;
+  }
+  return hasComplexBondTypeQuery(*query);
 }
 
 RDKIT_GRAPHMOL_EXPORT bool isMetal(const Atom &atom);

--- a/Code/GraphMol/RDMol.cpp
+++ b/Code/GraphMol/RDMol.cpp
@@ -1,0 +1,3627 @@
+//
+//  Copyright (C) 2025 NVIDIA Corporation & Affiliates and other RDKit contributors
+//
+//   @@ All Rights Reserved @@
+//  This file is part of the RDKit.
+//  The contents are covered by the terms of the BSD license
+//  which is included in the file license.txt, found at the root
+//  of the RDKit source tree.
+//
+#include "RDMol.h"
+#include "Atom.h"
+#include "Bond.h"
+#include "Conformer.h"
+
+#include "PeriodicTable.h"
+#include "SanitException.h"
+#include "RDGeneral/vector_utils.h"
+
+#include "QueryAtom.h"
+#include "QueryBond.h"
+#include "QueryOps.h"
+
+#include <mutex>
+#include <type_traits>
+
+namespace Queries {
+// Forward declaration
+template <class NonCompatType>
+class RDKIT_QUERY_EXPORT NonCompatQuery;
+
+//! This class is for wrapping an existing Query that was created using the new
+//! atom/bond types, for example, when constructing CompatibilityData, or when
+//! setting a Query when CompatibilityData already exists.
+//!
+//! It's unlikely, but possible, for callers to call the modification functions, so they need
+//! to work, but don't need to be efficient. This also needs to reflect changes applied to the
+//! other Query. If callers hold onto pointers to both, that's not feasible to support, though.
+template <class CompatType>
+class RDKIT_QUERY_EXPORT CompatQuery : public Query<int, CompatType, true> {
+ public:
+  using MatchFuncArgType = int;
+  using DataFuncArgType = CompatType;
+  static constexpr bool needsConversion = true;
+  using BASE = Query<int, CompatType, true>;
+  static constexpr bool isAtom = std::is_same_v<CompatType, const RDKit::Atom *>;
+  using NonCompatType = std::conditional_t<isAtom, RDKit::ConstRDMolAtom, RDKit::ConstRDMolBond>;
+  using INNER_TYPE = Query<int, NonCompatType, true>;
+
+  INNER_TYPE *inner;
+  bool ownsInner;
+
+  CompatQuery(INNER_TYPE *innerIn, bool ownsInnerIn)
+      : inner(innerIn), ownsInner(ownsInnerIn) {
+    BASE::d_description = inner->getDescription();
+    BASE::d_queryType = inner->getTypeLabel();
+  }
+  CompatQuery(CompatQuery &&) = default;
+  ~CompatQuery() {
+    if (ownsInner) {
+      delete inner;
+    }
+  }
+
+  bool Match(const CompatType what) const override {
+    PRECONDITION(BASE::d_children.size() == 0,
+                 "Children must be added to the inner query, not this");
+    PRECONDITION(!BASE::getNegation(),
+                 "Negation must be applied to the inner query, not this");
+    return inner->Match(
+        NonCompatType(&what->getOwningMol().asRDMol(), what->getIdx()));
+  }
+  BASE *copy() const override {
+    PRECONDITION(BASE::d_children.size() == 0,
+                 "Children must be added to the inner query, not this");
+    // This copy will own the inner query
+    CompatQuery<CompatType> *res = new CompatQuery<CompatType>(inner->copy(), true);
+    res->d_description = this->d_description;
+    res->d_queryType = this->d_queryType;
+    return res;
+  }
+
+  void setMatchFunc(bool (*what)(MatchFuncArgType)) override {
+    raiseNonImplementedFunction("CompatQuery::setMatchFunc");
+  }
+  void setDataFunc(MatchFuncArgType(*what)(DataFuncArgType)) override {
+    raiseNonImplementedFunction("CompatQuery::setDataFunc");
+  }
+  void setNegation(bool what) override { inner->setNegation(what); }
+  void addChild(typename BASE::CHILD_TYPE child) override;
+};
+
+//! This class is for wrapping an existing Query that was created using the
+//! compatibility atom/bond types, for example, when QueryAtom::setQuery is called.
+template <class NonCompatType>
+class RDKIT_QUERY_EXPORT NonCompatQuery : public Query<int, NonCompatType, true> {
+ public:
+  using MatchFuncArgType = int;
+  using DataFuncArgType = NonCompatType;
+  static constexpr bool needsConversion = true;
+  using BASE = Query<int, NonCompatType, true>;
+  static constexpr bool isAtom = std::is_same_v<NonCompatType, RDKit::ConstRDMolAtom>;
+  using CompatType = std::conditional_t<isAtom, const RDKit::Atom *, const RDKit::Bond *>;
+  using INNER_TYPE = Query<int, CompatType, true>;
+
+  INNER_TYPE *inner;
+  bool ownsInner;
+
+  NonCompatQuery(INNER_TYPE *innerIn, bool ownsInnerIn)
+      : inner(innerIn), ownsInner(ownsInnerIn) {
+    BASE::d_description = inner->getDescription();
+    BASE::d_queryType = inner->getTypeLabel();
+  }
+  NonCompatQuery(NonCompatQuery &&) = default;
+  ~NonCompatQuery() {
+    if (ownsInner) {
+      delete inner;
+    }
+  }
+
+  bool Match(const NonCompatType what) const override {
+    PRECONDITION(BASE::d_children.size() == 0,
+                 "Children must be added to the inner query, not this");
+    PRECONDITION(!BASE::getNegation(),
+                 "Negation must be applied to the inner query, not this");
+    if constexpr (isAtom) {
+      return inner->Match(what.mol().asROMol().getAtomWithIdx(what.index()));
+    } else {
+      return inner->Match(what.mol().asROMol().getBondWithIdx(what.index()));
+    }
+  }
+  BASE *copy() const override {
+    PRECONDITION(BASE::d_children.size() == 0,
+                 "Children must be added to the inner query, not this");
+    // This copy will own the inner query
+    NonCompatQuery<NonCompatType> *res =
+        new NonCompatQuery<NonCompatType>(inner->copy(), true);
+    res->d_description = this->d_description;
+    res->d_queryType = this->d_queryType;
+    return res;
+  }
+
+  void setMatchFunc(bool (*what)(MatchFuncArgType)) override {
+    raiseNonImplementedFunction("NonCompatQuery::setMatchFunc");
+  }
+  void setDataFunc(MatchFuncArgType(*what)(DataFuncArgType)) override {
+    raiseNonImplementedFunction("NonCompatQuery::setDataFunc");
+  }
+  void setNegation(bool what) override { inner->setNegation(what); }
+  void addChild(typename BASE::CHILD_TYPE child) override {
+    inner->addChild(
+        std::make_shared<CompatQuery<CompatType>>(child->copy(), true));
+  }
+};
+
+// Defined after NonCompatQuery class due to dependence
+template <class CompatType>
+void CompatQuery<CompatType>::addChild(typename BASE::CHILD_TYPE child) {
+  inner->addChild(
+      std::make_shared<NonCompatQuery<NonCompatType>>(child->copy(), true));
+}
+
+template <class NonCompatType>
+Query<int,
+      std::conditional_t<std::is_same_v<NonCompatType, RDKit::ConstRDMolAtom>,
+                         const RDKit::Atom *, const RDKit::Bond *>,
+      true> *
+makeNewCompatQuery(Query<int, NonCompatType, true> *inner) {
+  static constexpr bool isAtom = std::is_same_v<NonCompatType, RDKit::ConstRDMolAtom>;
+  using CompatType = std::conditional_t<isAtom, const RDKit::Atom *, const RDKit::Bond *>;
+  using INNER_TYPE = NonCompatQuery<NonCompatType>;
+  using OUTER_TYPE = CompatQuery<CompatType>;
+  auto *nonCompatInner = dynamic_cast<INNER_TYPE *>(inner);
+  if (nonCompatInner != nullptr) {
+    // Don't re-wrap if already wrapped
+    if (nonCompatInner->ownsInner) {
+      // This was from a copy, so take ownership of inner, to avoid duplicating it again
+      nonCompatInner->ownsInner = false;
+      return nonCompatInner->inner;
+    }
+    // Not already a copy, so make a new copy of the original type
+    return nonCompatInner->inner->copy();
+  }
+  // Not already wrapped, so construct as normal
+  return new OUTER_TYPE(inner, false);
+}
+
+template <class CompatType>
+Query<int,
+      std::conditional_t<std::is_same_v<CompatType, const RDKit::Atom *>,
+                         RDKit::ConstRDMolAtom, RDKit::ConstRDMolBond>,
+      true> *
+makeNewNonCompatQuery(Query<int, CompatType, true> *inner) {
+  static constexpr bool isAtom = std::is_same_v<CompatType, const RDKit::Atom *>;
+  using NonCompatType = std::conditional_t<isAtom, RDKit::ConstRDMolAtom, RDKit::ConstRDMolBond>;
+  using INNER_TYPE = CompatQuery<CompatType>;
+  using OUTER_TYPE = NonCompatQuery<NonCompatType>;
+  auto *compatInner = dynamic_cast<INNER_TYPE *>(inner);
+  if (compatInner != nullptr) {
+    // Don't re-wrap if already wrapped
+    if (compatInner->ownsInner) {
+      // This was from a copy, so take ownership of inner, to avoid duplicating it again
+      compatInner->ownsInner = false;
+      return compatInner->inner;
+    }
+    // Not already a copy, so make a new copy of the original type
+    return compatInner->inner->copy();
+  }
+  // Not already wrapped, so construct as normal
+  return new OUTER_TYPE(inner, false);
+}
+
+}  // namespace Queries
+
+namespace RDKit {
+
+double AtomData::getMass() const {
+  auto *table = PeriodicTable::getTable();
+  if (isotope) {
+    double res = table->getMassForIsotope(atomicNum, isotope);
+    if (atomicNum != 0 && res == 0.0) {
+      res = isotope;
+    }
+    return res;
+  }
+  return table->getAtomicWeight(atomicNum);
+}
+
+namespace {
+
+enum class CompatSyncStatus { lastUpdatedRDMol = 0, lastUpdatedCompat, inSync };
+
+void copyRingInfoToCompatibilityData(const RingInfoCache &input,
+                                     RingInfo &output, uint32_t numAtoms,
+                                     uint32_t numBonds) {
+  output.reset();
+
+  // This handles the case where input is uninitialized, in case
+  // the two structures must be synchronized to be equally uninitialized
+  if (!input.isInitialized()) {
+    return;
+  }
+
+  output.initialize(input.findRingType);
+  INT_VECT atomIndices;
+  INT_VECT bondIndices;
+  const size_t numRings = input.numRings();
+
+  for (size_t ringIndex = 0; ringIndex < numRings; ++ringIndex) {
+    atomIndices.clear();
+    bondIndices.clear();
+    const uint32_t ringBeginIndex = input.ringBegins[ringIndex];
+    const uint32_t ringEndIndex = input.ringBegins[ringIndex + 1];
+    for (uint32_t atomBondIndex = ringBeginIndex; atomBondIndex < ringEndIndex;
+         ++atomBondIndex) {
+      atomIndices.push_back(input.atomsInRings[atomBondIndex]);
+      bondIndices.push_back(input.bondsInRings[atomBondIndex]);
+    }
+    output.addRing(atomIndices, bondIndices);
+  }
+}
+void copyRingInfoFromCompatibilityData(const RingInfo &input,
+                                       RingInfoCache &output, uint32_t numAtoms,
+                                       uint32_t numBonds) {
+  output.reset();
+
+  // This handles the case where input is uninitialized, in case
+  // the two structures must be synchronized to be equally uninitialized
+  if (!input.isInitialized()) {
+    return;
+  }
+
+  output.isInit = true;
+  output.findRingType = input.getRingType();
+
+  const size_t numRings = input.numRings();
+  output.ringBegins.reserve(numRings + 1);
+  const VECT_INT_VECT &atomRings = input.atomRings();
+  const VECT_INT_VECT &bondRings = input.bondRings();
+  PRECONDITION(atomRings.size() == numRings, "atomRings size mismatch");
+  PRECONDITION(bondRings.size() == numRings, "bondRings size mismatch");
+  size_t offset = 0;
+  for (size_t i = 0; i < numRings; ++i) {
+    output.ringBegins.push_back(offset);
+    offset += atomRings[i].size();
+    PRECONDITION(atomRings[i].size() == bondRings[i].size(), "atom vs. bond ring mismatch");
+  }
+  const size_t totalSize = offset;
+  output.ringBegins.push_back(totalSize);
+
+  output.atomsInRings.reserve(totalSize);
+  output.bondsInRings.reserve(totalSize);
+  for (size_t i = 0; i < numRings; ++i) {
+    for (auto atom : atomRings[i]) {
+      output.atomsInRings.push_back(atom);
+    }
+    for (auto bond : bondRings[i]) {
+      output.bondsInRings.push_back(bond);
+    }
+  }
+
+  output.atomMembershipBegins.resize(numAtoms + 1, 0);
+  output.bondMembershipBegins.resize(numBonds + 1, 0);
+  // Count the atoms and bonds
+  for (size_t i = 0; i < numRings; ++i) {
+    for (auto atom : atomRings[i]) {
+      ++output.atomMembershipBegins[atom + 1];
+    }
+    for (auto bond : bondRings[i]) {
+      ++output.bondMembershipBegins[bond + 1];
+    }
+  }
+  // Partial sum to figure out where they go
+  std::partial_sum(output.atomMembershipBegins.begin() + 1,
+                   output.atomMembershipBegins.end(),
+                   output.atomMembershipBegins.begin() + 1);
+  std::partial_sum(output.bondMembershipBegins.begin() + 1,
+                   output.bondMembershipBegins.end(),
+                   output.bondMembershipBegins.begin() + 1);
+
+  // Fill in the ring memberships for each atom and bond
+  output.atomMemberships.resize(totalSize);
+  output.bondMemberships.resize(totalSize);
+  for (size_t i = 0; i < numRings; ++i) {
+    for (auto atom : atomRings[i]) {
+      auto &next = output.atomMembershipBegins[atom];
+      output.atomMemberships[next] = i;
+      ++next;
+    }
+    for (auto bond : bondRings[i]) {
+      auto &next = output.bondMembershipBegins[bond];
+      output.bondMemberships[next] = i;
+      ++next;
+    }
+  }
+  // Shift forward 1 to undo the increments
+  uint32_t prev = 0;
+  for (size_t i = 0; i < numRings; ++i) {
+    std::swap(prev, output.atomMemberships[i]);
+  }
+  prev = 0;
+  for (size_t i = 0; i < numRings; ++i) {
+    std::swap(prev, output.bondMemberships[i]);
+  }
+
+  // Call clear first to ensure all elements reinitialized to false or 0
+  output.areRingsFused.clear();
+  output.areRingsFused.resize(numRings * numRings, false);
+  output.numFusedBonds.clear();
+  output.numFusedBonds.resize(numRings, 0);
+  if (numRings <= 1) {
+    return;
+  }
+
+  // Create 2D bit vector of whether two rings share a bond
+  for (size_t bondIndex = 0; bondIndex < numBonds; ++bondIndex) {
+    uint32_t begin = output.bondMembershipBegins[bondIndex];
+    uint32_t end = output.bondMembershipBegins[bondIndex + 1];
+    for (; begin + 1 < end; ++begin) {
+      auto ring1 = output.bondMemberships[begin];
+      for (uint32_t other = begin + 1; other < end; ++other) {
+        auto ring2 = output.bondMemberships[other];
+        output.areRingsFused[ring1 * numRings + ring2] = true;
+        output.areRingsFused[ring2 * numRings + ring1] = true;
+        ++output.numFusedBonds[ring1];
+        ++output.numFusedBonds[ring2];
+      }
+    }
+  }
+}
+}  // namespace
+
+struct RDMol::CompatibilityData {
+  ROMol *compatMol = nullptr;
+  std::unique_ptr<RWMol> mol;
+  std::vector<std::unique_ptr<Atom>> atoms;
+  std::vector<std::unique_ptr<Bond>> bonds;
+  std::map<int, std::list<Atom *>> atomBookmarks;
+  std::map<int, std::list<Bond *>> bondBookmarks;
+  // Each INT_VECT is wrapped in a unique_ptr so that removing bonds doesn't
+  // change the address of the INT_VECT. testGitHubIssue8() in molopstest.cpp
+  // relies on this persistence.
+  std::vector<std::unique_ptr<INT_VECT>> bondStereoAtoms;
+  // stereoGroups is initialized on demand in getStereoGroupsCompat
+  std::atomic<std::vector<StereoGroup> *> stereoGroups = nullptr;
+
+  ROMol::CONF_SPTR_LIST conformers;
+  mutable std::atomic<CompatSyncStatus> conformerSyncStatus;
+
+  std::unique_ptr<RingInfo> ringInfo;
+  mutable std::atomic<CompatSyncStatus> ringInfoSyncStatus;
+
+  CompatibilityData(RDMol &rdmol, ROMol *existingROMolPtr = nullptr)
+      : atoms(rdmol.getNumAtoms()),
+        bonds(rdmol.getNumBonds()),
+        bondStereoAtoms(rdmol.getNumBonds()),
+        conformerSyncStatus(CompatSyncStatus::inSync),
+        ringInfoSyncStatus(CompatSyncStatus::inSync) {
+    // For a self-owning compat mol, we need pointer compatibility.
+    if (existingROMolPtr) {
+      compatMol = existingROMolPtr;
+      if (!existingROMolPtr->d_ownedBySelf) {
+        auto rwmolPtr = dynamic_cast<RWMol *>(existingROMolPtr);
+        if (!rwmolPtr) {
+          throw ValueErrorException("Existing ROMol ptr must be an RWMol if not owned by self");
+        }
+        mol.reset(rwmolPtr);
+      }
+    } else {
+      mol.reset(new RWMol(&rdmol));
+      mol->d_ownedBySelf = false;
+      compatMol = mol.get();
+    }
+
+    for (uint32_t i = 0, n = rdmol.getNumBonds(); i < n; ++i) {
+      bondStereoAtoms[i] = std::make_unique<INT_VECT>();
+    }
+
+    const uint32_t numAtoms = rdmol.getNumAtoms();
+    for (uint32_t i = 0, n = numAtoms; i < n; ++i) {
+      auto *query = rdmol.getAtomQuery(i);
+      Atom *atom;
+      if (query == nullptr) {
+        atom = new Atom(&rdmol, i);
+      } else {
+        atom = new QueryAtom(&rdmol, i, makeNewCompatQuery(query));
+      }
+      atoms[i].reset(atom);
+    }
+    for (uint32_t i = 0, n = rdmol.getNumBonds(); i < n; ++i) {
+      auto *query = rdmol.getBondQuery(i);
+      Bond *bond;
+      if (query == nullptr) {
+        bond = new Bond(&rdmol, i);
+      } else {
+        bond = new QueryBond(&rdmol, i, makeNewCompatQuery(query));
+      }
+      bonds[i].reset(bond);
+      const uint32_t *stereoAtoms = rdmol.getBond(i).stereoAtoms;
+      if (*stereoAtoms != atomindex_t(-1)) {
+        bondStereoAtoms[i]->reserve(2);
+        bondStereoAtoms[i]->push_back(*stereoAtoms);
+        bondStereoAtoms[i]->push_back(*(stereoAtoms + 1));
+      }
+    }
+
+    const double *conformerPositions = rdmol.conformerPositionData.data();
+    const size_t conformerOffsetStride = rdmol.conformerAtomCapacity * 3;
+    for (uint32_t conformerIndex = 0, n = rdmol.getNumConformers();
+         conformerIndex < n; ++conformerIndex) {
+      const size_t conformerOffset = conformerIndex * conformerOffsetStride;
+      auto *conformer = new Conformer();
+      conformer->getPositions().reserve(numAtoms);
+      for (uint32_t atomIndex = 0; atomIndex < numAtoms; ++atomIndex) {
+        conformer->getPositions().push_back(RDGeom::Point3D(
+            conformerPositions[conformerOffset + 3 * atomIndex + 0],
+            conformerPositions[conformerOffset + 3 * atomIndex + 1],
+            conformerPositions[conformerOffset + 3 * atomIndex + 2]
+            ));
+      }
+      if (rdmol.conformerIdsAndFlags.size() > 0) {
+        conformer->setId(rdmol.conformerIdsAndFlags[conformerIndex].id);
+        conformer->set3D(rdmol.conformerIdsAndFlags[conformerIndex].is3D);
+      } else {
+        conformer->setId(conformerIndex);
+        conformer->set3D(true);
+      }
+      conformer->setOwningMol(compatMol);
+      conformers.push_back(CONFORMER_SPTR(conformer));
+    }
+
+    for (const auto &[mark, atomIndices] : rdmol.atomBookmarks) {
+      for (int atomIndex : atomIndices) {
+        atomBookmarks[mark].push_back(atoms[atomIndex].get());
+      }
+    }
+    for (const auto &[mark, bondIndices] : rdmol.bondBookmarks) {
+      for (int bondIndex : bondIndices) {
+        bondBookmarks[mark].push_back(bonds[bondIndex].get());
+      }
+    }
+
+    ringInfo.reset(new RingInfo());
+    if (rdmol.ringInfo.isInitialized()) {
+      copyRingInfoToCompatibilityData(rdmol.ringInfo, *ringInfo,
+                                      rdmol.getNumAtoms(), rdmol.getNumBonds());
+    }
+  }
+
+  ~CompatibilityData() {
+    delete stereoGroups.load(std::memory_order_relaxed);
+  }
+
+  void setNewOwner(RDMol &rdmol) {
+    compatMol->dp_mol = &rdmol;
+    for (auto &atom : atoms) {
+      atom->dp_dataMol = &rdmol;
+      atom->dp_owningMol = &rdmol;
+    }
+    for (auto &bond : bonds) {
+      bond->dp_dataMol = &rdmol;
+      bond->dp_owningMol = &rdmol;
+    }
+    for (auto &conformer : conformers) {
+      conformer->setOwningMol(compatMol);
+    }
+  }
+};
+
+void RDMol::releaseCompatMolOwnership() {
+  std::ignore = ensureCompatInit()->mol.release();
+};
+
+void RDMol::setCompatPointersToSelf() {
+  ensureCompatInit()->setNewOwner(*this);
+}
+
+void RDMol::setROMolPointerCompat(ROMol* ptr) {
+  auto *compat = ensureCompatInit();
+  compat->compatMol = ptr;
+  if (!ptr->d_ownedBySelf) {
+    auto *rwmol = dynamic_cast<RWMol *>(ptr);
+    if (rwmol == nullptr) {
+      throw ValueErrorException(
+          "Existing ROMol ptr must be an RWMol if not owned by self");
+    }
+    compat->mol.reset(rwmol);
+  }
+}
+
+Atom *RDMol::getAtomCompat(uint32_t atomIndex) {
+  return ensureCompatInit()->atoms[atomIndex].get();
+}
+const Atom *RDMol::getAtomCompat(uint32_t atomIndex) const {
+  return ensureCompatInit()->atoms[atomIndex].get();
+}
+
+Bond *RDMol::getBondCompat(uint32_t bondIndex) {
+  return ensureCompatInit()->bonds[bondIndex].get();
+}
+const Bond *RDMol::getBondCompat(uint32_t bondIndex) const {
+  return ensureCompatInit()->bonds[bondIndex].get();
+}
+
+std::list<Atom *>& RDMol::getAtomBookmarksCompat(int mark) {
+  RDMol::CompatibilityData* compat = ensureCompatInit();
+  auto found = compat->atomBookmarks.find(mark);
+  PRECONDITION(found != compat->atomBookmarks.end(),
+               "No atom bookmark with mark " + std::to_string(mark));
+  return found->second;
+}
+
+std::list<Bond *>& RDMol::getBondBookmarksCompat(int mark) {
+  RDMol::CompatibilityData* compat = ensureCompatInit();
+  auto found = compat->bondBookmarks.find(mark);
+  PRECONDITION(found != compat->bondBookmarks.end(),
+               "No bond bookmark with mark " + std::to_string(mark));
+  return found->second;
+}
+
+std::map<int, std::list<Atom *>>* RDMol::getAtomBookmarksCompat() {
+  RDMol::CompatibilityData* compat = ensureCompatInit();
+  return &compat->atomBookmarks;
+}
+
+std::map<int, std::list<Bond *>>* RDMol::getBondBookmarksCompat() {
+  RDMol::CompatibilityData* compat = ensureCompatInit();
+  return &compat->bondBookmarks;
+}
+
+void RDMol::setAtomQueryCompat(atomindex_t atomIndex,
+                               Atom::QUERYATOM_QUERY *query) {
+  if (atomQueries.size() != getNumAtoms()) {
+    atomQueries.resize(getNumAtoms());
+  }
+  atomQueries[atomIndex].reset(makeNewNonCompatQuery(query));
+}
+
+void RDMol::setBondQueryCompat(uint32_t bondIndex, Bond::QUERYBOND_QUERY *query) {
+  if (bondQueries.size() != getNumBonds()) {
+    bondQueries.resize(getNumBonds());
+  }
+  bondQueries[bondIndex].reset(makeNewNonCompatQuery(query));
+}
+
+void RDMol::setAtomQueryCompatFull(
+    atomindex_t atomIndex, Queries::Query<int, const Atom *, true> *query) {
+  auto *compat = ensureCompatInit();
+  Atom *atom = compat->atoms[atomIndex].get();
+  QueryAtom *queryAtom = dynamic_cast<QueryAtom *>(atom);
+  if (queryAtom == nullptr) {
+    // Convert to a QueryAtom now that there's a query
+    compat->atoms[atomIndex].reset(new QueryAtom(this, atomIndex, query));
+  } else {
+    queryAtom->setQueryPrivate(query);
+  }
+
+  setAtomQueryCompat(atomIndex, query);
+}
+
+void RDMol::setBondQueryCompatFull(
+    uint32_t bondIndex, Queries::Query<int, const Bond *, true> *query) {
+  auto *compat = ensureCompatInit();
+  Bond *bond = compat->bonds[bondIndex].get();
+  QueryBond *queryBond = dynamic_cast<QueryBond *>(bond);
+  if (queryBond == nullptr) {
+    // Convert to a QueryBond now that there's a query
+    compat->bonds[bondIndex].reset(new QueryBond(this, bondIndex, query));
+  } else {
+    queryBond->setQueryPrivate(query);
+  }
+
+  setBondQueryCompat(bondIndex, query);
+}
+
+
+void RDMol::clearBondStereoAtomsCompat(uint32_t bondIndex) {
+  ensureCompatInit()->bondStereoAtoms[bondIndex]->clear();
+}
+bool RDMol::hasBondStereoAtomsCompat(uint32_t bondIndex) const {
+  return !ensureCompatInit()->bondStereoAtoms[bondIndex]->empty();
+}
+const INT_VECT* RDMol::getBondStereoAtomsCompat(uint32_t bondIndex) const {
+  // Because RDMol::setBondStereoAtoms and RDMol::clearBondStereoAtoms update
+  // these lists, no synchronization is needed here.
+  return ensureCompatInit()->bondStereoAtoms[bondIndex].get();
+}
+INT_VECT* RDMol::getBondStereoAtomsCompat(uint32_t bondIndex) {
+  // Because RDMol::setBondStereoAtoms and RDMol::clearBondStereoAtoms update
+  // these lists, no synchronization is needed here.
+  return ensureCompatInit()->bondStereoAtoms[bondIndex].get();
+}
+
+void RDMol::replaceAtomPointerCompat(Atom* atom, uint32_t index) {
+  PRECONDITION(atom->dp_owningMol == nullptr || atom->dp_owningMol == this,
+               "Atom cannot have another owning mol");
+  PRECONDITION(atom->dp_dataMol != this, "About to delete this RDMol");
+
+  // First clean up previous data. We're only taking the pointer, so no need to
+  // copy the data.
+  delete atom->dp_dataMol;
+
+  auto *compat = ensureCompatInit();
+
+  // Store original pointer for bookmark replacement.
+  auto &atom_ptr = compat->atoms[index];
+  Atom *origAtom = atom_ptr.get();
+
+  // Now set the pointers for this RDMol.
+  // The Atom pointed to by origAtom is invalid after calling reset,
+  // but only the pointer value is used below.
+  atom_ptr.reset(atom);
+  atom->setIdx(index);
+  atom->dp_dataMol = this;
+  atom->dp_owningMol = this;
+
+  // Replace pointers in bookmarks.
+  for (auto &ab : compat->atomBookmarks) {
+    for (auto &elem : ab.second) {
+      if (elem == origAtom) {
+        elem = atom;
+      }
+    }
+  }
+
+  // This could replace the atom pointer in compat->stereoGroups, if it's
+  // not null, but because nothing should be reading while they're being
+  // modified anyway, they can be cleared and recreated on read.
+  // If this is ever a performance issue, some more extensive work may be
+  // required, because StereoGroup doesn't have a function to replace atoms.
+  compat->stereoGroups.store(nullptr, std::memory_order_relaxed);
+
+  if (atom->hasQuery()) {
+    auto *query = atom->getQuery();
+    PRECONDITION(query != nullptr,
+                 "Atom hasQuery returns true, but the query is null");
+    setAtomQueryCompat(index, query);
+  }
+}
+
+void RDMol::replaceBondPointerCompat(Bond* bond, uint32_t index) {
+  PRECONDITION(bond->dp_owningMol == nullptr || bond->dp_owningMol == this,
+               "Bond cannot have another owning mol");
+  PRECONDITION(bond->dp_dataMol != this, "About to delete this RDMol");
+
+  // First clean up previous data. We're only taking the pointer, so no need to
+  // copy the data.
+  delete bond->dp_dataMol;
+
+  auto *compat = ensureCompatInit();
+
+  // Store original pointer for bookmark replacement.
+  auto &bond_ptr = compat->bonds[index];
+  Bond *origBond = bond_ptr.get();
+
+  // Now set the pointers for this RDMol.
+  // The Bond pointed to by origBond is invalid after calling reset,
+  // but only the pointer value is used below.
+  bond_ptr.reset(bond);
+  bond->setIdx(index);
+  bond->dp_dataMol = this;
+  bond->dp_owningMol = this;
+
+  // Replace pointers in bookmarks.
+  for (auto &ab : compat->bondBookmarks) {
+    for (auto &elem : ab.second) {
+      if (elem == origBond) {
+        elem = bond;
+      }
+    }
+  }
+
+  // This could replace the bond pointer in compat->stereoGroups, if it's
+  // not null, but because nothing should be reading while they're being
+  // modified anyway, they can be cleared and recreated on read.
+  // If this is ever a performance issue, some more extensive work may be
+  // required, because StereoGroup doesn't have a function to replace bonds.
+  compat->stereoGroups.store(nullptr, std::memory_order_relaxed);
+
+  if (bond->hasQuery()) {
+    auto *query = bond->getQuery();
+    PRECONDITION(query != nullptr,
+                 "Bond hasQuery returns true, but the query is null");
+    setBondQueryCompat(index, query);
+  }
+}
+
+template <bool toCompat, typename F>
+void initCompatForWriteHelper(std::atomic<CompatSyncStatus> &syncStatus,
+                              std::mutex &compatibilityMutex, F &&f) {
+  const CompatSyncStatus fromStatus = toCompat
+                                          ? CompatSyncStatus::lastUpdatedRDMol
+                                          : CompatSyncStatus::lastUpdatedCompat;
+  const CompatSyncStatus toStatus = toCompat
+                                        ? CompatSyncStatus::lastUpdatedCompat
+                                        : CompatSyncStatus::lastUpdatedRDMol;
+
+  // Because the CPU treats reading the status an independent read from reading
+  // the conformer data, memory_order_acquire must be used to prevent
+  // speculative reads.
+  auto status = syncStatus.load(std::memory_order_acquire);
+  if (status != toStatus) {
+    if (status == fromStatus) {
+      std::lock_guard<std::mutex> lock_scope(compatibilityMutex);
+      // Don't re-copy if another thread already copied while this thread was
+      // waiting to acquire the lock.
+      status = syncStatus.load(std::memory_order_acquire);
+      if (status == fromStatus) {
+        f();
+
+        // memory_order_release must be used to prevent delayed writes of the
+        // conformer data.
+        syncStatus.store(toStatus, std::memory_order_release);
+      } else if (status == CompatSyncStatus::inSync) {
+        // Another thread must have requested read access at the same time.
+        // Going from inSync to lastUpdatedCompat, conformer data has already
+        // been written out to main memory, so can do a relaxed store.
+        syncStatus.store(toStatus, std::memory_order_relaxed);
+      }
+    } else {
+      // Already in sync. Conformer data has already been
+      // written out to main memory, so can do a relaxed store.
+      syncStatus.store(toStatus, std::memory_order_relaxed);
+    }
+  }
+}
+
+template <bool toCompat, typename F>
+void initCompatForReadHelper(std::atomic<CompatSyncStatus> &syncStatus,
+                             std::mutex &compatibilityMutex, F &&f) {
+  const CompatSyncStatus fromStatus = toCompat
+                                          ? CompatSyncStatus::lastUpdatedRDMol
+                                          : CompatSyncStatus::lastUpdatedCompat;
+  // Because the CPU treats reading the status an independent read from reading
+  // the conformer data, memory_order_acquire must be used to prevent
+  // speculative reads.
+  auto status = syncStatus.load(std::memory_order_acquire);
+  if (status == fromStatus) {
+    std::lock_guard<std::mutex> lock_scope(compatibilityMutex);
+    // Don't re-copy if another thread already copied while this thread was
+    // waiting to acquire the lock.
+    status = syncStatus.load(std::memory_order_acquire);
+    if (status == fromStatus) {
+      f();
+
+      // Only requesting read access in this thread, so status can
+      // be set to inSync. memory_order_release must be used to prevent
+      // delayed writes of the conformer data.
+      syncStatus.store(CompatSyncStatus::inSync, std::memory_order_release);
+    }
+  }
+}
+
+ROMol::CONF_SPTR_LIST& RDMol::getConformersCompat() {
+  auto *const compat = ensureCompatInit();
+  initCompatForWriteHelper<true>(
+      compat->conformerSyncStatus, compatibilityMutex,
+      [&]() { copyConformersToCompatibilityData(compat); });
+  return compat->conformers;
+}
+const ROMol::CONF_SPTR_LIST& RDMol::getConformersCompat() const {
+  auto *const compat = ensureCompatInit();
+  initCompatForReadHelper<true>(compat->conformerSyncStatus, compatibilityMutex,
+                          [&]() { copyConformersToCompatibilityData(compat); });
+  return compat->conformers;
+}
+
+RingInfo &RDMol::getRingInfoCompat() {
+  auto *const compat = ensureCompatInit();
+  initCompatForWriteHelper<true>(
+    compat->ringInfoSyncStatus, compatibilityMutex, [&]() {
+      copyRingInfoToCompatibilityData(ringInfo, *compat->ringInfo,
+                                      getNumAtoms(), getNumBonds());
+  });
+  return *compat->ringInfo;
+}
+const RingInfo &RDMol::getRingInfoCompat() const {
+  auto *const compat = ensureCompatInit();
+  initCompatForReadHelper<true>(
+    compat->ringInfoSyncStatus, compatibilityMutex, [&]() {
+      copyRingInfoToCompatibilityData(ringInfo, *compat->ringInfo,
+                                      getNumAtoms(), getNumBonds());
+  });
+  return *compat->ringInfo;
+}
+
+const std::vector<StereoGroup> &RDMol::getStereoGroupsCompat() {
+  RDMol::CompatibilityData *compat = ensureCompatInit();
+
+  // First, try without locking
+  // We can do a relaxed load of the pointer, because accessing the other data
+  // requires dereferencing the pointer, so would all be dependent reads.
+  auto *stereoGroupsData =
+      compat->stereoGroups.load(std::memory_order_relaxed);
+  if (stereoGroupsData != nullptr) {
+    return *stereoGroupsData;
+  }
+
+  std::lock_guard<std::mutex> lock_scope(compatibilityMutex);
+  // Check again after locking
+  stereoGroupsData = compat->stereoGroups.load(std::memory_order_relaxed);
+  if (stereoGroupsData != nullptr) {
+    return *stereoGroupsData;
+  }
+
+  // TODO: This approach of allocating a new std::vector<StereoGroup> after
+  // modification results in a varying address, whereas the previous interface
+  // had a persistent address across writes. Does this need to be preserved?
+  // See also setStereoGroups
+  stereoGroupsData = new std::vector<StereoGroup>();
+
+  if (stereoGroups.get() != nullptr) {
+    const std::vector<StereoGroupType> &types = stereoGroups->stereoTypes;
+    const std::vector<uint32_t> &atomIndices = stereoGroups->atoms;
+    const std::vector<uint32_t> &bondIndices = stereoGroups->bonds;
+    const std::vector<uint32_t> &atomBegins = stereoGroups->atomBegins;
+    const std::vector<uint32_t> &bondBegins = stereoGroups->bondBegins;
+
+    const size_t numGroups = stereoGroups->getNumGroups();
+    CHECK_INVARIANT(atomBegins.size() == numGroups + 1,
+                    "Atom begins must be size 1 + number of groups");
+    CHECK_INVARIANT(bondBegins.size() == numGroups + 1,
+                    "Bond begins must be size 1 + number of groups");
+
+    for (size_t i = 0; i < numGroups; i++) {
+      std::vector<Atom *> atomPtrs;
+      atomPtrs.reserve(atomBegins[i + 1] - atomBegins[i]);
+      for (size_t j = atomBegins[i]; j < atomBegins[i + 1]; j++) {
+        atomPtrs.push_back(compat->atoms[atomIndices[j]].get());
+      }
+      std::vector<Bond *> bondPtrs;
+      bondPtrs.reserve(bondBegins[i + 1] - bondBegins[i]);
+      for (size_t j = bondBegins[i]; j < bondBegins[i + 1]; j++) {
+        bondPtrs.push_back(compat->bonds[bondIndices[j]].get());
+      }
+      stereoGroupsData->emplace_back(types[i], std::move(atomPtrs),
+                                std::move(bondPtrs),
+                                stereoGroups->readIds[i]);
+      stereoGroupsData->back().setWriteId(stereoGroups->writeIds[i]);
+    }
+  }
+
+  // std::memory_order_release ensures that the other data has been written to
+  // memory before the pointer is written.
+  compat->stereoGroups.store(stereoGroupsData, std::memory_order_release);
+  return *stereoGroupsData;
+}
+
+void RDMol::copyFromCompatibilityData(const CompatibilityData *source,
+                                      bool quickCopy, int confId) {
+  if (source == nullptr) {
+    source = compatibilityData.load(std::memory_order_acquire);
+
+    if (source == nullptr) {
+      // Nothing to copy or clear
+      return;
+    }
+  }
+
+  // Copy back bookmarks. Bookmarks are all in CompatibilityData if it exists.
+  atomBookmarks.clear();
+  if (!quickCopy) {
+    atomBookmarks.reserve(source->atomBookmarks.size());
+    for (const auto &sourcePair : source->atomBookmarks) {
+      std::vector<int> atomIndices;
+      atomIndices.reserve(sourcePair.second.size());
+      for (const auto *atom : sourcePair.second) {
+            atomIndices.push_back(atom->getIdx());
+      }
+      atomBookmarks.insert(
+          std::make_pair(sourcePair.first, std::move(atomIndices)));
+    }
+  }
+  bondBookmarks.clear();
+  if (!quickCopy) {
+    bondBookmarks.reserve(source->bondBookmarks.size());
+    for (const auto &sourcePair : source->bondBookmarks) {
+      std::vector<int> bondIndices;
+      bondIndices.reserve(sourcePair.second.size());
+      for (const auto *bond : sourcePair.second) {
+            bondIndices.push_back(bond->getIdx());
+      }
+      bondBookmarks.insert(
+          std::make_pair(sourcePair.first, std::move(bondIndices)));
+    }
+  }
+
+  // Copy back bond stereo atoms.  Values are only in CompatibilityData for non-empty vectors.
+  // Any other values are expected to have been copied separately, if source is not owned by this.
+  PRECONDITION(source->bondStereoAtoms.size() == getNumBonds(), "CompatibilityData::bondStereoAtoms must have correct size for this RDMol");
+  for (uint32_t bondIndex = 0, numBonds = getNumBonds(); bondIndex < numBonds;
+       ++bondIndex) {
+    const auto &atoms = *source->bondStereoAtoms[bondIndex];
+    PRECONDITION(atoms.size() == 0 || atoms.size() == 2, "bondStereoAtoms must have either no atoms or 2 atoms");
+    if (atoms.size() == 2) {
+      BondData &bond = getBond(bondIndex);
+      bond.stereoAtoms[0] = atoms[0];
+      bond.stereoAtoms[1] = atoms[1];
+    }
+  }
+
+  // memory_order_acquire here is probably excessive, because no thread should
+  // be synchronizing conformers at the same time, but play it safe.
+  if (!quickCopy &&
+      source->conformerSyncStatus.load(std::memory_order_acquire) ==
+          CompatSyncStatus::lastUpdatedCompat) {
+    copyConformersFromCompatibilityData(source, confId);
+  }
+
+  if (source->ringInfoSyncStatus.load(std::memory_order_acquire) ==
+      CompatSyncStatus::lastUpdatedCompat) {
+    copyRingInfoFromCompatibilityData(*source->ringInfo, ringInfo,
+                                      getNumAtoms(), getNumBonds());
+  }
+
+  delete compatibilityData.load(std::memory_order_relaxed);
+  compatibilityData.store(nullptr, std::memory_order::memory_order_relaxed);
+}
+
+RDMol::RDMol(ROMol* existingPtr): RDMol() {
+  auto* dataCopy = new CompatibilityData(*this, existingPtr);
+  compatibilityData.store(dataCopy, std::memory_order_relaxed);
+}
+
+RDMol::RDMol(const RDMol &other, bool quickCopy, int confId, ROMol *existingPtr) {
+  initFromOther(other, quickCopy, confId, existingPtr);
+}
+
+RDMol::RDMol(const RDMol &other, bool quickCopy, int confId)
+    : RDMol(other, quickCopy, confId, nullptr) {}
+
+RDMol::RDMol(const RDMol &other, ROMol *existingPtr)
+    : RDMol(other, false, -1, existingPtr) {}
+
+RDMol::RDMol(const RDMol &other) : RDMol(other, false, -1, nullptr) {}
+
+RDMol &RDMol::operator=(const RDMol &other) {
+  if (this == &other) {
+    return *this;
+  }
+  atomData = other.atomData;
+  atomBondStarts = other.atomBondStarts;
+  otherAtomIndices = other.otherAtomIndices;
+  bondDataIndices = other.bondDataIndices;
+  bondData = other.bondData;
+  ringInfo = other.ringInfo;
+  numConformers = other.numConformers;
+  conformerAtomCapacity = other.conformerAtomCapacity;
+  conformerPositionData = other.conformerPositionData;
+  conformerIdsAndFlags = other.conformerIdsAndFlags;
+  substanceGroups = other.substanceGroups;
+  isStereochemDone = other.isStereochemDone;
+  properties = other.properties;
+  atomBookmarks = other.atomBookmarks;
+  bondBookmarks = other.bondBookmarks;
+
+  if (other.dp_delAtoms != nullptr) {
+    dp_delAtoms = std::make_unique<boost::dynamic_bitset<>>(*other.dp_delAtoms);
+    dp_delBonds = std::make_unique<boost::dynamic_bitset<>>(*other.dp_delBonds);
+  }
+
+  for (const auto &[key, value] : other.monomerInfo) {
+    monomerInfo[key] = std::unique_ptr<AtomMonomerInfo>(value->copy());
+  }
+
+  if (other.stereoGroups != nullptr) {
+    stereoGroups = std::make_unique<StereoGroups>(*other.stereoGroups);
+  }
+
+  delete compatibilityData.load(std::memory_order_relaxed);
+  compatibilityData.store(nullptr, std::memory_order_relaxed);
+  if (other.hasCompatibilityData()) {
+    copyFromCompatibilityData(other.getCompatibilityDataIfPresent());
+  }
+
+  for (auto &sg : substanceGroups) {
+    sg.setOwningMol(&asROMol());
+  }
+
+  return *this;
+}
+
+RDMol::RDMol(RDMol &&other) noexcept
+    : atomData(std::move(other.atomData)),
+      atomBondStarts(std::move(other.atomBondStarts)),
+      otherAtomIndices(std::move(other.otherAtomIndices)),
+      bondDataIndices(std::move(other.bondDataIndices)),
+      bondData(std::move(other.bondData)),
+      stereoGroups(std::move(other.stereoGroups)),
+      ringInfo(std::move(other.ringInfo)),
+      substanceGroups(std::move(other.substanceGroups)),
+      numConformers(other.numConformers),
+      conformerAtomCapacity(other.conformerAtomCapacity),
+      conformerPositionData(std::move(other.conformerPositionData)),
+      conformerIdsAndFlags(std::move(other.conformerIdsAndFlags)),
+      isStereochemDone(std::move(other.isStereochemDone)),
+      dp_delAtoms(std::move(other.dp_delAtoms)),
+      dp_delBonds(std::move(other.dp_delBonds)),
+      properties(std::move(other.properties)),
+      atomBookmarks(std::move(other.atomBookmarks)),
+      bondBookmarks(std::move(other.bondBookmarks)),
+      monomerInfo(std::move(other.monomerInfo))
+{
+  CompatibilityData *data =
+      other.compatibilityData.load(std::memory_order_relaxed);
+  if (data != nullptr) {
+    data->setNewOwner(*this);
+  }
+  compatibilityData.store(data, std::memory_order_relaxed);
+  other.compatibilityData.store(nullptr, std::memory_order_relaxed);
+}
+
+RDMol &RDMol::operator=(RDMol &&other) noexcept {
+  if (this == &other) {
+    return *this;
+  }
+
+  atomData = std::move(other.atomData);
+  atomBondStarts = std::move(other.atomBondStarts);
+  otherAtomIndices = std::move(other.otherAtomIndices);
+  bondDataIndices = std::move(other.bondDataIndices);
+  bondData = std::move(other.bondData);
+  stereoGroups = std::move(other.stereoGroups);
+  ringInfo = std::move(other.ringInfo);
+  substanceGroups = std::move(other.substanceGroups);
+  numConformers = other.numConformers;
+  conformerAtomCapacity = other.conformerAtomCapacity;
+  conformerPositionData = std::move(other.conformerPositionData);
+  conformerIdsAndFlags = std::move(other.conformerIdsAndFlags);
+  isStereochemDone = std::move(other.isStereochemDone);
+  dp_delAtoms = std::move(other.dp_delAtoms);
+  dp_delBonds = std::move(other.dp_delBonds);
+  properties = std::move(other.properties);
+  atomBookmarks = std::move(other.atomBookmarks);
+  bondBookmarks = std::move(other.bondBookmarks);
+  monomerInfo = std::move(other.monomerInfo);
+
+  delete compatibilityData.load(std::memory_order_relaxed);
+  CompatibilityData *data =
+      other.compatibilityData.load(std::memory_order_relaxed);
+  if (data != nullptr) {
+    data->setNewOwner(*this);
+  }
+  compatibilityData.store(data, std::memory_order_relaxed);
+  other.compatibilityData.store(nullptr, std::memory_order_relaxed);
+
+  return *this;
+}
+
+void RDMol::initFromOther(const RDMol &other, bool quickCopy, int confId, ROMol *existingPtr) {
+  atomData = other.atomData;
+  atomBondStarts = other.atomBondStarts;
+  otherAtomIndices = other.otherAtomIndices;
+  bondDataIndices = other.bondDataIndices;
+  bondData = other.bondData;
+  ringInfo = other.ringInfo;
+  if (other.atomQueries.size() != 0) {
+    atomQueries.reserve(other.atomQueries.size());
+    for (auto &&query : other.atomQueries) {
+      atomQueries.emplace_back((query != nullptr) ? query->copy() : nullptr);
+    }
+  }
+  if (other.bondQueries.size() != 0) {
+    bondQueries.reserve(other.bondQueries.size());
+    for (auto &&query : other.bondQueries) {
+      bondQueries.emplace_back((query != nullptr) ? query->copy() : nullptr);
+    }
+  }
+
+  if (other.stereoGroups != nullptr) {
+    stereoGroups = std::make_unique<StereoGroups>(*other.stereoGroups);
+  }
+
+  if (other.dp_delAtoms != nullptr) {
+    dp_delAtoms = std::make_unique<boost::dynamic_bitset<>>(*other.dp_delAtoms);
+    dp_delBonds = std::make_unique<boost::dynamic_bitset<>>(*other.dp_delBonds);
+  }
+
+  for (const auto &[key, value] : other.monomerInfo) {
+    monomerInfo[key] = std::unique_ptr<AtomMonomerInfo>(value->copy());
+  }
+
+  // This is currently only called in cases of construction or with quickCopy
+  // being false, so it's unclear what should happen to existing bookmarks and
+  // conformers if quickCopy is true, though the previous
+  // ROMol::initFromOther code did explicitly clear props.
+  PRECONDITION(
+      !quickCopy || (atomBookmarks.size() == 0 && bondBookmarks.size() == 0 &&
+                     numConformers == 0),
+      "RDMol::initFromOther wasn't designed for quickCopy over existing data");
+  if (quickCopy) {
+    properties.clear();
+  } else {
+    properties = other.properties;
+    atomBookmarks = other.atomBookmarks;
+    bondBookmarks = other.bondBookmarks;
+
+    if (confId < 0) {
+      // Copy all conformers
+      conformerIdsAndFlags = other.conformerIdsAndFlags;
+      conformerPositionData = other.conformerPositionData;
+      numConformers = other.numConformers;
+      conformerAtomCapacity = other.conformerAtomCapacity;
+    } else {
+      uint32_t index = other.numConformers;
+      try {
+        index = other.findConformerIndex(confId);
+      } catch (const ConformerException&) {
+        // Noop, matching ROMol behavior.
+      }
+      if (index != other.numConformers) {
+        allocateConformers(1, other.getNumAtoms());
+        const double *otherData = other.conformerPositionData.data() +
+                                  index * other.conformerAtomCapacity * 3;
+        std::copy(otherData, otherData + other.getNumAtoms() * 3, conformerPositionData.begin());
+        if (other.conformerIdsAndFlags.size() > 0 &&
+            (confId != 0 || !other.conformerIdsAndFlags[index].is3D)) {
+          conformerIdsAndFlags.push_back(other.conformerIdsAndFlags[index]);
+        }
+        numConformers = 1;
+      }
+    }
+  }
+
+  const CompatibilityData* otherCompat = other.getCompatibilityDataIfPresent();
+  const bool otherHasCompat = otherCompat != nullptr;
+  if (otherHasCompat) {
+    // The behaviour of quickCopy and confId above must match the behaviour
+    // in copyFromCompatibilityData
+    copyFromCompatibilityData(otherCompat, quickCopy, confId);
+  }
+
+  if (existingPtr) {
+    PRECONDITION(!hasCompatibilityData(), "Cannot create RDMol with existing ROMol pointer and compatibility data");
+    CompatibilityData *data = new CompatibilityData(*this, existingPtr);
+    existingPtr->dp_mol = this;
+    // Ensure the compatibility data is written out to main memory before the
+    // pointer to it (memory_order_release), in case another thread reads it
+    // before the cache is flushed.
+    compatibilityData.store(data, std::memory_order_release);
+  }
+
+  if (!quickCopy && other.substanceGroups.size() > 0) {
+    // If substance groups exist, instantiate after we have an ROMol pointer.
+    substanceGroups = other.substanceGroups;
+    ROMol* thisROMol = &asROMol();
+    for (auto &sg : substanceGroups) {
+      sg.setOwningMol(thisROMol);
+    }
+  }
+}
+
+PropArray::PropArray() {
+  size = 0;
+  family = PropertyType::CHAR;
+  data = nullptr;
+}
+
+PropArray::PropArray(uint32_t size, PropertyType family, bool isSet)
+    : size(size), family(family) {
+  construct(isSet);
+}
+
+namespace {
+
+constexpr bool is8BitType(PropertyType family) {
+  static_assert(sizeof(bool) == sizeof(char), "size assumption bool==char violated");
+  return family == PropertyType::CHAR || family == PropertyType::BOOL;
+}
+
+constexpr bool is32BitType(PropertyType family) {
+  static_assert(sizeof(float) == sizeof(int), "size assumption float==int violated");
+  return family == PropertyType::INT32 || family == PropertyType::UINT32 ||
+         family == PropertyType::FLOAT;
+}
+
+constexpr bool is64BitType(PropertyType family) {
+  static_assert(sizeof(double) == sizeof(int64_t), "size assumption double==int64_t violated");
+  return family == PropertyType::INT64 || family == PropertyType::UINT64 ||
+         family == PropertyType::DOUBLE;
+}
+
+}  // namespace
+
+
+PropArray::PropArray(const PropArray& other): PropArray(other.size, other.family, false) {
+  if (is8BitType(family)) {
+    std::copy(static_cast<char*>(other.data), static_cast<char*>(other.data) + size, static_cast<char*>(data));
+  } else if (is32BitType(family)) {
+    std::copy(static_cast<int32_t*>(other.data), static_cast<int32_t*>(other.data) + size, static_cast<int32_t*>(data));
+  } else if (is64BitType(family)) {
+    std::copy(static_cast<int64_t*>(other.data), static_cast<int64_t*>(other.data) + size, static_cast<int64_t*>(data));
+  } else {
+    for (uint32_t i = 0; i < size; ++i) {
+      copy_rdvalue(static_cast<RDValue*>(data)[i], static_cast<RDValue*>(other.data)[i]);
+    }
+  }
+  std::copy(other.isSetMask.get(), other.isSetMask.get() + size, isSetMask.get());
+  numSet = other.numSet;
+};
+
+PropArray& PropArray::operator=(const PropArray& other) {
+  if (this == &other) {
+    return *this;
+  }
+  if (size > 0) {
+    destroy();
+  }
+  size = other.size;
+  family = other.family;
+  construct(/*isSet=*/false);
+  isSetMask = std::make_unique<bool[]>(size);
+  std::copy(other.isSetMask.get(), other.isSetMask.get() + size, isSetMask.get());
+  numSet = other.numSet;
+  return *this;
+}
+
+PropArray::PropArray(PropArray&& other) {
+  size = other.size;
+  family = other.family;
+  data = other.data;
+  isSetMask = std::move(other.isSetMask);
+  numSet = other.numSet;
+  other.data = nullptr;
+  other.size = 0;
+}
+
+PropArray& PropArray::operator=(PropArray&& other) {
+  if (this == &other) {
+    return *this;
+  }
+  if (size > 0) {
+    destroy();
+  }
+  size = other.size;
+  family = other.family;
+  data = other.data;
+  isSetMask = std::move(other.isSetMask);
+  numSet = other.numSet;
+  other.data = nullptr;
+  other.size = 0;
+  return *this;
+}
+
+PropArray::~PropArray() noexcept {
+  destroy();
+}
+
+void PropArray::construct(bool isSet)  {
+  PRECONDITION(data == nullptr, "Constructing on existing data");
+  isSetMask = std::make_unique<bool[]>(size);
+  std::fill(isSetMask.get(), isSetMask.get() + size, isSet);
+  numSet = isSet ? size : 0;
+  if (is8BitType(family)) {
+    data = new char[size];
+  } else if (is32BitType(family)) {
+    data = new int32_t[size];
+  } else if (is64BitType(family)) {
+    data = new int64_t[size];
+  } else {
+    // These are default constructed
+    data = new RDValue[size];
+  }
+}
+
+void PropArray::destroy() {
+  if (is8BitType(family)) {
+    delete[] static_cast<char*>(data);
+  } else if (is32BitType(family)) {
+    delete[] static_cast<int32_t *>(data);
+  } else if (is64BitType(family)) {
+    delete[] static_cast<double*>(data);
+  } else {
+    for (uint32_t i = 0; i < size; ++i) {
+      RDValue::cleanup_rdvalue(static_cast<RDValue*>(data)[i]);
+    }
+    delete[] static_cast<RDValue*>(data);
+  }
+}
+
+RDValue PropArray::toRDValue(uint32_t idx) const {
+  PRECONDITION(data != nullptr, "Accessing null prop array");
+  switch (family) {
+    case PropertyType::CHAR:
+      return RDValue(static_cast<char*>(data)[idx]);
+    case PropertyType::BOOL:
+      return RDValue(static_cast<bool*>(data)[idx]);
+    case PropertyType::INT32:
+      return RDValue(static_cast<int32_t*>(data)[idx]);
+    case PropertyType::UINT32:
+      return RDValue(static_cast<uint32_t*>(data)[idx]);
+    case PropertyType::FLOAT:
+      return RDValue(static_cast<float*>(data)[idx]);
+    case PropertyType::INT64:
+      return RDValue(static_cast<int64_t*>(data)[idx]);
+    case PropertyType::UINT64:
+      return RDValue(static_cast<uint64_t*>(data)[idx]);
+    case PropertyType::DOUBLE:
+        return RDValue(static_cast<double*>(data)[idx]);
+    default:
+      RDValue res;
+      copy_rdvalue(res, static_cast<RDValue*>(data)[idx]);
+      return res;
+  }
+}
+
+
+void PropArray::appendElement() {
+  ++size;
+  std::unique_ptr<bool[]> newMask = std::make_unique<bool[]>(size);
+  std::copy(isSetMask.get(), isSetMask.get() + size - 1, newMask.get());
+  newMask[size - 1] = false;
+  isSetMask = std::move(newMask);
+  if (is8BitType(family)) {
+    auto *newData = new char[size];
+    std::copy(static_cast<char *>(data), static_cast<char *>(data) + size - 1,
+              newData);
+    delete[] static_cast<char *>(data);
+    data = newData;
+  } else if (is32BitType(family)) {
+    auto *newData = new int32_t[size];
+    std::copy(static_cast<int32_t *>(data),
+              static_cast<int32_t *>(data) + size - 1, newData);
+    delete[] static_cast<int32_t *>(data);
+    data = newData;
+  } else if (is64BitType(family)) {
+    auto *newData = new int64_t[size];
+    std::copy(static_cast<int64_t *>(data),
+              static_cast<int64_t *>(data) + size - 1, newData);
+    delete[] static_cast<int64_t *>(data);
+    data = newData;
+  } else {
+    auto *newData = new RDValue[size];
+    for (uint32_t i = 0; i < size - 1; ++i) {
+      RDValue* orig = static_cast<RDValue *>(data) + i;
+      // TODO: A move should be possible here.
+      copy_rdvalue(newData[i], *orig);
+      RDValue::cleanup_rdvalue(*orig);
+    }
+    newData[size - 1] = RDValue();
+    delete[] static_cast<RDValue*>(data);
+    data = newData;
+  }
+}
+
+void PropArray::removeElement(uint32_t index) {
+  URANGE_CHECK(index, size);
+
+  // Shift down isSetMask. Note that isSetMask is now at least one element larger
+  // than data, but this is never a problem. If elements are added instead of
+  // removed, the mask is recreated.
+  std::copy(isSetMask.get() + index + 1, isSetMask.get() + size,
+            isSetMask.get() + index);
+
+  if (is8BitType(family)) {
+    std::copy(static_cast<char*>(data) + index + 1, static_cast<char*>(data) + size, static_cast<char*>(data) + index);
+  } else if (is32BitType(family)) {
+    std::copy(static_cast<int32_t*>(data) + index + 1, static_cast<int32_t*>(data) + size, static_cast<int32_t*>(data) + index);
+  } else if (is64BitType(family)) {
+    std::copy(static_cast<int64_t *>(data) + index + 1,
+              static_cast<int64_t *>(data) + size,
+              static_cast<int64_t *>(data) + index);
+  } else {
+    auto* dataPtr = static_cast<RDValue*>(data);
+    for (uint32_t i = index + 1; i < size; ++i) {
+      copy_rdvalue(dataPtr[i - 1], dataPtr[i]);
+    }
+    RDValue::cleanup_rdvalue(dataPtr[size - 1]);
+  }
+  --size;
+}
+
+namespace {
+template<typename T>
+RDValue *convertToRDValueHelper(const T *data, bool *isSetMask, uint32_t size) {
+  RDValue *output = new RDValue[size];
+  for (uint32_t i = 0; i < size; ++i) {
+    if (isSetMask[i]) {
+      output[i] = RDValue(data[i]);
+    }
+  }
+  return output;
+}
+}
+
+void PropArray::convertToRDValue() {
+  if (family == PropertyType::ANY) {
+    return;
+  }
+  PRECONDITION(data != nullptr, "Accessing null prop array");
+  // This null value will never be used. It's to avoid uninitialized value warnings.
+  RDValue *newData = nullptr;
+  switch (family) {
+    case PropertyType::CHAR:
+      newData = convertToRDValueHelper(static_cast<char *>(data), isSetMask.get(), size);
+      break;
+    case PropertyType::BOOL:
+      newData = convertToRDValueHelper(static_cast<bool *>(data), isSetMask.get(), size);
+      break;
+    case PropertyType::INT32:
+      newData = convertToRDValueHelper(static_cast<int32_t *>(data), isSetMask.get(), size);
+      break;
+    case PropertyType::UINT32:
+      newData = convertToRDValueHelper(static_cast<uint32_t *>(data), isSetMask.get(), size);
+      break;
+    case PropertyType::FLOAT:
+      newData = convertToRDValueHelper(static_cast<float *>(data), isSetMask.get(), size);
+      break;
+    case PropertyType::INT64:
+      newData = convertToRDValueHelper(static_cast<int64_t *>(data), isSetMask.get(), size);
+      break;
+    case PropertyType::UINT64:
+      newData = convertToRDValueHelper(static_cast<uint64_t *>(data), isSetMask.get(), size);
+      break;
+    case PropertyType::DOUBLE:
+      newData = convertToRDValueHelper(static_cast<double *>(data), isSetMask.get(), size);
+      break;
+    default:
+      raiseNonImplementedDetail("Unsupported type in PropArray::convertToRDValue");
+  }
+  destroy();
+  data = newData;
+  family = PropertyType::ANY;
+}
+
+void StereoGroups::addGroup(StereoGroupType type, const std::vector<uint32_t>& atomIndices,
+                            const std::vector<uint32_t>& bondIndices, uint32_t readId) {
+  const uint32_t currentNumGroups = stereoTypes.size();
+  stereoTypes.push_back(type);
+  readIds.push_back(readId);
+  writeIds.push_back(undefinedGroupId);
+  const int atomBegin = atomBegins[currentNumGroups];
+  const int bondBegin = bondBegins[currentNumGroups];
+  atomBegins.push_back(atomBegin + atomIndices.size());
+  bondBegins.push_back(bondBegin + bondIndices.size());
+  atoms.insert(atoms.end(), atomIndices.begin(), atomIndices.end());
+  bonds.insert(bonds.end(), bondIndices.begin(), bondIndices.end());
+}
+
+bool StereoGroups::GroupsEq(uint32_t index1, uint32_t index2) {
+  URANGE_CHECK(index1, stereoTypes.size());
+  URANGE_CHECK(index2, stereoTypes.size());
+  if (stereoTypes[index1] != stereoTypes[index2]) {
+    return false;
+  }
+  // Note read and write IDs not part of comparison
+
+  const uint32_t atomBegin1 = atomBegins[index1];
+  const uint32_t atomEnd1 = atomBegins[index1 + 1];
+  const uint32_t atomBegin2 = atomBegins[index2];
+  const uint32_t atomEnd2 = atomBegins[index2 + 1];
+  if (atomEnd1 - atomBegin1 != atomEnd2 - atomBegin2) {
+    return false;
+  }
+
+  const uint32_t bondBegin1 = bondBegins[index1];
+  const uint32_t bondEnd1 = bondBegins[index1 + 1];
+  const uint32_t bondBegin2 = bondBegins[index2];
+  const uint32_t bondEnd2 = bondBegins[index2 + 1];
+  if (bondEnd1 - bondBegin1 != bondEnd2 - bondBegin2) {
+    return false;
+  }
+
+  return std::equal(atoms.begin() + atomBegin1, atoms.begin() + atomEnd1, atoms.begin() + atomBegin2) &&
+           std::equal(bonds.begin() + bondBegin1, bonds.begin() + bondEnd1, bonds.begin() + bondBegin2);
+}
+
+void StereoGroups::removeGroup(uint32_t groupIndex) {
+  URANGE_CHECK(groupIndex, stereoTypes.size());
+  const uint32_t atomBegin = atomBegins[groupIndex];
+  const uint32_t atomEnd = atomBegins[groupIndex + 1];
+  const uint32_t bondBegin = bondBegins[groupIndex];
+  const uint32_t bondEnd = bondBegins[groupIndex + 1];
+
+  const uint32_t numAtomsErased = atomEnd - atomBegin;
+  const uint32_t numBondsErased = bondEnd - bondBegin;
+
+  stereoTypes.erase(stereoTypes.begin() + groupIndex);
+  readIds.erase(readIds.begin() + groupIndex);
+  writeIds.erase(writeIds.begin() + groupIndex);
+  atomBegins.erase(atomBegins.begin() + groupIndex);
+  bondBegins.erase(bondBegins.begin() + groupIndex);
+
+  atoms.erase(atoms.begin() + atomBegin, atoms.begin() + atomEnd);
+  bonds.erase(bonds.begin() + bondBegin, bonds.begin() + bondEnd);
+
+  for (uint32_t j = groupIndex; j < atomBegins.size(); ++j) {
+    atomBegins[j] -= numAtomsErased;
+  }
+  for (uint32_t j = groupIndex; j < bondBegins.size(); ++j) {
+    bondBegins[j] -= numBondsErased;
+  }
+}
+
+namespace {
+template <typename T>
+void removeGroups(StereoGroups &groups, const T &keepPredicate) {
+  // Do a single pass to remove any groups, to avoid n^2 time
+  const uint32_t numGroups = groups.stereoTypes.size();
+  uint32_t runningNumGroups = 0;
+  uint32_t runningNumAtoms = 0;
+  uint32_t runningNumBonds = 0;
+  for (uint32_t i = 0; i < numGroups; i++) {
+    if (!keepPredicate(groups, i)) {
+      continue;
+    }
+
+    uint32_t beginNumAtoms = runningNumAtoms;
+    uint32_t beginNumBonds = runningNumBonds;
+
+    // Group is kept, so copy it to its new location
+    if (runningNumAtoms != groups.atomBegins[i]) {
+      for (uint32_t j = groups.atomBegins[i], end = groups.atomBegins[i + 1];
+           j < end; ++j) {
+            groups.atoms[runningNumAtoms] = groups.atoms[j];
+            ++runningNumAtoms;
+      }
+    } else {
+      runningNumAtoms = groups.atomBegins[i + 1];
+    }
+
+    if (runningNumBonds != groups.bondBegins[i]) {
+      for (uint32_t j = groups.bondBegins[i], end = groups.bondBegins[i + 1];
+           j < end; ++j) {
+            groups.bonds[runningNumBonds] = groups.bonds[j];
+            ++runningNumBonds;
+      }
+    } else {
+      runningNumBonds = groups.bondBegins[i + 1];
+    }
+
+    groups.atomBegins[runningNumGroups] = beginNumAtoms;
+    groups.bondBegins[runningNumGroups] = beginNumBonds;
+    groups.stereoTypes[runningNumGroups] = groups.stereoTypes[i];
+    groups.readIds[runningNumGroups] = groups.readIds[i];
+    groups.writeIds[runningNumGroups] = groups.writeIds[i];
+
+    ++runningNumGroups;
+  }
+
+  groups.atoms.resize(runningNumAtoms);
+  groups.bonds.resize(runningNumBonds);
+
+  groups.atomBegins[runningNumGroups] = runningNumAtoms;
+  groups.bondBegins[runningNumGroups] = runningNumBonds;
+  groups.atomBegins.resize(runningNumGroups + 1);
+  groups.bondBegins.resize(runningNumGroups + 1);
+  groups.stereoTypes.resize(runningNumGroups);
+  groups.readIds.resize(runningNumGroups);
+  groups.writeIds.resize(runningNumGroups);
+}
+}  // namespace
+
+void StereoGroups::removeAtomFromGroups(uint32_t atomIndex, bool decrementIndices) {
+  const uint32_t numGroups = stereoTypes.size();
+  uint32_t runningNumAtoms = 0;
+  for (uint32_t i = 0; i < numGroups; i++) {
+    const uint32_t atomBegin = atomBegins[i];
+    const uint32_t atomEnd = atomBegins[i + 1];
+
+    // set atomBegins again now that we've stored the previous value.
+    atomBegins[i] = runningNumAtoms;
+
+    for (uint32_t j = atomBegin; j < atomEnd; ++j) {
+      if (atoms[j] != atomIndex) {
+        atoms[runningNumAtoms] = atoms[j];
+        if (decrementIndices && atoms[j] > atomIndex) {
+          atoms[runningNumAtoms]--;
+        }
+        ++runningNumAtoms;
+      }
+    }
+  }
+  atomBegins[numGroups] = runningNumAtoms;
+  atoms.resize(runningNumAtoms);
+
+  // Remove groups with no atoms
+  removeGroups(*this, [](const StereoGroups &groups, uint32_t i) {
+    return groups.atomBegins[i] != groups.atomBegins[i + 1];
+  });
+}
+
+void StereoGroups::removeGroupsWithAtom(const uint32_t atomIndex) {
+  removeGroups(*this, [atomIndex](const StereoGroups &groups, uint32_t i) {
+    const uint32_t atomBegin = groups.atomBegins[i];
+    const uint32_t atomEnd = groups.atomBegins[i + 1];
+    for (uint32_t j = atomBegin; j < atomEnd; ++j) {
+      if (groups.atoms[j] == atomIndex) {
+        return false;
+      }
+    }
+    return true;
+  });
+}
+
+void StereoGroups::removeGroupsWithAtoms(const std::vector<uint32_t>& atomIndices) {
+  removeGroups(*this, [&atomIndices](const StereoGroups &groups, uint32_t i) {
+    const uint32_t atomBegin = groups.atomBegins[i];
+    const uint32_t atomEnd = groups.atomBegins[i + 1];
+    for (uint32_t j = atomBegin; j < atomEnd; ++j) {
+      if (std::find(atomIndices.begin(), atomIndices.end(), groups.atoms[j]) !=
+          atomIndices.end()) {
+        return false;
+      }
+    }
+    return true;
+  });
+}
+
+void StereoGroups::removeGroupsWithBond(const uint32_t bondIndex) {
+  removeGroups(*this, [bondIndex](const StereoGroups &groups, uint32_t i) {
+    const uint32_t bondBegin = groups.bondBegins[i];
+    const uint32_t bondEnd = groups.bondBegins[i + 1];
+    for (uint32_t j = bondBegin; j < bondEnd; ++j) {
+      if (groups.bonds[j] == bondIndex) {
+        return false;
+      }
+    }
+    return true;
+  });
+}
+
+void StereoGroups::removeGroupsWithBonds(const std::vector<uint32_t>& bondIndices) {
+  removeGroups(*this, [&bondIndices](const StereoGroups &groups, uint32_t i) {
+    const uint32_t bondBegin = groups.bondBegins[i];
+    const uint32_t bondEnd = groups.bondBegins[i + 1];
+    for (uint32_t j = bondBegin; j < bondEnd; ++j) {
+      if (std::find(bondIndices.begin(), bondIndices.end(), groups.bonds[j]) !=
+          bondIndices.end()) {
+        return false;
+      }
+    }
+    return true;
+  });
+}
+
+// Stero group ID assignment adapted directly from StereoGroup.cpp
+namespace {
+void storeIdsInUse(boost::dynamic_bitset<> &ids, unsigned int& groupId) {
+  if (groupId == StereoGroups::undefinedGroupId) {
+    return;
+  } else if (groupId >= ids.size()) {
+    ids.resize(groupId + 1);
+  }
+  if (ids[groupId]) {
+    // This id is duplicate, let's reset it so we can reassign it later
+    BOOST_LOG(rdWarningLog)
+        << "StereoGroup ID " << groupId
+        << " is used by more than one group, and will be reassigned"
+        << std::endl;
+    groupId = 0;
+  } else {
+    ids[groupId] = true;
+  }
+};
+
+void assignMissingIds(const boost::dynamic_bitset<> &ids, unsigned &nextId, unsigned& groupId) {
+  if (groupId == StereoGroups::undefinedGroupId) {
+    ++nextId;
+    while (nextId < ids.size() && ids[nextId]) {
+      ++nextId;
+    }
+    groupId = nextId;
+  }
+};
+}  // namespace
+
+void StereoGroups::assignStereoGroupIds() {
+  if (getNumGroups() == 0) {
+    return;
+  }
+
+  boost::dynamic_bitset<> andIds;
+  boost::dynamic_bitset<> orIds;
+
+  for (uint32_t i = 0; i < stereoTypes.size(); i++) {
+    const StereoGroupType groupType = stereoTypes[i];
+    if (groupType == StereoGroupType::STEREO_AND) {
+      storeIdsInUse(andIds, writeIds[i]);
+    } else if (groupType== StereoGroupType::STEREO_OR) {
+      storeIdsInUse(orIds, writeIds[i]);
+    }
+  }
+
+  unsigned andId = undefinedGroupId;
+  unsigned orId = undefinedGroupId;
+  for (uint32_t i = 0; i < stereoTypes.size(); i++) {
+    const StereoGroupType groupType = stereoTypes[i];
+    if (groupType == StereoGroupType::STEREO_AND) {
+      assignMissingIds(andIds, andId, writeIds[i]);
+    } else if (groupType == StereoGroupType::STEREO_OR) {
+      assignMissingIds(orIds, orId, writeIds[i]);
+    }
+  }
+}
+
+void StereoGroups::forwardStereoGroupIds(){
+  for (uint32_t i = 0; i < stereoTypes.size(); i++) {
+    writeIds[i] = readIds[i];
+  }
+}
+
+RDMol::~RDMol() {
+  // This is needed because default destruction wouldn't delete
+  // compatibilityData.
+  clear();
+}
+
+void RDMol::clear() {
+  atomData.resize(0);
+  atomBondStarts.resize(0);
+  otherAtomIndices.resize(0);
+  bondDataIndices.resize(0);
+  bondData.resize(0);
+  stereoGroups.reset();
+  ringInfo.reset();
+  substanceGroups.clear();
+  numConformers = 0;
+  conformerAtomCapacity = 0;
+  conformerPositionData.clear();
+  conformerIdsAndFlags.clear();
+  atomQueries.resize(0);
+  bondQueries.resize(0);
+  isStereochemDone = false;
+  delete compatibilityData.load(std::memory_order_relaxed);
+  compatibilityData.store(nullptr, std::memory_order_relaxed);
+  properties.resize(0);
+  atomBookmarks.clear();
+  bondBookmarks.clear();
+  monomerInfo.clear();
+}
+
+namespace {
+
+unsigned int getEffectiveAtomicNum(const AtomData &atom, bool checkValue,
+                                   const atomindex_t atomIndex) {
+  auto effectiveAtomicNum =
+      static_cast<int>(atom.getAtomicNum()) - atom.getFormalCharge();
+  if (checkValue &&
+      (effectiveAtomicNum < 0 ||
+       effectiveAtomicNum >
+           static_cast<int>(PeriodicTable::getTable()->getMaxAtomicNumber()))) {
+    throw AtomValenceException("Effective atomic number out of range",
+                               atomIndex);
+  }
+  effectiveAtomicNum = std::clamp(
+      effectiveAtomicNum, 0,
+      static_cast<int>(PeriodicTable::getTable()->getMaxAtomicNumber()));
+  return static_cast<unsigned int>(effectiveAtomicNum);
+}
+
+bool canBeHypervalent(const AtomData &atom, unsigned int effectiveAtomicNum) {
+  return (effectiveAtomicNum > 16 &&
+          (atom.getAtomicNum() == 15 || atom.getAtomicNum() == 16)) ||
+         (effectiveAtomicNum > 34 &&
+          (atom.getAtomicNum() == 33 || atom.getAtomicNum() == 34));
+}
+
+}  // namespace
+
+int RDMol::calculateExplicitValence(atomindex_t atomIndex, bool strict,
+                                    bool checkIt) const {
+  const AtomData &atom = getAtom(atomIndex);
+
+  // FIX: contributions of bonds to valence are being done at best
+  // approximately
+  uint32_t accumx2 = 0;
+  accumx2 += 2 * atom.getNumExplicitHs();
+  if (getNumBonds() > 0) {
+    auto [atomBondBegin, atomBondEnd] = getAtomBonds(atomIndex);
+    for (; atomBondBegin != atomBondEnd; ++atomBondBegin) {
+      const BondData &bond = getBond(*atomBondBegin);
+      accumx2 += bond.getTwiceValenceContrib(atomIndex);
+    }
+  }
+
+  const auto &ovalens =
+      PeriodicTable::getTable()->getValenceList(atom.getAtomicNum());
+  // if we start with an atom that doesn't have specified valences, we stick
+  // with that. otherwise we will use the effective valence
+  unsigned int effectiveAtomicNum = atom.getAtomicNum();
+  if (ovalens.size() > 1 || ovalens[0] != -1) {
+    effectiveAtomicNum = getEffectiveAtomicNum(atom, checkIt, atomIndex);
+  }
+  unsigned int dv =
+      PeriodicTable::getTable()->getDefaultValence(effectiveAtomicNum);
+  const auto &valens =
+      PeriodicTable::getTable()->getValenceList(effectiveAtomicNum);
+  if (accumx2 > 2 * dv && isAromaticAtom(atomIndex)) {
+    // this needs some explanation : if the atom is aromatic and
+    // accum > dv we assume that no hydrogen can be added
+    // to this atom.  We set x = (v + chr) such that x is the
+    // closest possible integer to "accum" but less than
+    // "accum".
+    //
+    // "v" here is one of the allowed valences. For example:
+    //    sulfur here : O=c1ccs(=O)cc1
+    //    nitrogen here : c1cccn1C
+
+    int pval = dv;
+    for (auto val : valens) {
+      if (val == -1) {
+        break;
+      }
+      if (2 * val > int(accumx2)) {
+        break;
+      } else {
+        pval = val;
+      }
+    }
+    // if we're within 1.5 of the allowed valence, go ahead and take it.
+    // this reflects things like the N in c1cccn1C, which starts with
+    // accum of 4, but which can be kekulized to C1=CC=CN1C, where
+    // the valence is 3 or the bridging N in c1ccn2cncc2c1, which starts
+    // with a valence of 4.5, but can be happily kekulized down to a valence
+    // of 3
+    if (accumx2 - 2 * pval <= 3) {
+      accumx2 = 2 * pval;
+    }
+  }
+  // despite promising to not to blame it on him - this a trick Greg
+  // came up with: if we have a bond order sum of x.5 (i.e. 1.5, 2.5
+  // etc) we would like it to round to the higher integer value --
+  // 2.5 to 3 instead of 2 -- so we will add 1 to accumx2.
+  // this plays a role in the number of hydrogen that are implicitly
+  // added. This will only happen when the accum is a non-integer
+  // value and less than the default valence (otherwise the above if
+  // statement should have caught it). An example of where this can
+  // happen is the following smiles:
+  //    C1ccccC1
+  // Daylight accepts this smiles and we should be able to Kekulize
+  // correctly.
+  uint32_t res = (accumx2 + 1) / 2;
+
+  if (strict || checkIt) {
+    int maxValence = valens.back();
+    int offset = 0;
+    // we have to include a special case here for negatively charged P, S, As,
+    // and Se, which all support "hypervalent" forms, but which can be
+    // isoelectronic to Cl/Ar or Br/Kr, which do not support hypervalent forms.
+    if (canBeHypervalent(atom, effectiveAtomicNum)) {
+      maxValence = ovalens.back();
+      offset -= atom.getFormalCharge();
+    }
+    // we have historically accepted two-coordinate [H-] as a valid atom. This
+    // is highly questionable, but changing it requires some thought. For now we
+    // will just keep accepting it
+    if (atom.getAtomicNum() == 1 && atom.getFormalCharge() == -1) {
+      maxValence = 2;
+    }
+    // maxValence == -1 signifies that we'll take anything at the high end
+    if (maxValence >= 0 && ovalens.back() >= 0 && (res + offset) > maxValence) {
+      // the explicit valence is greater than any
+      // allowed valence for the atoms
+
+      if (strict) {
+        // raise an error
+        std::ostringstream errout;
+        errout << "Explicit valence for atom # " << atomIndex << " "
+               << PeriodicTable::getTable()->getElementSymbol(
+                      atom.getAtomicNum())
+               << ", " << res << ", is greater than permitted";
+        std::string msg = errout.str();
+        BOOST_LOG(rdErrorLog) << msg << std::endl;
+        throw AtomValenceException(msg, atomIndex);
+      } else {
+        return -1;
+      }
+    }
+  }
+  return res;
+}
+
+// NOTE: this uses the explicitValence, so it will call
+// calculateExplicitValence if it is not set on the given atom
+int RDMol::calculateImplicitValence(atomindex_t atomIndex, bool strict,
+                                    bool checkIt) const {
+  const AtomData &atom = getAtom(atomIndex);
+  if (atom.noImplicit) {
+    return 0;
+  }
+  auto explicitValence = atom.explicitValence;
+  if (explicitValence == AtomData::unsetValenceVal) {
+    explicitValence = calculateExplicitValence(atomIndex, strict, checkIt);
+  }
+  // special cases
+  auto atomicNum = atom.getAtomicNum();
+  if (atomicNum == 0) {
+    return 0;
+  }
+  for (auto [begin, end] = getAtomBonds(atomIndex); begin != end; ++begin) {
+    if (QueryOps::hasComplexBondTypeQuery(ConstRDMolBond(this, *begin))) {
+      return 0;
+    }
+  }
+
+  auto formalCharge = atom.getFormalCharge();
+  auto numRadicalElectrons = atom.getNumRadicalElectrons();
+  if (explicitValence == 0 && numRadicalElectrons == 0 && atomicNum == 1) {
+    if (formalCharge == 1 || formalCharge == -1) {
+      return 0;
+    } else if (formalCharge == 0) {
+      return 1;
+    } else {
+      if (strict) {
+        std::ostringstream errout;
+        errout << "Unreasonable formal charge on atom # " << atomIndex << ".";
+        std::string msg = errout.str();
+        BOOST_LOG(rdErrorLog) << msg << std::endl;
+        throw AtomValenceException(msg, atomIndex);
+      } else if (checkIt) {
+        return -1;
+      } else {
+        return 0;
+      }
+    }
+  }
+  int explicitPlusRadV = atom.explicitValence + atom.getNumRadicalElectrons();
+
+  const auto &ovalens = PeriodicTable::getTable()->getValenceList(atomicNum);
+  // if we start with an atom that doesn't have specified valences, we stick
+  // with that. otherwise we will use the effective valence for the rest of
+  // this.
+  unsigned int effectiveAtomicNum = atomicNum;
+  if (ovalens.size() > 1 || ovalens[0] != -1) {
+    effectiveAtomicNum = getEffectiveAtomicNum(atom, checkIt, atomIndex);
+  }
+  if (effectiveAtomicNum == 0) {
+    return 0;
+  }
+
+  // this is basically the difference between the allowed valence of
+  // the atom and the explicit valence already specified - tells how
+  // many Hs to add
+  //
+
+  // The d-block and f-block of the periodic table (i.e. transition metals,
+  // lanthanoids and actinoids) have no default valence.
+  int dv = PeriodicTable::getTable()->getDefaultValence(effectiveAtomicNum);
+  if (dv == -1) {
+    return 0;
+  }
+
+  // here is how we are going to deal with the possibility of
+  // multiple valences
+  // - check the explicit valence "ev"
+  // - if it is already equal to one of the allowed valences for the
+  //    atom return 0
+  // - otherwise take return difference between next larger allowed
+  //   valence and "ev"
+  // if "ev" is greater than all allowed valences for the atom raise an
+  // exception
+  // finally aromatic cases are dealt with differently - these atoms are allowed
+  // only default valences
+
+  // we have to include a special case here for negatively charged P, S, As,
+  // and Se, which all support "hypervalent" forms, but which can be
+  // isoelectronic to Cl/Ar or Br/Kr, which do not support hypervalent forms.
+  if (canBeHypervalent(atom, effectiveAtomicNum)) {
+    effectiveAtomicNum = atomicNum;
+    explicitPlusRadV -= formalCharge;
+  }
+  const auto &valens =
+      PeriodicTable::getTable()->getValenceList(effectiveAtomicNum);
+
+  int res = 0;
+  // if we have an aromatic case treat it differently
+  if (isAromaticAtom(atomIndex)) {
+    if (explicitPlusRadV <= dv) {
+      res = dv - explicitPlusRadV;
+    } else {
+      // As we assume when finding the explicitPlusRadValence if we are
+      // aromatic we should not be adding any hydrogen and already
+      // be at an accepted valence state,
+
+      // FIX: this is just ERROR checking and probably moot - the
+      // explicitPlusRadValence function called above should assure us that
+      // we satisfy one of the accepted valence states for the
+      // atom. The only diff I can think of is in the way we handle
+      // formal charge here vs the explicit valence function.
+      bool satis = false;
+      for (auto vi = valens.begin(); vi != valens.end() && *vi > 0; ++vi) {
+        if (explicitPlusRadV == *vi) {
+          satis = true;
+          break;
+        }
+      }
+      if (!satis && (strict || checkIt)) {
+        if (strict) {
+          std::ostringstream errout;
+          errout << "Explicit valence for aromatic atom # " << atomIndex
+                 << " not equal to any accepted valence\n";
+          std::string msg = errout.str();
+          BOOST_LOG(rdErrorLog) << msg << std::endl;
+          throw AtomValenceException(msg, atomIndex);
+        } else {
+          return -1;
+        }
+      }
+      res = 0;
+    }
+  } else {
+    // non-aromatic case we are allowed to have non default valences
+    // and be able to add hydrogens
+    res = -1;
+    for (auto vi = valens.begin(); vi != valens.end() && *vi >= 0; ++vi) {
+      int tot = *vi;
+      if (explicitPlusRadV <= tot) {
+        res = tot - explicitPlusRadV;
+        break;
+      }
+    }
+    if (res < 0) {
+      if ((strict || checkIt) && valens.back() != -1 && ovalens.back() > 0) {
+        // this means that the explicit valence is greater than any
+        // allowed valence for the atoms
+        if (strict) {
+          // raise an error
+          std::ostringstream errout;
+          errout << "Explicit valence for atom # " << atomIndex << " "
+                 << PeriodicTable::getTable()->getElementSymbol(atomicNum)
+                 << " greater than permitted";
+          std::string msg = errout.str();
+          BOOST_LOG(rdErrorLog) << msg << std::endl;
+          throw AtomValenceException(msg, atomIndex);
+        } else {
+          return -1;
+        }
+      } else {
+        res = 0;
+      }
+    }
+  }
+  return res;
+}
+
+uint32_t RDMol::calcExplicitValence(atomindex_t atomIndex, bool strict) {
+  bool checkIt = false;
+  AtomData &atom = getAtom(atomIndex);
+  atom.explicitValence = calculateExplicitValence(atomIndex, strict, checkIt);
+  return atom.explicitValence;
+}
+
+uint32_t RDMol::calcImplicitValence(atomindex_t atomIndex, bool strict) {
+  AtomData &atom = getAtom(atomIndex);
+  if (atom.explicitValence == AtomData::unsetValenceVal) {
+    calcExplicitValence(atomIndex, strict);
+  }
+  bool checkIt = false;
+  atom.implicitValence = calculateImplicitValence(atomIndex, strict, checkIt);
+  return atom.implicitValence;
+}
+
+bool RDMol::hasValenceViolation(atomindex_t atomIndex) const {
+  // Ignore dummy atoms, query atoms, or atoms attached to query bonds
+  auto [begin, end] = getAtomBonds(atomIndex);
+  auto is_query = [this](auto b) { return hasBondQuery(b); };
+  const AtomData &atom = getAtom(atomIndex);
+  auto atomicNum = atom.getAtomicNum();
+  if (atomicNum == 0 || hasAtomQuery(atomIndex) ||
+      std::any_of(begin, end, is_query)) {
+    return false;
+  }
+
+  unsigned int effectiveAtomicNum;
+  try {
+    bool checkIt = true;
+    effectiveAtomicNum = getEffectiveAtomicNum(atom, checkIt, atomIndex);
+  } catch (const AtomValenceException &) {
+    return true;
+  }
+
+  // special case for H:
+  if (atomicNum == 1) {
+    if (atom.getFormalCharge() > 1 || atom.getFormalCharge() < -1) {
+      return true;
+    }
+  } else {
+    // Non-H checks for absurd charge values:
+    //   1. the formal charge is larger than the atomic number
+    //   2. the formal charge moves us to a different row of the periodic table
+    if (atom.getFormalCharge() > atomicNum ||
+        PeriodicTable::getTable()->getRow(atomicNum) !=
+            PeriodicTable::getTable()->getRow(effectiveAtomicNum)) {
+      return true;
+    }
+  }
+
+  bool strict = false;
+  bool checkIt = true;
+  if (calculateExplicitValence(atomIndex, strict, checkIt) == -1 ||
+      calculateImplicitValence(atomIndex, strict, checkIt) == -1) {
+    return true;
+  }
+  return false;
+}
+
+// These are copied from Atom.cpp
+static const unsigned char octahedral_invert[31] = {
+    0,   //  0 -> 0
+    2,   //  1 -> 2
+    1,   //  2 -> 1
+    16,  //  3 -> 16
+    14,  //  4 -> 14
+    15,  //  5 -> 15
+    18,  //  6 -> 18
+    17,  //  7 -> 17
+    10,  //  8 -> 10
+    11,  //  9 -> 11
+    8,   // 10 -> 8
+    9,   // 11 -> 9
+    13,  // 12 -> 13
+    12,  // 13 -> 12
+    4,   // 14 -> 4
+    5,   // 15 -> 5
+    3,   // 16 -> 3
+    7,   // 17 -> 7
+    6,   // 18 -> 6
+    24,  // 19 -> 24
+    23,  // 20 -> 23
+    22,  // 21 -> 22
+    21,  // 22 -> 21
+    20,  // 23 -> 20
+    19,  // 24 -> 19
+    30,  // 25 -> 30
+    29,  // 26 -> 29
+    28,  // 27 -> 28
+    27,  // 28 -> 27
+    26,  // 29 -> 26
+    25   // 30 -> 25
+};
+
+static const unsigned char trigonalbipyramidal_invert[21] = {
+    0,   //  0 -> 0
+    2,   //  1 -> 2
+    1,   //  2 -> 1
+    4,   //  3 -> 4
+    3,   //  4 -> 3
+    6,   //  5 -> 6
+    5,   //  6 -> 5
+    8,   //  7 -> 8
+    7,   //  8 -> 7
+    11,  //  9 -> 11
+    12,  // 10 -> 12
+    9,   // 11 -> 9
+    10,  // 12 -> 10
+    14,  // 13 -> 14
+    13,  // 14 -> 13
+    20,  // 15 -> 20
+    19,  // 16 -> 19
+    18,  // 17 -> 28
+    17,  // 18 -> 17
+    16,  // 19 -> 16
+    15   // 20 -> 15
+};
+
+bool RDMol::invertAtomChirality(atomindex_t atomIndex) {
+  AtomData &atom = getAtom(atomIndex);
+  using AtomEnums::ChiralType;
+  const ChiralType type = atom.getChiralTag();
+  if (type == ChiralType::CHI_TETRAHEDRAL_CW) {
+    atom.setChiralTag(ChiralType::CHI_TETRAHEDRAL_CCW);
+    return true;
+  }
+  if (type == ChiralType::CHI_TETRAHEDRAL_CCW) {
+    atom.setChiralTag(ChiralType::CHI_TETRAHEDRAL_CW);
+    return true;
+  }
+  uint32_t *permProp = getAtomPropArrayIfPresent<uint32_t>(common_properties::_chiralPermutationToken);
+  if (permProp == nullptr) {
+    return false;
+  }
+
+  uint32_t perm = permProp[atomIndex];
+  switch (type) {
+    case ChiralType::CHI_TETRAHEDRAL:
+      if (perm == 1) {
+        perm = 2;
+      } else if (perm == 2) {
+        perm = 1;
+      } else {
+        perm = 0;
+      }
+      permProp[atomIndex] = perm;
+      return perm != 0;
+    case ChiralType::CHI_TRIGONALBIPYRAMIDAL:
+      perm = (perm <= 20) ? trigonalbipyramidal_invert[perm] : 0;
+      permProp[atomIndex] = perm;
+      return perm != 0;
+    case ChiralType::CHI_OCTAHEDRAL:
+      perm = (perm <= 30) ? octahedral_invert[perm] : 0;
+      permProp[atomIndex] = perm;
+      return perm != 0;
+    default:
+      break;
+  }
+  return false;
+}
+
+void RDMol::clearComputedProps(bool includeRings) {
+  // the SSSR information:
+  if (includeRings) {
+    ringInfo.reset();
+  }
+
+  // Clear "computed" properties
+  size_t destPropIndex = 0;
+  for (size_t sourcePropIndex = 0, numProps = properties.size();
+       sourcePropIndex < numProps; ++sourcePropIndex) {
+    if (!properties[sourcePropIndex].isComputed) {
+      if (destPropIndex != sourcePropIndex) {
+        properties[destPropIndex] = std::move(properties[sourcePropIndex]);
+      }
+      ++destPropIndex;
+    }
+  }
+  if (destPropIndex != properties.size()) {
+    properties.resize(destPropIndex);
+  }
+}
+
+std::vector<std::string> RDMol::getPropList(bool includePrivate,
+                                            bool includeComputed, Scope scope,
+                                            uint32_t index) const {
+  PRECONDITION(scope == Scope::MOL || index == PropIterator::anyIndexMarker ||
+                   (scope == Scope::ATOM && index < getNumAtoms()) ||
+                   (scope == Scope::BOND && index < getNumBonds()),
+               "RDMol::getPropList index out of range");
+  std::vector<std::string> res;
+  for (const auto &prop : properties) {
+    if (prop.scope != scope) {
+      continue;
+    }
+    if (scope != Scope::MOL && index != PropIterator::anyIndexMarker && !prop.arrayData.isSetMask[index]) {
+      continue;
+    }
+    if (!includeComputed && prop.isComputed) {
+      continue;
+    }
+    const std::string &name = prop.name.getString();
+    if (!includePrivate && name[0] == '_') {
+      continue;
+    }
+    res.push_back(name);
+  }
+  return res;
+}
+
+
+void RDMol::clearProps() {
+  properties.clear();
+}
+
+void RDMol::copyProp(const PropToken &destinationName, const RDMol &sourceMol,
+                     const PropToken &sourceName, Scope scope) {
+  PRECONDITION(
+      scope == Scope::MOL ||
+          (scope == Scope::ATOM && getNumAtoms() == sourceMol.getNumAtoms()) ||
+          (scope == Scope::BOND && getNumBonds() == sourceMol.getNumBonds()),
+      "Atom or bond counts must match in RDMol::copyProp");
+  const auto *sourceProp = sourceMol.findProp(sourceName, scope);
+  PRECONDITION(sourceProp != nullptr, "Source property missing in RDMol::copyProp");
+  if (!sourceProp) {
+    return;
+  }
+  auto *existingDestProp = findProp(destinationName, scope);
+  if (existingDestProp != nullptr) {
+    // No need to copy to self
+    if (existingDestProp != sourceProp) {
+      // Overwrite existing
+      *existingDestProp = *sourceProp;
+    }
+    return;
+  }
+  auto& destProp = properties.emplace_back(*sourceProp);
+  destProp.name = destinationName;
+}
+
+void RDMol::copySingleProp(const PropToken &destinationName,
+    uint32_t destinationIndex, const RDMol& sourceMol,
+    const PropToken& sourceName, uint32_t sourceIndex, Scope scope) {
+  PRECONDITION(scope != Scope::MOL, "RDMol::copyPropSingleIndex doesn't support molecule scope");
+  PRECONDITION(
+      (scope == Scope::ATOM && sourceIndex < sourceMol.getNumAtoms() &&
+       destinationIndex < getNumAtoms()) ||
+          (scope == Scope::BOND && sourceIndex < sourceMol.getNumBonds() &&
+           destinationIndex < getNumBonds()),
+      "atom or bond indices must be in bounds in RDMol::copyPropSingleIndex");
+  const auto *sourceProp = sourceMol.findProp(sourceName, scope);
+  PRECONDITION(sourceProp != nullptr,
+               "Source property missing in RDMol::copyProp");
+
+  auto *destProp = findProp(destinationName, scope);
+  if (destProp == nullptr) {
+    destProp = &properties.emplace_back();
+    destProp->name = destinationName;
+    destProp->isComputed = sourceProp->isComputed;
+    destProp->scope = scope;
+    uint32_t destSize = (scope == Scope::ATOM) ? getNumAtoms() : getNumBonds();
+    destProp->arrayData = PropArray(destSize, sourceProp->arrayData.family, false);
+  } else if (sourceProp->arrayData.family != destProp->arrayData.family) {
+    // Convert to RDValue to support type mismatch
+    if (destProp->arrayData.family != PropertyType::ANY) {
+      destProp->arrayData.convertToRDValue();
+    }
+    PRECONDITION(destProp->arrayData.family == PropertyType::ANY,
+                 "convertToRDValue should make family ANY");
+    destProp->isComputed = sourceProp->isComputed;
+    auto *destData = static_cast<RDValue *>(destProp->arrayData.data);
+    RDValue::cleanup_rdvalue(destData[destinationIndex]);
+    static_cast<RDValue *>(destData)[destinationIndex] =
+        sourceProp->arrayData.getValueAs<RDValue>(sourceIndex);
+    return;
+  }
+
+  // Copy directly
+  destProp->isComputed = sourceProp->isComputed;
+  auto family = sourceProp->arrayData.family;
+  const auto *sourceData = sourceProp->arrayData.data;
+  auto *destData = destProp->arrayData.data;
+  if (is8BitType(family)) {
+    static_cast<char *>(destData)[destinationIndex] =
+        static_cast<const char *>(sourceData)[sourceIndex];
+  } else if (is32BitType(family)) {
+    static_cast<int32_t *>(destData)[destinationIndex] =
+        static_cast<const int32_t *>(sourceData)[sourceIndex];
+  } else if (is64BitType(family)) {
+    static_cast<int64_t *>(destData)[destinationIndex] =
+        static_cast<const int64_t *>(sourceData)[sourceIndex];
+  } else {
+    copy_rdvalue(static_cast<RDValue *>(destData)[destinationIndex],
+                 static_cast<const RDValue *>(sourceData)[sourceIndex]);
+  }
+  bool &isSet = destProp->arrayData.isSetMask[destinationIndex];
+  if (!isSet) {
+    isSet = true;
+    ++destProp->arrayData.numSet;
+  }
+}
+
+bool RDMol::hasProp(const PropToken& name) const {
+  return findProp(name, Scope::MOL) != nullptr;
+}
+
+bool RDMol::hasAtomProp(const PropToken& name, const std::uint32_t index) const {
+    const Property* prop = findProp(name, Scope::ATOM);
+    if (prop == nullptr) {
+        return false;
+    }
+    return prop->arrayData.isSetMask[index];
+}
+
+bool RDMol::hasBondProp(const PropToken& name, const std::uint32_t index) const {
+  const Property* prop = findProp(name, Scope::BOND);
+  if (prop == nullptr) {
+    return false;
+  }
+  return prop->arrayData.isSetMask[index];
+}
+
+void RDMol::updatePropertyCache(bool strict) {
+  for (uint32_t atomIndex = 0, numAtoms = getNumAtoms();
+       atomIndex < numAtoms; ++atomIndex) {
+    updateAtomPropertyCache(atomIndex, strict);
+  }
+  for (uint32_t bondIndex = 0, numBonds = getNumBonds();
+       bondIndex < numBonds; ++bondIndex) {
+    updateBondPropertyCache(bondIndex, strict);
+  }
+}
+
+bool RDMol::needsUpdatePropertyCache() const {
+  for (uint32_t atomIndex = 0, numAtoms = getNumAtoms(); atomIndex < numAtoms;
+       ++atomIndex) {
+    if (getAtom(atomIndex).needsUpdatePropertyCache()) {
+      return true;
+    }
+  }
+  // there is no test for bonds yet since they do not obtain a valence property
+  return false;
+}
+
+AtomData& RDMol::addAtom() {
+  const atomindex_t newAtomIndex = atomData.size();
+  auto& newAtom = atomData.emplace_back();
+  atomBondStarts.push_back(bondDataIndices.size());
+
+  // Handle properties
+  for (Property& property : properties) {
+    if (property.scope != Scope::ATOM) {
+      continue;
+    }
+    property.arrayData.appendElement();
+  }
+
+  // Resize atomQueries, but only if it's already in use
+  if (atomQueries.size() != 0 && atomQueries.size() == newAtomIndex) {
+    atomQueries.emplace_back(nullptr);
+  }
+
+  if (numConformers > 0) {
+    allocateConformers(numConformers, getNumAtoms());
+    for (size_t i = 0; i < numConformers; i++) {
+      const size_t lastElementAtomIdx = i * 3 * conformerAtomCapacity + 3 * newAtomIndex;
+      for (int j = 0; j < 3; j++) {
+        conformerPositionData[lastElementAtomIdx + j] = 0.0;
+      }
+    }
+  }
+
+  // Handle compat
+  auto *compat = getCompatibilityDataIfPresent();
+  if (compat != nullptr) {
+    // Assume that it's a regular Atom until a query is added
+    auto &atom = compat->atoms.emplace_back(new Atom(this, newAtomIndex));
+
+    for (auto& conf: compat->conformers) {
+      conf->resize(getNumAtoms());
+      conf->setAtomPos(newAtomIndex, RDGeom::Point3D(0.0, 0.0, 0.0));
+    }
+  }
+
+  return newAtom;
+}
+
+BondData& RDMol::addBond(uint32_t beginAtomIdx, uint32_t endAtomIdx, BondEnums::BondType bondType, bool updateAromaticity) {
+  URANGE_CHECK(beginAtomIdx, getNumAtoms());
+  URANGE_CHECK(endAtomIdx, getNumAtoms());
+  PRECONDITION(beginAtomIdx != endAtomIdx, "Cannot create a bond between an atom and itself");
+  PRECONDITION(getBondIndexBetweenAtoms(beginAtomIdx, endAtomIdx) == std::numeric_limits<uint32_t>::max(), "Bond already exists between atoms");
+  const int firstAtomIdx = std::max(beginAtomIdx, endAtomIdx);
+  const int secondAtomIdx = std::min(beginAtomIdx, endAtomIdx);
+
+  // Insert the larger atom index first
+  const uint32_t newBondIndex = bondData.size();
+  auto &newBond = bondData.emplace_back();
+  bondDataIndices.insert(bondDataIndices.begin() + atomBondStarts[firstAtomIdx + 1], bondData.size() - 1);
+  bondDataIndices.insert(bondDataIndices.begin() + atomBondStarts[secondAtomIdx + 1], bondData.size() - 1);
+  otherAtomIndices.insert(otherAtomIndices.begin() + atomBondStarts[firstAtomIdx + 1], secondAtomIdx);
+  otherAtomIndices.insert(otherAtomIndices.begin() + atomBondStarts[secondAtomIdx + 1], firstAtomIdx);
+
+  newBond.bondType = bondType;
+  newBond.beginAtomIdx = beginAtomIdx;
+  newBond.endAtomIdx = endAtomIdx;
+  
+  for (uint32_t i = 0; i < atomBondStarts.size(); i++) {
+    auto& atomBondStart = atomBondStarts[i];
+    if (i > endAtomIdx) {
+      atomBondStart++;
+    }
+    if (i > beginAtomIdx) {
+      atomBondStart++;
+    }
+  }
+
+  if (bondType == BondEnums::BondType::AROMATIC) {
+    newBond.setIsAromatic(true);
+    if (updateAromaticity) {
+      getAtom(beginAtomIdx).setIsAromatic(true);
+      getAtom(endAtomIdx).setIsAromatic(true);
+    }
+  }
+
+  // Handle properties
+  for (Property& property : properties) {
+    if (property.scope != Scope::BOND) {
+      continue;
+    }
+    property.arrayData.appendElement();
+  }
+
+  // Resize bondQueries, but only if it's already in use
+  if (bondQueries.size() != 0 && bondQueries.size() == newBondIndex) {
+    bondQueries.emplace_back(nullptr);
+  }
+  auto *compat = getCompatibilityDataIfPresent();
+
+  // if both atoms have a degree>1, reset our ring info structure,
+  // because there's a non-trivial chance that it's now wrong.
+  if (getRingInfo().isInitialized() && getAtomDegree(beginAtomIdx) > 1 &&
+      getAtomDegree(endAtomIdx) > 1) {
+    ringInfo.reset();
+    if (compat != nullptr) {
+      compat->ringInfo->reset();
+      compat->ringInfoSyncStatus.store(CompatSyncStatus::inSync, std::memory_order_relaxed);
+    }
+  }
+
+  // Handle compat
+  if (compat != nullptr) {
+    // Assume that it's a regular Bond until a query is added
+    auto &bond = compat->bonds.emplace_back(new Bond(this, newBondIndex));
+    compat->bondStereoAtoms.push_back(std::make_unique<INT_VECT>());
+  }
+  return newBond;
+}
+
+namespace {
+
+//! Finds all instances of index and removes them from vectors. Decrements all indices greater than index.
+void removeIndexAndDecrementBookmarks(std::unordered_map<int, std::vector<int>>& bookmarks, int index) {
+  for (auto& [idx, marks] : bookmarks) {
+    auto removeIt = marks.end();
+    for (auto it = marks.begin(); it != marks.end(); ++it) {
+      if (*it == int(index)) {
+        removeIt = it;
+      }
+      if (*it > int(index)) {
+        --(*it);
+      }
+    }
+    if (removeIt != marks.end()) {
+      marks.erase(removeIt);
+      // TODO: Should this remove the bookmark if marks is now empty?
+    }
+  }
+}
+
+} // namespace
+
+void RDMol::removeAtom(atomindex_t atomIndex, bool clearProps) {
+  URANGE_CHECK(atomIndex, getNumAtoms());
+
+  if (dp_delAtoms != nullptr) {
+    if (dp_delAtoms->size() < getNumAtoms()) {
+      dp_delAtoms->resize(getNumAtoms(), false);
+    }
+    dp_delAtoms->set(atomIndex);
+    return;
+  }
+
+  // Remove bonds attached to the atom.  removeBond will change this array,
+  // so we copy it, first.
+  // TODO: To avoid having to copy the atom indices to a new array and delete the
+  // bonds based on atom indices, and shift bond properties multiple times,
+  // delete all of the bonds in bulk.
+  const uint32_t numAtomsOrig = getNumAtoms();
+  auto [atomBondsBegin, atomBondsEnd] = getAtomBonds(atomIndex);
+  constexpr uint32_t localBufferSize = 8;
+  uint32_t localBuffer[localBufferSize];
+  uint32_t numBonds = atomBondsEnd - atomBondsBegin;
+  std::unique_ptr<uint32_t[]> bondsDeleter;
+  uint32_t *bondsToDelete;
+  if (numBonds < localBufferSize) {
+    bondsToDelete = localBuffer;
+  } else {
+    bondsToDelete = new uint32_t[numBonds];
+    bondsDeleter.reset(bondsToDelete);
+  }
+  for (uint32_t i = 0; i < numBonds; i++) {
+    bondsToDelete[i] = atomBondsBegin[i];
+  }
+  // Sort in descending order so that we can remove bonds without changing the indexing
+  std::sort(bondsToDelete, bondsToDelete + numBonds, std::greater<uint32_t>());
+
+  for (uint32_t i = 0; i < numBonds; ++i) {
+    removeBond(bondsToDelete[i]);
+  }
+
+  // Update atom indices in otherAtomIndices
+  for (unsigned int & a : otherAtomIndices) {
+    if (a > atomIndex) {
+      --a;
+    }
+  }
+  // Update bond data
+  for (BondData &bond : bondData) {
+    if (bond.beginAtomIdx > atomIndex) {
+      --bond.beginAtomIdx;
+    }
+    if (bond.endAtomIdx > atomIndex) {
+      --bond.endAtomIdx;
+    }
+  }
+
+  // Update queries
+  if (atomQueries.size() != 0) {
+    atomQueries.erase(atomQueries.begin() + atomIndex);
+  }
+
+  // Handle conformers
+  if (atomIndex != numAtomsOrig - 1) {
+    const int conformerOffset = conformerAtomCapacity * 3;
+    const int copySize =
+        sizeof(conformerPositionData[0]) * 3 * (numAtomsOrig - atomIndex - 1);
+
+    for (uint32_t i = 0; i < numConformers; i++) {
+      std::memmove(
+          &conformerPositionData[i * conformerOffset + atomIndex * 3],
+          &conformerPositionData[i * conformerOffset + (atomIndex + 1) * 3],
+          copySize);
+    }
+  }
+
+  // Update bookmarks
+  CompatibilityData *compat = getCompatibilityDataIfPresent();
+  if (compat != nullptr) {
+    const Atom *want = compat->atoms[atomIndex].get();
+    std::vector<int> deleteList;
+    for (auto &[key, val] : compat->atomBookmarks) {
+      auto it = std::find(val.begin(), val.end(), want);
+      if (it != val.end()) {
+        val.erase(it);
+      }
+      if (val.empty()) {
+        deleteList.push_back(key);
+      }
+    }
+    for (int key : deleteList) {
+      compat->atomBookmarks.erase(key);
+    }
+
+    for (auto &conf : compat->conformers) {
+      RDGeom::POINT3D_VECT &positions = conf->getPositions();
+      std::copy(positions.begin() + atomIndex + 1, positions.end(),
+                positions.begin() + atomIndex);
+      positions.pop_back();
+    }
+  } else {
+    removeIndexAndDecrementBookmarks(atomBookmarks, atomIndex);
+  }
+
+  // Update atom indices in bond stereoAtoms
+  for (size_t i = 0, n = getNumBonds(); i < n; ++i) {
+    BondData &bond = getBond(i);
+    if (hasBondStereoAtoms(i)) {
+      const atomindex_t* stereoAtoms = getBondStereoAtoms(i);
+      if (stereoAtoms[0] == atomIndex || stereoAtoms[1] == atomIndex) {
+        clearBondStereoAtoms(i);
+      } else {
+        atomindex_t newStereoAtom0 = stereoAtoms[0];
+        atomindex_t newStereoAtom1 = stereoAtoms[1];
+        if (newStereoAtom0 > atomIndex) {
+          --newStereoAtom0;
+        }
+        if (newStereoAtom1 > atomIndex) {
+          --newStereoAtom1;
+        }
+        setBondStereoAtoms(i, newStereoAtom0, newStereoAtom1);
+      }
+    }
+  }
+
+  // Update substance groups.
+  removeSubstanceGroupsReferencingAtom(*this, atomIndex);
+
+  // Update stereo groups.
+  if (stereoGroups != nullptr) {
+    stereoGroups->removeAtomFromGroups(atomIndex, /*decrement=*/true);
+  }
+
+  // Clear computed properties
+  if (clearProps) {
+    clearComputedProps(true);
+  }
+
+  // Shift atom property data back
+  for (Property &property : properties) {
+    if (property.scope != Scope::ATOM) {
+      continue;
+    }
+    property.arrayData.removeElement(atomIndex);
+  }
+
+  // Update special cases of properties referring to atom indices.
+  // The _ringStereoAtomsAll, _ringStereoAtomsBegins, and
+  // _ringStereoGroup properties are all "computed", so should be removed above.
+  // TODO: Do they need to be removed in case !clearProps?
+  // TODO: Handle _MolFileBondEndPts like in the original RWMol::removeAtom
+  // There aren't any other special cases yet.
+  // Shift back atomData and atomBondStarts
+  atomData.erase(atomData.begin() + atomIndex);
+  atomBondStarts.erase(atomBondStarts.begin() + atomIndex);
+
+  // Reset our ring info structure, because it is pretty likely
+  // to be wrong now. This might have already been done in removeBond or
+  // clearComputedProps above, but removing an isolated atom can still
+  // invalidate ringInfo.
+  ringInfo.reset();
+
+  if (compat != nullptr) {
+    compat->ringInfo->reset();
+    compat->ringInfoSyncStatus.store(CompatSyncStatus::inSync, std::memory_order_relaxed);
+
+    for (uint32_t i = atomIndex + 1; i < numAtomsOrig; ++i) {
+      compat->atoms[i]->d_index--;
+    }
+    compat->atoms.erase(compat->atoms.begin() + atomIndex);
+  }
+}
+
+void RDMol::removeBond(uint32_t bondIndex) {
+  // Match ROMol nullop for removing nonexistent bond.
+  if (bondIndex >= getNumBonds()) {
+    return;
+  }
+
+  if (dp_delBonds != nullptr) {
+    if (dp_delBonds->size() < getNumBonds()) {
+      dp_delBonds->resize(getNumBonds(), false);
+    }
+    dp_delBonds->set(bondIndex);
+    return;
+  }
+
+  uint32_t startAtom = getBond(bondIndex).beginAtomIdx;
+  uint32_t endAtom = getBond(bondIndex).endAtomIdx;
+  const uint32_t  numBondsOrig = getNumBonds();
+  // Handle props
+  for (Property &property : properties) {
+    if (property.scope != Scope::BOND) {
+      continue;
+    }
+    property.arrayData.removeElement(bondIndex);
+  }
+
+  // Update queries
+  if (bondQueries.size() != 0) {
+    bondQueries.erase(bondQueries.begin() + bondIndex);
+  }
+
+  // remove any bookmarks which point to this bond:
+  CompatibilityData *compat = getCompatibilityDataIfPresent();
+  if (compat != nullptr) {
+    const Bond *want = compat->bonds[bondIndex].get();
+    std::vector<int> deleteList;
+    for (auto &[key, val] : compat->bondBookmarks) {
+      auto it = std::find(val.begin(), val.end(), want);
+      if (it != val.end()) {
+        val.erase(it);
+      }
+      if (val.empty()) {
+        deleteList.push_back(key);
+      }
+    }
+    for (int key : deleteList) {
+      compat->bondBookmarks.erase(key);
+    }
+  } else {
+    removeIndexAndDecrementBookmarks(bondBookmarks, bondIndex);
+  }
+
+  // Handle stereo. We loop over all bonds of both atoms, searching to see if
+  // the second atom of the pair was listed as the stereo atom of one of these
+  // bonds. See RWMol removeBond for details.
+  std::array<std::pair<uint32_t, uint32_t>, 2> iterateAndLookupIndices = {
+      std::pair<uint32_t, uint32_t>{startAtom, endAtom},
+      std::pair<uint32_t, uint32_t>{endAtom, startAtom}
+  };
+
+  for (const auto& [iterateOverBondsIndex, lookForAtomAsStereoIndex] : iterateAndLookupIndices) {
+    auto [begin, end] = getAtomBonds(iterateOverBondsIndex);
+    for (auto bondIterator = begin; bondIterator != end; ++bondIterator) {
+      if (*bondIterator == bondIndex) {
+        // This is the self bond, it's going away anyway.
+        continue;
+      }
+      auto stereoAtoms = getBondStereoAtoms(*bondIterator);
+      if (stereoAtoms[0] == lookForAtomAsStereoIndex || stereoAtoms[1] == lookForAtomAsStereoIndex) {
+        clearBondStereoAtoms(*bondIterator);
+        // github #6900 if we remove stereo atoms we need to remove
+        //  the CIS and or TRANS since this requires stereo atoms
+        BondData &oBondData = getBond(*bondIterator);
+        const BondEnums::BondStereo stereo = oBondData.getStereo();
+        if (stereo == BondEnums::BondStereo::STEREOCIS ||
+            stereo == BondEnums::BondStereo::STEREOTRANS) {
+          oBondData.setStereo(BondEnums::BondStereo::STEREONONE);
+        }
+      }
+    }
+  }
+
+  // reset our ring info structure, because it is pretty likely
+  // to be wrong now:
+  ringInfo.reset();
+  if (compat != nullptr) {
+    compat->ringInfo->reset();
+    compat->ringInfoSyncStatus.store(CompatSyncStatus::inSync, std::memory_order_relaxed);
+  }
+  // Handle substance groups
+  removeSubstanceGroupsReferencingBond(*this, bondIndex);
+
+  // Finally remove the bond and update index vectors.
+  bondData.erase(bondData.begin() + bondIndex);
+
+  // Find the relevant entry in bondDataIndices. Note that these may be out of order.
+  uint32_t beginSearchIdx = atomBondStarts[endAtom];
+  uint32_t endSearchIdx = atomBondStarts[endAtom + 1];
+  while (beginSearchIdx < endSearchIdx) {
+    if (bondDataIndices[beginSearchIdx] == bondIndex) {
+      break;
+    }
+    ++beginSearchIdx;
+  }
+  if (beginSearchIdx == endSearchIdx) {
+    throw ValueErrorException("Bond not found in atomBondStarts range");
+  }
+  uint32_t endToErase = beginSearchIdx;
+
+  // Now do the same for the begin atom.
+  beginSearchIdx = atomBondStarts[startAtom];
+  endSearchIdx = atomBondStarts[startAtom + 1];
+  while (beginSearchIdx < endSearchIdx) {
+    if (bondDataIndices[beginSearchIdx] == bondIndex) {
+      break;
+    }
+    ++beginSearchIdx;
+  }
+  if (beginSearchIdx == endSearchIdx) {
+    throw ValueErrorException("Bond not found in atomBondStarts range");
+  }
+  const uint32_t beginToErase = beginSearchIdx;
+
+  const uint32_t removeIndices[2]{
+      std::min(beginToErase, endToErase), std::max(beginToErase, endToErase)
+  };
+  eraseMultipleIndices(bondDataIndices, removeIndices, 2);
+  eraseMultipleIndices(otherAtomIndices, removeIndices, 2);
+
+  for (uint32_t i = 0; i < atomBondStarts.size(); i++) {
+    auto& atomBondStart = atomBondStarts[i];
+    if (i > endAtom) {
+      atomBondStart--;
+    }
+    if (i > startAtom) {
+      atomBondStart--;
+    }
+  }
+
+  for (uint32_t& dataIndex: bondDataIndices) {
+    if (dataIndex > bondIndex) {
+      --dataIndex;
+    }
+  }
+
+  if (compat != nullptr) {
+    for (uint32_t i = bondIndex + 1; i < numBondsOrig; ++i) {
+      compat->bonds[i]->d_index--;
+    }
+    compat->bonds.erase(compat->bonds.begin() + bondIndex);
+    compat->bondStereoAtoms.erase(compat->bondStereoAtoms.begin() + bondIndex);
+  }
+}
+
+void RDMol::beginBatchEdit() {
+  if (dp_delAtoms != nullptr) {
+    throw ValueErrorException("Attempt to re-enter batchEdit mode");
+  }
+  dp_delAtoms = std::make_unique<boost::dynamic_bitset<>>(getNumAtoms(), false);
+  dp_delBonds = std::make_unique<boost::dynamic_bitset<>>(getNumBonds(), false);
+
+}
+
+void RDMol::commitBatchEdit() {
+  if (dp_delAtoms == nullptr) {
+    return;
+  }
+
+  // Find all bonds that would be removed by their atom being removed.
+  for (uint32_t i = 0; i < dp_delAtoms->size(); i++) {
+    if (!dp_delAtoms->test(i)) {
+      continue;
+    }
+    auto [begin, end] = getAtomBonds(i);
+    for (auto bondIterator = begin; bondIterator != end; ++bondIterator) {
+      dp_delBonds->set(*bondIterator);
+    }
+  }
+
+  auto movedDelAtoms = std::move(dp_delAtoms);
+  auto movedDelBonds = std::move(dp_delBonds);
+  dp_delAtoms.reset();
+  dp_delBonds.reset();
+
+  // Now delete bonds in reverse order
+  for (int i = movedDelBonds->size() - 1; i >= 0; i--) {
+    if (movedDelBonds->test(i)) {
+      removeBond(i);
+    }
+  }
+
+  // Delete atoms in reverse order
+  for (int i = movedDelAtoms->size() - 1; i >= 0; i--) {
+    if (movedDelAtoms->test(i)) {
+      removeAtom(i);
+    }
+  }
+
+  dp_delAtoms.reset();
+  dp_delBonds.reset();
+}
+
+void RDMol::rollbackBatchEdit() {
+  dp_delAtoms.reset();
+  dp_delBonds.reset();
+}
+
+// -----------------------------
+// Atom bookmarks
+// -----------------------------
+
+void RDMol::setAtomBookmark(int atomIdx, int mark) {
+  CompatibilityData* compatData = getCompatibilityDataIfPresent();
+  if (compatData != nullptr) {
+    compatData->atomBookmarks[mark].push_back(compatData->atoms[atomIdx].get());
+    return;
+  }
+
+  // Non legacy path.
+  atomBookmarks[mark].push_back(atomIdx);
+}
+void RDMol::replaceAtomBookmark(int atomIdx, int mark) {
+  CompatibilityData* compatData = getCompatibilityDataIfPresent();
+  if (compatData != nullptr) {
+    auto& bookmark = compatData->atomBookmarks[mark];
+    bookmark.clear();
+    bookmark.push_back(compatData->atoms[atomIdx].get());
+    return;
+  }
+  // Nonlegacy path
+  std::vector<int>& marks = atomBookmarks[mark];
+  marks.resize(1);
+  marks[0] = atomIdx;
+}
+std::vector<int> RDMol::getAllAtomsWithBookmarks(int mark) {
+  if (hasCompatibilityData()) {
+    std::list<Atom*>& bookmarks = getAtomBookmarksCompat(mark);
+    std::vector<int> res;
+    res.reserve(bookmarks.size());
+    for (Atom* atom : bookmarks) {
+      res.push_back(atom->getIdx());
+    }
+    return res;
+  }
+
+  // Non-legacy path
+  auto it = atomBookmarks.find(mark);
+  PRECONDITION(it != atomBookmarks.end(), "Bookmark not found");
+  return it->second;
+}
+
+int RDMol::getAtomWithBookmark(int mark)  {
+  const CompatibilityData* compatData = getCompatibilityDataIfPresent();
+  if (compatData != nullptr) {
+    auto found = compatData->atomBookmarks.find(mark);
+    PRECONDITION(found != compatData->atomBookmarks.end(), "Bookmark not found");
+    return found->second.front()->getIdx();
+  }
+
+  // Non-legacy path
+  auto it = atomBookmarks.find(mark);
+  PRECONDITION(it != atomBookmarks.end(), "Bookmark not found");
+  return *it->second.begin();
+}
+void RDMol::clearAtomBookmark(int mark) {
+  CompatibilityData* compatData = getCompatibilityDataIfPresent();
+  if (compatData != nullptr) {
+    compatData->atomBookmarks.erase(mark);
+    return;
+  }
+
+  // non legacy path
+  atomBookmarks.erase(mark);
+}
+
+void RDMol::clearAtomBookmark(int atomIdx, int mark) {
+  CompatibilityData* compatData = getCompatibilityDataIfPresent();
+  if (compatData != nullptr) {
+    auto foundMark = compatData->atomBookmarks.find(mark);
+    if (foundMark == compatData->atomBookmarks.end()) {
+      return;
+    }
+    auto& marks = foundMark->second;
+    auto removeIt = std::find_if(marks.begin(), marks.end(), [atomIdx](const Atom* atom) {
+      return int(atom->getIdx()) == atomIdx;
+    });
+    if (removeIt != marks.end()) {
+      marks.erase(removeIt);
+    }
+    return;
+  }
+
+  auto it = atomBookmarks.find(mark);
+  if (it == atomBookmarks.end()) {
+    return;
+  }
+  std::vector<int>& marks = it->second;
+  auto removeIt = std::find(marks.begin(), marks.end(), atomIdx);
+  if (removeIt != marks.end()) {
+    marks.erase(removeIt);
+  }
+}
+
+void RDMol::clearAllAtomBookmarks() {
+  CompatibilityData* compatData = getCompatibilityDataIfPresent();
+  if (compatData != nullptr) {
+    compatData->atomBookmarks.clear();
+  }
+  atomBookmarks.clear();
+}
+
+bool RDMol::hasAtomBookmark(int mark) const {
+  const CompatibilityData* compatData = getCompatibilityDataIfPresent();
+  if (compatData != nullptr) {
+    return compatData->atomBookmarks.count(mark) > 0;
+  }
+
+  if (auto it = atomBookmarks.find(mark); it != atomBookmarks.end()) {
+    return !it->second.empty();
+  }
+  return false;
+}
+
+// -----------------------------
+// Bond bookmarks
+// -----------------------------
+
+void RDMol::setBondBookmark(int bondIdx, int mark) {
+  CompatibilityData* compatData = getCompatibilityDataIfPresent();
+  if (compatData != nullptr) {
+    compatData->bondBookmarks[mark].push_back(compatData->bonds[bondIdx].get());
+    return;
+  }
+
+  // Non legacy path.
+  bondBookmarks[mark].push_back(bondIdx);
+}
+
+std::vector<int> RDMol::getAllBondsWithBookmarks(int mark) {
+  if (hasCompatibilityData()) {
+    std::list<Bond*> bookmarks = getBondBookmarksCompat(mark);
+    std::vector<int> res;
+    res.reserve(bookmarks.size());
+    for (Bond* bond : bookmarks) {
+      res.push_back(bond->getIdx());
+    }
+    return res;
+  }
+
+  // Non-legacy path
+  auto it = bondBookmarks.find(mark);
+  PRECONDITION(it != bondBookmarks.end(), "Bookmark not found");
+  return it->second;
+}
+
+int RDMol::getBondWithBookmark(int mark)  {
+  const CompatibilityData* compatData = getCompatibilityDataIfPresent();
+  if (compatData != nullptr) {
+    auto found = compatData->bondBookmarks.find(mark);
+    PRECONDITION(found != compatData->bondBookmarks.end(), "Bookmark not found");
+    return found->second.front()->getIdx();
+  }
+
+  // Non-legacy path
+  auto it = bondBookmarks.find(mark);
+  PRECONDITION(it != bondBookmarks.end(), "Bookmark not found");
+  return *it->second.begin();
+}
+
+void RDMol::clearBondBookmark(int mark) {
+  CompatibilityData* compatData = getCompatibilityDataIfPresent();
+  if (compatData != nullptr) {
+    compatData->bondBookmarks.erase(mark);
+    return;
+  }
+
+  // non legacy path
+  bondBookmarks.erase(mark);
+}
+void RDMol::clearBondBookmark(int bondIdx, int mark) {
+  CompatibilityData* compatData = getCompatibilityDataIfPresent();
+  if (compatData != nullptr) {
+    auto foundMark = compatData->bondBookmarks.find(mark);
+    if (foundMark == compatData->bondBookmarks.end()) {
+      return;
+    }
+    auto& marks = foundMark->second;
+    auto removeIt = std::find_if(marks.begin(), marks.end(), [bondIdx](const Bond* bond) {
+      return int(bond->getIdx()) == bondIdx;
+    });
+    if (removeIt != marks.end()) {
+      marks.erase(removeIt);
+    }
+    return;
+  }
+
+  auto it = bondBookmarks.find(mark);
+  if (it == bondBookmarks.end()) {
+    return;
+  }
+  std::vector<int>& marks = it->second;
+  auto removeIt = std::find(marks.begin(), marks.end(), bondIdx);
+  if (removeIt != marks.end()) {
+    marks.erase(removeIt);
+  }
+}
+
+void RDMol::clearAllBondBookmarks() {
+  CompatibilityData* compatData = getCompatibilityDataIfPresent();
+  if (compatData != nullptr) {
+    compatData->bondBookmarks.clear();
+  }
+  bondBookmarks.clear();
+}
+
+bool RDMol::hasBondBookmark(int mark) const {
+  const CompatibilityData* compatData = getCompatibilityDataIfPresent();
+  if (compatData != nullptr) {
+    return compatData->bondBookmarks.count(mark) > 0;
+  }
+
+  if (auto it = bondBookmarks.find(mark); it != bondBookmarks.end()) {
+    return !it->second.empty();
+  }
+  return false;
+}
+
+void RDMol::setStereoGroups(std::unique_ptr<StereoGroups> &&groups) {
+  // Nothing should be trying to read the stereo groups while it's being written,
+  // so it's safe to clear the old compatibility data without locking.
+  RDMol::CompatibilityData *compat = compatibilityData.load(std::memory_order_relaxed);
+  if (compat != nullptr) {
+    auto *compatStereoGroups = compat->stereoGroups.load(std::memory_order_relaxed);
+    if (compatStereoGroups != nullptr) {
+      // TODO: This approach of allocating a new std::vector<StereoGroup> after
+      // modification results in a varying address, whereas the previous interface
+      // had a persistent address across writes. Does this need to be preserved?
+      // See also getStereoGroupsCompat
+      delete compatStereoGroups;
+      compat->stereoGroups.store(nullptr, std::memory_order_relaxed);
+    }
+  }
+  
+  stereoGroups = std::move(groups);
+}
+
+void RDMol::setAtomQuery(atomindex_t atomIndex,
+                         std::unique_ptr<QUERYATOM_QUERY> query) {
+  if (atomQueries.size() != getNumAtoms()) {
+    atomQueries.resize(getNumAtoms());
+  }
+  atomQueries[atomIndex] = std::move(query);
+
+  auto *compatData = getCompatibilityDataIfPresent();
+  if (compatData != nullptr) {
+    Atom *atom = compatData->atoms[atomIndex].get();
+    QueryAtom *queryAtom = dynamic_cast<QueryAtom *>(atom);
+    auto *newQuery = makeNewCompatQuery(atomQueries[atomIndex].get());
+    if (queryAtom == nullptr) {
+      // Convert to a QueryAtom now that there's a query
+      compatData->atoms[atomIndex].reset(
+          new QueryAtom(this, atomIndex, newQuery));
+    } else {
+      queryAtom->setQueryPrivate(newQuery);
+    }
+  }
+}
+void RDMol::setBondQuery(uint32_t bondIndex,
+                         std::unique_ptr<QUERYBOND_QUERY> query) {
+  if (bondQueries.size() != getNumBonds()) {
+    bondQueries.resize(getNumBonds());
+  }
+  bondQueries[bondIndex] = std::move(query);
+
+  auto *compatData = getCompatibilityDataIfPresent();
+  if (compatData != nullptr) {
+    Bond *bond = compatData->bonds[bondIndex].get();
+    QueryBond *queryBond = dynamic_cast<QueryBond *>(bond);
+    auto *newQuery = makeNewCompatQuery(bondQueries[bondIndex].get());
+    if (queryBond == nullptr) {
+      // Convert to a QueryBond now that there's a query
+      compatData->bonds[bondIndex].reset(
+          new QueryBond(this, bondIndex, newQuery));
+    } else {
+      queryBond->setQueryPrivate(newQuery);
+    }
+  }
+}
+
+ROMol &RDMol::asROMol() { return *ensureCompatInit()->compatMol; }
+const ROMol& RDMol::asROMol() const { return *ensureCompatInit()->compatMol; }
+RWMol &RDMol::asRWMol() {
+  auto* mol = dynamic_cast<RWMol* >(&asROMol());
+  CHECK_INVARIANT(mol, "Failed to cast ROMol to RWMol");
+  return *mol;
+}
+
+const RWMol& RDMol::asRWMol() const {
+  const auto* mol = dynamic_cast<const RWMol* >(&asROMol());
+  CHECK_INVARIANT(mol, "Failed to cast ROMol to RWMol");
+  return *mol;
+}
+
+RDMol::CompatibilityData *RDMol::ensureCompatInit() const {
+  // First, try without locking
+  // We can do a relaxed load of the pointer, because accessing the other data requires
+  // dereferencing the pointer, so would all be dependent reads.
+  CompatibilityData *data = compatibilityData.load(std::memory_order_relaxed);
+  if (data != nullptr) {
+    return data;
+  }
+
+  std::lock_guard<std::mutex> lock_scope(compatibilityMutex);
+  // Check again after locking
+  data = compatibilityData.load(std::memory_order_relaxed);
+  if (data != nullptr) {
+    return data;
+  }
+
+  // NOTE: This casts away const because Atom and Bond structures may later
+  // need write access.  This is in a private function for initializing
+  // a mutable data member, so it should be okay.
+  data = new CompatibilityData(const_cast<RDMol&>(*this));
+  compatibilityData.store(data, std::memory_order_release);
+  return data;
+}
+
+uint32_t RDMol::getNumConformers() const {
+  return numConformers;
+}
+
+namespace {
+
+void throwIDNotFound(int id) {
+  std::string exceptionMessage =
+      "Can't find conformation with ID: " + std::to_string(id);
+  throw ConformerException(std::move(exceptionMessage));
+}
+
+} // namespace
+
+uint32_t RDMol::findConformerIndex(int32_t id) const {
+  // make sure we have more than one conformation
+  if (numConformers == 0) {
+    throw ConformerException("No conformations available on the molecule");
+  }
+  if (id < 0) {
+    // Negative id means index 0
+    return 0;
+  }
+
+  if (conformerIdsAndFlags.size() == 0) {
+    // Fast path for ids being equal to indices
+    if (id >= numConformers) {
+      throwIDNotFound(id);
+    }
+    return id;
+  }
+
+  CHECK_INVARIANT(conformerIdsAndFlags.size() == numConformers,
+                  "conformerIdsAndFlags incorrect size in findConformerIndex");
+  for (uint32_t i = 0; i < numConformers; ++i) {
+    if (conformerIdsAndFlags[i].id == id) {
+      return i;
+    }
+  }
+  throwIDNotFound(id);
+}
+
+const double* RDMol::getConformerPositions(int32_t id) const {
+  auto *compat = getCompatibilityDataIfPresent();
+  if (compat != nullptr) {
+    initCompatForReadHelper<false>(
+        compat->conformerSyncStatus, compatibilityMutex,
+        [&]() { copyConformersFromCompatibilityData(compat); });
+  }
+  uint32_t index = findConformerIndex(id);
+  CHECK_INVARIANT(conformerAtomCapacity >= getNumAtoms(),
+                  "Conformer positions not allocated in getConformerPositions");
+  return conformerPositionData.data() +
+         size_t(3) * conformerAtomCapacity * index;
+}
+
+double* RDMol::getConformerPositions(int32_t id) {
+  auto *compat = getCompatibilityDataIfPresent();
+  if (compat != nullptr) {
+    initCompatForWriteHelper<false>(
+        compat->conformerSyncStatus, compatibilityMutex,
+        [&]() { copyConformersFromCompatibilityData(compat); });
+  }
+  uint32_t index = findConformerIndex(id);
+  CHECK_INVARIANT(conformerAtomCapacity >= getNumAtoms(),
+                  "Conformer positions not allocated in getConformerPositions");
+  return conformerPositionData.data() +
+         size_t(3) * conformerAtomCapacity * index;
+}
+
+bool RDMol::is3DConformer(uint32_t id) const {
+  auto *compat = getCompatibilityDataIfPresent();
+  if (compat != nullptr) {
+    initCompatForReadHelper<false>(
+        compat->conformerSyncStatus, compatibilityMutex,
+        [&]() { copyConformersFromCompatibilityData(compat); });
+  }
+  uint32_t index = findConformerIndex(id);
+  if (index == numConformers) {
+    throwIDNotFound(id);
+  }
+  return (conformerIdsAndFlags.size() == 0) || conformerIdsAndFlags[index].is3D;
+}
+
+void RDMol::clearConformers() {
+  // Free the memory by swapping with empty vectors
+  std::vector<double> tempDouble;
+  conformerPositionData.swap(tempDouble);
+  std::vector<ConformerIdAndFlags> tempIdsAndFlags;
+  conformerIdsAndFlags.swap(tempIdsAndFlags);
+  numConformers = 0;
+  conformerAtomCapacity = 0;
+
+  if (auto* compatData = getCompatibilityDataIfPresent(); compatData != nullptr) {
+    compatData->conformers.clear();
+    // It might be excessive to use memory_order_release, but this will ensure
+    // that the clearing of the conformers is completed before marking them
+    // as in sync.
+    compatData->conformerSyncStatus.store(CompatSyncStatus::inSync,
+                                          std::memory_order_release);
+  }
+}
+
+static void expandConformerIdsAndFlags(
+    std::vector<ConformerIdAndFlags> &conformerIdsAndFlags,
+    size_t numConformers) {
+  PRECONDITION(conformerIdsAndFlags.size() == 0, "Expanding conformerIdsAndFlags that's already expanded");
+  conformerIdsAndFlags.reserve(numConformers);
+  for (size_t i = 0; i < numConformers; ++i) {
+    auto &confData = conformerIdsAndFlags.emplace_back();
+    confData.id = i;
+    confData.is3D = true;
+  }
+}
+
+void RDMol::copyConformersFromCompatibilityData(const CompatibilityData* compatData, int confId) const {
+  PRECONDITION(compatData != nullptr, "No compatibility data to copy from");
+  PRECONDITION((confId >= 0 && numConformers == 1) ||
+                   compatData->conformers.size() == numConformers,
+               "Add space for conformers before copying from compatibility data");
+  size_t confIndex = 0;
+  const size_t numAtoms = getNumAtoms();
+  for (const auto& conf : compatData->conformers) {
+    if (confId < 0 || int(conf->getId()) == confId) {
+      size_t atomPositionOffset = confIndex * conformerAtomCapacity * 3;
+      const RDGeom::POINT3D_VECT& positions = conf->getPositions();
+      PRECONDITION(positions.size() == numAtoms,
+                   "Conformers must have one position per atom");
+      for (size_t i = 0; i < numAtoms; ++i) {
+        conformerPositionData[atomPositionOffset] = positions[i].x;
+        conformerPositionData[atomPositionOffset + 1] = positions[i].y;
+        conformerPositionData[atomPositionOffset + 2] = positions[i].z;
+        atomPositionOffset += 3;
+      }
+
+      if (conformerIdsAndFlags.size() > 0) {
+        conformerIdsAndFlags[confIndex].is3D = conf->is3D();
+        conformerIdsAndFlags[confIndex].id = conf->getId();
+      } else if (!conf->is3D() || conf->getId() != confIndex) {
+        expandConformerIdsAndFlags(conformerIdsAndFlags, numConformers);
+        conformerIdsAndFlags[confIndex].is3D = conf->is3D();
+        conformerIdsAndFlags[confIndex].id = conf->getId();
+      }
+      confIndex++;
+    }
+  }
+}
+
+void RDMol::copyConformersToCompatibilityData(CompatibilityData* compatData) const {
+  PRECONDITION(compatData != nullptr, "No compatibility data to copy to");
+  PRECONDITION(compatData->conformers.size() == numConformers,
+               "Add conformers before copying to compatibility data");
+  size_t confIndex = 0;
+  const size_t numAtoms = getNumAtoms();
+  for (auto &conf : compatData->conformers) {
+    size_t atomPositionOffset = confIndex * conformerAtomCapacity * 3;
+    RDGeom::POINT3D_VECT &positions = conf->getPositions();
+    PRECONDITION(positions.size() == numAtoms,
+                 "Conformers must have one position per atom");
+    for (size_t i = 0; i < numAtoms; ++i) {
+      positions[i].x = conformerPositionData[atomPositionOffset];
+      positions[i].y = conformerPositionData[atomPositionOffset + 1];
+      positions[i].z = conformerPositionData[atomPositionOffset + 2];
+      atomPositionOffset += 3;
+    }
+    conf->set3D(conformerIdsAndFlags.size() == 0 ||
+                conformerIdsAndFlags[confIndex].is3D);
+    confIndex++;
+  }
+}
+
+void RDMol::markConformersAsCompatModified() const {
+  if (const CompatibilityData* compatData = getCompatibilityDataIfPresent(); compatData != nullptr) {
+    compatData->conformerSyncStatus = CompatSyncStatus::lastUpdatedCompat;
+  }
+}
+
+void RDMol::removeConformer(uint32_t id) {
+  if (int32_t(id) < 0) {
+    return;
+  }
+  uint32_t index;
+  try {
+    index = findConformerIndex(id);
+  } catch (ConformerException) {
+    return;
+  }
+
+  const uint32_t numAtoms = getNumAtoms();
+  if (index != numConformers - 1) {
+    // Overwrite the position at index with the position at numConformers - 1
+    if (numAtoms > 0) {
+      // Stride is 3*conformerAtomCapacity, but amount to copy is 3*numAtoms
+      double *dest = conformerPositionData.data() +
+                     size_t(3) * conformerAtomCapacity * index;
+      const double *source =
+          conformerPositionData.data() +
+          size_t(3) * conformerAtomCapacity * (numConformers - 1);
+      std::copy(source, source + size_t(3) * numAtoms, dest);
+    }
+
+    if (conformerIdsAndFlags.size() == 0) {
+      // We can no longer have 0 to n based indexing, populate
+      // conformerIdsAndFlags.
+      expandConformerIdsAndFlags(conformerIdsAndFlags, numConformers - 1);
+      conformerIdsAndFlags[index].id = numConformers - 1;
+    } else {
+      conformerIdsAndFlags[index] = conformerIdsAndFlags[numConformers - 1];
+      conformerIdsAndFlags.pop_back();
+    }
+  } else if (conformerIdsAndFlags.size() != 0) {
+    // Removing last conformer, so remove the last entry from conformerIdsAndFlags
+    conformerIdsAndFlags.pop_back();
+  }
+
+  if (auto* compatData = getCompatibilityDataIfPresent(); compatData != nullptr) {
+    for (auto iter = compatData->conformers.begin(); iter != compatData->conformers.end(); ++iter) {
+      if ((*iter)->getId() == id) {
+        compatData->conformers.erase(iter);
+        break;
+      }
+    }
+  }
+
+  numConformers--;
+}
+
+uint32_t RDMol::addConformer(const double *positions, int32_t id, bool is3D) {
+  allocateConformers(numConformers + 1);
+  const size_t numConformersPrev = numConformers;
+  ++numConformers;
+
+  if (getNumAtoms() > 0) {
+    if (positions != nullptr) {
+      std::copy(positions, positions + getNumAtoms() * 3,
+                conformerPositionData.data() +
+                    3 * conformerAtomCapacity * numConformersPrev);
+    }
+  }
+
+  // Add to compat data. Only need if this is not being invoked as part of the
+  // ROMol addConformer, so we check to make sure ROMol hasn't already appended
+  // for itself.
+  auto* compatData = getCompatibilityDataIfPresent();
+  const bool needsCompatUpdate = compatData != nullptr && compatData->conformers.size() < numConformers;
+  if (needsCompatUpdate) {
+    auto *conf = new Conformer(getNumAtoms());
+    if (positions != nullptr) {
+      for (size_t i = 0; i < getNumAtoms(); ++i) {
+        conf->setAtomPos(i, RDGeom::Point3D(positions[i * 3], positions[i * 3 + 1], positions[i * 3 + 2]));
+      }
+    }
+    conf->set3D(is3D);
+    compatData->conformers.push_back(CONFORMER_SPTR(conf));
+  }
+
+  const bool hadLinearIds = conformerIdsAndFlags.size() == 0;
+  // Case where we're allowed to set ID, and default flags.
+  const bool allowsLinearIds = is3D && (id < 0 || id == numConformersPrev);  
+
+  if (allowsLinearIds && hadLinearIds) {
+    if (needsCompatUpdate) {
+      compatData->conformers.back()->setId(numConformersPrev);
+    }
+    return numConformersPrev;
+  }
+
+  if (hadLinearIds) {
+    // We now need to populate all IDs that were previously implicit.
+    // We know they were 3D and the implict IDs were in order.
+    expandConformerIdsAndFlags(conformerIdsAndFlags, numConformers);
+    auto& newConfData = conformerIdsAndFlags.back();
+    newConfData.is3D = is3D;
+    newConfData.id = id < 0 ? numConformersPrev : id;
+    if (needsCompatUpdate) {
+      compatData->conformers.back()->setId(newConfData.id);
+    }
+    return newConfData.id;
+  }
+
+  // Previous IDs are populated.
+  auto &newConfData = conformerIdsAndFlags.emplace_back();
+
+  if (id < 0) {
+    // We need to find an ID to give the new conformer.
+    int64_t max = -1;
+    for (const auto &confData : conformerIdsAndFlags) {
+      max = std::max(max, int64_t(confData.id));
+    }
+    id = max + 1;
+  }
+  newConfData.id = id;
+  newConfData.is3D = is3D;
+
+  // Add to compat data
+  if (needsCompatUpdate) {
+    compatData->conformers.back()->setId(id);
+  }
+  return newConfData.id;
+}
+
+std::pair<uint32_t, double*> RDMol::addConformer(int32_t id, bool is3D) {
+  uint32_t gotId = addConformer(nullptr, id, is3D);
+  return {gotId, getConformerPositions(gotId)};
+}
+
+
+void RDMol::allocateConformers(size_t newNumConformers, size_t newNumAtoms) {
+  size_t newConformerAtomCapacity = conformerAtomCapacity;
+  if (conformerAtomCapacity < newNumAtoms) {
+    newConformerAtomCapacity = std::max(2 * conformerAtomCapacity, newNumAtoms);
+  }
+  size_t numConformersCapacity =
+      (conformerAtomCapacity!= 0) ? (conformerPositionData.size() / (size_t(3) * conformerAtomCapacity)) : 0;
+  if (numConformersCapacity < newNumConformers) {
+    numConformersCapacity =
+        std::max(2 * numConformersCapacity, newNumConformers);
+  }
+
+  conformerPositionData.resize(size_t(3) * newConformerAtomCapacity *
+                               numConformersCapacity);
+
+  if (newConformerAtomCapacity != conformerAtomCapacity) {
+    // This only works if we can't decrease the atom capacity
+    assert(newConformerAtomCapacity > conformerAtomCapacity);
+
+    // Copy the previous data to the new locations, with a backward loop and memmove
+    // to avoid issues with overlap.
+    size_t numConformersToCopy =
+        (getNumAtoms() != 0) ? std::min(numConformers, newNumConformers) : 0;
+    const size_t oldConformerStride = 3 * conformerAtomCapacity;
+    const size_t newConformerStride = 3 * newConformerAtomCapacity;
+    for (size_t i = numConformersToCopy; i > 0; ) {
+        --i;
+        auto *dest = conformerPositionData.data() + i * newConformerStride;
+        const auto *source =
+            conformerPositionData.data() + i * oldConformerStride;
+        // Move the existing data
+        std::memmove(dest, source,
+                     sizeof(conformerPositionData[0]) * 3 * getNumAtoms() );
+    }
+
+    conformerAtomCapacity = newConformerAtomCapacity;
+  }
+}
+
+const RingInfoCache& RDMol::getRingInfo() const {
+  auto* compat = getCompatibilityDataIfPresent();
+  if (compat != nullptr) {
+    initCompatForReadHelper<false>(
+        compat->ringInfoSyncStatus, compatibilityMutex, [&]() {
+          copyRingInfoFromCompatibilityData(*compat->ringInfo, ringInfo,
+                                          getNumAtoms(), getNumBonds());
+        });
+  }
+  return ringInfo;
+}
+RingInfoCache &RDMol::getRingInfo() {
+  auto *compat = getCompatibilityDataIfPresent();
+  if (compat != nullptr) {
+    initCompatForWriteHelper<false>(
+        compat->ringInfoSyncStatus, compatibilityMutex, [&]() {
+          copyRingInfoFromCompatibilityData(*compat->ringInfo, ringInfo,
+                                            getNumAtoms(), getNumBonds());
+        });
+  }
+  return ringInfo;
+}
+
+} // namespace RDKit
+

--- a/Code/GraphMol/RDMol.h
+++ b/Code/GraphMol/RDMol.h
@@ -1,0 +1,2084 @@
+//
+//  Copyright (C) 2025 NVIDIA Corporation & Affiliates and other RDKit contributors
+//
+//   @@ All Rights Reserved @@
+//  This file is part of the RDKit.
+//  The contents are covered by the terms of the BSD license
+//  which is included in the file license.txt, found at the root
+//  of the RDKit source tree.
+//
+#pragma once
+
+#include "GraphMolEnums.h"
+
+#include "details.h"
+#include "RingInfo.h"
+#include "StereoGroup.h"
+#include "SubstanceGroup.h"
+
+#include <RDGeneral/export.h>
+#include <RDGeneral/types.h>
+#include <RDGeneral/Invariant.h>
+#include <GraphMol/rdmol_throw.h>
+#include <GraphMol/MonomerInfo.h>
+#include <Query/Query.h>
+
+#include <boost/dynamic_bitset.hpp>
+
+#include <atomic>
+#include <limits>
+#include <mutex>
+#include <stdint.h>
+#include <vector>
+
+namespace RDKit {
+
+class RDMol;
+class ConstRDMolAtom;
+class RDMolAtom;
+class ConstRDMolBond;
+class RDMolBond;
+
+class Atom;
+class Bond;
+class Conformer;
+class ROMol;
+class RWMol;
+
+class AtomData {
+  static constexpr uint8_t unsetValenceVal =
+      std::numeric_limits<uint8_t>::max();
+
+  uint8_t atomicNum = 0;
+  uint8_t numExplicitHs = 0;
+  uint8_t explicitValence = unsetValenceVal;
+  uint8_t implicitValence = unsetValenceVal;
+  bool isAromatic = false;
+  bool noImplicit = false;
+  int8_t formalCharge = 0;
+  uint8_t chiralTag = AtomEnums::ChiralType::CHI_UNSPECIFIED;
+  uint8_t numRadicalElectrons = 0;
+  uint8_t hybridization = AtomEnums::HybridizationType::UNSPECIFIED;
+  uint16_t isotope = 0;
+
+  friend class RDMol;
+  friend class MolPickler;
+  friend class Atom;
+
+public:
+  uint32_t getAtomicNum() const { return atomicNum; }
+  void setAtomicNum(uint32_t num) { atomicNum = num; }
+  uint32_t getNumExplicitHs() const {
+    return numExplicitHs;
+  }
+  void setNumExplicitHs(uint32_t num) {
+    PRECONDITION(num <= unsetValenceVal,
+                 "setNumExplicitHs called with too large number");
+    numExplicitHs = num;
+  }
+  uint32_t getExplicitValence() const {
+    PRECONDITION(explicitValence != unsetValenceVal,
+                 "getExplicitValence() called without preceding call to "
+                 "calcExplicitValence()");
+    return explicitValence;
+  }
+  uint32_t getImplicitValence() const {
+    // TODO: This PRECONDITION check was added to Atom::getValence, in the
+    // commit adding Atom::getValence, but there's code in Chirality.cpp and
+    // Atropisomers.cpp that checks for Atom::getImplicitValence returning -1,
+    // which can only happen if the PRECONDITION check fails.
+    // Is this correct?  Should the code checking for -1 be updated?
+    PRECONDITION(noImplicit || implicitValence != unsetValenceVal,
+                 "getImplicitValence() called without preceding call to "
+                 "calcImplicitValence()");
+    return noImplicit ? 0 : implicitValence;
+  }
+  uint32_t getTotalValence() const {
+    return getExplicitValence() + getImplicitValence();
+  }
+
+  enum class ValenceType : std::uint8_t {
+    IMPLICIT = 0,
+    EXPLICIT
+  };
+
+  uint32_t getValence(ValenceType which) {
+    if (which == ValenceType::EXPLICIT) {
+      return getExplicitValence();
+    }
+    return getImplicitValence();
+  }
+
+  bool getNoImplicit() const { return noImplicit; }
+  void setNoImplicit(bool value) { noImplicit = value; }
+
+  // This is just a synonym of getImplicitValence
+  uint32_t getNumImplicitHs() const {
+    PRECONDITION(noImplicit || (implicitValence != unsetValenceVal),
+                 "getNumImplicitHs() called without preceding call to "
+                 "calcImplicitValence()");
+    return getImplicitValence();
+  }
+  int8_t getFormalCharge() const {
+    return formalCharge;
+  }
+  void setFormalCharge(int8_t charge) { formalCharge = charge; }
+
+  uint32_t getIsotope() const { return isotope; }
+  void setIsotope(uint32_t value) { isotope = value; }
+
+  AtomEnums::ChiralType getChiralTag() const {
+    return AtomEnums::ChiralType(chiralTag);
+  }
+  void setChiralTag(AtomEnums::ChiralType tag) {
+    chiralTag = uint8_t(tag);
+  }
+
+  AtomEnums::HybridizationType getHybridization() const {
+    return AtomEnums::HybridizationType(hybridization);
+  }
+  void setHybridization(AtomEnums::HybridizationType value) {
+    hybridization = uint8_t(value);
+  }
+
+  bool getIsAromatic() const { return isAromatic; }
+  void setIsAromatic(bool value) { isAromatic = value; }
+
+  uint32_t getNumRadicalElectrons() const { return numRadicalElectrons; }
+  void setNumRadicalElectrons(uint32_t num) { numRadicalElectrons = num; }
+
+  bool needsUpdatePropertyCache() const {
+    return explicitValence == unsetValenceVal ||
+           (!noImplicit && implicitValence == unsetValenceVal);
+  }
+
+  double getMass() const;
+};
+
+inline uint32_t getTwiceBondType(BondEnums::BondType type) {
+  using BondEnums::BondType;
+  switch (type) {
+    case BondType::UNSPECIFIED:
+    case BondType::IONIC:
+    case BondType::ZERO:
+      return 0;
+    case BondType::SINGLE:
+      return 2;
+    case BondType::DOUBLE:
+      return 4;
+    case BondType::TRIPLE:
+      return 6;
+    case BondType::QUADRUPLE:
+      return 8;
+    case BondType::QUINTUPLE:
+      return 10;
+    case BondType::HEXTUPLE:
+      return 12;
+    case BondType::ONEANDAHALF:
+      return 3;
+    case BondType::TWOANDAHALF:
+      return 5;
+    case BondType::THREEANDAHALF:
+      return 7;
+    case BondType::FOURANDAHALF:
+      return 9;
+    case BondType::FIVEANDAHALF:
+      return 11;
+    case BondType::AROMATIC:
+      return 3;
+    case BondType::DATIVEONE:
+      return 2; // FIX: this should probably be different
+    case BondType::DATIVE:
+      return 2; // FIX: again probably wrong
+    case BondType::HYDROGEN:
+      return 0;
+    default:
+      UNDER_CONSTRUCTION("Bad bond type");
+      return 0;
+  }
+}
+
+class BondData {
+  uint8_t bondType = BondEnums::BondType::UNSPECIFIED;
+  uint8_t dirTag = BondEnums::BondDir::NONE;
+  uint8_t stereo = BondEnums::BondStereo::STEREONONE;
+  bool isAromatic = false;
+  bool isConjugated = false;
+  atomindex_t beginAtomIdx = atomindex_t(-1);
+  atomindex_t endAtomIdx = atomindex_t(-1);
+  atomindex_t stereoAtoms[2] = {atomindex_t(-1), atomindex_t(-1)};
+
+  friend class RDMol;
+  friend class Bond;
+ public:
+
+  BondEnums::BondType getBondType() const {
+    return BondEnums::BondType(bondType);
+  }
+  void setBondType(BondEnums::BondType type) { bondType = uint8_t(type); }
+
+  BondEnums::BondStereo getStereo() const {
+    return BondEnums::BondStereo(stereo);
+  }
+  void setStereo(BondEnums::BondStereo value) {
+    //PRECONDITION(value <= BondEnums::BondStereo::STEREOE || hasStereoAtoms(),
+    //             "Stereo atoms should be specified before specifying CIS/TRANS "
+    //             "bond stereochemistry")
+    stereo = uint8_t(value);
+  }
+
+  atomindex_t getBeginAtomIdx() const { return beginAtomIdx; }
+  void setBeginAtomIdx(atomindex_t atomIdx) { beginAtomIdx = atomIdx; }
+  atomindex_t getEndAtomIdx() const { return endAtomIdx; }
+  void setEndAtomIdx(atomindex_t atomIdx) { endAtomIdx = atomIdx; }
+
+  atomindex_t getOtherAtomIdx(const atomindex_t thisIdx) const {
+    PRECONDITION(beginAtomIdx == thisIdx || endAtomIdx == thisIdx,
+                 "bad index");
+    return (beginAtomIdx == thisIdx) ? endAtomIdx : beginAtomIdx;
+  }
+
+  BondEnums::BondDir getBondDir() const { return BondEnums::BondDir(dirTag); }
+  void setBondDir(BondEnums::BondDir dir) { dirTag = BondEnums::BondDir(dir); }
+
+  bool getIsAromatic() const { return isAromatic; }
+  void setIsAromatic(bool value) { isAromatic = value; }
+
+  bool getIsConjugated() const { return isConjugated; }
+  void setIsConjugated(bool value) { isConjugated = value; }
+
+  uint32_t getTwiceValenceContrib(const atomindex_t atomIndex) const {
+    if (atomIndex != beginAtomIdx && atomIndex != endAtomIdx) {
+      return 0;
+    }
+    using BondEnums::BondType;
+    if ((bondType == BondType::DATIVE || bondType == BondType::DATIVEONE) &&
+        atomIndex != endAtomIdx) {
+      return 0;
+    }
+    return getTwiceBondType(BondType(bondType));
+  }
+};
+
+class RingInfoCache {
+ public:
+  // Indices into atomsInRings and bondsInRings where each ring begins
+  // Size is numRings+1
+  std::vector<uint32_t> ringBegins;
+  // Size is the combined size of all rings (ringBegins.back())
+  // Each ring starts at ringBegins[ringIndex]
+  std::vector<uint32_t> atomsInRings;
+  // Size is the combined size of all rings (ringBegins.back())
+  // Each ring starts at ringBegins[ringIndex]
+  // TODO: Consider combining bondsInRings with atomsInRings, since they're always kept the same length.
+  std::vector<uint32_t> bondsInRings;
+  // Size is numAtoms+1
+  std::vector<uint32_t> atomMembershipBegins;
+  // Size is the combined size of all rings (atomMembershipBegins.back())
+  // Each atom's list of rings starts at atomMembershipBegins[atomIndex]
+  std::vector<uint32_t> atomMemberships;
+  // Size is numBonds+1
+  std::vector<uint32_t> bondMembershipBegins;
+  // Size is the combined size of all rings (bondMembershipBegins.back())
+  // Each bond's list of rings starts at bondMembershipBegins[bondIndex]
+  std::vector<uint32_t> bondMemberships;
+
+  // 2D bit vector representing whether each pair of rings shares at least one bond.
+  // Size is numRings x numRings, in one contiguous bit vector
+  std::vector<bool> areRingsFused;
+  // The number of bonds in each ring that are shared with any other rings.
+  // Size is numRings
+  std::vector<uint32_t> numFusedBonds;
+
+  // TODO: Add support for ring families
+
+  INT_VECT tempPerAtomInts;
+  std::vector<std::pair<int,int>> tempPerAtomPairs;
+
+  RDKit::FIND_RING_TYPE findRingType = FIND_RING_TYPE_OTHER_OR_UNKNOWN;
+
+  bool isInit = false;
+
+  // FIXME: Implement lazy caching of fused ring bit vectors from RingInfo
+  // They indicate whether each ring, i, shares a bond with each other ring, j, or not.
+
+  bool isInitialized() const { return isInit; }
+
+  void reset() {
+    ringBegins.resize(0);
+    atomsInRings.resize(0);
+    bondsInRings.resize(0);
+    atomMembershipBegins.resize(0);
+    atomMemberships.resize(0);
+    bondMembershipBegins.resize(0);
+    bondMemberships.resize(0);
+    areRingsFused.resize(0);
+    numFusedBonds.resize(0);
+    tempPerAtomInts.resize(0);
+    tempPerAtomPairs.resize(0);
+    findRingType = FIND_RING_TYPE_OTHER_OR_UNKNOWN;
+    isInit = false;
+  }
+
+  uint32_t numRings() const {
+    return (ringBegins.size() == 0) ? 0 : (ringBegins.size() - 1);
+  }
+
+  uint32_t numAtomRings(atomindex_t atomIndex) const {
+    return atomMembershipBegins[atomIndex + 1] -
+           atomMembershipBegins[atomIndex];
+  }
+
+  uint32_t numBondRings(uint32_t bondIndex) const {
+    return bondMembershipBegins[bondIndex + 1] -
+           bondMembershipBegins[bondIndex];
+  }
+
+  bool isAtomInRingOfSize(atomindex_t atomIndex, uint32_t size) const {
+    const uint32_t* atomMembershipBegin =
+        atomMemberships.data() + atomMembershipBegins[atomIndex];
+    const uint32_t* atomMembershipEnd =
+        atomMemberships.data() + atomMembershipBegins[atomIndex + 1];
+    for (; atomMembershipBegin != atomMembershipEnd; ++atomMembershipBegin) {
+      const uint32_t ring = *atomMembershipBegin;
+      if (ringBegins[ring + 1] - ringBegins[ring] == size) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  bool isBondInRingOfSize(uint32_t bondIndex, uint32_t size) const {
+    const uint32_t* bondMembershipBegin =
+        bondMemberships.data() + bondMembershipBegins[bondIndex];
+    const uint32_t* bondMembershipEnd =
+        bondMemberships.data() + bondMembershipBegins[bondIndex + 1];
+    for (; bondMembershipBegin != bondMembershipEnd; ++bondMembershipBegin) {
+      const uint32_t ring = *bondMembershipBegin;
+      if (ringBegins[ring + 1] - ringBegins[ring] == size) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  uint32_t minAtomRingSize(atomindex_t atomIndex) const {
+    uint32_t minSize = std::numeric_limits<uint32_t>::max();
+    const uint32_t* atomMembershipBegin =
+        atomMemberships.data() + atomMembershipBegins[atomIndex];
+    const uint32_t* atomMembershipEnd =
+        atomMemberships.data() + atomMembershipBegins[atomIndex + 1];
+    for (; atomMembershipBegin != atomMembershipEnd; ++atomMembershipBegin) {
+      const uint32_t ring = *atomMembershipBegin;
+      const uint32_t size = ringBegins[ring + 1] - ringBegins[ring];
+      if (size < minSize) {
+        minSize = size;
+      }
+    }
+    return minSize;
+  }
+
+  uint32_t minBondRingSize(uint32_t bondIndex) const {
+    uint32_t minSize = std::numeric_limits<uint32_t>::max();
+    const uint32_t* bondMembershipBegin =
+        bondMemberships.data() + bondMembershipBegins[bondIndex];
+    const uint32_t* bondMembershipEnd =
+        bondMemberships.data() + bondMembershipBegins[bondIndex + 1];
+    for (; bondMembershipBegin != bondMembershipEnd; ++bondMembershipBegin) {
+      const uint32_t ring = *bondMembershipBegin;
+      const uint32_t size = ringBegins[ring + 1] - ringBegins[ring];
+      if (size < minSize) {
+        minSize = size;
+      }
+    }
+    return minSize;
+  }
+};
+
+struct StereoGroups {
+  static constexpr uint32_t undefinedGroupId = 0;
+
+  // 1 per group
+  std::vector<StereoGroupType> stereoTypes;
+  std::vector<uint32_t> readIds;
+  std::vector<uint32_t> writeIds;
+
+  // Size n_groups + 1
+  std::vector<uint32_t> atomBegins = {0};
+  std::vector<uint32_t> bondBegins = {0};
+
+  // Size atomBegins[n_atoms]
+  std::vector<uint32_t> atoms;
+  // Size bondBegins[n_bonds]
+  std::vector<uint32_t> bonds;
+
+
+  //! Returns the number of stereo groups.
+  uint32_t getNumGroups() const {return stereoTypes.size();}
+  //! Removes a stereo group by index.
+  void removeGroup(uint32_t groupIndex);
+
+  void addGroup(StereoGroupType type, const std::vector<uint32_t>& atomIndices,
+                const std::vector<uint32_t>& bondIndices, uint32_t readId = undefinedGroupId);
+
+  StereoGroupType getGroupType(uint32_t groupIndex) const {
+    URANGE_CHECK(groupIndex, stereoTypes.size());
+    return stereoTypes[groupIndex];
+  }
+
+  uint32_t getReadID(uint32_t groupIndex) const {
+    URANGE_CHECK(groupIndex, readIds.size());
+    return readIds[groupIndex];
+  }
+
+  uint32_t getWriteID(uint32_t groupIndex) const {
+    URANGE_CHECK(groupIndex, writeIds.size());
+    return writeIds[groupIndex];
+  }
+  void setWriteID(uint32_t groupIndex, uint32_t value) {
+    URANGE_CHECK(groupIndex, writeIds.size());
+    writeIds[groupIndex] = value;
+  }
+
+  std::pair<uint32_t*, uint32_t*> getAtoms(uint32_t groupIndex) {
+    URANGE_CHECK(groupIndex + 1, atomBegins.size());
+    return {atoms.data() + atomBegins[groupIndex], atoms.data() + atomBegins[groupIndex + 1]};
+  }
+  std::pair<const uint32_t*, const uint32_t*> getAtoms(uint32_t groupIndex) const {
+    URANGE_CHECK(groupIndex + 1, atomBegins.size());
+    return {atoms.data() + atomBegins[groupIndex], atoms.data() + atomBegins[groupIndex + 1]};
+  }
+  std::pair<uint32_t*, uint32_t*> getBonds(uint32_t groupIndex) {
+    URANGE_CHECK(groupIndex + 1, bondBegins.size());
+    return {bonds.data() + bondBegins[groupIndex], bonds.data() + bondBegins[groupIndex + 1]};
+  }
+  std::pair<const uint32_t*, const uint32_t*> getBonds(uint32_t groupIndex) const {
+    URANGE_CHECK(groupIndex + 1, bondBegins.size());
+    return {bonds.data() + bondBegins[groupIndex], bonds.data() + bondBegins[groupIndex + 1]};
+  }
+
+  //! Compare two groups for equality. Does not compare read and write IDs.
+  bool GroupsEq(uint32_t index1, uint32_t index2);
+  //! Removes atom index from all groups where present. If decrementIndices is true,
+  //! all atom indices greater than the removed index are decremented.
+  void removeAtomFromGroups(uint32_t atomIndex, bool decrementIndices = false);
+  //! Remove any group containing the specified atom.
+  void removeGroupsWithAtom(uint32_t atomIndex);
+  //! Remove any group containing any of the specified atoms.
+  void removeGroupsWithAtoms(const std::vector<uint32_t>& atomIndices);
+  //! Remove any group containing the specified bond.
+  void removeGroupsWithBond(uint32_t bondIndex);
+  //! Remove any group containing any of the specified bonds.
+  void removeGroupsWithBonds(const std::vector<uint32_t>& bondIndices);
+  //! Populates write IDs for stereo groups that don't have them.
+  void assignStereoGroupIds();
+  //! Populates all write IDs from read IDs.
+  void forwardStereoGroupIds();
+};
+
+struct ConformerIdAndFlags {
+  uint32_t id;
+  bool is3D;
+};
+
+enum class PropertyType : uint8_t {
+  CHAR,     // 8 bit
+  BOOL,     // 8 bit,
+  INT32,    // 32 bit
+  UINT32,   // 32 bit
+  INT64,    // 64 bit
+  UINT64,   // 64 bit
+  FLOAT,    // 32 bit
+  DOUBLE,   // 64 bit
+  ANY       // RDValue
+};
+
+template <typename T>
+struct TypeToPropertyType {
+  static constexpr PropertyType family = PropertyType::ANY;
+};
+template<> struct TypeToPropertyType<bool> { static constexpr PropertyType family = PropertyType::BOOL;};
+template<> struct TypeToPropertyType<char> { static constexpr PropertyType family = PropertyType::CHAR;};
+template<> struct TypeToPropertyType<int> { static constexpr PropertyType family = PropertyType::INT32;};
+template<> struct TypeToPropertyType<unsigned int> { static constexpr PropertyType family = PropertyType::UINT32;};
+template<> struct TypeToPropertyType<int64_t> { static constexpr PropertyType family = PropertyType::INT64;};
+template<> struct TypeToPropertyType<uint64_t> { static constexpr PropertyType family = PropertyType::UINT64;};
+template<> struct TypeToPropertyType<float> { static constexpr PropertyType family = PropertyType::FLOAT;};
+template<> struct TypeToPropertyType<double> { static constexpr PropertyType family = PropertyType::DOUBLE;};
+
+//! Variant for holding scalar array properties
+struct PropArray {
+  //! Number of elements
+  uint32_t size = 0;
+  //! Scalar family
+  PropertyType family;
+  //! Data pointer
+  void* data = nullptr;
+  //! Mask for set values (bool);
+  std::unique_ptr<bool[]> isSetMask = nullptr;
+  uint32_t numSet = 0;
+
+  PropArray();
+  PropArray(uint32_t size, PropertyType family, bool isSet);
+  PropArray(const PropArray& other);
+  PropArray& operator=(const PropArray& other);
+  PropArray(PropArray&& other);
+  PropArray& operator=(PropArray&& other);
+  ~PropArray() noexcept;
+
+  //! Set up array data.
+  void construct(bool isSet);
+
+  //! Tear down array data
+  void destroy();
+
+  //! Cast an array data point to an RDValue containing that data point.
+  RDValue toRDValue(uint32_t idx) const;
+
+  template<typename T>
+  T getValueAs(uint32_t index) const {
+    using RawType = std::remove_cv_t<std::remove_reference_t<T>>;
+    // There are 4 combinations of scalar/RDvalue request/content we need to
+    // account for.
+    // Note that any invalid conversions, such as int to vector of int, will be
+    // caught via RDValue cast.
+    if constexpr (TypeToPropertyType<RawType>::family == PropertyType::ANY) {
+      // Case where we need an RDValue and have one already.
+      if (family == PropertyType::ANY) {
+        RDValue &caster = static_cast<RDValue *>(data)[index];
+        if constexpr (std::is_same_v<RawType, std::string>) {
+          std::string res;
+          rdvalue_tostring(caster, res);
+          return res;
+        } else {
+          return from_rdvalue<T>(caster);
+        }
+      }
+      // Case where we need an RDValue but have a scalar.
+      else {
+        RDValue caster = toRDValue(index);
+        if constexpr (std::is_same_v<RawType, std::string>) {
+          std::string res;
+          try {
+            rdvalue_tostring(caster, res);
+            RDValue::cleanup_rdvalue(caster);
+            return res;
+          } catch (...) {
+            RDValue::cleanup_rdvalue(caster);
+            throw;
+          }
+        } else {
+          try {
+            T res = rdvalue_cast<T>(caster);
+            RDValue::cleanup_rdvalue(caster);
+            return res;
+          } catch (...) {
+            RDValue::cleanup_rdvalue(caster);
+            throw;
+          }
+        }
+      }
+    } else {
+      // Case where we need a scalar but have an RDValue.
+      if (family == PropertyType::ANY) {
+        RDValue &caster = static_cast<RDValue *>(data)[index];
+        return from_rdvalue<T>(caster);
+      }
+      // Case where we have a scalar and need a scalar.
+      else {
+        if (family == TypeToPropertyType<RawType>::family) {
+          return static_cast<T *>(data)[index];
+        }
+        RDValue tempVal = toRDValue(index);
+        try {
+          T res = rdvalue_cast<T>(tempVal);
+          RDValue::cleanup_rdvalue(tempVal);
+          return res;
+        } catch (...) {
+            RDValue::cleanup_rdvalue(tempVal);
+            throw;
+        };
+
+      }
+    }
+  }
+
+  //! Adds a single new property to the end of the array.
+  void appendElement();
+  //! Removes an element from the array.
+  void removeElement(uint32_t index);
+
+  //! Converts storage type to RDValue, family PropertyType::ANY,
+  //! or does nothing if already RDValue.
+  void convertToRDValue();
+};
+
+namespace Ranges {
+template <bool ISBOND, bool ISCONST>
+class IndexRange;
+template <bool ISBOND, bool ISCONST>
+class IndirectRange;
+}  // namespace Ranges
+
+class RDKIT_GRAPHMOL_EXPORT RDMol {
+  std::vector<AtomData> atomData;
+  std::vector<uint32_t> atomBondStarts = {0u};
+  std::vector<uint32_t> otherAtomIndices;
+  std::vector<uint32_t> bondDataIndices;
+  // Mutable only for compatibility synchronization in getBondStereoAtoms below
+  mutable std::vector<BondData> bondData;
+
+  std::unique_ptr<StereoGroups> stereoGroups;
+  // Mutable only for compatibility synchronization while locked.
+  mutable RingInfoCache ringInfo;
+
+  // FIXME: Sort out a more efficient representation for substance groups.
+  std::vector<SubstanceGroup> substanceGroups;
+
+  size_t numConformers = 0;
+  size_t conformerAtomCapacity = 0;
+
+  // All conformers are stored in conformerPositionData, which consists of
+  // numConformers x conformerAtomCapacity x 3 doubles.
+  // It's resized when adding conformers or when the number of atoms exceeds
+  // conformerAtomCapacity.
+  // Mutable only for compatibility synchronization while locked.
+  mutable std::vector<double> conformerPositionData;
+
+  // This is unused if all conformer IDs are equal to their index and
+  // all conformers are 3D.
+  // Mutable only for compatibility synchronization while locked.
+  mutable std::vector<ConformerIdAndFlags> conformerIdsAndFlags;
+
+public:
+  using QUERYATOM_QUERY = Queries::Query<int, ConstRDMolAtom, true>;
+  using QUERYBOND_QUERY = Queries::Query<int, ConstRDMolBond, true>;
+
+private:
+  std::vector<std::unique_ptr<QUERYATOM_QUERY>> atomQueries;
+  std::vector<std::unique_ptr<QUERYBOND_QUERY>> bondQueries;
+
+  bool isStereochemDone = false;
+
+  //! Atom tracker for batch edits. A batch edit is in progress if non-null.
+  std::unique_ptr<boost::dynamic_bitset<>> dp_delAtoms;
+  //! Bond tracker for batch edits. A batch edit is in progress if non-null.
+  std::unique_ptr<boost::dynamic_bitset<>> dp_delBonds;
+
+  struct CompatibilityData;
+  // CompatibilityData needs private access to Conformer for setOwningMol,
+  // but CompatibilityData itself is private, so Conformer needs private access here.
+  friend class Conformer;
+  mutable std::mutex compatibilityMutex;
+  mutable std::atomic<CompatibilityData*> compatibilityData = nullptr;
+
+  enum class Scope : uint8_t {
+    MOL,   // Just 1 value (can be an array value)
+    ATOM,  // 1 value per atom
+    BOND   // 1 value per bond
+  };
+  struct RDKIT_GRAPHMOL_EXPORT Property {
+    PropToken name;
+    Scope scope;
+    bool isComputed;
+    RDValue inPlaceData;
+    PropArray arrayData;
+
+    // Default initialization just needs to indicate a type with no allocation.
+    Property()
+        : name(),
+          scope(Scope::MOL),
+          isComputed(false){
+    }
+    Property(Property&& other) noexcept
+        : name(std::move(other.name)),
+          scope(other.scope),
+          isComputed(other.isComputed),
+          inPlaceData(std::move(other.inPlaceData)),
+          arrayData(std::move(other.arrayData)) {
+      // If a move constructor is ever added to RDValue, setting the type here
+      // may not be required and may be invalid, but the static_assert will
+      // force someone to check what the correct behaviour should be.
+      static_assert(std::is_trivially_move_constructible_v<RDValue>);
+      if (std::is_trivially_move_constructible_v<RDValue>) {
+        other.inPlaceData.type = RDTypeTag::EmptyTag;
+      }
+    }
+    ~Property() { RDValue::cleanup_rdvalue(inPlaceData); }
+    Property& operator=(Property&& other) noexcept {
+      if (this == &other) {
+        return *this;
+      }
+      name = std::move(other.name);
+      scope = other.scope;
+      isComputed = other.isComputed;
+      inPlaceData = std::move(other.inPlaceData);
+      // If a move constructor is ever added to RDValue, setting the type here
+      // may not be required and may be invalid, but the static_assert will
+      // force someone to check what the correct behaviour should be.
+      static_assert(std::is_trivially_move_constructible_v<RDValue>);
+      if (std::is_trivially_move_constructible_v<RDValue>) {
+        other.inPlaceData.type = RDTypeTag::EmptyTag;
+      }
+      arrayData = std::move(other.arrayData);
+      return *this;
+    }
+    Property(const Property &other) : name(other.name), scope(other.scope), isComputed(other.isComputed), arrayData(other.arrayData) {
+        copy_rdvalue(inPlaceData, other.inPlaceData);
+    }
+    Property &operator=(const Property &other) {
+      if (this == &other) {
+        return *this;
+      }
+      name = other.name;
+      scope = other.scope;
+      isComputed = other.isComputed;
+      copy_rdvalue(inPlaceData, other.inPlaceData);
+      arrayData = other.arrayData;
+      return *this;
+    }
+
+    template<typename T>
+    void setVal(const T& val) {
+      RDValue::cleanup_rdvalue(inPlaceData);
+      inPlaceData = val;
+    }
+    void setVal(const RDValue &val) {
+      copy_rdvalue(inPlaceData, val);
+    }
+    void setVal(const char *val) {
+      std::string s(val);
+      setVal(s);
+    }
+
+    template<typename T>
+    T getVal() {
+      return rdvalue_cast<T>(inPlaceData);
+    }
+  };
+
+  public:
+  class RDKIT_GRAPHMOL_EXPORT PropIterator {
+    std::vector<Property>::const_iterator d_current;
+    std::vector<Property>::const_iterator d_end;
+    bool d_includeComputed;
+    Scope d_scope;
+    uint32_t d_index;
+
+    bool currentScopeIsCorrect() const {
+      if (d_current->scope != d_scope) {
+        return false;
+      }
+      if (!d_includeComputed && d_current->isComputed) {
+        return false;
+      }
+      if (d_scope != Scope::MOL && d_index != anyIndexMarker &&
+          !d_current->arrayData.isSetMask[d_index]) {
+        return false;
+      }
+      return true;
+    }
+
+   public:
+    static constexpr uint32_t anyIndexMarker = uint32_t(-1);
+
+    using difference_type = size_t;
+    using value_type = PropToken;
+    using pointer = PropToken*;
+    using reference = PropToken&;
+    using iterator_category = std::forward_iterator_tag;
+
+    PropIterator() = default;
+    PropIterator(PropIterator&&) = default;
+    PropIterator(const PropIterator&) = default;
+    PropIterator &operator=(PropIterator&&) = default;
+    PropIterator &operator=(const PropIterator&) = default;
+
+    PropIterator(std::vector<Property>::const_iterator current,
+                 std::vector<Property>::const_iterator end,
+                 bool includeComputed, Scope scope, uint32_t index)
+        : d_current(current),
+          d_end(end),
+          d_includeComputed(includeComputed),
+          d_scope(scope),
+          d_index(index) {
+      // Iterate to the first matching property.
+      while (d_current != d_end && !currentScopeIsCorrect()) {
+        ++d_current;
+      }
+    }
+
+    const PropToken &operator*() const {
+      PRECONDITION(d_current != d_end, "PropIterator::operator* end");
+      PRECONDITION(d_current->scope == d_scope, "PropIterator::operator* scope");
+      PRECONDITION(d_includeComputed || !d_current->isComputed,
+                   "PropIterator::operator* isComputed");
+      PRECONDITION(d_scope == Scope::MOL || d_index == anyIndexMarker ||
+                       (d_index < d_current->arrayData.size &&
+                        d_current->arrayData.isSetMask[d_index]),
+                   "PropIterator::operator* index")
+      return d_current->name;
+    }
+    const PropToken* operator->() const { return &**this; }
+
+    PropIterator &operator++() {
+      PRECONDITION(d_current != d_end, "PropIterator::operator++ end");
+      PRECONDITION(d_scope == Scope::MOL || d_index == anyIndexMarker ||
+                       d_index < d_current->arrayData.size,
+                   "PropIterator::operator++ index");
+      while (true) {
+        ++d_current;
+        if (d_current == d_end) {
+          break;
+        }
+        if (currentScopeIsCorrect()) {
+          break;
+        }
+      }
+      return *this;
+    }
+
+    PropIterator operator++(int) {
+      auto copy = *this;
+      ++(*this);
+      return copy;
+    }
+
+    bool operator==(const PropIterator &that) const {
+      return d_current == that.d_current;
+    }
+    bool operator!=(const PropIterator &that) const { return !(*this == that); }
+  };
+
+ private:
+
+  std::vector<Property> properties;
+
+  //! Map of bookmarks to atom indices associated with that bookmark
+  std::unordered_map<int, std::vector<int>> atomBookmarks;
+  //! Map of bookmarks to bond indices associated with that bookmark
+  std::unordered_map<int, std::vector<int>> bondBookmarks;
+
+  std::unordered_map<int, std::unique_ptr<AtomMonomerInfo>> monomerInfo;
+  friend class ROMol;
+  friend class RWMol;
+  friend class Atom;
+  friend class Bond;
+  friend class QueryAtom;
+  friend class QueryBond;
+
+ public:
+  using ADJ_ITER_PAIR = std::pair<const uint32_t*,const uint32_t*>;
+
+  RDMol() = default;
+  explicit RDMol(const RDMol &other);
+  RDMol(const RDMol &other, bool quickCopy, int confId = -1);
+  RDMol &operator=(const RDMol &other);
+  RDMol(RDMol &&other) noexcept;
+  RDMol &operator=(RDMol &&other) noexcept;
+
+  ~RDMol();
+  void clear();
+
+  // Returns the number of explicit atoms
+  uint32_t getNumAtoms() const {
+    return uint32_t(atomData.size());
+  }
+  uint32_t getNumAtoms(bool onlyExplicit) const {
+    const uint32_t numAtoms = uint32_t(atomData.size());
+    uint32_t res = numAtoms;
+    if (!onlyExplicit) {
+      for (uint32_t atom = 0; atom < numAtoms; ++atom) {
+        res += getTotalNumHs(atom, false);
+      }
+    }
+    return res;
+  }
+  uint32_t getNumHeavyAtoms() const {
+    const uint32_t numAtoms = uint32_t(atomData.size());
+    uint32_t res = 0;
+    for (uint32_t i = 0; i != numAtoms; ++i) {
+      if (atomData[i].getAtomicNum() > 1) {
+        ++res;
+      }
+    }
+    return res;
+  };
+
+  const AtomData& getAtom(uint32_t atomIndex) const {
+    URANGE_CHECK(atomIndex, getNumAtoms());
+    return atomData[atomIndex];
+  }
+  AtomData& getAtom(uint32_t atomIndex) {
+    URANGE_CHECK(atomIndex, getNumAtoms());
+    return atomData[atomIndex];
+  }
+  const BondData& getBond(uint32_t bondIndex) const {
+    URANGE_CHECK(bondIndex, getNumBonds());
+    return bondData[bondIndex];
+  }
+  BondData& getBond(uint32_t bondIndex) {
+    URANGE_CHECK(bondIndex, getNumBonds());
+    return bondData[bondIndex];
+  }
+
+  uint32_t getTotalNumHs(uint32_t atomIndex, bool includeNeighbors = false) const {
+    PRECONDITION(atomIndex < getNumAtoms(), "RDMol::getTotalNumHs called with out of bounds atomIndex");
+    const AtomData& atom = atomData[atomIndex];
+    uint32_t res = atom.getNumExplicitHs() + atom.getNumImplicitHs();
+    if (includeNeighbors) {
+      uint32_t atomBegin = atomBondStarts[atomIndex];
+      const uint32_t atomEnd = atomBondStarts[atomIndex+1];
+      for (; atomBegin < atomEnd; ++atomBegin) {
+        const AtomData& nbr = atomData[otherAtomIndices[atomBegin]];
+        if (nbr.getAtomicNum() == 1) {
+          ++res;
+        }
+      }
+    }
+    return res;
+  }
+  uint32_t getAtomDegree(uint32_t atomIndex) const {
+    URANGE_CHECK(atomIndex, getNumAtoms());
+    uint32_t atomBegin = atomBondStarts[atomIndex];
+    uint32_t atomEnd = atomBondStarts[atomIndex + 1];
+    return atomEnd - atomBegin;
+  }
+  uint32_t getAtomTotalDegree(uint32_t atomIndex) const {
+    return getTotalNumHs(atomIndex, false) + getAtomDegree(atomIndex);
+  }
+  uint32_t getNumBonds(bool onlyHeavy = true) const {
+    // By default return the bonds that connect only the heavy atoms
+    // hydrogen connecting bonds are ignores
+    uint32_t numBonds = uint32_t(bondData.size());
+    if (!onlyHeavy) {
+      // If we need hydrogen connecting bonds add them up
+      for (uint32_t atom = 0, numAtoms = getNumAtoms(); atom < numAtoms; ++atom) {
+        numBonds += getTotalNumHs(atom, false);
+      }
+    }
+    return numBonds;
+  }
+
+  bool isAromaticAtom(atomindex_t atomIndex) const {
+    PRECONDITION(atomIndex < getNumAtoms(),
+                 "RDMol::isAromaticAtom called with out of bounds atomIndex");
+    const AtomData& atom = atomData[atomIndex];
+    if (atom.getIsAromatic()) {
+      return true;
+    }
+    uint32_t atomBegin = atomBondStarts[atomIndex];
+    const uint32_t atomEnd = atomBondStarts[atomIndex + 1];
+    for (; atomBegin < atomEnd; ++atomBegin) {
+      const BondData& bond = bondData[bondDataIndices[atomBegin]];
+      if (bond.getIsAromatic() ||
+          bond.getBondType() == BondEnums::BondType::AROMATIC) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  // These bond stereo atoms functions are on RDMol instead of BondData so that
+  // it has access to the compatibility fallback.  This fallback is necessary
+  // because the original interface returns references to INT_VECT, and the
+  // compatibility interface needs to still provide that without breaking
+  // the access to values via this new interface.
+
+  void clearBondStereoAtoms(uint32_t bondIndex) {
+    URANGE_CHECK(bondIndex, getNumBonds());
+    BondData& bond = bondData[bondIndex];
+    bond.stereoAtoms[0] = atomindex_t(-1);
+    bond.stereoAtoms[1] = atomindex_t(-1);
+    if (hasCompatibilityData()) {
+      clearBondStereoAtomsCompat(bondIndex);
+    }
+  }
+  bool hasBondStereoAtoms(uint32_t bondIndex) const {
+    URANGE_CHECK(bondIndex, getNumBonds());
+    const BondData& bond = bondData[bondIndex];
+    if (!hasCompatibilityData()) {
+      PRECONDITION(
+          (bond.stereoAtoms[0] == atomindex_t(-1)) ==
+              (bond.stereoAtoms[1] == atomindex_t(-1)),
+          "BondData::hasStereoAtoms called and only one valid stereo atom index");
+      return (bond.stereoAtoms[0] != atomindex_t(-1));
+    }
+    return hasBondStereoAtomsCompat(bondIndex);
+  }
+  void setBondStereoAtoms(uint32_t bondIndex, atomindex_t a, atomindex_t b, bool checkAtomIndices = true) {
+    URANGE_CHECK(bondIndex, getNumBonds());
+    if (checkAtomIndices) {
+      PRECONDITION(a != atomindex_t(-1) && b != atomindex_t(-1),
+                   "BondData::setStereoAtoms called with invalid indices");
+      URANGE_CHECK(a, getNumAtoms());
+      URANGE_CHECK(b, getNumAtoms());
+    }
+    BondData& bond = bondData[bondIndex];
+    bond.stereoAtoms[0] = a;
+    bond.stereoAtoms[1] = b;
+    if (hasCompatibilityData()) {
+      auto *compatStereo = getBondStereoAtomsCompat(bondIndex);
+      CHECK_INVARIANT(compatStereo, "No stereo atoms in compatibility data");
+      compatStereo->clear();
+      compatStereo->push_back(a);
+      compatStereo->push_back(b);
+    }
+  }
+  const atomindex_t* getBondStereoAtoms(uint32_t bondIndex) const {
+    URANGE_CHECK(bondIndex, getNumBonds());
+    if (hasCompatibilityData()) {
+      const INT_VECT* data = getBondStereoAtomsCompat(bondIndex);
+      PRECONDITION(data, "bond stereo compat data not initialized");
+      if (data->size() > 0) {
+        PRECONDITION(data->size() == 2, "bond stereo compat data not size 2");
+        static_assert(sizeof(atomindex_t) == sizeof((*data)[0]));
+        return reinterpret_cast<const atomindex_t*>(data->data());
+      }
+
+      // If the non-const overload of Bond::getStereoAtoms is called and the
+      // caller clears the vector, this will fall back to BondData::stereoAtoms,
+      // but it must be set to -1 to indicate being empty.  This should be
+      // threadsdafe for reading cases, because all threads will write the same
+      // values here and won't return until they've written the values.
+      BondData &bond = bondData[bondIndex];
+      bond.stereoAtoms[0] = atomindex_t(-1);
+      bond.stereoAtoms[1] = atomindex_t(-1);
+      return bond.stereoAtoms;
+    }
+    const BondData& bond = bondData[bondIndex];
+    return bond.stereoAtoms;
+  }
+
+  uint32_t calcExplicitValence(atomindex_t atomIndex, bool strict);
+  uint32_t calcImplicitValence(atomindex_t atomIndex, bool strict);
+
+  bool hasValenceViolation(atomindex_t atomIndex) const;
+
+  //! inverts the atom's \c chiralTag, returns whether or not a change was made
+  bool invertAtomChirality(atomindex_t atomIndex);
+
+  ADJ_ITER_PAIR getAtomNeighbors(atomindex_t atomIndex) const {
+    URANGE_CHECK(atomIndex, getNumAtoms());
+    uint32_t atomBegin = atomBondStarts[atomIndex];
+    uint32_t atomEnd = atomBondStarts[atomIndex + 1];
+    return ADJ_ITER_PAIR(otherAtomIndices.data() + atomBegin,
+                         otherAtomIndices.data() + atomEnd);
+  }
+  ADJ_ITER_PAIR getAtomBonds(atomindex_t atomIndex) const {
+    URANGE_CHECK(atomIndex, getNumAtoms());
+    uint32_t atomBegin = atomBondStarts[atomIndex];
+    uint32_t atomEnd = atomBondStarts[atomIndex + 1];
+    return ADJ_ITER_PAIR(bondDataIndices.data() + atomBegin,
+                         bondDataIndices.data() + atomEnd);
+  }
+  uint32_t getBondIndexBetweenAtoms(atomindex_t atom0, atomindex_t atom1) const {
+    URANGE_CHECK(atom0, getNumAtoms());
+    URANGE_CHECK(atom1, getNumAtoms());
+    uint32_t atomBegin = atomBondStarts[atom0];
+    const uint32_t atomEnd = atomBondStarts[atom0 + 1];
+    for (; atomBegin < atomEnd; ++atomBegin) {
+      uint32_t otherAtomIndex = otherAtomIndices[atomBegin];
+      if (otherAtomIndex == atom1) {
+        return bondDataIndices[atomBegin];
+      }
+    }
+    return std::numeric_limits<std::uint32_t>::max();
+  }
+  const uint32_t* getAtomBondStarts() const {
+    return atomBondStarts.data();
+  }
+  const uint32_t* getOtherAtomIndices() const {
+    return otherAtomIndices.data();
+  }
+  const uint32_t* getBondDataIndices() const {
+    return bondDataIndices.data();
+  }
+
+  // For RDKit use only
+  std::vector<AtomData>& getAtomDataVector() { return atomData; }
+  // For RDKit use only
+  std::vector<BondData>& getBondDataVector() { return bondData; }
+  // For RDKit use only
+  std::vector<uint32_t>& getAtomBondStartsVector() { return atomBondStarts; }
+  // For RDKit use only
+  std::vector<uint32_t>& getOtherAtomIndicesVector() { return otherAtomIndices; }
+  // For RDKit use only
+  std::vector<uint32_t>& getBondDataIndicesVector() { return bondDataIndices; }
+
+  bool hasProp(const PropToken& name) const;
+  bool hasAtomProp(const PropToken& name, uint32_t index) const;
+  bool hasBondProp(const PropToken& name, uint32_t index) const;
+
+  std::vector<std::string> getPropList(
+      bool includePrivate = true,
+      bool includeComputed = true,
+      Scope scope = Scope::MOL,
+      uint32_t index = PropIterator::anyIndexMarker) const;
+
+  PropIterator beginProps(bool includeComputed = true, Scope scope = Scope::MOL,
+                          uint32_t index = PropIterator::anyIndexMarker) const {
+    return PropIterator(properties.cbegin(), properties.cend(), includeComputed,
+                        scope, index);
+  }
+  PropIterator endProps() const {
+    return PropIterator(properties.cend(), properties.cend(), true, Scope::MOL,
+                        PropIterator::anyIndexMarker);
+  }
+
+  template <typename T>
+  T getMolProp(const PropToken &name) const {
+    const Property *prop = findProp(name, Scope::MOL);
+    if (prop == nullptr) {
+      throw KeyErrorException(name.getString());
+    }
+    return from_rdvalue<T>(prop->inPlaceData);
+  }
+
+  template <typename T>
+  T getAtomProp(const PropToken &name, uint32_t index) const {
+    const Property *prop = findProp(name, Scope::ATOM);
+    if (prop == nullptr || !prop->arrayData.isSetMask[index]) {
+      throw KeyErrorException(name.getString());
+    }
+    return prop->arrayData.getValueAs<T>(index);
+  }
+
+  template <typename T>
+  T getBondProp(const PropToken &name, uint32_t index) const {
+    const Property *prop = findProp(name, Scope::BOND);
+    if (prop == nullptr || !prop->arrayData.isSetMask[index]) {
+      throw KeyErrorException(name.getString());
+    }
+    return prop->arrayData.getValueAs<T>(index);
+  }
+
+  //! Populates res with the property with token name, if present. Returns whether token was found.
+  template <typename T>
+  bool getMolPropIfPresent(const PropToken& name, T& res) const {
+    const Property* prop = findProp(name, Scope::MOL);
+    if (prop == nullptr) {
+      return false;
+    }
+    if constexpr (std::is_same_v<T, std::string>) {
+      rdvalue_tostring(prop->inPlaceData, res);
+    } else {
+      res = from_rdvalue<T>(prop->inPlaceData);
+    }
+    return true;
+  }
+
+  //! Populates res with the property with token name, if present. Returns whether token was found.
+  template <typename T>
+  bool getAtomPropIfPresent(const PropToken& name, uint32_t index, T& res) const {
+    return getArrayPropIfPresent<T>(name, Scope::ATOM, index, res);
+  }
+
+  //! Populates res with the property with token name, if present. Returns whether token was found.
+  template <typename T>
+  bool getBondPropIfPresent(const PropToken& name, uint32_t index, T& res) const {
+    return getArrayPropIfPresent<T>(name, Scope::BOND, index, res);
+  }
+
+  //! Returns pointer to array of atom properties with token name, or nullptr if not present.
+  //! Returns nullptr if the property is not a basic scalar type (use getAtomPropIfPresent).
+  template <typename T> T* getAtomPropArrayIfPresent(const PropToken& name) {
+    if constexpr (TypeToPropertyType<T>::family == PropertyType::ANY) {
+      return nullptr;
+    }
+    const Property* prop = findProp(name, Scope::ATOM);
+    if (prop == nullptr) {
+      return nullptr;
+    }
+    if (prop->arrayData.family != TypeToPropertyType<T>::family) {
+      return nullptr;
+    }
+    return static_cast<T*>(prop->arrayData.data);
+  }
+
+  //! \overload
+  template <typename T> const T* getAtomPropArrayIfPresent(const PropToken& name) const {
+    if constexpr (TypeToPropertyType<T>::family == PropertyType::ANY) {
+      return nullptr;
+    }
+    const Property* prop = findProp(name, Scope::ATOM);
+    if (prop == nullptr) {
+      return nullptr;
+    }
+    if (prop->arrayData.family != TypeToPropertyType<T>::family) {
+      return nullptr;
+    }
+    return static_cast<T*>(prop->arrayData.data);
+  }
+
+  //! Returns pointer to array of bond properties with token name, or nullptr if not present.
+  //! Returns nullptr if the property is not a basic scalar type (use getBondPropIfPresent).
+  template <typename T> T* getBondPropArrayIfPresent(const PropToken& name) {
+    if constexpr (TypeToPropertyType<T>::family == PropertyType::ANY) {
+      return nullptr;
+    }
+    const Property* prop = findProp(name, Scope::BOND);
+    if (prop == nullptr) {
+      return nullptr;
+    }
+    if (prop->arrayData.family != TypeToPropertyType<T>::family) {
+      return nullptr;
+    }
+    return static_cast<T*>(prop->arrayData.data);
+  }
+
+  //! \overload
+  template <typename T> const T* getBondPropArrayIfPresent(const PropToken& name) const {
+    if constexpr (TypeToPropertyType<T>::family == PropertyType::ANY) {
+      return nullptr;
+    }
+    const Property* prop = findProp(name, Scope::BOND);
+    if (prop == nullptr) {
+      return nullptr;
+    }
+    if (prop->arrayData.family != TypeToPropertyType<T>::family) {
+      return nullptr;
+    }
+    return static_cast<T*>(prop->arrayData.data);
+  }
+
+  //! Adds a property with token name and value to the molecule. If the property already exists, it is overwritten.
+  template <typename T> void addMolProp(const PropToken& name, const T& value, bool computed = false) {
+    if (Property *prop = findProp(name, Scope::MOL); prop != nullptr) {
+      prop->setVal(value);
+      prop->isComputed = computed;
+      return;
+    }
+    Property& newProp = properties.emplace_back();
+    newProp.name = std::move(name);
+    newProp.scope = Scope::MOL;
+    newProp.isComputed = computed;
+    newProp.setVal(value);
+  }
+
+  //! Alias of addMolProp
+  template <typename T> void setMolProp(const PropToken& name, const T& value, bool computed = false) {
+    addMolProp(name, value, computed);
+  }
+
+  //! Adds a property array with token name and value for all atoms
+  //! Returns a pointer to the array if a scalar type, or nullptr if not.
+  template <typename T>
+  T* addAtomProp(const PropToken& name, T defaultValue, bool computed = false) {
+    Property * newProp = addPerElementProp<T>(name, Scope::ATOM, defaultValue, computed);
+    if constexpr (TypeToPropertyType<T>::family == PropertyType::ANY) {
+      return nullptr;
+    }
+    return static_cast<T*>(newProp->arrayData.data);
+  }
+
+  //! Adds a property array with token name and value for all bonds
+  //! Returns a pointer to the array if a scalar type, or nullptr if not.
+  template<typename T>
+  T* addBondProp(const PropToken& name, T defaultValue, bool computed = false) {
+    Property * newProp = addPerElementProp<T>(name, Scope::BOND, defaultValue, computed);
+    if constexpr (TypeToPropertyType<T>::family == PropertyType::ANY) {
+      return nullptr;
+    }
+    return static_cast<T*>(newProp->arrayData.data);
+  }
+
+  //! Sets an atom property at the given index
+  template<typename T>
+  void setSingleAtomProp(const PropToken &name, const std::uint32_t index,
+                         const T &value, bool computed = false,
+                         bool supportTypeMismatch = false) {
+    setSingleProp<T>(name, Scope::ATOM, index, value, computed,
+                     supportTypeMismatch);
+  }
+
+  //! Sets a bond property at the given index
+  template<typename T>
+  void setSingleBondProp(const PropToken &name, const std::uint32_t index,
+                         const T &value, bool computed = false,
+                         bool supportTypeMismatch = false) {
+    setSingleProp<T>(name, Scope::BOND, index, value, computed,
+                     supportTypeMismatch);
+  }
+
+  //! Clears a molecule property if present
+  void clearMolPropIfPresent(const PropToken& name) {
+    for (auto it = properties.begin(), end = properties.end(); it != end; ++it) {
+      if (it->name == name && it->scope == Scope::MOL) {
+        properties.erase(it);
+        return;
+      }
+    }
+  }
+
+  //! Clears all atom props with the given name
+  void clearAtomPropIfPresent(const PropToken& name) {
+    for (auto it = properties.begin(), end = properties.end(); it != end; ++it) {
+      if (it->name == name && it->scope == Scope::ATOM) {
+        properties.erase(it);
+        return;
+      }
+    }
+  }
+
+  //! Clears all bond props with the given name
+  void clearBondPropIfPresent(const PropToken& name) {
+    for (auto it = properties.begin(), end = properties.end(); it != end; ++it) {
+      if (it->name == name && it->scope == Scope::BOND) {
+        properties.erase(it);
+        return;
+      }
+    }
+  }
+
+  //! Clears a single atom prop at the given index
+  void clearSingleAtomProp(const PropToken& name, const std::uint32_t atomIndex) {
+    for (auto it = properties.begin(), end = properties.end(); it != end; ++it) {
+      if (it->name == name && it->scope == Scope::ATOM &&
+          it->arrayData.isSetMask[atomIndex]) {
+        --it->arrayData.numSet;
+        if (it->arrayData.numSet == 0) {
+          properties.erase(it);
+          return;
+        }
+        it->arrayData.isSetMask[atomIndex] = false;
+        return;
+      }
+    }
+  }
+
+  //! Clears a single bond prop at the given index
+  void clearSingleBondProp(const PropToken& name, const std::uint32_t bondIndex) {
+    for (auto it = properties.begin(), end = properties.end(); it != end; ++it) {
+      if (it->name == name && it->scope == Scope::BOND &&
+          it->arrayData.isSetMask[bondIndex]) {
+        --it->arrayData.numSet;
+        if (it->arrayData.numSet == 0) {
+          properties.erase(it);
+          return;
+        }
+        it->arrayData.isSetMask[bondIndex] = false;
+        return;
+      }
+    }
+  }
+
+  //! Clears all props for a given atom
+  void clearSingleAtomAllProps(const std::uint32_t atomIndex, const bool onlyComputed = false) {
+    for (auto it = properties.begin(), end = properties.end(); it != end; ) {
+      bool erased = false;
+      if (it->scope == Scope::ATOM && (!onlyComputed || it->isComputed) &&
+          it->arrayData.isSetMask[atomIndex]) {
+        --it->arrayData.numSet;
+        if (it->arrayData.numSet == 0) {
+          it = properties.erase(it);
+          end = properties.end();
+          erased = true;
+        } else {
+          it->arrayData.isSetMask[atomIndex] = false;
+        }
+      }
+      if (!erased) {
+        ++it;
+      }
+    }
+  }
+
+  //! Clears all props for a given bond
+  void clearSingleBondAllProps(const std::uint32_t bondIndex, const bool onlyComputed = false) {
+    for (auto it = properties.begin(), end = properties.end(); it != end; ) {
+      bool erased = false;
+      if (it->scope == Scope::BOND && (!onlyComputed || it->isComputed) &&
+          it->arrayData.isSetMask[bondIndex]) {
+        --it->arrayData.numSet;
+        if (it->arrayData.numSet == 0) {
+          it = properties.erase(it);
+          end = properties.end();
+          erased = true;
+        } else {
+          it->arrayData.isSetMask[bondIndex] = false;
+        }
+      }
+      if (!erased) {
+        ++it;
+      }
+    }
+  }
+  //! Clear all mol, atom, and bond properties.
+  void clearProps();
+
+  void copyProp(const PropToken &destinationName, const RDMol &sourceMol,
+                const PropToken &sourceName, Scope scope = Scope::MOL);
+  void copySingleProp(const PropToken &destinationName,
+                           uint32_t destinationIndex, const RDMol &sourceMol,
+                           const PropToken &sourceName, uint32_t sourceIndex,
+                           Scope scope);
+
+  //! Associates an atom index with a bookmark
+  void setAtomBookmark(int atomIdx, int mark);
+  //! Associates an atom index with a bookmark, removing any previous bookmark with the same mark
+  void replaceAtomBookmark(int atomIdx, int mark);
+  //! Returns a vector of atom indices associated with a bookmark
+  std::vector<int> getAllAtomsWithBookmarks(int mark);
+  //! Returns the first atom index associated with a bookmark. This will be the first atom bookmarked with the given mark.
+  int getAtomWithBookmark(int mark);
+  //! Removes a bookmark.
+  void clearAtomBookmark(int mark);
+  //! Removes a bookmark from a specific atom.
+  void clearAtomBookmark(int atomIdx, int mark);
+  //! Removes all atom bookmarks.
+  void clearAllAtomBookmarks();
+  //! Returns whether a bookmark exists.
+  bool hasAtomBookmark(int mark) const;
+
+  //! Associates a bond index with a bookmark
+  void setBondBookmark(int bondIdx, int mark);
+  //! Returns a vector of Bond indices associated with a bookmark
+  std::vector<int> getAllBondsWithBookmarks(int mark);
+  //! Returns the first bond index associated with a bookmark. This will be the first bond bookmarked with the given mark.
+  int getBondWithBookmark(int mark);
+  //! Removes a bookmark.
+  void clearBondBookmark(int mark);
+  //! Removes a bookmark from a specific bond.
+  void clearBondBookmark(int bondIdx, int mark);
+  //! Removes all bond bookmarks.
+  void clearAllBondBookmarks();
+  //! Returns whether a bookmark exists.
+  bool hasBondBookmark(int mark) const;
+
+  const StereoGroups* getStereoGroups() const { return stereoGroups.get(); }
+  StereoGroups* getStereoGroups() { return stereoGroups.get(); }
+  void setStereoGroups(std::unique_ptr<StereoGroups> &&groups);
+
+  std::vector<SubstanceGroup>& getSubstanceGroups() { return substanceGroups; }
+  const std::vector<SubstanceGroup>& getSubstanceGroups() const { return substanceGroups; }
+
+  bool getIsStereochemDone() const { return isStereochemDone; }
+  void setIsStereochemDone(bool value) { isStereochemDone = value; }
+
+  //! \name Properties
+  //! @{
+
+  //! clears all of our \c computed \c properties
+  void clearComputedProps(bool includeRings = true);
+  //! calculates any of our lazy \c properties
+  /*!
+    <b>Notes:</b>
+       - this calls \c updatePropertyCache() on each of our Atoms and Bonds
+  */
+  void updatePropertyCache(bool strict = true);
+
+  void updateAtomPropertyCache(atomindex_t atomIndex, bool strict = true) {
+    calcExplicitValence(atomIndex, strict);
+    calcImplicitValence(atomIndex, strict);
+  }
+  void updateBondPropertyCache([[maybe_unused]] uint32_t bondIndex,
+                               [[maybe_unused]] bool strict = true) {
+    // Currently nothing
+  }
+
+  bool needsUpdatePropertyCache() const;
+
+  //! @}
+
+  int getAtomMapNum(uint32_t atomIndex) const {
+    const int* atomMap = getAtomPropArrayIfPresent<int>(
+        common_properties::molAtomMapNumberToken);
+    return (atomMap != nullptr) ? atomMap[atomIndex] : 0;
+  }
+
+  const QUERYATOM_QUERY *getAtomQuery(uint32_t atomIndex) const {
+    URANGE_CHECK(atomIndex, getNumAtoms());
+    PRECONDITION(atomQueries.size() == 0 || atomQueries.size() == getNumAtoms(),
+                 "atomQueries invalid size");
+    return (atomQueries.size() == 0) ? nullptr : atomQueries[atomIndex].get();
+  }
+  QUERYATOM_QUERY *getAtomQuery(uint32_t atomIndex) {
+    URANGE_CHECK(atomIndex, getNumAtoms());
+    PRECONDITION(atomQueries.size() == 0 || atomQueries.size() == getNumAtoms(),
+                 "atomQueries invalid size");
+    return (atomQueries.size() == 0) ? nullptr : atomQueries[atomIndex].get();
+  }
+  const QUERYBOND_QUERY *getBondQuery(uint32_t bondIndex) const {
+    URANGE_CHECK(bondIndex, getNumBonds());
+    PRECONDITION(bondQueries.size() == 0 || bondQueries.size() == getNumBonds(),
+                 "bondQueries invalid size");
+    return (bondQueries.size() == 0) ? nullptr : bondQueries[bondIndex].get();
+  }
+  QUERYBOND_QUERY *getBondQuery(uint32_t bondIndex) {
+    URANGE_CHECK(bondIndex, getNumBonds());
+    PRECONDITION(bondQueries.size() == 0 || bondQueries.size() == getNumBonds(),
+                 "bondQueries invalid size");
+    return (bondQueries.size() == 0) ? nullptr : bondQueries[bondIndex].get();
+  }
+  bool hasAtomQuery(uint32_t atomIndex) const {
+    return getAtomQuery(atomIndex) != nullptr;
+  }
+  bool hasBondQuery(uint32_t bondIndex) const {
+    return getBondQuery(bondIndex) != nullptr;
+  }
+
+  //! Add a new atom to the molecule.
+  AtomData& addAtom();
+  //! Add a new bond to the molecule between the atoms with the given indices.
+  //! If updateAromaticity is true, the atoms will be marked as aromatic if the bond is aromatic.
+  BondData& addBond(uint32_t beginAtomIdx, uint32_t endAtomIdx, BondEnums::BondType bondType, bool updateAromaticity = true);
+  void removeAtom(atomindex_t atomIndex, bool clearProps = true);
+  void removeBond(uint32_t bondIndex);
+
+  //! Begin batch edit. All changes will be made upon commit.
+  void beginBatchEdit();
+  //! Commit batch edit to apply changes.
+  void commitBatchEdit();
+  //! Rollback batch edit to discard changes.
+  void rollbackBatchEdit();
+
+  //! Returns the number of conformers.
+  uint32_t getNumConformers() const;
+  //! Return the coordinates of the conformer with the given ID.
+  const double* getConformerPositions(int32_t id = -1) const;
+  //! Return the coordinates of the conformer with the given ID.
+  double* getConformerPositions(int32_t id = -1);
+  //! Remove all conformers.
+  //! Return whether the conformer with the given ID is 3D.
+  bool is3DConformer(uint32_t id) const;
+  void clearConformers();
+  //! Remove the given conformer ID if it exists;
+  void removeConformer(uint32_t id);
+  //! Add a conformer, return the index. Assigns an ID if id < 0;
+  uint32_t addConformer(const double* positions, int32_t id = -1, bool is3D = true);
+  //! Adds an unset conformer, returns the index and data pointer. Assigns an ID if id < 0;
+  std::pair<uint32_t, double*> addConformer(int32_t id = -1, bool is3D = true);
+  //! Allocates memory for n conformers. Helpful for performance when adding many conformers or atoms.
+  void allocateConformers(size_t newNumConformers) {
+    allocateConformers(newNumConformers, getNumAtoms());
+  }
+  //! \overload
+  void allocateConformers(size_t newNumConformers, size_t newNumAtoms);
+
+  const RingInfoCache &getRingInfo() const;
+  RingInfoCache &getRingInfo();
+
+  void setAtomQuery(atomindex_t atomIndex,
+                    std::unique_ptr<QUERYATOM_QUERY> query);
+  void setBondQuery(uint32_t bondIndex,
+                    std::unique_ptr<QUERYBOND_QUERY> query);
+
+  // Compatibity interface access
+  ROMol& asROMol();
+  const ROMol& asROMol() const;
+  RWMol& asRWMol();
+  const RWMol& asRWMol() const;
+
+  Ranges::IndexRange<false, false> atoms();
+  Ranges::IndexRange<false, true> atoms() const;
+  Ranges::IndexRange<true, false> bonds();
+  Ranges::IndexRange<true, true> bonds() const;
+  Ranges::IndirectRange<false, false> atomNeighbors(atomindex_t atomIndex);
+  Ranges::IndirectRange<false, true> atomNeighbors(atomindex_t atomIndex) const;
+  Ranges::IndirectRange<true, false> atomBonds(atomindex_t atomIndex);
+  Ranges::IndirectRange<true, true> atomBonds(atomindex_t atomIndex) const;
+
+ private:
+  //! Instantiate an RDMol with a stable ROMol pointer.
+  RDMol(ROMol* existingPtr);
+  //! Copy constructor with stable ROMol pointer.
+  RDMol(const RDMol &other, ROMol *existingPtr);
+  //! \overload
+  RDMol(const RDMol &other, bool quickCopy, int confId, ROMol *existingPtr);
+
+  void initFromOther(const RDMol &other, bool quickCopy, int confId, ROMol *existingPtr);
+
+  //! Used by Bond to initialize single-bond non-owning molecule. Avoids atom index bounds checking.
+  void addUnconnectedBond() {bondData.resize(1);}
+
+  //! Returns handle to property if found, else nullptr
+  const Property* findProp(const PropToken& name, Scope scope) const {
+    for (const auto &property : properties) {
+      if (property.name == name && property.scope == scope) {
+        return &property;
+      }
+    }
+    return nullptr;
+  }
+
+  //! Non-const overload
+  Property* findProp(const PropToken& name, Scope scope) {
+    for (auto &property : properties) {
+      if (property.name == name && property.scope == scope) {
+        return &property;
+      }
+    }
+    return nullptr;
+  }
+
+  //! Adds a new array property for bonds or atoms.
+  template <typename T>
+  Property* addPerElementProp(const PropToken& name, Scope scope, const T& defaultValue, bool computed = false, bool setAll = true) {
+    // Throw if not atom or bond scope
+    if (scope != Scope::ATOM && scope != Scope::BOND) {
+      throw ValueErrorException("Per-element properties must be atom or bond scope");
+    }
+    Property* existing = findProp(name, scope);
+    if (existing != nullptr) {
+      if (existing->arrayData.family == TypeToPropertyType<T>::family) {
+        existing->isComputed = computed;
+        return existing;
+      }
+      // If we have an existing prop with the wrong type, clear it.
+      if (scope == Scope::ATOM) {
+        clearAtomPropIfPresent(name);
+      } else {
+        clearBondPropIfPresent(name);
+      }
+    }
+
+    const uint32_t numElements = scope == Scope::ATOM ? getNumAtoms() : getNumBonds();
+    Property& newProperty = properties.emplace_back();
+    newProperty.name = name;
+    newProperty.scope = scope;
+    newProperty.isComputed = computed;
+    newProperty.arrayData.size = numElements;
+    newProperty.arrayData.family = TypeToPropertyType<T>::family;
+    newProperty.arrayData.construct(setAll);
+
+    if constexpr (TypeToPropertyType<T>::family == PropertyType::ANY) {
+      auto* data = static_cast<RDValue*>(newProperty.arrayData.data);
+      for (uint32_t i = 0; i < numElements; ++i) {
+        if constexpr (std::is_same_v<T, RDValue>) {
+          copy_rdvalue(data[i], defaultValue);
+        } else if constexpr (std::is_same_v<T, const char*>) {
+          data[i] = std::string(defaultValue);
+        } else {
+          data[i] = defaultValue;
+        }
+      }
+    } else {
+      auto* data = static_cast<T*>(newProperty.arrayData.data);
+      for (uint32_t i = 0; i < numElements; ++i) {
+        data[i] = defaultValue;
+      }
+    }
+    return &newProperty;
+  }
+
+  // Overload to treat const char* as a string
+  Property *addPerElementProp(const PropToken &name, Scope scope,
+                              const char *defaultValue, bool computed = false,
+                              bool setAll = true) {
+    std::string s = defaultValue == nullptr ? "" : defaultValue;
+    return addPerElementProp(name, scope, s, computed, setAll);
+  }
+
+
+  template<typename T>
+  void setSingleProp(const PropToken &name, const Scope scope,
+                     const std::uint32_t index, const T &value,
+                     bool computed = false, bool supportTypeMismatch = false) {
+    Property* existing = findProp(name, scope);
+    if (existing == nullptr) {
+      if constexpr (std::is_default_constructible_v<T>) {
+        existing = addPerElementProp(name, scope, T(), computed, false);
+      } else {
+        existing = addPerElementProp(name, scope, value, computed, false);
+      }
+    }
+    existing->isComputed = computed;
+    auto existingFamily = existing->arrayData.family;
+    if (existingFamily != TypeToPropertyType<T>::family && existingFamily != PropertyType::ANY) {
+      if (!supportTypeMismatch) {
+        throw ValueErrorException("Property type mismatch");
+      }
+      // Convert to RDValue
+      existing->arrayData.convertToRDValue();
+      PRECONDITION(existing->arrayData.family == PropertyType::ANY,
+                   "convertToRDValue should make family ANY");
+      existingFamily = PropertyType::ANY;
+    }
+    auto& arr = existing->arrayData;
+    if (TypeToPropertyType<T>::family == PropertyType::ANY || existingFamily == PropertyType::ANY) {
+      auto* data = static_cast<RDValue*>(arr.data);
+      // Default value may still need cleaning even if not previously set.
+      RDValue::cleanup_rdvalue(data[index]);
+      if constexpr (std::is_same_v<T, RDValue>) {
+        copy_rdvalue(data[index], value);
+      } else if constexpr (std::is_same_v<T, const char*>) {
+        data[index] = std::string(value);
+      } else {
+        data[index] = value;
+      }
+    } else {
+      auto *data = static_cast<T *>(arr.data);
+      data[index] = value;
+    }
+    arr.isSetMask[index] = true;
+    ++arr.numSet;
+  }
+
+  // Overload to treat const char* as a string
+  void setSingleProp(const PropToken &name, const Scope scope,
+                     const std::uint32_t index, const char *value,
+                     bool computed = false, bool supportTypeMismatch = false) {
+    std::string s(value);
+    setSingleProp(name, scope, index, s, computed, supportTypeMismatch);
+  }
+
+  template <typename T>
+  bool getArrayPropIfPresent(const PropToken& name, Scope scope, std::uint32_t index, T& res) const {
+    const Property* prop = findProp(name, scope);
+    if (prop == nullptr) {
+      return false;
+    }
+
+    if (scope == Scope::ATOM && index >= getNumAtoms()) {
+      throw ValueErrorException("Atom index out of bounds");
+    }
+
+    if (scope == Scope::BOND && index >= getNumBonds()) {
+      throw ValueErrorException("Bond index out of bounds");
+    }
+
+    const PropArray& arr = prop->arrayData;
+    if (arr.isSetMask[index]) {
+      res = arr.getValueAs<T>(index);
+      return true;
+    }
+    return false;
+  }
+
+  //! Gets the index of a conformer based on its ID, or throws
+  //! ConformerException if not found. Negative id returns index 0.
+  uint32_t findConformerIndex(int32_t id) const;
+  //! Pushes positions and metadata from conformers to compatibility data.
+  //! If confId is -1, all conformers are copied.
+  //! If confId is positive, only the conformer with that id is copied,
+  //! or none, if no conformer exists with that id.
+  void copyConformersFromCompatibilityData(const CompatibilityData* compatData, int confId = -1) const;
+  //! Pulls positions and metadata from compatibility data to conformers.
+  void copyConformersToCompatibilityData(CompatibilityData* compatData) const;
+  //! Manually tell rdmol that the compat data conformers may have been modified.
+  void markConformersAsCompatModified() const;
+
+  int calculateExplicitValence(atomindex_t atomIndex, bool strict,
+                               bool checkIt) const;
+  int calculateImplicitValence(atomindex_t atomIndex, bool strict,
+                               bool checkIt) const;
+
+  // NOTE: This can change in another thread, so only use it in situations where
+  // the caller is planning to modify data or where the result changing would
+  // only be relevant conditional upon data being modified.
+  bool hasCompatibilityData() const {
+    return compatibilityData.load(std::memory_order_relaxed) != nullptr;
+  }
+  CompatibilityData* getCompatibilityDataIfPresent() {
+    return compatibilityData.load(std::memory_order_relaxed);
+  }
+  const CompatibilityData* getCompatibilityDataIfPresent() const {
+    return compatibilityData.load(std::memory_order_relaxed);
+  }
+  CompatibilityData* ensureCompatInit() const;
+  void clearBondStereoAtomsCompat(uint32_t bondIndex);
+  bool hasBondStereoAtomsCompat(uint32_t bondIndex) const;
+  const INT_VECT* getBondStereoAtomsCompat(uint32_t bondIndex) const;
+  INT_VECT* getBondStereoAtomsCompat(uint32_t bondIndex);
+  Atom* getAtomCompat(uint32_t atomIndex);
+  const Atom* getAtomCompat(uint32_t atomIndex) const;
+  Bond* getBondCompat(uint32_t bondIndex);
+  const Bond* getBondCompat(uint32_t bondIndex) const;
+  void releaseCompatMolOwnership();
+  //! Set atom, bond, conformer pointers to be owned by this RDMol. Required for
+  //! move operation ownership transfer.
+  void setCompatPointersToSelf();
+  //! Sets the compatibililty data ROMol pointer.
+  void setROMolPointerCompat(ROMol* ptr);
+
+  std::list<Atom *>& getAtomBookmarksCompat(int mark);
+  std::list<Bond *>& getBondBookmarksCompat(int mark);
+
+  std::map<int, std::list<Atom *>>* getAtomBookmarksCompat();
+  std::map<int, std::list<Bond *>>* getBondBookmarksCompat();
+
+
+  std::list<boost::shared_ptr<Conformer>>& getConformersCompat();
+  const std::list<boost::shared_ptr<Conformer>>& getConformersCompat() const;
+
+  RingInfo &getRingInfoCompat();
+  const RingInfo &getRingInfoCompat() const;
+
+  const std::vector<StereoGroup> &getStereoGroupsCompat();
+
+  // Replaces an atom handle in compatibility data. Cleans up previous data mol.
+  // Does not copy any data, but replaces pointers in compatibility structures.
+  void replaceAtomPointerCompat(Atom* atom, uint32_t index);
+  // Replaces a bond handle in compatibility data. Cleans up previous data mol.
+  // Does not copy any data, but replaces pointers in compatibility structures.
+  void replaceBondPointerCompat(Bond* atom, uint32_t index);
+
+  // source can be owned by a different RDMol, but null means to copy from
+  // this RDMol's compatibilityData.
+  // If quickCopy is true, bookmarks and conformers are cleared and not copied.
+  // If confId is -1, all conformers are copied.
+  // If confId is positive, only the conformer with that id is copied,
+  // or none, if no conformer exists with that id.
+  void copyFromCompatibilityData(const CompatibilityData *source,
+                                 bool quickCopy = false, int confId = -1);
+
+  // This only wraps query and sets the wrapper into atomQueries.
+  // Called from QueryAtom, which must have already updated its Query
+  void setAtomQueryCompat(atomindex_t atomIndex, Queries::Query<int, const Atom *, true> *query);
+
+  // This only wraps query and sets the wrapper into bondQueries.
+  // Called from QueryBond, which must have already updated its Query
+  void setBondQueryCompat(uint32_t bondIndex, Queries::Query<int, const Bond *, true> *query);
+
+  // This forces the specified atom to be a QueryAtom, sets its query to this, taking ownership,
+  // and then also wraps it and sets the wrapper into atomQueries.
+  void setAtomQueryCompatFull(atomindex_t atomIndex,
+                              Queries::Query<int, const Atom *, true> *query);
+
+  // This forces the specified bond to be a QueryBond, sets its query to this, taking ownership,
+  // and then also wraps it and sets the wrapper into bondQueries.
+  void setBondQueryCompatFull(uint32_t bondIndex,
+                              Queries::Query<int, const Bond *, true> *query);
+};
+
+
+template<bool ISCONST>
+class RDMolWrapperBase {
+ protected:
+  using MolType = std::conditional_t<ISCONST, const RDMol, RDMol>;
+
+ private:
+  MolType* d_mol;
+  uint32_t d_index;
+
+ protected:
+  RDMolWrapperBase() : d_mol(nullptr), d_index(0) {}
+  RDMolWrapperBase(MolType* mol, uint32_t index)
+      : d_mol(mol), d_index(index) {}
+  RDMolWrapperBase(const RDMolWrapperBase&) = default;
+  RDMolWrapperBase& operator=(const RDMolWrapperBase&) = default;
+ public:
+  bool isValid() const { return (d_mol != nullptr); }
+  MolType& mol() { return *d_mol; }
+  const RDMol& mol() const { return *d_mol; }
+  uint32_t index() const { return d_index; }
+};
+
+template<bool ISCONST>
+class RDMolAtomBase : public RDMolWrapperBase<ISCONST> {
+  using MolType = typename RDMolWrapperBase<ISCONST>::MolType;
+ protected:
+  RDMolAtomBase() : RDMolWrapperBase<ISCONST>() {}
+  RDMolAtomBase(MolType* mol, uint32_t atomIndex) : RDMolWrapperBase<ISCONST>(mol, atomIndex) {}
+  RDMolAtomBase(const RDMolAtomBase&) = default;
+  RDMolAtomBase& operator=(const RDMolAtomBase&) = default;
+};
+
+class ConstRDMolAtom : public RDMolAtomBase<true> {
+ public:
+  ConstRDMolAtom() : RDMolAtomBase() {}
+  ConstRDMolAtom(const RDMol* mol, uint32_t atomIndex) : RDMolAtomBase(mol, atomIndex) {}
+  ConstRDMolAtom(const ConstRDMolAtom&) = default;
+  ConstRDMolAtom& operator=(const ConstRDMolAtom&) = default;
+  ConstRDMolAtom(const RDMolAtom&);
+
+  const AtomData& data() const { return mol().getAtom(index()); }
+};
+
+class RDMolAtom : public RDMolAtomBase<false> {
+ public:
+  RDMolAtom() : RDMolAtomBase() {}
+  RDMolAtom(RDMol* mol, uint32_t atomIndex) : RDMolAtomBase(mol, atomIndex) {}
+  RDMolAtom(const RDMolAtom&) = default;
+  RDMolAtom& operator=(const RDMolAtom&) = default;
+
+  AtomData& data() { return mol().getAtom(index()); }
+};
+
+inline ConstRDMolAtom::ConstRDMolAtom(const RDMolAtom& other)
+    : RDMolAtomBase(&other.mol(), other.index()) {}
+
+template<bool ISCONST>
+class RDMolBondBase : public RDMolWrapperBase<ISCONST> {
+  using MolType = typename RDMolWrapperBase<ISCONST>::MolType;
+ protected:
+  RDMolBondBase() : RDMolWrapperBase<ISCONST>() {}
+  RDMolBondBase(MolType* mol, uint32_t bondIndex) : RDMolWrapperBase<ISCONST>(mol, bondIndex) {}
+  RDMolBondBase(const RDMolBondBase&) = default;
+  RDMolBondBase& operator=(const RDMolBondBase&) = default;
+};
+
+class ConstRDMolBond : public RDMolBondBase<true> {
+ public:
+  ConstRDMolBond() : RDMolBondBase() {}
+  ConstRDMolBond(const RDMol* mol, uint32_t bondIndex) : RDMolBondBase(mol, bondIndex) {}
+  ConstRDMolBond(const ConstRDMolBond&) = default;
+  ConstRDMolBond& operator=(const ConstRDMolBond&) = default;
+  ConstRDMolBond(const RDMolBond&);
+
+  const BondData& data() const { return mol().getBond(index()); }
+};
+
+class RDMolBond : public RDMolBondBase<false> {
+ public:
+  RDMolBond() : RDMolBondBase() {}
+  RDMolBond(RDMol* mol, uint32_t bondIndex) : RDMolBondBase(mol, bondIndex) {}
+  RDMolBond(const RDMolBond&) = default;
+  RDMolBond& operator=(const RDMolBond&) = default;
+
+  BondData& data() { return mol().getBond(index()); }
+};
+
+inline ConstRDMolBond::ConstRDMolBond(const RDMolBond& other)
+    : RDMolBondBase(&other.mol(), other.index()) {}
+
+namespace Ranges {
+//! This class is only intended to be used by IndexRange
+template <bool ISBOND, bool ISCONST>
+class IndexIter {
+  using MolType = std::conditional_t<ISCONST, const RDMol, RDMol>;
+  MolType *d_mol;
+  uint32_t d_index;
+
+  using value_type = std::conditional_t<ISBOND,
+      std::conditional_t<ISCONST, ConstRDMolBond, RDMolBond>,
+      std::conditional_t<ISCONST, ConstRDMolAtom, RDMolAtom>>;
+  using iterator_category = std::forward_iterator_tag;
+
+  friend class IndexRange<ISBOND, ISCONST>;
+
+  IndexIter(MolType *mol, uint32_t index) : d_mol(mol), d_index(index) {}
+
+ public:
+  IndexIter(const IndexIter &) = default;
+  IndexIter &operator=(const IndexIter &) = default;
+
+  value_type operator*() const { return value_type(d_mol, d_index); }
+
+  IndexIter &operator++() {
+    ++d_index;
+    return *this;
+  }
+  IndexIter operator++(int) {
+    IndexIter copy = *this;
+    ++d_index;
+    return copy;
+  }
+  bool operator==(const IndexIter &other) const {
+    return d_index == other.d_index && d_mol == other.d_mol;
+  }
+  bool operator!=(const IndexIter &other) const { return !(*this == other); }
+};
+
+//! This class is only intended to be used by range-based for loops via
+//! RDMol::atoms() and  RDMol::bonds()
+template <bool ISBOND, bool ISCONST>
+class IndexRange {
+  using MolType = std::conditional_t<ISCONST, const RDMol, RDMol>;
+  using Iter = IndexIter<ISBOND, ISCONST>;
+  MolType *d_mol;
+
+  friend class RDMol;
+  IndexRange(MolType *mol) : d_mol(mol) {}
+
+ public:
+  IndexRange(const IndexRange<ISBOND, ISCONST> &) = default;
+  IndexRange &operator=(const IndexRange<ISBOND, ISCONST> &) = default;
+  Iter begin() const { return Iter(d_mol, 0); }
+  Iter end() const { return Iter(d_mol, d_mol->getNumAtoms()); }
+};
+
+//! This class is only intended to be used by IndirectRange
+template <bool ISBOND, bool ISCONST>
+class IndirectIter {
+  using MolType = std::conditional_t<ISCONST, const RDMol, RDMol>;
+  MolType *d_mol;
+  const uint32_t *d_indices;
+
+  using value_type = std::conditional_t<ISBOND,
+      std::conditional_t<ISCONST, ConstRDMolBond, RDMolBond>,
+      std::conditional_t<ISCONST, ConstRDMolAtom, RDMolAtom>>;
+  using iterator_category = std::forward_iterator_tag;
+
+  friend class IndirectRange<ISBOND, ISCONST>;
+
+  IndirectIter(MolType *mol, const uint32_t *indices)
+      : d_mol(mol), d_indices(indices) {}
+
+ public:
+  IndirectIter(const IndirectIter &) = default;
+  IndirectIter &operator=(const IndirectIter &) = default;
+
+  value_type operator*() const { return value_type(d_mol, *d_indices); }
+
+  IndirectIter &operator++() {
+    ++d_indices;
+    return *this;
+  }
+  IndirectIter operator++(int) {
+    IndirectIter copy = *this;
+    ++d_indices;
+    return copy;
+  }
+  bool operator==(const IndirectIter &other) const {
+    return d_indices == other.d_indices && d_mol == other.d_mol;
+  }
+  bool operator!=(const IndirectIter &other) const { return !(*this == other); }
+};
+
+//! This class is only intended to be used by range-based for loops via
+//! RDMol::atomNeighbors() and RDMol::atomBonds()
+template <bool ISBOND, bool ISCONST>
+class IndirectRange {
+  using MolType = std::conditional_t<ISCONST, const RDMol, RDMol>;
+  using Iter = IndirectIter<ISBOND, ISCONST>;
+  MolType *d_mol;
+  const uint32_t *d_begin;
+  const uint32_t *d_end;
+
+  friend class RDMol;
+  IndirectRange(MolType *mol, const uint32_t *beginIndices,
+                     const uint32_t *endIndices)
+      : d_mol(mol), d_begin(beginIndices), d_end(endIndices) {}
+
+ public:
+  IndirectRange(const IndirectRange<ISBOND, ISCONST> &) = default;
+  IndirectRange &operator=(const IndirectRange<ISBOND, ISCONST> &) = default;
+  Iter begin() const { return Iter(d_mol, d_begin); }
+  Iter end() const { return Iter(d_mol, d_end); }
+};
+
+}  // namespace Ranges
+
+inline Ranges::IndexRange<false, false> RDMol::atoms() {
+  return Ranges::IndexRange<false, false>(this);
+}
+inline Ranges::IndexRange<false, true> RDMol::atoms() const {
+  return Ranges::IndexRange<false, true>(this);
+}
+inline Ranges::IndexRange<true, false> RDMol::bonds() {
+  return Ranges::IndexRange<true, false>(this);
+}
+inline Ranges::IndexRange<true, true> RDMol::bonds() const {
+  return Ranges::IndexRange<true, true>(this);
+}
+inline Ranges::IndirectRange<false, false> RDMol::atomNeighbors(atomindex_t atomIndex) {
+  auto [begin, end] = getAtomNeighbors(atomIndex);
+  return Ranges::IndirectRange<false, false>(this, begin, end);
+}
+inline Ranges::IndirectRange<false, true> RDMol::atomNeighbors(atomindex_t atomIndex) const {
+  auto [begin, end] = getAtomNeighbors(atomIndex);
+  return Ranges::IndirectRange<false, true>(this, begin, end);
+}
+inline Ranges::IndirectRange<true, false> RDMol::atomBonds(atomindex_t atomIndex) {
+  auto [begin, end] = getAtomBonds(atomIndex);
+  return Ranges::IndirectRange<true, false>(this, begin, end);
+}
+inline Ranges::IndirectRange<true, true> RDMol::atomBonds(atomindex_t atomIndex) const {
+  auto [begin, end] = getAtomBonds(atomIndex);
+  return Ranges::IndirectRange<true, true>(this, begin, end);
+}
+
+}  // namespace RDKit

--- a/Code/GraphMol/ROMol.cpp
+++ b/Code/GraphMol/ROMol.cpp
@@ -21,7 +21,7 @@
 #include "MolPickler.h"
 #include "Conformer.h"
 #include "SubstanceGroup.h"
-
+#include <GraphMol/rdmol_throw.h>
 #ifdef RDK_USE_BOOST_SERIALIZATION
 #include <RDGeneral/BoostStartInclude.h>
 #include <boost/archive/text_oarchive.hpp>
@@ -37,439 +37,141 @@ const int ci_RIGHTMOST_ATOM = -0xBADBEEF;
 const int ci_LEADING_BOND = -0xBADBEEF + 1;
 const int ci_ATOM_HOLDER = -0xDEADD06;
 
-void ROMol::destroy() {
-  d_atomBookmarks.clear();
-  d_bondBookmarks.clear();
-
-  auto atItP = boost::vertices(d_graph);
-  while (atItP.first != atItP.second) {
-    delete (d_graph)[*(atItP.first++)];
-  }
-
-  auto bondItP = boost::edges(d_graph);
-  while (bondItP.first != bondItP.second) {
-    delete (d_graph)[*(bondItP.first++)];
-  }
-
-  d_graph.clear();
-
-  delete dp_ringInfo;
-
-  d_sgroups.clear();
-  d_stereo_groups.clear();
+ROMol::ROMol() : d_ownedBySelf(true) {
+  // d_ownedBySelf must be initialized before dp_mol, because dp_mol
+  // compat data initialization depends on d_ownedBySelf.
+  dp_mol = new RDKit::RDMol(this);
 }
-
-ROMol::ROMol(const std::string &pickle) : RDProps() {
-  initMol();
-  numBonds = 0;
+ROMol::ROMol(const ROMol &other, bool quickCopy , int confId) {
+  // Self ownership must be set before dp_mol is created.
+  d_ownedBySelf = true;
+  dp_mol = new RDKit::RDMol(*other.dp_mol, quickCopy, confId, this);
+}
+ROMol::ROMol(const std::string &pickle) : ROMol() {
   MolPickler::molFromPickle(pickle, *this);
-  numBonds = rdcast<unsigned int>(boost::num_edges(d_graph));
 }
-
-ROMol::ROMol(const std::string &pickle, unsigned int propertyFlags)
-    : RDProps() {
-  initMol();
-  numBonds = 0;
+ROMol::ROMol(const std::string &pickle, unsigned int propertyFlags) : ROMol() {
   MolPickler::molFromPickle(pickle, *this, propertyFlags);
-  numBonds = rdcast<unsigned int>(boost::num_edges(d_graph));
+}
+ROMol::ROMol(ROMol&& other) noexcept{
+  dp_mol = other.dp_mol;
+  d_ownedBySelf = true;
+  if (other.d_ownedBySelf) {
+    dp_mol->releaseCompatMolOwnership();
+  }
+  dp_mol->setROMolPointerCompat(this);
+  dp_mol->setCompatPointersToSelf();
+  // Moved from object must be usable per unit tests
+  other.dp_mol = new RDKit::RDMol();
+  other.d_ownedBySelf = true;
 }
 
-void ROMol::initFromOther(const ROMol &other, bool quickCopy, int confId) {
+ROMol &ROMol::operator=(ROMol &&other) noexcept {
   if (this == &other) {
-    return;
+    return *this;
   }
-  numBonds = 0;
-  // std::cerr<<"    init from other: "<<this<<" "<<&other<<std::endl;
-  // copy over the atoms
-  for (const auto oatom : other.atoms()) {
-    constexpr bool updateLabel = false;
-    constexpr bool takeOwnership = true;
-    addAtom(oatom->copy(), updateLabel, takeOwnership);
-  }
-
-  // and the bonds:
-  for (const auto obond : other.bonds()) {
-    addBond(obond->copy(), true);
-  }
-
-  // ring information
-  delete dp_ringInfo;
-  if (other.dp_ringInfo) {
-    dp_ringInfo = new RingInfo(*(other.dp_ringInfo));
+  if (d_ownedBySelf && other.d_ownedBySelf) {
+    delete dp_mol;
+    dp_mol = other.dp_mol;
+    // Moved from object must be usable per unit tests
+    other.dp_mol = new RDKit::RDMol();
   } else {
-    dp_ringInfo = new RingInfo();
+    // In concept, something equivalent to this could happen:
+    // RDMol mol;
+    // mol.asROMol() = std::move(inputROMol);
+    // in which case, this can't own the RDMol, so dp_mol must stay
+    // the same and d_ownedBySelf must stay the same as before.
+    // To avoid dp_mol deleting this upon assignment, temporarily release ownership of this.
+    if (!d_ownedBySelf) {
+      dp_mol->releaseCompatMolOwnership();
+    }
+    // Can't fully transfer ownership, so use copy assignment
+    *dp_mol = *other.dp_mol;
   }
+  dp_mol->setROMolPointerCompat(this);
+  dp_mol->setCompatPointersToSelf();
 
-  // enhanced stereochemical information
-  d_stereo_groups.clear();
-  for (auto &otherGroup : other.d_stereo_groups) {
-    std::vector<Atom *> atoms;
-    for (auto &otherAtom : otherGroup.getAtoms()) {
-      atoms.push_back(getAtomWithIdx(otherAtom->getIdx()));
-    }
-    std::vector<Bond *> bonds;
-    for (auto &otherBond : otherGroup.getBonds()) {
-      bonds.push_back(getBondWithIdx(otherBond->getIdx()));
-    }
-    d_stereo_groups.emplace_back(otherGroup.getGroupType(), std::move(atoms),
-                                 std::move(bonds), otherGroup.getReadId());
-    d_stereo_groups.back().setWriteId(otherGroup.getWriteId());
-  }
-
-  if (other.dp_delAtoms) {
-    dp_delAtoms.reset(new boost::dynamic_bitset<>(*other.dp_delAtoms));
-  } else {
-    dp_delAtoms.reset(nullptr);
-  }
-  if (other.dp_delBonds) {
-    dp_delBonds.reset(new boost::dynamic_bitset<>(*other.dp_delBonds));
-  } else {
-    dp_delBonds.reset(nullptr);
-  }
-
-  if (!quickCopy) {
-    // copy conformations
-    for (const auto &conf : other.d_confs) {
-      if (confId < 0 || rdcast<int>(conf->getId()) == confId) {
-        this->addConformer(new Conformer(*conf));
-      }
-    }
-
-    // Copy sgroups
-    for (const auto &sg : getSubstanceGroups(other)) {
-      addSubstanceGroup(*this, sg);
-    }
-
-    d_props = other.d_props;
-
-    // Bookmarks should be copied as well:
-    for (auto abmI : other.d_atomBookmarks) {
-      for (const auto *aptr : abmI.second) {
-        setAtomBookmark(getAtomWithIdx(aptr->getIdx()), abmI.first);
-      }
-    }
-    for (auto bbmI : other.d_bondBookmarks) {
-      for (const auto *bptr : bbmI.second) {
-        setBondBookmark(getBondWithIdx(bptr->getIdx()), bbmI.first);
-      }
-    }
-  } else {
-    d_props.reset();
-    STR_VECT computed;
-    d_props.setVal(RDKit::detail::computedPropName, computed);
-  }
-
-  // std::cerr<<"---------    done init from other: "<<this<<"
-  // "<<&other<<std::endl;
+  return *this;
 }
 
-void ROMol::initMol() {
-  d_props.reset();
-  dp_ringInfo = new RingInfo();
-  // ok every molecule contains a property entry called
-  // RDKit::detail::computedPropName
-  // which provides
-  //  list of property keys that correspond to value that have been computed
-  // this can used to blow out all computed properties while leaving the rest
-  // along
-  // initialize this list to an empty vector of strings
-  STR_VECT computed;
-  d_props.setVal(RDKit::detail::computedPropName, computed);
+ROMol::~ROMol() {
+  if (d_ownedBySelf) {
+    delete dp_mol;
+  }
 }
 
-unsigned int ROMol::getAtomDegree(const Atom *at) const {
+RingInfo* ROMol::getRingInfo() const {
+  auto &ringInfo = dp_mol->getRingInfoCompat();
+  return &ringInfo;
+}
+
+unsigned int ROMol::getNumAtoms() const { return dp_mol->getNumAtoms(); }
+unsigned int ROMol::getNumAtoms(bool onlyExplicit) const {
+  return dp_mol->getNumAtoms(onlyExplicit);
+}
+unsigned int ROMol::getNumHeavyAtoms() const {
+  return dp_mol->getNumHeavyAtoms();
+}
+Atom* ROMol::getAtomWithIdx(unsigned int idx) {
+  PRECONDITION(getNumAtoms() > 0, "no atoms");
+  URANGE_CHECK(idx, getNumAtoms());
+  return dp_mol->getAtomCompat(idx);
+}
+const Atom* ROMol::getAtomWithIdx(unsigned int idx) const {
+  PRECONDITION(getNumAtoms() > 0, "no atoms");
+  URANGE_CHECK(idx, getNumAtoms());
+  return dp_mol->getAtomCompat(idx);
+}
+unsigned int ROMol::getAtomDegree(const Atom* at) const {
   PRECONDITION(at, "no atom");
+  PRECONDITION(at->hasOwningMol(), "atom not associated with a molecule");
   PRECONDITION(&at->getOwningMol() == this,
                "atom not associated with this molecule");
-  return rdcast<unsigned int>(boost::out_degree(at->getIdx(), d_graph));
-};
-
-unsigned int ROMol::getNumAtoms(bool onlyExplicit) const {
-  int res = rdcast<int>(boost::num_vertices(d_graph));
-  if (!onlyExplicit) {
-    // if we are interested in hydrogens as well add them up from
-    // each
-    for (const auto atom : atoms()) {
-      res += atom->getTotalNumHs();
-    }
-  }
-  return res;
-};
-unsigned int ROMol::getNumHeavyAtoms() const {
-  unsigned int res = 0;
-  for (const auto atom : atoms()) {
-    if (atom->getAtomicNum() > 1) {
-      ++res;
-    }
-  }
-  return res;
-};
-
-Atom *ROMol::getAtomWithIdx(unsigned int idx) {
-  URANGE_CHECK(idx, getNumAtoms());
-
-  auto vd = boost::vertex(idx, d_graph);
-  auto res = d_graph[vd];
-  POSTCONDITION(res, "");
-  return res;
+  return dp_mol->getAtomDegree(at->getIdx());
 }
-
-const Atom *ROMol::getAtomWithIdx(unsigned int idx) const {
-  URANGE_CHECK(idx, getNumAtoms());
-
-  auto vd = boost::vertex(idx, d_graph);
-  const auto res = d_graph[vd];
-
-  POSTCONDITION(res, "");
-  return res;
-}
-
-// returns the first inserted atom with the given bookmark
-Atom *ROMol::getAtomWithBookmark(int mark) {
-  auto lu = d_atomBookmarks.find(mark);
-  PRECONDITION((lu != d_atomBookmarks.end() && !lu->second.empty()),
-               "atom bookmark not found");
-  return lu->second.front();
-};
-
-// returns all atoms with the given bookmark
-ROMol::ATOM_PTR_LIST &ROMol::getAllAtomsWithBookmark(int mark) {
-  auto lu = d_atomBookmarks.find(mark);
-  PRECONDITION(lu != d_atomBookmarks.end(), "atom bookmark not found");
-  return lu->second;
-};
-
-// returns the unique atom with the given bookmark
-Atom *ROMol::getUniqueAtomWithBookmark(int mark) {
-  auto lu = d_atomBookmarks.find(mark);
-  PRECONDITION((lu != d_atomBookmarks.end()), "bookmark not found");
-  return lu->second.front();
-}
-
-// returns the first inserted bond with the given bookmark
-Bond *ROMol::getBondWithBookmark(int mark) {
-  auto lu = d_bondBookmarks.find(mark);
-  PRECONDITION((lu != d_bondBookmarks.end() && !lu->second.empty()),
-               "bond bookmark not found");
-  return lu->second.front();
-};
-
-// returns all bonds with the given bookmark
-ROMol::BOND_PTR_LIST &ROMol::getAllBondsWithBookmark(int mark) {
-  auto lu = d_bondBookmarks.find(mark);
-  PRECONDITION(lu != d_bondBookmarks.end(), "bond bookmark not found");
-  return lu->second;
-};
-
-// returns the unique bond with the given bookmark
-Bond *ROMol::getUniqueBondWithBookmark(int mark) {
-  auto lu = d_bondBookmarks.find(mark);
-  PRECONDITION((lu != d_bondBookmarks.end()), "bookmark not found");
-  return lu->second.front();
-}
-
-void ROMol::clearAtomBookmark(const int mark) { d_atomBookmarks.erase(mark); }
-
-void ROMol::clearAtomBookmark(int mark, const Atom *atom) {
-  PRECONDITION(atom, "no atom");
-  auto lu = d_atomBookmarks.find(mark);
-  if (lu != d_atomBookmarks.end()) {
-    auto &marks = lu->second;
-    unsigned int tgtIdx = atom->getIdx();
-    auto entry = std::find_if(marks.begin(), marks.end(), [&tgtIdx](auto ptr) {
-      return ptr->getIdx() == tgtIdx;
-    });
-    if (entry != marks.end()) {
-      marks.erase(entry);
-    }
-    if (marks.empty()) {
-      d_atomBookmarks.erase(mark);
-    }
-  }
-}
-
-void ROMol::clearBondBookmark(int mark) { d_bondBookmarks.erase(mark); }
-void ROMol::clearBondBookmark(int mark, const Bond *bond) {
-  PRECONDITION(bond, "no bond");
-  auto lu = d_bondBookmarks.find(mark);
-  if (lu != d_bondBookmarks.end()) {
-    auto &marks = lu->second;
-    unsigned int tgtIdx = bond->getIdx();
-    auto entry = std::find_if(marks.begin(), marks.end(), [&tgtIdx](auto ptr) {
-      return ptr->getIdx() == tgtIdx;
-    });
-    if (entry != marks.end()) {
-      marks.erase(entry);
-    }
-    if (marks.empty()) {
-      d_bondBookmarks.erase(mark);
-    }
-  }
-}
-
 unsigned int ROMol::getNumBonds(bool onlyHeavy) const {
-  // By default return the bonds that connect only the heavy atoms
-  // hydrogen connecting bonds are ignores
-  auto res = numBonds;
-  if (!onlyHeavy) {
-    // If we need hydrogen connecting bonds add them up
-    for (const auto atom : atoms()) {
-      res += atom->getTotalNumHs();
-    }
-  }
-  return res;
+  return dp_mol->getNumBonds(onlyHeavy);
 }
-
-Bond *ROMol::getBondWithIdx(unsigned int idx) {
-  return const_cast<Bond *>(static_cast<const ROMol *>(this)->getBondWithIdx(
-      idx));  // avoid code duplication
-}
-
-const Bond *ROMol::getBondWithIdx(unsigned int idx) const {
+Bond* ROMol::getBondWithIdx(unsigned int idx) {
+  PRECONDITION(getNumBonds() > 0, "no bonds");
   URANGE_CHECK(idx, getNumBonds());
-
-  // boost::graph doesn't give us random-access to edges,
-  // so we have to iterate to it
-  auto [iter, end] = getEdges();
-  for (unsigned int i = 0; i < idx; i++) {
-    ++iter;
-  }
-  const Bond *res = d_graph[*iter];
-
-  POSTCONDITION(res != nullptr, "Invalid bond requested");
-  return res;
+  return dp_mol->getBondCompat(idx);
 }
-
-Bond *ROMol::getBondBetweenAtoms(unsigned int idx1, unsigned int idx2) {
-  return const_cast<Bond *>(
-      static_cast<const ROMol *>(this)->getBondBetweenAtoms(
-          idx1, idx2));  // avoid code duplication
+const Bond* ROMol::getBondWithIdx(unsigned int idx) const {
+  PRECONDITION(getNumBonds() > 0, "no bonds");
+  URANGE_CHECK(idx, getNumBonds());
+  return dp_mol->getBondCompat(idx);
 }
-
-const Bond *ROMol::getBondBetweenAtoms(unsigned int idx1,
-                                       unsigned int idx2) const {
+Bond* ROMol::getBondBetweenAtoms(unsigned int idx1, unsigned int idx2) {
   URANGE_CHECK(idx1, getNumAtoms());
   URANGE_CHECK(idx2, getNumAtoms());
-  const Bond *res = nullptr;
-
-  auto [edge, found] = boost::edge(boost::vertex(idx1, d_graph),
-                                   boost::vertex(idx2, d_graph), d_graph);
-  if (found) {
-    res = d_graph[edge];
-  }
-  return res;
+  const uint32_t bondIndex = dp_mol->getBondIndexBetweenAtoms(idx1, idx2);
+  return (bondIndex == std::numeric_limits<std::uint32_t>::max())
+             ? nullptr
+             : getBondWithIdx(bondIndex);
 }
-
-ROMol::ADJ_ITER_PAIR ROMol::getAtomNeighbors(Atom const *at) const {
-  PRECONDITION(at, "no atom");
-  PRECONDITION(&at->getOwningMol() == this,
-               "atom not associated with this molecule");
-  return boost::adjacent_vertices(at->getIdx(), d_graph);
-};
-
-ROMol::OBOND_ITER_PAIR ROMol::getAtomBonds(Atom const *at) const {
-  PRECONDITION(at, "no atom");
-  PRECONDITION(&at->getOwningMol() == this,
-               "atom not associated with this molecule");
-  return boost::out_edges(at->getIdx(), d_graph);
+const Bond* ROMol::getBondBetweenAtoms(unsigned int idx1, unsigned int idx2) const {
+  URANGE_CHECK(idx1, getNumAtoms());
+  URANGE_CHECK(idx2, getNumAtoms());
+  const uint32_t bondIndex = dp_mol->getBondIndexBetweenAtoms(idx1, idx2);
+  return (bondIndex == std::numeric_limits<std::uint32_t>::max())
+             ? nullptr
+             : getBondWithIdx(bondIndex);
 }
-
-ROMol::ATOM_ITER_PAIR ROMol::getVertices() { return boost::vertices(d_graph); }
-ROMol::BOND_ITER_PAIR ROMol::getEdges() { return boost::edges(d_graph); }
+ROMol::ADJ_ITER_PAIR ROMol::getAtomNeighbors(Atom const* at) const {
+  auto [beginNeighbors, endNeighbors] = dp_mol->getAtomNeighbors(at->getIdx());
+  return ADJ_ITER_PAIR{ADJ_ITER{beginNeighbors}, ADJ_ITER{endNeighbors}};
+}
+ROMol::OBOND_ITER_PAIR ROMol::getAtomBonds(Atom const* at) const {
+  auto [beginBonds, endBonds] = dp_mol->getAtomBonds(at->getIdx());
+  return OBOND_ITER_PAIR{OEDGE_ITER{beginBonds}, OEDGE_ITER{endBonds}};
+}
 ROMol::ATOM_ITER_PAIR ROMol::getVertices() const {
-  return boost::vertices(d_graph);
+  return ATOM_ITER_PAIR{VERTEX_ITER{0}, VERTEX_ITER{getNumAtoms()}};
 }
-ROMol::BOND_ITER_PAIR ROMol::getEdges() const { return boost::edges(d_graph); }
-
-unsigned int ROMol::addAtom(Atom *atom_pin, bool updateLabel,
-                            bool takeOwnership) {
-  PRECONDITION(atom_pin, "null atom passed in");
-  PRECONDITION(!takeOwnership || !atom_pin->hasOwningMol() ||
-                   &atom_pin->getOwningMol() == this,
-               "cannot take ownership of an atom which already has an owner");
-  Atom *atom_p;
-  if (!takeOwnership) {
-    atom_p = atom_pin->copy();
-  } else {
-    atom_p = atom_pin;
-  }
-
-  atom_p->setOwningMol(this);
-  auto which = boost::add_vertex(d_graph);
-  d_graph[which] = atom_p;
-  atom_p->setIdx(which);
-  if (updateLabel) {
-    replaceAtomBookmark(atom_p, ci_RIGHTMOST_ATOM);
-  }
-  for (auto &conf : d_confs) {
-    conf->setAtomPos(which, RDGeom::Point3D(0.0, 0.0, 0.0));
-  }
-  return rdcast<unsigned int>(which);
-};
-
-unsigned int ROMol::addBond(Bond *bond_pin, bool takeOwnership) {
-  PRECONDITION(bond_pin, "null bond passed in");
-  PRECONDITION(!takeOwnership || !bond_pin->hasOwningMol() ||
-                   &bond_pin->getOwningMol() == this,
-               "cannot take ownership of an bond which already has an owner");
-  URANGE_CHECK(bond_pin->getBeginAtomIdx(), getNumAtoms());
-  URANGE_CHECK(bond_pin->getEndAtomIdx(), getNumAtoms());
-  PRECONDITION(bond_pin->getBeginAtomIdx() != bond_pin->getEndAtomIdx(),
-               "attempt to add self-bond");
-  PRECONDITION(!(boost::edge(bond_pin->getBeginAtomIdx(),
-                             bond_pin->getEndAtomIdx(), d_graph)
-                     .second),
-               "bond already exists");
-
-  Bond *bond_p;
-  if (!takeOwnership) {
-    bond_p = bond_pin->copy();
-  } else {
-    bond_p = bond_pin;
-  }
-
-  bond_p->setOwningMol(this);
-  auto [which, ok] = boost::add_edge(bond_p->getBeginAtomIdx(),
-                                     bond_p->getEndAtomIdx(), d_graph);
-  CHECK_INVARIANT(ok, "bond could not be added");
-  d_graph[which] = bond_p;
-  bond_p->setIdx(numBonds);
-  numBonds++;
-  return numBonds;
-}
-
-void ROMol::setStereoGroups(std::vector<StereoGroup> stereo_groups) {
-  d_stereo_groups = std::move(stereo_groups);
-}
-
-void ROMol::debugMol(std::ostream &str) const {
-  str << "Atoms:" << std::endl;
-  for (const auto atom : atoms()) {
-    str << "\t" << *atom << std::endl;
-  }
-
-  str << "Bonds:" << std::endl;
-  for (const auto bond : bonds()) {
-    str << "\t" << *bond << std::endl;
-  }
-
-  const auto &sgs = getSubstanceGroups(*this);
-  if (!sgs.empty()) {
-    str << "Substance Groups:" << std::endl;
-    for (const auto &sg : sgs) {
-      str << "\t" << sg << std::endl;
-    }
-  }
-
-  const auto &stgs = getStereoGroups();
-  if (!stgs.empty()) {
-    unsigned idx = 0;
-    str << "Stereo Groups:" << std::endl;
-    for (const auto &stg : stgs) {
-      str << "\t" << idx << ' ' << stg << std::endl;
-      ++idx;
-    }
-  }
+ROMol::BOND_ITER_PAIR ROMol::getEdges() const {
+  return BOND_ITER_PAIR{EDGE_ITER{edge_descriptor{0}},
+                        EDGE_ITER{edge_descriptor{getNumBonds()}}};
 }
 
 // --------------------------------------------
@@ -528,11 +230,11 @@ bool ROMol::hasQuery() const {
   return false;
 }
 
-ROMol::QueryAtomIterator ROMol::beginQueryAtoms(QueryAtom const *what) {
+ROMol::QueryAtomIterator ROMol::beginQueryAtoms(QueryAtom const* what) {
   return QueryAtomIterator(this, what);
 }
 ROMol::ConstQueryAtomIterator ROMol::beginQueryAtoms(
-    QueryAtom const *what) const {
+    QueryAtom const* what) const {
   return ConstQueryAtomIterator(this, what);
 }
 ROMol::QueryAtomIterator ROMol::endQueryAtoms() {
@@ -541,11 +243,11 @@ ROMol::QueryAtomIterator ROMol::endQueryAtoms() {
 ROMol::ConstQueryAtomIterator ROMol::endQueryAtoms() const {
   return ConstQueryAtomIterator(this, getNumAtoms());
 }
-ROMol::MatchingAtomIterator ROMol::beginMatchingAtoms(bool (*what)(Atom *)) {
+ROMol::MatchingAtomIterator ROMol::beginMatchingAtoms(bool (*what)(Atom*)) {
   return MatchingAtomIterator(this, what);
 }
 ROMol::ConstMatchingAtomIterator ROMol::beginMatchingAtoms(
-    bool (*what)(const Atom *)) const {
+    bool (*what)(const Atom*)) const {
   return ConstMatchingAtomIterator(this, what);
 }
 ROMol::MatchingAtomIterator ROMol::endMatchingAtoms() {
@@ -568,53 +270,305 @@ ROMol::ConstBondIterator ROMol::endBonds() const {
   return ConstBondIterator(this, end);
 }
 
-void ROMol::clearComputedProps(bool includeRings) const {
-  // the SSSR information:
-  if (includeRings) {
-    this->dp_ringInfo->reset();
-  }
-
-  RDProps::clearComputedProps();
-
-  for (auto atom : atoms()) {
-    atom->clearComputedProps();
-  }
-
-  for (auto bond : bonds()) {
-    bond->clearComputedProps();
-  }
+unsigned int ROMol::getNumConformers() const {
+  return dp_mol->getNumConformers();
 }
 
-void ROMol::updatePropertyCache(bool strict) {
-  for (auto atom : atoms()) {
-    atom->updatePropertyCache(strict);
-  }
-  for (auto bond : bonds()) {
-    bond->updatePropertyCache(strict);
-  }
+void ROMol::clearComputedProps(bool includeRings) const {
+  dp_mol->clearComputedProps(includeRings);
 }
 
 bool ROMol::needsUpdatePropertyCache() const {
-  for (const auto atom : atoms()) {
-    if (atom->needsUpdatePropertyCache()) {
-      return true;
-    }
-  }
-  // there is no test for bonds yet since they do not obtain a valence property
-  return false;
+  return dp_mol->needsUpdatePropertyCache();
 }
 
-const Conformer &ROMol::getConformer(int id) const {
-  // make sure we have more than one conformation
-  if (d_confs.size() == 0) {
+void ROMol::updatePropertyCache(bool strict) {
+  dp_mol->updatePropertyCache(strict);
+}
+
+const std::vector<StereoGroup> &ROMol::getStereoGroups() const {
+  return dp_mol->getStereoGroupsCompat();
+}
+
+void ROMol::setStereoGroups(std::vector<StereoGroup> stereo_groups) {
+  auto newGroups = std::make_unique<StereoGroups>();
+  std::vector<StereoGroupType> &types = newGroups->stereoTypes;
+  std::vector<uint32_t> &atomIndices = newGroups->atoms;
+  std::vector<uint32_t> &bondIndices = newGroups->bonds;
+  std::vector<uint32_t> &atomBegins = newGroups->atomBegins;
+  std::vector<uint32_t> &bondBegins = newGroups->bondBegins;
+  std::vector<uint32_t> &readIds = newGroups->readIds;
+  std::vector<uint32_t> &writeIds = newGroups->writeIds;
+
+  for (const auto &group : stereo_groups) {
+    types.push_back(group.getGroupType());
+
+    const auto &atoms = group.getAtoms();
+    for (const auto *atom : atoms) {
+      atomIndices.push_back(atom->getIdx());
+    }
+    const auto &bonds = group.getBonds();
+    for (const auto *bond : bonds) {
+      bondIndices.push_back(bond->getIdx());
+    }
+
+    atomBegins.push_back(atoms.size() + atomBegins.back());
+    bondBegins.push_back(bonds.size() + bondBegins.back());
+    readIds.push_back(group.getReadId());
+    writeIds.push_back(group.getWriteId());
+  }
+  dp_mol->setStereoGroups(std::move(newGroups));
+}
+
+STR_VECT ROMol::getPropList(bool includePrivate, bool includeComputed) const {
+  return dp_mol->getPropList(includePrivate, includeComputed);
+}
+
+bool ROMol::hasProp(const std::string &key) const {
+  return dp_mol->hasProp(PropToken(key));
+}
+
+void ROMol::clearProp(const std::string &key) const {
+  dp_mol->clearMolPropIfPresent(PropToken(key));
+}
+
+void ROMol::updateProps(const RDKit::ROMol &source, bool preserveExisting) {
+  if (&source == this) {
+    return;
+  }
+  // Remove all properties if !preserveExisting
+  if (!preserveExisting) {
+    dp_mol->clearProps();
+  }
+
+  for (const RDMol::Property &prop : source.asRDMol().properties) {
+    if (prop.scope == RDMol::Scope::MOL) {
+      dp_mol->setMolProp(prop.name, prop.inPlaceData, prop.isComputed);
+    }
+  }
+}
+
+void ROMol::updateProps(const RDProps &source, bool preserveExisting) {
+  // Remove all properties if !preserveExisting
+  if (!preserveExisting) {
+    dp_mol->clearProps();
+  }
+
+  const STR_VECT keys = source.getPropList();
+  std::vector<std::string> computedPropList;
+  source.getPropIfPresent<std::vector<std::string>>(
+      RDKit::detail::computedPropName, computedPropList);
+  for (const auto &key : keys) {
+    if (key == RDKit::detail::computedPropName) {
+      continue;
+    }
+    const PropToken token(key);
+    const RDValue &val = source.getPropRDValue(key);
+    bool isComputed =
+        std::find(computedPropList.begin(), computedPropList.end(), key) !=
+        computedPropList.end();
+    dp_mol->setMolProp(token, val, isComputed);
+  }
+}
+
+void ROMol::clear(){dp_mol->clearProps();}
+
+void ROMol::debugMol(std::ostream& str) const {
+  str << "Atoms:" << std::endl;
+  for (const auto atom : atoms()) {
+    str << "\t" << *atom << std::endl;
+  }
+
+  str << "Bonds:" << std::endl;
+  for (const auto bond : bonds()) {
+    str << "\t" << *bond << std::endl;
+  }
+
+  const auto &sgs = getSubstanceGroups(*this);
+  if (!sgs.empty()) {
+    str << "Substance Groups:" << std::endl;
+    for (const auto &sg : sgs) {
+      str << "\t" << sg << std::endl;
+    }
+  }
+
+  const auto &stgs = getStereoGroups();
+  if (!stgs.empty()) {
+    unsigned idx = 0;
+    str << "Stereo Groups:" << std::endl;
+    for (const auto &stg : stgs) {
+      str << "\t" << idx << ' ' << stg << std::endl;
+      ++idx;
+    }
+  }
+}
+
+// --------------
+// Atom bookmarks
+// --------------
+
+void ROMol::setAtomBookmark(Atom *at, int mark) {
+  // The atom may not be added to its owning molecule yet if it's an isolated
+  // atom, but the ROMol still needs to be able to store a bookmark for it,
+  // even though this isn't supported by the public RDMol interface.
+  PRECONDITION(
+      (&at->getOwningMol() == this &&
+       ((&at->getOwningMol().asRDMol() != &at->getDataRDMol()) ||
+        at->getOwningMol().getAtomWithIdx(at->getIdx()) == at)),
+      "Bookmark atom must be for this ROMol, even if it's not added to the ROMol");
+
+  auto &marks = (*dp_mol->getAtomBookmarksCompat())[mark];
+  marks.push_back(at);
+}
+
+void ROMol::replaceAtomBookmark(Atom *at, int mark) {
+  // The atom may not be added to its owning molecule yet if it's an isolated
+  // atom, but the ROMol still needs to be able to store a bookmark for it,
+  // even though this isn't supported by the public RDMol interface.
+  PRECONDITION(
+      (&at->getOwningMol() == this &&
+       ((&at->getOwningMol().asRDMol() != &at->getDataRDMol()) ||
+        at->getOwningMol().getAtomWithIdx(at->getIdx()) == at)),
+      "Bookmark atom must be for this ROMol, even if it's not added to the ROMol");
+
+  auto &marks = (*dp_mol->getAtomBookmarksCompat())[mark];
+  marks.clear();
+  marks.push_back(at);
+}
+Atom * ROMol::getAtomWithBookmark(int mark) {
+  auto *allMarks = dp_mol->getAtomBookmarksCompat();
+  PRECONDITION(allMarks != nullptr, "null atom bookmarks map");
+  auto it = allMarks->find(mark);
+  PRECONDITION(it != allMarks->end(), "atom bookmark not found");
+  auto &marks = it->second;
+  PRECONDITION(marks.size() != 0, "atom bookmark not found");
+  return marks.front();
+}
+
+Atom * ROMol::getUniqueAtomWithBookmark(int mark) {
+  return getAtomWithBookmark(mark);
+}
+
+ROMol::ATOM_PTR_LIST & ROMol::getAllAtomsWithBookmark(int mark) {
+  return dp_mol->getAtomBookmarksCompat(mark);
+}
+void ROMol::clearAtomBookmark(int mark) {
+  dp_mol->clearAtomBookmark(mark);
+}
+void ROMol::clearAtomBookmark(int mark, const Atom *at) {
+  // The atom may not be added to its owning molecule yet if it's an isolated
+  // atom, but the ROMol still needs to be able to store a bookmark for it,
+  // even though this isn't supported by the public RDMol interface.
+  PRECONDITION(
+      (&at->getOwningMol() == this &&
+       ((&at->getOwningMol().asRDMol() != &at->getDataRDMol()) ||
+        at->getOwningMol().getAtomWithIdx(at->getIdx()) == at)),
+      "Bookmark atom must be for this ROMol, even if it's not added to the ROMol");
+  if (!dp_mol->hasAtomBookmark(mark)) {
+    return;
+  }
+
+  auto &marks = dp_mol->getAtomBookmarksCompat(mark);
+  auto removeIt = std::find(marks.begin(), marks.end(), at);
+  if (removeIt != marks.end()) {
+    marks.erase(removeIt);
+    if (marks.size() == 0) {
+      dp_mol->clearAtomBookmark(mark);
+    }
+  }
+}
+
+void ROMol::clearAllAtomBookmarks() {
+  dp_mol->clearAllAtomBookmarks();
+}
+
+bool ROMol::hasAtomBookmark(int mark) const {
+  return dp_mol->hasAtomBookmark(mark);
+}
+ROMol::ATOM_BOOKMARK_MAP *ROMol::getAtomBookmarks() {
+  return dp_mol->getAtomBookmarksCompat();
+}
+
+// --------------
+// Bond bookmarks
+// --------------
+
+void ROMol::setBondBookmark(Bond *bond, int mark) {
+  // The bond may not be added to its owning molecule yet if it's an isolated
+  // bond, but the ROMol still needs to be able to store a bookmark for it,
+  // even though this isn't supported by the public RDMol interface.
+  PRECONDITION(
+      (&bond->getOwningMol() == this &&
+       ((&bond->getOwningMol().asRDMol() != &bond->getDataRDMol()) ||
+        bond->getOwningMol().getBondWithIdx(bond->getIdx()) == bond)),
+      "Bookmark bond must be for this ROMol, even if it's not added to the ROMol");
+
+  auto &marks = (*dp_mol->getBondBookmarksCompat())[mark];
+  marks.push_back(bond);
+}
+Bond * ROMol::getBondWithBookmark(int mark) {
+  auto *allMarks = dp_mol->getBondBookmarksCompat();
+  PRECONDITION(allMarks != nullptr, "null bond bookmarks map");
+  auto it = allMarks->find(mark);
+  PRECONDITION(it != allMarks->end(), "bond bookmark not found");
+  auto &marks = it->second;
+  PRECONDITION(marks.size() != 0, "bond bookmark not found");
+  return marks.front();
+}
+
+Bond * ROMol::getUniqueBondWithBookmark(int mark) {
+  return getBondWithBookmark(mark);
+}
+ROMol::BOND_PTR_LIST & ROMol::getAllBondsWithBookmark(int mark) {
+  return dp_mol->getBondBookmarksCompat(mark);
+}
+void ROMol::clearBondBookmark(int mark) {
+  dp_mol->clearBondBookmark(mark);
+}
+void ROMol::clearBondBookmark(int mark, const Bond *bond) {
+  // The bond may not be added to its owning molecule yet if it's an isolated
+  // bond, but the ROMol still needs to be able to store a bookmark for it,
+  // even though this isn't supported by the public RDMol interface.
+  PRECONDITION(
+      (&bond->getOwningMol() == this &&
+       ((&bond->getOwningMol().asRDMol() != &bond->getDataRDMol()) ||
+        bond->getOwningMol().getBondWithIdx(bond->getIdx()) == bond)),
+      "Bookmark bond must be for this ROMol, even if it's not added to the ROMol");
+  if (!dp_mol->hasBondBookmark(mark)) {
+    return;
+  }
+
+  auto &marks = dp_mol->getBondBookmarksCompat(mark);
+  auto removeIt = std::find(marks.begin(), marks.end(), bond);
+  if (removeIt != marks.end()) {
+    marks.erase(removeIt);
+    if (marks.size() == 0) {
+      dp_mol->clearBondBookmark(mark);
+    }
+  }
+}
+void ROMol::clearAllBondBookmarks() {
+  dp_mol->clearAllBondBookmarks();
+}
+bool ROMol::hasBondBookmark(int mark) const {
+  return dp_mol->hasBondBookmark(mark);
+}
+ROMol::BOND_BOOKMARK_MAP * ROMol::getBondBookmarks() {
+  return dp_mol->getBondBookmarksCompat();
+}
+
+
+const Conformer& ROMol::getConformer(int id) const {
+  const auto& confs = dp_mol->getConformersCompat();
+  if (confs.size() == 0) {
     throw ConformerException("No conformations available on the molecule");
   }
 
   if (id < 0) {
-    return *(d_confs.front());
+    return *(confs.front());
   }
   auto cid = (unsigned int)id;
-  for (auto conf : d_confs) {
+  for (auto& conf : confs) {
     if (conf->getId() == cid) {
       return *conf;
     }
@@ -625,36 +579,114 @@ const Conformer &ROMol::getConformer(int id) const {
   throw ConformerException(mesg);
 }
 
-Conformer &ROMol::getConformer(int id) {
-  return const_cast<Conformer &>(
-      static_cast<const ROMol *>(this)->getConformer(id));
+Conformer& ROMol::getConformer(int id) {
+  auto& confs = dp_mol->getConformersCompat();
+  if (confs.size() == 0) {
+    throw ConformerException("No conformations available on the molecule");
+  }
+
+  if (id < 0) {
+    return *(confs.front());
+  }
+  auto cid = (unsigned int)id;
+  for (auto& conf : confs) {
+    if (conf->getId() == cid) {
+      return *conf;
+    }
+  }
+  // we did not find a conformation with the specified ID
+  std::string mesg = "Can't find conformation with ID: ";
+  mesg += id;
+  throw ConformerException(mesg);
 }
 
 void ROMol::removeConformer(unsigned int id) {
-  for (auto ci = d_confs.begin(); ci != d_confs.end(); ++ci) {
-    if ((*ci)->getId() == id) {
-      d_confs.erase(ci);
-      return;
-    }
-  }
+  dp_mol->removeConformer(id);
 }
 
-unsigned int ROMol::addConformer(Conformer *conf, bool assignId) {
+void ROMol::clearConformers() {
+  dp_mol->clearConformers();
+}
+
+unsigned int ROMol::addConformer(Conformer* conf, bool assignId) {
   PRECONDITION(conf, "bad conformer");
   PRECONDITION(conf->getNumAtoms() == this->getNumAtoms(),
                "Number of atom mismatch");
+  auto& confs = dp_mol->getConformersCompat();
+  int maxId = -1;
   if (assignId) {
-    int maxId = -1;
-    for (auto cptr : d_confs) {
+    for (const auto& cptr : confs) {
       maxId = std::max((int)(cptr->getId()), maxId);
     }
     maxId++;
     conf->setId((unsigned int)maxId);
+  } else {
+    maxId = conf->getId();
   }
   conf->setOwningMol(this);
-  CONFORMER_SPTR nConf(conf);
-  d_confs.push_back(nConf);
+  confs.push_back(CONFORMER_SPTR(conf));
+
+  auto [returnId, confData] = dp_mol->addConformer(maxId, conf->is3D());
+  PRECONDITION(returnId == maxId, "Id mismatch");
+  PRECONDITION(getNumAtoms() == 0 || confData != nullptr, "Null conformer positions");
+
+  // Special case of addConformer - non-const confData means that it marked the
+  // conformer as being out of sync after synchronizing the positions, but
+  // they're actually in sync. However, the caller may modify the positions from
+  // the Conformer pointer it passed in without requesting it again, so mark
+  // it as being modified.
+  dp_mol->markConformersAsCompatModified();
+
   return conf->getId();
+}
+
+void ROMol::clearSubstanceGroups() {
+  dp_mol->getSubstanceGroups().clear();
+}
+
+unsigned int ROMol::addAtom(Atom* atom, bool updateLabel, bool takeOwnership) {
+  PRECONDITION(atom, "NULL atom provided");
+
+  const uint32_t newAtomIdx = dp_mol->getNumAtoms();
+  dp_mol->addAtom();
+  getAtomWithIdx(newAtomIdx)->initFromOther(*atom);
+
+  if (takeOwnership) {
+    // Allow for stable pointer by resetting the compat entry.
+    dp_mol->replaceAtomPointerCompat(atom, newAtomIdx);
+  } else if (atom->hasQuery()) {
+    dp_mol->setAtomQueryCompatFull(newAtomIdx, atom->getQuery()->copy());
+  }
+
+  if (updateLabel) {
+    dp_mol->clearAtomBookmark(ci_RIGHTMOST_ATOM);
+    dp_mol->setAtomBookmark(newAtomIdx, ci_RIGHTMOST_ATOM);
+  }
+  return newAtomIdx;
+}
+
+unsigned int ROMol::addBond(Bond* bond, bool takeOwnership) {
+  PRECONDITION(bond, "NULL bond passed in");
+  const uint32_t newBondIdx = getNumBonds();
+  // Note that the ROMol version does not do aromaticity updates.
+  auto& bondInfo = dp_mol->addBond(bond->getBeginAtomIdx(),
+                                   bond->getEndAtomIdx(),
+                                   BondEnums::BondType(bond->getBondType()),
+                                   /*updateAromaticity=*/false);
+  getBondWithIdx(newBondIdx)->initFromOther(*bond);
+
+  if (takeOwnership) {
+    // Allow for stable pointer by resetting the compat entry.
+    dp_mol->replaceBondPointerCompat(bond, newBondIdx);
+  } else if (bond->hasQuery()) {
+    dp_mol->setBondQueryCompatFull(newBondIdx, bond->getQuery()->copy());
+  }
+
+  return getNumBonds();
+}
+
+void ROMol::initFromOther(const ROMol& other, bool quickCopy, int confId) {
+  raiseNonImplementedFunction("initFromOther");
 }
 
 #ifdef RDK_USE_BOOST_SERIALIZATION
@@ -670,18 +702,22 @@ void ROMol::load(Archive &ar, const unsigned int) {
   std::string pkl;
   ar >> pkl;
 
-  delete dp_ringInfo;
-  initMol();
-
-  numBonds = 0;
   MolPickler::molFromPickle(pkl, *this, PicklerOps::AllProps);
-  numBonds = rdcast<unsigned int>(boost::num_edges(d_graph));
 }
 
 template RDKIT_GRAPHMOL_EXPORT void ROMol::save<boost::archive::text_oarchive>(
     boost::archive::text_oarchive &, const unsigned int) const;
 template RDKIT_GRAPHMOL_EXPORT void ROMol::load<boost::archive::text_iarchive>(
     boost::archive::text_iarchive &, const unsigned int);
-#endif
+#endif // RDK_USE_BOOST_SERIALIZATION
+
+
+uint32_t num_vertices(const ROMol& mol) {
+  return mol.getNumAtoms();
+}
+
+uint32_t num_edges(const ROMol& mol) {
+  return mol.getNumBonds();
+}
 
 }  // namespace RDKit

--- a/Code/GraphMol/ROMol.h
+++ b/Code/GraphMol/ROMol.h
@@ -41,18 +41,16 @@
 #include "Atom.h"
 #include "Bond.h"
 #include "Conformer.h"
+#include "RDMol.h"
 #include "SubstanceGroup.h"
 #include "StereoGroup.h"
 #include "RingInfo.h"
+#include <GraphMol/rdmol_throw.h>
 
 namespace RDKit {
 class SubstanceGroup;
 class Atom;
 class Bond;
-//! This is the BGL type used to store the topology:
-typedef boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS,
-                              Atom *, Bond *>
-    MolGraph;
 class MolPickler;
 class RWMol;
 class QueryAtom;
@@ -125,13 +123,15 @@ struct CXXAtomIterator {
 
     Graph *graph;
     Iterator pos;
-    Atom *current;
+    value_type current;
 
     CXXAtomIter(Graph *graph, Iterator pos)
         : graph(graph), pos(pos), current(nullptr) {}
 
-    reference operator*() {
-      current = (*graph)[*pos];
+    const value_type &operator*() {
+      // The const_cast is to maintain the same behaviour as the previous
+      // interface.
+      current = const_cast<value_type>((*graph)[*pos]);
       return current;
     }
     CXXAtomIter &operator++() {
@@ -143,7 +143,7 @@ struct CXXAtomIterator {
   };
 
   CXXAtomIterator(Graph *graph) : graph(graph) {
-    auto vs = boost::vertices(*graph);
+    auto vs = graph->getVertices();
     vstart = vs.first;
     vend = vs.second;
   }
@@ -168,13 +168,15 @@ struct CXXBondIterator {
 
     Graph *graph;
     Iterator pos;
-    Bond *current;
+    value_type current;
 
     CXXBondIter(Graph *graph, Iterator pos)
         : graph(graph), pos(pos), current(nullptr) {}
 
-    reference operator*() {
-      current = (*graph)[*pos];
+    const value_type &operator*() {
+      // The const_cast is to maintain the same behaviour as the previous
+      // interface.
+      current = const_cast<value_type>((*graph)[*pos]);
       return current;
     }
     CXXBondIter &operator++() {
@@ -186,7 +188,7 @@ struct CXXBondIterator {
   };
 
   CXXBondIterator(Graph *graph) : graph(graph) {
-    auto vs = boost::edges(*graph);
+    auto vs = graph->getEdges();
     vstart = vs.first;
     vend = vs.second;
   }
@@ -196,22 +198,321 @@ struct CXXBondIterator {
   CXXBondIter end() { return {graph, vend}; }
 };
 
-class RDKIT_GRAPHMOL_EXPORT ROMol : public RDProps {
- public:
+class RDKIT_GRAPHMOL_EXPORT ROMol {
+  RDMol *dp_mol;
+  bool d_ownedBySelf;
+
   friend class MolPickler;
+  friend class RDMol;
   friend class RWMol;
+
+ public:
+  // MolGraph compatibility descriptor and iterator definitions
+
+  // For compatibility, since vertex_descriptor is often passed by reference,
+  // this is kept as an exact match of size_t.
+  using vertex_descriptor = size_t;
+  // edge_descriptor needs to be incompatible with vertex_descriptor, without
+  // an implicit conversion chain, to avoid ambiguity compile errors.
+  class edge_descriptor {
+    uint32_t index;
+
+    friend class ROMol;
+
+   public:
+    edge_descriptor() : index(uint32_t(-1)) {}
+    explicit edge_descriptor(uint32_t i) : index(i) {}
+    edge_descriptor(const edge_descriptor &that) = default;
+    edge_descriptor &operator=(const edge_descriptor &that) = default;
+    bool operator==(const edge_descriptor &that) const {
+      return index == that.index;
+    }
+    bool operator!=(const edge_descriptor &that) const {
+      return index != that.index;
+    }
+    uint32_t operator*() const { return index; }
+    edge_descriptor &operator++() {
+      ++index;
+      return *this;
+    }
+    edge_descriptor operator++(int) {
+      edge_descriptor prev = *this;
+      ++index;
+      return prev;
+    }
+    edge_descriptor &operator--() {
+      --index;
+      return *this;
+    }
+    edge_descriptor operator--(int) {
+      edge_descriptor prev = *this;
+      --index;
+      return prev;
+    }
+    uint32_t operator-(const edge_descriptor &that) const {
+      return index - that.index;
+    }
+
+    edge_descriptor operator+(size_t offset) const {
+      return edge_descriptor(index + offset);
+    }
+    edge_descriptor operator-(size_t offset) const {
+      return edge_descriptor(index - offset);
+    }
+    edge_descriptor &operator+=(size_t offset) {
+      index += offset;
+      return *this;
+    }
+    edge_descriptor &operator-=(size_t offset) {
+      index -= offset;
+      return *this;
+    }
+  };
+
+  // This iterator is for iterating over edges of the graph in order.
+  class edge_iterator {
+    edge_descriptor i;
+
+   public:
+    edge_iterator() = default;
+    explicit edge_iterator(edge_descriptor index) : i(index) {}
+    edge_iterator(const edge_iterator &) = default;
+    edge_iterator &operator=(const edge_iterator &) = default;
+    bool operator==(const edge_iterator &that) const { return i == that.i; }
+    bool operator!=(const edge_iterator &that) const { return i != that.i; }
+    edge_descriptor operator*() const { return i; }
+    edge_iterator &operator++() {
+      ++i;
+      return *this;
+    }
+    edge_iterator operator++(int) {
+      edge_iterator prev = *this;
+      ++i;
+      return prev;
+    }
+    edge_iterator &operator--() {
+      --i;
+      return *this;
+    }
+    edge_iterator operator--(int) {
+      edge_iterator prev = *this;
+      --i;
+      return prev;
+    }
+    size_t operator-(const edge_iterator &that) const {
+      return i - that.i;
+    }
+
+    edge_iterator operator+(size_t offset) const {
+      return edge_iterator(i + offset);
+    }
+    edge_iterator operator-(size_t offset) const {
+      return edge_iterator(i - offset);
+    }
+    edge_iterator &operator+=(size_t offset) {
+      i += offset;
+      return *this;
+    }
+    edge_iterator &operator-=(size_t offset) {
+      i -= offset;
+      return *this;
+    }
+
+    using iterator_category = std::forward_iterator_tag;
+    using difference_type = size_t;
+    using value_type = edge_descriptor;
+    using pointer = edge_descriptor *;
+    using reference = edge_descriptor &;
+  };
+
+  // This iterator is for iterating over the edges of a vertex.
+  // This is similar to adjacency_iterator, but yielding the bond,
+  // instead of the opposite vertex.
+  class out_edge_iterator {
+    const uint32_t *p;
+
+   public:
+    out_edge_iterator() : p(nullptr) {}
+    explicit out_edge_iterator(const uint32_t *edges) : p(edges) {}
+    out_edge_iterator(const out_edge_iterator &) = default;
+    out_edge_iterator &operator=(const out_edge_iterator &) = default;
+    bool operator==(const out_edge_iterator &that) const { return p == that.p; }
+    bool operator!=(const out_edge_iterator &that) const { return p != that.p; }
+    edge_descriptor operator*() const { return edge_descriptor{*p}; }
+    out_edge_iterator &operator++() {
+      ++p;
+      return *this;
+    }
+    out_edge_iterator operator++(int) {
+      out_edge_iterator prev = *this;
+      ++p;
+      return prev;
+    }
+    out_edge_iterator &operator--() {
+      --p;
+      return *this;
+    }
+    out_edge_iterator operator--(int) {
+      out_edge_iterator prev = *this;
+      --p;
+      return prev;
+    }
+    std::ptrdiff_t operator-(const out_edge_iterator &that) const {
+      return p - that.p;
+    }
+
+    out_edge_iterator operator+(size_t offset) const {
+      return out_edge_iterator(p + offset);
+    }
+    out_edge_iterator operator-(size_t offset) const {
+      return out_edge_iterator(p - offset);
+    }
+    out_edge_iterator &operator+=(size_t offset) {
+      p += offset;
+      return *this;
+    }
+    out_edge_iterator &operator-=(size_t offset) {
+      p -= offset;
+      return *this;
+    }
+
+    using iterator_category = std::forward_iterator_tag;
+    using difference_type = std::ptrdiff_t;
+    using value_type = edge_descriptor;
+    using pointer = edge_descriptor *;
+    using reference = edge_descriptor &;
+  };
+
+  // This iterator is for iterating over vertices of the graph in order.
+  class vertex_iterator {
+    vertex_descriptor i;
+
+   public:
+    vertex_iterator() : i(size_t(-1)) {}
+    explicit vertex_iterator(vertex_descriptor index) : i(index) {}
+    vertex_iterator(const vertex_iterator &) = default;
+    vertex_iterator &operator=(const vertex_iterator &) = default;
+    bool operator==(const vertex_iterator &that) const { return i == that.i; }
+    bool operator!=(const vertex_iterator &that) const { return i != that.i; }
+    vertex_descriptor operator*() const { return i; }
+    vertex_iterator &operator++() {
+      ++i;
+      return *this;
+    }
+    vertex_iterator operator++(int) {
+      vertex_iterator prev = *this;
+      ++i;
+      return prev;
+    }
+    vertex_iterator &operator--() {
+      --i;
+      return *this;
+    }
+    vertex_iterator operator--(int) {
+      vertex_iterator prev = *this;
+      --i;
+      return prev;
+    }
+    size_t operator-(const vertex_iterator &that) const {
+      return i - that.i;
+    }
+
+    vertex_iterator operator+(size_t offset) const {
+      return vertex_iterator(i + offset);
+    }
+    vertex_iterator operator-(size_t offset) const {
+      return vertex_iterator(i - offset);
+    }
+    vertex_iterator &operator+=(size_t offset) {
+      i += offset;
+      return *this;
+    }
+    vertex_iterator &operator-=(size_t offset) {
+      i -= offset;
+      return *this;
+    }
+
+    using iterator_category = std::forward_iterator_tag;
+    using difference_type = size_t;
+    using value_type = vertex_descriptor;
+    using pointer = vertex_descriptor *;
+    using reference = vertex_descriptor &;
+  };
+
+  // This iterator is for iterating over the vertices adjacent to a vertex.
+  // This is similar to out_edge_iterator, but yielding the opposite vertex,
+  // instead of the bond.
+  class adjacency_iterator {
+    const uint32_t *p;
+
+   public:
+    adjacency_iterator() : p(nullptr) {}
+    explicit adjacency_iterator(const uint32_t *neighbors) : p(neighbors) {}
+    adjacency_iterator(const adjacency_iterator &) = default;
+    adjacency_iterator &operator=(const adjacency_iterator &) = default;
+    bool operator==(const adjacency_iterator &that) const {
+      return p == that.p;
+    }
+    bool operator!=(const adjacency_iterator &that) const {
+      return p != that.p;
+    }
+    vertex_descriptor operator*() const { return vertex_descriptor{*p}; }
+    adjacency_iterator &operator++() {
+      ++p;
+      return *this;
+    }
+    adjacency_iterator operator++(int) {
+      adjacency_iterator prev = *this;
+      ++p;
+      return prev;
+    }
+    adjacency_iterator &operator--() {
+      --p;
+      return *this;
+    }
+    adjacency_iterator operator--(int) {
+      adjacency_iterator prev = *this;
+      --p;
+      return prev;
+    }
+    std::ptrdiff_t operator-(const adjacency_iterator& that) const {
+      return p - that.p;
+    }
+
+    adjacency_iterator operator+(size_t offset) const {
+      return adjacency_iterator(p + offset);
+    }
+    adjacency_iterator operator-(size_t offset) const {
+      return adjacency_iterator(p - offset);
+    }
+    adjacency_iterator &operator+=(size_t offset) {
+      p += offset;
+      return *this;
+    }
+    adjacency_iterator &operator-=(size_t offset) {
+      p -= offset;
+      return *this;
+    }
+
+    bool operator<(const adjacency_iterator &that) const {
+      return p < that.p;
+    }
+
+    using iterator_category = std::forward_iterator_tag;
+    using difference_type = std::ptrdiff_t;
+    using value_type = vertex_descriptor;
+    using pointer = vertex_descriptor *;
+    using reference = vertex_descriptor &;
+  };
 
   //! \cond TYPEDEFS
 
   //! \name typedefs
   //! @{
-  typedef MolGraph::vertex_descriptor vertex_descriptor;
-  typedef MolGraph::edge_descriptor edge_descriptor;
-
-  typedef MolGraph::edge_iterator EDGE_ITER;
-  typedef MolGraph::out_edge_iterator OEDGE_ITER;
-  typedef MolGraph::vertex_iterator VERTEX_ITER;
-  typedef MolGraph::adjacency_iterator ADJ_ITER;
+  typedef edge_iterator EDGE_ITER;
+  typedef out_edge_iterator OEDGE_ITER;
+  typedef vertex_iterator VERTEX_ITER;
+  typedef adjacency_iterator ADJ_ITER;
   typedef std::pair<EDGE_ITER, EDGE_ITER> BOND_ITER_PAIR;
   typedef std::pair<OEDGE_ITER, OEDGE_ITER> OBOND_ITER_PAIR;
   typedef std::pair<VERTEX_ITER, VERTEX_ITER> ATOM_ITER_PAIR;
@@ -274,34 +575,38 @@ class RDKIT_GRAPHMOL_EXPORT ROMol : public RDProps {
     \endcode
    */
 
-  CXXAtomIterator<MolGraph, Atom *> atoms() { return {&d_graph}; }
+  CXXAtomIterator<ROMol, Atom *> atoms() { return {this}; }
 
-  CXXAtomIterator<const MolGraph, Atom *const> atoms() const {
-    return {&d_graph};
-  }
+  // NOTE: This yields pointers to non-const Atoms, because the previous
+  // interface did.
+  CXXAtomIterator<const ROMol, Atom *> atoms() const { return {this}; }
 
-  CXXAtomIterator<const MolGraph, Atom *const, MolGraph::adjacency_iterator>
+  // NOTE: This yields pointers to non-const Atoms, because the previous
+  // interface did.
+  CXXAtomIterator<const ROMol, Atom *, adjacency_iterator>
   atomNeighbors(Atom const *at) const {
     auto pr = getAtomNeighbors(at);
-    return {&d_graph, pr.first, pr.second};
+    return {this, pr.first, pr.second};
   }
 
-  CXXAtomIterator<MolGraph, Atom *, MolGraph::adjacency_iterator> atomNeighbors(
+  CXXAtomIterator<ROMol, Atom *, adjacency_iterator> atomNeighbors(
       Atom const *at) {
     auto pr = getAtomNeighbors(at);
-    return {&d_graph, pr.first, pr.second};
+    return {this, pr.first, pr.second};
   }
 
-  CXXBondIterator<const MolGraph, Bond *const, MolGraph::out_edge_iterator>
+  // NOTE: This yields pointers to non-const Bonds, because the previous
+  // interface did.
+  CXXBondIterator<const ROMol, Bond *, out_edge_iterator>
   atomBonds(Atom const *at) const {
     auto pr = getAtomBonds(at);
-    return {&d_graph, pr.first, pr.second};
+    return {this, pr.first, pr.second};
   }
 
-  CXXBondIterator<MolGraph, Bond *, MolGraph::out_edge_iterator> atomBonds(
+  CXXBondIterator<ROMol, Bond *, out_edge_iterator> atomBonds(
       Atom const *at) {
     auto pr = getAtomBonds(at);
-    return {&d_graph, pr.first, pr.second};
+    return {this, pr.first, pr.second};
   }
 
   /*!
@@ -313,13 +618,17 @@ class RDKIT_GRAPHMOL_EXPORT ROMol : public RDProps {
   \endcode
  */
 
-  CXXBondIterator<MolGraph, Bond *> bonds() { return {&d_graph}; }
+  CXXBondIterator<ROMol, Bond *> bonds() { return {this}; }
 
-  CXXBondIterator<const MolGraph, Bond *const> bonds() const {
-    return {&d_graph};
-  }
+  // NOTE: This yields pointers to non-const Bonds, because the previous
+  // interface did.
+  CXXBondIterator<const ROMol, Bond *> bonds() const { return {this}; }
 
-  ROMol() : RDProps() { initMol(); }
+ protected:
+  ROMol(RDMol *mol) : dp_mol(mol), d_ownedBySelf(false) {}
+
+ public:
+  ROMol();
 
   //! copy constructor with a twist
   /*!
@@ -332,95 +641,28 @@ class RDKIT_GRAPHMOL_EXPORT ROMol : public RDProps {
     only
          the specified conformer from \c other.
   */
-  ROMol(const ROMol &other, bool quickCopy = false, int confId = -1)
-      : RDProps() {
-    dp_ringInfo = nullptr;
-    initFromOther(other, quickCopy, confId);
-    numBonds = rdcast<unsigned int>(boost::num_edges(d_graph));
-  }
+  ROMol(const ROMol &other, bool quickCopy = false, int confId = -1);
   //! construct a molecule from a pickle string
   ROMol(const std::string &binStr);
   //! construct a molecule from a pickle string
   ROMol(const std::string &binStr, unsigned int propertyFlags);
 
-  ROMol(ROMol &&o) noexcept
-      : RDProps(std::move(o)),
-        d_graph(std::move(o.d_graph)),
-        d_atomBookmarks(std::move(o.d_atomBookmarks)),
-        d_bondBookmarks(std::move(o.d_bondBookmarks)),
-        d_confs(std::move(o.d_confs)),
-        d_sgroups(std::move(o.d_sgroups)),
-        d_stereo_groups(std::move(o.d_stereo_groups)),
-        numBonds(o.numBonds) {
-    for (auto atom : atoms()) {
-      atom->setOwningMol(this);
-    }
-    for (auto bond : bonds()) {
-      bond->setOwningMol(this);
-    }
-    for (auto conf : d_confs) {
-      conf->setOwningMol(this);
-    }
-    for (auto &sg : d_sgroups) {
-      sg.setOwningMol(this);
-    }
-    o.d_graph.clear();
-    o.numBonds = 0;
-    dp_ringInfo = std::exchange(o.dp_ringInfo, nullptr);
-    dp_delAtoms = std::exchange(o.dp_delAtoms, nullptr);
-    dp_delBonds = std::exchange(o.dp_delBonds, nullptr);
-  }
-  ROMol &operator=(ROMol &&o) noexcept {
-    if (this == &o) {
-      return *this;
-    }
-    RDProps::operator=(std::move(o));
-    d_graph = std::move(o.d_graph);
-    d_atomBookmarks = std::move(o.d_atomBookmarks);
-    d_bondBookmarks = std::move(o.d_bondBookmarks);
-    if (dp_ringInfo) {
-      delete dp_ringInfo;
-    }
-    dp_ringInfo = std::exchange(o.dp_ringInfo, nullptr);
-
-    d_confs = std::move(o.d_confs);
-    d_sgroups = std::move(o.d_sgroups);
-    d_stereo_groups = std::move(o.d_stereo_groups);
-    dp_delAtoms = std::exchange(o.dp_delAtoms, nullptr);
-    dp_delBonds = std::exchange(o.dp_delBonds, nullptr);
-    numBonds = o.numBonds;
-    o.numBonds = 0;
-
-    for (auto atom : atoms()) {
-      atom->setOwningMol(this);
-    }
-    for (auto bond : bonds()) {
-      bond->setOwningMol(this);
-    }
-    for (auto conf : d_confs) {
-      conf->setOwningMol(this);
-    }
-    for (auto &sg : d_sgroups) {
-      sg.setOwningMol(this);
-    }
-
-    o.d_graph.clear();
-    return *this;
-  }
-
+  ROMol(ROMol &&o) noexcept;
+  ROMol &operator=(ROMol &&o) noexcept;
   ROMol &operator=(const ROMol &) =
       delete;  // disable assignment, RWMol's support assignment
 
-  virtual ~ROMol() { destroy(); }
+  RDMol &asRDMol() { return *dp_mol; }
+  const RDMol &asRDMol() const { return *dp_mol; }
+
+  virtual ~ROMol();
 
   //! @}
   //! \name Atoms
   //! @{
 
   //! returns our number of atoms
-  inline unsigned int getNumAtoms() const {
-    return rdcast<unsigned int>(boost::num_vertices(d_graph));
-  }
+  unsigned int getNumAtoms() const;
   unsigned int getNumAtoms(bool onlyExplicit) const;
   //! returns our number of heavy atoms (atomic number > 1)
   unsigned int getNumHeavyAtoms() const;
@@ -446,7 +688,7 @@ class RDKIT_GRAPHMOL_EXPORT ROMol : public RDProps {
   //! @{
 
   //! returns our number of Bonds
-  unsigned int getNumBonds(bool onlyHeavy = 1) const;
+  unsigned int getNumBonds(bool onlyHeavy = true) const;
   //! returns a pointer to a particular Bond
   Bond *getBondWithIdx(unsigned int idx);
   //! \overload
@@ -480,101 +722,12 @@ class RDKIT_GRAPHMOL_EXPORT ROMol : public RDProps {
 
   //! @}
 
-  //! \name Bookmarks
-  //! @{
-
-  //! associates an Atom pointer with a bookmark
-  void setAtomBookmark(Atom *at, int mark) {
-    d_atomBookmarks[mark].push_back(at);
-  }
-  //! associates an Atom pointer with a bookmark
-  void replaceAtomBookmark(Atom *at, int mark) {
-    d_atomBookmarks[mark].clear();
-    d_atomBookmarks[mark].push_back(at);
-  }
-  //! returns the first Atom associated with the \c bookmark provided
-  Atom *getAtomWithBookmark(int mark);
-  //! returns the Atom associated with the \c bookmark provided
-  //! a check is made to ensure it is the only atom with that bookmark
-  Atom *getUniqueAtomWithBookmark(int mark);
-  //! returns all Atoms associated with the \c bookmark provided
-  ATOM_PTR_LIST &getAllAtomsWithBookmark(int mark);
-  //! removes a \c bookmark from our collection
-  void clearAtomBookmark(int mark);
-  //! removes a particular Atom from the list associated with the \c bookmark
-  void clearAtomBookmark(int mark, const Atom *atom);
-
-  //! blows out all atomic \c bookmarks
-  void clearAllAtomBookmarks() { d_atomBookmarks.clear(); }
-  //! queries whether or not any atoms are associated with a \c bookmark
-  bool hasAtomBookmark(int mark) const { return d_atomBookmarks.count(mark); }
-  //! returns a pointer to all of our atom \c bookmarks
-  ATOM_BOOKMARK_MAP *getAtomBookmarks() { return &d_atomBookmarks; }
-
-  //! associates a Bond pointer with a bookmark
-  void setBondBookmark(Bond *bond, int mark) {
-    d_bondBookmarks[mark].push_back(bond);
-  }
-  //! returns the first Bond associated with the \c bookmark provided
-  Bond *getBondWithBookmark(int mark);
-  //! returns the Bond associated with the \c bookmark provided
-  //! a check is made to ensure it is the only bond with that bookmark
-  Bond *getUniqueBondWithBookmark(int mark);
-  //! returns all bonds associated with the \c bookmark provided
-  BOND_PTR_LIST &getAllBondsWithBookmark(int mark);
-  //! removes a \c bookmark from our collection
-  void clearBondBookmark(int mark);
-  //! removes a particular Bond from the list associated with the \c bookmark
-  void clearBondBookmark(int mark, const Bond *bond);
-
-  //! blows out all bond \c bookmarks
-  void clearAllBondBookmarks() { d_bondBookmarks.clear(); }
-  //! queries whether or not any bonds are associated with a \c bookmark
-  bool hasBondBookmark(int mark) const { return d_bondBookmarks.count(mark); }
-  //! returns a pointer to all of our bond \c bookmarks
-  BOND_BOOKMARK_MAP *getBondBookmarks() { return &d_bondBookmarks; }
-
-  //! @}
-
-  //! \name Conformers
-  //! @{
-
-  //! return the conformer with a specified ID
-  //! if the ID is negative the first conformation will be returned
-  const Conformer &getConformer(int id = -1) const;
-
-  //! return the conformer with a specified ID
-  //! if the ID is negative the first conformation will be returned
-  Conformer &getConformer(int id = -1);
-
-  //! Delete the conformation with the specified ID
-  void removeConformer(unsigned int id);
-
-  //! Clear all the conformations on the molecule
-  void clearConformers() { d_confs.clear(); }
-
-  //! Add a new conformation to the molecule
-  /*!
-    \param conf - conformation to be added to the molecule, this molecule takes
-    ownership
-                  of the conformer
-    \param assignId - a unique ID will be assigned to the conformation if
-    true
-                      otherwise it is assumed that the conformation already has
-    an (unique) ID set
-  */
-  unsigned int addConformer(Conformer *conf, bool assignId = false);
-
-  inline unsigned int getNumConformers() const {
-    return rdcast<unsigned int>(d_confs.size());
-  }
-
   //! \name Topology
   //! @{
 
   //! returns a pointer to our RingInfo structure
   //! <b>Note:</b> the client should not delete this.
-  RingInfo *getRingInfo() const { return dp_ringInfo; }
+  RingInfo *getRingInfo() const;
 
   //! provides access to all neighbors around an Atom
   /*!
@@ -592,7 +745,6 @@ class RDKIT_GRAPHMOL_EXPORT ROMol : public RDProps {
       }
 
     \endcode
-
   */
   ADJ_ITER_PAIR getAtomNeighbors(Atom const *at) const;
 
@@ -622,8 +774,6 @@ class RDKIT_GRAPHMOL_EXPORT ROMol : public RDProps {
         // nbr is a bond pointer
       }
     \endcode
-
-
   */
   OBOND_ITER_PAIR getAtomBonds(Atom const *at) const;
 
@@ -642,7 +792,7 @@ class RDKIT_GRAPHMOL_EXPORT ROMol : public RDProps {
       }
     \endcode
   */
-  ATOM_ITER_PAIR getVertices();
+  ATOM_ITER_PAIR getVertices() const;
   //! returns an iterator pair for looping over all Bonds
   /*!
 
@@ -658,10 +808,6 @@ class RDKIT_GRAPHMOL_EXPORT ROMol : public RDProps {
       }
     \endcode
   */
-  BOND_ITER_PAIR getEdges();
-  //! \overload
-  ATOM_ITER_PAIR getVertices() const;
-  //! \overload
   BOND_ITER_PAIR getEdges() const;
 
   //! brief returns a pointer to our underlying BGL object
@@ -677,7 +823,7 @@ class RDKIT_GRAPHMOL_EXPORT ROMol : public RDProps {
          int res = boost::connected_components(G_p,&mapping[0]);
       \endcode
    */
-  MolGraph const &getTopology() const { return d_graph; }
+  ROMol const &getTopology() const { return *this; }
   //! @}
 
   //! \name Iterators
@@ -718,9 +864,6 @@ class RDKIT_GRAPHMOL_EXPORT ROMol : public RDProps {
   //! \overload
   ConstHeteroatomIterator endHeteros() const;
 
-  //! if the Mol has any Query atoms or bonds
-  bool hasQuery() const;
-
   //! get an AtomIterator pointing at our first Atom that matches \c query
   QueryAtomIterator beginQueryAtoms(QueryAtom const *query);
   //! \overload
@@ -729,6 +872,8 @@ class RDKIT_GRAPHMOL_EXPORT ROMol : public RDProps {
   QueryAtomIterator endQueryAtoms();
   //! \overload
   ConstQueryAtomIterator endQueryAtoms() const;
+
+  bool hasQuery() const;
 
   //! get an AtomIterator pointing at our first Atom that matches \c query
   MatchingAtomIterator beginMatchingAtoms(bool (*query)(Atom *));
@@ -740,15 +885,18 @@ class RDKIT_GRAPHMOL_EXPORT ROMol : public RDProps {
   //! \overload
   ConstMatchingAtomIterator endMatchingAtoms() const;
 
-  inline ConformerIterator beginConformers() { return d_confs.begin(); }
-
-  inline ConformerIterator endConformers() { return d_confs.end(); }
-
-  inline ConstConformerIterator beginConformers() const {
-    return d_confs.begin();
+  inline ConformerIterator beginConformers() {
+    return dp_mol->getConformersCompat().begin();
   }
-
-  inline ConstConformerIterator endConformers() const { return d_confs.end(); }
+  inline ConformerIterator endConformers() {
+    return dp_mol->getConformersCompat().end();
+  }
+  inline ConstConformerIterator beginConformers() const {
+    return dp_mol->getConformersCompat().begin();
+  }
+  inline ConstConformerIterator endConformers() const {
+    return dp_mol->getConformersCompat().end();
+  }
 
   //! @}
 
@@ -756,6 +904,13 @@ class RDKIT_GRAPHMOL_EXPORT ROMol : public RDProps {
   //! @{
 
   //! clears all of our \c computed \c properties
+  /*!
+    <b>Notes:</b>
+    - This must be allowed on a const ROMol for backward compatibility,
+    but DO NOT call this while this molecule might be being modified in another
+    thread, NOR while any properties on the same molecule or its atoms or bonds
+    might be being read or written.
+  */
   void clearComputedProps(bool includeRings = true) const;
   //! calculates any of our lazy \c properties
   /*!
@@ -774,22 +929,22 @@ class RDKIT_GRAPHMOL_EXPORT ROMol : public RDProps {
   void debugMol(std::ostream &str) const;
   //! @}
 
-  Atom *operator[](const vertex_descriptor &v) { return d_graph[v]; }
+  Atom *operator[](const vertex_descriptor &v) { return getAtomWithIdx(v); }
   const Atom *operator[](const vertex_descriptor &v) const {
-    return d_graph[v];
+    return getAtomWithIdx(v);
   }
 
-  Bond *operator[](const edge_descriptor &e) { return d_graph[e]; }
-  const Bond *operator[](const edge_descriptor &e) const { return d_graph[e]; }
+  Bond *operator[](const edge_descriptor &e) { return getBondWithIdx(*e); }
+  const Bond *operator[](const edge_descriptor &e) const {
+    return getBondWithIdx(*e);
+  }
 
   //! Gets a reference to the groups of atoms with relative stereochemistry
   /*!
     Stereo groups are also called enhanced stereochemistry in the SDF/Mol3000
     file format.
   */
-  const std::vector<StereoGroup> &getStereoGroups() const {
-    return d_stereo_groups;
-  }
+  const std::vector<StereoGroup> &getStereoGroups() const;
 
   //! Sets groups of atoms with relative stereochemistry
   /*!
@@ -800,41 +955,212 @@ class RDKIT_GRAPHMOL_EXPORT ROMol : public RDProps {
   */
   void setStereoGroups(std::vector<StereoGroup> stereo_groups);
 
-#ifdef RDK_USE_BOOST_SERIALIZATION
-  //! \name boost::serialization support
-  //! @{
-  template <class Archive>
-  void save(Archive &ar, const unsigned int version) const;
-  template <class Archive>
-  void load(Archive &ar, const unsigned int version);
-  BOOST_SERIALIZATION_SPLIT_MEMBER()
-  //! @}
-#endif
 
- private:
-  MolGraph d_graph;
-  ATOM_BOOKMARK_MAP d_atomBookmarks;
-  BOND_BOOKMARK_MAP d_bondBookmarks;
-  RingInfo *dp_ringInfo = nullptr;
-  CONF_SPTR_LIST d_confs;
-  std::vector<SubstanceGroup> d_sgroups;
-  std::vector<StereoGroup> d_stereo_groups;
-  std::unique_ptr<boost::dynamic_bitset<>> dp_delAtoms = nullptr;
-  std::unique_ptr<boost::dynamic_bitset<>> dp_delBonds = nullptr;
+  //! returns a list with the names of our \c properties
+  STR_VECT getPropList(bool includePrivate = true,
+                       bool includeComputed = true) const;
+
+  //! sets a \c property value
+  /*!
+    \param key the name under which the \c property should be stored.
+    If a \c property is already stored under this name, it will be
+    replaced.
+    \param val the value to be stored
+    \param computed (optional) allows the \c property to be flagged
+    \c computed.
+
+    <b>Notes:</b>
+    - This must be allowed on a const ROMol for backward compatibility,
+    but DO NOT call this while this molecule might be being modified in another
+    thread, NOR while any properties on the same molecule or its atoms or bonds
+    might be being read or written.
+  */
+  //! \overload
+  template <typename T>
+  void setProp(const std::string &key, T val, bool computed = false) const {
+    dp_mol->setMolProp(PropToken(key), val, computed);
+  }
+  //! allows retrieval of a particular property value
+  /*!
+    \param key the name under which the \c property should be stored.
+    If a \c property is already stored under this name, it will be
+    replaced.
+    \param res a reference to the storage location for the value.
+
+    <b>Notes:</b>
+    - if no \c property with name \c key exists, a KeyErrorException will be
+    thrown.
+    - the \c boost::lexical_cast machinery is used to attempt type
+    conversions.
+    If this fails, a \c boost::bad_lexical_cast exception will be thrown.
+  */
+  //! \overload
+  template <typename T>
+  void getProp(const std::string &key, T &res) const {
+    bool found = dp_mol->getMolPropIfPresent(PropToken(key), res);
+    if (!found) {
+      throw KeyErrorException(key);
+    }
+  }
+
+  //! \overload
+  template <typename T>
+  T getProp(const std::string &key) const {
+    return dp_mol->getMolProp<T>(PropToken(key));
+  }
+
+  //! returns whether or not we have a \c property with name \c key
+  //!  and assigns the value if we do
+  //! \overload
+  template <typename T>
+  bool getPropIfPresent(const std::string &key, T &res) const {
+      return dp_mol->getMolPropIfPresent(PropToken(key), res);
+  }
+
+  bool hasProp(const std::string &key) const;
+
+  //! clears the value of a \c property
+  /*!
+    <b>Notes:</b>
+    - if no \c property with name \c key exists, a KeyErrorException
+    will be thrown.
+    - if the \c property is marked as \c computed, it will also be removed
+    from our list of \c computedProperties
+
+    <b>Notes:</b>
+    - This must be allowed on a const ROMol for backward compatibility,
+    but DO NOT call this while this molecule might be being modified in another
+    thread, NOR while any properties on the same molecule or its atoms or bonds
+    might be being read or written.
+  */
+  //! \overload
+  void clearProp(const std::string &key) const;
+
+  //! update the properties from another
+  /*
+    \param source    Source to update the properties from
+    \param preserve  Existing If true keep existing data, else override from
+    the source
+  */
+
+  void updateProps(const ROMol& source, bool preserveExisting = false);
+  void updateProps(const RDProps& source, bool preserveExisting = false);
+
+  Dict& getDict() {
+    raiseNonImplementedFunction("GetDict");
+    Dict dict;
+    return dict;
+  }
+  const Dict& getDict() const {
+    raiseNonImplementedFunction("GetDict");
+    Dict dict;
+    return dict;
+  }
+
+  //! Clear all properties.
+  void clear();
+
+  //! \name Bookmarks
+  //! @{
+
+  //! associates an Atom pointer with a bookmark
+  void setAtomBookmark(Atom *at, int mark);
+  //! associates an Atom pointer with a bookmark
+  void replaceAtomBookmark(Atom *at, int mark);
+  //! returns the first Atom associated with the \c bookmark provided
+  Atom *getAtomWithBookmark(int mark);
+  //! returns the Atom associated with the \c bookmark provided
+  //! a check is made to ensure it is the only atom with that bookmark
+  Atom *getUniqueAtomWithBookmark(int mark);
+  //! returns all Atoms associated with the \c bookmark provided
+  ATOM_PTR_LIST &getAllAtomsWithBookmark(int mark);
+  //! removes a \c bookmark from our collection
+  void clearAtomBookmark(int mark);
+  //! removes a particular Atom from the list associated with the \c bookmark
+  void clearAtomBookmark(int mark, const Atom *atom);
+  //! blows out all atomic \c bookmarks
+  void clearAllAtomBookmarks();
+  //! queries whether or not any atoms are associated with a \c bookmark
+  bool hasAtomBookmark(int mark) const;
+  //! returns a pointer to all of our atom \c bookmarks
+  ATOM_BOOKMARK_MAP *getAtomBookmarks();
+
+  //! associates a Bond pointer with a bookmark
+  void setBondBookmark(Bond *bond, int mark);
+  //! returns the first Bond associated with the \c bookmark provided
+  Bond *getBondWithBookmark(int mark);
+  //! returns the Bond associated with the \c bookmark provided
+  //! a check is made to ensure it is the only bond with that bookmark
+  Bond *getUniqueBondWithBookmark(int mark);
+  //! returns all bonds associated with the \c bookmark provided
+  BOND_PTR_LIST &getAllBondsWithBookmark(int mark);
+  //! removes a \c bookmark from our collection
+  void clearBondBookmark(int mark);
+  //! removes a particular Bond from the list associated with the \c bookmark
+  void clearBondBookmark(int mark, const Bond *bond);
+  //! blows out all bond \c bookmarks
+  void clearAllBondBookmarks();
+  //! queries whether or not any bonds are associated with a \c bookmark
+  bool hasBondBookmark(int mark) const;
+  //! returns a pointer to all of our bond \c bookmarks
+  BOND_BOOKMARK_MAP *getBondBookmarks();
+
+  //! @}
+
+  //! \name Conformers
+  //! @{
+
+  //! return the conformer with a specified ID
+  //! if the ID is negative the first conformation will be returned
+  const Conformer &getConformer(int id = -1) const;
+
+  //! return the conformer with a specified ID
+  //! if the ID is negative the first conformation will be returned
+  Conformer &getConformer(int id = -1);
+
+  //! Delete the conformation with the specified ID
+  void removeConformer(unsigned int id);
+
+  //! Clear all the conformations on the molecule
+  void clearConformers();
+
+  //! Add a new conformation to the molecule
+  /*!
+    \param conf - conformation to be added to the molecule, this molecule takes
+    ownership
+                  of the conformer
+    \param assignId - a unique ID will be assigned to the conformation if
+    true
+                      otherwise it is assumed that the conformation already has
+    an (unique) ID set
+  */
+  unsigned int addConformer(Conformer *conf, bool assignId = false);
+
+  unsigned int getNumConformers() const;
 
   friend RDKIT_GRAPHMOL_EXPORT std::vector<SubstanceGroup> &getSubstanceGroups(
       ROMol &);
   friend RDKIT_GRAPHMOL_EXPORT const std::vector<SubstanceGroup> &
   getSubstanceGroups(const ROMol &);
-  void clearSubstanceGroups() { d_sgroups.clear(); }
+  void clearSubstanceGroups();
+
+
+  #ifdef RDK_USE_BOOST_SERIALIZATION
+    //! \name boost::serialization support
+    //! @{
+    template <class Archive>
+    void save(Archive &ar, const unsigned int version) const;
+    template <class Archive>
+    void load(Archive &ar, const unsigned int version);
+    BOOST_SERIALIZATION_SPLIT_MEMBER()
+    //! @}
+  #endif
 
  protected:
-  unsigned int numBonds{0};
 #ifndef WIN32
  private:
 #endif
-  void initMol();
-  virtual void destroy();
+
   //! adds an Atom to our collection
   /*!
     \param atom          pointer to the Atom to add
@@ -872,6 +1198,8 @@ class RDKIT_GRAPHMOL_EXPORT ROMol : public RDProps {
   void initFromOther(const ROMol &other, bool quickCopy, int confId);
 };
 
+using MolGraph = ROMol;
+
 typedef std::vector<ROMol> MOL_VECT;
 typedef boost::shared_ptr<ROMol> ROMOL_SPTR;
 typedef std::vector<ROMol *> MOL_PTR_VECT;
@@ -879,6 +1207,10 @@ typedef std::vector<ROMOL_SPTR> MOL_SPTR_VECT;
 
 typedef MOL_PTR_VECT::const_iterator MOL_PTR_VECT_CI;
 typedef MOL_PTR_VECT::iterator MOL_PTR_VECT_I;
+//! Number of vertices for boost VF2
+uint32_t num_vertices(const ROMol &mol);
+//! Number of edges for boost VF2
+uint32_t num_edges(const ROMol &mol);
 
 };  // namespace RDKit
 #endif

--- a/Code/GraphMol/RWMol.cpp
+++ b/Code/GraphMol/RWMol.cpp
@@ -22,6 +22,9 @@
 #include "RingInfo.h"
 #include "SubstanceGroup.h"
 
+#include <GraphMol/QueryAtom.h>
+#include <GraphMol/QueryBond.h>
+#include <GraphMol/rdmol_throw.h>
 namespace RDKit {
 
 namespace {
@@ -75,14 +78,14 @@ void insertStereoGroups(RWMol &mol, const ROMol &other,
       new_groups.push_back(std::move(new_group));
     }
   }
-  if (!abs_atoms.empty() || !abs_bonds.empty()) {
+  if (abs_atoms.size() > 0 || abs_bonds.size() > 0) {
     new_groups.emplace_back(RDKit::StereoGroupType::STEREO_ABSOLUTE, abs_atoms,
                             abs_bonds);
   }
   mol.setStereoGroups(new_groups);
 }
 
-void insertSubstanceGroups(RWMol &mol, const RWMol &other,
+void insertSubstanceGroups(RWMol &mol, const ROMol &other,
                            unsigned int origNumAtoms,
                            unsigned int origNumBonds) {
   for (auto sgroup : getSubstanceGroups(other)) {
@@ -133,17 +136,26 @@ void insertSubstanceGroups(RWMol &mol, const RWMol &other,
 }  // namespace
 
 RWMol &RWMol::operator=(const RWMol &other) {
-  if (this != &other) {
-    this->clear();
-    numBonds = 0;
-    initFromOther(other, false, -1);
+
+  if (this == &other) {
+    return *this;
   }
+  // If there is an RWMol owned by the CompatibilityData, it should be this,
+  // so to avoid deleting this in RDMol::clear, RDMol needs to release
+  // ownership of this.  In that case, this will temporarily be owned by the
+  // current function, initFromOther will return ownership back to the RDMol.
+  // If this was not owned by CompatibilityData, it will remain owned by the
+  // calling code that previously owned it.
+  dp_mol->releaseCompatMolOwnership();
+  dp_mol->clear();
+  dp_mol->initFromOther(*other.dp_mol, false, -1, this);
+
   return *this;
 }
 
 void RWMol::insertMol(const ROMol &other) {
-  auto origNumAtoms = getNumAtoms();
-  auto origNumBonds = getNumBonds();
+  const uint32_t origNumAtoms = getNumAtoms();
+  const uint32_t origNumBonds = getNumBonds();
   for (const auto oatom : other.atoms()) {
     Atom *newAt = oatom->copy();
     const bool updateLabel = false;
@@ -168,24 +180,32 @@ void RWMol::insertMol(const ROMol &other) {
     }
   }
 
+  // We need to update stereo atoms after adding the bonds, to not trip
+  // precondition checks
+  std::unordered_map<int, std::vector<int>> newStereoAtomMap;
   for (const auto obond : other.bonds()) {
     Bond *bond_p = obond->copy();
     unsigned int idx1, idx2;
     idx1 = bond_p->getBeginAtomIdx() + origNumAtoms;
     idx2 = bond_p->getEndAtomIdx() + origNumAtoms;
-    bond_p->setOwningMol(this);
     bond_p->setBeginAtomIdx(idx1);
     bond_p->setEndAtomIdx(idx2);
-    for (auto &v : bond_p->getStereoAtoms()) {
-      v += origNumAtoms;
+    if (auto& stereoAtoms = bond_p->getStereoAtoms(); stereoAtoms.size() == 2 && stereoAtoms[0] != -1 && stereoAtoms[1] != -1) {
+      newStereoAtomMap[obond->getIdx()] = stereoAtoms;
     }
-    const bool takeOwnership = true;
-    addBond(bond_p, takeOwnership);
+    addBond(bond_p, /*takeOwnership=*/true);
+  }
+
+  // Now that all bonds are added, we can update the stereo atoms
+  for (auto& [bondIdx, stereoAtoms] : newStereoAtomMap) {
+    auto* bond = getBondWithIdx(bondIdx + origNumBonds);
+    bond->setStereoAtoms(stereoAtoms[0] + origNumAtoms, stereoAtoms[1] + origNumAtoms);
   }
 
   // add atom to any conformers as well, if we have any
   if (other.getNumConformers() && !getNumConformers()) {
-    for (const auto &oconf : other.d_confs) {
+    for (auto cfi = other.beginConformers(); cfi != other.endConformers(); ++cfi) {
+      const auto *oconf = (*cfi).get();
       auto *nconf = new Conformer(getNumAtoms());
       nconf->set3D(oconf->is3D());
       nconf->setId(oconf->getId());
@@ -211,25 +231,22 @@ void RWMol::insertMol(const ROMol &other) {
   // add stereo groups
   insertStereoGroups(*this, other, origNumAtoms, origNumBonds);
   // add substance groups
-  insertSubstanceGroups(*this, other, origNumAtoms, origNumBonds);
-}
+  insertSubstanceGroups(*this, other, origNumAtoms, origNumBonds);}
 
 unsigned int RWMol::addAtom(bool updateLabel) {
-  auto *atom_p = new Atom();
-  atom_p->setOwningMol(this);
-  auto which = boost::add_vertex(d_graph);
-  d_graph[which] = atom_p;
-  atom_p->setIdx(which);
-  if (updateLabel) {
-    clearAtomBookmark(ci_RIGHTMOST_ATOM);
-    setAtomBookmark(atom_p, ci_RIGHTMOST_ATOM);
-  }
+  const uint32_t  idx = dp_mol->getNumAtoms();
+  dp_mol->addAtom();
 
-  // add atom to any conformers as well, if we have any
-  for (auto &conf : d_confs) {
-    conf->setAtomPos(which, RDGeom::Point3D(0.0, 0.0, 0.0));
+  if (updateLabel) {
+    dp_mol->clearAtomBookmark(ci_RIGHTMOST_ATOM);
+    dp_mol->setAtomBookmark(idx, ci_RIGHTMOST_ATOM);
   }
-  return rdcast<unsigned int>(which);
+  return idx;
+}
+
+unsigned int RWMol::addAtom(Atom *atom, bool updateLabel,
+                            bool takeOwnership) {
+  return ROMol::addAtom(atom, updateLabel, takeOwnership);
 }
 
 void RWMol::replaceAtom(unsigned int idx, Atom *atom_pin, bool,
@@ -237,63 +254,35 @@ void RWMol::replaceAtom(unsigned int idx, Atom *atom_pin, bool,
   PRECONDITION(atom_pin, "bad atom passed to replaceAtom");
   URANGE_CHECK(idx, getNumAtoms());
   auto atom_p = atom_pin->copy();
-  atom_p->setOwningMol(this);
-  atom_p->setIdx(idx);
-  auto vd = boost::vertex(idx, d_graph);
-  if (preserveProps) {
-    const bool replaceExistingData = false;
-    atom_p->updateProps(*d_graph[vd], replaceExistingData);
-  }
+  auto existing_atom = getAtomWithIdx(idx);
 
-  const auto orig_p = d_graph[vd];
-  delete orig_p;
-  d_graph[vd] = atom_p;
+  existing_atom->initFromOther(*atom_pin, preserveProps);
 
-  // handle bookmarks
-  for (auto &ab : d_atomBookmarks) {
-    for (auto &elem : ab.second) {
-      if (elem == orig_p) {
-        elem = atom_p;
-      }
-    }
-  }
-
-  // handle stereo group
-  for (auto &group : d_stereo_groups) {
-    auto groupId = group.getReadId();
-    auto atoms = group.getAtoms();
-    auto bonds = group.getBonds();
-    auto aiter = std::find(atoms.begin(), atoms.end(), orig_p);
-    while (aiter != atoms.end()) {
-      *aiter = atom_p;
-      ++aiter;
-      aiter = std::find(aiter, atoms.end(), orig_p);
-    }
-    group = StereoGroup(group.getGroupType(), std::move(atoms),
-                        std::move(bonds), groupId);
-  }
+  dp_mol->replaceAtomPointerCompat(atom_p, idx);
 };
 
 void RWMol::replaceBond(unsigned int idx, Bond *bond_pin, bool preserveProps,
                         bool keepSGroups) {
   PRECONDITION(bond_pin, "bad bond passed to replaceBond");
   URANGE_CHECK(idx, getNumBonds());
-  auto bIter = getEdges();
-  for (unsigned int i = 0; i < idx; i++) {
-    ++bIter.first;
-  }
-  const auto *obond = d_graph[*(bIter.first)];
-  auto *bond_p = bond_pin->copy();
-  bond_p->setOwningMol(this);
-  bond_p->setIdx(idx);
-  bond_p->setBeginAtomIdx(obond->getBeginAtomIdx());
-  bond_p->setEndAtomIdx(obond->getEndAtomIdx());
+
+  Bond* newBond = bond_pin->copy();
+  Bond* existingBond = getBondWithIdx(idx);
+  const double prevBondType = existingBond->getBondTypeAsDouble();
+
+  // We use initFromOther to handle data members and properties of the new bond,
+  // but need to write in the indices of the bond being replaced first.
+  newBond->setBeginAtomIdx(existingBond->getBeginAtomIdx());
+  newBond->setEndAtomIdx(existingBond->getEndAtomIdx());
+  existingBond->initFromOther(*newBond, preserveProps);
+
+  dp_mol->replaceBondPointerCompat(newBond, idx);
 
   // Update explicit Hs, if set, on both ends. This was github #7128
   auto orderDifference =
-      bond_p->getBondTypeAsDouble() - obond->getBondTypeAsDouble();
+       newBond->getBondTypeAsDouble() - prevBondType;
   if (orderDifference > 0) {
-    for (auto atom : {bond_p->getBeginAtom(), bond_p->getEndAtom()}) {
+    for (auto atom : {newBond->getBeginAtom(), newBond->getEndAtom()}) {
       if (auto explicit_hs = atom->getNumExplicitHs(); explicit_hs > 0) {
         auto new_hs = static_cast<int>(explicit_hs - orderDifference);
         atom->setNumExplicitHs(std::max(new_hs, 0));
@@ -301,26 +290,8 @@ void RWMol::replaceBond(unsigned int idx, Bond *bond_pin, bool preserveProps,
     }
   }
 
-  if (preserveProps) {
-    const bool replaceExistingData = false;
-    bond_p->updateProps(*d_graph[*(bIter.first)], replaceExistingData);
-  }
-
-  const auto orig_p = d_graph[*(bIter.first)];
-  delete orig_p;
-  d_graph[*(bIter.first)] = bond_p;
-
   if (!keepSGroups) {
     removeSubstanceGroupsReferencingBond(*this, idx);
-  }
-
-  // handle bookmarks
-  for (auto &ab : d_bondBookmarks) {
-    for (auto &elem : ab.second) {
-      if (elem == orig_p) {
-        elem = bond_p;
-      }
-    }
   }
 };
 
@@ -344,198 +315,17 @@ void RWMol::setActiveAtom(unsigned int idx) {
 void RWMol::removeAtom(unsigned int idx) { removeAtom(getAtomWithIdx(idx)); }
 
 void RWMol::removeAtom(Atom *atom, bool clearProps) {
-  PRECONDITION(atom, "NULL atom provided");
-  PRECONDITION(static_cast<RWMol *>(&atom->getOwningMol()) == this,
-               "atom not owned by this molecule");
-  unsigned int idx = atom->getIdx();
-
-  // remove bonds attached to the atom
-  //  In batch mode this will schedule bond removal
-  std::vector<std::pair<unsigned int, unsigned int>> nbrs;
-  ADJ_ITER b1, b2;
-  boost::tie(b1, b2) = getAtomNeighbors(atom);
-  while (b1 != b2) {
-    nbrs.emplace_back(atom->getIdx(), rdcast<unsigned int>(*b1));
-    ++b1;
-  }
-  for (auto &nbr : nbrs) {
-    removeBond(nbr.first, nbr.second);
-  }
-
-  if (dp_delAtoms) {
-    // we're in a batch edit
-    // if atoms have been added since we started, resize dp_delAtoms
-    if (dp_delAtoms->size() < getNumAtoms()) {
-      dp_delAtoms->resize(getNumAtoms());
-    }
-    dp_delAtoms->set(idx);
-    return;
-  }
-
-  // remove any bookmarks which point to this atom:
-  ATOM_BOOKMARK_MAP *marks = getAtomBookmarks();
-  auto markI = marks->begin();
-  while (markI != marks->end()) {
-    const ATOM_PTR_LIST &atoms = markI->second;
-    // we need to copy the iterator then increment it, because the
-    // deletion we're going to do in clearAtomBookmark will invalidate
-    // it.
-    auto tmpI = markI;
-    ++markI;
-    if (std::find(atoms.begin(), atoms.end(), atom) != atoms.end()) {
-      clearAtomBookmark(tmpI->first, atom);
-    }
-  }
-
-  // loop over all atoms with higher indices and update their indices
-  for (unsigned int i = idx + 1; i < getNumAtoms(); i++) {
-    Atom *higher_index_atom = getAtomWithIdx(i);
-    higher_index_atom->setIdx(i - 1);
-  }
-
-  // do the same with the coordinates in the conformations
-  for (auto conf : d_confs) {
-    RDGeom::POINT3D_VECT &positions = conf->getPositions();
-    auto pi = positions.begin();
-    for (unsigned int i = 0; i < getNumAtoms() - 1; i++) {
-      ++pi;
-      if (i >= idx) {
-        positions[i] = positions[i + 1];
-      }
-    }
-    positions.erase(pi);
-  }
-  // now deal with bonds:
-  //   their end indices may need to be decremented and their
-  //   indices will need to be handled and if they have an
-  //   ENDPTS prop that includes idx, it will need updating.
-  unsigned int nBonds = 0;
-  EDGE_ITER beg, end;
-  boost::tie(beg, end) = getEdges();
-  std::string sprop;
-  while (beg != end) {
-    Bond *bond = d_graph[*beg++];
-    if (bond->getPropIfPresent(RDKit::common_properties::_MolFileBondEndPts,
-                               sprop)) {
-      // This would ideally use ParseV3000Array but I'm buggered if I can get
-      // the linker to find it.
-      //      std::vector<unsigned int> oats =
-      //          RDKit::SGroupParsing::ParseV3000Array<unsigned int>(sprop);
-      if ('(' == sprop.front() && ')' == sprop.back()) {
-        sprop = sprop.substr(1, sprop.length() - 2);
-
-        // This is doing what ParseV3000Array would do.
-        boost::char_separator<char> sep(" ");
-        boost::tokenizer<boost::char_separator<char>> tokens(sprop, sep);
-        unsigned int num_ats = std::stod(*tokens.begin());
-        std::vector<unsigned int> oats;
-        auto beg = tokens.begin();
-        ++beg;
-        std::transform(beg, tokens.end(), std::back_inserter(oats),
-                       [](const std::string &a) { return std::stod(a); });
-
-        auto idx_pos = std::find(oats.begin(), oats.end(), idx + 1);
-        if (idx_pos != oats.end()) {
-          oats.erase(idx_pos);
-          --num_ats;
-        }
-        if (!num_ats) {
-          bond->clearProp(RDKit::common_properties::_MolFileBondEndPts);
-          bond->clearProp(common_properties::_MolFileBondAttach);
-        } else {
-          sprop = "(" + std::to_string(num_ats) + " ";
-          for (auto &i : oats) {
-            if (i > idx + 1) {
-              --i;
-            }
-            sprop += std::to_string(i) + " ";
-          }
-          sprop[sprop.length() - 1] = ')';
-          bond->setProp(RDKit::common_properties::_MolFileBondEndPts, sprop);
-        }
-      }
-    }
-    unsigned int tmpIdx = bond->getBeginAtomIdx();
-    if (tmpIdx > idx) {
-      bond->setBeginAtomIdx(tmpIdx - 1);
-    }
-    tmpIdx = bond->getEndAtomIdx();
-    if (tmpIdx > idx) {
-      bond->setEndAtomIdx(tmpIdx - 1);
-    }
-    bond->setIdx(nBonds++);
-    for (auto bsi = bond->getStereoAtoms().begin();
-         bsi != bond->getStereoAtoms().end(); ++bsi) {
-      if ((*bsi) == rdcast<int>(idx)) {
-        bond->getStereoAtoms().clear();
-        break;
-      } else if ((*bsi) > rdcast<int>(idx)) {
-        --(*bsi);
-      }
-    }
-  }
-
-  removeSubstanceGroupsReferencingAtom(*this, idx);
-
-  // Remove this atom from any stereo group
-  removeAtomFromGroups(atom, d_stereo_groups);
-
-  // clear computed properties and reset our ring info structure
-  // they are pretty likely to be wrong now:
-  if (clearProps) {
-    clearComputedProps(true);
-  }
-
-  atom->setOwningMol(nullptr);
-
-  // remove all connections to the atom:
-  MolGraph::vertex_descriptor vd = boost::vertex(idx, d_graph);
-  boost::clear_vertex(vd, d_graph);
-  // finally remove the vertex itself
-  boost::remove_vertex(vd, d_graph);
-  delete atom;
+  PRECONDITION(atom->dp_owningMol == dp_mol, "Atom does not belong to this molecule");
+  dp_mol->removeAtom(atom->getIdx(), clearProps);
 }
 
 void RWMol::removeAtom(Atom *atom) { removeAtom(atom, true); }
 
 unsigned int RWMol::addBond(unsigned int atomIdx1, unsigned int atomIdx2,
                             Bond::BondType bondType) {
-  URANGE_CHECK(atomIdx1, getNumAtoms());
-  URANGE_CHECK(atomIdx2, getNumAtoms());
-  PRECONDITION(atomIdx1 != atomIdx2, "attempt to add self-bond");
-  PRECONDITION(!(boost::edge(atomIdx1, atomIdx2, d_graph).second),
-               "bond already exists");
-
-  auto *b = new Bond(bondType);
-  b->setOwningMol(this);
-  if (bondType == Bond::AROMATIC) {
-    b->setIsAromatic(1);
-    //
-    // assume that aromatic bonds connect aromatic atoms
-    //   This is relevant for file formats like MOL, where there
-    //   is no such thing as an aromatic atom, but bonds can be
-    //   marked aromatic.
-    //
-    getAtomWithIdx(atomIdx1)->setIsAromatic(1);
-    getAtomWithIdx(atomIdx2)->setIsAromatic(1);
-  }
-  auto [which, ok] = boost::add_edge(atomIdx1, atomIdx2, d_graph);
-  d_graph[which] = b;
-  // unsigned int res = rdcast<unsigned int>(boost::num_edges(d_graph));
-  ++numBonds;
-  b->setIdx(numBonds - 1);
-  b->setBeginAtomIdx(atomIdx1);
-  b->setEndAtomIdx(atomIdx2);
-
-  // if both atoms have a degree>1, reset our ring info structure,
-  // because there's a non-trivial chance that it's now wrong.
-  if (dp_ringInfo && dp_ringInfo->isInitialized() &&
-      boost::out_degree(atomIdx1, d_graph) > 1 &&
-      boost::out_degree(atomIdx2, d_graph) > 1) {
-    dp_ringInfo->reset();
-  }
-
-  return numBonds;  // res;
+  // Note that the RWMol version updates aromaticity, while the ROMol version does not.
+  dp_mol->addBond(atomIdx1, atomIdx2, BondEnums::BondType(bondType), /*updateAromaticity=*/true);
+  return getNumBonds();
 }
 
 unsigned int RWMol::addBond(Atom *atom1, Atom *atom2, Bond::BondType bondType) {
@@ -543,83 +333,18 @@ unsigned int RWMol::addBond(Atom *atom1, Atom *atom2, Bond::BondType bondType) {
   return addBond(atom1->getIdx(), atom2->getIdx(), bondType);
 }
 
+unsigned int RWMol::addBond(Bond *bond, bool takeOwnership ) {
+  return ROMol::addBond(bond, takeOwnership);
+}
+
 void RWMol::removeBond(unsigned int aid1, unsigned int aid2) {
-  URANGE_CHECK(aid1, getNumAtoms());
-  URANGE_CHECK(aid2, getNumAtoms());
-  auto *bnd = getBondBetweenAtoms(aid1, aid2);
-  if (!bnd) {
-    return;
-  }
-  auto idx = bnd->getIdx();
-  if (dp_delBonds) {
-    // we're in a batch edit
-    // if bonds have been added since we started, resize dp_delBonds
-    if (dp_delBonds->size() < getNumBonds()) {
-      dp_delBonds->resize(getNumBonds());
+    URANGE_CHECK(aid1 , getNumAtoms());
+    URANGE_CHECK(aid2 , getNumAtoms());
+    auto bondIdx = dp_mol->getBondIndexBetweenAtoms(aid1, aid2);
+    if (bondIdx >= getNumBonds()) {
+      return;
     }
-    dp_delBonds->set(idx);
-    return;
-  }
-
-  // remove any bookmarks which point to this bond:
-  BOND_BOOKMARK_MAP *marks = getBondBookmarks();
-  auto markI = marks->begin();
-  while (markI != marks->end()) {
-    BOND_PTR_LIST &bonds = markI->second;
-    // we need to copy the iterator then increment it, because the
-    // deletion we're going to do in clearBondBookmark will invalidate
-    // it.
-    auto tmpI = markI;
-    ++markI;
-    if (std::find(bonds.begin(), bonds.end(), bnd) != bonds.end()) {
-      clearBondBookmark(tmpI->first, bnd);
-    }
-  }
-
-  // loop over neighboring double bonds and remove their stereo atom
-  //  information. This is definitely now invalid (was github issue 8)
-  auto beginAtm = bnd->getBeginAtom();
-  auto endAtm = bnd->getEndAtom();
-  std::vector<std::vector<Atom *>> bond_atoms = {{beginAtm, endAtm},
-                                                 {endAtm, beginAtm}};
-  for (const auto &atoms : bond_atoms) {
-    for (auto obnd : this->atomBonds(atoms[0])) {
-      if (obnd == bnd) {
-        continue;
-      }
-      if (std::find(obnd->getStereoAtoms().begin(),
-                    obnd->getStereoAtoms().end(),
-                    atoms[1]->getIdx()) != obnd->getStereoAtoms().end()) {
-        // github #6900 if we remove stereo atoms we need to remove
-        //  the CIS and or TRANS since this requires stereo atoms
-        if (obnd->getStereo() == Bond::BondStereo::STEREOCIS ||
-            obnd->getStereo() == Bond::BondStereo::STEREOTRANS) {
-          obnd->setStereo(Bond::BondStereo::STEREONONE);
-        }
-
-        obnd->getStereoAtoms().clear();
-      }
-    }
-  }
-  // reset our ring info structure, because it is pretty likely
-  // to be wrong now:
-  dp_ringInfo->reset();
-
-  removeSubstanceGroupsReferencingBond(*this, idx);
-
-  // loop over all bonds with higher indices and update their indices
-  for (auto bond : bonds()) {
-    if (bond->getIdx() > idx) {
-      bond->setIdx(bond->getIdx() - 1);
-    }
-  }
-  bnd->setOwningMol(nullptr);
-
-  auto vd1 = boost::vertex(bnd->getBeginAtomIdx(), d_graph);
-  auto vd2 = boost::vertex(bnd->getEndAtomIdx(), d_graph);
-  boost::remove_edge(vd1, vd2, d_graph);
-  delete bnd;
-  --numBonds;
+    dp_mol->removeBond(bondIdx);
 }
 
 Bond *RWMol::createPartialBond(unsigned int atomIdx1, Bond::BondType bondType) {
@@ -646,116 +371,18 @@ unsigned int RWMol::finishPartialBond(unsigned int atomIdx2, int bondBookmark,
 }
 
 void RWMol::beginBatchEdit() {
-  if (dp_delAtoms || dp_delBonds) {
-    throw ValueErrorException("Attempt to re-enter batchEdit mode");
-  }
-  dp_delAtoms.reset(new boost::dynamic_bitset<>(getNumAtoms()));
-  dp_delBonds.reset(new boost::dynamic_bitset<>(getNumBonds()));
+  dp_mol->beginBatchEdit();
 }
 
 void RWMol::commitBatchEdit() {
-  if (!(dp_delBonds || dp_delAtoms)) {
-    return;
-  } else if (dp_delBonds->none() && dp_delAtoms->none()) {
-    // no need to reset ring info & calculated properties,
-    // since nothing gets removed
-    dp_delBonds.reset();
-    dp_delAtoms.reset();
-    return;
-  }
-
-  batchRemoveBonds();
-  batchRemoveAtoms();
-
-  // remove ring info
-  dp_ringInfo->reset();
-
-  // fix properties
-  clearComputedProps(true);
-  dp_delBonds.reset();
-  dp_delAtoms.reset();
+  dp_mol->commitBatchEdit();
 }
 
-void RWMol::batchRemoveBonds() {
-  if (!dp_delBonds || dp_delBonds->none()) {
-    return;
-  }
-
-  auto &delBonds = *dp_delBonds;
-  unsigned int min_idx = getNumBonds();
-  for (unsigned int i = rdcast<unsigned int>(delBonds.size()); i > 0; --i) {
-    if (!delBonds[i - 1]) continue;
-    unsigned int idx = rdcast<unsigned int>(i - 1);
-    Bond *bnd = getBondWithIdx(idx);
-    if (!bnd) {
-      continue;
-    }
-
-    min_idx = idx;
-    // remove any bookmarks which point to this bond:
-    BOND_BOOKMARK_MAP *marks = getBondBookmarks();
-    auto markI = marks->begin();
-    while (markI != marks->end()) {
-      BOND_PTR_LIST &bonds = markI->second;
-      // we need to copy the iterator then increment it, because the
-      // deletion we're going to do in clearBondBookmark will invalidate
-      // it.
-      auto tmpI = markI;
-      ++markI;
-      if (std::find(bonds.begin(), bonds.end(), bnd) != bonds.end()) {
-        clearBondBookmark(tmpI->first, bnd);
-      }
-    }
-
-    // loop over neighboring double bonds and remove their stereo atom
-    //  information. This is definitely now invalid (was github issue 8)
-    auto beginAtm = bnd->getBeginAtom();
-    auto endAtm = bnd->getEndAtom();
-    std::vector<std::vector<Atom *>> bond_atoms = {{beginAtm, endAtm},
-                                                   {endAtm, beginAtm}};
-    for (const auto &atoms : bond_atoms) {
-      for (auto obnd : atomBonds(atoms[0])) {
-        if (obnd == bnd) {
-          continue;
-        }
-        if (std::find(obnd->getStereoAtoms().begin(),
-                      obnd->getStereoAtoms().end(),
-                      atoms[1]->getIdx()) != obnd->getStereoAtoms().end()) {
-          // github #6900 if we remove stereo atoms we need to remove
-          //  the CIS and or TRANS since this requires stereo atoms
-          if (obnd->getStereo() == Bond::BondStereo::STEREOCIS ||
-              obnd->getStereo() == Bond::BondStereo::STEREOTRANS) {
-            obnd->setStereo(Bond::BondStereo::STEREONONE);
-          }
-          obnd->getStereoAtoms().clear();
-        }
-      }
-    }
-
-    removeSubstanceGroupsReferencingBond(*this, idx);
-
-    bnd->setOwningMol(nullptr);
-
-    auto vd1 = boost::vertex(bnd->getBeginAtomIdx(), d_graph);
-    auto vd2 = boost::vertex(bnd->getEndAtomIdx(), d_graph);
-    boost::remove_edge(vd1, vd2, d_graph);
-    delete bnd;
-    --numBonds;
-  }
-
-  // loop over all bonds with higher indices than the minimum modified and
-  // update their indices
-  auto [firstB, lastB] = this->getEdges();
-  unsigned int next_idx = min_idx;
-  while (firstB != lastB) {
-    Bond *bond = (*this)[*firstB];
-    if (bond->getIdx() > min_idx) {
-      bond->setIdx(next_idx++);
-    }
-    ++firstB;
-  }
+void RWMol::rollbackBatchEdit() {
+  dp_mol->rollbackBatchEdit();
 }
 
+#if 0
 void RWMol::batchRemoveAtoms() {
   if (!dp_delAtoms || dp_delAtoms->none()) {
     return;
@@ -896,5 +523,6 @@ void RWMol::batchRemoveAtoms() {
     positions.swap(newPositions);
   }
 }
+#endif
 
 }  // namespace RDKit

--- a/Code/GraphMol/RWMol.h
+++ b/Code/GraphMol/RWMol.h
@@ -30,6 +30,12 @@ namespace RDKit {
 
  */
 class RDKIT_GRAPHMOL_EXPORT RWMol : public ROMol {
+  friend class RDMol;
+  friend class ROMol;
+
+ protected:
+  RWMol(RDMol *mol) : ROMol(mol) {}
+
  public:
   RWMol() : ROMol() {}
   //! copy constructor with a twist
@@ -80,9 +86,7 @@ class RDKIT_GRAPHMOL_EXPORT RWMol : public ROMol {
     \return the index of the added atom
   */
   unsigned int addAtom(Atom *atom, bool updateLabel = true,
-                       bool takeOwnership = false) {
-    return ROMol::addAtom(atom, updateLabel, takeOwnership);
-  }
+                       bool takeOwnership = false);
 
   //! adds an Atom to our collection
 
@@ -92,6 +96,7 @@ class RDKIT_GRAPHMOL_EXPORT RWMol : public ROMol {
     \param atom         the new atom, which will be copied.
     \param updateLabel   (optional) if this is true, the new Atom will be
                          our \c activeAtom
+                         NOTE: This parameter is currently ignored.
     \param preserveProps if true preserve the original atom property data
 
   */
@@ -140,9 +145,7 @@ class RDKIT_GRAPHMOL_EXPORT RWMol : public ROMol {
 
     \return the new number of bonds
   */
-  unsigned int addBond(Bond *bond, bool takeOwnership = false) {
-    return ROMol::addBond(bond, takeOwnership);
-  }
+  unsigned int addBond(Bond *bond, bool takeOwnership = false);
 
   //! starts a Bond and sets its beginAtomIdx
   /*!
@@ -200,23 +203,13 @@ class RDKIT_GRAPHMOL_EXPORT RWMol : public ROMol {
   //! @}
 
   //! removes all atoms, bonds, properties, bookmarks, etc.
-  void clear() {
-    destroy();
-    d_confs.clear();
-    ROMol::initMol();  // make sure we have a "fresh" ready to go copy
-    numBonds = 0;
-  }
 
   void beginBatchEdit();
-  void rollbackBatchEdit() {
-    dp_delAtoms.reset();
-    dp_delBonds.reset();
-  }
+  void rollbackBatchEdit();
   void commitBatchEdit();
 
- private:
-  void batchRemoveBonds();
-  void batchRemoveAtoms();
+  //! Clear underlying molecule. Note that this deliberately hides ROMol clear.
+  void clear() {dp_mol->clear(); }
 };
 
 typedef boost::shared_ptr<RWMol> RWMOL_SPTR;

--- a/Code/GraphMol/RingInfo.cpp
+++ b/Code/GraphMol/RingInfo.cpp
@@ -308,6 +308,7 @@ void RingInfo::reset() {
   d_atomRingFamilies.clear();
   d_bondRingFamilies.clear();
 #endif
+  // TODO: Should this clear d_fusedRings and d_numFusedBonds?
 }
 void RingInfo::preallocate(unsigned int numAtoms, unsigned int numBonds) {
   d_atomMembers.resize(numAtoms);

--- a/Code/GraphMol/SLNParse/Wrap/rdSLNParse.cpp
+++ b/Code/GraphMol/SLNParse/Wrap/rdSLNParse.cpp
@@ -34,6 +34,8 @@
 //
 #include <RDBoost/python.h>
 #include <GraphMol/SLNParse/SLNParse.h>
+#include <GraphMol/RWMol.h>
+#include <GraphMol/ROMol.h>
 
 #include <RDBoost/Wrap.h>
 #include <RDGeneral/Exceptions.h>

--- a/Code/GraphMol/SanitException.h
+++ b/Code/GraphMol/SanitException.h
@@ -12,11 +12,6 @@
 #ifndef RD_SANITEXCEPTION_H
 #define RD_SANITEXCEPTION_H
 
-#include <RDGeneral/types.h>
-#include <GraphMol/GraphMol.h>
-#include <GraphMol/Atom.h>
-#include <GraphMol/Bond.h>
-
 #include <string>
 #include <utility>
 #include <vector>

--- a/Code/GraphMol/SmilesParse/CMakeLists.txt
+++ b/Code/GraphMol/SmilesParse/CMakeLists.txt
@@ -62,6 +62,7 @@ rdkit_library(SmilesParse
               SmilesParse.cpp SmilesParseOps.cpp
               SmilesWrite.cpp SmartsWrite.cpp CXSmilesOps.cpp
               CanonicalizeStereoGroups.cpp SmilesJSONParsers.cpp
+              SmilesParseInternal.cpp
               ${BISON_OUTPUT_FILES}
               ${FLEX_OUTPUT_FILES}
               LINK_LIBRARIES GraphMol RDGeneral)
@@ -70,6 +71,7 @@ target_compile_definitions(SmilesParse PRIVATE RDKIT_SMILESPARSE_BUILD)
 rdkit_headers(SmartsWrite.h
               SmilesParse.h
               SmilesParseOps.h
+              SmilesParseInternal.h
               SmilesWrite.h 
               CanonicalizeStereoGroups.h
               SmilesJSONParsers.h DEST GraphMol/SmilesParse)

--- a/Code/GraphMol/SmilesParse/SmilesParse.cpp
+++ b/Code/GraphMol/SmilesParse/SmilesParse.cpp
@@ -24,6 +24,7 @@
 //
 //
 #include "SmilesParse.h"
+#include "SmilesParseInternal.h"
 #include <RDGeneral/BoostStartInclude.h>
 #include <boost/algorithm/string.hpp>
 #include <boost/lexical_cast.hpp>
@@ -59,6 +60,66 @@ int yysmarts_lex_destroy(void *);
 size_t setup_smarts_string(const std::string &text, void *);
 extern int yysmarts_debug;
 namespace RDKit {
+
+namespace v1 {
+
+bool SmilesToMol(const char *smiles,
+                 const SmilesParserParams &params,
+                 RDMol &mol, SmilesParseTemp &temp) {
+  bool success = SmilesParseInternal::parseSmiles(smiles, mol, temp);
+  if (success && (params.sanitize || params.removeHs)) {
+    raiseNonImplementedDetail("sanitization or removeHs in new SmilesToMol");
+#if 0
+    if (res->hasProp(SmilesParseOps::detail::_needsDetectAtomStereo)) {
+      // we encountered a wedged bond in the CXSMILES,
+      // these need to be handled the same way they were in mol files
+      res->clearProp(SmilesParseOps::detail::_needsDetectAtomStereo);
+      if (res->getNumConformers()) {
+        const auto &conf = res->getConformer();
+        if (!conf.is3D()) {
+          MolOps::assignChiralTypesFromBondDirs(*res, conf.getId());
+        }
+      }
+    }
+    // if we read a 3D conformer, set the stereo:
+    if (res->getNumConformers() && res->getConformer().is3D()) {
+      res->updatePropertyCache(false);
+      MolOps::assignChiralTypesFrom3D(*res, res->getConformer().getId(), true);
+    }
+#endif
+#if 0
+    try {
+      if (params.removeHs) {
+        bool implicitOnly = false, updateExplicitCount = true;
+        MolOps::removeHs(mol, temp.sanitizeTemp, implicitOnly, updateExplicitCount,
+                         params.sanitize);
+      } else if (params.sanitize) {
+        MolOps::sanitizeMol(mol, temp.sanitizeTemp);
+      }
+    } catch (...) {
+      mol.clear();
+      return false;
+    }
+#endif
+#if 0
+    if (res->hasProp(SmilesParseOps::detail::_needsDetectBondStereo)) {
+      // we encountered either wiggly bond in the CXSMILES,
+      // these need to be handled the same way they were in mol files
+      res->clearProp(SmilesParseOps::detail::_needsDetectBondStereo);
+      MolOps::clearSingleBondDirFlags(*res);
+      MolOps::detectBondStereochemistry(*res);
+    }
+#endif
+    // figure out stereochemistry:
+    //bool cleanIt = true, force = true, flagPossible = true;
+    //MolOps::assignStereochemistry(mol, temp.chiralityTemp, cleanIt, force, flagPossible);
+  }
+
+  return success;
+}
+}
+
+
 namespace v2 {
 namespace SmilesParse {
 namespace {
@@ -424,8 +485,8 @@ std::unique_ptr<RWMol> MolFromSmiles(const std::string &smiles,
   // the value of debugParse is different for different threads. The if
   // statement below avoids a TSAN warning in the case where multiple threads
   // all use the same value for debugParse.
-  if (yysmiles_debug != params.debugParse) {
-    yysmiles_debug = params.debugParse;
+  if ((yysmiles_debug != 0) != params.debugParse) {
+    yysmiles_debug = params.debugParse ? 1 : 0;
   }
 
   std::string lsmiles, name, cxPart;
@@ -552,8 +613,8 @@ std::unique_ptr<RWMol> MolFromSmarts(const std::string &smarts,
   // the value of debugParse is different for different threads. The if
   // statement below avoids a TSAN warning in the case where multiple threads
   // all use the same value for debugParse.
-  if (yysmarts_debug != params.debugParse) {
-    yysmarts_debug = params.debugParse;
+  if ((yysmarts_debug != 0) != params.debugParse) {
+    yysmarts_debug = params.debugParse ? 1 : 0;
   }
 
   std::string lsmarts, name, cxPart;

--- a/Code/GraphMol/SmilesParse/SmilesParse.h
+++ b/Code/GraphMol/SmilesParse/SmilesParse.h
@@ -11,6 +11,9 @@
 #ifndef RD_SMILESPARSE_H
 #define RD_SMILESPARSE_H
 
+#include <GraphMol/RWMol.h>
+#include <GraphMol/RDMol.h>
+#include <GraphMol/Chirality.h>
 #include <GraphMol/SanitException.h>
 #include <string>
 #include <exception>
@@ -140,6 +143,39 @@ inline Atom *SmilesToAtom(const std::string &smi) {
 inline Bond *SmilesToBond(const std::string &smi) {
   return RDKit::v2::SmilesParse::BondFromSmiles(smi).release();
 }
+struct SmilesParseTemp {
+  std::vector<uint32_t> branchStack;
+  std::vector<uint32_t> openBondTable;
+  size_t numOpenBonds;
+
+  std::vector<int> atomMapNumbers;
+  std::vector<uint32_t> chiralityPermutations;
+
+  constexpr static uint32_t INVALID_OPEN_BOND = uint32_t(-1);
+
+  SmilesParseTemp() {
+    branchStack.reserve(16);
+    openBondTable.reserve(100);
+    numOpenBonds = 0;
+  }
+
+  void clearForError() {
+    branchStack.resize(0);
+    if (numOpenBonds > 0) {
+      numOpenBonds = 0;
+      std::fill(openBondTable.begin(), openBondTable.end(), INVALID_OPEN_BOND);
+    }
+    atomMapNumbers.resize(0);
+    chiralityPermutations.resize(0);
+  }
+};
+
+RDKIT_SMILESPARSE_EXPORT bool SmilesToMol(const char *smiles,
+                                          const SmilesParserParams &params,
+                                          RDMol &mol, SmilesParseTemp &temp);
+
+RDKIT_SMILESPARSE_EXPORT Atom *SmilesToAtom(const std::string &smi);
+RDKIT_SMILESPARSE_EXPORT Bond *SmilesToBond(const std::string &smi);
 
 //! Construct a molecule from a SMILES string
 /*!

--- a/Code/GraphMol/SmilesParse/SmilesParseInternal.cpp
+++ b/Code/GraphMol/SmilesParse/SmilesParseInternal.cpp
@@ -1,0 +1,654 @@
+//
+//  Copyright (C) 2025 NVIDIA Corporation & Affiliates and other RDKit contributors
+//
+//   @@ All Rights Reserved @@
+//  This file is part of the RDKit.
+//  The contents are covered by the terms of the BSD license
+//  which is included in the file license.txt, found at the root
+//  of the RDKit source tree.
+//
+#include "SmilesParseInternal.h"
+#include "SmilesParse.h"
+
+#include <GraphMol/RDMol.h>
+
+#include <vector>
+#include <assert.h>
+#include <numeric>
+#include <memory>
+
+using namespace RDKit;
+using BondEnums::BondType;
+
+constexpr static uint32_t INVALID_OPEN_BOND =
+    SmilesParseTemp::INVALID_OPEN_BOND;
+
+namespace {
+
+constexpr size_t elementSymbolLookupStart[27] = {
+    0,    // Ac Ag Al Am Ar As At Au             ( 8)
+    8,    // B  Ba Be Bh Bi Bk Br                ( 7)
+    15,   // C  Ca Cd Ce Cf Cl Cm Cn Co Cr Cs Cu (12)
+    27,   // Db Ds Dy                            ( 3)
+    30,   // Er Es Eu                            ( 3)
+    33,   // F  Fe Fl Fm Fr                      ( 5)
+    38,   // Ga Gd Ge                            ( 3)
+    41,   // H  He Hf Hg Ho Hs                   ( 6)
+    47,   // I  In Ir                            ( 3)
+    50,   //                                     ( 0)
+    50,   // K  Kr                               ( 2)
+    52,   // La Li Lr Lu Lv                      ( 5)
+    57,   // Mc Md Mg Mn Mo Mt                   ( 6)
+    63,   // N  Na Nb Nd Ne Nh Ni No Np          ( 9)
+    72,   // O  Og Os                            ( 3)
+    75,   // P  Pa Pb Pd Pm Po Pr Pt Pu          ( 9)
+    84,   //                                     ( 0)
+    84,   // Ra Rb Re Rf Rg Rh Rn Ru             ( 8)
+    92,   // S  Sb Sc Se Sg Si Sm Sn Sr          ( 9)
+    101,  // Ta Tb Tc Te Th Ti Tl Tm Ts          ( 9)
+    110,  // U                                   ( 1)
+    111,  // V                                   ( 1)
+    112,  // W                                   ( 1)
+    113,  // Xe                                  ( 1)
+    114,  // Y  Yb                               ( 2)
+    116,  // Zn Zr                               ( 2)
+    118};
+
+// These are in *alphabetical* order by element symbol
+constexpr char elementSymbolSecond[118] = {
+    'c', 'g', 'l', 'm', 'r', 's', 't', 'u', 0,   'a', 'e', 'h', 'i',
+    'k', 'r', 0,   'a', 'd', 'e', 'f', 'l', 'm', 'n', 'o', 'r', 's',
+    'u', 'b', 's', 'y', 'r', 's', 'u', 0,   'e', 'l', 'm', 'r', 'a',
+    'd', 'e', 0,   'e', 'f', 'g', 'o', 's', 0,   'n', 'r',
+
+    0,   'r', 'a', 'i', 'r', 'u', 'v', 'c', 'd', 'g', 'n', 'o', 't',
+    0,   'a', 'b', 'd', 'e', 'h', 'i', 'o', 'p', 0,   'g', 's', 0,
+    'a', 'b', 'd', 'm', 'o', 'r', 't', 'u',
+
+    'a', 'b', 'e', 'f', 'g', 'h', 'n', 'u', 0,   'b', 'c', 'e', 'g',
+    'i', 'm', 'n', 'r', 'a', 'b', 'c', 'e', 'h', 'i', 'l', 'm', 's',
+    0,   0,   0,   'e', 0,   'b', 'n', 'r'};
+
+// These are in *alphabetical* order by element symbol, same order as
+// elementSymbolSecond
+constexpr int8_t elementAtomicNum[118] = {
+    89, 47,  13,  95,  18,  33,  85,  79,  5,   56,  4,   107, 83,
+    97, 35,  6,   20,  48,  58,  98,  17,  96,  112, 27,  24,  55,
+    29, 105, 110, 66,  68,  99,  63,  9,   26,  114, 100, 87,  31,
+    64, 32,  1,   2,   72,  80,  67,  108, 53,  49,  77,
+
+    19, 36,  57,  3,   103, 71,  116, 115, 101, 12,  25,  42,  109,
+    7,  11,  41,  60,  10,  113, 28,  102, 93,  8,   118, 76,  15,
+    91, 82,  46,  61,  84,  59,  78,  94,
+
+    88, 37,  75,  104, 111, 45,  86,  44,  16,  51,  21,  34,  106,
+    14, 62,  50,  38,  73,  65,  43,  52,  90,  22,  81,  69,  117,
+    92, 23,  74,  54,  39,  70,  30,  40};
+
+// Fill vectors representing the molecule's graph in CSR format.
+void toCSR(const size_t numAtoms, const std::vector<BondData>& bonds, RDMol& mol) {
+  const size_t numBonds = bonds.size();
+
+  mol.getAtomBondStartsVector().resize(numAtoms + 1);
+  uint32_t* neighbourStarts = mol.getAtomBondStartsVector().data();
+  for (size_t i = 0; i <= numAtoms; ++i) {
+    neighbourStarts[i] = 0;
+  }
+
+  // First, get atom neighbour counts
+  for (size_t i = 0; i < numBonds; ++i) {
+    uint32_t a = bonds[i].getBeginAtomIdx();
+    uint32_t b = bonds[i].getEndAtomIdx();
+    // NOTE: +1 is because first entry will stay zero.
+    ++neighbourStarts[a + 1];
+    ++neighbourStarts[b + 1];
+  }
+
+  // Find the starts by partial-summing the neighbour counts.
+  // NOTE: +1 is because first entry will stay zero.
+  std::partial_sum(neighbourStarts + 1, neighbourStarts + 1 + numAtoms,
+                   neighbourStarts + 1);
+
+  // Fill in the neighbours and bondIndices arrays.
+  mol.getOtherAtomIndicesVector().resize(2 * numBonds);
+  uint32_t* neighbours = mol.getOtherAtomIndicesVector().data();
+  mol.getBondDataIndicesVector().resize(2 * numBonds);
+  uint32_t* bondIndices = mol.getBondDataIndicesVector().data();
+  for (uint32_t i = 0; i < numBonds; ++i) {
+    uint32_t a = bonds[i].getBeginAtomIdx();
+    uint32_t b = bonds[i].getEndAtomIdx();
+
+    uint32_t ai = neighbourStarts[a];
+    neighbours[ai] = b;
+    bondIndices[ai] = i;
+    ++neighbourStarts[a];
+
+    uint32_t bi = neighbourStarts[b];
+    neighbours[bi] = a;
+    bondIndices[bi] = i;
+    ++neighbourStarts[b];
+  }
+
+  // Shift neighbourStarts forward one after incrementing it.
+  uint32_t previous = 0;
+  for (size_t i = 0; i < numAtoms; ++i) {
+    uint32_t next = neighbourStarts[i];
+    neighbourStarts[i] = previous;
+    previous = next;
+  }
+  assert(neighbourStarts[numAtoms] == previous);
+}
+
+// text starts out pointing to it
+inline int parseInt(const char*& text) {
+  char c = *text;
+  int v = c - '0';
+  ++text;
+  c = *text;
+  while (c >= '0' && c <= '9') {
+    v = v * 10 + (c - '0');
+    ++text;
+    c = *text;
+  }
+  return v;
+}
+
+static bool parseBracketAtom(const char*& text, AtomData& atom,
+                             uint32_t atomIndex, SmilesParseTemp& temp) {
+  char c = *text;
+  if (c >= '0' && c <= '9') {
+    // Isotope
+    atom.setIsotope(parseInt(text));
+    c = *text;
+  }
+
+  if (c >= 'A' && c <= 'Z') {
+    // Element symbol
+    const size_t firstLetterIndex = c - 'A';
+    ++text;
+    c = *text;
+    char secondLetter = (c >= 'a' && c <= 'z') ? c : 0;
+    const size_t firstLetterIndexBegin =
+        elementSymbolLookupStart[firstLetterIndex];
+    const size_t firstLetterIndexEnd =
+        elementSymbolLookupStart[firstLetterIndex + 1];
+    size_t elementAlphabeticalIndex = firstLetterIndexBegin;
+    while (elementAlphabeticalIndex < firstLetterIndexEnd &&
+           secondLetter != elementSymbolSecond[elementAlphabeticalIndex]) {
+      ++elementAlphabeticalIndex;
+    }
+    if (elementAlphabeticalIndex == firstLetterIndexEnd) {
+      return false;
+    }
+    if (secondLetter != 0) {
+      ++text;
+      c = *text;
+    }
+    atom.setAtomicNum(elementAtomicNum[elementAlphabeticalIndex]);
+  } else if (c >= 'a' && c <= 'z') {
+    ++text;
+    // Aromatic element symbol
+    // More elements are allowed to be aromatic when bracketed than unbracketed.
+    uint32_t atomicNum;
+    switch (c) {
+      case 'a':
+        c = *text;
+        if (c != 's') {
+          return false;
+        }
+        ++text;
+        atomicNum = 33;  // As
+        break;
+      case 'b':
+        atomicNum = 5;  // B
+        break;
+      case 'c':
+        atomicNum = 6;  // C
+        break;
+      case 'n':
+        atomicNum = 7;  // N
+        break;
+      case 'o':
+        atomicNum = 8;  // O
+        break;
+      case 'p':
+        atomicNum = 15;  // P
+        break;
+      case 's':
+        c = *text;
+        if (c != 'e') {
+          atomicNum = 16;  // S
+        } else {
+          ++text;
+          atomicNum = 34;  // Se
+        }
+        break;
+      default:
+        return false;
+    }
+    atom.setAtomicNum(atomicNum);
+    atom.setIsAromatic(true);
+    c = *text;
+  } else if (c == '*') {
+    // Unknown element
+    atom.setAtomicNum(0);
+    ++text;
+    c = *text;
+  } else {
+    return false;
+  }
+
+  if (c == '@') {
+    // Chirality
+    ++text;
+    c = *text;
+    if ((c == 'A') || (c == 'O') || (c == 'S') || (c == 'T')) {
+      ++text;
+      char c2 = *text;
+      if (c == 'A') {
+        // Only AL is valid "Allenal" (1 or 2)
+        if (c2 != 'L') {
+          return false;
+        }
+        atom.setChiralTag(AtomEnums::ChiralType::CHI_ALLENE);
+      } else if (c2 == 'O') {
+        // Only OH is valid "Octahedral" (up to 2 digits)
+        if (c2 != 'H') {
+          return false;
+        }
+        atom.setChiralTag(AtomEnums::ChiralType::CHI_OCTAHEDRAL);
+      } else if (c == 'S') {
+        // Only SP is valid "Square Planar" (1, 2, or 3)
+        if (c2 != 'P') {
+          return false;
+        }
+        atom.setChiralTag(AtomEnums::ChiralType::CHI_SQUAREPLANAR);
+      } else if (c == 'T') {
+        if (c2 == 'B') {
+          // TB "Trigonal Bipyramidal" (up to 2 digits)
+          atom.setChiralTag(AtomEnums::ChiralType::CHI_TRIGONALBIPYRAMIDAL);
+        } else if (c2 == 'H') {
+          // TH "Tetrahedral" (1 or 2)
+          atom.setChiralTag(AtomEnums::ChiralType::CHI_TETRAHEDRAL);
+        } else {
+          return false;
+        }
+      }
+      ++text;
+      c = *text;
+      if (c < '0' || c > '9') {
+        return false;
+      }
+      int number = (c - '0');
+      ++text;
+      c = *text;
+      if (c >= '0' && c <= '9') {
+        number = number * 10 + (c - '0');
+        ++text;
+        c = *text;
+      }
+      if (temp.chiralityPermutations.size() <= atomIndex) {
+        temp.chiralityPermutations.resize(atomIndex + 1, 0);
+      }
+      temp.chiralityPermutations[atomIndex] = number;
+    } else {
+      if (c == '@') {
+        ++text;
+        c = *text;
+        // chirality permutation number 2;
+        atom.setChiralTag(AtomEnums::ChiralType::CHI_TETRAHEDRAL_CW);
+      } else {
+        // chirality permutation number 1;
+        atom.setChiralTag(AtomEnums::ChiralType::CHI_TETRAHEDRAL_CCW);
+      }
+    }
+  }
+
+  if (c == 'H') {
+    // Explicit hydrogen count
+    ++text;
+    c = *text;
+    if (c >= '0' && c <= '9') {
+      atom.setNumExplicitHs(c - '0');
+      ++text;
+      c = *text;
+    } else {
+      atom.setNumExplicitHs(1);
+    }
+  } else {
+    // Bracketed atoms need explicit hydrogen counts, else no hydrogens.
+    atom.setNumExplicitHs(0);
+  }
+  atom.setNoImplicit(true);
+
+  if (c == '+' || c == '-') {
+    // Charge
+    const bool isNegative = (c == '-');
+    const char sign = c;
+    ++text;
+    c = *text;
+    int count = 1;
+    if (c == sign) {
+      count = 2;
+      ++text;
+      c = *text;
+    } else if (c >= '0' && c <= '9') {
+      count = (c - '0');
+      ++text;
+      c = *text;
+      // Limit of 2 digits for charge
+      if (c >= '0' && c <= '9') {
+        count = count * 10 + (c - '0');
+        ++text;
+        c = *text;
+      }
+    }
+    atom.setFormalCharge(isNegative ? -count : count);
+  }
+
+  if (c == ':') {
+    // Class
+    ++text;
+    c = *text;
+    if (!(c >= '0' && c <= '9')) {
+      return false;
+    }
+    if (temp.atomMapNumbers.size() <= atomIndex) {
+      temp.atomMapNumbers.resize(atomIndex + 1, -1);
+    }
+    temp.atomMapNumbers[atomIndex] = parseInt(text);
+    //atom.atomClass = parseInt(text);
+    c = *text;
+  }
+
+  if (c == ']') {
+    ++text;
+    return true;
+  }
+  return false;
+}
+
+static bool parseAtom(const char*& text, AtomData& atom, atomindex_t atomIndex, SmilesParseTemp &temp) {
+  char c = *text;
+  if (c == '[') {
+    ++text;
+    return parseBracketAtom(text, atom, atomIndex, temp);
+  }
+
+  ++text;
+  bool isAromatic = (c & 0x20) != 0;
+  c = c & ~0x20;
+  int atomicNum;
+  switch (c) {
+    case 'B':
+      if (!isAromatic && *text == 'r') {
+        ++text;
+        atomicNum = 35;  // Br
+      } else {
+        atomicNum = 5;  // B
+      }
+      break;
+    case 'C':
+      if (!isAromatic && *text == 'l') {
+        ++text;
+        atomicNum = 17;  // Cl
+      } else {
+        atomicNum = 6;  // C
+      }
+      break;
+    case 'F':
+      if (isAromatic) {
+        return false;
+      }
+      atomicNum = 9;
+      break;
+    case 'I':
+      if (isAromatic) {
+        return false;
+      }
+      atomicNum = 53;
+      break;
+    case 'N':
+      atomicNum = 7;
+      break;
+    case 'O':
+      atomicNum = 8;
+      break;
+    case 'P':
+      atomicNum = 15;
+      break;
+    case 'S':
+      atomicNum = 16;
+      break;
+    case '*':
+      atomicNum = 0;
+      // '*' could be aromatic, but that needs to be determined later.
+      isAromatic = false;
+      // No implicit hydrogens on unknown element.
+      atom.setNumExplicitHs(0);
+      atom.setNoImplicit(true);
+      break;
+    default:
+      return false;
+  }
+  atom.setAtomicNum(atomicNum);
+  atom.setIsAromatic(isAromatic);
+  return true;
+}
+
+inline BondType bondTypeFromChar(char c) {
+  switch (c) {
+    case '.':
+      return BondType::ZERO;
+    case '-':
+    case '/':
+    case '\\':
+      return BondType::SINGLE;
+    case '=':
+      return BondType::DOUBLE;
+    case '#':
+      return BondType::TRIPLE;
+    case '$':
+      return BondType::QUADRUPLE;
+    case ':':
+      return BondType::AROMATIC;
+  }
+  return BondType::OTHER;
+}
+
+static void handleAnyRingBonds(const char*& text, uint32_t recentAtomIndex,
+                               std::vector<AtomData>& atoms,
+                               std::vector<BondData>& bonds,
+                               SmilesParseTemp& temp) {
+  const char* localText = text;
+  char c = *localText;
+  while ((c < 'A' || c == '\\') && (c != '(') && (c != ')')) {
+    BondType type = bondTypeFromChar(c);
+    if (type == BondType::ZERO) {
+      // Dot isn't allowed for ring bonds.
+      return;
+    }
+    if (type != BondType::OTHER) {
+      ++localText;
+      c = *localText;
+    } else {
+      type = BondType::UNSPECIFIED;
+    }
+    bool twoDigits = (c == '%');
+    if (twoDigits) {
+      ++localText;
+      c = *localText;
+    }
+    if (c < '0' || c > '9') {
+      // Possibly a regular bond, not a ring bond.
+      return;
+    }
+    size_t index = (c - '0');
+    ++localText;
+    c = *localText;
+    if (twoDigits) {
+      if (c < '0' || c > '9') {
+        return;
+      }
+      index = index * 10 + (c - '0');
+      ++localText;
+      c = *localText;
+    }
+    if (index >= temp.openBondTable.size()) {
+      temp.openBondTable.resize(index + 1, INVALID_OPEN_BOND);
+    }
+    uint32_t existingAtomIndex = temp.openBondTable[index];
+    if (existingAtomIndex == INVALID_OPEN_BOND) {
+      // Open a new bond
+      temp.openBondTable[index] = recentAtomIndex;
+      ++temp.numOpenBonds;
+    } else {
+      // Complete an open bond
+      assert(temp.numOpenBonds > 0);
+      assert(existingAtomIndex < recentAtomIndex);
+      BondData bond;
+      bond.setBeginAtomIdx(existingAtomIndex);
+      bond.setEndAtomIdx(recentAtomIndex);
+      bond.setBondType(type);
+      bonds.push_back(std::move(bond));
+      //++numNeighbors[existingAtomIndex];
+      //++numNeighbors[recentAtomIndex];
+      temp.openBondTable[index] = INVALID_OPEN_BOND;
+      --temp.numOpenBonds;
+    }
+
+    // Done ring bond, so update text pointer in caller.
+    text = localText;
+  }
+
+  // Not a bond type or '%' or number, so return
+}
+
+}  // namespace
+
+namespace SmilesParseInternal {
+
+bool parseSmiles(const char* text, RDMol &mol, SmilesParseTemp& temp) {
+  std::vector<AtomData> &atoms = mol.getAtomDataVector();
+  std::vector<BondData> &bonds = mol.getBondDataVector();
+
+  atoms.resize(0);
+  bonds.resize(0);
+  assert(temp.numOpenBonds == 0);
+  temp.atomMapNumbers.resize(0);
+  temp.chiralityPermutations.resize(0);
+
+  uint32_t prevAtomIndex = 0;
+  bool isBondAllowed = false;
+  bool isBranchAllowed = false;
+  char c = *text;
+  while (c > ' ') {
+    // If branching, the bond is after the bracket, not before,
+    // so process the bracket first.
+    if (isBranchAllowed && (c == '(')) {
+      ++text;
+      c = *text;
+      temp.branchStack.push_back(prevAtomIndex);
+      isBondAllowed = true;
+      isBranchAllowed = false;
+      continue;
+    }
+
+    const uint32_t nextAtomIndex = uint32_t(atoms.size());
+    if (isBondAllowed) {
+      BondData bond;
+      bond.setBeginAtomIdx(prevAtomIndex);
+      bond.setEndAtomIdx(nextAtomIndex);
+      if (c < 'A') {
+        auto bondType = bondTypeFromChar(c);
+        if (bondType == BondType::OTHER) {
+          temp.clearForError();
+          return false;
+        }
+        bond.setBondType(bondType);
+        ++text;
+        c = *text;
+      } else if (c == '\\') {
+        bond.setBondType(BondType::SINGLE);
+        ++text;
+        c = *text;
+      } else {
+        bond.setBondType(BondType::UNSPECIFIED);
+      }
+      if (bond.getBondType() != BondType::ZERO) {
+        bonds.push_back(bond);
+      }
+    }
+
+    AtomData atom;
+    bool success = parseAtom(text, atom, nextAtomIndex, temp);
+    if (!success) {
+      temp.clearForError();
+      return false;
+    }
+    atoms.push_back(atom);
+    prevAtomIndex = nextAtomIndex;
+    handleAnyRingBonds(text, prevAtomIndex, atoms, bonds, temp);
+
+    c = *text;
+    while (c == ')') {
+      if (temp.branchStack.size() == 0) {
+        temp.clearForError();
+        return false;
+      }
+      ++text;
+      c = *text;
+      prevAtomIndex = temp.branchStack.back();
+      temp.branchStack.pop_back();
+    }
+
+    isBondAllowed = true;
+    isBranchAllowed = true;
+  }
+  if (temp.branchStack.size() != 0) {
+    temp.clearForError();
+    return false;
+  }
+  if (temp.numOpenBonds != 0) {
+    temp.clearForError();
+    return false;
+  }
+
+  // Post-processing
+
+  // Prepare CSR graph
+  toCSR(atoms.size(), bonds, mol);
+
+  // Change any implicit bonds to single or aromatic.
+  for (BondData& bond : bonds) {
+    uint32_t atom0 = bond.getBeginAtomIdx();
+    uint32_t atom1 = bond.getEndAtomIdx();
+    if (bond.getBondType() == BondType::UNSPECIFIED) {
+      const bool isAromatic0 = atoms[atom0].getIsAromatic();
+      const bool isAromatic1 = atoms[atom1].getIsAromatic();
+      if (isAromatic0 == isAromatic1) {
+        // Both atoms aromatic or not
+        bond.setBondType(isAromatic0 ? BondType::AROMATIC : BondType::SINGLE);
+      } else {
+#if 0
+        const bool isUnknown0 = (atoms[atom0].getAtomicNum() == 0);
+        const bool isUnknown1 = (atoms[atom1].getAtomicNum() == 0);
+        // Exactly one of the two atoms is marked as aromatic.
+        // Heuristic guess that if the bond is in a ring and the non-aromatic
+        // atom is unknown, it should be aromatic, but just couldn't be marked
+        // aromatic because it was unknown. Unknown atoms are rare, so this
+        // almost always assigns a single bond type.
+        bond.setBondType(((isUnknown0 || isUnknown1) && bond.isInRing)
+                            ? BondType::AROMATIC
+                            : BondType::SINGLE);
+#endif
+        // Because we're not determining bond rings here, just assign SINGLE.
+        // FIXME: This should probably be handled properly.
+        bond.setBondType(BondType::SINGLE);
+      }
+    }
+  }
+  return true;
+}
+
+}  // namespace SmilesParseInternal

--- a/Code/GraphMol/SmilesParse/SmilesParseInternal.h
+++ b/Code/GraphMol/SmilesParse/SmilesParseInternal.h
@@ -1,0 +1,21 @@
+//
+//  Copyright (C) 2025 NVIDIA Corporation & Affiliates and other RDKit contributors
+//
+//   @@ All Rights Reserved @@
+//  This file is part of the RDKit.
+//  The contents are covered by the terms of the BSD license
+//  which is included in the file license.txt, found at the root
+//  of the RDKit source tree.
+//
+#pragma once
+
+#include "SmilesParse.h"
+
+#include <GraphMol/RDMol.h>
+
+#include <vector>
+
+namespace SmilesParseInternal {
+bool parseSmiles(const char* text, RDKit::RDMol& mol,
+                 RDKit::SmilesParseTemp& temp);
+}

--- a/Code/GraphMol/SmilesParse/cxsmiles_test.cpp
+++ b/Code/GraphMol/SmilesParse/cxsmiles_test.cpp
@@ -11,6 +11,7 @@
 #include <RDGeneral/test.h>
 #include <string>
 #include <vector>
+#include <GraphMol/RDMol.h>
 #include <GraphMol/RDKitBase.h>
 #include <GraphMol/test_fixtures.h>
 #include <GraphMol/FileParsers/FileParsers.h>
@@ -38,6 +39,12 @@ TEST_CASE("base functionality") {
     REQUIRE(m);
     CHECK(m->getNumAtoms() == 2);
     delete m;
+
+    SmilesParseTemp temp;
+    RDMol mol;
+    bool success = SmilesToMol(smiles.c_str(), params, mol, temp);
+    TEST_ASSERT(success);
+    TEST_ASSERT(mol.getNumAtoms() == 2);
   }
 }
 TEST_CASE("reading 2D coordinates") {

--- a/Code/GraphMol/SubstanceGroup.cpp
+++ b/Code/GraphMol/SubstanceGroup.cpp
@@ -348,10 +348,18 @@ bool SubstanceGroupChecks::isSubstanceGroupIdFree(const ROMol &mol,
 }
 
 std::vector<SubstanceGroup> &getSubstanceGroups(ROMol &mol) {
-  return mol.d_sgroups;
+  return mol.dp_mol->getSubstanceGroups();
 }
 const std::vector<SubstanceGroup> &getSubstanceGroups(const ROMol &mol) {
-  return mol.d_sgroups;
+  return mol.dp_mol->getSubstanceGroups();
+}
+
+std::vector<SubstanceGroup> &getSubstanceGroups(RDMol &mol) {
+  return mol.getSubstanceGroups();
+}
+
+const std::vector<SubstanceGroup> &getSubstanceGroups(const RDMol &mol) {
+  return mol.getSubstanceGroups();
 }
 
 unsigned int addSubstanceGroup(ROMol &mol, SubstanceGroup sgroup) {
@@ -400,8 +408,9 @@ bool removedParentInHierarchy(
 }
 
 template <bool INCLUDES_METHOD(SubstanceGroup &, unsigned int),
-          void ADJUST_METHOD(SubstanceGroup &, unsigned int)>
-void removeSubstanceGroupsReferencing(RWMol &mol, unsigned int idx) {
+          void ADJUST_METHOD(SubstanceGroup &, unsigned int),
+          typename molT>
+void removeSubstanceGroupsReferencing(molT &mol, unsigned int idx) {
   auto &sgs = getSubstanceGroups(mol);
   if (!sgs.empty()) {
     // first collect the ones that should be removed
@@ -478,9 +487,17 @@ void removeSubstanceGroupsReferencingAtom(RWMol &mol, unsigned int idx) {
   removeSubstanceGroupsReferencing<includesAtom, removedAtom>(mol, idx);
 }
 
+void removeSubstanceGroupsReferencingAtom(RDMol &mol, unsigned int idx) {
+  removeSubstanceGroupsReferencing<includesAtom, removedAtom>(mol, idx);
+}
+
 void removeSubstanceGroupsReferencingBond(RWMol &mol, unsigned int idx) {
   // Delete substance groups containing this bond. It could be that it's ok to
   // keep it, but we just don't know
+  removeSubstanceGroupsReferencing<includesBond, removedBond>(mol, idx);
+}
+
+void removeSubstanceGroupsReferencingBond(RDMol &mol, unsigned int idx) {
   removeSubstanceGroupsReferencing<includesBond, removedBond>(mol, idx);
 }
 

--- a/Code/GraphMol/SubstanceGroup.h
+++ b/Code/GraphMol/SubstanceGroup.h
@@ -27,6 +27,7 @@
 #include <boost/smart_ptr.hpp>
 
 namespace RDKit {
+class RDMol;
 class ROMol;
 class RWMol;
 class Bond;
@@ -269,6 +270,8 @@ RDKIT_GRAPHMOL_EXPORT std::vector<SubstanceGroup> &getSubstanceGroups(
     ROMol &mol);
 RDKIT_GRAPHMOL_EXPORT const std::vector<SubstanceGroup> &getSubstanceGroups(
     const ROMol &mol);
+std::vector<SubstanceGroup> &getSubstanceGroups(RDMol &mol);
+const std::vector<SubstanceGroup> &getSubstanceGroups(const RDMol &mol);
 
 //! Add a new SubstanceGroup. A copy is added, so we can be sure that no other
 //! references to the SubstanceGroup exist.
@@ -285,6 +288,8 @@ RDKIT_GRAPHMOL_EXPORT unsigned int addSubstanceGroup(ROMol &mol,
 */
 RDKIT_GRAPHMOL_EXPORT void removeSubstanceGroupsReferencingAtom(
     RWMol &mol, unsigned int idx);
+//! \overload
+void removeSubstanceGroupsReferencingAtom(RDMol &mol, unsigned int idx);
 //! Removes SubstanceGroups which reference a particular bond index
 /*!
   \param mol - molecule to be edited.
@@ -292,6 +297,9 @@ RDKIT_GRAPHMOL_EXPORT void removeSubstanceGroupsReferencingAtom(
 */
 RDKIT_GRAPHMOL_EXPORT void removeSubstanceGroupsReferencingBond(
     RWMol &mol, unsigned int idx);
+//! \overload
+RDKIT_GRAPHMOL_EXPORT void removeSubstanceGroupsReferencingBond(
+    RDMol &mol, unsigned int idx);
 //! @}
 
 }  // namespace RDKit

--- a/Code/GraphMol/Substruct/SubstructUtils.cpp
+++ b/Code/GraphMol/Substruct/SubstructUtils.cpp
@@ -139,7 +139,8 @@ bool atomCompat(const Atom *a1, const Atom *a2,
     res = a1->Match(a2);
   }
   if (res && !ps.atomProperties.empty()) {
-    res = propertyCompat(a1, a2, ps.atomProperties);
+    raiseNonImplementedDetail("Cast atom to prop");
+    // res = propertyCompat(a1, a2, ps.atomProperties);
   }
 
   return res;
@@ -211,7 +212,8 @@ bool bondCompat(const Bond *b1, const Bond *b2,
     }
   }
   if (res && !ps.bondProperties.empty()) {
-    res = propertyCompat(b1, b2, ps.bondProperties);
+    raiseNonImplementedDetail("cast bond to prop");
+    // res = propertyCompat(b1, b2, ps.bondProperties);
   }
   // std::cerr << "\t\tbondCompat: " << b1->getIdx() << "-" << b2->getIdx() <<
   // ":"

--- a/Code/GraphMol/Substruct/vf2.hpp
+++ b/Code/GraphMol/Substruct/vf2.hpp
@@ -21,6 +21,49 @@
 #define RDK_ADJ_ITER typename Graph::adjacency_iterator
 
 namespace boost {
+
+using ::RDKit::ROMol;
+using vertex_descriptor = ::RDKit::ROMol::vertex_descriptor;
+using edge_descriptor = ::RDKit::ROMol::edge_descriptor;
+using vertex_iterator = ::RDKit::ROMol::vertex_iterator;
+using edge_iterator = ::RDKit::ROMol::edge_iterator;
+
+// ROMol dropins for boost graph functions.
+size_t out_degree(vertex_descriptor v, const ROMol &g) {
+  return g.getAtomWithIdx(v)->getDegree();
+}
+
+std::pair<edge_descriptor, bool> edge(vertex_descriptor v1, vertex_descriptor v2,
+                                      const ROMol &g) {
+  try {
+    auto bond = g.getBondBetweenAtoms(v1, v2);
+    CHECK_INVARIANT(bond, "This may not be expected");
+    return std::make_pair(edge_descriptor(bond->getIdx()), true);
+
+  } catch (Invar::Invariant) {
+    return std::make_pair(edge_descriptor(0), false);
+  }
+}
+vertex_descriptor source(edge_descriptor e, const ROMol &g) {
+  return g.getBondWithIdx(*e)->getBeginAtomIdx();
+}
+
+vertex_descriptor target(edge_descriptor e, const ROMol &g) {
+  return g.getBondWithIdx(*e)->getEndAtomIdx();
+}
+
+std::pair<vertex_iterator, vertex_iterator> vertices(const ROMol &g) {
+  return g.getVertices();
+}
+
+std::pair<ROMol::adjacency_iterator, ROMol::adjacency_iterator> adjacent_vertices(vertex_descriptor u, const ROMol &g) {
+  return g.getAtomNeighbors(g.getAtomWithIdx(u));
+}
+
+std::pair<ROMol::out_edge_iterator, ROMol::out_edge_iterator> out_edges(vertex_descriptor u, const ROMol &g) {
+  return g.getAtomBonds(g.getAtomWithIdx(u));
+}
+
 namespace detail {
 typedef std::uint32_t node_id;
 const node_id NULL_NODE = 0xFFFFFFFF;
@@ -109,7 +152,7 @@ VertexDescr getOtherIdx(const Graph &g, const EdgeDescr &edge,
 template <class Graph>
 node_id *SortNodesByFrequency(const Graph *g) {
   std::vector<NodeInfo> vect;
-  vect.reserve(boost::num_vertices(*g));
+  vect.reserve(num_vertices(*g));
   typename Graph::vertex_iterator bNode, eNode;
   boost::tie(bNode, eNode) = boost::vertices(*g);
   while (bNode != eNode) {
@@ -616,7 +659,10 @@ bool match(node_id c1[], node_id c2[], SubState &s,
   s.MatchAll(c1, c2, res, max_results);
   return !res.empty();
 }
+
+
 };  // end of namespace detail
+
 
 template <
     class Graph, class VertexLabeling  // binary predicate
@@ -629,9 +675,11 @@ template <
     BackInsertionSequence  // contains
                            // std::pair<vertex_descriptor,vertex_descriptor>
     >
+
 bool vf2(const Graph &g1, const Graph &g2, VertexLabeling &vertex_labeling,
          EdgeLabeling &edge_labeling, MatchChecking &match_checking,
          BackInsertionSequence &F) {
+
   detail::VF2SubState<const Graph, VertexLabeling, EdgeLabeling, MatchChecking>
       s0(&g1, &g2, vertex_labeling, edge_labeling, match_checking, false);
   detail::node_id *ni1 = new detail::node_id[num_vertices(g1)];
@@ -648,9 +696,10 @@ bool vf2(const Graph &g1, const Graph &g2, VertexLabeling &vertex_labeling,
   }
   delete[] ni1;
   delete[] ni2;
-
   return !F.empty();
 };
+
+
 template <class Graph, class VertexLabeling  // binary predicate
           ,
           class EdgeLabeling  // binary predicate
@@ -672,11 +721,12 @@ bool vf2_all(const Graph &g1, const Graph &g2, VertexLabeling &vertex_labeling,
   F.resize(0);
 
   match(ni1.get(), ni2.get(), s0, F, max_results);
-
   return !F.empty();
 };
+
 }  // end of namespace boost
-#endif
 
 #undef RDK_VF2_PRUNING
 #undef RDK_ADJ_ITER
+
+#endif // __BGL_VF2_SUB_STATE_H__

--- a/Code/GraphMol/Wrap/MolOps.cpp
+++ b/Code/GraphMol/Wrap/MolOps.cpp
@@ -1060,6 +1060,7 @@ void _testSetProps(RDProps &props, const std::string &prefix) {
 }
 
 void testSetProps(ROMol &mol) {
+  raiseNonImplementedFunction("romol props");/*
   _testSetProps(mol, "mol_");
   for (auto &atom : mol.atoms()) {
     _testSetProps(*atom, std::string("atom_") + std::to_string(atom->getIdx()));
@@ -1070,7 +1071,7 @@ void testSetProps(ROMol &mol) {
   for (unsigned conf_idx = 0; conf_idx < mol.getNumConformers(); ++conf_idx) {
     _testSetProps(mol.getConformer(conf_idx),
                   "conf_" + std::to_string(conf_idx));
-  }
+  }*/
 }
 
 void expandAttachmentPointsHelper(ROMol &mol, bool addAsQueries,
@@ -1160,7 +1161,7 @@ struct molops_wrapper {
   \n\
     - mol: the molecule to be modified\n\
 \n";
-    python::def("SetBondStereoFromDirections",
+    python::def<void(ROMol&)>("SetBondStereoFromDirections",
                 MolOps::setBondStereoFromDirections, (python::arg("mol")),
                 docString.c_str());
 
@@ -1253,7 +1254,7 @@ struct molops_wrapper {
 \n\
   RETURNS: Nothing\n\
 \n";
-    python::def("FastFindRings", MolOps::fastFindRings, docString.c_str(),
+    python::def<void(const ROMol&)>("FastFindRings", MolOps::fastFindRings, docString.c_str(),
                 python::args("mol"));
 #ifdef RDK_USE_URF
     python::def("FindRingFamilies", MolOps::findRingFamilies,
@@ -2215,7 +2216,7 @@ RETURNS:
     - flagPossibleStereoCenters (optional)   set the _ChiralityPossible property on
       atoms that are possible stereocenters
 )DOC";
-    python::def("AssignStereochemistry", MolOps::assignStereochemistry,
+    python::def<void(ROMol&, bool, bool, bool)>("AssignStereochemistry", MolOps::assignStereochemistry,
                 (python::arg("mol"), python::arg("cleanIt") = false,
                  python::arg("force") = false,
                  python::arg("flagPossibleStereoCenters") = false),
@@ -3310,10 +3311,10 @@ enantiomer" or "OR enantiomer". CIP labels, if present, are removed.
     python::def("_TestSetProps", testSetProps, python::arg("mol"));
     python::def("NeedsHs", MolOps::needsHs, (python::arg("mol")),
                 "returns whether or not the molecule needs to have Hs added");
-    python::def(
+    python::def<int(const Atom*)>(
         "CountAtomElec", MolOps::countAtomElec, (python::arg("atom")),
         "returns the number of electrons available on an atom to donate for aromaticity");
-    python::def(
+    python::def<bool(const Atom*)>(
         "AtomHasConjugatedBond", MolOps::atomHasConjugatedBond,
         (python::arg("atom")),
         "returns whether or not the atom is involved in a conjugated bond");

--- a/Code/GraphMol/catch_rdmol.cpp
+++ b/Code/GraphMol/catch_rdmol.cpp
@@ -1,0 +1,1823 @@
+//
+//  Copyright (C) 2025 NVIDIA Corporation & Affiliates and other RDKit contributors
+//
+//   @@ All Rights Reserved @@
+//  This file is part of the RDKit.
+//  The contents are covered by the terms of the BSD license
+//  which is included in the file license.txt, found at the root
+//  of the RDKit source tree.
+//
+#include <catch2/catch_all.hpp>
+#include <catch2/catch_session.hpp>
+
+#include <GraphMol/RDMol.h>
+#include <GraphMol/SmilesParse/SmilesParse.h>
+
+using namespace RDKit;
+
+namespace {
+
+std::unique_ptr<RDMol> parseSmiles(const char *smiles, bool sanitize = false,
+                                   bool removeHs = false) {
+  auto mol = std::make_unique<RDMol>();
+  RDKit::SmilesParseTemp temp;
+  SmilesParserParams params;
+  params.sanitize = sanitize;
+  params.removeHs = removeHs;
+
+  REQUIRE(RDKit::SmilesToMol(smiles, params, *mol, temp) == true);
+  return mol;
+}
+
+std::unique_ptr<RDMol> basicMol() {
+  auto mol = parseSmiles("CCC=C");
+  REQUIRE(mol->getNumAtoms() == 4);
+  REQUIRE(mol->getNumBonds() == 3);
+  REQUIRE(mol->getBond(2).getBondType() == BondEnums::BondType::DOUBLE);
+
+  return mol;
+}
+
+static PropToken unusedToken("unused");
+static PropToken unsignedIntToken("unsigned int");
+static PropToken floatToken("float");
+static PropToken complexToken("nonPOD");
+static PropToken signedIntToken("signed int");
+
+}  // namespace
+
+void checkPropsAndGroups(const RDMol &mol) {
+  // Check mol props
+  float resf;
+  unsigned int resu;
+  CHECK(mol.getMolPropIfPresent(floatToken, resf));
+  CHECK(resf == 2.0f);
+
+  const int *resi = mol.getAtomPropArrayIfPresent<int>(signedIntToken);
+  REQUIRE(resi != nullptr);
+  CHECK(resi[1] == 3);
+
+  CHECK(mol.getBondPropIfPresent(unsignedIntToken, 1, resu));
+  CHECK(resu == 4u);
+
+  const auto *stereoGroups = mol.getStereoGroups();
+  REQUIRE(stereoGroups != nullptr);
+  CHECK(stereoGroups->getGroupType(0) == StereoGroupType::STEREO_ABSOLUTE);
+  const auto &[begAtom, endAtom] = stereoGroups->getAtoms(0);
+  CHECK(*begAtom == 1);
+  CHECK(*(begAtom + 1) == 2);
+
+  const auto &substanceGroups = mol.getSubstanceGroups();
+  REQUIRE(substanceGroups.size() == 1);
+  CHECK(substanceGroups[0].getProp<std::string>("TYPE") == "TEST");
+  CHECK(&substanceGroups[0].getOwningMol() == &mol.asROMol());
+}
+
+void checkConformers(const RDMol &mol) {
+  REQUIRE(mol.getNumConformers() == 2);
+
+  const auto *conf1 = mol.getConformerPositions(0);
+  const auto *conf2 = mol.getConformerPositions(5);
+
+  REQUIRE(conf1 != nullptr);
+  REQUIRE(conf2 != nullptr);
+
+  for (int i = 0; i < 12; ++i) {
+    CHECK(conf1[i] == 1.0);
+    CHECK(conf2[i] == 2.0);
+  }
+
+  CHECK(mol.is3DConformer(0));
+  CHECK(!mol.is3DConformer(5));
+}
+
+TEST_CASE("RDMol Constructors") {
+  auto molPtr = basicMol();
+  RDMol &mol = *molPtr;
+  mol.setAtomBookmark(1, 0);
+
+  AtomData &atom1 = mol.getAtom(1);
+  atom1.setAtomicNum(4);
+
+  mol.setMolProp(floatToken, 2.0f);
+  mol.addAtomProp(signedIntToken, 3);
+  mol.setSingleBondProp(unsignedIntToken, 1, 4u);
+
+  // Substance groups
+  std::vector<SubstanceGroup> &sgs = mol.getSubstanceGroups();
+  sgs.emplace_back(&mol.asROMol(), "TEST");
+
+  // Stereo groups
+  auto stereoGroups = std::make_unique<StereoGroups>();
+  stereoGroups->addGroup(StereoGroupType::STEREO_ABSOLUTE, {1, 2}, {1});
+  mol.setStereoGroups(std::move(stereoGroups));
+
+  // Conformers
+  auto [conf1Id, conf1Pos] = mol.addConformer();
+  std::fill(conf1Pos, conf1Pos + 12, 1.0);
+  auto [conf2Id, conf2Pos] = mol.addConformer(5, false);
+  std::fill(conf2Pos, conf2Pos + 12, 2.0);
+
+  SECTION("Default") {
+    RDMol mol2;
+    CHECK(mol2.getNumAtoms() == 0);
+    CHECK(mol2.getNumBonds() == 0);
+  }
+
+  SECTION("Copy constructor, no params") {
+    RDMol mol2(mol);
+    CHECK(mol2.getNumAtoms() == 4);
+    CHECK(mol2.getNumBonds() == 3);
+
+    CHECK(mol2.hasAtomBookmark(0));
+    mol.clearAllAtomBookmarks();
+    CHECK(mol2.hasAtomBookmark(0));
+
+    AtomData &mol2Atom1 = mol2.getAtom(1);
+    // First check that the set before copy propagated.
+    CHECK(mol2Atom1.getAtomicNum() == 4);
+    atom1.setAtomicNum(8);
+    // Now check that the copies aren't linked.
+    CHECK(mol2Atom1.getAtomicNum() == 4);
+
+    checkPropsAndGroups(mol2);
+    checkConformers(mol2);
+  }
+
+  SECTION("Copy constructor, quick") {
+    RDMol mol2(mol, true);
+    CHECK(mol2.getNumAtoms() == 4);
+    CHECK(mol2.getNumBonds() == 3);
+
+    // Bookmarks and properties should not have been copied.
+    CHECK(!mol2.hasAtomBookmark(0));
+    CHECK(!mol2.hasProp(floatToken));
+    CHECK(mol2.getAtomPropArrayIfPresent<int>(signedIntToken) == nullptr);
+  }
+
+  SECTION("Copy constructor, not quick with ID") {
+    RDMol mol2(mol, false, 5);
+    CHECK(mol2.getNumAtoms() == 4);
+    CHECK(mol2.getNumBonds() == 3);
+
+    CHECK(mol2.getNumConformers() == 1);
+    const double* confPos = mol2.getConformerPositions(5);
+    REQUIRE(confPos != nullptr);
+    CHECK(confPos[0] == 2.0);
+    CHECK(confPos[11] == 2.0);
+  }
+
+  SECTION("copy constructor, not quick with non-existent ID") {
+    RDMol mol2(mol, false, 6);
+    CHECK(mol2.getNumAtoms() == 4);
+    CHECK(mol2.getNumBonds() == 3);
+
+    CHECK(mol2.getNumConformers() == 0);
+  }
+
+  SECTION("Copy assignment operator") {
+    RDMol mol2;
+    mol2 = mol;
+    CHECK(mol2.getNumAtoms() == 4);
+    CHECK(mol2.getNumBonds() == 3);
+
+    CHECK(mol2.hasAtomBookmark(0));
+    mol.clearAllAtomBookmarks();
+    CHECK(mol2.hasAtomBookmark(0));
+
+    AtomData &mol2Atom1 = mol2.getAtom(1);
+    // First check that the set before copy propagated.
+    CHECK(mol2Atom1.getAtomicNum() == 4);
+    atom1.setAtomicNum(8);
+    // Now check that the copies aren't linked.
+    CHECK(mol2Atom1.getAtomicNum() == 4);
+
+    checkPropsAndGroups(mol2);
+    checkConformers(mol2);
+  }
+
+  SECTION("Move constructor") {
+    RDMol mol2(std::move(mol));
+
+    CHECK(mol2.getNumAtoms() == 4);
+    CHECK(mol2.getNumBonds() == 3);
+    CHECK(mol2.hasAtomBookmark(0));
+
+    AtomData &mol2Atom = mol2.getAtom(1);
+    CHECK(mol2Atom.getAtomicNum() == 4);
+
+    checkPropsAndGroups(mol2);
+    checkConformers(mol2);
+  }
+
+  SECTION("Move assignment operator") {
+    RDMol mol2;
+    mol2 = std::move(mol);
+
+    CHECK(mol2.getNumAtoms() == 4);
+    CHECK(mol2.getNumBonds() == 3);
+    CHECK(mol2.hasAtomBookmark(0));
+
+    AtomData &mol2Atom = mol2.getAtom(1);
+    CHECK(mol2Atom.getAtomicNum() == 4);
+
+    checkPropsAndGroups(mol2);
+    checkConformers(mol2);
+  }
+
+  SECTION("Copy constructor with compat data copies back") {
+    auto& romol = mol.asROMol();
+    romol.setAtomBookmark(romol.getAtomWithIdx(1), 5);
+    romol.setBondBookmark(romol.getBondWithIdx(2), 6);
+    romol.getBondWithIdx(2)->setStereoAtoms(1, 2);
+
+    RDMol mol2(mol);
+
+    CHECK(mol2.getAtomWithBookmark(0) == 1);
+    CHECK(mol2.getAtomWithBookmark(5) == 1);
+    CHECK(mol2.getBondWithBookmark(6) == 2);
+
+    const auto* stereoAtoms = mol2.getBondStereoAtoms(2);
+    REQUIRE(stereoAtoms != nullptr);
+    CHECK(stereoAtoms[0] == 1);
+    CHECK(stereoAtoms[1] == 2);
+  }
+}
+
+TEST_CASE("RDMol Bookmarks") {
+  RDMol mol;
+  RDKit::SmilesParseTemp temp;
+  static const char *basicSmiles = "CCCC";
+
+  SmilesParserParams params;
+  params.sanitize = false;
+  params.removeHs = false;
+
+  REQUIRE(RDKit::SmilesToMol(basicSmiles, params, mol, temp) == true);
+  REQUIRE(mol.getNumAtoms() == 4);
+  REQUIRE(mol.getNumBonds() == 3);
+
+  SECTION("Basic bookmarking") {
+    mol.setAtomBookmark(1, 0);
+    mol.setAtomBookmark(3, -6);
+    mol.setBondBookmark(1, 0);
+
+    CHECK(mol.getAtomWithBookmark(0) == 1);
+    CHECK(mol.getAtomWithBookmark(-6) == 3);
+    CHECK(mol.getBondWithBookmark(0) == 1);
+  }
+
+  SECTION("Multiple atoms in bookmark") {
+    mol.setAtomBookmark(1, 0);
+    mol.setAtomBookmark(2, 0);
+    mol.setAtomBookmark(3, 0);
+
+    CHECK(mol.getAtomWithBookmark(0) == 1);
+
+    std::vector<int> res = mol.getAllAtomsWithBookmarks(0);
+    std::vector<int> want = {1, 2, 3};
+    CHECK(res == want);
+  }
+
+  SECTION("Multiple bonds in bookmark") {
+    mol.setBondBookmark(3, 0);
+    mol.setBondBookmark(2, 0);
+    mol.setBondBookmark(1, 0);
+
+    CHECK(mol.getBondWithBookmark(0) == 3);
+
+    std::vector<int> res = mol.getAllBondsWithBookmarks(0);
+    std::vector<int> want = {3, 2, 1};
+    CHECK(res == want);
+  }
+
+  SECTION("Replace atom bookmarks") {
+    mol.setAtomBookmark(3, 1);
+    mol.setAtomBookmark(0, 0);
+    mol.setAtomBookmark(2, 0);
+
+    mol.replaceAtomBookmark(1, 0);
+
+    CHECK(mol.getAtomWithBookmark(0) == 1);
+
+    std::vector<int> res = mol.getAllAtomsWithBookmarks(0);
+    std::vector<int> want = {1};
+    CHECK(res == want);
+  }
+
+  SECTION("Multiple bookmarks same atom is fine") {
+    mol.setAtomBookmark(1, 0);
+    mol.setAtomBookmark(1, 1);
+    mol.setAtomBookmark(1, 2);
+
+    CHECK(mol.getAtomWithBookmark(0) == 1);
+    CHECK(mol.getAtomWithBookmark(1) == 1);
+    CHECK(mol.getAtomWithBookmark(2) == 1);
+
+    std::vector<int> res = mol.getAllAtomsWithBookmarks(0);
+    std::vector<int> want = {1};
+    CHECK(res == want);
+  }
+
+  SECTION("Missing bookmark throws") {
+    mol.setAtomBookmark(1, 1);
+    mol.setBondBookmark(1, 2);
+
+    CHECK_THROWS_AS(mol.getAtomWithBookmark(0), Invar::Invariant);
+    CHECK_THROWS_AS(mol.getBondWithBookmark(0), Invar::Invariant);
+
+    CHECK_THROWS_AS(mol.getAllAtomsWithBookmarks(0), Invar::Invariant);
+    CHECK_THROWS_AS(mol.getAllBondsWithBookmarks(0), Invar::Invariant);
+  }
+
+  SECTION("Clear atom bookmarks") {
+    mol.setAtomBookmark(1, 0);
+    mol.setAtomBookmark(1, 1);
+    mol.setAtomBookmark(1, 2);
+
+    mol.clearAtomBookmark(0);
+    CHECK_THROWS_AS(mol.getAtomWithBookmark(0), Invar::Invariant);
+    CHECK(mol.getAtomWithBookmark(1) == 1);
+    CHECK(mol.getAtomWithBookmark(2) == 1);
+
+    mol.clearAllAtomBookmarks();
+    CHECK_THROWS_AS(mol.getAtomWithBookmark(0), Invar::Invariant);
+    CHECK_THROWS_AS(mol.getAtomWithBookmark(1), Invar::Invariant);
+    CHECK_THROWS_AS(mol.getAtomWithBookmark(2), Invar::Invariant);
+  }
+
+  SECTION("Clear bond bookmarks") {
+    mol.setBondBookmark(1, 0);
+    mol.setBondBookmark(1, 1);
+    mol.setBondBookmark(1, 2);
+
+    mol.clearBondBookmark(0);
+    CHECK_THROWS_AS(mol.getBondWithBookmark(0), Invar::Invariant);
+    CHECK(mol.getBondWithBookmark(1) == 1);
+    CHECK(mol.getBondWithBookmark(2) == 1);
+
+    mol.clearAllBondBookmarks();
+    CHECK_THROWS_AS(mol.getBondWithBookmark(0), Invar::Invariant);
+    CHECK_THROWS_AS(mol.getBondWithBookmark(1), Invar::Invariant);
+    CHECK_THROWS_AS(mol.getBondWithBookmark(2), Invar::Invariant);
+  }
+
+  SECTION("Clear individual atom idx bookmark") {
+    mol.setAtomBookmark(0, 1);
+    mol.setAtomBookmark(1, 1);
+    mol.setAtomBookmark(2, 1);
+
+    mol.clearAtomBookmark(1, 1);
+    std::vector<int> res = mol.getAllAtomsWithBookmarks(1);
+    std::vector<int> want = {0, 2};
+    CHECK(res == want);
+  }
+
+  SECTION("Clear individual bond idx bookmark") {
+    mol.setBondBookmark(0, 1);
+    mol.setBondBookmark(1, 1);
+    mol.setBondBookmark(2, 1);
+
+    mol.clearBondBookmark(1, 1);
+    std::vector<int> res = mol.getAllBondsWithBookmarks(1);
+    std::vector<int> want = {0, 2};
+    CHECK(res == want);
+  }
+
+  SECTION("Has bookmark") {
+    mol.setAtomBookmark(1, 0);
+    mol.setAtomBookmark(1, 1);
+    mol.setAtomBookmark(1, 2);
+
+    CHECK(mol.hasAtomBookmark(0));
+    CHECK(mol.hasAtomBookmark(1));
+    CHECK(mol.hasAtomBookmark(2));
+    CHECK(!mol.hasAtomBookmark(3));
+
+    mol.setBondBookmark(1, 0);
+    mol.setBondBookmark(1, 1);
+    mol.setBondBookmark(1, 2);
+
+    CHECK(mol.hasBondBookmark(0));
+    CHECK(mol.hasBondBookmark(1));
+    CHECK(mol.hasBondBookmark(2));
+    CHECK(!mol.hasBondBookmark(3));
+
+    mol.clearAtomBookmark(0);
+    CHECK(!mol.hasAtomBookmark(0));
+  }
+}
+
+TEST_CASE("RDMol Mol properties") {
+  RDMol mol;
+
+  SECTION("Self basic properties") {
+    mol.addMolProp(signedIntToken, 3);
+    mol.addMolProp(unsignedIntToken, 3u);
+    mol.addMolProp(floatToken, 3.0f);
+
+    int res;
+    REQUIRE(mol.getMolPropIfPresent<int>(signedIntToken, res));
+    CHECK(res == 3);
+
+    REQUIRE(!mol.getMolPropIfPresent<int>(unusedToken, res));
+  }
+
+  SECTION("Prop handle updates in place") {
+    mol.addMolProp(signedIntToken, 3);
+    int res;
+    REQUIRE(mol.getMolPropIfPresent<int>(signedIntToken, res));
+    REQUIRE(res == 3);
+
+    mol.setMolProp(signedIntToken, 4);
+    REQUIRE(mol.getMolPropIfPresent<int>(signedIntToken, res));
+    CHECK(res == 4);
+  }
+
+  SECTION("Clear Mol Props") {
+    mol.addMolProp(floatToken, 3.0f);
+    mol.addMolProp(unsignedIntToken, 3u);
+
+    mol.clearMolPropIfPresent(unsignedIntToken);
+    mol.clearMolPropIfPresent(floatToken);
+
+    float resf;
+    unsigned int resu;
+    CHECK(!mol.getMolPropIfPresent<unsigned int>(unsignedIntToken, resu));
+    CHECK(!mol.getMolPropIfPresent<float>(floatToken, resf));
+  }
+
+  SECTION("Computed props and clear") {
+    mol.addMolProp(floatToken, 3.0f, true);
+    mol.addMolProp(unsignedIntToken, 3u);
+
+    mol.clearComputedProps();
+    float resf;
+    unsigned int resu;
+    CHECK(mol.getMolPropIfPresent<unsigned int>(unsignedIntToken, resu));
+    CHECK(!mol.getMolPropIfPresent<float>(floatToken, resf));
+  }
+
+  SECTION("Mol prop nonstandard data - nonPOD") {
+    mol.addMolProp(signedIntToken,
+                   boost::shared_array<int>(new int[3]{1, 2, 3}));
+
+    boost::shared_array<int> res;
+    REQUIRE(mol.getMolPropIfPresent(signedIntToken, res));
+
+    CHECK(res[1] == 2);
+  }
+
+  SECTION("String to int conversion") {
+    mol.addMolProp(signedIntToken, std::string("3"));
+    int res;
+    REQUIRE(mol.getMolPropIfPresent<int>(signedIntToken, res));
+    CHECK(res == 3);
+  }
+
+  SECTION("char to int conversion") {
+    mol.addMolProp(signedIntToken, "30");
+    int res;
+    REQUIRE(mol.getMolPropIfPresent<int>(signedIntToken, res));
+    CHECK(res == 30);
+  }
+}
+
+TEST_CASE("RDMol Atom/bond properties") {
+  RDMol mol;
+  RDKit::SmilesParseTemp temp;
+  static const char *basicSmiles = "CCCC";
+
+  SmilesParserParams params;
+  params.sanitize = false;
+  params.removeHs = false;
+
+  REQUIRE(RDKit::SmilesToMol(basicSmiles, params, mol, temp) == true);
+  REQUIRE(mol.getNumAtoms() == 4);
+  REQUIRE(mol.getNumBonds() == 3);
+
+  SECTION("Atom properties access and override") {
+    int *atomProps = mol.addAtomProp(signedIntToken, 3);
+    REQUIRE(atomProps != nullptr);
+    CHECK(*atomProps == 3);
+    CHECK(*(atomProps + 3) == 3);
+
+    int *atomProps2 = mol.getAtomPropArrayIfPresent<int>(signedIntToken);
+    CHECK(atomProps == atomProps2);
+    REQUIRE(mol.addAtomProp(signedIntToken, 4));
+    int *atomProps3 = mol.getAtomPropArrayIfPresent<int>(signedIntToken);
+    CHECK(*atomProps3 == 3);
+    CHECK(*(atomProps + 3) == 3);
+  }
+
+  SECTION("Atom single access/set from existing property") {
+    REQUIRE(mol.addAtomProp(signedIntToken, 3) != nullptr);
+    mol.setSingleAtomProp(signedIntToken, 1, 4);
+    int res1, res2;
+    REQUIRE(mol.getAtomPropIfPresent<int>(signedIntToken, 0, res1));
+    REQUIRE(mol.getAtomPropIfPresent<int>(signedIntToken, 1, res2));
+    CHECK(res1 == 3);
+    CHECK(res2 == 4);
+    CHECK(!mol.getAtomPropIfPresent<int>(unusedToken, 2, res1));
+  }
+
+  SECTION("Atom single access/set new property") {
+    mol.setSingleAtomProp<int>(signedIntToken, 1, 4);
+    // Not present, the above should only set the second atom present bit.
+    int res1, res2;
+    REQUIRE(!mol.getAtomPropIfPresent<int>(signedIntToken, 0, res1));
+    REQUIRE(mol.getAtomPropIfPresent<int>(signedIntToken, 1, res2));
+    CHECK(res2 == 4);
+  }
+
+  SECTION("Atom array props basic") {
+    const std::vector<int> defaultVals = {1, 2, 3};
+    mol.addAtomProp<std::vector<int>>(signedIntToken, defaultVals);
+
+    std::vector<int> res;
+    REQUIRE(mol.getAtomPropIfPresent<std::vector<int>>(signedIntToken, 1, res));
+    REQUIRE(mol.getAtomPropArrayIfPresent<int>(unsignedIntToken) == nullptr);
+
+    CHECK(res == defaultVals);
+  }
+
+  SECTION("Atom prop remove all atoms") {
+    mol.setSingleAtomProp(signedIntToken, 1, 7);
+    mol.setSingleAtomProp(signedIntToken, 2, 11);
+    int *prop = mol.getAtomPropArrayIfPresent<int>(signedIntToken);
+    REQUIRE(prop != nullptr);
+    CHECK(prop[1] == 7);
+    CHECK(prop[2] == 11);
+
+    mol.clearSingleAtomProp(signedIntToken, 1);
+    mol.clearSingleAtomProp(signedIntToken, 2);
+
+    prop = mol.getAtomPropArrayIfPresent<int>(signedIntToken);
+    CHECK(prop == nullptr);
+  }
+
+  SECTION("Bond properties access and override") {
+    int *BondProps = mol.addBondProp(signedIntToken, 3);
+    REQUIRE(BondProps != nullptr);
+    CHECK(*BondProps == 3);
+    CHECK(*(BondProps + 1) == 3);
+
+    int *BondProps2 = mol.getBondPropArrayIfPresent<int>(signedIntToken);
+    CHECK(BondProps == BondProps2);
+    REQUIRE(mol.addBondProp(signedIntToken, 4));
+    int *BondProps3 = mol.getBondPropArrayIfPresent<int>(signedIntToken);
+    CHECK(*BondProps3 == 3);
+    CHECK(*(BondProps + 1) == 3);
+  }
+
+  SECTION("Bond single access/set from existing property") {
+    REQUIRE(mol.addBondProp(signedIntToken, 3) != nullptr);
+    mol.setSingleBondProp(signedIntToken, 1, 4);
+    int res1, res2;
+    REQUIRE(mol.getBondPropIfPresent<int>(signedIntToken, 0, res1));
+    REQUIRE(mol.getBondPropIfPresent<int>(signedIntToken, 1, res2));
+    CHECK(res1 == 3);
+    CHECK(res2 == 4);
+    CHECK(!mol.getBondPropIfPresent<int>(unusedToken, 2, res1));
+  }
+
+  SECTION("Bond single access/set new property") {
+    mol.setSingleBondProp<int>(signedIntToken, 1, 4);
+    // Not present, the above should only set the second Bond present bit.
+    int res1, res2;
+    REQUIRE(!mol.getBondPropIfPresent<int>(signedIntToken, 0, res1));
+    REQUIRE(mol.getBondPropIfPresent<int>(signedIntToken, 1, res2));
+    CHECK(res2 == 4);
+  }
+
+  SECTION("Bond array props basic") {
+    const std::vector<int> defaultVals = {1, 2, 3};
+    mol.addBondProp<std::vector<int>>(signedIntToken, defaultVals);
+
+    std::vector<int> res;
+    REQUIRE(mol.getBondPropIfPresent<std::vector<int>>(signedIntToken, 1, res));
+
+    REQUIRE(mol.getBondPropArrayIfPresent<int>(unsignedIntToken) == nullptr);
+    CHECK(res == defaultVals);
+  }
+
+  SECTION("Bond prop remove all bonds") {
+    mol.setSingleBondProp(signedIntToken, 1, 7);
+    mol.setSingleBondProp(signedIntToken, 2, 11);
+    int *prop = mol.getBondPropArrayIfPresent<int>(signedIntToken);
+    REQUIRE(prop != nullptr);
+    CHECK(prop[1] == 7);
+    CHECK(prop[2] == 11);
+
+    mol.clearSingleBondProp(signedIntToken, 1);
+    mol.clearSingleBondProp(signedIntToken, 2);
+
+    prop = mol.getBondPropArrayIfPresent<int>(signedIntToken);
+    CHECK(prop == nullptr);
+  }
+
+  SECTION("Get array prop of different type returns null") {
+    mol.setSingleAtomProp<int>(signedIntToken, 1, 4);
+    mol.setSingleBondProp<int>(signedIntToken, 1, 4);
+    REQUIRE(mol.getBondPropArrayIfPresent<float>(signedIntToken) == nullptr);
+    REQUIRE(mol.getAtomPropArrayIfPresent<float>(signedIntToken) == nullptr);
+  }
+
+  SECTION("Atom/bond/mol do not clash") {
+    mol.addMolProp(floatToken, 3.0f);
+    mol.addAtomProp(floatToken, 4.0f);
+    mol.addBondProp(floatToken, 5.0f);
+
+    float molRes, AtomRes, bondRes;
+
+    REQUIRE(mol.getMolPropIfPresent<float>(floatToken, molRes));
+    REQUIRE(mol.getAtomPropIfPresent<float>(floatToken, 0, AtomRes));
+    REQUIRE(mol.getBondPropIfPresent<float>(floatToken, 0, bondRes));
+
+    CHECK(molRes == 3.0f);
+    CHECK(AtomRes == 4.0f);
+    CHECK(bondRes == 5.0f);
+  }
+
+
+  SECTION("Overrides existing prop of different type") {
+    mol.addBondProp(floatToken, 3.0f);
+    mol.addAtomProp(floatToken, 4.0f);
+
+    mol.addBondProp(floatToken, 6u);
+    mol.addAtomProp(floatToken, 6u);
+
+    unsigned int atomRes, bondRes;
+    REQUIRE(mol.getAtomPropIfPresent<unsigned int>(floatToken, 0, atomRes));
+    REQUIRE(mol.getBondPropIfPresent<unsigned int>(floatToken, 0, bondRes));
+    CHECK(atomRes == 6u);
+    CHECK(bondRes == 6u);
+  }
+
+  SECTION("Clear Full properties") {
+    REQUIRE(mol.addAtomProp(floatToken, 3.0f) != nullptr);
+    REQUIRE(mol.addAtomProp(signedIntToken, 5) != nullptr);
+    REQUIRE(mol.addBondProp(floatToken, 3.0f) != nullptr);
+
+    mol.clearAtomPropIfPresent(floatToken);
+    mol.clearBondPropIfPresent(floatToken);
+    CHECK(!mol.getAtomPropArrayIfPresent<float>(floatToken));
+    CHECK(!mol.getBondPropArrayIfPresent<int>(floatToken));
+
+    int *res = mol.getAtomPropArrayIfPresent<int>(signedIntToken);
+    REQUIRE(res != nullptr);
+    CHECK(*res == 5);
+  }
+
+  SECTION("Clear atom properties") {
+    REQUIRE(mol.addAtomProp(floatToken, 3.0f) != nullptr);
+    mol.clearSingleAtomProp(floatToken, 1);
+    float res;
+    CHECK(mol.getAtomPropIfPresent<float>(floatToken, 0, res));
+    CHECK(!mol.getAtomPropIfPresent<float>(floatToken, 1, res));
+    CHECK(mol.getAtomPropIfPresent<float>(floatToken, 2, res));
+  }
+
+  SECTION("Clear bond properties") {
+    REQUIRE(mol.addBondProp(floatToken, 3.0f) != nullptr);
+    mol.clearSingleBondProp(floatToken, 1);
+    float res;
+    CHECK(mol.getBondPropIfPresent<float>(floatToken, 0, res));
+    CHECK(!mol.getBondPropIfPresent<float>(floatToken, 1, res));
+    CHECK(mol.getBondPropIfPresent<float>(floatToken, 2, res));
+  }
+
+  SECTION("Non scalar types non array accessible") {
+    REQUIRE(mol.addAtomProp<std::vector<int>>(signedIntToken, {1, 2, 3}) ==
+            nullptr);
+    std::vector<int> res;
+    CHECK(mol.getAtomPropIfPresent<std::vector<int>>(signedIntToken, 0, res));
+    CHECK(res == std::vector<int>{1, 2, 3});
+    CHECK(mol.getAtomPropArrayIfPresent<std::vector<int>>(signedIntToken) ==
+          nullptr);
+  }
+
+  SECTION("Request scalar from nonscalar fails") {
+    REQUIRE(mol.addAtomProp<std::vector<int>>(signedIntToken, {1, 2, 3}) ==
+            nullptr);
+    int res;
+    CHECK_THROWS_AS(mol.getAtomPropIfPresent<int>(signedIntToken, 0, res),
+                    std::bad_any_cast);
+  }
+
+  SECTION("Request non-scalar from scalar fails") {
+    REQUIRE(mol.addAtomProp(signedIntToken, 3) != nullptr);
+    std::vector<int> res;
+    CHECK_THROWS_AS(
+        mol.getAtomPropIfPresent<std::vector<int>>(signedIntToken, 0, res),
+        std::bad_any_cast);
+  }
+}
+
+static  PropToken testToken("test");
+
+template<typename initT, typename resT> void checkCast(RDMol& mol) {
+  std::string message = "Testing with type: " + std::string(typeid(initT).name()) + "->" + std::string(typeid(resT).name());
+  INFO(message);
+
+  // Check basic positive, negative, and overflow values
+  constexpr std::array<int64_t, 3> testVals = {5, -10, int64_t (std::numeric_limits<int>::max()) + 1};
+  for (auto& testVal: testVals) {
+    auto typedVal = initT(testVal);
+    mol.clearAtomPropIfPresent(testToken);
+    mol.addAtomProp<initT>(testToken, typedVal);
+    RDValue caster = typedVal;
+    resT wantVal;
+    bool expectThrowAnyCast = false;
+    bool expectThrowBoostNumeric = false;
+    try {
+      wantVal = rdvalue_cast<resT>(caster);
+    } catch (std::bad_any_cast &e) {
+      expectThrowAnyCast = true;
+    } catch (boost::bad_numeric_cast &e) {
+      expectThrowBoostNumeric = true;
+    }
+
+    if (expectThrowAnyCast) {
+      CHECK_THROWS_AS(mol.getAtomPropIfPresent<resT>(testToken, 0, wantVal),
+                      std::bad_any_cast);
+    } else if (expectThrowBoostNumeric) {
+      CHECK_THROWS_AS(mol.getAtomPropIfPresent<resT>(testToken, 0, wantVal),
+                      boost::bad_numeric_cast);
+    } else {
+      resT gotVal;
+      REQUIRE(mol.getAtomPropIfPresent<resT>(testToken, 0, gotVal));
+      CHECK(gotVal == wantVal);
+    }
+    RDValue::cleanup_rdvalue(caster);
+  }
+}
+
+TEMPLATE_TEST_CASE("Property default type conversions", "",
+                   bool, char, int16_t, int, unsigned int, int64_t, uint64_t, float,
+                   double) {
+  RDMol mol;
+  RDKit::SmilesParseTemp temp;
+  static const char *basicSmiles = "CCCC";
+
+  SmilesParserParams params;
+  params.sanitize = false;
+  params.removeHs = false;
+
+  REQUIRE(RDKit::SmilesToMol(basicSmiles, params, mol, temp) == true);
+  REQUIRE(mol.getNumAtoms() == 4);
+  REQUIRE(mol.getNumBonds() == 3);
+  SECTION("Cast to char") {
+    checkCast<TestType, char>(mol);
+  }
+  SECTION("Cast to bool") {
+    checkCast<TestType, bool>(mol);
+  }
+  SECTION("Cast to int16") {
+    checkCast<TestType, int16_t>(mol);
+  }
+  SECTION("Cast to int") {
+    checkCast<TestType, int>(mol);
+  }
+  SECTION("Cast to unsigned int") {
+    checkCast<TestType, unsigned int>(mol);
+  }
+  SECTION("Cast to int64_t") {
+    checkCast<TestType, int64_t>(mol);
+  }
+  SECTION("Cast to uint64_t") {
+    checkCast<TestType, uint64_t>(mol);
+  }
+  SECTION("Cast to float") {
+    checkCast<TestType, float>(mol);
+  }
+  SECTION("Cast to double") {
+    checkCast<TestType, double>(mol);
+  }
+}
+
+TEST_CASE("Bond stereo atoms") {
+  auto molPtr = basicMol();
+  RDMol &mol = *molPtr;
+
+  SECTION("Basic set") {
+    mol.setBondStereoAtoms(1, 1, 2);
+    const auto *stereoAtoms = mol.getBondStereoAtoms(1);
+    REQUIRE(stereoAtoms != nullptr);
+    CHECK(stereoAtoms[0] == 1);
+    CHECK(stereoAtoms[1] == 2);
+    CHECK(mol.hasBondStereoAtoms(1));
+
+    CHECK(!mol.hasBondStereoAtoms(2));
+    auto* stereoAtoms2 = mol.getBondStereoAtoms(2);
+    CHECK(stereoAtoms2 != nullptr);
+    CHECK(stereoAtoms2[0] == atomindex_t(-1));
+  }
+
+  SECTION("Clear") {
+    mol.setBondStereoAtoms(1, 1, 2);
+    CHECK(mol.hasBondStereoAtoms(1));
+    mol.clearBondStereoAtoms(1);
+    const auto *stereoAtoms = mol.getBondStereoAtoms(1);
+    CHECK(stereoAtoms != nullptr);
+    CHECK(stereoAtoms[0] == atomindex_t(-1));
+    CHECK(!mol.hasBondStereoAtoms(1));
+  }
+
+  SECTION("Get, populated from ROMol API") {
+    ROMol& romol = mol.asROMol();
+    romol.getBondWithIdx(1)->setStereoAtoms(0, 3);
+    const auto *stereoAtoms = mol.getBondStereoAtoms(1);
+    REQUIRE(stereoAtoms != nullptr);
+    CHECK(stereoAtoms[0] == 0);
+    CHECK(stereoAtoms[1] == 3);
+    CHECK(mol.hasBondStereoAtoms(1));
+
+    CHECK(!mol.hasBondStereoAtoms(2));
+    auto* stereoAtoms2 = mol.getBondStereoAtoms(2);
+    CHECK(stereoAtoms2 != nullptr);
+    CHECK(stereoAtoms2[0] == atomindex_t(-1));
+  }
+}
+
+
+TEST_CASE("RDMol add atom") {
+  RDMol mol;
+  RDKit::SmilesParseTemp temp;
+  static const char* basicSmiles = "CNPO";
+  SmilesParserParams params;
+  params.sanitize = false;
+  params.removeHs = false;
+
+  REQUIRE(RDKit::SmilesToMol(basicSmiles, params, mol, temp) == true);
+  REQUIRE(mol.getNumAtoms() == 4);
+  REQUIRE(mol.getNumBonds() == 3);
+
+  mol.setSingleAtomProp(signedIntToken, 1, 3);
+  mol.setSingleBondProp(signedIntToken, 1, 4); // Checking filter out of non-atom props
+  REQUIRE(mol.hasAtomProp(signedIntToken, 1));
+
+  std::vector<double> conf1(3 * mol.getNumAtoms(), 1.0);
+  std::vector<double> conf2(3 * mol.getNumAtoms(), 2.0);
+  mol.addConformer(conf1.data());
+  mol.addConformer(conf2.data());
+
+  AtomData& newAtom = mol.addAtom();
+  SECTION("Default values and set") {
+    CHECK(mol.getNumAtoms() == 5);
+    CHECK(mol.getNumBonds() == 3);
+    CHECK(newAtom.getAtomicNum() == 0);
+    newAtom.setAtomicNum(6);
+
+    AtomData& secondHandle = mol.getAtom(4);
+    CHECK(secondHandle.getAtomicNum() == 6);
+
+    const double* confPos = mol.getConformerPositions(0);
+    REQUIRE(confPos != nullptr);
+    const double* confPos2 = mol.getConformerPositions(1);
+    REQUIRE(confPos2 != nullptr);
+    for (size_t i = 0; i < 12; i++) {
+      CHECK(confPos[i] == 1.0);
+      CHECK(confPos2[i] == 2.0);
+    }
+    for (size_t i = 12; i < 15; i++) {
+      CHECK(confPos[12] == 0.0);
+      CHECK(confPos2[12] == 0.0);
+    }
+  }
+
+  SECTION("Properties") {
+    // Check that previous properties were not displaced
+    CHECK(mol.hasAtomProp(signedIntToken, 1));
+    CHECK(!mol.hasAtomProp(signedIntToken, 2));
+    mol.setSingleAtomProp(signedIntToken, 4, 5);
+    CHECK(mol.hasAtomProp(signedIntToken, 4));
+  }
+
+}
+
+std::vector<uint32_t> iteratorToIndexVector(const std::pair<const uint32_t*, const uint32_t*>& iter) {
+  std::vector<uint32_t> res;
+  for (const uint32_t* idx = iter.first; idx != iter.second; idx++) {
+    res.push_back(*idx);
+  }
+  return res;
+}
+
+TEST_CASE("Add Bond") {
+  auto molPtr = basicMol();
+  RDMol& mol = *molPtr;
+
+  SECTION("Bond to self throws") {
+    CHECK_THROWS_AS(mol.addBond(1, 1, BondEnums::BondType::SINGLE), Invar::Invariant);
+  }
+
+  SECTION("Bond to out of bounds throws") {
+    CHECK_THROWS_AS(mol.addBond(1, 5, BondEnums::BondType::SINGLE), Invar::Invariant);
+  }
+
+  SECTION("Basic set") {
+    BondData& newBond =  mol.addBond(1, 3, BondEnums::BondType::DOUBLE);
+    CHECK(mol.getNumBonds() == 4);
+    CHECK(!newBond.getIsAromatic());
+    CHECK(newBond.getBondType() == BondEnums::BondType::DOUBLE);
+    newBond.setBondDir(BondEnums::BondDir::ENDUPRIGHT);
+
+    BondData& sameBondNewRef = mol.getBond(3);
+    CHECK(newBond.getBondDir() == BondEnums::BondDir::ENDUPRIGHT);
+  }
+
+  SECTION("Iterate over bond atoms") {
+    BondData& newBond =  mol.addBond(1, 3, BondEnums::BondType::DOUBLE);
+    AtomData& atom1 = mol.getAtom(1);
+    AtomData& atom3 = mol.getAtom(3);
+
+    auto atom1BondIterator = mol.getAtomBonds(1);
+    auto atom2BondIterator = mol.getAtomBonds(2);
+    auto atom3BondIterator = mol.getAtomBonds(3);
+
+    std::vector<uint32_t> atom1BondIdxs = iteratorToIndexVector(atom1BondIterator);
+    std::vector<uint32_t> atom2BondIdxs = iteratorToIndexVector(atom2BondIterator);
+    std::vector<uint32_t> atom3BondIdxs = iteratorToIndexVector(atom3BondIterator);
+
+    CHECK_THAT(atom1BondIdxs, Catch::Matchers::UnorderedEquals(std::vector<uint32_t>{0, 1, 3}));
+    CHECK_THAT(atom2BondIdxs, Catch::Matchers::UnorderedEquals(std::vector<uint32_t>{1, 2}));
+    CHECK_THAT(atom3BondIdxs, Catch::Matchers::UnorderedEquals(std::vector<uint32_t>{2, 3}));
+
+    auto neighbors1 = mol.getAtomNeighbors(1);
+    auto neighbors2 = mol.getAtomNeighbors(2);
+    auto neighbors3 = mol.getAtomNeighbors(3);
+
+    std::vector<uint32_t> neighbors1Idxs = iteratorToIndexVector(neighbors1);
+    std::vector<uint32_t> neighbors2Idxs = iteratorToIndexVector(neighbors2);
+    std::vector<uint32_t> neighbors3Idxs = iteratorToIndexVector(neighbors3);
+
+    CHECK_THAT(neighbors1Idxs, Catch::Matchers::UnorderedEquals(std::vector<uint32_t>{0, 2, 3}));
+    CHECK_THAT(neighbors2Idxs, Catch::Matchers::UnorderedEquals(std::vector<uint32_t>{1, 3}));
+    CHECK_THAT(neighbors3Idxs, Catch::Matchers::UnorderedEquals(std::vector<uint32_t>{1, 2}));
+
+  }
+
+  SECTION("Set reverse order") {
+    BondData& newBond =  mol.addBond(3, 1, BondEnums::BondType::DOUBLE);
+    CHECK(mol.getNumBonds() == 4);
+    CHECK(!newBond.getIsAromatic());
+    CHECK(newBond.getBondType() == BondEnums::BondType::DOUBLE);
+    CHECK(newBond.getBeginAtomIdx() == 3);
+    CHECK(newBond.getEndAtomIdx() == 1);
+  }
+
+  SECTION("Set aromatic") {
+    AtomData& atom1 = mol.getAtom(1);
+    AtomData& atom3 = mol.getAtom(3);
+    CHECK(atom1.getIsAromatic() == false);
+    CHECK(atom3.getIsAromatic() == false);
+    BondData& newBond =  mol.addBond(1, 3, BondEnums::BondType::AROMATIC);
+    CHECK(newBond.getIsAromatic());
+    CHECK(atom1.getIsAromatic());
+    CHECK(atom3.getIsAromatic());
+  }
+
+  SECTION("Set aromatic, noAromaticity") {
+    AtomData& atom1 = mol.getAtom(1);
+    AtomData& atom3 = mol.getAtom(3);
+    CHECK(atom1.getIsAromatic() == false);
+    CHECK(atom3.getIsAromatic() == false);
+    BondData& newBond =  mol.addBond(1, 3, BondEnums::BondType::AROMATIC, false);
+    CHECK(newBond.getIsAromatic());
+    CHECK(!atom1.getIsAromatic());
+    CHECK(!atom3.getIsAromatic());
+  }
+
+  SECTION("Properties") {
+    mol.setSingleAtomProp(signedIntToken, 1, 5); // Checking filtering out of non-bond type props
+    mol.setSingleBondProp(signedIntToken, 1, 3);
+    mol.setSingleBondProp(signedIntToken, 2, 4);
+    mol.setSingleBondProp(complexToken, 0, std::vector<int>({1, 2, 3}));
+
+    CHECK(mol.hasBondProp(signedIntToken, 1));
+    CHECK(mol.hasBondProp(signedIntToken, 2));
+    CHECK(!mol.hasBondProp(signedIntToken, 0));
+
+    BondData& newBond = mol.addBond(1, 3, BondEnums::BondType::DOUBLE);
+    CHECK(!mol.hasBondProp(signedIntToken, 3));
+    CHECK(mol.hasBondProp(signedIntToken, 1));
+    CHECK(mol.hasBondProp(signedIntToken, 2));
+    CHECK(mol.hasBondProp(complexToken, 0));
+    CHECK(!mol.hasBondProp(complexToken, 3));
+
+    mol.setSingleBondProp(signedIntToken, 3, 5);
+    CHECK(mol.hasBondProp(signedIntToken, 3));
+  }
+}
+
+TEST_CASE("Atom valence") {
+  SECTION("Neither implicit nor explicit set") {
+    RDMol mol;
+    mol.addAtom().setAtomicNum(6);
+    CHECK_THROWS_AS(mol.getAtom(0).getExplicitValence(), Invar::Invariant);
+    CHECK(mol.getAtom(0).getImplicitValence() == 255);
+    CHECK(mol.getAtom(0).needsUpdatePropertyCache());
+  }
+
+  SECTION("Explicit valence set") {
+    RDMol mol;
+    mol.addAtom().setAtomicNum(6);
+    mol.calcExplicitValence(0, false);
+    CHECK(mol.getAtom(0).getExplicitValence() == 0);
+    CHECK(mol.getAtom(0).getImplicitValence() == 255);
+
+    // Still needs implicit.
+    CHECK(mol.getAtom(0).needsUpdatePropertyCache());
+  }
+
+  SECTION("No implicit set") {
+    RDMol mol;
+    AtomData& atom = mol.addAtom();
+    atom.setAtomicNum(6);
+    atom.setNoImplicit(true);
+    CHECK(atom.getImplicitValence() == 0);
+
+    // Check that no implicit means no need to update implicit.
+    CHECK(atom.needsUpdatePropertyCache());
+    mol.calcExplicitValence(0, false);
+    CHECK(!atom.needsUpdatePropertyCache());
+  }
+
+  SECTION("Correct after calculation") {
+    auto molPtr = basicMol();
+    RDMol& mol = *molPtr;
+
+    mol.calcImplicitValence(0, false);
+    mol.calcImplicitValence(1, false);
+    mol.calcImplicitValence(2, false);
+    mol.calcImplicitValence(3, false);
+
+    CHECK(!mol.getAtom(0).needsUpdatePropertyCache());
+
+    CHECK(mol.getAtom(0).getExplicitValence() == 1);
+    CHECK(mol.getAtom(1).getExplicitValence() == 2);
+    CHECK(mol.getAtom(2).getExplicitValence() == 3); // Double bond to 3
+    CHECK(mol.getAtom(3).getExplicitValence() == 2);
+
+    CHECK(mol.getAtom(0).getImplicitValence() == 3);
+    CHECK(mol.getAtom(1).getImplicitValence() == 2);
+    CHECK(mol.getAtom(2).getImplicitValence() == 1);
+    CHECK(mol.getAtom(3).getImplicitValence() == 2);
+  }
+}
+
+TEST_CASE("Conformers") {
+  auto molPtr = basicMol();
+  RDMol& mol = *molPtr;
+  const int numDoublesInConf = 3 * mol.getNumAtoms();
+
+  std::vector<double> conf0(numDoublesInConf, 1.0);
+  std::vector<double> conf1(numDoublesInConf, 2.0);
+  std::vector<double> conf2(numDoublesInConf, 3.0);
+
+  SECTION("No conformers") {
+    CHECK(mol.getNumConformers() == 0);
+    CHECK_THROWS_AS(mol.getConformerPositions(), ConformerException);
+    CHECK_THROWS_AS(mol.getConformerPositions(3), ConformerException);
+  }
+
+  SECTION("Access missing conformer") {
+    uint32_t id1 = mol.addConformer(conf1.data());
+    CHECK_THROWS_AS(mol.getConformerPositions(15), ConformerException);
+    CHECK_THROWS_AS(mol.is3DConformer(15), ConformerException);
+  }
+
+  SECTION("Add in order, and get") {
+    uint32_t id1 = mol.addConformer(conf1.data());
+    uint32_t id2 = mol.addConformer(conf0.data());
+    uint32_t id3 = mol.addConformer(conf2.data());
+
+    // Check that reserving is OK
+    mol.allocateConformers(10);
+
+    CHECK(mol.getNumConformers() == 3);
+    CHECK(id1 == 0);
+    CHECK(id2 == 1);
+    CHECK(id3 == 2);
+
+    double* res1 = mol.getConformerPositions(id1);
+    CHECK(res1[0] == 2.0);
+    CHECK(res1[numDoublesInConf - 1] == 2.0);
+    double* res2 = mol.getConformerPositions(id2);
+    CHECK(res2[0] == 1.0);
+    CHECK(res2[numDoublesInConf - 1] == 1.0);
+    double* res3 = mol.getConformerPositions(id3);
+    CHECK(res3[0] == 3.0);
+    CHECK(res3[numDoublesInConf - 1] == 3.0);
+
+    CHECK(mol.is3DConformer(id1));
+    CHECK(mol.is3DConformer(id2));
+    CHECK(mol.is3DConformer(id3));
+  }
+
+  SECTION("Get default conformer") {
+    uint32_t id1 = mol.addConformer(conf1.data());
+    uint32_t id2 = mol.addConformer(conf0.data());
+    double* res1 = mol.getConformerPositions();
+    CHECK(res1[0] == 2.0);
+  }
+
+  SECTION("Add in order, then add one non3D") {
+    uint32_t id1 = mol.addConformer(conf1.data());
+    uint32_t id2 = mol.addConformer(conf0.data());
+    uint32_t id3 = mol.addConformer(conf2.data(), -1 , false);
+
+    CHECK(mol.getNumConformers() == 3);
+    double* res1 = mol.getConformerPositions(id1);
+    CHECK(res1[0] == 2.0);
+    CHECK(res1[numDoublesInConf - 1] == 2.0);
+    double* res2 = mol.getConformerPositions(id2);
+    CHECK(res2[0] == 1.0);
+    CHECK(res2[numDoublesInConf - 1] == 1.0);
+    const double* res3 = mol.getConformerPositions(id3);
+    CHECK(res3[0] == 3.0);
+    CHECK(res3[numDoublesInConf - 1] == 3.0);
+
+    CHECK(mol.is3DConformer(id1));
+    CHECK(mol.is3DConformer(id2));
+    CHECK(!mol.is3DConformer(id3));
+  }
+
+  SECTION("Add in order, then add one with a different ID") {
+    uint32_t id1 = mol.addConformer(conf1.data());
+    uint32_t id2 = mol.addConformer(conf0.data());
+    uint32_t id3 = mol.addConformer(conf2.data(), 42);
+
+    CHECK(id3 == 42);
+
+    CHECK(mol.getNumConformers() == 3);
+    double* res1 = mol.getConformerPositions(id1);
+    CHECK(res1[0] == 2.0);
+    CHECK(res1[numDoublesInConf - 1] == 2.0);
+    double* res2 = mol.getConformerPositions(id2);
+    CHECK(res2[0] == 1.0);
+    CHECK(res2[numDoublesInConf - 1] == 1.0);
+    const double* res3 = mol.getConformerPositions(id3);
+    CHECK(res3[0] == 3.0);
+    CHECK(res3[numDoublesInConf - 1] == 3.0);
+
+    CHECK(mol.is3DConformer(id1));
+    CHECK(mol.is3DConformer(id2));
+    CHECK(mol.is3DConformer(id3));
+  }
+
+  SECTION("Add with an ID, then add others with default") {
+    uint32_t id1 = mol.addConformer(conf1.data(), 42);
+    uint32_t id2 = mol.addConformer(conf0.data(), -1, false);
+    uint32_t id3 = mol.addConformer(conf2.data());
+
+    CHECK(id1 == 42);
+
+    CHECK(mol.getNumConformers() == 3);
+    double* res1 = mol.getConformerPositions(id1);
+    CHECK(res1[0] == 2.0);
+    CHECK(res1[numDoublesInConf - 1] == 2.0);
+    double* res2 = mol.getConformerPositions(id2);
+    CHECK(res2[0] == 1.0);
+    CHECK(res2[numDoublesInConf - 1] == 1.0);
+    const double* res3 = mol.getConformerPositions(id3);
+    CHECK(res3[0] == 3.0);
+    CHECK(res3[numDoublesInConf - 1] == 3.0);
+
+    CHECK(mol.is3DConformer(id1));
+    CHECK(!mol.is3DConformer(id2));
+    CHECK(mol.is3DConformer(id3));
+  }
+
+  SECTION("Clear all conformers") {
+    uint32_t id1 = mol.addConformer(conf1.data(), 42);
+    uint32_t id2 = mol.addConformer(conf0.data(), -1, false);
+    uint32_t id3 = mol.addConformer(conf2.data());
+
+    CHECK(mol.getNumConformers() == 3);
+    mol.clearConformers();
+    CHECK(mol.getNumConformers() == 0);
+  }
+
+  SECTION("Clear one conformer, previously set IDs") {
+    uint32_t id1 = mol.addConformer(conf1.data(), 42);
+    uint32_t id2 = mol.addConformer(conf0.data(), -1, false);
+    uint32_t id3 = mol.addConformer(conf2.data());
+
+    CHECK(mol.getNumConformers() == 3);
+    mol.removeConformer(id1);
+    CHECK(mol.getNumConformers() == 2);
+
+    CHECK_THROWS_AS(mol.getConformerPositions(id1), ConformerException);
+    double* res2 = mol.getConformerPositions(id2);
+    CHECK(res2[0] == 1.0);
+    CHECK(res2[numDoublesInConf - 1] == 1.0);
+    double* res3 = mol.getConformerPositions(id3);
+    CHECK(res3[0] == 3.0);
+    CHECK(res3[numDoublesInConf - 1] == 3.0);
+
+    CHECK_THROWS_AS(mol.is3DConformer(id1), ConformerException);
+    CHECK(!mol.is3DConformer(id2));
+    CHECK(mol.is3DConformer(id3));
+  }
+
+  SECTION("Clear one conformer, no previously set IDs") {
+    uint32_t id1 = mol.addConformer(conf1.data());
+    uint32_t id2 = mol.addConformer(conf0.data());
+    uint32_t id3 = mol.addConformer(conf2.data());
+
+    CHECK(mol.getNumConformers() == 3);
+    mol.removeConformer(id1);
+    CHECK(mol.getNumConformers() == 2);
+
+    CHECK_THROWS_AS(mol.getConformerPositions(id1), ConformerException);
+    double* res2 = mol.getConformerPositions(id2);
+    CHECK(res2[0] == 1.0);
+    CHECK(res2[numDoublesInConf - 1] == 1.0);
+    double* res3 = mol.getConformerPositions(id3);
+    CHECK(res3[0] == 3.0);
+    CHECK(res3[numDoublesInConf - 1] == 3.0);
+
+    CHECK_THROWS_AS(mol.is3DConformer(id1), ConformerException);
+    CHECK(mol.is3DConformer(id2));
+    CHECK(mol.is3DConformer(id3));
+  }
+
+  SECTION("Remove nonexistent conformer does nothing") {
+    uint32_t id1 = mol.addConformer(conf1.data());
+    uint32_t id2 = mol.addConformer(conf0.data());
+
+    mol.removeConformer(50);
+    CHECK(mol.getNumConformers() == 2);
+  }
+
+  SECTION("Valid behavior with no atoms") {
+    RDMol emptyMol;
+    CHECK(emptyMol.getNumConformers() == 0);
+    CHECK_THROWS_AS(emptyMol.getConformerPositions(), ConformerException);
+    CHECK_THROWS_AS(emptyMol.getConformerPositions(3), ConformerException);
+    CHECK(emptyMol.addConformer(nullptr) == 0);
+    CHECK(emptyMol.addConformer(nullptr, 5) == 5);
+    CHECK(emptyMol.addConformer(nullptr) == 6);
+    CHECK(emptyMol.getNumConformers() == 3);
+    CHECK_NOTHROW(emptyMol.getConformerPositions());
+    CHECK_NOTHROW(emptyMol.getConformerPositions(5));
+    CHECK(emptyMol.is3DConformer(0) == true);
+    emptyMol.removeConformer(5);
+    CHECK(emptyMol.getNumConformers() == 2);
+    emptyMol.clearConformers();
+    CHECK(emptyMol.getNumConformers() == 0);
+  }
+
+  SECTION("Multiple conformers same ID valid") {
+    uint32_t id1 = mol.addConformer(conf1.data(), 3, false);
+    uint32_t id2 = mol.addConformer(conf0.data(), 3, true);
+    CHECK(mol.getNumConformers() == 2);
+    CHECK(id1 == id2);
+    double* res1 = mol.getConformerPositions(id1);
+    CHECK(res1[0] == 2.0);
+    CHECK(!mol.is3DConformer(id1));
+  }
+}
+
+TEST_CASE("Remove bond") {
+  auto molPtr = basicMol();
+  RDMol& mol = *molPtr;
+
+  SECTION("Nullop") {
+    mol.removeBond(5);
+    CHECK(mol.getNumBonds() == 3);
+  }
+
+  SECTION("Basic remove") {
+    int atomIdx1, atomIdx2;
+    {
+      BondData& bondToRemove = mol.getBond(1);
+      atomIdx1 = bondToRemove.getBeginAtomIdx();
+      atomIdx2 = bondToRemove.getEndAtomIdx();
+    }
+    AtomData& atom1 = mol.getAtom(atomIdx1);
+    AtomData& atom2 = mol.getAtom(atomIdx2);
+
+    uint32_t degree1 = mol.getAtomDegree(atomIdx1);
+    uint32_t degree2 = mol.getAtomDegree(atomIdx2);
+
+
+    mol.removeBond(1);
+    CHECK(mol.getNumBonds() == 2);
+    // Check that the index has shifted down.
+    CHECK(mol.getBond(0).getBondType() == BondEnums::BondType::SINGLE);
+    CHECK(mol.getBond(1).getBondType() == BondEnums::BondType::DOUBLE);
+
+    CHECK(mol.getAtomDegree(atomIdx1) == degree1 - 1);
+    CHECK(mol.getAtomDegree(atomIdx2) == degree2 - 1);
+
+    auto neighbors0 = mol.getAtomNeighbors(0);
+    auto neighbors1 = mol.getAtomNeighbors(1);
+    auto neighbors2 = mol.getAtomNeighbors(2);
+    auto neighbors3 = mol.getAtomNeighbors(3);
+
+    std::vector<uint32_t> neighbors0Idxs = iteratorToIndexVector(neighbors0);
+    std::vector<uint32_t> neighbors1Idxs = iteratorToIndexVector(neighbors1);
+    std::vector<uint32_t> neighbors2Idxs = iteratorToIndexVector(neighbors2);
+    std::vector<uint32_t> neighbors3Idxs = iteratorToIndexVector(neighbors3);
+
+    CHECK_THAT(neighbors0Idxs, Catch::Matchers::UnorderedEquals(std::vector<uint32_t>{1}));
+    CHECK_THAT(neighbors1Idxs, Catch::Matchers::UnorderedEquals(std::vector<uint32_t>{0}));
+    CHECK_THAT(neighbors2Idxs, Catch::Matchers::UnorderedEquals(std::vector<uint32_t>{3}));
+    CHECK_THAT(neighbors3Idxs, Catch::Matchers::UnorderedEquals(std::vector<uint32_t>{2}));
+  }
+
+  SECTION("Properties") {
+    mol.setSingleBondProp(signedIntToken, 1, 3);
+    mol.setSingleBondProp(signedIntToken, 2, 4);
+
+    mol.removeBond(1);
+
+    // Check that we shifted down, and index 1 now points to what was previously index 2.
+    CHECK(mol.getNumBonds() == 2);
+    int res;
+    CHECK(mol.getBondPropIfPresent(signedIntToken, 1, res));
+    CHECK(res == 4);
+  }
+
+  SECTION("Bookmarks") {
+    mol.setBondBookmark(0, 4);
+    mol.setBondBookmark(0, 3);
+    mol.setBondBookmark(1, 0);
+    mol.setBondBookmark(1, 3);
+    mol.setBondBookmark(1, 4);
+    mol.setBondBookmark(2, 0);
+    mol.setBondBookmark(2, 3);
+    mol.removeBond(1);
+    // The bookmark for bond 0 should be the same.
+    CHECK(mol.getBondWithBookmark(4) == 0);
+    // The bookmark for bond 2 should now be 1.
+    CHECK(mol.getBondWithBookmark(0) == 1);
+
+    std::vector<int> res  = mol.getAllBondsWithBookmarks(3);
+    // The previous bond 1 bookmark is gone, but bond 2 shifts to 1 now.
+    CHECK(res == std::vector<int>{0, 1});
+
+    // Only atom 0 should still be here.
+    res = mol.getAllBondsWithBookmarks(4);
+    CHECK(res == std::vector<int>{0});
+  }
+
+  SECTION("Substance groups") {
+    auto& sgs = mol.getSubstanceGroups();
+    REQUIRE(sgs.size() == 0);
+
+    ROMol& romol = mol.asROMol();
+
+    SubstanceGroup& sg = sgs.emplace_back(&romol, "A");
+    sg.addAtomWithIdx(0);
+    sg.addBondWithIdx(1);
+    sg.addBondWithIdx(2);
+    sg.setProp("index", 0);
+    SubstanceGroup& sg2 = sgs.emplace_back(&romol, "B");
+    sg2.addAtomWithIdx(1);
+    sg2.addBondWithIdx(0);
+    sg2.setProp("PARENT", 0);
+    SubstanceGroup& sg3 = sgs.emplace_back(&romol, "C");
+    sg3.addAtomWithIdx(2);
+    sg3.addBondWithIdx(2);
+
+    mol.removeBond(1);
+
+    CHECK(sgs.size() == 1);
+    // SG 0 should be removed. Since it is the parent of 1, so is 1. 2 Remains shifted down.
+    CHECK(sgs[0].getAtoms() == std::vector<unsigned int>{2});
+    CHECK(sgs[0].getBonds() == std::vector<unsigned int>{1});
+  }
+}
+
+TEST_CASE("Remove bond with stereo") {
+  RDMol mol;
+  RDKit::SmilesParseTemp temp;
+
+  // The middle bond is trans, so the stereo atoms are 0 and 3, on the far ends
+  // of the double bond respectively. The other 2 ends of the 4 bonds that determine
+  // the cis/trans stereo are hydrogens.
+  static const char* basicSmiles = "C/C=C/C";
+
+  SmilesParserParams params;
+  params.sanitize = true;
+  params.removeHs = true;
+
+  REQUIRE(RDKit::SmilesToMol(basicSmiles, params, mol, temp) == true);
+  REQUIRE(mol.getNumAtoms() == 4);
+  REQUIRE(mol.getNumBonds() == 3);
+
+  auto& doubleBond = mol.getBond(1);
+  doubleBond.setStereo(BondEnums::BondStereo::STEREOTRANS);
+  mol.setBondStereoAtoms(1, 0, 3);
+  REQUIRE(mol.getBond(1).getStereo() == BondEnums::BondStereo::STEREOTRANS);
+  REQUIRE(mol.getBondStereoAtoms(1)[0] == 0);
+  REQUIRE(mol.getBondStereoAtoms(1)[1] == 3);
+  REQUIRE(mol.hasBondStereoAtoms(1));
+
+  mol.removeBond(0);
+  CHECK(mol.getNumBonds() == 2);
+  CHECK(mol.getBond(1).getStereo() == BondEnums::BondStereo::STEREONONE);
+  CHECK(!mol.hasBondStereoAtoms(1));
+}
+
+TEST_CASE("Remove Atom") {
+  auto molPtr = basicMol();
+  RDMol &mol = *molPtr;
+
+  SECTION("Basic, no bond removal, no stereochem") {
+    // Change up atom numbers for better testing.
+    mol.getAtom(1).setAtomicNum(7);
+    mol.getAtom(2).setAtomicNum(8);
+
+    REQUIRE(mol.getNumAtoms() == 4);
+    REQUIRE(mol.getNumBonds() == 3);
+    REQUIRE(mol.getAtom(0).getAtomicNum() == 6);
+    REQUIRE(mol.getAtom(1).getAtomicNum() == 7);
+    REQUIRE(mol.getBond(0).getBeginAtomIdx() == 0);
+    REQUIRE(mol.getBond(0).getEndAtomIdx() == 1);
+    mol.removeAtom(0);
+
+    CHECK(mol.getNumAtoms() == 3);
+    CHECK(mol.getNumBonds() == 2);
+
+    CHECK(mol.getAtom(0).getAtomicNum() == 7);
+    CHECK(mol.getAtom(1).getAtomicNum() == 8);
+
+    // Check that bond atom refs are updated.
+    CHECK(mol.getBond(0).getBeginAtomIdx() == 0);
+    CHECK(mol.getBond(0).getEndAtomIdx() == 1);
+
+    // Check atom neighbor iteration unchanged except for indices
+    auto neighbors0 = mol.getAtomNeighbors(0);
+    auto neighbors1 = mol.getAtomNeighbors(1);
+    auto neighbors2 = mol.getAtomNeighbors(2);
+
+    std::vector<uint32_t> neighbors0Idxs = iteratorToIndexVector(neighbors0);
+    std::vector<uint32_t> neighbors1Idxs = iteratorToIndexVector(neighbors1);
+    std::vector<uint32_t> neighbors2Idxs = iteratorToIndexVector(neighbors2);
+
+    CHECK_THAT(neighbors0Idxs, Catch::Matchers::UnorderedEquals(std::vector<uint32_t>{1}));
+    CHECK_THAT(neighbors1Idxs, Catch::Matchers::UnorderedEquals(std::vector<uint32_t>{0, 2}));
+    CHECK_THAT(neighbors2Idxs, Catch::Matchers::UnorderedEquals(std::vector<uint32_t>{1}));
+  }
+
+  SECTION("Removes associated bonds") {
+    REQUIRE(mol.getNumAtoms() == 4);
+    REQUIRE(mol.getNumBonds() == 3);
+
+    mol.removeAtom(1);
+    // C is now disconnected, O and F are still connected.
+
+    CHECK(mol.getNumAtoms() == 3);
+    CHECK(mol.getNumBonds() == 1);
+
+    auto neighbors0 = mol.getAtomNeighbors(0);
+    auto neighbors1 = mol.getAtomNeighbors(1);
+    auto neighbors2 = mol.getAtomNeighbors(2);
+
+    std::vector<uint32_t> neighbors0Idxs = iteratorToIndexVector(neighbors0);
+    std::vector<uint32_t> neighbors1Idxs = iteratorToIndexVector(neighbors1);
+    std::vector<uint32_t> neighbors2Idxs = iteratorToIndexVector(neighbors2);
+
+    CHECK_THAT(neighbors0Idxs, Catch::Matchers::UnorderedEquals(std::vector<uint32_t>{}));
+    CHECK_THAT(neighbors1Idxs, Catch::Matchers::UnorderedEquals(std::vector<uint32_t>{2}));
+    CHECK_THAT(neighbors2Idxs, Catch::Matchers::UnorderedEquals(std::vector<uint32_t>{1}));
+  }
+
+  SECTION("Stereo groups") {
+    auto groups = std::make_unique<StereoGroups>();
+    groups->addGroup(RDKit::StereoGroupType::STEREO_ABSOLUTE,
+                     std::vector<uint32_t>{1}, std::vector<uint32_t>{});
+    groups->addGroup(RDKit::StereoGroupType::STEREO_OR,
+                     std::vector<uint32_t>{0, 1, 2}, std::vector<uint32_t>{},
+                     /*readId=*/5);
+    groups->addGroup(RDKit::StereoGroupType::STEREO_AND,
+                     std::vector<uint32_t>{2, 3}, std::vector<uint32_t>{});
+    mol.setStereoGroups(std::move(groups));
+
+    mol.removeAtom(1);
+    StereoGroups* res = mol.getStereoGroups();
+    REQUIRE(res != nullptr);
+    REQUIRE(res->getNumGroups() == 2);
+    auto group1Atoms = iteratorToIndexVector(res->getAtoms(0));
+    auto group2Atoms = iteratorToIndexVector(res->getAtoms(1));
+
+    CHECK(group1Atoms == std::vector<uint32_t>{0, 1});
+    CHECK(group2Atoms == std::vector<uint32_t>{1, 2});
+  }
+
+  SECTION("Bookmarks") {
+    mol.setAtomBookmark(0, 0);
+    mol.setAtomBookmark(1, 0);
+    mol.setAtomBookmark(2, 0);
+    mol.setAtomBookmark(3, 0);
+    mol.setAtomBookmark(1, 1);
+    mol.setAtomBookmark(2, 1);
+    mol.setAtomBookmark(3, 2);
+
+    mol.setBondBookmark(0, 0);
+    mol.setBondBookmark(1, 0);
+    mol.setBondBookmark(2, 0);
+    mol.setBondBookmark(0, 1);
+    mol.setBondBookmark(1, 1);
+    mol.setBondBookmark(2, 2);
+
+    // Before deletion, we have {bookmark: indices}
+    // atoms:
+    // 0: 0, 1, 2, 3
+    // 1: 1, 2
+    // 2: 3
+    // bonds:
+    // 0: 0, 1, 2
+    // 1: 0, 1
+    // 2: 2
+
+    // We are deleting bonds 0 and 1, atom 1. Bond 2 now maps to 0. Atoms 2 and 3 now map to 1 and 2.
+    mol.removeAtom(1);
+
+    std::vector<int> atomBookmarks0 = mol.getAllAtomsWithBookmarks(0);
+    std::vector<int> atomBookmarks1 = mol.getAllAtomsWithBookmarks(1);
+    std::vector<int> atomBookmarks2 = mol.getAllAtomsWithBookmarks(2);
+
+    std::vector<int> bondBookmarks0 = mol.getAllBondsWithBookmarks(0);
+    std::vector<int> bondBookmarks1 = mol.getAllBondsWithBookmarks(1);
+    std::vector<int> bondBookmarks2 = mol.getAllBondsWithBookmarks(2);
+
+    CHECK(atomBookmarks0 == std::vector<int>{0, 1, 2});
+    CHECK(atomBookmarks1 == std::vector<int>{1});
+    CHECK(atomBookmarks2 == std::vector<int>{2});
+
+    CHECK(bondBookmarks0 == std::vector<int>{0});
+    CHECK(bondBookmarks1 == std::vector<int>{});
+    CHECK(bondBookmarks2 == std::vector<int>{0});
+  }
+
+  SECTION("Properties") {
+    {
+      int *atomProps = mol.addAtomProp(signedIntToken, 0);
+      std::iota(atomProps, atomProps + mol.getNumAtoms(), 0);
+      int *bondProps = mol.addBondProp(signedIntToken, 0);
+      std::iota(bondProps, bondProps + mol.getNumBonds(), 0);
+    }
+    mol.removeAtom(1);
+    int* atomProps = mol.getAtomPropArrayIfPresent<int>(signedIntToken);
+    int* bondProps = mol.getBondPropArrayIfPresent<int>(signedIntToken);
+    CHECK(atomProps[0] == 0);
+    CHECK(atomProps[1] == 2);
+    CHECK(atomProps[2] == 3);
+    CHECK(bondProps[0] == 2);
+  }
+
+  SECTION("Conformers") {
+    const int numDoublesInConf = 3 * mol.getNumAtoms();
+
+    std::vector<double> conf0(numDoublesInConf, 1.0);
+    std::vector<double> conf1(numDoublesInConf, 2.0);
+    std::vector<double> conf2(numDoublesInConf, 3.0);
+
+    uint32_t id1 = mol.addConformer(conf0.data());
+    uint32_t id2 = mol.addConformer(conf1.data(), 3);
+    uint32_t id3 = mol.addConformer(conf2.data(), -1, false);
+
+    mol.removeAtom(1);
+    const int newNumDoublesInConf = 3 * mol.getNumAtoms();
+
+    CHECK(mol.getNumConformers() == 3);
+    double* res1 = mol.getConformerPositions(id1);
+    CHECK(res1[0] == 1.0);
+    CHECK(res1[newNumDoublesInConf - 1] == 1.0);
+    double* res2 = mol.getConformerPositions(id2);
+    CHECK(res2[0] == 2.0);
+    CHECK(res2[newNumDoublesInConf - 1] == 2.0);
+    const double* res3 = mol.getConformerPositions(id3);
+    CHECK(res3[0] == 3.0);
+    CHECK(res3[newNumDoublesInConf - 1] == 3.0);
+
+    CHECK(mol.is3DConformer(id1));
+    CHECK(mol.is3DConformer(id2));
+    CHECK(!mol.is3DConformer(id3));
+  }
+}
+
+
+void checkBasicEdit(const RDMol& mol) {
+  CHECK(mol.getNumAtoms() == 3);
+  CHECK(mol.getNumBonds() == 1);
+
+  // Check that the atom and bond indices have shifted down.
+  CHECK(mol.getAtom(0).getAtomicNum() == 6);
+  CHECK(mol.getAtom(1).getAtomicNum() == 6);
+  CHECK(mol.getAtom(2).getAtomicNum() == 7);
+
+  CHECK(mol.getBond(0).getBondType() == BondEnums::BondType::DOUBLE);
+
+  // check neighbors
+  auto neighbors0 = mol.getAtomNeighbors(0);
+  auto neighbors1 = mol.getAtomNeighbors(1);
+  auto neighbors2 = mol.getAtomNeighbors(2);
+
+  std::vector<uint32_t> neighbors0Idxs = iteratorToIndexVector(neighbors0);
+  std::vector<uint32_t> neighbors1Idxs = iteratorToIndexVector(neighbors1);
+  std::vector<uint32_t> neighbors2Idxs = iteratorToIndexVector(neighbors2);
+
+  CHECK_THAT(neighbors0Idxs, Catch::Matchers::UnorderedEquals(std::vector<uint32_t>{}));
+  CHECK_THAT(neighbors1Idxs, Catch::Matchers::UnorderedEquals(std::vector<uint32_t>{2}));
+  CHECK_THAT(neighbors2Idxs, Catch::Matchers::UnorderedEquals(std::vector<uint32_t>{1}));
+}
+
+TEST_CASE("Batch edits") {
+  auto molPtr = parseSmiles("OCC=NC");
+  RDMol& mol = *molPtr;
+  mol.setAtomBookmark(0, 0);
+  mol.setAtomBookmark(1, 1);
+  mol.setBondBookmark(0, 0);
+  mol.setBondBookmark(3, 0);
+  mol.setSingleAtomProp(signedIntToken, 0, 1);
+  mol.setSingleAtomProp(signedIntToken, 1, 2);
+  mol.setSingleAtomProp(signedIntToken, 4, 3);
+  mol.setSingleBondProp(signedIntToken, 0, 3);
+  mol.setSingleBondProp(signedIntToken, 2, 4);
+
+  SECTION("Empty") {
+    mol.beginBatchEdit();
+    mol.commitBatchEdit();
+    CHECK(mol.getNumAtoms() == 5);
+    CHECK(mol.getNumBonds() == 4);
+  }
+
+  SECTION("Edit empty mol") {
+    RDMol empty;
+    empty.beginBatchEdit();
+    empty.commitBatchEdit();
+    CHECK(empty.getNumAtoms() == 0);
+    CHECK(empty.getNumBonds() == 0);
+  }
+
+  SECTION("Basics") {
+    mol.beginBatchEdit();
+    mol.removeAtom(0);
+    mol.removeBond(1);
+    mol.removeAtom(4); // Note that if incorrectly set, this would be past nAtoms.
+    // Include that atoms and bonds aren't deleted until end of edit.
+
+    CHECK(mol.getNumAtoms() == 5);
+    CHECK(mol.getNumBonds() == 4);
+    mol.commitBatchEdit();
+
+    checkBasicEdit(mol);
+
+    // Include that after finishing, we can begin again.
+    mol.beginBatchEdit();
+  }
+
+  SECTION("commit does nothing if no begin") {
+    mol.commitBatchEdit();
+    CHECK(mol.getNumAtoms() == 5);
+    CHECK(mol.getNumBonds() == 4);
+  }
+
+  SECTION("Can't begin twice") {
+    mol.beginBatchEdit();
+    CHECK_THROWS_AS(mol.beginBatchEdit(), ValueErrorException);
+  }
+
+  SECTION("Remove all atoms and bonds") {
+    mol.beginBatchEdit();
+    mol.removeAtom(0);
+    mol.removeAtom(1);
+    mol.removeAtom(2);
+    mol.removeAtom(3);
+    mol.removeAtom(4);
+    mol.removeBond(0);
+    mol.removeBond(1);
+    mol.removeBond(2);
+    mol.removeBond(3);
+    mol.commitBatchEdit();
+
+    CHECK(mol.getNumAtoms() == 0);
+    CHECK(mol.getNumBonds() == 0);
+  }
+
+  SECTION("Adding atoms/bonds during edit") {
+    mol.beginBatchEdit();
+    mol.addAtom().setAtomicNum(5);
+    mol.addBond(2, 4, BondEnums::BondType::AROMATIC);
+    mol.removeAtom(3);
+    mol.removeBond(0);
+    mol.addAtom().setAtomicNum(9);
+    mol.removeAtom(5);
+
+    mol.commitBatchEdit();
+
+    CHECK(mol.getNumAtoms() == 5);
+    CHECK(mol.getNumBonds() == 2);
+
+    // OCC=NC 9
+    CHECK(mol.getAtom(0).getAtomicNum() == 8);
+    CHECK(mol.getAtom(1).getAtomicNum() == 6);
+    CHECK(mol.getAtom(2).getAtomicNum() == 6);
+    CHECK(mol.getAtom(3).getAtomicNum() == 6);
+    CHECK(mol.getAtom(4).getAtomicNum() == 9);
+
+    CHECK(mol.getBond(0).getBondType() == BondEnums::BondType::SINGLE);
+    CHECK(mol.getBond(1).getBondType() == BondEnums::BondType::AROMATIC);
+  }
+
+  SECTION("Bookmarks updated") {
+    mol.beginBatchEdit();
+    mol.removeAtom(0);
+    mol.removeBond(1);
+    mol.removeAtom(4);
+    mol.commitBatchEdit();
+
+    CHECK(!mol.hasAtomBookmark(0));
+    CHECK(mol.getAtomWithBookmark(1) == 0);
+    CHECK(mol.getBondWithBookmark(0) == 0);
+  }
+
+  SECTION("Properties updated") {
+    mol.beginBatchEdit();
+    mol.removeAtom(0);
+    mol.removeBond(1);
+    mol.removeAtom(4);
+    mol.commitBatchEdit();
+
+    int res;
+    CHECK(mol.getAtomPropIfPresent(signedIntToken, 0, res));
+    CHECK(res == 2);
+    CHECK(mol.getBondPropIfPresent(signedIntToken, 0, res));
+    CHECK(res == 4);
+
+  }
+
+  SECTION("Copy during edit") {
+    mol.beginBatchEdit();
+    mol.removeAtom(0);
+    mol.removeBond(1);
+    mol.removeAtom(4);
+
+    CHECK(mol.getNumAtoms() == 5);
+    CHECK(mol.getNumBonds() == 4);
+
+    RDMol mol2(mol);
+
+    mol2.commitBatchEdit();
+    checkBasicEdit(mol2);
+  }
+
+  SECTION("Move during edit") {
+    mol.beginBatchEdit();
+    mol.removeAtom(0);
+    mol.removeBond(1);
+    mol.removeAtom(4);
+
+    CHECK(mol.getNumAtoms() == 5);
+    CHECK(mol.getNumBonds() == 4);
+
+    RDMol mol2(std::move(mol));
+
+    mol2.commitBatchEdit();
+    checkBasicEdit(mol2);
+  }
+
+  SECTION("Rollback") {
+    mol.beginBatchEdit();
+    mol.removeAtom(0);
+    mol.removeBond(1);
+    mol.removeAtom(4);
+
+    mol.rollbackBatchEdit();
+    mol.commitBatchEdit();
+
+    CHECK(mol.getNumAtoms() == 5);
+    CHECK(mol.getNumBonds() == 4);
+  }
+
+  SECTION("Double delete is nullop") {
+    mol.beginBatchEdit();
+    mol.removeAtom(0);
+    mol.removeAtom(0);
+    mol.commitBatchEdit();
+    CHECK(mol.getNumAtoms() == 4);
+    CHECK(mol.getNumBonds() == 3);
+  }
+
+  SECTION("Delete end atom is safe after previous deletion") {
+    mol.beginBatchEdit();
+    mol.removeAtom(3);
+    mol.removeAtom(4);
+    mol.commitBatchEdit();
+    CHECK(mol.getNumAtoms() == 3);
+    CHECK(mol.getNumBonds() == 2);
+  }
+}
+
+
+// Explicit main needed as Catch returns odd exit codes by default and messes with gcovr.
+int main( int argc, char* argv[] ) {
+  return Catch::Session().run( argc, argv );
+}

--- a/Code/GraphMol/catch_romol_compat.cpp
+++ b/Code/GraphMol/catch_romol_compat.cpp
@@ -1,0 +1,2150 @@
+//
+//  Copyright (C) 2025 NVIDIA Corporation & Affiliates and other RDKit contributors
+//
+//   @@ All Rights Reserved @@
+//  This file is part of the RDKit.
+//  The contents are covered by the terms of the BSD license
+//  which is included in the file license.txt, found at the root
+//  of the RDKit source tree.
+//
+#include <thread>
+
+#include <catch2/catch_all.hpp>
+
+#include <GraphMol/RDMol.h>
+#include <GraphMol/SmilesParse/SmilesParse.h>
+#include <GraphMol/MonomerInfo.h>
+
+using namespace RDKit;
+
+std::unique_ptr<RDMol> parseSmiles(const char *smiles, bool sanitize = false,
+                                   bool removeHs = false) {
+  auto mol = std::make_unique<RDMol>();
+  RDKit::SmilesParseTemp temp;
+  SmilesParserParams params;
+  params.sanitize = sanitize;
+  params.removeHs = removeHs;
+
+  REQUIRE(RDKit::SmilesToMol(smiles, params, *mol, temp) == true);
+  return mol;
+}
+
+std::unique_ptr<RDMol> basicMol() {
+  auto mol = parseSmiles("CCC=C");
+  REQUIRE(mol->getNumAtoms() == 4);
+  REQUIRE(mol->getNumBonds() == 3);
+  REQUIRE(mol->getBond(2).getBondType() == BondEnums::BondType::DOUBLE);
+
+  return mol;
+}
+
+struct MyCustomClass {
+  static size_t copyCount;
+  int value;
+  MyCustomClass() : value(0) {}
+  MyCustomClass(int initValue) : value(initValue) {}
+  MyCustomClass(const MyCustomClass &that) : value(that.value) {
+      ++copyCount;
+  }
+};
+size_t MyCustomClass::copyCount = 0;
+
+TEST_CASE("ROMol self initialization") {
+  ROMol mol;
+  CHECK(mol.getNumAtoms() == 0);
+  CHECK(mol.getNumBonds() == 0);
+  CHECK(mol.getNumHeavyAtoms() == 0);
+
+  CHECK_THROWS_AS(mol.getAtomWithIdx(0), Invar::Invariant);
+  CHECK_THROWS_AS(mol.getBondWithIdx(0), Invar::Invariant);
+}
+
+TEST_CASE("ROMol move constructor") {
+  ROMol mol;
+  RDMol* rdmol = &mol.asRDMol();
+  auto* conf = new Conformer();
+  mol.addConformer(conf, true);
+  CHECK(&conf->getOwningMol() == &mol);
+  mol.setProp("test", 1);
+  ROMol mol2(std::move(mol));
+  CHECK(&mol2.asRDMol() == rdmol);
+  int res;
+  CHECK(mol2.getPropIfPresent("test", res));
+  CHECK(res == 1);
+  CHECK(&conf->getOwningMol() == &mol2);
+  CHECK(&rdmol->asROMol() == &mol2);
+}
+
+TEST_CASE("ROMol move assignment operator") {
+  ROMol mol;
+  RDMol* rdmol = &mol.asRDMol();
+  auto* conf = new Conformer();
+  mol.addConformer(conf, true);
+  CHECK(&conf->getOwningMol() == &mol);
+  mol.setProp("test", 1);
+  ROMol mol2 = std::move(mol);
+  CHECK(&mol2.asRDMol() == rdmol);
+  int res;
+  CHECK(mol2.getPropIfPresent("test", res));
+  CHECK(res == 1);
+  CHECK(&conf->getOwningMol() == &mol2);
+  CHECK(&rdmol->asROMol() == &mol2);
+}
+
+TEST_CASE("ROMol move constructor - previous owner") {
+  auto molPtr = basicMol();
+  RDMol& mol = *molPtr;
+  molPtr.release(); // Will be moved from.
+  ROMol& romol = mol.asROMol();
+  romol.setProp("test", 1);
+  Atom* atom = romol.getAtomWithIdx(0);
+  CHECK(&atom->getOwningMol() == &romol);
+  ROMol mol2(std::move(romol));
+  CHECK(&mol2.asRDMol() == &mol);
+  CHECK(romol.getNumAtoms() == 0);
+  CHECK(romol.getNumBonds() == 0);
+  CHECK(mol2.getNumAtoms() == 4);
+  CHECK(mol2.getNumBonds() == 3);
+  CHECK(mol2.getAtomWithIdx(0) == atom);
+  int res;
+  CHECK(mol2.getPropIfPresent("test", res));
+  CHECK(res == 1);
+  CHECK(&atom->getOwningMol() == &mol2);
+  CHECK(&mol2.asRDMol().asROMol() == &mol2);
+}
+
+
+TEST_CASE("ROMol copy constructor") {
+  auto mol = std::make_unique<ROMol>();
+
+  mol->setProp("prop", 3);
+  ROMol mol2(*mol);
+  mol.reset();
+  int res;
+  REQUIRE(mol2.getPropIfPresent<int>("prop", res));
+  CHECK(res == 3);
+}
+
+template<typename MolT>
+void createConformer(MolT &mol) {
+  auto * conf = new Conformer(mol.getNumAtoms());
+  conf->set3D(false);
+  for (unsigned int i = 0; i < mol.getNumAtoms(); ++i) {
+    conf->setAtomPos(i, RDGeom::Point3D(i, i, i));
+  }
+  mol.addConformer(conf, true);
+}
+
+void checkConformer(const ROMol& mol) {
+  const Conformer &conf = mol.getConformer();
+  for (unsigned int i = 0; i < mol.getNumAtoms(); ++i) {
+    const RDGeom::Point3D &pos = conf.getAtomPos(i);
+    CHECK(pos.x == i);
+    CHECK(pos.y == i);
+    CHECK(pos.z == i);
+  }
+}
+
+TEST_CASE("ROMol copy constructor with owning RDMol") {
+  auto rdmol = basicMol();
+  auto &mol = rdmol->asROMol();
+
+  createConformer(mol);
+  mol.setProp("prop", 3);
+  Atom *at = mol.getAtomWithIdx(1);
+  at->setProp("atomprop", 5);
+  mol.setAtomBookmark(at, 42);
+  mol.setBondBookmark(mol.getBondWithIdx(0), 43);
+  mol.getBondWithIdx(1)->setStereoAtoms(0, 3);
+
+  // Stereo groups
+  std::vector<StereoGroup> groups;
+  std::vector<Atom *> atoms = {mol.getAtomWithIdx(1)};
+  groups.push_back(StereoGroup(StereoGroupType::STEREO_OR, std::move(atoms),
+                               {}));
+  mol.setStereoGroups(groups);
+
+  // Substance groups
+  std::vector<SubstanceGroup> &sgs = getSubstanceGroups(mol);
+  sgs.emplace_back(&mol, "TEST");
+
+
+  ROMol mol2(mol);
+
+  const auto& romolpos = mol.getConformer();
+  const auto& romol2pos = mol2.getConformer();
+
+  int res;
+  REQUIRE(mol2.getPropIfPresent<int>("prop", res));
+  CHECK(res == 3);
+
+  REQUIRE(mol2.getAtomWithIdx(1)->getPropIfPresent<int>("atomprop", res));
+  CHECK(res == 5);
+
+  // Check that setting one doesn't affect the other now
+  at->setProp("atomprop", 6);
+  REQUIRE(mol2.getAtomWithIdx(1)->getPropIfPresent<int>("atomprop", res));
+  CHECK(res == 5);
+
+  CHECK(mol2.getAtomWithBookmark(42) == mol2.getAtomWithIdx(1));
+  CHECK(mol2.getBondWithBookmark(43) == mol2.getBondWithIdx(0));
+
+  checkConformer(mol);
+  checkConformer(mol2);
+
+  const std::vector<int> want = {0, 3};
+  CHECK(mol2.getBondWithIdx(1)->getStereoAtoms() == want);
+
+  // Get stereo groups
+  const std::vector<StereoGroup> &resultStereoGroups = mol2.getStereoGroups();
+  CHECK(resultStereoGroups.size() == 1);
+  CHECK(resultStereoGroups[0].getGroupType() == StereoGroupType::STEREO_OR);
+  CHECK(resultStereoGroups[0].getAtoms() == std::vector<Atom*>{mol2.getAtomWithIdx(1)});
+
+  // Get substance groups
+  const std::vector<SubstanceGroup> & resultSubstanceGroups = getSubstanceGroups(mol2);
+  CHECK(resultSubstanceGroups.size() == 1);
+  CHECK(resultSubstanceGroups[0].getProp<std::string>("TYPE") == "TEST");
+}
+
+TEST_CASE("ROMol stable when RDMol is moved") {
+  auto rdmol = basicMol();
+  auto &mol = rdmol->asROMol();
+
+  Atom *at = mol.getAtomWithIdx(1);
+  at->setProp("atomprop", 5);
+
+  RDMol rdmol2(std::move(*rdmol));
+  int res;
+  REQUIRE(mol.getAtomWithIdx(1)->getPropIfPresent<int>("atomprop", res));
+  CHECK(res == 5);
+}
+
+TEST_CASE("ROMol Compat Bookmarks") {
+  RDMol rdmol;
+  RDKit::SmilesParseTemp temp;
+  static const char *basicSmiles = "CCCC";
+
+  SmilesParserParams params;
+  params.sanitize = false;
+  params.removeHs = false;
+
+  REQUIRE(RDKit::SmilesToMol(basicSmiles, params, rdmol, temp) == true);
+  REQUIRE(rdmol.getNumAtoms() == 4);
+  REQUIRE(rdmol.getNumBonds() == 3);
+  auto &mol = rdmol.asROMol();
+
+  auto *atom0 = mol.getAtomWithIdx(0);
+  auto *atom1 = mol.getAtomWithIdx(1);
+  auto *atom2 = mol.getAtomWithIdx(2);
+  auto *atom3 = mol.getAtomWithIdx(3);
+
+  auto *bond0 = mol.getBondWithIdx(0);
+  auto *bond1 = mol.getBondWithIdx(1);
+  auto *bond2 = mol.getBondWithIdx(2);
+
+  SECTION("Basic bookmarking") {
+    mol.setAtomBookmark(atom1, 0);
+    mol.setAtomBookmark(atom3, -6);
+    mol.setBondBookmark(bond1, 0);
+
+    CHECK(mol.getAtomWithBookmark(0) == atom1);
+    CHECK(mol.getAtomWithBookmark(-6) == atom3);
+    CHECK(mol.getBondWithBookmark(0) == bond1);
+  }
+
+  SECTION("Multiple atoms in bookmark") {
+    mol.setAtomBookmark(atom1, 0);
+    mol.setAtomBookmark(atom2, 0);
+    mol.setAtomBookmark(atom3, 0);
+
+    CHECK(mol.getAtomWithBookmark(0) == atom1);
+
+    const std::list<Atom *> &res = mol.getAllAtomsWithBookmark(0);
+    const std::list<Atom *> want = {atom1, atom2, atom3};
+    CHECK(res == want);
+  }
+
+  SECTION("Multiple bonds in bookmark") {
+    mol.setBondBookmark(bond2, 0);
+    mol.setBondBookmark(bond1, 0);
+    mol.setBondBookmark(bond0, 0);
+
+    CHECK(mol.getBondWithBookmark(0) == bond2);
+
+    const std::list<Bond *> &res = mol.getAllBondsWithBookmark(0);
+    const std::list<Bond *> want = {bond2, bond1, bond0};
+    CHECK(res == want);
+  }
+
+  SECTION("Replace atom bookmarks") {
+    mol.setAtomBookmark(atom3, 0);
+    mol.setAtomBookmark(atom2, 0);
+    mol.setAtomBookmark(atom1, 0);
+
+    mol.replaceAtomBookmark(atom0, 0);
+
+    CHECK(mol.getAtomWithBookmark(0) == atom0);
+
+    const std::list<Atom *> &res = mol.getAllAtomsWithBookmark(0);
+    const std::list<Atom *> want = {atom0};
+    CHECK(res == want);
+  }
+
+  SECTION("Multiple bookmarks same atom is fine") {
+    mol.setAtomBookmark(atom1, 2);
+    mol.setAtomBookmark(atom1, 1);
+    mol.setAtomBookmark(atom1, 0);
+
+    CHECK(mol.getAtomWithBookmark(0) == atom1);
+    CHECK(mol.getAtomWithBookmark(1) == atom1);
+    CHECK(mol.getAtomWithBookmark(2) == atom1);
+
+    const std::list<Atom *> &res = mol.getAllAtomsWithBookmark(0);
+    const std::list<Atom *> want = {atom1};
+    CHECK(res == want);
+  }
+
+  SECTION("Missing bookmark throws") {
+    mol.setAtomBookmark(atom0, 1);
+    mol.setBondBookmark(bond0, 2);
+
+    CHECK_THROWS_AS(mol.getAtomWithBookmark(0), Invar::Invariant);
+    CHECK_THROWS_AS(mol.getBondWithBookmark(0), Invar::Invariant);
+
+    CHECK_THROWS_AS(mol.getAllAtomsWithBookmark(0), Invar::Invariant);
+    CHECK_THROWS_AS(mol.getAllBondsWithBookmark(0), Invar::Invariant);
+  }
+
+  SECTION("Clear atom bookmarks") {
+    mol.setAtomBookmark(atom1, 0);
+    mol.setAtomBookmark(atom1, 1);
+    mol.setAtomBookmark(atom1, 2);
+
+    mol.clearAtomBookmark(0);
+    CHECK_THROWS_AS(mol.getAtomWithBookmark(0), Invar::Invariant);
+    CHECK(mol.getAtomWithBookmark(1) == atom1);
+    CHECK(mol.getAtomWithBookmark(2) == atom1);
+
+    mol.clearAllAtomBookmarks();
+    CHECK_THROWS_AS(mol.getAtomWithBookmark(0), Invar::Invariant);
+    CHECK_THROWS_AS(mol.getAtomWithBookmark(1), Invar::Invariant);
+    CHECK_THROWS_AS(mol.getAtomWithBookmark(2), Invar::Invariant);
+  }
+
+  SECTION("Clear bond bookmarks") {
+    mol.setBondBookmark(bond1, 0);
+    mol.setBondBookmark(bond1, 1);
+    mol.setBondBookmark(bond1, 2);
+
+    mol.clearBondBookmark(0);
+    CHECK_THROWS_AS(mol.getBondWithBookmark(0), Invar::Invariant);
+    CHECK(mol.getBondWithBookmark(1) == bond1);
+    CHECK(mol.getBondWithBookmark(2) == bond1);
+
+    mol.clearAllBondBookmarks();
+    CHECK_THROWS_AS(mol.getBondWithBookmark(0), Invar::Invariant);
+    CHECK_THROWS_AS(mol.getBondWithBookmark(1), Invar::Invariant);
+    CHECK_THROWS_AS(mol.getBondWithBookmark(2), Invar::Invariant);
+  }
+
+  SECTION("Has bookmark") {
+    mol.setAtomBookmark(atom1, 0);
+    mol.setAtomBookmark(atom1, 1);
+    mol.setAtomBookmark(atom1, 2);
+
+    CHECK(mol.hasAtomBookmark(0));
+    CHECK(mol.hasAtomBookmark(1));
+    CHECK(mol.hasAtomBookmark(2));
+    CHECK(!mol.hasAtomBookmark(3));
+
+    mol.setBondBookmark(bond1, 0);
+    mol.setBondBookmark(bond1, 1);
+    mol.setBondBookmark(bond1, 2);
+
+    CHECK(mol.hasBondBookmark(0));
+    CHECK(mol.hasBondBookmark(1));
+    CHECK(mol.hasBondBookmark(2));
+    CHECK(!mol.hasBondBookmark(3));
+
+    mol.clearAtomBookmark(0);
+    CHECK(!mol.hasAtomBookmark(0));
+  }
+
+  SECTION("Full atom bookmark array compat") {
+    mol.setAtomBookmark(atom2, 0);
+    mol.setAtomBookmark(atom0, 0);
+    mol.setAtomBookmark(atom1, 5);
+
+    std::map<int, std::list<Atom *>> *atomBookmarks = mol.getAtomBookmarks();
+    REQUIRE(atomBookmarks->size() == 2);
+    REQUIRE(atomBookmarks->find(0) != atomBookmarks->end());
+    std::list<Atom *> &res1 = atomBookmarks->at(0);
+    std::list<Atom *> want1 = {atom2, atom0};
+    CHECK(res1 == want1);
+    REQUIRE(atomBookmarks->find(5) != atomBookmarks->end());
+    std::list<Atom *> &res2 = atomBookmarks->at(5);
+    std::list<Atom *> want2 = {atom1};
+    CHECK(res2 == want2);
+  }
+
+  SECTION("Full bond bookmark array compat") {
+    mol.setBondBookmark(bond2, 0);
+    mol.setBondBookmark(bond0, 0);
+    mol.setBondBookmark(bond1, 5);
+
+    std::map<int, std::list<Bond *>> *bondBookmarks = mol.getBondBookmarks();
+    REQUIRE(bondBookmarks->size() == 2);
+    REQUIRE(bondBookmarks->find(0) != bondBookmarks->end());
+    std::list<Bond *> &res1 = bondBookmarks->at(0);
+    std::list<Bond *> want1 = {bond2, bond0};
+    CHECK(res1 == want1);
+    REQUIRE(bondBookmarks->find(5) != bondBookmarks->end());
+    std::list<Bond *> &res2 = bondBookmarks->at(5);
+    std::list<Bond *> want2 = {bond1};
+    CHECK(res2 == want2);
+  }
+
+  SECTION("RDMol/ROMol bookmarks work") {
+    rdmol.setAtomBookmark(2, 1);
+    CHECK(mol.getAtomWithBookmark(1) == atom2);
+  }
+}
+
+TEST_CASE("ROMol Compat Mol properties") {
+  std::string signedIntToken("signed int");
+  std::string unusedToken("unused");
+  std::string unsignedIntToken("unsigned int");
+  std::string floatToken("float");
+  RDMol rdmol;
+  auto& mol = rdmol.asROMol();
+
+  SECTION("Self basic properties") {
+    mol.setProp(signedIntToken, 3);
+    mol.setProp(unsignedIntToken, 3u);
+    mol.setProp(floatToken, 3.0f);
+
+    int res;
+    REQUIRE(mol.getPropIfPresent<int>(signedIntToken, res));
+    CHECK(res == 3);
+    REQUIRE(!mol.getPropIfPresent<int>(unusedToken, res));
+  }
+
+  SECTION("Prop handle updates in place") {
+    mol.setProp(signedIntToken, 3);
+
+    int res;
+    REQUIRE(mol.getPropIfPresent<int>(signedIntToken, res));
+    REQUIRE(res == 3);
+
+    mol.setProp(signedIntToken, 4);
+    REQUIRE(mol.getPropIfPresent<int>(signedIntToken, res));
+    CHECK(res == 4);
+  }
+
+  SECTION("Clear Mol Props") {
+    mol.setProp(floatToken, 3.0f);
+    mol.setProp(unsignedIntToken, 3u);
+
+    mol.clearProp(unsignedIntToken);
+    mol.clearProp(floatToken);
+
+    float resf;
+    unsigned int resu;
+    CHECK(!mol.getPropIfPresent<unsigned int>(unsignedIntToken, resu));
+    CHECK(!mol.getPropIfPresent<float>(floatToken, resf));
+  }
+
+  SECTION("Computed props and clear") {
+    mol.setProp(floatToken, 3.0f, true);
+    mol.setProp(unsignedIntToken, 3u);
+
+    mol.clearComputedProps();
+    float resf;
+    unsigned int resu;
+    CHECK(mol.getPropIfPresent<unsigned int>(unsignedIntToken, resu));
+    CHECK(!mol.getPropIfPresent<float>(floatToken, resf));
+  }
+
+  SECTION("nonPOD Data") {
+    mol.setProp(signedIntToken, boost::shared_array<int>(new int[3]{1,2,3}));
+
+    boost::shared_array<int> res;
+    REQUIRE(mol.getPropIfPresent(signedIntToken, res));
+
+    CHECK(res[1] == 2);
+  }
+
+  SECTION("Has prop") {
+    mol.setProp(floatToken, 3.0f);
+    mol.setProp(signedIntToken, 5);
+
+    CHECK(mol.hasProp(floatToken));
+    CHECK(mol.hasProp(signedIntToken));
+    CHECK(!mol.hasProp(unsignedIntToken));
+  }
+
+  SECTION("clear() RDProp API") {
+    mol.setProp(floatToken, 3.0f);
+    mol.clear();
+    CHECK(!mol.hasProp(floatToken));
+  }
+
+  SECTION("UpdateProps RDProp no preserve") {
+    RDProps props;
+    props.setProp(floatToken, 3.0f);
+    props.setProp(signedIntToken, 5);
+    std::string vector2Token("vector2");
+    const std::vector<int> vector2Value{6, 7};
+    props.setProp(vector2Token, vector2Value);
+
+    mol.setProp(floatToken, 4.0f);
+    std::string vectorToken("vector");
+    const std::vector<int> vectorValue{4, 5};
+    mol.setProp(vectorToken, vectorValue);
+
+    // Update from self should do nothing
+    mol.updateProps(mol, /*preserve=*/false);
+    float res;
+    int intres;
+    std::vector<int> vectorRes;
+    REQUIRE(mol.getPropIfPresent(floatToken, res));
+    CHECK(res == 4.0f);
+    CHECK_FALSE(mol.getPropIfPresent(signedIntToken, intres));
+    REQUIRE(mol.getPropIfPresent(vectorToken, vectorRes));
+    CHECK(vectorRes == vectorValue);
+    CHECK_FALSE(mol.getPropIfPresent(vector2Token, vectorRes));
+
+
+    RDMol rdmol2;
+    rdmol2.addAtom();
+    rdmol2.addAtom();
+    rdmol2.addBond(0, 1, BondEnums::BondType::SINGLE);
+    PropToken atomPropName("atomProp");
+    PropToken bondPropName("bondProp");
+    rdmol2.addAtomProp(atomPropName, 2);
+    rdmol2.addBondProp(bondPropName, 3);
+    CHECK(rdmol2.getBondPropIfPresent(bondPropName, 0, intres));
+
+    // Atom and bond props should not become mol props
+    mol.updateProps(rdmol2.asROMol(), /*preserve=*/true);
+
+    CHECK_FALSE(mol.getPropIfPresent(atomPropName.getString(), intres));
+    CHECK_FALSE(mol.getPropIfPresent(bondPropName.getString(), intres));
+    CHECK(rdmol2.getAtomPropIfPresent(atomPropName, 0, intres));
+    CHECK(rdmol2.getBondPropIfPresent(bondPropName, 0, intres));
+    CHECK_FALSE(
+        rdmol2.asROMol().getPropIfPresent(atomPropName.getString(), intres));
+    CHECK_FALSE(
+        rdmol2.asROMol().getPropIfPresent(bondPropName.getString(), intres));
+
+    // Update from other with preserve should add and replace props, but not remove
+    mol.updateProps(props, /*preserve=*/true);
+
+    REQUIRE(mol.getPropIfPresent(floatToken, res));
+    CHECK(res == 3.0f);
+    REQUIRE(mol.getPropIfPresent(signedIntToken, intres));
+    CHECK(intres == 5);
+    REQUIRE(mol.getPropIfPresent(vectorToken, vectorRes));
+    CHECK(vectorRes == vectorValue);
+    REQUIRE(mol.getPropIfPresent(vector2Token, vectorRes));
+    CHECK(vectorRes == vector2Value);
+
+    mol.setProp(floatToken, 4.0f);
+    REQUIRE(mol.getPropIfPresent(floatToken, res));
+    CHECK(res == 4.0f);
+    mol.clearProp(signedIntToken);
+    CHECK_FALSE(mol.getPropIfPresent(signedIntToken, intres));
+    mol.clearProp(vector2Token);
+    CHECK_FALSE(mol.getPropIfPresent(vector2Token, intres));
+
+    // Update from other with preserve should add and replace props, and remove
+    mol.updateProps(props, /*preserve=*/false);
+
+    REQUIRE(mol.getPropIfPresent(floatToken, res));
+    CHECK(res == 3.0f);
+    REQUIRE(mol.getPropIfPresent(signedIntToken, intres));
+    CHECK(intres == 5);
+    CHECK_FALSE(mol.getPropIfPresent(vectorToken, vectorRes));
+    REQUIRE(mol.getPropIfPresent(vector2Token, vectorRes));
+    CHECK(vectorRes == vector2Value);
+  }
+
+  SECTION("Get Prop list") {
+    const std::string privateToken = "_private";
+    mol.setProp(floatToken, 3.0f, false);
+    mol.setProp(signedIntToken, 5, true);
+    mol.setProp(privateToken, 5, false);
+
+    CHECK_THAT(mol.getPropList(true, true), Catch::Matchers::UnorderedEquals(std::vector<std::string>({floatToken, signedIntToken, privateToken})));
+    CHECK_THAT(mol.getPropList(true, false), Catch::Matchers::UnorderedEquals(std::vector<std::string>({floatToken, privateToken})));
+    CHECK_THAT(mol.getPropList(false, true), Catch::Matchers::UnorderedEquals(std::vector<std::string>({floatToken, signedIntToken,})));
+    CHECK_THAT(mol.getPropList(false, false), Catch::Matchers::UnorderedEquals(std::vector<std::string>({floatToken})));
+  }
+
+  SECTION("Custom Data Copying") {
+    mol.setProp(signedIntToken, MyCustomClass(7));
+    size_t copyCount1 = MyCustomClass::copyCount;
+    MyCustomClass copy = mol.getProp<MyCustomClass>(signedIntToken);
+    size_t copyCount2 = MyCustomClass::copyCount;
+    const MyCustomClass &a = mol.getProp<const MyCustomClass &>(signedIntToken);
+    size_t copyCount3 = MyCustomClass::copyCount;
+    const MyCustomClass &b = mol.getProp<const MyCustomClass &>(signedIntToken);
+    size_t copyCount4 = MyCustomClass::copyCount;
+
+    CHECK(copy.value == 7);
+    CHECK(a.value == 7);
+    CHECK(b.value == 7);
+    CHECK(copyCount2 > copyCount1);
+    CHECK(copyCount3 == copyCount2);
+    CHECK(copyCount4 == copyCount3);
+  }
+}
+
+
+template<typename T>
+void addPropToAllAtoms(ROMol& mol, const std::string& token, const T& val, bool computed = false) {
+  for (auto atom : mol.atoms()) {
+    atom->setProp<T>(token, val, computed);
+  }
+}
+
+template<typename T>
+void addPropToAllBonds(ROMol& mol, const std::string& token, const T& val, bool computed = false) {
+  for (auto bond : mol.bonds()) {
+    bond->setProp<T>(token, val, computed);
+  }
+}
+
+TEST_CASE("ROMol compat Atom/bond properties") {
+  std::string signedIntToken("signed int");
+  std::string unusedToken("unused");
+  std::string unsignedIntToken("unsigned int");
+  std::string floatToken("float");
+
+  RDMol rdmol;
+  RDKit::SmilesParseTemp temp;
+  static const char* basicSmiles = "CCCC";
+
+  SmilesParserParams params;
+  params.sanitize = false;
+  params.removeHs = false;
+
+  REQUIRE(RDKit::SmilesToMol(basicSmiles, params, rdmol, temp) == true);
+  REQUIRE(rdmol.getNumAtoms() == 4);
+  REQUIRE(rdmol.getNumBonds() == 3);
+  auto& mol = rdmol.asROMol();
+
+  Atom* atom0 = mol.getAtomWithIdx(0);
+  Atom* atom1 = mol.getAtomWithIdx(1);
+  Atom* atom2 = mol.getAtomWithIdx(2);
+
+  REQUIRE(atom0 != nullptr);
+  REQUIRE(atom1 != nullptr);
+  REQUIRE(atom2 != nullptr);
+
+  Bond* bond0 = mol.getBondWithIdx(0);
+  Bond* bond1 = mol.getBondWithIdx(1);
+
+  REQUIRE(bond0 != nullptr);
+  REQUIRE(bond1 != nullptr);
+
+  SECTION("Atom properties access and override") {
+    addPropToAllAtoms(mol, signedIntToken, 3);
+    REQUIRE(atom0 != nullptr);
+    int res;
+    REQUIRE(atom0->getPropIfPresent<int>(signedIntToken, res));
+    CHECK(res == 3);
+    atom0->setProp(signedIntToken, 4);
+    REQUIRE(atom0->getPropIfPresent<int>(signedIntToken, res));
+    CHECK(res == 4);
+    REQUIRE(atom2->getPropIfPresent<int>(signedIntToken, res));
+    CHECK(res == 3);
+  }
+
+  SECTION("Atom non-POD") {
+    addPropToAllAtoms(mol, signedIntToken, std::vector<int>({1,2,3}));
+    std::vector<int> res;
+    REQUIRE(atom1->getPropIfPresent(signedIntToken, res));
+    CHECK(res[1] == 2);
+  }
+
+  SECTION("Bond properties access and override") {
+    addPropToAllBonds(mol, signedIntToken, 3);
+    int res;
+    REQUIRE(bond1->getPropIfPresent<int>(signedIntToken, res));
+    CHECK(res == 3);
+
+    bond1->setProp(signedIntToken, 4);
+    REQUIRE(bond1->getPropIfPresent<int>(signedIntToken, res));
+    CHECK(res == 4);
+
+    Bond* bond2 = mol.getBondWithIdx(2);
+    REQUIRE(bond2 != nullptr);
+    REQUIRE(bond2->getPropIfPresent<int>(signedIntToken, res));
+    CHECK(res == 3);
+  }
+
+  SECTION("Bond non-POD") {
+    addPropToAllBonds(mol, signedIntToken, boost::shared_array<int>(new int[3]{1,2,3}));
+    Bond* bond = mol.getBondWithIdx(0);
+    boost::shared_array<int> res;
+    REQUIRE(bond->getPropIfPresent(signedIntToken, res));
+    CHECK(res[1] == 2);
+  }
+
+
+  SECTION("Clear atom properties") {
+    addPropToAllAtoms(mol, floatToken, 3.0f);
+    addPropToAllAtoms(mol, signedIntToken, 5);
+
+    atom0->clearProp(floatToken);
+
+    // Check that we've cleared atom 0
+    float res;
+    int intres;
+    CHECK(!atom0->getPropIfPresent<float>(floatToken, res));
+
+    // Check that we haven't cleared atom 1
+    REQUIRE(atom1->getPropIfPresent<float>(floatToken, res));
+
+    // Check that we haven't cleared the int prop
+    REQUIRE(atom0->getPropIfPresent<int>(signedIntToken, intres));
+  }
+
+  SECTION("Clear bond properties") {
+    addPropToAllBonds(mol, floatToken, 3.0f);
+    addPropToAllBonds(mol, signedIntToken, 5);
+
+    bond0->clearProp(floatToken);
+
+    // Check that we've cleared atom 0
+    float res;
+    int intres;
+    CHECK(!bond0->getPropIfPresent<float>(floatToken, res));
+
+    // Check that we haven't cleared atom 1
+    REQUIRE(bond1->getPropIfPresent<float>(floatToken, res));
+
+    // Check that we haven't cleared the int prop
+    REQUIRE(bond0->getPropIfPresent<int>(signedIntToken, intres));
+  }
+
+  SECTION("Clear computed also clears atoms and bonds") {
+    addPropToAllAtoms(mol, floatToken, 3.0f, true);
+    addPropToAllBonds(mol, signedIntToken, 5, true);
+    addPropToAllBonds(mol, floatToken, 4.0f, false);
+
+    mol.clearComputedProps();
+
+    float res;
+    int intres;
+    CHECK(!atom0->getPropIfPresent<float>(floatToken, res));
+    CHECK(!bond0->getPropIfPresent<int>(signedIntToken, intres));
+    // Non-computed should remain.
+    CHECK(bond0->getPropIfPresent<float>(floatToken, res));
+  }
+
+  SECTION("Has prop") {
+    addPropToAllAtoms(mol, floatToken, 3.0f, true);
+    addPropToAllBonds(mol, signedIntToken, 5, true);
+
+    CHECK(atom0->hasProp(floatToken));
+    CHECK(bond0->hasProp(signedIntToken));
+    CHECK(!atom0->hasProp(signedIntToken));
+  }
+
+  SECTION("clear() RDProp API") {
+    addPropToAllAtoms(mol, floatToken, 3.0f, true);
+    atom0->clear();
+    CHECK(!atom0->hasProp(floatToken));
+  }
+
+  SECTION("Store different types with same key") {
+    atom1->setProp(floatToken, 5u);
+    atom0->setProp(floatToken, -3.0f);
+
+    bond0->setProp(floatToken, 4.0f);
+    std::vector<int> storeVal = {1, 2, 3};
+    bond1->setProp(floatToken, storeVal);
+
+    float resf;
+    unsigned int resu;
+    REQUIRE(atom0->getPropIfPresent<float>(floatToken, resf));
+    CHECK(resf == -3.0f);
+    REQUIRE(atom1->getPropIfPresent<unsigned int>(floatToken, resu));
+    CHECK(resu == 5u);
+
+    std::vector<int> resv;
+    REQUIRE(bond1->getPropIfPresent(std::string(floatToken), resv));
+    CHECK(resv == storeVal);
+    REQUIRE(bond0->getPropIfPresent<float>(floatToken, resf));
+    CHECK(resf == 4.0f);
+  }
+
+  SECTION("Clear all") {
+    atom0->setProp(floatToken, 3.0f);
+    atom1->setProp(signedIntToken, 5);
+    bond0->setProp(floatToken, 4.0f);
+    bond1->setProp(signedIntToken, 6);
+    mol.setProp(unsignedIntToken, 7);
+
+    mol.clear();
+    CHECK(!atom0->hasProp(floatToken));
+    CHECK(!atom1->hasProp(signedIntToken));
+    CHECK(!bond0->hasProp(floatToken));
+    CHECK(!bond1->hasProp(signedIntToken));
+    CHECK(!mol.hasProp(unsignedIntToken));
+  }
+
+  SECTION("Custom Atom Data Copying") {
+    std::string testPropName("test");
+    atom0->clearProp(testPropName);
+    atom1->clearProp(testPropName);
+    atom0->setProp(testPropName, MyCustomClass(11));
+    atom1->setProp(testPropName, MyCustomClass(17));
+    size_t copyCount1 = MyCustomClass::copyCount;
+    MyCustomClass copy = atom0->getProp<MyCustomClass>(testPropName);
+    size_t copyCount2 = MyCustomClass::copyCount;
+    const MyCustomClass &a0 = atom0->getProp<const MyCustomClass &>(testPropName);
+    size_t copyCount3 = MyCustomClass::copyCount;
+    const MyCustomClass &b0 = atom0->getProp<const MyCustomClass &>(testPropName);
+    size_t copyCount4 = MyCustomClass::copyCount;
+
+    CHECK(copy.value == 11);
+    CHECK(a0.value == 11);
+    CHECK(b0.value == 11);
+    CHECK(copyCount2 > copyCount1);
+    CHECK(copyCount3 == copyCount2);
+    CHECK(copyCount4 == copyCount3);
+
+    copy = atom1->getProp<MyCustomClass>(testPropName);
+    size_t copyCount5 = MyCustomClass::copyCount;
+    const MyCustomClass &a1 = atom1->getProp<const MyCustomClass &>(testPropName);
+    size_t copyCount6 = MyCustomClass::copyCount;
+    const MyCustomClass &b1 = atom1->getProp<const MyCustomClass &>(testPropName);
+    size_t copyCount7 = MyCustomClass::copyCount;
+
+    CHECK(copy.value == 17);
+    CHECK(a1.value == 17);
+    CHECK(b1.value == 17);
+    CHECK(copyCount5 > copyCount4);
+    CHECK(copyCount6 == copyCount5);
+    CHECK(copyCount7 == copyCount6);
+  }
+
+  SECTION("Custom Bond Data Copying") {
+    std::string testPropName("testb");
+    bond0->setProp(testPropName, MyCustomClass(12));
+    bond1->setProp(testPropName, MyCustomClass(18));
+    size_t copyCount1 = MyCustomClass::copyCount;
+    MyCustomClass copy = bond0->getProp<MyCustomClass>(testPropName);
+
+    size_t copyCount2 = MyCustomClass::copyCount;
+    const MyCustomClass &a0 = bond0->getProp<const MyCustomClass &>(testPropName);
+    size_t copyCount3 = MyCustomClass::copyCount;
+    const MyCustomClass &b0 = bond0->getProp<const MyCustomClass &>(testPropName);
+    size_t copyCount4 = MyCustomClass::copyCount;
+
+    CHECK(copy.value == 12);
+    CHECK(a0.value == 12);
+    CHECK(b0.value == 12);
+    CHECK(copyCount2 > copyCount1);
+    CHECK(copyCount3 == copyCount2);
+    CHECK(copyCount4 == copyCount3);
+
+    copy = bond1->getProp<MyCustomClass>(testPropName);
+    size_t copyCount5 = MyCustomClass::copyCount;
+    const MyCustomClass &a1 = bond1->getProp<const MyCustomClass &>(testPropName);
+    size_t copyCount6 = MyCustomClass::copyCount;
+    const MyCustomClass &b1 = bond1->getProp<const MyCustomClass &>(testPropName);
+    size_t copyCount7 = MyCustomClass::copyCount;
+
+    CHECK(copy.value == 18);
+    CHECK(a1.value == 18);
+    CHECK(b1.value == 18);
+    CHECK(copyCount5 > copyCount4);
+    CHECK(copyCount6 == copyCount5);
+    CHECK(copyCount7 == copyCount6);
+  }
+}
+
+template <typename T1, typename T2>
+void setPropsForUpdatePropsTest(T1 &prop1, T2 &prop2) {
+  // basics
+  prop1.clear();
+  prop2.clear();
+  prop1.setProp("first", 3);
+  prop1.setProp("second", "value");
+  prop2.setProp("first", 5.0);
+  prop2.setProp("third", 7);
+
+  // computed behavior
+  // First, one that's only in source
+  prop1.setProp("firstComputed", 4, true);
+  // Next, one that's computed in both.
+  prop1.setProp("computedInBoth", "value1", true);
+  prop2.setProp("computedInBoth", "value2", true);
+  // Next, computed only in source
+  prop1.setProp("computedOnlyIn1", 1, true);
+  prop2.setProp("computedOnlyIn1", 2, false);
+  // Finally, computed only in dest
+  prop1.setProp("computedOnlyIn2", 1, false);
+  prop2.setProp("computedOnlyIn2", 2, true);
+}
+
+template <typename T>
+void checkUpdatePropsValuesNoPreserve(const T &prop2,
+                                      const std::string &message) {
+  INFO(message);
+  CHECK(prop2.template getProp<int>("first") == 3);
+  CHECK(prop2.template getProp<std::string>("second") == "value");
+  CHECK(!prop2.hasProp("third"));
+
+  CHECK(prop2.template getProp<int>("firstComputed") == 4);
+  CHECK(prop2.template getProp<std::string>("computedInBoth") == "value1");
+  CHECK(prop2.template getProp<int>("computedOnlyIn1") == 1);
+  CHECK(prop2.template getProp<int>("computedOnlyIn2") == 1);
+
+  // Get a list of the computed props
+  std::vector<std::string> computedProps = prop2.getPropList(false, true);
+  std::vector<std::string> nonComputedProps = prop2.getPropList(false, false);
+
+  for (const auto &prop : nonComputedProps) {
+    computedProps.erase(
+        std::remove(computedProps.begin(), computedProps.end(), prop),
+        computedProps.end());
+  }
+  // Handle the private __computedProps implementation of RDProps
+  computedProps.erase(std::remove(computedProps.begin(), computedProps.end(),
+                                  std::string("__computedProps")),
+                      computedProps.end());
+
+  std::vector<std::string> wantComputedProps = {
+      "firstComputed", "computedInBoth", "computedOnlyIn1"};
+  CHECK_THAT(computedProps,
+             Catch::Matchers::UnorderedEquals(wantComputedProps));
+}
+
+template <typename T>
+void checkUpdatePropsValuesPreserve(const T &prop2,
+                                    const std::string &message) {
+  INFO(message);
+  CHECK(prop2.template getProp<int>("first") == 3);
+  CHECK(prop2.template getProp<std::string>("second") == "value");
+  CHECK(prop2.template getProp<int>("third") == 7);
+
+  CHECK(prop2.template getProp<int>("firstComputed") == 4);
+  CHECK(prop2.template getProp<std::string>("computedInBoth") == "value1");
+  CHECK(prop2.template getProp<int>("computedOnlyIn1") == 1);
+  CHECK(prop2.template getProp<int>("computedOnlyIn2") == 1);
+
+  // Get computed props
+  std::vector<std::string> computedProps = prop2.getPropList(false, true);
+  std::vector<std::string> nonComputedProps = prop2.getPropList(false, false);
+
+  for (const auto &prop : nonComputedProps) {
+    computedProps.erase(
+        std::remove(computedProps.begin(), computedProps.end(), prop),
+        computedProps.end());
+  }
+  // Handle the private __computedProps implementation of RDProps
+  computedProps.erase(std::remove(computedProps.begin(), computedProps.end(),
+                                  std::string("__computedProps")),
+                      computedProps.end());
+
+  std::vector<std::string> wantComputedProps = {
+      "firstComputed", "computedInBoth", "computedOnlyIn1"};
+  CHECK_THAT(computedProps,
+             Catch::Matchers::UnorderedEquals(wantComputedProps));
+}
+
+template <typename T1, typename T2>
+void runFullUpdatePropsSequence(T1 &prop1, T2 &prop2,
+                                const std::string &message) {
+  setPropsForUpdatePropsTest(prop1, prop2);
+  prop2.updateProps(prop1, /*preserve=*/false);
+  checkUpdatePropsValuesNoPreserve(prop2, message + ": no preserve");
+
+  setPropsForUpdatePropsTest(prop1, prop2);
+  prop2.updateProps(prop1, /*preserve=*/true);
+  checkUpdatePropsValuesPreserve(prop2, message + ": preserve");
+}
+
+TEST_CASE("Atom/bond updateprops") {
+  auto mol = basicMol();
+  ROMol &romol = mol->asROMol();
+  auto mol2 = basicMol();
+  ROMol &romol2 = mol2->asROMol();
+  Atom soloAtom(6);
+  Atom soloAtom2(8);
+
+  Bond soloBond;
+  Bond soloBond2;
+
+  SECTION("Check RDProps behavior assumptions") {
+    RDProps prop1, prop2;
+    runFullUpdatePropsSequence(prop1, prop2, "RDProps");
+  }
+
+  SECTION("Solo Atom to solo Atom") {
+    runFullUpdatePropsSequence(soloAtom, soloAtom2, "Solo atom to solo atom");
+  }
+
+  SECTION("Mol Atom to mol Atom") {
+    runFullUpdatePropsSequence(*romol.getAtomWithIdx(1),
+                               *romol2.getAtomWithIdx(2),
+                               "mol atom to mol atom");
+  }
+
+  SECTION("Mol Atom to non-mol Atom") {
+    runFullUpdatePropsSequence(*romol.getAtomWithIdx(1), soloAtom,
+                               "mol atom to non-mol atom");
+  }
+
+  SECTION("Non-Atom to Atom") {
+    Conformer conf;
+    runFullUpdatePropsSequence(conf, *romol.getAtomWithIdx(1),
+                               "non-atom to atom");
+  }
+  // Note: Bond to generic non-Bond not supported, as the inherited APIs take
+  // in an RDProps.
+
+  SECTION("Solo Bond to solo Bond") {
+    runFullUpdatePropsSequence(soloBond, soloBond2, "solo bond to solo bond");
+  }
+
+  SECTION("Mol Bond to mol Bond") {
+    runFullUpdatePropsSequence(*romol.getBondWithIdx(1),
+                               *romol2.getBondWithIdx(2),
+                               "mol bond to mol bond");
+  }
+
+  SECTION("Mol Bond to non-mol Bond") {
+    runFullUpdatePropsSequence(*romol.getBondWithIdx(1), soloBond,
+                               "mol bond to nonmol bond");
+  }
+
+  SECTION("Non-Bond to Bond") {
+    Conformer conf;
+    runFullUpdatePropsSequence(conf, *romol.getBondWithIdx(1),
+                               "nonbond to bond");
+  }
+
+  SECTION("Mol to Mol") {
+    runFullUpdatePropsSequence(romol, romol2, "mol to mol");
+  }
+
+  SECTION("Non-mol to Mol") {
+    Conformer conf;
+    runFullUpdatePropsSequence(conf, romol, "non mol to mol");
+  }
+}
+
+TEST_CASE("Atom Monomomer info") {
+  auto mol = basicMol();
+  ROMol &romol = mol->asROMol();
+  Atom *atom = romol.getAtomWithIdx(0);
+  Atom *atom2 = romol.getAtomWithIdx(1);
+  const Atom* atom3 = romol.getAtomWithIdx(2);  // Used to check const overload of null entry
+  Atom* atom4 = romol.getAtomWithIdx(3); // Used to check non-const overload of null entry
+
+  SECTION("Has None") {
+    CHECK(atom->getMonomerInfo() == nullptr);
+    CHECK(atom2->getMonomerInfo() == nullptr);
+  }
+
+  SECTION("Set/get") {
+    auto *baseClassInfo = new AtomMonomerInfo(AtomMonomerInfo::OTHER);
+    atom->setMonomerInfo(baseClassInfo);
+    auto *PDBInfo = new AtomPDBResidueInfo("dummy", /*serial=*/3);
+    atom2->setMonomerInfo(PDBInfo);
+
+    CHECK(atom4->getMonomerInfo() == nullptr);
+    AtomMonomerInfo *res1 = atom->getMonomerInfo();
+    const AtomMonomerInfo *res2 = atom2->getMonomerInfo();
+
+    CHECK(res1->getMonomerType() == AtomMonomerInfo::OTHER);
+    CHECK(res2->getMonomerType() == AtomMonomerInfo::PDBRESIDUE);
+
+    auto *res2PDB = dynamic_cast<const AtomPDBResidueInfo *>(res2);
+    CHECK(res2PDB != nullptr);
+    CHECK(res2PDB->getSerialNumber() == 3);
+
+    // Const overload
+    const Atom *atomConst = atom;
+    const AtomMonomerInfo *res1Const = atomConst->getMonomerInfo();
+    CHECK(res1Const->getMonomerType() == AtomMonomerInfo::OTHER);
+    CHECK(atom3->getMonomerInfo() == nullptr);
+  }
+
+  SECTION("Override") {
+    auto *baseClassInfo = new AtomMonomerInfo(AtomMonomerInfo::OTHER);
+    atom->setMonomerInfo(baseClassInfo);
+    auto *PDBInfo = new AtomPDBResidueInfo("dummy", /*serial=*/3);
+    atom->setMonomerInfo(PDBInfo);
+
+    AtomMonomerInfo *res1 = atom->getMonomerInfo();
+    CHECK(res1->getMonomerType() == RDKit::AtomMonomerInfo::PDBRESIDUE);
+  }
+}
+
+TEST_CASE("Atom constructors/ownership") {
+  SECTION("Default") {
+    Atom atom;
+    CHECK(!atom.hasOwningMol());
+
+    Atom atom2(6);
+    CHECK(!atom2.hasOwningMol());
+    CHECK(atom2.getAtomicNum() == 6);
+
+    Atom atom3("C");
+    CHECK(!atom3.hasOwningMol());
+    CHECK(atom3.getAtomicNum() == 6);
+  }
+
+  SECTION("Copy, no previous owner") {
+    Atom atom(6);
+    atom.setProp("test", 3, /*computed=*/ true);
+    atom.setProp("complexTest", std::vector<int>({1, 2, 3}));
+    atom.setMonomerInfo(new AtomMonomerInfo(AtomMonomerInfo::OTHER));
+
+    Atom atom2(atom);
+    CHECK(!atom2.hasOwningMol());
+    CHECK(atom2.getAtomicNum() == 6);
+
+    Atom atom3 = atom;
+    CHECK(!atom3.hasOwningMol());
+    CHECK(atom3.getAtomicNum() == 6);
+
+    int res;
+    REQUIRE(atom3.getPropIfPresent<int>("test", res));
+    CHECK(res == 3);
+    std::vector<int> resv;
+    REQUIRE(atom3.getPropIfPresent("complexTest", resv));
+    CHECK(resv == std::vector<int>({1, 2, 3}));
+
+    AtomMonomerInfo *info = atom3.getMonomerInfo();
+    REQUIRE(info != nullptr);
+    CHECK(info->getMonomerType() == AtomMonomerInfo::OTHER);
+  }
+
+  SECTION("Copy, previous owner") {
+    auto molPtr = basicMol();
+    RDMol& mol = *molPtr;
+    auto &romol = mol.asROMol();
+
+    Atom *atom = romol.getAtomWithIdx(0);
+    atom->setProp("test", 3, /*computed=*/ true);
+    atom->setProp("complexTest", std::vector<int>({1, 2, 3}));
+    atom->setMonomerInfo(new AtomMonomerInfo(AtomMonomerInfo::OTHER));
+
+    REQUIRE(atom != nullptr);
+    REQUIRE(atom->getAtomicNum() == 6);
+    REQUIRE(&atom->getOwningMol() == &romol);
+
+    Atom atom2(*atom);
+    CHECK(!atom2.hasOwningMol());
+    CHECK(atom2.getAtomicNum() == 6);
+
+    int res;
+    REQUIRE(atom2.getPropIfPresent<int>("test", res));
+    CHECK(res == 3);
+    std::vector<int> resv;
+    REQUIRE(atom2.getPropIfPresent("complexTest", resv));
+    CHECK(resv == std::vector<int>({1, 2, 3}));
+
+    AtomMonomerInfo *info = atom2.getMonomerInfo();
+    REQUIRE(info != nullptr);
+    CHECK(info->getMonomerType() == AtomMonomerInfo::OTHER);
+  }
+
+  SECTION("move, no previous owner") {
+      Atom atom(6);
+      atom.setProp("test", 3, /*computed=*/ true);
+      atom.setProp("complexTest", std::vector<int>({1, 2, 3}));
+      atom.setMonomerInfo(new AtomMonomerInfo(AtomMonomerInfo::OTHER));
+      Atom atom2 = std::move(atom);
+      CHECK(!atom2.hasOwningMol());
+      CHECK(atom2.getAtomicNum() == 6);
+
+      int res;
+      REQUIRE(atom2.getPropIfPresent<int>("test", res));
+      CHECK(res == 3);
+      std::vector<int> resv;
+      REQUIRE(atom2.getPropIfPresent("complexTest", resv));
+      CHECK(resv == std::vector<int>({1, 2, 3}));
+
+      AtomMonomerInfo *info = atom2.getMonomerInfo();
+      REQUIRE(info != nullptr);
+      CHECK(info->getMonomerType() == AtomMonomerInfo::OTHER);
+  }
+
+  SECTION("Move, previous owner") {
+      auto molPtr = basicMol();
+      RDMol& mol = *molPtr;
+      auto &romol = mol.asROMol();
+
+      Atom *atom = romol.getAtomWithIdx(0);
+      atom->setProp("test", 3, /*computed=*/ true);
+      atom->setProp("complexTest", std::vector<int>({1, 2, 3}));
+      atom->setMonomerInfo(new AtomMonomerInfo(AtomMonomerInfo::OTHER));
+
+      REQUIRE(atom != nullptr);
+      REQUIRE(atom->getAtomicNum() == 6);
+      REQUIRE(&atom->getOwningMol() == &romol);
+
+      Atom atom2(std::move(*atom));
+      CHECK(atom2.hasOwningMol());
+      CHECK(atom2.getAtomicNum() == 6);
+
+      int res;
+      REQUIRE(atom2.getPropIfPresent<int>("test", res));
+      CHECK(res == 3);
+      std::vector<int> resv;
+      REQUIRE(atom2.getPropIfPresent("complexTest", resv));
+      CHECK(resv == std::vector<int>({1, 2, 3}));
+
+      AtomMonomerInfo *info = atom2.getMonomerInfo();
+      REQUIRE(info != nullptr);
+      CHECK(info->getMonomerType() == AtomMonomerInfo::OTHER);
+  }
+}
+
+TEST_CASE("Bond constructors/ownership") {
+  SECTION("Default") {
+    Bond bond;
+    CHECK(!bond.hasOwningMol());
+
+    Bond bond2(Bond::BondType::SINGLE);
+    CHECK(!bond2.hasOwningMol());
+    CHECK(bond2.getBondType() == Bond::BondType::SINGLE);
+  }
+
+  SECTION("Constructors, no previous owner") {
+    Bond bond(Bond::BondType::SINGLE);
+    bond.setProp("test", 3, /*computed=*/ true);
+    bond.setProp("complexTest", std::vector<int>({1, 2, 3}));
+    Bond bond2(bond);
+    CHECK(!bond2.hasOwningMol());
+
+    Bond bond3(std::move(bond));
+    CHECK(!bond3.hasOwningMol());
+
+    int res;
+    REQUIRE(bond3.getPropIfPresent<int>("test", res));
+    CHECK(res == 3);
+    std::vector<int> resv;
+    REQUIRE(bond3.getPropIfPresent("complexTest", resv));
+    CHECK(resv == std::vector<int>({1, 2, 3}));
+  }
+
+  SECTION("Copy assignment operator, previous owner") {
+    auto molPtr = basicMol();
+    RDMol& mol = *molPtr;
+    auto &romol = mol.asROMol();
+
+    Bond *bond = romol.getBondWithIdx(0);
+    bond->setProp("test", 3, /*computed=*/ true);
+    bond->setProp("complexTest", std::vector<int>({1, 2, 3}));
+    REQUIRE(bond != nullptr);
+    REQUIRE(bond->getBondType() == Bond::BondType::SINGLE);
+    REQUIRE(&bond->getOwningMol() == &romol);
+
+    Bond bond2 = *bond;
+    CHECK(!bond2.hasOwningMol());
+    int res;
+    REQUIRE(bond2.getPropIfPresent<int>("test", res));
+    CHECK(res == 3);
+    std::vector<int> resv;
+    REQUIRE(bond2.getPropIfPresent("complexTest", resv));
+    CHECK(resv == std::vector<int>({1, 2, 3}));
+  }
+
+  SECTION("Move assign operator, no previous owner") {
+    Bond bond(Bond::BondType::SINGLE);
+    bond.setProp("test", 3, /*computed=*/ true);
+    bond.setProp("complexTest", std::vector<int>({1, 2, 3}));
+    Bond bond2 = std::move(bond);
+    CHECK(!bond2.hasOwningMol());
+    int res;
+    REQUIRE(bond2.getPropIfPresent<int>("test", res));
+    CHECK(res == 3);
+    std::vector<int> resv;
+    REQUIRE(bond2.getPropIfPresent("complexTest", resv));
+    CHECK(resv == std::vector<int>({1, 2, 3}));
+  }
+
+  SECTION("Move constructor, previous owner") {
+    auto molPtr = basicMol();
+    RDMol& mol = *molPtr;
+    auto &romol = mol.asROMol();
+
+    Bond *bond = romol.getBondWithIdx(0);
+    bond->setProp("test", 3, /*computed=*/ true);
+    bond->setProp("complexTest", std::vector<int>({1, 2, 3}));
+    REQUIRE(bond != nullptr);
+    REQUIRE(bond->getBondType() == Bond::BondType::SINGLE);
+    REQUIRE(&bond->getOwningMol() == &romol);
+
+    Bond bond2(std::move(*bond));
+    CHECK(bond2.hasOwningMol());
+    int res;
+    REQUIRE(bond2.getPropIfPresent<int>("test", res));
+    CHECK(res == 3);
+    std::vector<int> resv;
+    REQUIRE(bond2.getPropIfPresent("complexTest", resv));
+    CHECK(resv == std::vector<int>({1, 2, 3}));
+  }
+}
+
+TEST_CASE("Atom map number") {
+  auto molPtr = basicMol();
+  auto &mol = molPtr->asROMol();
+  Atom *atom0 = mol.getAtomWithIdx(0);
+  Atom *atom1 = mol.getAtomWithIdx(1);
+
+  SECTION("Set and get atom map number") {
+    atom0->setAtomMapNum(1);
+    atom1->setAtomMapNum(2);
+    CHECK(atom0->getAtomMapNum() == 1);
+    CHECK(atom1->getAtomMapNum() == 2);
+  }
+
+  SECTION("Strict/non-strict") {
+    atom0->setAtomMapNum(-10, false);
+    CHECK(atom0->getAtomMapNum() == -10);
+    CHECK_THROWS_AS(atom1->setAtomMapNum(-10, true), Invar::Invariant);
+  }
+
+  SECTION("Default") { CHECK(atom0->getAtomMapNum() == 0); }
+
+  SECTION("Set as 0 clears") {
+    atom0->setAtomMapNum(1);
+    atom0->setAtomMapNum(0);
+    atom1->setAtomMapNum(0);
+    CHECK(atom0->getAtomMapNum() == 0);
+    CHECK(atom1->getAtomMapNum() == 0);
+  }
+}
+
+// Test cases taken from comment above function implementation.
+TEST_CASE("GetPerturbationOrder") {
+  const std::string fourBondedCarbon = "C(N)(N)(N)N";
+  auto mol = parseSmiles(fourBondedCarbon.c_str());
+  auto &romol = mol->asROMol();
+  Atom *atom0 = romol.getAtomWithIdx(0);
+
+  INT_LIST inputOrder;
+  inputOrder.push_back(1);
+  inputOrder.push_back(0);
+  inputOrder.push_back(2);
+  inputOrder.push_back(3);
+  CHECK(atom0->getPerturbationOrder(inputOrder) == 1);
+
+  inputOrder.clear();
+  inputOrder.push_back(1);
+  inputOrder.push_back(2);
+  inputOrder.push_back(3);
+  inputOrder.push_back(0);
+  CHECK(atom0->getPerturbationOrder(inputOrder) == 3);
+
+  inputOrder.clear();
+  inputOrder.push_back(1);
+  inputOrder.push_back(2);
+  inputOrder.push_back(0);
+  inputOrder.push_back(3);
+  CHECK(atom0->getPerturbationOrder(inputOrder) == 2);
+}
+
+TEST_CASE("Atom valence conversions from RDMol") {
+  auto molPtr = basicMol();
+  auto &mol = molPtr->asROMol();
+  Atom *atom0 = mol.getAtomWithIdx(0);
+  Atom *atom1 = mol.getAtomWithIdx(1);
+  Atom *atom2 = mol.getAtomWithIdx(2);
+  Atom* atom3 = mol.getAtomWithIdx(3);
+
+  SECTION("Neither implicit nor explicit set") {
+    CHECK_THROWS_AS(atom0->getExplicitValence(), Invar::Invariant);
+    CHECK_THROWS_AS(atom0->getImplicitValence(), Invar::Invariant);
+  }
+
+  SECTION("Explicit set") {
+    atom0->calcExplicitValence(false);
+    CHECK(atom0->getExplicitValence() == 1);
+    CHECK_THROWS_AS(atom0->getImplicitValence(), Invar::Invariant);
+  }
+
+  SECTION("No implict set") {
+    atom0->setNoImplicit(true);
+    CHECK(atom0->getImplicitValence() == 0);
+  }
+
+  SECTION("Correct after calculation") {
+    atom0->calcImplicitValence(false);
+    atom1->calcImplicitValence(false);
+    atom2->calcImplicitValence(false);
+    atom3->calcImplicitValence(false);
+
+    CHECK(atom0->getExplicitValence() == 1);
+    CHECK(atom1->getExplicitValence() == 2);
+    CHECK(atom2->getExplicitValence() == 3); // double bond
+    CHECK(atom3->getExplicitValence() == 2);
+
+    CHECK(atom0->getImplicitValence() == 3);
+    CHECK(atom1->getImplicitValence() == 2);
+    CHECK(atom2->getImplicitValence() == 1);
+    CHECK(atom3->getImplicitValence() == 2);
+  }
+
+  SECTION("Atom with no bonds but explicit hydrogens") {
+    auto singleAtomMol = parseSmiles("C", false, false);
+    auto& romol = singleAtomMol->asROMol();
+    auto* atom = romol.getAtomWithIdx(0);
+    atom->setNumExplicitHs(3);
+    atom->calcExplicitValence(false);
+    CHECK(atom->getExplicitValence() == 3);
+  }
+}
+
+TEST_CASE("Bond getOtherAtom and getOtherAtomIdx") {
+  auto molPtr = basicMol();
+  auto &mol = molPtr->asROMol();
+  Bond *bond1 = mol.getBondWithIdx(1);
+  REQUIRE(bond1 != nullptr);
+  REQUIRE(bond1->getBeginAtomIdx() == 1);
+  REQUIRE(bond1->getEndAtomIdx() == 2);
+
+  SECTION("getOtherAtom") {
+    Atom* atom1 = bond1->getBeginAtom();
+    Atom* atom2 = bond1->getEndAtom();
+    Atom* other1 = bond1->getOtherAtom(atom1);
+    Atom* other2 = bond1->getOtherAtom(atom2);
+    CHECK(other1 == atom2);
+    CHECK(other2 == atom1);
+  }
+
+  SECTION("getOtherAtomFails") {
+    CHECK_THROWS_AS(bond1->getOtherAtom(nullptr), Invar::Invariant);
+
+    // getOtherAtom needs an owning molecule
+    std::unique_ptr<Bond> isolatedBond(
+        new Bond(RDKit::Bond::BondType::SINGLE));
+    isolatedBond->setBeginAtomIdx(bond1->getBeginAtomIdx());
+    isolatedBond->setEndAtomIdx(bond1->getEndAtomIdx());
+    CHECK_THROWS_AS(isolatedBond->getOtherAtom(bond1->getBeginAtom()),
+                    Invar::Invariant);
+  }
+
+  SECTION("getOtherAtomIdx") {
+    CHECK(bond1->getOtherAtomIdx(1) == 2);
+    CHECK(bond1->getOtherAtomIdx(2) == 1);
+  }
+
+  SECTION("GetOtherAtomIdxFails") {
+    CHECK_THROWS_AS(bond1->getOtherAtomIdx(3), Invar::Invariant);
+  }
+}
+
+TEST_CASE("Update property cache") {
+  auto molPtr = basicMol();
+  auto &mol = molPtr->asROMol();
+  Atom *atom0 = mol.getAtomWithIdx(0);
+  Atom *atom1 = mol.getAtomWithIdx(1);
+
+  SECTION("Needs update - explicit") {
+    CHECK(atom0->needsUpdatePropertyCache() == true);
+  }
+
+  SECTION("Needs update - implicit") {
+    atom1->calcExplicitValence(false);
+    CHECK(atom1->needsUpdatePropertyCache() == true);
+  }
+
+  SECTION("Does not need - noimplict") {
+    atom0->setNoImplicit(true);
+    atom0->calcExplicitValence(false);
+    CHECK(atom0->needsUpdatePropertyCache() == false);
+  }
+
+  SECTION("Update cache") {
+    CHECK(atom0->needsUpdatePropertyCache() == true);
+    mol.updatePropertyCache();
+    CHECK(atom0->needsUpdatePropertyCache() == false);
+  }
+}
+
+TEST_CASE("Bond Stereo Atoms") {
+  RDMol rdmol;
+  RDKit::SmilesParseTemp temp;
+  static const char *basicSmiles = "CC1C(C)C1";
+
+  SmilesParserParams params;
+  params.sanitize = false;
+  params.removeHs = false;
+
+  REQUIRE(RDKit::SmilesToMol(basicSmiles, params, rdmol, temp) == true);
+  REQUIRE(rdmol.getNumAtoms() == 5);
+  REQUIRE(rdmol.getNumBonds() == 5);
+
+  SECTION("Sync various combinations") {
+    // Start with only RDMol
+    REQUIRE(rdmol.getBondIndexBetweenAtoms(1, 2) == 1);
+    REQUIRE(rdmol.getBondIndexBetweenAtoms(1, 4) < 5);
+    REQUIRE(rdmol.getBondIndexBetweenAtoms(0, 1) < 5);
+    REQUIRE(rdmol.getBondIndexBetweenAtoms(2, 3) < 5);
+    REQUIRE(rdmol.getBondIndexBetweenAtoms(2, 4) < 5);
+    {
+      const atomindex_t *newStereoAtoms = rdmol.getBondStereoAtoms(1);
+      REQUIRE(newStereoAtoms != nullptr);
+      CHECK(newStereoAtoms[0] == atomindex_t(-1));
+      CHECK(newStereoAtoms[1] == atomindex_t(-1));
+    }
+    rdmol.setBondStereoAtoms(1, 4, 4);
+    {
+      const atomindex_t *newStereoAtoms = rdmol.getBondStereoAtoms(1);
+      REQUIRE(newStereoAtoms != nullptr);
+      CHECK(newStereoAtoms[0] == 4);
+      CHECK(newStereoAtoms[1] == 4);
+    }
+    rdmol.clearBondStereoAtoms(1);
+    {
+      const atomindex_t *newStereoAtoms = rdmol.getBondStereoAtoms(1);
+      REQUIRE(newStereoAtoms != nullptr);
+      CHECK(newStereoAtoms[0] == atomindex_t(-1));
+      CHECK(newStereoAtoms[1] == atomindex_t(-1));
+    }
+
+    auto &mol = rdmol.asROMol();
+
+    Bond *bond1 = mol.getBondWithIdx(1);
+    REQUIRE(mol.getBondBetweenAtoms(1, 2) == bond1);
+    REQUIRE(mol.getBondBetweenAtoms(1, 4) != nullptr);
+    REQUIRE(mol.getBondBetweenAtoms(0, 1) != nullptr);
+    REQUIRE(mol.getBondBetweenAtoms(2, 3) != nullptr);
+    REQUIRE(mol.getBondBetweenAtoms(2, 4) != nullptr);
+    {
+      const RDKit::INT_VECT &stereoAtoms = bond1->getStereoAtoms();
+      REQUIRE(stereoAtoms.size() == 0);
+      const atomindex_t *newStereoAtoms = rdmol.getBondStereoAtoms(1);
+      REQUIRE(newStereoAtoms != nullptr);
+      CHECK(newStereoAtoms[0] == atomindex_t(-1));
+      CHECK(newStereoAtoms[1] == atomindex_t(-1));
+    }
+    bond1->setStereoAtoms(0, 4);
+    {
+      const RDKit::INT_VECT &stereoAtoms = bond1->getStereoAtoms();
+      REQUIRE(stereoAtoms.size() == 2);
+      CHECK(stereoAtoms[0] == 0);
+      CHECK(stereoAtoms[1] == 4);
+      const atomindex_t *newStereoAtoms = rdmol.getBondStereoAtoms(1);
+      REQUIRE(newStereoAtoms != nullptr);
+      CHECK(newStereoAtoms[0] == 0);
+      CHECK(newStereoAtoms[1] == 4);
+    }
+    rdmol.setBondStereoAtoms(1, 4, 3);
+    {
+      const RDKit::INT_VECT &stereoAtoms = bond1->getStereoAtoms();
+      REQUIRE(stereoAtoms.size() == 2);
+      CHECK(stereoAtoms[0] == 4);
+      CHECK(stereoAtoms[1] == 3);
+      const atomindex_t *newStereoAtoms = rdmol.getBondStereoAtoms(1);
+      REQUIRE(newStereoAtoms != nullptr);
+      CHECK(newStereoAtoms[0] == 4);
+      CHECK(newStereoAtoms[1] == 3);
+    }
+    bond1->setStereoAtoms(0, 3);
+    {
+      const RDKit::INT_VECT &stereoAtoms = bond1->getStereoAtoms();
+      REQUIRE(stereoAtoms.size() == 2);
+      CHECK(stereoAtoms[0] == 0);
+      CHECK(stereoAtoms[1] == 3);
+      const atomindex_t *newStereoAtoms = rdmol.getBondStereoAtoms(1);
+      REQUIRE(newStereoAtoms != nullptr);
+      CHECK(newStereoAtoms[0] == 0);
+      CHECK(newStereoAtoms[1] == 3);
+    }
+  }
+}
+
+TEST_CASE("Stereo Groups") {
+  RDMol rdmol;
+  RDKit::SmilesParseTemp temp;
+  static const char *basicSmiles = "CCCCCC";
+
+  SmilesParserParams params;
+  params.sanitize = false;
+  params.removeHs = false;
+
+  REQUIRE(RDKit::SmilesToMol(basicSmiles, params, rdmol, temp) == true);
+  REQUIRE(rdmol.getNumAtoms() == 6);
+  REQUIRE(rdmol.getNumBonds() == 5);
+  auto &mol = rdmol.asROMol();
+
+  Atom *atom0 = mol.getAtomWithIdx(0);
+  Atom *atom1 = mol.getAtomWithIdx(1);
+  Atom *atom2 = mol.getAtomWithIdx(2);
+  Atom *atom3 = mol.getAtomWithIdx(3);
+  Atom *atom4 = mol.getAtomWithIdx(4);
+  Atom *atom5 = mol.getAtomWithIdx(5);
+
+  Bond *bond0 = mol.getBondWithIdx(0);
+  Bond *bond1 = mol.getBondWithIdx(1);
+  Bond *bond2 = mol.getBondWithIdx(2);
+  Bond *bond3 = mol.getBondWithIdx(3);
+  Bond *bond4 = mol.getBondWithIdx(4);
+
+  SECTION("Empty") { CHECK(mol.getStereoGroups().size() == 0); }
+
+  SECTION("Set/get") {
+    std::vector<StereoGroup> groups;
+    std::vector<Atom *> atoms = {atom0, atom2, atom1};
+    std::vector<Bond *> bonds = {bond4, bond3};
+    groups.push_back(StereoGroup(StereoGroupType::STEREO_OR, std::move(atoms),
+                                 std::move(bonds)));
+
+    std::vector<Atom *> atoms2 = {atom5, atom4};
+    std::vector<Bond *> bonds2 = {bond2};
+
+    groups.push_back(StereoGroup(StereoGroupType::STEREO_AND, std::move(atoms2),
+                                 std::move(bonds2)));
+
+    mol.setStereoGroups(std::move(groups));
+
+    const std::vector<StereoGroup> &res = mol.getStereoGroups();
+    REQUIRE(res.size() == 2);
+    CHECK(res[0].getGroupType() == StereoGroupType::STEREO_OR);
+    CHECK(res[1].getGroupType() == StereoGroupType::STEREO_AND);
+
+    CHECK(res[0].getAtoms().size() == 3);
+    CHECK(res[1].getAtoms().size() == 2);
+
+    CHECK_THAT(res[0].getAtoms(), Catch::Matchers::UnorderedEquals(atoms));
+    CHECK_THAT(res[1].getAtoms(), Catch::Matchers::UnorderedEquals(atoms2));
+
+    CHECK_THAT(res[0].getBonds(), Catch::Matchers::UnorderedEquals(bonds));
+    CHECK_THAT(res[1].getBonds(), Catch::Matchers::UnorderedEquals(bonds2));
+  }
+
+  SECTION("Set ROMol / get RDMol") {
+    std::vector<StereoGroup> groups;
+    std::vector<Atom *> atoms = {atom0, atom2, atom1};
+    std::vector<Bond *> bonds = {bond4, bond3};
+    groups.push_back(StereoGroup(StereoGroupType::STEREO_OR, std::move(atoms),
+                                 std::move(bonds)));
+
+    std::vector<Atom *> atoms2 = {atom5, atom4};
+    std::vector<Bond *> bonds2 = {bond2};
+
+    groups.push_back(StereoGroup(StereoGroupType::STEREO_AND, std::move(atoms2),
+                                 std::move(bonds2)));
+
+    mol.setStereoGroups(std::move(groups));
+
+    const StereoGroups *res = rdmol.getStereoGroups();
+
+    REQUIRE(res != nullptr);
+
+    const auto &types = res->stereoTypes;
+    const auto &atomBegins = res->atomBegins;
+    const auto &bondBegins = res->bondBegins;
+    const auto &atomIndices = res->atoms;
+    const auto &bondIndices = res->bonds;
+
+    CHECK(types == std::vector<StereoGroupType>({StereoGroupType::STEREO_OR,
+                                                 StereoGroupType::STEREO_AND}));
+
+    CHECK(atomBegins == std::vector<uint32_t>({0, 3, 5}));
+    CHECK(bondBegins == std::vector<uint32_t>({0, 2, 3}));
+
+    std::vector<uint32_t> atomSection1(3);
+    std::vector<uint32_t> atomSection2(2);
+    std::vector<uint32_t> bondSection1(2);
+    std::vector<uint32_t> bondSection2(1);
+
+    std::copy(atomIndices.begin(), atomIndices.begin() + 3,
+              atomSection1.begin());
+    std::copy(atomIndices.begin() + 3, atomIndices.begin() + 5,
+              atomSection2.begin());
+    std::copy(bondIndices.begin(), bondIndices.begin() + 2,
+              bondSection1.begin());
+    std::copy(bondIndices.begin() + 2, bondIndices.begin() + 3,
+              bondSection2.begin());
+
+    CHECK_THAT(atomSection1, Catch::Matchers::UnorderedEquals(
+                                 std::vector<uint32_t>({0, 2, 1})));
+    CHECK_THAT(atomSection2,
+               Catch::Matchers::UnorderedEquals(std::vector<uint32_t>({5, 4})));
+    CHECK_THAT(bondSection1,
+               Catch::Matchers::UnorderedEquals(std::vector<uint32_t>({4, 3})));
+    CHECK_THAT(bondSection2,
+               Catch::Matchers::UnorderedEquals(std::vector<uint32_t>({2})));
+  }
+
+  SECTION("Set RDMol / get ROMol") {
+    auto groups = std::make_unique<StereoGroups>();
+    groups->addGroup(StereoGroupType::STEREO_OR, {0, 2, 1}, {4, 3}, 1);
+    groups->addGroup(StereoGroupType::STEREO_AND, {5, 4}, {2}, 2);
+    rdmol.setStereoGroups(std::move(groups));
+
+    const std::vector<StereoGroup> &res = mol.getStereoGroups();
+    REQUIRE(res.size() == 2);
+    CHECK(res[0].getGroupType() == StereoGroupType::STEREO_OR);
+    CHECK(res[1].getGroupType() == StereoGroupType::STEREO_AND);
+
+    CHECK(res[0].getAtoms().size() == 3);
+    CHECK(res[1].getAtoms().size() == 2);
+
+    CHECK(res[0].getReadId() == 1);
+    CHECK(res[1].getReadId() == 2);
+
+    CHECK_THAT(res[0].getAtoms(),
+               Catch::Matchers::UnorderedEquals(
+                   std::vector<Atom *>({atom0, atom2, atom1})));
+    CHECK_THAT(res[1].getAtoms(), Catch::Matchers::UnorderedEquals(
+                                      std::vector<Atom *>({atom5, atom4})));
+
+    CHECK_THAT(res[0].getBonds(), Catch::Matchers::UnorderedEquals(
+                                      std::vector<Bond *>({bond3, bond4})));
+    CHECK_THAT(res[1].getBonds(),
+               Catch::Matchers::UnorderedEquals(std::vector<Bond *>({bond2})));
+  }
+
+  SECTION("Threadsafety") {
+    auto groups = std::make_unique<StereoGroups>();
+    groups->addGroup(StereoGroupType::STEREO_OR, {0, 2, 1}, {4, 3}, 1);
+    groups->addGroup(StereoGroupType::STEREO_AND, {5, 4}, {2}, 2);
+    rdmol.setStereoGroups(std::move(groups));
+
+    const size_t numThreads = 8;
+    std::vector<std::thread> threads;
+    std::atomic_int atomicInt(0);
+    std::atomic<const std::vector<StereoGroup>*> atomicPtr(nullptr);
+    std::atomic_int successCount(0);
+
+    for (size_t i = 0; i < numThreads; ++i) {
+      threads.emplace_back(
+          [&atomicInt, &atomicPtr, numThreads, &mol, &successCount]() {
+            atomicInt.fetch_add(1);
+            // Just spin as a barrier, to increase the chances of all threads
+            // being in sync
+            while (atomicInt.load() != numThreads) {
+            }
+            // Have all threads call getStereoGroups at the same time
+            const std::vector<StereoGroup> &res = mol.getStereoGroups();
+            const std::vector<StereoGroup> *value = nullptr;
+            if (!atomicPtr.compare_exchange_strong(value, &res)) {
+              // All threads should have received the same address without
+              // crashing
+              CHECK(&res == value);
+              if (&res == value) {
+                ++successCount;
+              }
+            } else {
+              ++successCount;
+            }
+          });
+    }
+    for (auto &thread : threads) {
+      thread.join();
+    }
+    CHECK(successCount.load() == numThreads);
+  }
+}
+
+TEST_CASE("Substance groups") {
+  auto mol = basicMol();
+  auto &romol = mol->asROMol();
+  Atom *atom0 = romol.getAtomWithIdx(0);
+  Atom *atom1 = romol.getAtomWithIdx(1);
+  Atom *atom2 = romol.getAtomWithIdx(2);
+  Atom *atom3 = romol.getAtomWithIdx(3);
+
+  SECTION("No substance groups") {
+    CHECK(getSubstanceGroups(romol).empty());
+  }
+
+  SECTION("Set from RDMol") {
+    std::vector<SubstanceGroup> &sgs = mol->getSubstanceGroups();
+    sgs.emplace_back(&mol->asROMol(), "TEST");
+
+    const std::vector<SubstanceGroup> &sgs2 = mol->getSubstanceGroups();
+    CHECK(sgs2.size() == 1);
+    CHECK(sgs2[0].getProp<std::string>("TYPE") == "TEST");
+    CHECK(&sgs2[0].getOwningMol() == &mol->asROMol());
+  }
+
+  SECTION("Set from ROMol") {
+    std::vector<SubstanceGroup> &sgs = getSubstanceGroups(romol);
+    sgs.emplace_back(&romol, "TEST");
+
+    const std::vector<SubstanceGroup> &sgs2 = mol->getSubstanceGroups();
+    CHECK(sgs2.size() == 1);
+    CHECK(sgs2[0].getProp<std::string>("TYPE") == "TEST");
+    CHECK(&sgs2[0].getOwningMol() == &mol->asROMol());
+  }
+
+  SECTION("Clear") {
+    std::vector<SubstanceGroup> &sgs = getSubstanceGroups(romol);
+    sgs.emplace_back(&romol, "TEST");
+    sgs.clear();
+    CHECK(getSubstanceGroups(romol).empty());
+  }
+}
+
+TEST_CASE("Conformers ROMol") {
+  auto mol = basicMol();
+  auto &romol = mol->asROMol();
+  auto conf = std::make_unique<Conformer>(romol.getNumAtoms());
+  for (size_t i = 0; i < romol.getNumAtoms(); ++i) {
+    conf->setAtomPos(i, RDGeom::Point3D(i, i, i));
+  }
+
+  SECTION("No conformers") {
+    CHECK(romol.getNumConformers() == 0);
+  }
+
+  SECTION("Add conformer to empty mol") {
+    ROMol emptyMol;
+    auto emptyConf = std::make_unique<Conformer>();
+    emptyMol.addConformer(emptyConf.release());
+    REQUIRE(emptyMol.getNumConformers() == 1);
+    CHECK(emptyMol.getConformer().getNumAtoms() == 0);
+    CHECK(&emptyMol.getConformer().getOwningMol() == &emptyMol);
+  }
+
+  SECTION("Add conformer fails - nullptr input") {
+    CHECK_THROWS_AS(romol.addConformer(nullptr), Invar::Invariant);
+  }
+
+  SECTION("Add conformer fails - wrong number of atoms") {
+    auto badConf = std::make_unique<Conformer>(romol.getNumAtoms() - 1);
+    CHECK_THROWS_AS(romol.addConformer(badConf.get()), Invar::Invariant);
+  }
+
+  SECTION("Add conformer") {
+    romol.addConformer(conf.release());
+    CHECK(romol.getNumConformers() == 1);
+    const auto& resultConf = romol.getConformer();
+    CHECK(resultConf.getNumAtoms() == 4);
+    CHECK(&resultConf.getOwningMol() == &romol);
+    CHECK(resultConf.getId() == 0);
+
+    // Check positions
+    for (size_t i = 0; i < romol.getNumAtoms(); ++i) {
+      CHECK(resultConf.getAtomPos(i).x == i);
+    }
+  }
+
+  SECTION("Add conformer with nonlinear ID") {
+    conf->setId(3);
+    romol.addConformer(conf.release());
+    CHECK(romol.getNumConformers() == 1);
+    const auto& resultConf = romol.getConformer();
+    CHECK(resultConf.getId() == 3);
+  }
+
+  SECTION("Add conformer with assignId") {
+    conf->setId(3);
+    romol.addConformer(conf.release(), /*assignID=*/ true);
+    CHECK(romol.getNumConformers() == 1);
+    const auto& resultConf = romol.getConformer();
+    CHECK(resultConf.getId() == 0);
+  }
+
+  SECTION("Add 2D conformer") {
+    conf->set3D(false);
+    romol.addConformer(conf.release());
+    CHECK(romol.getNumConformers() == 1);
+    const auto& resultConf = romol.getConformer();
+    CHECK(resultConf.is3D() == false);
+  }
+
+  SECTION("Remove conformer") {
+    auto secondConf = std::make_unique<Conformer>(romol.getNumAtoms());
+    for (size_t i = 0; i < romol.getNumAtoms(); ++i) {
+      secondConf->setAtomPos(i, RDGeom::Point3D(i + romol.getNumAtoms(), i + romol.getNumAtoms(), i + romol.getNumAtoms()));
+    }
+    secondConf->set3D(false);
+    romol.addConformer(conf.release());
+    romol.addConformer(secondConf.release(), /*assignId=*/ true);
+    CHECK(romol.getNumConformers() == 2);
+    romol.removeConformer(0);
+    CHECK(romol.getNumConformers() == 1);
+
+    auto& resultConf = romol.getConformer();
+    CHECK(resultConf.getNumAtoms() == 4);
+    CHECK(resultConf.getId() == 1);
+    CHECK(resultConf.is3D() == false);
+    // Check positions
+    for (size_t i = 0; i < romol.getNumAtoms(); ++i) {
+      CHECK(resultConf.getAtomPos(i).x == i + romol.getNumAtoms());
+    }
+  }
+
+  SECTION("Remove conformer no-op null ID") {
+    romol.addConformer(conf.release());
+    CHECK(romol.getNumConformers() == 1);
+    romol.removeConformer(1);
+    CHECK(romol.getNumConformers() == 1);
+  }
+
+  SECTION("Clear conformers") {
+    auto secondConf = std::make_unique<Conformer>(romol.getNumAtoms());
+    romol.addConformer(conf.release());
+    romol.addConformer(secondConf.release());
+    CHECK(romol.getNumConformers() == 2);
+    romol.clearConformers();
+    CHECK(romol.getNumConformers() == 0);
+  }
+}
+
+TEST_CASE("Conformers RDMol/ROMol interop") {
+  SECTION("RDMol setup, ROMol access") {
+    RDMol mol;
+    mol.addAtom();
+    mol.addAtom();
+
+    auto [confId, confPos] = mol.addConformer(3, true);
+    std::iota(confPos, confPos + 6, 0);
+
+    auto [confId2, confPos2] = mol.addConformer(-1, false);
+    std::iota(confPos2, confPos2 + 6, 6);
+
+    auto &romol = mol.asROMol();
+    CHECK(romol.getNumConformers() == 2);
+    const auto& conf = romol.getConformer(confId);
+    CHECK(conf.getNumAtoms() == 2);
+    CHECK(conf.getAtomPos(0).x == 0);
+    CHECK(conf.getAtomPos(1).x == 3);
+    CHECK(conf.getId() == confId);
+    CHECK(conf.is3D() == true);
+
+    const auto& conf2 = romol.getConformer(confId2);
+    CHECK(conf2.getNumAtoms() == 2);
+    CHECK(conf2.getAtomPos(0).x == 6);
+    CHECK(conf2.getAtomPos(1).x == 9);
+    CHECK(conf2.getId() == confId2);
+    CHECK(conf2.is3D() == false);
+
+    mol.removeConformer(confId);
+    CHECK(romol.getNumConformers() == 1);
+    CHECK(romol.getConformer().getId() == confId2);
+  }
+
+  SECTION("RDMol setup, add to existing ROMol") {
+    // Identical setup to above, except the RDMol APIs are called after
+    // the compat data is set up, exercising the in-call updates rather than
+    // the initial setup of compat data.
+    RDMol mol;
+    auto &romol = mol.asROMol();
+
+    mol.addAtom();
+    mol.addAtom();
+
+    std::vector<double> pos1(6, 0);
+    std::iota(pos1.begin(), pos1.end(), 0);
+    std::vector<double> pos2(6, 0);
+    std::iota(pos2.begin(), pos2.end(), 6);
+
+    auto confId = mol.addConformer(pos1.data(), 3, true);
+    auto confId2 = mol.addConformer(pos2.data(), -1, false);
+
+    CHECK(romol.getNumConformers() == 2);
+    const auto& conf = romol.getConformer(confId);
+    CHECK(conf.getNumAtoms() == 2);
+    CHECK(conf.getAtomPos(0).x == 0);
+    CHECK(conf.getAtomPos(1).x == 3);
+    CHECK(conf.getId() == confId);
+    CHECK(conf.is3D() == true);
+
+    const auto& conf2 = romol.getConformer(confId2);
+    CHECK(conf2.getNumAtoms() == 2);
+    CHECK(conf2.getAtomPos(0).x == 6);
+    CHECK(conf2.getAtomPos(1).x == 9);
+    CHECK(conf2.getId() == confId2);
+    CHECK(conf2.is3D() == false);
+
+    mol.removeConformer(confId);
+    CHECK(romol.getNumConformers() == 1);
+    CHECK(romol.getConformer().getId() == confId2);
+  }
+
+  SECTION("ROMol setup, RDMol access") {
+    RDMol mol;
+    mol.addAtom();
+    mol.addAtom();
+    ROMol& romol = mol.asROMol();
+
+    auto conf1 = std::make_unique<Conformer>(2);
+    conf1->setAtomPos(0, RDGeom::Point3D(0, 1, 2));
+    conf1->setAtomPos(1, RDGeom::Point3D(3, 4, 5));
+    auto conf2 = std::make_unique<Conformer>(2);
+    conf2->setAtomPos(0, RDGeom::Point3D(6, 7, 8));
+    conf2->setAtomPos(1, RDGeom::Point3D(9, 10, 11));
+
+    conf1->setId(3);
+    conf2->set3D(false);
+
+    romol.addConformer(conf1.release());
+    romol.addConformer(conf2.release(), true);
+
+    CHECK(mol.getNumConformers() == 2);
+    const double* conf1Pos = mol.getConformerPositions(3);
+    const double* conf2Pos = mol.getConformerPositions(4);
+    REQUIRE(conf1Pos != nullptr);
+    REQUIRE(conf2Pos != nullptr);
+
+    CHECK(conf1Pos[0] == 0);
+    CHECK(conf1Pos[3] == 3);
+    CHECK(conf2Pos[0] == 6);
+    CHECK(conf2Pos[3] == 9);
+
+    CHECK(mol.is3DConformer(3) == true);
+    CHECK(mol.is3DConformer(4) == false);
+
+    romol.removeConformer(3);
+    CHECK(mol.getNumConformers() == 1);
+    double* pos = mol.getConformerPositions(4);
+    REQUIRE(pos != nullptr);
+    CHECK(pos[0] == 6);
+    CHECK(pos[3] == 9);
+    CHECK(mol.is3DConformer(4) == false);
+  }
+
+  SECTION("Syncing updates") {
+    RDMol mol;
+    mol.addAtom();
+    mol.addAtom();
+    ROMol& romol = mol.asROMol();
+    auto conf = std::make_unique<Conformer>(2);
+    conf->setAtomPos(0, RDGeom::Point3D(0, 1, 2));
+    romol.addConformer(conf.release());
+
+    double* pos = mol.getConformerPositions(0);
+    pos[0]++;
+    pos[1]++;
+    pos[2]++;
+
+    Conformer& confHandle = romol.getConformer();
+    CHECK(confHandle.getAtomPos(0).x == 1);
+    CHECK(confHandle.getAtomPos(0).y == 2);
+    CHECK(confHandle.getAtomPos(0).z == 3);
+
+    confHandle.getAtomPos(0).x++;
+    confHandle.getAtomPos(0).y++;
+    confHandle.getAtomPos(0).z++;
+
+    const double* nextCheckedPos = mol.getConformerPositions(0);
+    CHECK(nextCheckedPos[0] == 2);
+    CHECK(nextCheckedPos[1] == 3);
+    CHECK(nextCheckedPos[2] == 4);
+  }
+
+  SECTION("Multithreaded access") {
+    RDMol mol;
+    mol.addAtom();
+    mol.addAtom();
+    ROMol& romol = mol.asROMol();
+    auto conf = std::make_unique<Conformer>(2);
+    conf->setAtomPos(0, RDGeom::Point3D(0, 1, 2));
+    romol.addConformer(conf.release());
+    auto& romolPos = romol.getConformer();
+    // Update the compat position to make sure they're not equal to the
+    // RDMol positions.
+    auto& atomPos = romolPos.getAtomPos(0);
+    atomPos.x++;
+    atomPos.y++;
+    atomPos.z++;
+    REQUIRE(atomPos.x == 1);
+    REQUIRE(atomPos.y == 2);
+    REQUIRE(atomPos.z == 3);
+
+    auto checkPos = [&mol]() {
+        const double* rdmolPos = mol.getConformerPositions(0);
+        CHECK(rdmolPos[0] == 1);
+        CHECK(rdmolPos[1] == 2);
+        CHECK(rdmolPos[2] == 3);
+    };
+    checkPos();
+    std::thread checkThread1(checkPos);
+    std::thread checkThread2(checkPos);
+    checkThread1.join();
+    checkThread2.join();
+   }
+}
+
+TEST_CASE("RingInfo RDMol/ROMol interop") {
+  SECTION("Test of sync bug") {
+    // Two pentagonal rings with a shared edge
+    auto mol = parseSmiles("C1CCC2C1CCC2");
+    MolOps::findSSSR(mol->asROMol());
+
+    REQUIRE(mol->asROMol().getRingInfo()->numRings() == 2);
+
+    // There was a bug in non-const RDMol::getRingInfo where it incorrectly
+    // marked the new and compat data structures as in sync, instead of
+    // the new data structure being modified.
+    RingInfoCache &ringInfoNew = mol->getRingInfo();
+
+    CHECK(ringInfoNew.numRings() == 2);
+    CHECK((ringInfoNew.ringBegins[0] == 0 && ringInfoNew.ringBegins[1] == 5 &&
+          ringInfoNew.ringBegins[2] == 10));
+    CHECK(ringInfoNew.findRingType == FIND_RING_TYPE_SSSR);
+
+    // Modify the new data structure
+    ringInfoNew.reset();
+    ringInfoNew.findRingType = FIND_RING_TYPE_FAST;
+    ringInfoNew.isInit = true;
+
+    // Ensure that the compat data structure receives the modification.
+    CHECK(mol->asROMol().getRingInfo()->numRings() == 0);
+    CHECK(mol->asROMol().getRingInfo()->getRingType() == FIND_RING_TYPE_FAST);
+  }
+
+  SECTION("Threadsafety") {
+    auto mol = parseSmiles("C1CCC2C1CCC2");
+    MolOps::findSSSR(mol->asROMol());
+
+    REQUIRE(mol->asROMol().getRingInfo()->numRings() == 2);
+
+    const size_t numThreads = 8;
+    std::vector<std::thread> threads;
+    std::atomic_int atomicInt(0);
+    std::atomic<const uint32_t *> atomicPtr(nullptr);
+    std::atomic_int successCount(0);
+
+    for (size_t i = 0; i < numThreads; ++i) {
+      threads.emplace_back(
+          [&atomicInt, &atomicPtr, numThreads, &mol, &successCount]() {
+            atomicInt.fetch_add(1);
+            // Just spin as a barrier, to increase the chances of all threads
+            // being in sync
+            while (atomicInt.load() != numThreads) {
+            }
+            // Have all threads call getRingInfo at the same time
+            const RingInfoCache &res = mol->getRingInfo();
+            // The ring info is a member variable, so they'd get the same
+            // address of res regardless of whether the results clobbered each
+            // other, so check one of the vectors.
+            const uint32_t *atomsInRings = res.atomsInRings.data();
+            const uint32_t *value = nullptr;
+            if (!atomicPtr.compare_exchange_strong(value, atomsInRings)) {
+              // All threads should have received the same address without
+              // crashing
+              CHECK(atomsInRings == value);
+              if (atomsInRings == value) {
+                ++successCount;
+              }
+            } else {
+              ++successCount;
+            }
+          });
+    }
+    for (auto &thread : threads) {
+      thread.join();
+    }
+    CHECK(successCount.load() == numThreads);
+  }
+}

--- a/Code/GraphMol/catch_rwmol_compat.cpp
+++ b/Code/GraphMol/catch_rwmol_compat.cpp
@@ -1,0 +1,1070 @@
+//
+//  Copyright (C) 2025 NVIDIA Corporation & Affiliates and other RDKit contributors
+//
+//   @@ All Rights Reserved @@
+//  This file is part of the RDKit.
+//  The contents are covered by the terms of the BSD license
+//  which is included in the file license.txt, found at the root
+//  of the RDKit source tree.
+//
+#include <catch2/catch_all.hpp>
+
+#include <GraphMol/RDMol.h>
+#include <GraphMol/SmilesParse/SmilesParse.h>
+#include <GraphMol/Bond.h>
+#include <GraphMol/MonomerInfo.h>
+#include <GraphMol/QueryAtom.h>
+
+using namespace RDKit;
+
+// TODO - consolidate rdmol/romol/rwmol test setup
+std::unique_ptr<RDMol> parseSmiles(const char *smiles, bool sanitize = false,
+                                   bool removeHs = false) {
+  auto mol = std::make_unique<RDMol>();
+  RDKit::SmilesParseTemp temp;
+  SmilesParserParams params;
+  params.sanitize = sanitize;
+  params.removeHs = removeHs;
+
+  REQUIRE(RDKit::SmilesToMol(smiles, params, *mol, temp) == true);
+  return mol;
+}
+
+std::unique_ptr<RDMol> basicMol() {
+  auto mol = parseSmiles("CCC=C");
+  REQUIRE(mol->getNumAtoms() == 4);
+  REQUIRE(mol->getNumBonds() == 3);
+  REQUIRE(mol->getBond(2).getBondType() == BondEnums::BondType::DOUBLE);
+
+  return mol;
+}
+
+
+TEST_CASE("Add atom") {
+  RWMol mol;
+  REQUIRE(mol.addAtom() == 0);
+  REQUIRE(mol.getNumAtoms() == 1);
+  REQUIRE(mol.getAtomWithIdx(0)->getAtomicNum() == 0);
+  REQUIRE(mol.addAtom() == 1);
+  REQUIRE(mol.getNumAtoms() == 2);
+  REQUIRE(mol.getAtomWithIdx(1)->getAtomicNum() == 0);
+
+  SECTION("Update label") {
+    REQUIRE(mol.addAtom(true) == 2);
+    CHECK(mol.getAtomWithBookmark(ci_RIGHTMOST_ATOM) == mol.getAtomWithIdx(2));
+  }
+
+  SECTION("Don't update label") {
+    REQUIRE(mol.addAtom(false) == 2);
+    CHECK(mol.getAtomWithBookmark(ci_RIGHTMOST_ATOM) == mol.getAtomWithIdx(1));
+  }
+}
+
+TEST_CASE("Add atom failures") {
+  SECTION("Null atom") {
+    RWMol mol;
+    CHECK_THROWS_AS(mol.addAtom(nullptr), Invar::Invariant);
+  }
+
+  SECTION("Take ownership of owned atom") {
+    RWMol mol1;
+    mol1.addAtom();
+    auto *atom = mol1.getAtomWithIdx(0);
+    REQUIRE(atom != nullptr);
+
+    RWMol mol2;
+    CHECK_THROWS_AS(mol2.addAtom(atom, false, /*takeOwnership=*/true),
+                    Invar::Invariant);
+  }
+
+  SECTION("Try to add atom owned by self") {
+    RWMol mol;
+    mol.addAtom();
+    auto *atom = mol.getAtomWithIdx(0);
+    REQUIRE(atom != nullptr);
+
+    CHECK_THROWS_AS(mol.addAtom(atom, false, /*takeOwnership=*/true),
+                    Invar::Invariant);
+  }
+}
+
+TEST_CASE("Add atom via Atom* API") {
+  RWMol mol;
+  // Add one in first to make sure we're indexing ok.
+  REQUIRE(mol.addAtom() == 0);
+
+  auto atom = std::make_unique<Atom>(6);
+  atom->setHybridization(Atom::SP3);
+  atom->setFormalCharge(1);
+  atom->setIsAromatic(true);
+  atom->setNumExplicitHs(2);
+  atom->setNoImplicit(true);
+  atom->setIsotope(13);
+  atom->setChiralTag(Atom::CHI_TETRAHEDRAL_CCW);
+  atom->setNumRadicalElectrons(1);
+
+  atom->setProp("test", 3);
+
+  SECTION("No ownership change") {
+    REQUIRE(mol.addAtom(atom.get(), false, /*takeOwnership=*/false) == 1);
+    Atom *newAtomHandle = mol.getAtomWithIdx(1);
+
+    // First check that we've created a new atom.
+    CHECK(newAtomHandle != atom.get());
+
+    // Next check properties have copied over.
+    CHECK(newAtomHandle->getAtomicNum() == 6);
+    CHECK(newAtomHandle->getHybridization() == Atom::SP3);
+    CHECK(newAtomHandle->getFormalCharge() == 1);
+    CHECK(newAtomHandle->getIsAromatic());
+    CHECK(newAtomHandle->getNumExplicitHs() == 2);
+    CHECK(newAtomHandle->getNoImplicit());
+    CHECK(newAtomHandle->getIsotope() == 13);
+    CHECK(newAtomHandle->getChiralTag() == Atom::CHI_TETRAHEDRAL_CCW);
+    CHECK(newAtomHandle->getNumRadicalElectrons() == 1);
+
+    // Finally make sure we don't depend on the old value.
+    atom.reset();
+    CHECK(newAtomHandle->getAtomicNum() == 6);
+    CHECK(newAtomHandle->getProp<int>("test") == 3);
+  }
+
+  SECTION("Ownership change") {
+    REQUIRE(mol.addAtom(atom.get(), false, /*takeOwnership=*/true) == 1);
+    Atom *newAtomHandle = mol.getAtomWithIdx(1);
+
+    // First check that we're using the same handle.
+    CHECK(newAtomHandle == atom.release());
+
+    // Next check properties have copied over.
+    CHECK(newAtomHandle->getAtomicNum() == 6);
+    CHECK(newAtomHandle->getHybridization() == Atom::SP3);
+    CHECK(newAtomHandle->getFormalCharge() == 1);
+    CHECK(newAtomHandle->getIsAromatic());
+    CHECK(newAtomHandle->getNumExplicitHs() == 2);
+    CHECK(newAtomHandle->getNoImplicit());
+    CHECK(newAtomHandle->getIsotope() == 13);
+    CHECK(newAtomHandle->getChiralTag() == Atom::CHI_TETRAHEDRAL_CCW);
+    CHECK(newAtomHandle->getNumRadicalElectrons() == 1);
+
+    CHECK(newAtomHandle->getProp<int>("test") == 3);
+  }
+
+  SECTION("Update label") {
+    REQUIRE(mol.addAtom(atom.get(), true) == 1);
+    CHECK(mol.getAtomWithBookmark(ci_RIGHTMOST_ATOM) == mol.getAtomWithIdx(1));
+  }
+
+  SECTION("Don't update label") {
+    REQUIRE(mol.addAtom(atom.get(), false) == 1);
+    CHECK(mol.getAtomWithBookmark(ci_RIGHTMOST_ATOM) != mol.getAtomWithIdx(1));
+  }
+
+  SECTION("Transferred monomer info") {
+    atom->setMonomerInfo(new AtomPDBResidueInfo("dummy", /*serial=*/3));
+    REQUIRE(mol.addAtom(atom.get(), false) == 1);
+    auto monomerInfo = mol.getAtomWithIdx(1)->getMonomerInfo();
+    REQUIRE(monomerInfo != nullptr);
+    auto castInfo = dynamic_cast<AtomPDBResidueInfo *>(monomerInfo);
+    REQUIRE(castInfo != nullptr);
+    CHECK(castInfo->getSerialNumber() == 3);
+  }
+}
+
+std::vector<int> getAtomNeighborIndices(const RWMol& mol, int atomIdx) {
+  std::vector<int> neighbors;
+  for (const auto& bondIter:  boost::make_iterator_range(mol.getAtomBonds(mol.getAtomWithIdx(atomIdx)))) {
+    const auto &nbr = (mol)[bondIter];
+    neighbors.push_back(nbr->getOtherAtomIdx(atomIdx));
+  }
+  return neighbors;
+}
+
+template<typename pointerT>
+std::vector<int> stdListToVec(const std::list<pointerT*>& lst) {
+  std::vector<int> res;
+  for (const auto& element: lst) {
+    res.push_back(element->getIdx());
+  }
+  return res;
+}
+
+TEST_CASE("Remove Atom") {
+  auto molPtr = basicMol();
+  RWMol &rwmol = molPtr->asRWMol();
+
+
+  SECTION("Basic, no bond removal, no stereochem") {
+    // Change up atom numbers for better testing.
+    rwmol.getAtomWithIdx(1)->setAtomicNum(7);
+    rwmol.getAtomWithIdx(2)->setAtomicNum(8);
+
+    REQUIRE(rwmol.getNumAtoms() == 4);
+    REQUIRE(rwmol.getNumBonds() == 3);
+    REQUIRE(rwmol.getAtomWithIdx(0)->getAtomicNum() == 6);
+    REQUIRE(rwmol.getAtomWithIdx(1)->getAtomicNum() == 7);
+    REQUIRE(rwmol.getBondWithIdx(0)->getBeginAtomIdx() == 0);
+    REQUIRE(rwmol.getBondWithIdx(0)->getEndAtomIdx() == 1);
+    rwmol.removeAtom((unsigned int)0);
+
+    CHECK(rwmol.getNumAtoms() == 3);
+    CHECK(rwmol.getNumBonds() == 2);
+
+    CHECK(rwmol.getAtomWithIdx(0)->getAtomicNum() == 7);
+    CHECK(rwmol.getAtomWithIdx(1)->getAtomicNum() == 8);
+
+    // Check that bond atom refs are updated.
+    CHECK(rwmol.getBondWithIdx(0)->getBeginAtomIdx() == 0);
+    CHECK(rwmol.getBondWithIdx(0)->getEndAtomIdx() == 1);
+
+    // Check atom neighbor iteration unchanged except for indices
+    std::vector<int> neighbors0 = getAtomNeighborIndices(rwmol, 0);
+    std::vector<int> neighbors1 = getAtomNeighborIndices(rwmol, 1);
+    std::vector<int> neighbors2 = getAtomNeighborIndices(rwmol, 2);
+    CHECK_THAT(neighbors0, Catch::Matchers::UnorderedEquals(std::vector<int>{1}));
+    CHECK_THAT(neighbors1, Catch::Matchers::UnorderedEquals(std::vector<int>{0, 2}));
+    CHECK_THAT(neighbors2, Catch::Matchers::UnorderedEquals(std::vector<int>{1}));
+  }
+
+  SECTION("Removes associated bonds") {
+    REQUIRE(rwmol.getNumAtoms() == 4);
+    REQUIRE(rwmol.getNumBonds() == 3);
+
+    rwmol.removeAtom(1);
+
+    CHECK(rwmol.getNumAtoms() == 3);
+    CHECK(rwmol.getNumBonds() == 1);
+
+    std::vector<int> neighbors0 = getAtomNeighborIndices(rwmol, 0);
+    std::vector<int> neighbors1 = getAtomNeighborIndices(rwmol, 1);
+    std::vector<int> neighbors2 = getAtomNeighborIndices(rwmol, 2);
+    CHECK_THAT(neighbors0, Catch::Matchers::UnorderedEquals(std::vector<int>{}));
+    CHECK_THAT(neighbors1, Catch::Matchers::UnorderedEquals(std::vector<int>{2}));
+    CHECK_THAT(neighbors2, Catch::Matchers::UnorderedEquals(std::vector<int>{1}));
+  }
+
+  SECTION("Stereo groups") {
+    Atom* atom0 = rwmol.getAtomWithIdx(0);
+    Atom* atom1 = rwmol.getAtomWithIdx(1);
+    Atom* atom2 = rwmol.getAtomWithIdx(2);
+
+    std::vector<StereoGroup> groups;
+    std::vector<Atom *> atoms = {atom0, atom2, atom1};
+    groups.push_back(StereoGroup(StereoGroupType::STEREO_OR, std::move(atoms), {}));
+    std::vector<Atom *> atoms2 = {rwmol.getAtomWithIdx(1)};
+    groups.push_back(StereoGroup(StereoGroupType::STEREO_AND, std::move(atoms2), {}));
+    rwmol.setStereoGroups(std::move(groups));
+
+    rwmol.removeAtom(1);
+
+    const auto& resultGroups = rwmol.getStereoGroups();
+    REQUIRE(resultGroups.size() == 1);
+    const auto& group = resultGroups[0];
+
+    CHECK(group.getGroupType() == StereoGroupType::STEREO_OR);
+    CHECK_THAT(group.getAtoms(), Catch::Matchers::UnorderedEquals(std::vector<Atom *>({atom0, atom2})));
+  }
+
+  SECTION("Bookmarks") {
+    rwmol.setAtomBookmark(rwmol.getAtomWithIdx(0), 0);
+    rwmol.setAtomBookmark(rwmol.getAtomWithIdx(1), 0);
+    rwmol.setAtomBookmark(rwmol.getAtomWithIdx(2), 0);
+    rwmol.setAtomBookmark(rwmol.getAtomWithIdx(3), 0);
+    rwmol.setAtomBookmark(rwmol.getAtomWithIdx(1), 1);
+    rwmol.setAtomBookmark(rwmol.getAtomWithIdx(2), 1);
+    rwmol.setAtomBookmark(rwmol.getAtomWithIdx(3), 2);
+
+    rwmol.setBondBookmark(rwmol.getBondWithIdx(0), 0);
+    rwmol.setBondBookmark(rwmol.getBondWithIdx(1), 0);
+    rwmol.setBondBookmark(rwmol.getBondWithIdx(2), 0);
+    rwmol.setBondBookmark(rwmol.getBondWithIdx(0), 1);
+    rwmol.setBondBookmark(rwmol.getBondWithIdx(1), 2);
+    rwmol.setBondBookmark(rwmol.getBondWithIdx(2), 2);
+
+    // Before deletion, we have {bookmark: indices}
+    // atoms:
+    // 0: 0, 1, 2, 3
+    // 1: 1, 2
+    // 2: 3
+    // bonds:
+    // 0: 0, 1, 2
+    // 1: 0, 1
+    // 2: 2
+
+    // We are deleting bonds 0 and 1, atom 1. Bond 2 now maps to 0. Atoms 2 and 3 now map to 1 and 2.
+    rwmol.removeAtom(1);
+
+    auto& atomBookmarks0 = rwmol.getAllAtomsWithBookmark(0);
+    auto& atomBookmarks1 = rwmol.getAllAtomsWithBookmark(1);
+    auto& atomBookmarks2 = rwmol.getAllAtomsWithBookmark(2);
+
+    auto& bondBookmarks0 = rwmol.getAllBondsWithBookmark(0);
+    CHECK_THROWS_AS(rwmol.getAllBondsWithBookmark(1), Invar::Invariant);
+    auto& bondBookmarks2 = rwmol.getAllBondsWithBookmark(2);
+
+    CHECK(stdListToVec(atomBookmarks0) == std::vector<int>{0, 1, 2});
+    CHECK(stdListToVec(atomBookmarks1) == std::vector<int>{1});
+    CHECK(stdListToVec(atomBookmarks2) == std::vector<int>{2});
+
+    CHECK(stdListToVec(bondBookmarks0) == std::vector<int>{0});
+    CHECK(stdListToVec(bondBookmarks2) == std::vector<int>{0});
+  }
+
+  SECTION("Properties") {
+    for (int i = 0; i < 4; ++i) {
+      rwmol.getAtomWithIdx(i)->setProp("test", i);
+    }
+    for (int i = 0; i < 3; ++i) {
+      rwmol.getBondWithIdx(i)->setProp("test", i);
+    }
+
+    rwmol.removeAtom(1);
+    CHECK(rwmol.getAtomWithIdx(0)->getProp<int>("test") == 0);
+    CHECK(rwmol.getAtomWithIdx(1)->getProp<int>("test") == 2);
+    CHECK(rwmol.getAtomWithIdx(2)->getProp<int>("test") == 3);
+    CHECK(rwmol.getBondWithIdx(0)->getProp<int>("test") == 2);
+  }
+
+  SECTION("Does not clear computed props") {
+    rwmol.getAtomWithIdx(0)->setProp("computed", 3, /*computed=*/ true);
+    rwmol.setProp("computed", 3, /*computed=*/ true);
+    rwmol.removeAtom(rwmol.getAtomWithIdx(1), /*clearComputedProps=*/false);
+    CHECK(rwmol.getAtomWithIdx(0)->getProp<int>("computed") == 3);
+    CHECK(rwmol.getProp<int>("computed") == 3);
+  }
+
+  SECTION("Clears computed props") {
+    rwmol.getAtomWithIdx(0)->setProp("computed", 3, /*computed=*/ true);
+    rwmol.setProp("computed", 3, /*computed=*/ true);
+    rwmol.removeAtom(rwmol.getAtomWithIdx(1), /*clearComputedProps=*/true);
+    CHECK(!rwmol.getAtomWithIdx(0)->hasProp("computed"));
+    CHECK(!rwmol.hasProp("computed"));
+  }
+
+  SECTION("Conformers") {
+    auto conf1 = std::make_unique<Conformer>(rwmol.getNumAtoms());
+    auto conf2 = std::make_unique<Conformer>(rwmol.getNumAtoms());
+
+    const int numAtoms = 4;
+    for (int i = 0; i < numAtoms; i ++) {
+      conf1->setAtomPos(i, RDGeom::Point3D(i, i, i));
+      conf2->setAtomPos(i, RDGeom::Point3D(i + numAtoms, i + numAtoms, i + numAtoms));
+    }
+
+    uint32_t id1 = rwmol.addConformer(conf1.release(), true);
+    uint32_t id2 = rwmol.addConformer(conf2.release(), true);
+
+    rwmol.removeAtom(1);
+
+    const Conformer* confResult = &rwmol.getConformer(id1);
+    const Conformer* conf2Result = &rwmol.getConformer(id2);
+
+    REQUIRE(rwmol.getNumConformers() == 2);
+    REQUIRE(confResult != nullptr);
+    REQUIRE(conf2Result != nullptr);
+
+    CHECK(confResult->getNumAtoms() == 3);
+    CHECK(conf2Result->getNumAtoms() == 3);
+
+    CHECK(confResult->getAtomPos(0).x == 0);
+    CHECK(confResult->getAtomPos(1).x == 2);
+    CHECK(confResult->getAtomPos(2).x == 3);
+    CHECK(conf2Result->getAtomPos(0).x == 4);
+    CHECK(conf2Result->getAtomPos(1).x == 6);
+    CHECK(conf2Result->getAtomPos(2).x == 7);
+  }
+
+  SECTION("Substance groups") {
+    std::vector<SubstanceGroup> &sgs = getSubstanceGroups(rwmol);
+    sgs.emplace_back(&rwmol, "REMOVE_HAS_ATOM");
+    sgs.back().addAtomWithIdx(0);
+    sgs.back().addAtomWithIdx(1);
+    sgs.back().addAtomWithIdx(2);
+    sgs.emplace_back(&rwmol, "REMOVE_HAS_REMOVED_BOND");
+    sgs.back().addBondWithIdx(0);
+    sgs.back().addBondWithIdx(2);
+    sgs.emplace_back(&rwmol, "DO_NOT_REMOVE");
+    sgs.back().addAtomWithIdx(0);
+    sgs.back().addAtomWithIdx(2);
+    sgs.back().addBondWithIdx(2);
+
+    rwmol.removeAtom(1);
+    std::vector<SubstanceGroup> &resultGroups = getSubstanceGroups(rwmol);
+    REQUIRE(resultGroups.size() == 1);
+    CHECK(resultGroups[0].getProp<std::string>("TYPE") == "DO_NOT_REMOVE");
+    // Make sure atoms and bonds are shifted
+    CHECK(resultGroups[0].getAtoms() == std::vector<unsigned int>{0, 1});
+    CHECK(resultGroups[0].getBonds() == std::vector<unsigned int>{0});
+  }
+}
+
+TEST_CASE("Replace atom") {
+  RWMol mol;
+  mol.addAtom();
+  mol.addAtom();
+  mol.getAtomWithIdx(1)->setAtomicNum(6);
+  Atom* existingAtom = mol.getAtomWithIdx(1);
+
+  auto atom = std::make_unique<Atom>(7);
+  Atom* newAtom = atom.get();
+  
+  SECTION("Fails - null input") {
+    CHECK_THROWS_AS(mol.replaceAtom(0, nullptr), Invar::Invariant);
+  }
+
+  SECTION("Fails - bad index") {
+    CHECK_THROWS_AS(mol.replaceAtom(2, atom.get()), Invar::Invariant);
+  }
+
+  SECTION("Basics") {
+    // replaceAtom does not take ownership, it makes a copy.
+    mol.replaceAtom(1, newAtom);
+    CHECK(mol.getAtomWithIdx(1) != newAtom);
+    CHECK(mol.getAtomWithIdx(1)->getAtomicNum() == 7);
+  }
+
+  SECTION("Overwrites properties") {
+    existingAtom->setProp("test", 3);
+    existingAtom->setProp("should_be_deleted", 1);
+    newAtom->setProp("otherprop", 5.0);
+    newAtom->setProp("test", 4);
+    mol.replaceAtom(1, newAtom);
+    CHECK(mol.getAtomWithIdx(1)->getProp<int>("test") == 4);
+    CHECK(mol.getAtomWithIdx(1)->getProp<double>("otherprop") == 5.0);
+    CHECK(!mol.getAtomWithIdx(1)->hasProp("should_be_deleted"));
+  }
+
+  SECTION("Does not overwrite properties when preserved") {
+    existingAtom->setProp("test", 3);
+    newAtom->setProp("otherprop", 5.0);
+    newAtom->setProp("test", 4);
+    mol.replaceAtom(1, newAtom, false, /*preserveProps=*/true);
+    CHECK(mol.getAtomWithIdx(1)->getProp<int>("test") == 3);
+    CHECK(!mol.getAtomWithIdx(1)->hasProp("otherprop"));
+  }
+
+  SECTION("Updates bookmarks") {
+    mol.setAtomBookmark(existingAtom, 3);
+    mol.replaceAtom(1, newAtom);
+    CHECK(mol.getAtomWithBookmark(3) == mol.getAtomWithIdx(1));
+  }
+
+  SECTION("Copies monomer info") {
+    newAtom->setMonomerInfo(new AtomPDBResidueInfo("dummy", /*serial=*/3));
+    mol.replaceAtom(1, newAtom);
+    auto monomerInfo = mol.getAtomWithIdx(1)->getMonomerInfo();
+    REQUIRE(monomerInfo != nullptr);
+    auto castInfo = dynamic_cast<AtomPDBResidueInfo *>(monomerInfo);
+    REQUIRE(castInfo != nullptr);
+    CHECK(castInfo->getSerialNumber() == 3);
+  }
+
+  SECTION("Clears existing monomer info") {
+    existingAtom->setMonomerInfo(new AtomPDBResidueInfo("dummy", /*serial=*/3));
+    mol.replaceAtom(1, newAtom);
+    CHECK(mol.getAtomWithIdx(1)->getMonomerInfo() == nullptr);
+  }
+}
+
+TEST_CASE("Replace bond") {
+  auto rdmol = basicMol();
+  auto& rwmol = rdmol->asRWMol();
+  Bond* existingBond = rwmol.getBondWithIdx(1);
+  auto newBond = std::make_unique<Bond>();
+  newBond->setBondType(Bond::BondType::TRIPLE);
+
+  std::vector<SubstanceGroup> &sgs = getSubstanceGroups(rwmol);
+  sgs.emplace_back(&rwmol, "TEST");
+  sgs.back().addBondWithIdx(1);
+  sgs.back().addBondWithIdx(2);
+  sgs.emplace_back(&rwmol, "UNRELATED");
+  sgs.back().addBondWithIdx(0);
+
+  SECTION("Fails - null input") {
+    CHECK_THROWS_AS(rwmol.replaceBond(0, nullptr), Invar::Invariant);
+  }
+
+  SECTION("Fails - bad index") {
+    CHECK_THROWS_AS(rwmol.replaceBond(3, newBond.get()), Invar::Invariant);
+  }
+
+  SECTION("Basics") {
+    // replacerwmol does not take ownership, it makes a copy.
+    rwmol.replaceBond(1, newBond.get());
+    CHECK(rwmol.getBondWithIdx(1) != newBond.get());
+    CHECK(rwmol.getBondWithIdx(1)->getBondType() == Bond::BondType::TRIPLE);
+  }
+
+  SECTION("Overwrites properties") {
+    existingBond->setProp("test", 3);
+    existingBond->setProp("should_be_deleted", 1);
+    newBond->setProp("otherprop", 5.0);
+    newBond->setProp("test", 4);
+    rwmol.replaceBond(1, newBond.get());
+    CHECK(rwmol.getBondWithIdx(1)->getProp<int>("test") == 4);
+    CHECK(rwmol.getBondWithIdx(1)->getProp<double>("otherprop") == 5.0);
+    CHECK(!rwmol.getBondWithIdx(1)->hasProp("should_be_deleted"));
+  }
+
+  SECTION("Does not overwrite properties when preserved") {
+    existingBond->setProp("test", 3);
+    newBond->setProp("otherprop", 5.0);
+    newBond->setProp("test", 4);
+    rwmol.replaceBond(1, newBond.get(), /*preserveProps=*/true);
+    CHECK(rwmol.getBondWithIdx(1)->getProp<int>("test") == 3);
+    CHECK(!rwmol.getBondWithIdx(1)->hasProp("otherprop"));
+  }
+
+  SECTION("Updates bookmarks") {
+    rwmol.setBondBookmark(existingBond, 3);
+    rwmol.replaceBond(1, newBond.get());
+    CHECK(rwmol.getBondWithBookmark(3) == rwmol.getBondWithIdx(1));
+  }
+
+  SECTION("Keeps substance groups") {
+    rwmol.replaceBond(1, newBond.get(), false, /*keepSGroups=*/true);
+    CHECK(sgs.size() == 2);
+    CHECK(sgs[0].getProp<std::string>("TYPE") == "TEST");
+  }
+
+  SECTION("Removes substance groups referencing bond") {
+    rwmol.replaceBond(1, newBond.get(), false, /*keepSGroups=*/false);
+    CHECK(sgs.size() == 1);
+    CHECK(sgs[0].getProp<std::string>("TYPE") == "UNRELATED");
+  }
+
+  SECTION("Explicit hydrogen handling - increase order") {
+    // Set one atom to have fewer explicit Hs than order difference
+    rwmol.getAtomWithIdx(1)->setNumExplicitHs(1);
+    // Set one atom to have greater explict Hs than order difference
+    // (not realistic but exercises code path)
+    rwmol.getAtomWithIdx(2)->setNumExplicitHs(3);
+    // Order difference of two
+    REQUIRE(rwmol.getBondWithIdx(1)->getBondType() == Bond::BondType::SINGLE);
+    rwmol.replaceBond(1, newBond.get());
+    CHECK(rwmol.getAtomWithIdx(1)->getNumExplicitHs() == 0);
+    CHECK(rwmol.getAtomWithIdx(2)->getNumExplicitHs() == 1);
+  }
+
+  SECTION("Explicit hydrogen handling - decrease order does nothing") {
+    rwmol.getAtomWithIdx(1)->setNumExplicitHs(1);
+    rwmol.getAtomWithIdx(2)->setNumExplicitHs(3);
+    // Order difference of -1
+    rwmol.getBondWithIdx(1)->setBondType(Bond::BondType::DOUBLE);
+    newBond->setBondType(Bond::BondType::SINGLE);
+    rwmol.replaceBond(1, newBond.get());
+    CHECK(rwmol.getAtomWithIdx(1)->getNumExplicitHs() == 1);
+    CHECK(rwmol.getAtomWithIdx(2)->getNumExplicitHs() == 3);
+  }
+}
+
+// Expects a bond add between atoms 1 and 3
+void checkBondConnections(const RWMol& mol, const Bond* bond) {
+  REQUIRE(bond != nullptr);
+
+  // Check neighbors of each atom
+  CHECK_THAT(getAtomNeighborIndices(mol, 0),
+             Catch::Matchers::UnorderedEquals(std::vector<int>({1})));
+  CHECK_THAT(getAtomNeighborIndices(mol, 1),
+             Catch::Matchers::UnorderedEquals(std::vector<int>({0, 2, 3})));
+  CHECK_THAT(getAtomNeighborIndices(mol, 2),
+             Catch::Matchers::UnorderedEquals(std::vector<int>({1, 3})));
+  CHECK_THAT(getAtomNeighborIndices(mol, 3),
+             Catch::Matchers::UnorderedEquals(std::vector<int>({1, 2})));
+}
+
+TEST_CASE("Add bond") {
+  auto rdmol = basicMol();
+  auto& rwmol = rdmol->asRWMol();
+  REQUIRE(rwmol.getNumAtoms() == 4);
+  REQUIRE(rwmol.getNumBonds() == 3);
+
+  auto bondToAdd = std::make_unique<Bond>();
+  REQUIRE(bondToAdd != nullptr);
+
+  bondToAdd->setBondDir(Bond::BondDir::ENDDOWNRIGHT);
+  bondToAdd->setBondType(Bond::BondType::DOUBLE);
+  bondToAdd->setIsConjugated(true);
+  bondToAdd->setStereo(Bond::BondStereo::STEREOCIS);
+  bondToAdd->setProp("test", 3);
+
+  SECTION("Index API fails, bad atom numbers") {
+      CHECK_THROWS_AS(rwmol.addBond(3, 5, Bond::BondType::SINGLE), Invar::Invariant);
+      CHECK_THROWS_AS(rwmol.addBond(5, 3, Bond::BondType::SINGLE), Invar::Invariant);
+  }
+
+  SECTION("Index API fails, same atoms for bond") {
+      CHECK_THROWS_AS(rwmol.addBond(1, 1, Bond::BondType::SINGLE), Invar::Invariant);
+  }
+
+  SECTION("Index API fails, bond exists") {
+      CHECK_THROWS_AS(rwmol.addBond(0, 1, Bond::BondType::SINGLE), Invar::Invariant);
+  }
+
+  SECTION("Index API succeeds") {
+    uint32_t idx = rwmol.addBond(3, 1, Bond::BondType::TRIPLE);
+    const Bond* bond = rwmol.getBondWithIdx(idx - 1);
+    checkBondConnections(rwmol, bond);
+
+    CHECK(bond->getBeginAtomIdx() == 3);
+    CHECK(bond->getEndAtomIdx() == 1);
+    CHECK(bond->getBondType() == Bond::BondType::TRIPLE);
+  }
+
+  SECTION("Index API with aromatic bond sets aromatic atoms") {
+    uint32_t idx = rwmol.addBond(1, 3, Bond::BondType::AROMATIC);
+    const Bond* bond = rwmol.getBondWithIdx(idx - 1);
+    checkBondConnections(rwmol, bond);
+
+    auto* atom1 = rwmol.getAtomWithIdx(1);
+    auto* atom3 = rwmol.getAtomWithIdx(3);
+    CHECK(bond->getIsAromatic());
+    CHECK(atom1->getIsAromatic());
+    CHECK(atom3->getIsAromatic());
+  }
+
+  SECTION("Atom* API fails, null atoms") {
+    auto atom = std::make_unique<Atom>();
+    CHECK_THROWS_AS(rwmol.addBond(atom.get(), nullptr, Bond::BondType::SINGLE), Invar::Invariant);
+    CHECK_THROWS_AS(rwmol.addBond(nullptr, atom.get(), Bond::BondType::SINGLE), Invar::Invariant);
+  }
+
+  SECTION("Atom API succeeds") {
+    auto* atom1 = rwmol.getAtomWithIdx(1);
+    auto* atom2 = rwmol.getAtomWithIdx(3);
+    REQUIRE(atom1 != nullptr);
+    REQUIRE(atom2 != nullptr);
+
+    uint32_t idx = rwmol.addBond(atom1, atom2, Bond::BondType::TRIPLE);
+    // New number of bonds
+    CHECK(idx == 4);
+    auto* bond = rwmol.getBondWithIdx(idx - 1);
+    checkBondConnections(rwmol, bond);
+  }
+
+  SECTION("Bond* API fails, null bond") {
+    CHECK_THROWS_AS(rwmol.addBond(nullptr), Invar::Invariant);
+  }
+
+  SECTION("Bond API fails, takeownership when already owned by mol") {
+    Bond* bond = rwmol.getBondWithIdx(0);
+    REQUIRE(bond != nullptr);
+    CHECK_THROWS_AS(rwmol.addBond(bond, /*takeOwnership=*/true), Invar::Invariant);
+  }
+
+  SECTION("Bond API fails, bad bond indices") {
+    bondToAdd->setBeginAtomIdx(5);
+    bondToAdd->setEndAtomIdx(3);
+    CHECK_THROWS_AS(rwmol.addBond(bondToAdd.get(), /*takeOwnership=*/false), Invar::Invariant);
+  }
+
+  SECTION("Bond API fails, self indices") {
+    bondToAdd->setBeginAtomIdx(1);
+    bondToAdd->setEndAtomIdx(1);
+    CHECK_THROWS_AS(rwmol.addBond(bondToAdd.get(), /*takeOwnership=*/false), Invar::Invariant);
+  }
+
+  SECTION("Bond API fail, existing bond in mol") {
+    REQUIRE(rwmol.getBondBetweenAtoms(1, 2) != nullptr);
+    bondToAdd->setBeginAtomIdx(1);
+    bondToAdd->setEndAtomIdx(2);
+    CHECK_THROWS_AS(rwmol.addBond(bondToAdd.get(), /*takeOwnership=*/false), Invar::Invariant);
+  }
+
+  SECTION("Bond API succeeds, don't take ownership") {
+    bondToAdd->setBeginAtomIdx(1);
+    bondToAdd->setEndAtomIdx(3);
+    Bond* bondPtrOrig = bondToAdd.get();
+    uint32_t idx = rwmol.addBond(bondToAdd.get(), /*takeOwnership=*/false);
+    auto* bond = rwmol.getBondWithIdx(idx - 1);
+    checkBondConnections(rwmol, bond);
+    CHECK(bond != bondPtrOrig);
+
+    CHECK(bond->getBondDir() == Bond::BondDir::ENDDOWNRIGHT);
+    CHECK(bond->getBondType() == Bond::BondType::DOUBLE);
+    CHECK(bond->getIsConjugated());
+    CHECK(bond->getStereo() == Bond::BondStereo::STEREOCIS);
+    CHECK(bond->getProp<int>("test") == 3);
+  }
+
+  SECTION("Bond API succeeds, does not update aromaticity") {
+    bondToAdd->setBeginAtomIdx(1);
+    bondToAdd->setEndAtomIdx(3);
+    bondToAdd->setBondType(Bond::BondType::AROMATIC);
+    uint32_t idx = rwmol.addBond(bondToAdd.get(), /*takeOwnership=*/false);
+    auto* bond = rwmol.getBondWithIdx(idx - 1);
+    checkBondConnections(rwmol, bond);
+    auto* atom1 = rwmol.getAtomWithIdx(1);
+    auto* atom3 = rwmol.getAtomWithIdx(3);
+    CHECK(!bond->getIsAromatic());
+    CHECK(!atom1->getIsAromatic());
+    CHECK(!atom3->getIsAromatic());
+  }
+
+  SECTION("Bond API succeeds, take ownership") {
+    bondToAdd->setBeginAtomIdx(1);
+    bondToAdd->setEndAtomIdx(3);
+    Bond* bondPtrOrig = bondToAdd.get();
+    uint32_t idx = rwmol.addBond(bondToAdd.release(), /*takeOwnership=*/true);
+    auto* bond = rwmol.getBondWithIdx(idx - 1);
+    CHECK(bond == bondPtrOrig);
+    checkBondConnections(rwmol, bond);
+
+    CHECK(bond->getBondDir() == Bond::BondDir::ENDDOWNRIGHT);
+    CHECK(bond->getBondType() == Bond::BondType::DOUBLE);
+    CHECK(bond->getIsConjugated());
+    CHECK(bond->getStereo() == Bond::BondStereo::STEREOCIS);
+    CHECK(bond->getProp<int>("test") == 3);
+  }
+}
+
+void addTestConformer(RWMol& mol, int startVal) {
+  auto conf = new Conformer(mol.getNumAtoms());
+  // Set each atom value to its index + startVal
+  for (uint32_t i = 0; i < mol.getNumAtoms(); ++i) {
+    conf->setAtomPos(i, RDGeom::Point3D(i + startVal, i + startVal, i + startVal));
+  }
+  mol.addConformer(conf, /*assignId=*/true);
+}
+
+TEST_CASE("InsertMol") {
+  auto rdmol = basicMol();
+  auto& rwmol = rdmol->asRWMol();
+  rwmol.getAtomWithIdx(0)->setProp("test_prev_atom", 5.0);
+
+  std::vector<SubstanceGroup> &sgs = getSubstanceGroups(rwmol);
+  sgs.emplace_back(&rwmol, "TEST_MOL1");
+  sgs.back().addAtomWithIdx(0);
+  sgs.back().addBondWithIdx(1);
+
+  std::vector<StereoGroup> groups;
+  std::vector<Atom *> atoms = {rwmol.getAtomWithIdx(1)};
+  groups.push_back(StereoGroup(StereoGroupType::STEREO_OR, std::move(atoms),
+                               {}));
+  rwmol.setStereoGroups(std::move(groups));
+
+  RWMol mol2;
+  auto atom1 = std::make_unique<Atom>(6);
+  atom1->setProp("test_new_atom", 3);
+  auto atom2 = std::make_unique<Atom>(7);
+  auto atom3 = std::make_unique<Atom>(8);
+  auto atom4 = std::make_unique<Atom>(9);
+
+  mol2.addAtom(atom1.get());
+  mol2.addAtom(atom2.get());
+  mol2.addAtom(atom3.get());
+  mol2.addAtom(atom4.get());
+  mol2.addBond(0, 1, Bond::BondType::SINGLE);
+  mol2.addBond(1, 2, Bond::BondType::DOUBLE);
+  mol2.addBond(2, 3, Bond::BondType::SINGLE);
+  mol2.getBondWithIdx(1)->setProp("test", 4);
+  mol2.getBondWithIdx(1)->setStereoAtoms(0, 3);
+
+  SECTION("Basics") {
+    rwmol.insertMol(mol2);
+
+    // Check that the new mol has been inserted
+    REQUIRE(rwmol.getNumAtoms() == 8);
+    REQUIRE(rwmol.getNumBonds() == 6);
+    CHECK(rwmol.getAtomWithIdx(5)->getAtomicNum() == 7);
+    CHECK(rwmol.getBondWithIdx(4)->getBondType() == Bond::BondType::DOUBLE);
+
+    // Check bond neighbor indices
+    CHECK_THAT(getAtomNeighborIndices(rwmol, 3),
+             Catch::Matchers::UnorderedEquals(std::vector<int>({2})));
+    CHECK_THAT(getAtomNeighborIndices(rwmol, 4),
+               Catch::Matchers::UnorderedEquals(std::vector<int>({5})));
+    CHECK_THAT(getAtomNeighborIndices(rwmol, 6),
+               Catch::Matchers::UnorderedEquals(std::vector<int>({5, 7})));
+
+    // Check properties
+    CHECK(rwmol.getAtomWithIdx(0)->getProp<double>("test_prev_atom") == 5.0);
+    CHECK(rwmol.getAtomWithIdx(4)->getProp<int>("test_new_atom") == 3);
+    CHECK(rwmol.getBondWithIdx(4)->getProp<int>("test") == 4);
+
+    CHECK(rwmol.getNumConformers() == 0);
+  }
+
+  SECTION("_ringStereoAtoms prop update") {
+    mol2.getAtomWithIdx(3)->setProp(common_properties::_ringStereoAtoms, std::vector<int>({0, -1, 2}));
+    rwmol.insertMol(mol2);
+
+    std::vector<int> gotStereoAtoms;
+    REQUIRE(rwmol.getAtomWithIdx(7)->getPropIfPresent(common_properties::_ringStereoAtoms, gotStereoAtoms));
+    CHECK(gotStereoAtoms == std::vector<int>({4, -5, 6}));
+  }
+
+  SECTION("Stereo atoms") {
+    mol2.getBondWithIdx(1)->setStereoAtoms(0, 3);
+    rwmol.insertMol(mol2);
+    const auto& result = rwmol.getBondWithIdx(4)->getStereoAtoms();
+    CHECK(result == std::vector<int>{4, 7});
+  }
+
+  SECTION("Stereo groups") {
+    std::vector<StereoGroup> groups2;
+    std::vector<Atom *> atoms2 = {mol2.getAtomWithIdx(3)};
+    groups2.push_back(StereoGroup(StereoGroupType::STEREO_AND, std::move(atoms2),
+                                 {}));
+    mol2.setStereoGroups(std::move(groups2));
+
+    rwmol.insertMol(mol2);
+
+    const auto& result = rwmol.getStereoGroups();
+    REQUIRE(result.size() == 2);
+    CHECK(result[0].getGroupType() == StereoGroupType::STEREO_OR);
+    CHECK(result[1].getGroupType() == StereoGroupType::STEREO_AND);
+
+    CHECK(result[0].getAtoms() == std::vector<Atom *>({rwmol.getAtomWithIdx(1)}));
+    CHECK(result[1].getAtoms() == std::vector<Atom *>({rwmol.getAtomWithIdx(7)}));
+  }
+
+  SECTION("Substance groups") {
+    std::vector<SubstanceGroup> &sgs2 = getSubstanceGroups(mol2);
+    sgs2.emplace_back(&rwmol, "TEST_MOL2");
+    sgs2.back().addAtomWithIdx(1);
+    sgs2.back().addBondWithIdx(2);
+
+    rwmol.insertMol(mol2);
+    const std::vector<SubstanceGroup> &result = getSubstanceGroups(rwmol);
+    REQUIRE(result.size() == 2);
+
+    CHECK(result[0].getProp<std::string>("TYPE") == "TEST_MOL1");
+    CHECK(result[1].getProp<std::string>("TYPE") == "TEST_MOL2");
+
+    CHECK(result[0].getAtoms() == std::vector<unsigned int>{0});
+    CHECK(result[0].getBonds() == std::vector<unsigned int>{1});
+    CHECK(result[1].getAtoms() == std::vector<unsigned int>{5});
+    CHECK(result[1].getBonds() == std::vector<unsigned int>{5});
+  }
+
+  SECTION("Conformers - only in original") {
+    addTestConformer(rwmol, 0);
+    rwmol.insertMol(mol2);
+
+    REQUIRE(rwmol.getNumConformers() == 1);
+    const auto& conf = rwmol.getConformer();
+    CHECK(conf.getNumAtoms() == 8);
+    CHECK(conf.getAtomPos(0).x == 0.0);
+    CHECK(conf.getAtomPos(3).y == 3.0);
+    // New atoms should be zeroed out.
+    CHECK(conf.getAtomPos(4).x == 0.0);
+    CHECK(conf.getAtomPos(7).z == 0.0);
+  }
+
+  SECTION("Conformers - only in mol to be merged") {
+    addTestConformer(mol2, 4.0);
+    rwmol.insertMol(mol2);
+
+    REQUIRE(rwmol.getNumConformers() == 1);
+    const auto& conf = rwmol.getConformer();
+    CHECK(conf.getNumAtoms() == 8);
+    CHECK(conf.getAtomPos(0).x == 0.0);
+    CHECK(conf.getAtomPos(3).y == 0.0);
+
+    CHECK(conf.getAtomPos(4).x == 4.0);
+    CHECK(conf.getAtomPos(7).z == 7.0);
+  }
+
+  SECTION("Conformers - in both") {
+    addTestConformer(rwmol, 0.0);
+    addTestConformer(mol2, 4.0);
+
+    rwmol.insertMol(mol2);
+    REQUIRE(rwmol.getNumConformers() == 1);
+    const auto& conf = rwmol.getConformer();
+    CHECK(conf.getNumAtoms() == 8);
+    CHECK(conf.getAtomPos(0).x == 0.0);
+    CHECK(conf.getAtomPos(3).y == 3.0);
+
+    CHECK(conf.getAtomPos(4).x == 4.0);
+    CHECK(conf.getAtomPos(7).z == 7.0);
+  }
+
+  SECTION("Conformers in both, more in original") {
+    addTestConformer(rwmol, 0.0);
+    addTestConformer(rwmol, 10.0);
+    addTestConformer(mol2, 4.0);
+
+    rwmol.insertMol(mol2);
+    REQUIRE(rwmol.getNumConformers() == 2);
+
+    const auto& conf1 = rwmol.getConformer(0);
+    CHECK(conf1.getNumAtoms() == 8);
+    CHECK(conf1.getAtomPos(0).x == 0.0);
+    CHECK(conf1.getAtomPos(3).y == 3.0);
+    CHECK(conf1.getAtomPos(4).x == 0.0); // New atoms not copied in this case.
+
+    const auto& conf2 = rwmol.getConformer(1);
+    CHECK(conf2.getNumAtoms() == 8);
+    CHECK(conf2.getAtomPos(0).x == 10.0);
+    CHECK(conf2.getAtomPos(3).y == 13.0);
+    CHECK(conf2.getAtomPos(4).z == 0.0);
+  }
+
+  SECTION("Conformers in both, more in mol to be merged") {
+    addTestConformer(rwmol, 0.0);
+    addTestConformer(mol2, 4.0);
+    addTestConformer(mol2, 8.0);
+
+    rwmol.insertMol(mol2);
+    REQUIRE(rwmol.getNumConformers() == 1);
+    const auto& conf = rwmol.getConformer();
+    CHECK(conf.getNumAtoms() == 8);
+    CHECK(conf.getAtomPos(0).x == 0.0);
+    CHECK(conf.getAtomPos(3).y == 3.0);
+    CHECK(conf.getAtomPos(4).x == 0.0); // New atoms not copied in this case.
+  }
+}
+
+TEST_CASE("RWMol assignment operator") {
+  SECTION("Basic molecule assignment") {
+    auto mol1ptr = parseSmiles("CCC=C");
+    RWMol& mol1 = mol1ptr->asRWMol();
+    RWMol mol2;
+    mol2 = mol1;
+
+    CHECK(mol2.getNumAtoms() == 4);
+    CHECK(mol2.getNumBonds() == 3);
+    CHECK(mol2.getBondWithIdx(2)->getBondType() == BondEnums::BondType::DOUBLE);
+    
+    // Check atoms are properly copied
+    for (unsigned int i = 0; i < mol2.getNumAtoms(); ++i) {
+      CHECK(mol2.getAtomWithIdx(i)->getAtomicNum() == mol1.getAtomWithIdx(i)->getAtomicNum());
+    }
+    mol1ptr.reset(); // Check lifetimes.
+    CHECK(mol2.getNumAtoms() == 4);
+    CHECK(mol2.getNumBonds() == 3);
+    CHECK(mol2.getBondWithIdx(2)->getBondType() == BondEnums::BondType::DOUBLE);
+  }
+
+  SECTION("Assignment with atom properties") {
+    auto mol1ptr = parseSmiles("CC");
+    RWMol& mol1 = mol1ptr->asRWMol();
+    mol1.getAtomWithIdx(0)->setProp("test_prop", 42);
+    mol1.getAtomWithIdx(1)->setProp("other_prop", "value");
+    
+    RWMol mol2;
+    mol2 = mol1;
+    mol1ptr.reset(); // Check lifetimes.
+
+    CHECK(mol2.getAtomWithIdx(0)->getProp<int>("test_prop") == 42);
+    CHECK(mol2.getAtomWithIdx(1)->getProp<std::string>("other_prop") == "value");
+  }
+
+  SECTION("Assignment with conformers") {
+    auto mol1ptr = parseSmiles("CC");
+    RWMol& mol1 = mol1ptr->asRWMol();
+    addTestConformer(mol1, 1);
+    addTestConformer(mol1, 2);
+    
+    RWMol mol2;
+    mol2 = mol1;
+    mol1ptr.reset(); // Check lifetimes.
+
+    CHECK(mol2.getNumConformers() == 2);
+    
+    // Check conformer coordinates
+    const auto conf1 = mol2.getConformer(0);
+    CHECK(conf1.getAtomPos(0).x == 1.0);
+    CHECK(conf1.getAtomPos(0).y == 1.0);
+    CHECK(conf1.getAtomPos(0).z == 1.0);
+    
+    const auto conf2 = mol2.getConformer(1);
+    CHECK(conf2.getAtomPos(0).x == 2.0);
+    CHECK(conf2.getAtomPos(0).y == 2.0);
+    CHECK(conf2.getAtomPos(0).z == 2.0);
+  }
+
+  SECTION("Assignment with stereo information") {
+    auto mol1ptr = parseSmiles("C[C@H](F)Cl");
+    RWMol& mol1 = mol1ptr->asRWMol();
+    RWMol mol2;
+    mol2 = mol1;
+
+    CHECK(mol2.getAtomWithIdx(1)->getChiralTag() == Atom::CHI_TETRAHEDRAL_CCW);
+    
+    // Add stereo groups to source molecule
+    std::vector<Atom*> atoms = {mol1.getAtomWithIdx(1)};
+    std::vector<Bond*> bonds;
+    std::vector<StereoGroup> groups;
+    groups.emplace_back(StereoGroupType::STEREO_OR, atoms, bonds);
+    mol1.setStereoGroups(std::move(groups));
+    
+    mol2 = mol1;
+    const auto& resultGroups = mol2.getStereoGroups();
+    CHECK(resultGroups.size() == 1);
+    CHECK(resultGroups[0].getGroupType() == StereoGroupType::STEREO_OR);
+    CHECK(resultGroups[0].getAtoms().size() == 1);
+  }
+
+  SECTION("Assignment with bookmarks") {
+    auto mol1ptr = parseSmiles("CC");
+    RWMol& mol1 = mol1ptr->asRWMol();
+    mol1.setAtomBookmark(mol1.getAtomWithIdx(0), 1);
+    mol1.setBondBookmark(mol1.getBondWithIdx(0), 2);
+    
+    RWMol mol2;
+    mol2 = mol1;
+    mol1ptr.reset(); // Check lifetimes.
+
+    CHECK(mol2.hasAtomBookmark(1));
+    CHECK(mol2.hasAtomBookmark(1));
+    CHECK(mol2.getAtomWithBookmark(1)->getIdx() == 0);
+    CHECK(mol2.getBondWithBookmark(2)->getIdx() == 0);
+  }
+
+  SECTION("Self assignment") {
+    auto mol1ptr = parseSmiles("CCC");
+    RWMol& mol1 = mol1ptr->asRWMol();
+    mol1 = mol1;
+
+    CHECK(mol1.getNumAtoms() == 3);
+    CHECK(mol1.getNumBonds() == 2);
+  }
+
+
+  SECTION("Assignment with queries") {
+    auto mol1ptr = parseSmiles("CC");
+    RWMol& mol1 = mol1ptr->asRWMol();
+    auto query = std::make_unique<QueryAtom>(6);
+    mol1.replaceAtom(0, query.get());
+    
+    RWMol mol2;
+    mol2 = mol1;
+    mol1ptr.reset(); // Check lifetimes.
+
+    CHECK(mol2.getAtomWithIdx(0)->hasQuery());
+    CHECK(!mol2.getAtomWithIdx(1)->hasQuery());
+  }
+
+  SECTION("Previously owned assignment") {
+    auto mol1ptr = parseSmiles("CC");
+    RWMol& mol1 = mol1ptr->asRWMol();
+    auto mol2ptr = parseSmiles("CCC");
+    RWMol& mol2 = mol2ptr->asRWMol();
+
+    mol2 = mol1;
+    mol1ptr.reset(); // Check lifetimes.
+
+    CHECK(mol2.getNumAtoms() == 2);
+    CHECK(mol2.getNumBonds() == 1);
+  }
+
+  SECTION("Both self-owned assignment") {
+        auto mol1Ptr = std::make_unique<RWMol>();
+        RWMol& mol1 = *mol1Ptr;
+        RWMol mol2;
+        auto atom = std::make_unique<Atom>(6);
+        auto atom2 = std::make_unique<Atom>(7);
+        mol1.addAtom(atom.get());
+        mol1.addAtom(atom2.get());
+        mol1.addBond(0, 1, Bond::BondType::SINGLE);
+        mol2 = mol1;
+        mol1Ptr.reset();
+
+        CHECK(mol2.getNumAtoms() == 2);
+        CHECK(mol2.getNumBonds() == 1);
+  }
+}
+

--- a/Code/GraphMol/catch_stereo_groups.cpp
+++ b/Code/GraphMol/catch_stereo_groups.cpp
@@ -1,0 +1,348 @@
+//
+//  Copyright (C) 2025 NVIDIA Corporation & Affiliates and other RDKit contributors
+//
+//   @@ All Rights Reserved @@
+//  This file is part of the RDKit.
+//  The contents are covered by the terms of the BSD license
+//  which is included in the file license.txt, found at the root
+//  of the RDKit source tree.
+//
+#include <catch2/catch_all.hpp>
+
+#include <GraphMol/Chirality.h>
+#include <GraphMol/RDMol.h>
+#include <GraphMol/SmilesParse/SmilesParse.h>
+#include <GraphMol/StereoGroup.h>
+
+using ::RDKit::StereoGroup;
+using ::RDKit::StereoGroups;
+using ::RDKit::Chirality::cleanupStereoGroups;
+
+namespace {
+
+StereoGroups makeGroups() {
+  StereoGroups groups;
+  groups.addGroup(RDKit::StereoGroupType::STEREO_ABSOLUTE,
+                  std::vector<uint32_t>{}, std::vector<uint32_t>{});
+  groups.addGroup(RDKit::StereoGroupType::STEREO_OR,
+                  std::vector<uint32_t>{0, 1, 2}, std::vector<uint32_t>{1},
+                  /*readId=*/5);
+  groups.addGroup(RDKit::StereoGroupType::STEREO_AND,
+                  std::vector<uint32_t>{2, 3}, std::vector<uint32_t>{0, 2});
+  return groups;
+}
+
+std::vector<uint32_t> iteratorToIndexVector(
+    const std::pair<const uint32_t *, const uint32_t *> &iter) {
+  std::vector<uint32_t> res;
+  for (const uint32_t *idx = iter.first; idx != iter.second; idx++) {
+    res.push_back(*idx);
+  }
+  return res;
+}
+
+}  // namespace
+
+TEST_CASE("Empty groups") {
+  StereoGroups groups;
+  CHECK_THROWS_AS(groups.getGroupType(0), Invar::Invariant);
+  CHECK_THROWS_AS(groups.getReadID(0), Invar::Invariant);
+  CHECK_THROWS_AS(groups.getWriteID(0), Invar::Invariant);
+  CHECK_THROWS_AS(groups.getAtoms(0), Invar::Invariant);
+  CHECK_THROWS_AS(groups.getBonds(0), Invar::Invariant);
+  CHECK_THROWS_AS(groups.GroupsEq(0, 0), Invar::Invariant);
+  // Check no crashes
+  groups.assignStereoGroupIds();
+  groups.forwardStereoGroupIds();
+  groups.removeAtomFromGroups(4);
+  groups.removeGroupsWithAtoms({4});
+}
+
+TEST_CASE("Basic get/set") {
+  StereoGroups groups = makeGroups();
+
+  CHECK(groups.getGroupType(0) == RDKit::StereoGroupType::STEREO_ABSOLUTE);
+  CHECK(groups.getGroupType(1) == RDKit::StereoGroupType::STEREO_OR);
+  CHECK(groups.getGroupType(2) == RDKit::StereoGroupType::STEREO_AND);
+
+  CHECK(groups.getReadID(0) == 0);
+  CHECK(groups.getReadID(1) == 5);
+  CHECK(groups.getReadID(2) == 0);
+
+  CHECK(groups.getWriteID(0) == 0);
+  CHECK(groups.getWriteID(1) == 0);
+  CHECK(groups.getWriteID(2) == 0);
+
+  auto group0Atoms = iteratorToIndexVector(groups.getAtoms(0));
+  auto group1Atoms = iteratorToIndexVector(groups.getAtoms(1));
+  auto group2Atoms = iteratorToIndexVector(groups.getAtoms(2));
+
+  auto group0Bonds = iteratorToIndexVector(groups.getBonds(0));
+  auto group1Bonds = iteratorToIndexVector(groups.getBonds(1));
+  auto group2Bonds = iteratorToIndexVector(groups.getBonds(2));
+
+  CHECK(group0Atoms.empty());
+  CHECK(group1Atoms == std::vector<uint32_t>{0, 1, 2});
+  CHECK(group2Atoms == std::vector<uint32_t>{2, 3});
+
+  CHECK(group0Bonds.empty());
+  CHECK(group1Bonds == std::vector<uint32_t>{1});
+  CHECK(group2Bonds == std::vector<uint32_t>{0, 2});
+}
+
+TEST_CASE("Group equality") {
+  StereoGroups groups = makeGroups();
+  // Add a group equal to 2
+  groups.addGroup(RDKit::StereoGroupType::STEREO_AND,
+                  std::vector<uint32_t>{2, 3}, std::vector<uint32_t>{0, 2});
+  // Different only in atoms
+  groups.addGroup(RDKit::StereoGroupType::STEREO_AND, std::vector<uint32_t>{2},
+                  std::vector<uint32_t>{0, 2});
+  // Different only in bonds
+  groups.addGroup(RDKit::StereoGroupType::STEREO_AND,
+                  std::vector<uint32_t>{2, 3}, std::vector<uint32_t>{0});
+  CHECK(groups.GroupsEq(0, 0));
+  CHECK_FALSE(groups.GroupsEq(0, 1));
+  CHECK_FALSE(groups.GroupsEq(0, 2));
+  CHECK_FALSE(groups.GroupsEq(1, 0));
+  CHECK(groups.GroupsEq(1, 1));
+  CHECK_FALSE(groups.GroupsEq(1, 2));
+  CHECK_FALSE(groups.GroupsEq(2, 0));
+  CHECK_FALSE(groups.GroupsEq(2, 1));
+  CHECK(groups.GroupsEq(2, 2));
+  CHECK(groups.GroupsEq(2, 3));
+  CHECK(!groups.GroupsEq(2, 4));
+  CHECK(!groups.GroupsEq(2, 5));
+}
+
+TEST_CASE("Remove atom from groups") {
+  StereoGroups groups = makeGroups();
+  groups.removeAtomFromGroups(2);
+
+  // removeAtomFromGroups removes the empty group 0, so there are only 2 groups left
+  REQUIRE(groups.getNumGroups() == 2);
+
+  auto group0Atoms = iteratorToIndexVector(groups.getAtoms(0));
+  auto group1Atoms = iteratorToIndexVector(groups.getAtoms(1));
+
+  CHECK(group0Atoms == std::vector<uint32_t>{0, 1});
+  CHECK(group1Atoms == std::vector<uint32_t>{3});
+}
+
+TEST_CASE("Remove groups with atoms") {
+  StereoGroups groups = makeGroups();
+  groups.removeGroupsWithAtoms({1});
+
+  // Only group 1, containing atom 1, should be removed
+  REQUIRE(groups.getNumGroups() == 2);
+
+  auto group0Atoms = iteratorToIndexVector(groups.getAtoms(0));
+  auto group1Atoms = iteratorToIndexVector(groups.getAtoms(1));
+  auto group0Bonds = iteratorToIndexVector(groups.getBonds(0));
+  auto group1Bonds = iteratorToIndexVector(groups.getBonds(1));
+
+  CHECK(group0Atoms.empty());
+  CHECK(group1Atoms == std::vector<uint32_t>{2, 3});
+  CHECK(group0Bonds.empty());
+  CHECK(group1Bonds == std::vector<uint32_t>{0, 2});
+
+  CHECK(groups.readIds[0] == 0);
+  CHECK(groups.readIds[1] == 0);
+}
+
+TEST_CASE("Assign IDs") {
+  StereoGroups groups = makeGroups();
+
+  std::vector<StereoGroup> legacyGroups;
+  legacyGroups.push_back(
+      StereoGroup(RDKit::StereoGroupType::STEREO_ABSOLUTE, {}, {}));
+  legacyGroups.push_back(
+      StereoGroup(RDKit::StereoGroupType::STEREO_OR, {}, {}, 5));
+  legacyGroups.push_back(
+      StereoGroup(RDKit::StereoGroupType::STEREO_AND, {}, {}));
+
+  RDKit::assignStereoGroupIds(legacyGroups);
+  groups.assignStereoGroupIds();
+
+  SECTION("Not preassigned") {
+    CHECK(legacyGroups[0].getWriteId() == groups.getWriteID(0));
+    CHECK(legacyGroups[1].getWriteId() == groups.getWriteID(1));
+    CHECK(legacyGroups[2].getWriteId() == groups.getWriteID(2));
+  }
+
+  SECTION("Preassigned, new group") {
+    groups.addGroup(RDKit::StereoGroupType::STEREO_OR, {}, {});
+    legacyGroups.push_back(
+        StereoGroup(RDKit::StereoGroupType::STEREO_OR, {}, {}));
+
+    RDKit::assignStereoGroupIds(legacyGroups);
+    groups.assignStereoGroupIds();
+    CHECK(legacyGroups[0].getWriteId() == groups.getWriteID(0));
+    CHECK(legacyGroups[1].getWriteId() == groups.getWriteID(1));
+    CHECK(legacyGroups[2].getWriteId() == groups.getWriteID(2));
+    CHECK(legacyGroups[3].getWriteId() == groups.getWriteID(3));
+  }
+
+  SECTION("Duplicates") {
+    groups.addGroup(RDKit::StereoGroupType::STEREO_OR, {}, {});
+    legacyGroups.push_back(
+        StereoGroup(RDKit::StereoGroupType::STEREO_OR, {}, {}));
+    legacyGroups[3].setWriteId(1);
+    groups.setWriteID(3, 1);
+    RDKit::assignStereoGroupIds(legacyGroups);
+    groups.assignStereoGroupIds();
+    CHECK(legacyGroups[0].getWriteId() == groups.getWriteID(0));
+    CHECK(legacyGroups[1].getWriteId() == groups.getWriteID(1));
+    CHECK(legacyGroups[2].getWriteId() == groups.getWriteID(2));
+  }
+}
+
+TEST_CASE("Forward IDs") {
+  StereoGroups groups = makeGroups();
+  CHECK(groups.getWriteID(0) == 0);
+  CHECK(groups.getWriteID(1) == 0);
+  CHECK(groups.getWriteID(2) == 0);
+  groups.forwardStereoGroupIds();
+  CHECK(groups.getWriteID(0) == 0);
+  CHECK(groups.getWriteID(1) == 5);
+  CHECK(groups.getWriteID(2) == 0);
+}
+
+TEST_CASE("Chirality cleanup") {
+  RDKit::RDMol mol;
+  RDKit::SmilesParseTemp temp;
+  static const char *basicSmiles = "CCCC";
+
+  RDKit::SmilesParserParams params;
+  params.sanitize = false;
+  params.removeHs = false;
+
+  REQUIRE(RDKit::SmilesToMol(basicSmiles, params, mol, temp) == true);
+  REQUIRE(mol.getNumAtoms() == 4);
+  REQUIRE(mol.getNumBonds() == 3);
+  mol.getAtom(0).setChiralTag(RDKit::AtomEnums::ChiralType::CHI_TETRAHEDRAL_CW);
+  mol.getAtom(1).setChiralTag(RDKit::AtomEnums::ChiralType::CHI_TETRAHEDRAL_CW);
+  mol.getAtom(2).setChiralTag(RDKit::AtomEnums::ChiralType::CHI_TETRAHEDRAL_CW);
+  mol.getAtom(3).setChiralTag(RDKit::AtomEnums::ChiralType::CHI_TETRAHEDRAL_CW);
+  mol.getBond(0).setStereo(RDKit::BondEnums::BondStereo::STEREOATROPCCW);
+  mol.getBond(1).setStereo(RDKit::BondEnums::BondStereo::STEREOATROPCW);
+  mol.getBond(2).setStereo(RDKit::BondEnums::BondStereo::STEREOATROPCW);
+
+  SECTION("Unset") {
+    cleanupStereoGroups(mol);
+    CHECK(mol.getStereoGroups() == nullptr);
+  }
+
+  SECTION("Empty") {
+    auto groups = std::make_unique<StereoGroups>();
+    mol.setStereoGroups(std::move(groups));
+    cleanupStereoGroups(mol);
+    CHECK(mol.getStereoGroups()->getNumGroups() == 0);
+  }
+
+  SECTION("No removals") {
+    auto groups = std::make_unique<StereoGroups>();
+    groups->addGroup(RDKit::StereoGroupType::STEREO_OR, {0, 1, 2}, {1}, 5);
+    groups->addGroup(RDKit::StereoGroupType::STEREO_AND, {2, 3}, {0, 2});
+    mol.setStereoGroups(std::move(groups));
+    cleanupStereoGroups(mol);
+    const auto *res = mol.getStereoGroups();
+    REQUIRE(res != nullptr);
+    REQUIRE(res->getNumGroups() == 2);
+
+    auto group0Atoms = iteratorToIndexVector(res->getAtoms(0));
+    auto group1Atoms = iteratorToIndexVector(res->getAtoms(1));
+    auto group0Bonds = iteratorToIndexVector(res->getBonds(0));
+    auto group1Bonds = iteratorToIndexVector(res->getBonds(1));
+
+    CHECK(group0Atoms == std::vector<uint32_t>{0, 1, 2});
+    CHECK(group1Atoms == std::vector<uint32_t>{2, 3});
+    CHECK(group0Bonds == std::vector<uint32_t>{1});
+    CHECK(group1Bonds == std::vector<uint32_t>{0, 2});
+  }
+
+  SECTION("Remove already empty group") {
+    auto groups = std::make_unique<StereoGroups>();
+    groups->addGroup(RDKit::StereoGroupType::STEREO_OR, {}, {}, 5);
+    groups->addGroup(RDKit::StereoGroupType::STEREO_AND, {2, 3}, {0, 2});
+    mol.setStereoGroups(std::move(groups));
+    cleanupStereoGroups(mol);
+    const auto *res = mol.getStereoGroups();
+    REQUIRE(res != nullptr);
+    REQUIRE(res->getNumGroups() == 1);
+
+    auto group0Atoms = iteratorToIndexVector(res->getAtoms(0));
+    auto group0Bonds = iteratorToIndexVector(res->getBonds(0));
+
+    CHECK(group0Atoms == std::vector<uint32_t>{2, 3});
+    CHECK(group0Bonds == std::vector<uint32_t>{0, 2});
+  }
+
+  SECTION("Atom removals, no empty groups") {
+    auto groups = std::make_unique<StereoGroups>();
+    mol.getAtom(2).setChiralTag(RDKit::AtomEnums::ChiralType::CHI_UNSPECIFIED);
+    groups->addGroup(RDKit::StereoGroupType::STEREO_OR, {1, 2}, {}, 5);
+    groups->addGroup(RDKit::StereoGroupType::STEREO_AND, {2, 3}, {0, 2});
+    mol.setStereoGroups(std::move(groups));
+    cleanupStereoGroups(mol);
+    const auto *res = mol.getStereoGroups();
+    REQUIRE(res != nullptr);
+    REQUIRE(res->getNumGroups() == 2);
+
+    auto group0Atoms = iteratorToIndexVector(res->getAtoms(0));
+    auto group1Atoms = iteratorToIndexVector(res->getAtoms(1));
+    auto group0Bonds = iteratorToIndexVector(res->getBonds(0));
+    auto group1Bonds = iteratorToIndexVector(res->getBonds(1));
+
+    CHECK(group0Atoms == std::vector<uint32_t>{1});
+    CHECK(group1Atoms == std::vector<uint32_t>{3});
+    CHECK(group0Bonds == std::vector<uint32_t>{});
+    CHECK(group1Bonds == std::vector<uint32_t>{0, 2});
+  }
+
+  SECTION("Atom removals, empty groups removed") {
+    auto groups = std::make_unique<StereoGroups>();
+    mol.getAtom(2).setChiralTag(RDKit::AtomEnums::ChiralType::CHI_UNSPECIFIED);
+    mol.getAtom(3).setChiralTag(RDKit::AtomEnums::ChiralType::CHI_UNSPECIFIED);
+    groups->addGroup(RDKit::StereoGroupType::STEREO_OR, {1, 2}, {}, 5);
+    groups->addGroup(RDKit::StereoGroupType::STEREO_AND, {2, 3}, {});
+    groups->addGroup(RDKit::StereoGroupType::STEREO_AND, {0, 1}, {2});
+
+    mol.setStereoGroups(std::move(groups));
+    cleanupStereoGroups(mol);
+    const auto *res = mol.getStereoGroups();
+    REQUIRE(res != nullptr);
+    REQUIRE(res->getNumGroups() == 2);
+
+    auto group0Atoms = iteratorToIndexVector(res->getAtoms(0));
+    auto group1Atoms = iteratorToIndexVector(res->getAtoms(1));
+    auto group0Bonds = iteratorToIndexVector(res->getBonds(0));
+    auto group1Bonds = iteratorToIndexVector(res->getBonds(1));
+
+    CHECK(group0Atoms == std::vector<uint32_t>{1});
+    CHECK(group1Atoms == std::vector<uint32_t>{0, 1});
+    CHECK(group0Bonds == std::vector<uint32_t>{});
+    CHECK(group1Bonds == std::vector<uint32_t>{2});
+  }
+
+  SECTION("Atom removals, group removed even if bonds in group") {
+    auto groups = std::make_unique<StereoGroups>();
+    mol.getAtom(2).setChiralTag(RDKit::AtomEnums::ChiralType::CHI_UNSPECIFIED);
+    mol.getAtom(3).setChiralTag(RDKit::AtomEnums::ChiralType::CHI_UNSPECIFIED);
+    groups->addGroup(RDKit::StereoGroupType::STEREO_OR, {1, 2}, {}, 5);
+    groups->addGroup(RDKit::StereoGroupType::STEREO_AND, {2, 3},
+                     {1});  // Note that the bond should not keep the group alive.
+
+    mol.setStereoGroups(std::move(groups));
+    cleanupStereoGroups(mol);
+    const auto *res = mol.getStereoGroups();
+    REQUIRE(res != nullptr);
+    REQUIRE(res->getNumGroups() == 1);
+
+    auto group0Atoms = iteratorToIndexVector(res->getAtoms(0));
+    auto group0Bonds = iteratorToIndexVector(res->getBonds(0));
+
+    CHECK(group0Atoms == std::vector<uint32_t>{1});
+    CHECK(group0Bonds == std::vector<uint32_t>{});
+  }
+}

--- a/Code/GraphMol/new_canon.cpp
+++ b/Code/GraphMol/new_canon.cpp
@@ -519,8 +519,7 @@ void getChiralBonds(const ROMol &mol, const Atom *at,
       // neglected."
       // FIX: this applies to more than just P
     } else {
-      nReps =
-          static_cast<unsigned int>(floor(2. * bond->getBondTypeAsDouble()));
+      nReps = getTwiceBondType(*bond);
     }
     unsigned int symclass =
         nbr->getAtomicNum() * ATNUM_CLASS_OFFSET + nbrIdx + 1;

--- a/Code/GraphMol/rdmol_throw.h
+++ b/Code/GraphMol/rdmol_throw.h
@@ -1,0 +1,26 @@
+//
+//  Copyright (C) 2025 NVIDIA Corporation & Affiliates and other RDKit contributors
+//
+//   @@ All Rights Reserved @@
+//  This file is part of the RDKit.
+//  The contents are covered by the terms of the BSD license
+//  which is included in the file license.txt, found at the root
+//  of the RDKit source tree.
+//
+#ifndef RDMOL_THROW_H
+#define RDMOL_THROW_H
+
+#include <string>
+#include <stdexcept>
+
+inline void raiseNonImplementedFunction(const std::string& func) {
+  std::string errorMessage = "This function is not implemented: " + func;
+  throw std::runtime_error(errorMessage);
+}
+
+inline void raiseNonImplementedDetail(const std::string& detail) {
+  std::string errorMessage = "This detail is not implemented: " + detail;
+  throw std::runtime_error(errorMessage);
+}
+
+#endif // RDMOL_THROW_H

--- a/Code/GraphMol/testPickler.cpp
+++ b/Code/GraphMol/testPickler.cpp
@@ -1681,6 +1681,8 @@ void testAdditionalQueryPickling() {
 
 void testBoostSerialization() {
 #ifdef RDK_USE_BOOST_SERIALIZATION
+  raiseNonImplementedDetail("Serialize");
+#if 0
   BOOST_LOG(rdErrorLog) << "-------------------------------------" << std::endl;
   BOOST_LOG(rdErrorLog) << "Testing boost::serialization integration"
                         << std::endl;
@@ -1734,7 +1736,7 @@ void testBoostSerialization() {
     TEST_ASSERT(pval == 3);
   }
   BOOST_LOG(rdErrorLog) << "\tdone" << std::endl;
-
+#endif
 #endif
 }
 int main(int argc, char *argv[]) {

--- a/Code/Query/Query.h
+++ b/Code/Query/Query.h
@@ -56,7 +56,7 @@ class RDKIT_QUERY_EXPORT Query {
   virtual ~Query() { this->d_children.clear(); }
 
   //! sets whether or not we are negated
-  void setNegation(bool what) { this->df_negate = what; }
+  virtual void setNegation(bool what) { this->df_negate = what; }
   //! returns whether or not we are negated
   bool getNegation() const { return this->df_negate; }
 
@@ -85,13 +85,13 @@ class RDKIT_QUERY_EXPORT Query {
   const std::string &getTypeLabel() const { return this->d_queryType; }
 
   //! sets our match function
-  void setMatchFunc(bool (*what)(MatchFuncArgType)) {
+  virtual void setMatchFunc(bool (*what)(MatchFuncArgType)) {
     this->d_matchFunc = what;
   }
   //! returns our match function:
   bool (*getMatchFunc() const)(MatchFuncArgType) { return this->d_matchFunc; }
   //! sets our data function
-  void setDataFunc(MatchFuncArgType (*what)(DataFuncArgType)) {
+  virtual void setDataFunc(MatchFuncArgType (*what)(DataFuncArgType)) {
     this->d_dataFunc = what;
   }
   //! returns our data function:
@@ -100,7 +100,7 @@ class RDKIT_QUERY_EXPORT Query {
   }
 
   //! adds a child to our list of children
-  void addChild(CHILD_TYPE child) { this->d_children.push_back(child); }
+  virtual void addChild(CHILD_TYPE child) { this->d_children.push_back(child); }
   //! returns an iterator for the beginning of our child vector
   CHILD_VECT_CI beginChildren() const { return this->d_children.begin(); }
   //! returns an iterator for the end of our child vector
@@ -205,6 +205,14 @@ int queryCmp(const T1 v1, const T2 v2, const T1 tol) {
   } else {
     return 1;
   }
-};
+}
+
+template <>
+inline int queryCmp(const bool v1, const bool v2, const bool tol) {
+  if (v1 == v2 || tol) {
+    return 0;
+  }
+  return v1 ? 1 : -1;
+}
 }  // namespace Queries
 #endif

--- a/Code/RDGeneral/CMakeLists.txt
+++ b/Code/RDGeneral/CMakeLists.txt
@@ -76,3 +76,6 @@ rdkit_catch_test(dictTestsCatch catch_dict.cpp
 
 rdkit_catch_test(logTestsCatch catch_logs.cpp
         LINK_LIBRARIES RDGeneral)
+
+rdkit_catch_test(vectorUtilsCatch catch_vector_utils.cpp
+        LINK_LIBRARIES RDGeneral )

--- a/Code/RDGeneral/Dict.h
+++ b/Code/RDGeneral/Dict.h
@@ -209,6 +209,15 @@ class RDKIT_RDGENERAL_EXPORT Dict {
     throw KeyErrorException(what);
   }
 
+  const RDValue &getRDValue(const std::string &what) const {
+    for (auto &data : _data) {
+      if (data.key == what) {
+        return data.val;
+      }
+    }
+    throw KeyErrorException(what);
+  }
+
   //----------------------------------------------------------
   //! \brief Potentially gets the value associated with a particular key
   //!        returns true on success/false on failure.

--- a/Code/RDGeneral/RDLog.cpp
+++ b/Code/RDGeneral/RDLog.cpp
@@ -15,6 +15,7 @@
 #include <ctime>
 #include <iostream>
 #include <sstream>
+#include <cstdint>
 
 RDLogger rdAppLog = nullptr;
 RDLogger rdDebugLog = nullptr;
@@ -33,7 +34,7 @@ const std::vector<RDLogger *> allLogs = {&rdAppLog,     &rdDebugLog,
 LogStateSetter::LogStateSetter() {
   for (auto i = 0u; i < allLogs.size(); ++i) {
     if (*allLogs[i] && (*allLogs[i])->df_enabled) {
-      d_origState |= 1 << i;
+      d_origState |= std::uint64_t(1) << i;
       (*allLogs[i])->df_enabled = false;
     }
   }
@@ -43,7 +44,7 @@ LogStateSetter::LogStateSetter(RDLoggerList toEnable) : LogStateSetter() {
   for (auto i = 0u; i < allLogs.size(); ++i) {
     if (*allLogs[i] && std::find(toEnable.begin(), toEnable.end(),
                                  *allLogs[i]) != toEnable.end()) {
-      d_origState ^= 1 << i;
+      d_origState ^= std::uint64_t(1) << i;
       (*allLogs[i])->df_enabled = true;
     }
   }

--- a/Code/RDGeneral/RDProps.h
+++ b/Code/RDGeneral/RDProps.h
@@ -114,6 +114,10 @@ class RDProps {
     return d_props.getVal<T>(key);
   }
 
+  const RDValue &getPropRDValue(const std::string &key) const {
+    return d_props.getRDValue(key);
+  }
+
   //! returns whether or not we have a \c property with name \c key
   //!  and assigns the value if we do
   //! \overload

--- a/Code/RDGeneral/RDValue-taggedunion.h
+++ b/Code/RDGeneral/RDValue-taggedunion.h
@@ -400,6 +400,11 @@ inline T rdvalue_cast(RDValue_cast_t v) {
   throw std::bad_any_cast();
 }
 
+template <>
+inline RDValue rdvalue_cast<RDValue>(RDValue_cast_t v) {
+  return v;
+}
+
 // POD casts
 template <>
 inline double rdvalue_cast<double>(RDValue_cast_t v) {

--- a/Code/RDGeneral/Ranking.h
+++ b/Code/RDGeneral/Ranking.h
@@ -40,7 +40,7 @@ inline auto pairLess = [](const auto &v1, const auto &v2) {
   \param res  is used to return the ranks of each entry
 */
 template <typename T1, typename T2>
-void rankVect(const std::vector<T1> &vect, T2 &res) {
+unsigned int rankVect(const std::vector<T1> &vect, T2 &res) {
   PRECONDITION(res.size() >= vect.size(), "vector size mismatch");
   unsigned int nEntries = rdcast<unsigned int>(vect.size());
 
@@ -51,7 +51,7 @@ void rankVect(const std::vector<T1> &vect, T2 &res) {
   std::sort(indices.begin(), indices.end(),
             [&](auto i1, auto i2) { return vect[i1] < vect[i2]; });
 
-  int currRank = 0;
+  unsigned int currRank = 0;
   unsigned int lastIdx = indices[0];
   for (auto idx : indices) {
     if (vect[idx] == vect[lastIdx]) {
@@ -61,6 +61,8 @@ void rankVect(const std::vector<T1> &vect, T2 &res) {
       lastIdx = idx;
     }
   }
+
+  return currRank + 1;
 }
 }  // namespace Rankers
 #endif

--- a/Code/RDGeneral/catch_vector_utils.cpp
+++ b/Code/RDGeneral/catch_vector_utils.cpp
@@ -1,0 +1,94 @@
+//
+//  Copyright (C) 2025 NVIDIA Corporation & Affiliates and other RDKit contributors
+//
+//   @@ All Rights Reserved @@
+//  This file is part of the RDKit.
+//  The contents are covered by the terms of the BSD license
+//  which is included in the file license.txt, found at the root
+//  of the RDKit source tree.
+//
+#include <catch2/catch_all.hpp>
+
+#include "vector_utils.h"
+
+using namespace RDKit;
+
+TEST_CASE("Test eraseMultipleIndices") {
+  std::vector<int> vec = {0, 1, 2, 3, 4};
+  SECTION("Empty indices") {
+    std::vector<size_t> indices;
+    std::vector<int> wantVec = vec;
+
+    eraseMultipleIndices(vec, indices);
+    CHECK(vec == wantVec);
+
+    std::vector<double> empty;
+    eraseMultipleIndices(empty, indices);
+    CHECK(empty.empty());
+  }
+
+  SECTION("Out of order indices") {
+    std::vector<size_t> indices = {3, 1};
+    CHECK_THROWS_AS(eraseMultipleIndices(vec, indices), Invar::Invariant);
+  }
+
+  SECTION("Out of range indices") {
+    std::vector<size_t> indices = {6};
+    CHECK_THROWS_AS(eraseMultipleIndices(vec, indices), Invar::Invariant);
+  }
+
+  SECTION("Normal case") {
+    std::vector<size_t> indices = {1, 3};
+    std::vector<int> wantVec = {0, 2, 4};
+
+    eraseMultipleIndices(vec, indices);
+    CHECK(vec == wantVec);
+  }
+
+  SECTION("Edge case: Erase last element") {
+    std::vector<size_t> indices = {1, 4};
+    std::vector<int> wantVec = {0, 2, 3};
+    eraseMultipleIndices(vec, indices);
+    CHECK(vec == wantVec);
+  }
+
+  SECTION("Edge case: Erase first element") {
+    std::vector<size_t> indices = {0, 3};
+    std::vector<int> wantVec = {1, 2, 4};
+    eraseMultipleIndices(vec, indices);
+    CHECK(vec == wantVec);
+  }
+
+  SECTION("Edge case: erase only one element") {
+    std::vector<size_t> indices = {2};
+    std::vector<int> wantVec = {0, 1, 3, 4};
+    eraseMultipleIndices(vec, indices);
+    CHECK(vec == wantVec);
+  }
+
+  SECTION("Edge case: Erase adjacent elements") {
+    std::vector<size_t> indices = {1, 2};
+    std::vector<int> wantVec = {0, 3, 4};
+    eraseMultipleIndices(vec, indices);
+    CHECK(vec == wantVec);
+  }
+
+  SECTION("Edge case: size 1 input") {
+    std::vector<int> input = {0};
+    std::vector<size_t> indices = {0};
+
+    eraseMultipleIndices(input, std::vector<size_t>{});
+    std::vector<int> wantFromEmptyIndices = input;
+    REQUIRE(input == wantFromEmptyIndices);
+    eraseMultipleIndices(input, indices);
+    REQUIRE(input == std::vector<int>{});
+  }
+
+  SECTION("Edge case: all elements erased") {
+    std::vector<size_t> indices = {0, 1, 2, 3, 4};
+    std::vector<int> wantVec = {};
+
+    eraseMultipleIndices(vec, indices);
+    CHECK(vec == wantVec);
+  }
+}

--- a/Code/RDGeneral/types.cpp
+++ b/Code/RDGeneral/types.cpp
@@ -146,6 +146,25 @@ const std::string _QueryAtomGenericLabel = "_QueryAtomGenericLabel";
 const std::string _displayLabel = "_displayLabel";
 const std::string _displayLabelW = "_displayLabelW";
 
+const PropToken _hasMassQueryToken = PropToken(_hasMassQuery);
+
+const PropToken _ChiralityPossibleToken = PropToken(_ChiralityPossible);
+const PropToken _chiralPermutationToken = PropToken(_chiralPermutation);
+const PropToken _CIPCodeToken = PropToken(_CIPCode);
+const PropToken _CIPRankToken = PropToken(_CIPRank);
+const PropToken _isotopicHsToken = PropToken(_isotopicHs);
+const PropToken _MolFileRLabelToken = PropToken(_MolFileRLabel);
+const PropToken _ringStereoAtomsAllToken = PropToken("_ringStereoAtomsAll");
+const PropToken _ringStereoAtomsBeginsToken = PropToken("_ringStereoAtomsBegins");
+const PropToken _ringStereoGroupToken = PropToken("_ringStereoGroup");
+const PropToken _supplementalSmilesLabelToken = PropToken(_supplementalSmilesLabel);
+const PropToken _UnknownStereoToken = PropToken(_UnknownStereo);
+const PropToken dummyLabelToken = PropToken(dummyLabel);
+const PropToken isImplicitToken = PropToken(isImplicit);
+const PropToken molAtomMapNumberToken = PropToken(molAtomMapNumber);
+const PropToken molFileAliasToken = PropToken(molFileAlias);
+const PropToken molFileValueToken = PropToken(molFileValue);
+
 }  // namespace common_properties
 
 const double MAX_DOUBLE = std::numeric_limits<double>::max();

--- a/Code/RDGeneral/types.h
+++ b/Code/RDGeneral/types.h
@@ -33,6 +33,7 @@
 #include <set>
 #include <string>
 #include <algorithm>
+#include <memory>
 #include <numeric>
 #include <list>
 #include <limits>
@@ -45,9 +46,170 @@
 
 namespace RDKit {
 
+class PropToken {
+  struct PropTokenImpl {
+    uint64_t hash;
+    std::string text;
+    PropTokenImpl(uint64_t initHash, std::string initText)
+        : hash(initHash), text(std::move(initText)) {}
+  };
+  std::shared_ptr<PropTokenImpl> impl;
+
+ public:
+  static uint64_t computeHash(const char *text) {
+    size_t length = strlen(text);
+    uint64_t hash = 0;
+    while (length >= 8) {
+      uint64_t v = *reinterpret_cast<const uint64_t*>(text);
+      // The large magic number is the golden ratio minus 1, times 2^64,
+      // which is good for a simple low discrepancy sequence.
+      // 12345 is arbitrary.
+      hash = 12345 * hash + v + 0x9E3779B97F4A7C15;
+      length -= 8;
+      text += 8;
+    }
+    if (length != 0) {
+      uint64_t v = 0;
+      for (size_t i = 0; i < length; ++i) {
+        v |= uint64_t(uint8_t(*text)) << (i * 8);
+        ++text;
+      }
+      hash = 12345 * hash + v + 0x9E3779B97F4A7C15;
+    }
+    return hash;
+  }
+
+  constexpr PropToken() = default;
+  explicit PropToken(const char *text)
+      : impl(std::make_shared<PropTokenImpl>(computeHash(text), text)) {}
+  explicit PropToken(const std::string &text)
+      : impl(std::make_shared<PropTokenImpl>(computeHash(text.c_str()), text)) {}
+  PropToken(const PropToken &) = default;
+  PropToken(PropToken &&) = default;
+  PropToken &operator=(const PropToken &) = default;
+  PropToken &operator=(PropToken &&) = default;
+  ~PropToken() = default;
+  bool operator==(const PropToken &other)
+          const {
+    const PropTokenImpl *p0 = impl.get();
+    const PropTokenImpl *p1 = other.impl.get();
+    if (p0 == p1) {
+      return true;
+    }
+    if (p0->hash != p1->hash) {
+      return false;
+    }
+    // For common tokens, this case should be relatively uncommon
+    return (p0->text == p1->text);
+  }
+  bool operator!=(const PropToken &other) const {
+    return !(*this == other);
+  }
+  bool operator==(const std::string &other) const {
+    return (impl->text == other);
+  }
+  bool operator!=(const std::string &other) const {
+    return !(*this == other);
+  }
+  bool operator==(const char *other) const {
+    return (impl->text == other);
+  }
+  bool operator!=(const char *other) const {
+    return !(*this == other);
+  }
+  const std::string &getString() const {
+    return impl->text;
+  }
+  const char *getText() const {
+    return impl->text.c_str();
+  }
+  bool isNull() const { return impl.get() == nullptr; }
+  operator bool() const { return impl.get() != nullptr; }
+  bool operator!() const { return impl.get() == nullptr; }
+};
+
 namespace detail {
 // used in various places for computed properties
 RDKIT_RDGENERAL_EXPORT extern const std::string computedPropName;
+
+// This wraps a vector or local buffer as a bit set,
+// so that often, no allocation is needed, and if it is
+// needed, it can be reused.
+class BitSetWrapper {
+  constexpr static size_t localBufferSize = 2;
+  uint64_t localBuffer[2] = {0, 0};
+  uint64_t *const buffer;
+  const size_t n;
+
+ public:
+  BitSetWrapper(std::vector<uint64_t> &storage, size_t n_, bool value = false)
+      : buffer((n_ > 64 * localBufferSize)
+                   ? (storage.clear(), storage.resize((n_ + 63) / 64, value ? ~uint64_t(0) : 0),
+                      storage.data())
+                   : localBuffer),
+        n(n_) {
+    if (value && n_ <= 64 * localBufferSize) {
+      for (size_t i = 0; i < localBufferSize; ++i) {
+        localBuffer[i] = ~uint64_t(0);
+      }
+    }
+  }
+  BitSetWrapper(uint64_t *storage, size_t n_) : buffer(storage), n(n_) {}
+  BitSetWrapper(uint64_t *storage, size_t n_, bool value)
+      : buffer(storage), n(n_) {
+    const size_t bufferSize = (n + 63) / 64;
+    for (size_t i = 0; i < bufferSize; ++i) {
+      buffer[i] = value ? ~uint64_t(0) : 0;
+    }
+  }
+
+  bool operator[](size_t i) const {
+    return (buffer[i / 64] & (uint64_t(1) << (i % 64))) != 0;
+  }
+  void set(size_t i) {
+    PRECONDITION(i < n, "BitSetWrapper::set index out of bounds");
+    buffer[i / 64] |= (uint64_t(1) << (i % 64));
+  }
+  void reset(size_t i) {
+    PRECONDITION(i < n, "BitSetWrapper::reset index out of bounds");
+    buffer[i / 64] &= ~(uint64_t(1) << (i % 64));
+  }
+  void set(size_t i, bool value) {
+    PRECONDITION(i < n, "BitSetWrapper::set index out of bounds");
+    if (value) {
+      buffer[i / 64] |= (uint64_t(1) << (i % 64));
+    } else {
+      buffer[i / 64] &= ~(uint64_t(1) << (i % 64));
+    }
+  }
+  void set() {
+    for (size_t i = 0; 64 * i < n; ++i) {
+      buffer[i] = ~uint64_t(0);
+    }
+  }
+  void reset() {
+    for (size_t i = 0; 64 * i < n; ++i) {
+      buffer[i] = 0;
+    }
+  }
+  size_t size() const { return n; }
+
+  bool empty() const {
+    assert(n != 0);
+    if (n == 0) {
+      return true;
+    }
+    const size_t bufferSize = (n + 63) / 64;
+    // Just OR together all the bits
+    uint64_t bits = 0;
+    for (size_t i = 0; i < bufferSize-1; ++i) {
+      bits |= buffer[i];
+    }
+    // Only include the valid bits for the last buffer element.
+    bits |= (buffer[bufferSize - 1] & (~uint64_t(0) >> ((-int64_t(n)) & 0x3F)));
+    return (bits == 0);
+  }
+};
 }  // namespace detail
 
 namespace common_properties {
@@ -267,6 +429,25 @@ RDKIT_RDGENERAL_EXPORT extern const std::string molNote;
 RDKIT_RDGENERAL_EXPORT extern const std::string atomNote;
 RDKIT_RDGENERAL_EXPORT extern const std::string bondNote;
 RDKIT_RDGENERAL_EXPORT extern const std::string _isotopicHs;
+
+RDKIT_RDGENERAL_EXPORT extern const PropToken _hasMassQueryToken;  // atom bool
+
+RDKIT_RDGENERAL_EXPORT extern const PropToken _ChiralityPossibleToken;  // bool
+RDKIT_RDGENERAL_EXPORT extern const PropToken _chiralPermutationToken;  // uint
+RDKIT_RDGENERAL_EXPORT extern const PropToken _CIPCodeToken;            // char
+RDKIT_RDGENERAL_EXPORT extern const PropToken _CIPRankToken;            // uint
+RDKIT_RDGENERAL_EXPORT extern const PropToken _isotopicHsToken;         // uint64
+RDKIT_RDGENERAL_EXPORT extern const PropToken _MolFileRLabelToken;      // uint
+RDKIT_RDGENERAL_EXPORT extern const PropToken _ringStereoAtomsAllToken; // int
+RDKIT_RDGENERAL_EXPORT extern const PropToken _ringStereoAtomsBeginsToken;// uint
+RDKIT_RDGENERAL_EXPORT extern const PropToken _ringStereoGroupToken;    // int
+RDKIT_RDGENERAL_EXPORT extern const PropToken _supplementalSmilesLabelToken;// string
+RDKIT_RDGENERAL_EXPORT extern const PropToken _UnknownStereoToken;      // bool
+RDKIT_RDGENERAL_EXPORT extern const PropToken dummyLabelToken;          // token
+RDKIT_RDGENERAL_EXPORT extern const PropToken isImplicitToken;          // bool
+RDKIT_RDGENERAL_EXPORT extern const PropToken molAtomMapNumberToken;    // int
+RDKIT_RDGENERAL_EXPORT extern const PropToken molFileAliasToken;        // string
+RDKIT_RDGENERAL_EXPORT extern const PropToken molFileValueToken;        // string
 
 }  // namespace common_properties
 #ifndef WIN32

--- a/Code/RDGeneral/vector_utils.h
+++ b/Code/RDGeneral/vector_utils.h
@@ -1,0 +1,53 @@
+//
+//  Copyright (C) 2025 NVIDIA Corporation & Affiliates and other RDKit contributors
+//
+//   @@ All Rights Reserved @@
+//  This file is part of the RDKit.
+//  The contents are covered by the terms of the BSD license
+//  which is included in the file license.txt, found at the root
+//  of the RDKit source tree.
+//
+#ifndef RD_VEC_UTILS_H
+#define RD_VEC_UTILS_H
+#include <vector>
+#include <cstddef>
+
+#include <RDGeneral/Invariant.h>
+
+namespace RDKit {
+
+//! Erases multiple indices from an iterable source. Indices must be in ascending order.
+//! Uses only one copy per element in vec, and one vector resize. Does not use
+//! intermediate buffers.
+template <typename T, typename iterT>
+void eraseMultipleIndices(std::vector<T> &vec, iterT indices, const size_t numIndices) {
+  using indexT = std::remove_cv_t<std::remove_reference_t<decltype(*indices)>>;
+  static_assert(std::is_integral_v<indexT>, "Indices must be integral");
+  if (numIndices == 0) {
+    return;
+  }
+  for (size_t i = 0; i < numIndices; ++i) {
+    const size_t idxToRemove = *indices;
+    ++indices;
+    PRECONDITION((i == numIndices - 1) || idxToRemove < *indices, "Indices must be in ascending order");
+    PRECONDITION(idxToRemove >= 0 && idxToRemove < vec.size(), "Index out of range");
+    if (idxToRemove == vec.size() - 1) {
+      break;
+    }
+    const size_t firstIdxToCopy = idxToRemove + 1;
+    const size_t lastIdxToCopy = (i == numIndices - 1) ? vec.size() : *indices;
+    const size_t destToCopy = idxToRemove - i;
+
+    std::copy(vec.begin() + firstIdxToCopy,
+              vec.begin() + lastIdxToCopy,
+              vec.begin() + destToCopy);
+  }
+  vec.resize(vec.size() - numIndices);
+}
+template <typename T, typename indexT>
+void eraseMultipleIndices(std::vector<T> &vec, const std::vector<indexT> indices) {
+  eraseMultipleIndices(vec, indices.data(), indices.size());
+}
+}  // namespace RDKit
+
+#endif // RD_VEC_UTILS_H

--- a/External/Eigen/CMakeLists.txt
+++ b/External/Eigen/CMakeLists.txt
@@ -1,5 +1,5 @@
 include(ExternalProject)
-set(EIGEN3_VERSION "3.3.9")
+set(EIGEN3_VERSION "3.4.0")
 set(EIGEN3_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/eigen)
 ExternalProject_Add(Eigen
   GIT_REPOSITORY https://gitlab.com/libeigen/eigen.git


### PR DESCRIPTION
This pull request is a draft primarily due to plans to break up RDMol.h and RDMol.cpp to make them less monolithic, and because there are also still some undebugged test failures.

#### Reference Issue
**TODO:** Search for any issues related to performance or memory usage of ROMol, Atom, Bond, RDProps, accessing conformers, RingInfo, etc.

#### What does this implement/fix? Explain your changes.
This is a very large change that replaces the implementations of several core data structures in GraphMol with data structures intended to use fewer memory allocations, less memory, and provide interfaces with less overhead on average.

#### Any other comments?
Wrappers are provided that try to maintain as much compatibility as is feasible, so that a vast majority of existing C++ code should function equivalently after recompiling, though some code not ported to use the new interfaces may be significantly slower than it was before. The hope is that most code ported to make effective use of the new interface will be about as fast as before or be significantly faster than before.

To keep the diff smaller, for now, large parts of GraphMol have not yet been ported to use the new interfaces, which in some notable cases, will prevent users from seeing any performance benefits.  For example, code corresponding with `sanitize` and `removeHs` options of `MolFromSmiles` haven't been ported, and the new function `SmilesToMol`, which uses the new interface and simplifies SMILES parsing, doesn't support those options yet either.  A separate pull request will be made with porting changes in GraphMol, unless having those changes in this pull request would be preferred.