### PR TITLE
Expose the onlyWedgeFlags parameter to SWIG ClearSingleBondDirFlags

### DIFF
--- a/Code/JavaWrappers/ROMol.i
+++ b/Code/JavaWrappers/ROMol.i
@@ -435,8 +435,8 @@ unsigned int getDefaultPickleProperties();
     RDKit::Chirality::pickBondsToWedge(*($self));
   };
   
-  void ClearSingleBondDirFlags() {
-    RDKit::ClearSingleBondDirFlags(*($self));
+  void ClearSingleBondDirFlags(bool onlyWedgeFlags=false) {
+  RDKit::MolOps::clearSingleBondDirFlags(*($self), onlyWedgeFlags);
   };
 
   void reapplyMolBlockWedging() {

--- a/Code/JavaWrappers/RWMol.i
+++ b/Code/JavaWrappers/RWMol.i
@@ -168,8 +168,8 @@ void DetectAtomStereoChemistry(const RDKit::Conformer *conf) {
 void DetectBondStereoChemistry(const RDKit::Conformer *conf) {
   RDKit::DetectBondStereoChemistry(*($self), conf);
 }
-void ClearSingleBondDirFlags() {
- RDKit::ClearSingleBondDirFlags(*($self));
+void ClearSingleBondDirFlags(bool onlyWedgeFlags=false) {
+ RDKit::MolOps::clearSingleBondDirFlags(*($self), onlyWedgeFlags);
 };
 void reapplyMolBlockWedging() {
   RDKit::Chirality::reapplyMolBlockWedging(*($self));

--- a/Code/JavaWrappers/gmwrapper/src-test/org/RDKit/Chemv2Tests.java
+++ b/Code/JavaWrappers/gmwrapper/src-test/org/RDKit/Chemv2Tests.java
@@ -710,6 +710,38 @@ public class Chemv2Tests extends GraphMolTest {
         }
     }
     
+    @Test
+    public void testClearSingleBondDirFlagsOnlyWedgeFlags() {
+        RWMol m = null;
+        RWMol m2 = null;
+        RWMol m3 = null;
+        try {
+            m = RWMol.MolFromSmiles("Cl[C@H](C)/C=C/CC");
+            m2 = new RWMol(m);
+            m2.compute2DCoords();
+            m2.ClearSingleBondDirFlags();
+            m2.WedgeMolBonds(m2.getConformer());
+            RDKFuncs.assignStereochemistry(m2, true, true);
+            assertEquals(m2.MolToSmiles(), "CCC=C[C@@H](C)Cl");
+            m3 = new RWMol(m);
+            m3.compute2DCoords();
+            m3.ClearSingleBondDirFlags(true);
+            m3.WedgeMolBonds(m3.getConformer());
+            RDKFuncs.assignStereochemistry(m3, true, true);
+            assertEquals(m3.MolToSmiles(), "CC/C=C/[C@@H](C)Cl");
+        } finally {
+            if (m != null) {
+                m.delete();
+            }
+            if (m2 != null) {
+                m2.delete();
+            }
+            if (m3 != null) {
+                m3.delete();
+            }
+        }
+    }
+
     public static void main(String args[]) {
         org.junit.runner.JUnitCore.main("org.RDKit.Chemv2Tests");
     }


### PR DESCRIPTION
This small PR exposes the `onlyWedgeFlags` to SWIG `ClearSingleBondDirFlags`, and adds a test for it.