### PR TITLE
Fixes #8586

### DIFF
--- a/Code/GraphMol/SmilesParse/CXSmilesOps.cpp
+++ b/Code/GraphMol/SmilesParse/CXSmilesOps.cpp
@@ -49,7 +49,9 @@ void addquery(Q *qry, std::string symbol, RDKit::RWMol &mol, unsigned int idx) {
   auto *qa = new QueryAtom(0);
   qa->setQuery(qry);
   qa->setNoImplicit(true);
-  mol.replaceAtom(idx, qa);
+  bool updateLabel = false;
+  bool preserveProps = true;
+  mol.replaceAtom(idx, qa, updateLabel, preserveProps);
   if (symbol != "") {
     mol.getAtomWithIdx(idx)->setProp(RDKit::common_properties::atomLabel,
                                      symbol);

--- a/Code/GraphMol/SmilesParse/cxsmiles_test.cpp
+++ b/Code/GraphMol/SmilesParse/cxsmiles_test.cpp
@@ -1636,3 +1636,13 @@ TEST_CASE("Github #8348: Unable to write wiggly bond information by default") {
     CHECK(output_cxsmiles.find("w:") != std::string::npos);
   }
 }
+
+TEST_CASE("Github #8586: MolFromSmiles loses atom maps if cxsmiles is used") {
+  SECTION("as reported") {
+    auto m = "[CH3:3]N([*:1])C[C@](C([*:2])=O)([H])CS |o1:4|"_smiles;
+    REQUIRE(m);
+    CHECK(m->getAtomWithIdx(0)->getAtomMapNum() == 3);
+    CHECK(m->getAtomWithIdx(2)->getAtomMapNum() == 1);
+    CHECK(m->getAtomWithIdx(6)->getAtomMapNum() == 2);
+  }
+}


### PR DESCRIPTION
Simple fix: have `replaceAtom()` transfer atomic properties to the new atom.

