### PR TITLE
Fixes the problems with wiggly bonds and EnumerateStereoisomers from #8508

### DIFF
--- a/Code/GraphMol/EnumerateStereoisomers/EnumerateStereoisomers.cpp
+++ b/Code/GraphMol/EnumerateStereoisomers/EnumerateStereoisomers.cpp
@@ -1,5 +1,5 @@
 //
-// Copyright (C) David Cosgrove 2025.
+// Copyright (C) 2025 David Cosgrove and other RDKit contributors.
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -34,7 +34,8 @@ StereoisomerEnumerator::StereoisomerEnumerator(
     atom->clearProp("_CIPCode");
   }
   for (auto bond : d_mol.bonds()) {
-    if (bond->getBondDir() == Bond::BondDir::EITHERDOUBLE) {
+    if (bond->getBondDir() == Bond::BondDir::EITHERDOUBLE ||
+        bond->getBondDir() == Bond::BondDir::UNKNOWN) {
       bond->setBondDir(Bond::BondDir::NONE);
     }
   }

--- a/Code/GraphMol/EnumerateStereoisomers/catch_tests.cpp
+++ b/Code/GraphMol/EnumerateStereoisomers/catch_tests.cpp
@@ -1,5 +1,5 @@
 //
-// Copyright (C) David Cosgrove 2025.
+// Copyright (C) 2025 David Cosgrove and other RDKit contributors.
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -520,5 +520,36 @@ M  END)CTAB"_ctab;
                                SmilesWrite::CXSmilesFields::CX_ALL_BUT_COORDS));
     }
     CHECK(got.size() == 2);
+  }
+}
+
+TEST_CASE("wiggly bonds and EnumerateStereoisomers") {
+  SECTION("as reported (bonds)") {
+    auto m1 = "CC=CC |w:1.0|"_smiles;
+    REQUIRE(m1);
+    StereoEnumerationOptions opts;
+    opts.onlyUnassigned = false;
+    StereoisomerEnumerator enu1(*m1, opts);
+    std::vector<std::string> got;
+    while (auto isomer = enu1.next()) {
+      got.push_back(MolToSmiles(*isomer));
+    }
+    CHECK(got.size() == 2);
+    CHECK(std::find(got.begin(), got.end(), "C/C=C/C") != got.end());
+    CHECK(std::find(got.begin(), got.end(), "C/C=C\\C") != got.end());
+  }
+  SECTION("chiral centers") {
+    auto m1 = "CC(F)(Cl)(Br) |w:1.0|"_smiles;
+    REQUIRE(m1);
+    StereoEnumerationOptions opts;
+    opts.onlyUnassigned = false;
+    StereoisomerEnumerator enu1(*m1, opts);
+    std::vector<std::string> got;
+    while (auto isomer = enu1.next()) {
+      got.push_back(MolToSmiles(*isomer));
+    }
+    CHECK(got.size() == 2);
+    CHECK(std::find(got.begin(), got.end(), "C[C@](F)(Cl)Br") != got.end());
+    CHECK(std::find(got.begin(), got.end(), "C[C@@](F)(Cl)Br") != got.end());
   }
 }

--- a/rdkit/Chem/EnumerateStereoisomers.py
+++ b/rdkit/Chem/EnumerateStereoisomers.py
@@ -301,7 +301,7 @@ def EnumerateStereoisomers(m, options=StereoEnumerationOptions(), verbose=False)
   for atom in tm.GetAtoms():
     atom.ClearProp("_CIPCode")
   for bond in tm.GetBonds():
-    if bond.GetBondDir() == Chem.BondDir.EITHERDOUBLE:
+    if bond.GetBondDir() == Chem.BondDir.EITHERDOUBLE or bond.GetBondDir() == Chem.BondDir.UNKNOWN:
       bond.SetBondDir(Chem.BondDir.NONE)
   flippers = _getFlippers(tm, options)
   nCenters = len(flippers)

--- a/rdkit/Chem/UnitTestChem.py
+++ b/rdkit/Chem/UnitTestChem.py
@@ -181,6 +181,20 @@ class TestCase(unittest.TestCase):
       sssr2 = [list(x) for x in Chem.GetSymmSSSR(sm)]
       self.assertEqual(sssr, sssr2)
 
+  def testWigglyBondsAndEnumerateStereoisomers(self):
+    from rdkit.Chem import EnumerateStereoisomers
+    m = Chem.MolFromSmiles('CC=CC |w:1.0|')
+    sms = [Chem.MolToSmiles(x) for x in EnumerateStereoisomers.EnumerateStereoisomers(m)]
+    self.assertEqual(len(sms), 2)
+    self.assertIn('C/C=C/C', sms)
+    self.assertIn('C/C=C\\C', sms)
+    from rdkit.Chem import EnumerateStereoisomers
+    m = Chem.MolFromSmiles('CC(F)(Cl)(Br) |w:1.0|')
+    sms = [Chem.MolToSmiles(x) for x in EnumerateStereoisomers.EnumerateStereoisomers(m)]
+    self.assertEqual(len(sms), 2)
+    self.assertIn('C[C@](F)(Cl)Br', sms)
+    self.assertIn('C[C@@](F)(Cl)Br', sms)
+
 
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
It's an easy fix: we were explicitly clearing the direction on crossed double bonds but ignoring wiggly bonds.