### PR TITLE
Switch a bunch of C++ tests to use catch2

### DIFF
--- a/Code/ChemicalFeatures/CMakeLists.txt
+++ b/Code/ChemicalFeatures/CMakeLists.txt
@@ -6,7 +6,7 @@ target_compile_definitions(ChemicalFeatures PRIVATE RDKIT_CHEMICALFEATURES_BUILD
 rdkit_headers(ChemicalFeature.h
               FreeChemicalFeature.h DEST ChemicalFeatures)
 
-rdkit_test(testChemicalFeatures testChemicalFeatures.cpp 
+rdkit_catch_test(testChemicalFeatures testChemicalFeatures.cpp 
            LINK_LIBRARIES ChemicalFeatures)
 
 if(RDK_BUILD_PYTHON_WRAPPERS)

--- a/Code/ChemicalFeatures/testChemicalFeatures.cpp
+++ b/Code/ChemicalFeatures/testChemicalFeatures.cpp
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2005-2019 Greg Landrum and Rational Discovery LLC
+//  Copyright (C) 2005-2025 Greg Landrum and other RDKit contributors
 //
 //  @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -9,56 +9,44 @@
 //
 //
 
-#include <RDGeneral/test.h>
-#include "FreeChemicalFeature.h"
+#include <catch2/catch_all.hpp>
 #include <Geometry/point.h>
-#include <iostream>
-#include <RDGeneral/Invariant.h>
+#include "FreeChemicalFeature.h"
 #include <RDGeneral/utils.h>
 
 using namespace ChemicalFeatures;
 
-void test1() {
-  std::cout << "-----------------------------------------" << std::endl;
-  std::cout << "Test1" << std::endl;
-
+TEST_CASE("FreeChemicalFeature Tests") {
   FreeChemicalFeature f1("foo", "bar", RDGeom::Point3D(1, 1, 1));
-  TEST_ASSERT(f1.getId() == -1);
-  TEST_ASSERT(f1.getFamily() == "foo");
-  TEST_ASSERT(f1.getType() == "bar");
-  TEST_ASSERT(RDKit::feq(f1.getPos().x, 1.0));
-  TEST_ASSERT(RDKit::feq(f1.getPos().y, 1.0));
-  TEST_ASSERT(RDKit::feq(f1.getPos().z, 1.0));
+  REQUIRE(f1.getId() == -1);
+  REQUIRE(f1.getFamily() == "foo");
+  REQUIRE(f1.getType() == "bar");
+  REQUIRE_THAT(f1.getPos().x, Catch::Matchers::WithinAbs(1.0, 1e-6));
+  REQUIRE_THAT(f1.getPos().y, Catch::Matchers::WithinAbs(1.0, 1e-6));
+  REQUIRE_THAT(f1.getPos().z, Catch::Matchers::WithinAbs(1.0, 1e-6));
 
   FreeChemicalFeature f2("foo", "bar", RDGeom::Point3D(1, 1, 1), 123);
-  TEST_ASSERT(f2.getId() == 123);
-  TEST_ASSERT(f2.getFamily() == "foo");
-  TEST_ASSERT(f2.getType() == "bar");
-  TEST_ASSERT(RDKit::feq(f2.getPos().x, 1.0));
-  TEST_ASSERT(RDKit::feq(f2.getPos().y, 1.0));
-  TEST_ASSERT(RDKit::feq(f2.getPos().z, 1.0));
+  REQUIRE(f2.getId() == 123);
+  REQUIRE(f2.getFamily() == "foo");
+  REQUIRE(f2.getType() == "bar");
+  REQUIRE_THAT(f2.getPos().x, Catch::Matchers::WithinAbs(1.0, 1e-6));
+  REQUIRE_THAT(f2.getPos().y, Catch::Matchers::WithinAbs(1.0, 1e-6));
+  REQUIRE_THAT(f2.getPos().z, Catch::Matchers::WithinAbs(1.0, 1e-6));
 
   FreeChemicalFeature f3;
   f3.initFromString(f2.toString());
-  TEST_ASSERT(f3.getId() == 123);
-  TEST_ASSERT(f3.getFamily() == "foo");
-  TEST_ASSERT(f3.getType() == "bar");
-  TEST_ASSERT(RDKit::feq(f3.getPos().x, 1.0));
-  TEST_ASSERT(RDKit::feq(f3.getPos().y, 1.0));
-  TEST_ASSERT(RDKit::feq(f3.getPos().z, 1.0));
+  REQUIRE(f3.getId() == 123);
+  REQUIRE(f3.getFamily() == "foo");
+  REQUIRE(f3.getType() == "bar");
+  REQUIRE_THAT(f3.getPos().x, Catch::Matchers::WithinAbs(1.0, 1e-6));
+  REQUIRE_THAT(f3.getPos().y, Catch::Matchers::WithinAbs(1.0, 1e-6));
+  REQUIRE_THAT(f3.getPos().z, Catch::Matchers::WithinAbs(1.0, 1e-6));
 
   FreeChemicalFeature f4(f2);
-  TEST_ASSERT(f4.getId() == 123);
-  TEST_ASSERT(f4.getFamily() == "foo");
-  TEST_ASSERT(f4.getType() == "bar");
-  TEST_ASSERT(RDKit::feq(f4.getPos().x, 1.0));
-  TEST_ASSERT(RDKit::feq(f4.getPos().y, 1.0));
-  TEST_ASSERT(RDKit::feq(f4.getPos().z, 1.0));
-
-  std::cout << "Done" << std::endl;
-}
-
-int main() {
-  test1();
-  return 0;
+  REQUIRE(f4.getId() == 123);
+  REQUIRE(f4.getFamily() == "foo");
+  REQUIRE(f4.getType() == "bar");
+  REQUIRE_THAT(f4.getPos().x, Catch::Matchers::WithinAbs(1.0, 1e-6));
+  REQUIRE_THAT(f4.getPos().y, Catch::Matchers::WithinAbs(1.0, 1e-6));
+  REQUIRE_THAT(f4.getPos().z, Catch::Matchers::WithinAbs(1.0, 1e-6));
 }

--- a/Code/DataStructs/CMakeLists.txt
+++ b/Code/DataStructs/CMakeLists.txt
@@ -34,7 +34,7 @@ rdkit_catch_test(testDataStructs testDatastructs.cpp
 rdkit_catch_test(testFPB testFPB.cpp
            LINK_LIBRARIES DataStructs )
 
-rdkit_test(testMultiFPB testMultiFPB.cpp
+rdkit_catch_test(testMultiFPB testMultiFPB.cpp
            LINK_LIBRARIES DataStructs )
 
 rdkit_catch_test(catchDataStructs catch_tests.cpp

--- a/Code/DataStructs/CMakeLists.txt
+++ b/Code/DataStructs/CMakeLists.txt
@@ -31,7 +31,7 @@ rdkit_headers(base64.h
 rdkit_catch_test(testDataStructs testDatastructs.cpp
            LINK_LIBRARIES DataStructs )
 
-rdkit_test(testFPB testFPB.cpp
+rdkit_catch_test(testFPB testFPB.cpp
            LINK_LIBRARIES DataStructs )
 
 rdkit_test(testMultiFPB testMultiFPB.cpp

--- a/Code/DataStructs/CMakeLists.txt
+++ b/Code/DataStructs/CMakeLists.txt
@@ -28,7 +28,7 @@ rdkit_headers(base64.h
               MultiFPBReader.h
               DEST DataStructs)
 
-rdkit_test(testDataStructs testDatastructs.cpp
+rdkit_catch_test(testDataStructs testDatastructs.cpp
            LINK_LIBRARIES DataStructs )
 
 rdkit_test(testFPB testFPB.cpp

--- a/Code/DataStructs/testDatastructs.cpp
+++ b/Code/DataStructs/testDatastructs.cpp
@@ -31,13 +31,10 @@
 
 using namespace std;
 using namespace RDKit;
+
 template <typename T>
 inline void TXTMSG(const char *__a__, T __b__) {
   BOOST_LOG(rdInfoLog) << (__a__) << " " << (__b__) << std::endl;
-}
-
-bool feq(double v1, double v2, double tol = 1e-4) {
-  return fabs(v1 - v2) < tol;
 }
 
 template <typename T>
@@ -126,7 +123,8 @@ void Test(T arg) {
 
   T t4(t1.toString());
   REQUIRE(t4 == t1);
-  REQUIRE(feq(TanimotoSimilarity(t1, t4), 1.0));
+  REQUIRE_THAT(TanimotoSimilarity(t1, t4),
+               Catch::Matchers::WithinAbs(1.0, 1e-4));
 
   T *t5 = FoldFingerprint(t1);
   REQUIRE(t5->getNumBits() == t1.getNumBits() / 2);
@@ -164,17 +162,17 @@ void TaniTest(T &arg) {
       T v2(256);
       FromDaylightString(v2, fps[j]);
       double tani = TanimotoSimilarity(v1, v2);
-      REQUIRE(feq(tani, dists[idx]));
+      REQUIRE_THAT(tani, Catch::Matchers::WithinAbs(dists[idx], 1e-4));
       tani = TverskySimilarity(v1, v2, 1., 1.);
-      REQUIRE(feq(tani, dists[idx]));
+      REQUIRE_THAT(tani, Catch::Matchers::WithinAbs(dists[idx], 1e-4));
       tani = SimilarityWrapper(v1, v2, TanimotoSimilarity<T, T>);
-      REQUIRE(feq(tani, dists[idx]));
+      REQUIRE_THAT(tani, Catch::Matchers::WithinAbs(dists[idx], 1e-4));
       tani = SimilarityWrapper(v1, v2, 1., 1., TverskySimilarity<T, T>);
-      REQUIRE(feq(tani, dists[idx]));
+      REQUIRE_THAT(tani, Catch::Matchers::WithinAbs(dists[idx], 1e-4));
       tani = SimilarityWrapper(v1, v2, TanimotoSimilarity<T, T>, true);
-      REQUIRE(feq(tani, 1. - dists[idx]));
+      REQUIRE_THAT(tani, Catch::Matchers::WithinAbs(1. - dists[idx], 1e-4));
       tani = SimilarityWrapper(v1, v2, 1., 1., TverskySimilarity<T, T>, true);
-      REQUIRE(feq(tani, 1. - dists[idx]));
+      REQUIRE_THAT(tani, Catch::Matchers::WithinAbs(1. - dists[idx], 1e-4));
       idx++;
     }
   }
@@ -549,7 +547,8 @@ TEST_CASE("test6SparseIntVect") {
     REQUIRE(iter->second == 4);
     ++iter;
     REQUIRE(iter == iV1.getNonzeroElements().end());
-    REQUIRE(feq(DiceSimilarity(iV1, iV1), 1.));
+    REQUIRE_THAT(DiceSimilarity(iV1, iV1),
+                 Catch::Matchers::WithinAbs(1., 1e-4));
   }
 
   {  // iV1 &= iV2
@@ -564,7 +563,8 @@ TEST_CASE("test6SparseIntVect") {
     iV2.setVal(3, 4);
     iV2.setVal(4, 6);
 
-    REQUIRE(feq(DiceSimilarity(iV1, iV2), 18. / 26.));
+    REQUIRE_THAT(DiceSimilarity(iV1, iV2),
+                 Catch::Matchers::WithinAbs(18. / 26., 1e-4));
 
     iV1 &= iV2;
     REQUIRE(iV1[0] == 0);
@@ -579,13 +579,18 @@ TEST_CASE("test6SparseIntVect") {
     REQUIRE(iV2[3] == 4);
     REQUIRE(iV2[4] == 6);
 
-    REQUIRE(feq(DiceSimilarity(iV1, iV2), 18. / 24.));
-    REQUIRE(feq(TverskySimilarity(iV1, iV2, 0.5, 0.5, false), 9. / 12.));
-    REQUIRE(feq(TverskySimilarity(iV1, iV2, 1.0, 1.0, false), 9. / 15.));
-    REQUIRE(feq(TanimotoSimilarity(iV1, iV2), 9. / 15.));
-    REQUIRE(feq(TverskySimilarity(iV1, iV2, 0.333333333, 0.66666666667, false),
-                9. / 13.));
-    REQUIRE(feq(TverskySimilarity(iV1, iV2, 1.0, 0.0, false), 9. / 9.));
+    REQUIRE_THAT(DiceSimilarity(iV1, iV2),
+                 Catch::Matchers::WithinAbs(18. / 24., 1e-4));
+    REQUIRE_THAT(TverskySimilarity(iV1, iV2, 0.5, 0.5, false),
+                 Catch::Matchers::WithinAbs(9. / 12., 1e-4));
+    REQUIRE_THAT(TverskySimilarity(iV1, iV2, 1.0, 1.0, false),
+                 Catch::Matchers::WithinAbs(9. / 15., 1e-4));
+    REQUIRE_THAT(TanimotoSimilarity(iV1, iV2),
+                 Catch::Matchers::WithinAbs(9. / 15., 1e-4));
+    REQUIRE_THAT(TverskySimilarity(iV1, iV2, 0.333333333, 0.66666666667, false),
+                 Catch::Matchers::WithinAbs(9. / 13., 1e-4));
+    REQUIRE_THAT(TverskySimilarity(iV1, iV2, 1.0, 0.0, false),
+                 Catch::Matchers::WithinAbs(9. / 9., 1e-4));
 
     try {
       iV1 &= iVect;
@@ -904,7 +909,8 @@ TEST_CASE("test6SparseIntVect") {
     iV2.setVal(3, -4);
     iV2.setVal(4, 6);
 
-    REQUIRE(feq(DiceSimilarity(iV1, iV2), 18. / 26.));
+    REQUIRE_THAT(DiceSimilarity(iV1, iV2),
+                 Catch::Matchers::WithinAbs(18. / 26., 1e-4));
   }
 }
 
@@ -1173,16 +1179,22 @@ TEST_CASE("test11SimilaritiesBV") {
   bv.setBit(9);
   ExplicitBitVect bv2 = bv;
 
-  REQUIRE(feq(TanimotoSimilarity(bv, bv2), 1.));
-  REQUIRE(feq(DiceSimilarity(bv, bv2), 1.));
-  REQUIRE(feq(CosineSimilarity(bv, bv2), 1.));
-  REQUIRE(feq(KulczynskiSimilarity(bv, bv2), 1.));
-  REQUIRE(feq(SokalSimilarity(bv, bv2), 1.));
-  REQUIRE(feq(McConnaugheySimilarity(bv, bv2), 1.));
-  REQUIRE(feq(BraunBlanquetSimilarity(bv, bv2), 1.));
-  REQUIRE(feq(RusselSimilarity(bv, bv2), 0.5));
-  REQUIRE(feq(RogotGoldbergSimilarity(bv, bv2), 1.));
-  REQUIRE(feq(AllBitSimilarity(bv, bv2), 1.));
+  REQUIRE_THAT(TanimotoSimilarity(bv, bv2),
+               Catch::Matchers::WithinAbs(1., 1e-4));
+  REQUIRE_THAT(DiceSimilarity(bv, bv2), Catch::Matchers::WithinAbs(1., 1e-4));
+  REQUIRE_THAT(CosineSimilarity(bv, bv2), Catch::Matchers::WithinAbs(1., 1e-4));
+  REQUIRE_THAT(KulczynskiSimilarity(bv, bv2),
+               Catch::Matchers::WithinAbs(1., 1e-4));
+  REQUIRE_THAT(SokalSimilarity(bv, bv2), Catch::Matchers::WithinAbs(1., 1e-4));
+  REQUIRE_THAT(McConnaugheySimilarity(bv, bv2),
+               Catch::Matchers::WithinAbs(1., 1e-4));
+  REQUIRE_THAT(BraunBlanquetSimilarity(bv, bv2),
+               Catch::Matchers::WithinAbs(1., 1e-4));
+  REQUIRE_THAT(RusselSimilarity(bv, bv2),
+               Catch::Matchers::WithinAbs(0.5, 1e-4));
+  REQUIRE_THAT(RogotGoldbergSimilarity(bv, bv2),
+               Catch::Matchers::WithinAbs(1., 1e-4));
+  REQUIRE_THAT(AllBitSimilarity(bv, bv2), Catch::Matchers::WithinAbs(1., 1e-4));
 
   // similarity = 0.0
   bv2 = ExplicitBitVect(10);
@@ -1192,16 +1204,21 @@ TEST_CASE("test11SimilaritiesBV") {
   bv2.setBit(7);
   bv2.setBit(8);
 
-  REQUIRE(feq(TanimotoSimilarity(bv, bv2), 0.));
-  REQUIRE(feq(DiceSimilarity(bv, bv2), 0.));
-  REQUIRE(feq(CosineSimilarity(bv, bv2), 0.));
-  REQUIRE(feq(KulczynskiSimilarity(bv, bv2), 0.));
-  REQUIRE(feq(SokalSimilarity(bv, bv2), 0.));
-  REQUIRE(feq(McConnaugheySimilarity(bv, bv2), -1.));
-  REQUIRE(feq(BraunBlanquetSimilarity(bv, bv2), 0.));
-  REQUIRE(feq(RusselSimilarity(bv, bv2), 0.));
-  REQUIRE(feq(RogotGoldbergSimilarity(bv, bv2), 0.));
-  REQUIRE(feq(AllBitSimilarity(bv, bv2), 0.));
+  REQUIRE_THAT(TanimotoSimilarity(bv, bv2),
+               Catch::Matchers::WithinAbs(0., 1e-4));
+  REQUIRE_THAT(DiceSimilarity(bv, bv2), Catch::Matchers::WithinAbs(0., 1e-4));
+  REQUIRE_THAT(CosineSimilarity(bv, bv2), Catch::Matchers::WithinAbs(0., 1e-4));
+  REQUIRE_THAT(KulczynskiSimilarity(bv, bv2),
+               Catch::Matchers::WithinAbs(0., 1e-4));
+  REQUIRE_THAT(SokalSimilarity(bv, bv2), Catch::Matchers::WithinAbs(0., 1e-4));
+  REQUIRE_THAT(McConnaugheySimilarity(bv, bv2),
+               Catch::Matchers::WithinAbs(-1., 1e-4));
+  REQUIRE_THAT(BraunBlanquetSimilarity(bv, bv2),
+               Catch::Matchers::WithinAbs(0., 1e-4));
+  REQUIRE_THAT(RusselSimilarity(bv, bv2), Catch::Matchers::WithinAbs(0., 1e-4));
+  REQUIRE_THAT(RogotGoldbergSimilarity(bv, bv2),
+               Catch::Matchers::WithinAbs(0., 1e-4));
+  REQUIRE_THAT(AllBitSimilarity(bv, bv2), Catch::Matchers::WithinAbs(0., 1e-4));
 
   // similarity ~= 0.5
   bv.setBit(5);
@@ -1213,16 +1230,26 @@ TEST_CASE("test11SimilaritiesBV") {
   bv2.setBit(8);
   bv2.setBit(9);
 
-  REQUIRE(feq(TanimotoSimilarity(bv, bv2), 0.5));
-  REQUIRE(feq(DiceSimilarity(bv, bv2), 0.6666));
-  REQUIRE(feq(CosineSimilarity(bv, bv2), 0.6666));
-  REQUIRE(feq(KulczynskiSimilarity(bv, bv2), 0.6666));
-  REQUIRE(feq(SokalSimilarity(bv, bv2), 0.3333));
-  REQUIRE(feq(McConnaugheySimilarity(bv, bv2), 0.3333));
-  REQUIRE(feq(BraunBlanquetSimilarity(bv, bv2), 0.6666));
-  REQUIRE(feq(RusselSimilarity(bv, bv2), 0.4));
-  REQUIRE(feq(RogotGoldbergSimilarity(bv, bv2), 0.5833));
-  REQUIRE(feq(AllBitSimilarity(bv, bv2), 0.6));
+  REQUIRE_THAT(TanimotoSimilarity(bv, bv2),
+               Catch::Matchers::WithinAbs(0.5, 1e-4));
+  REQUIRE_THAT(DiceSimilarity(bv, bv2),
+               Catch::Matchers::WithinAbs(0.6666, 1e-4));
+  REQUIRE_THAT(CosineSimilarity(bv, bv2),
+               Catch::Matchers::WithinAbs(0.6666, 1e-4));
+  REQUIRE_THAT(KulczynskiSimilarity(bv, bv2),
+               Catch::Matchers::WithinAbs(0.6666, 1e-4));
+  REQUIRE_THAT(SokalSimilarity(bv, bv2),
+               Catch::Matchers::WithinAbs(0.3333, 1e-4));
+  REQUIRE_THAT(McConnaugheySimilarity(bv, bv2),
+               Catch::Matchers::WithinAbs(0.3333, 1e-4));
+  REQUIRE_THAT(BraunBlanquetSimilarity(bv, bv2),
+               Catch::Matchers::WithinAbs(0.6666, 1e-4));
+  REQUIRE_THAT(RusselSimilarity(bv, bv2),
+               Catch::Matchers::WithinAbs(0.4, 1e-4));
+  REQUIRE_THAT(RogotGoldbergSimilarity(bv, bv2),
+               Catch::Matchers::WithinAbs(0.5833, 1e-4));
+  REQUIRE_THAT(AllBitSimilarity(bv, bv2),
+               Catch::Matchers::WithinAbs(0.6, 1e-4));
 }
 
 TEST_CASE("test12SimilaritiesSparseBV") {
@@ -1235,16 +1262,25 @@ TEST_CASE("test12SimilaritiesSparseBV") {
   sbv.setBit(9);
   SparseBitVect sbv2 = sbv;
 
-  REQUIRE(feq(TanimotoSimilarity(sbv, sbv2), 1.));
-  REQUIRE(feq(DiceSimilarity(sbv, sbv2), 1.));
-  REQUIRE(feq(CosineSimilarity(sbv, sbv2), 1.));
-  REQUIRE(feq(KulczynskiSimilarity(sbv, sbv2), 1.));
-  REQUIRE(feq(SokalSimilarity(sbv, sbv2), 1.));
-  REQUIRE(feq(McConnaugheySimilarity(sbv, sbv2), 1.));
-  REQUIRE(feq(BraunBlanquetSimilarity(sbv, sbv2), 1.));
-  REQUIRE(feq(RusselSimilarity(sbv, sbv2), 0.5));
-  REQUIRE(feq(RogotGoldbergSimilarity(sbv, sbv2), 1.));
-  REQUIRE(feq(AllBitSimilarity(sbv, sbv2), 1.));
+  REQUIRE_THAT(TanimotoSimilarity(sbv, sbv2),
+               Catch::Matchers::WithinAbs(1., 1e-4));
+  REQUIRE_THAT(DiceSimilarity(sbv, sbv2), Catch::Matchers::WithinAbs(1., 1e-4));
+  REQUIRE_THAT(CosineSimilarity(sbv, sbv2),
+               Catch::Matchers::WithinAbs(1., 1e-4));
+  REQUIRE_THAT(KulczynskiSimilarity(sbv, sbv2),
+               Catch::Matchers::WithinAbs(1., 1e-4));
+  REQUIRE_THAT(SokalSimilarity(sbv, sbv2),
+               Catch::Matchers::WithinAbs(1., 1e-4));
+  REQUIRE_THAT(McConnaugheySimilarity(sbv, sbv2),
+               Catch::Matchers::WithinAbs(1., 1e-4));
+  REQUIRE_THAT(BraunBlanquetSimilarity(sbv, sbv2),
+               Catch::Matchers::WithinAbs(1., 1e-4));
+  REQUIRE_THAT(RusselSimilarity(sbv, sbv2),
+               Catch::Matchers::WithinAbs(0.5, 1e-4));
+  REQUIRE_THAT(RogotGoldbergSimilarity(sbv, sbv2),
+               Catch::Matchers::WithinAbs(1., 1e-4));
+  REQUIRE_THAT(AllBitSimilarity(sbv, sbv2),
+               Catch::Matchers::WithinAbs(1., 1e-4));
 
   // similarity = 0.0
   sbv2 = SparseBitVect(10);
@@ -1254,16 +1290,25 @@ TEST_CASE("test12SimilaritiesSparseBV") {
   sbv2.setBit(7);
   sbv2.setBit(8);
 
-  REQUIRE(feq(TanimotoSimilarity(sbv, sbv2), 0.));
-  REQUIRE(feq(DiceSimilarity(sbv, sbv2), 0.));
-  REQUIRE(feq(CosineSimilarity(sbv, sbv2), 0.));
-  REQUIRE(feq(KulczynskiSimilarity(sbv, sbv2), 0.));
-  REQUIRE(feq(SokalSimilarity(sbv, sbv2), 0.));
-  REQUIRE(feq(McConnaugheySimilarity(sbv, sbv2), -1.));
-  REQUIRE(feq(BraunBlanquetSimilarity(sbv, sbv2), 0.));
-  REQUIRE(feq(RusselSimilarity(sbv, sbv2), 0.));
-  REQUIRE(feq(RogotGoldbergSimilarity(sbv, sbv2), 0.));
-  REQUIRE(feq(AllBitSimilarity(sbv, sbv2), 0.));
+  REQUIRE_THAT(TanimotoSimilarity(sbv, sbv2),
+               Catch::Matchers::WithinAbs(0., 1e-4));
+  REQUIRE_THAT(DiceSimilarity(sbv, sbv2), Catch::Matchers::WithinAbs(0., 1e-4));
+  REQUIRE_THAT(CosineSimilarity(sbv, sbv2),
+               Catch::Matchers::WithinAbs(0., 1e-4));
+  REQUIRE_THAT(KulczynskiSimilarity(sbv, sbv2),
+               Catch::Matchers::WithinAbs(0., 1e-4));
+  REQUIRE_THAT(SokalSimilarity(sbv, sbv2),
+               Catch::Matchers::WithinAbs(0., 1e-4));
+  REQUIRE_THAT(McConnaugheySimilarity(sbv, sbv2),
+               Catch::Matchers::WithinAbs(-1., 1e-4));
+  REQUIRE_THAT(BraunBlanquetSimilarity(sbv, sbv2),
+               Catch::Matchers::WithinAbs(0., 1e-4));
+  REQUIRE_THAT(RusselSimilarity(sbv, sbv2),
+               Catch::Matchers::WithinAbs(0., 1e-4));
+  REQUIRE_THAT(RogotGoldbergSimilarity(sbv, sbv2),
+               Catch::Matchers::WithinAbs(0., 1e-4));
+  REQUIRE_THAT(AllBitSimilarity(sbv, sbv2),
+               Catch::Matchers::WithinAbs(0., 1e-4));
 
   // similarity ~= 0.5
   sbv.setBit(5);
@@ -1275,16 +1320,26 @@ TEST_CASE("test12SimilaritiesSparseBV") {
   sbv2.setBit(8);
   sbv2.setBit(9);
 
-  REQUIRE(feq(TanimotoSimilarity(sbv, sbv2), 0.5));
-  REQUIRE(feq(DiceSimilarity(sbv, sbv2), 0.6666));
-  REQUIRE(feq(CosineSimilarity(sbv, sbv2), 0.6666));
-  REQUIRE(feq(KulczynskiSimilarity(sbv, sbv2), 0.6666));
-  REQUIRE(feq(SokalSimilarity(sbv, sbv2), 0.3333));
-  REQUIRE(feq(McConnaugheySimilarity(sbv, sbv2), 0.3333));
-  REQUIRE(feq(BraunBlanquetSimilarity(sbv, sbv2), 0.6666));
-  REQUIRE(feq(RusselSimilarity(sbv, sbv2), 0.4));
-  REQUIRE(feq(RogotGoldbergSimilarity(sbv, sbv2), 0.5833));
-  REQUIRE(feq(AllBitSimilarity(sbv, sbv2), 0.6));
+  REQUIRE_THAT(TanimotoSimilarity(sbv, sbv2),
+               Catch::Matchers::WithinAbs(0.5, 1e-4));
+  REQUIRE_THAT(DiceSimilarity(sbv, sbv2),
+               Catch::Matchers::WithinAbs(0.6666, 1e-4));
+  REQUIRE_THAT(CosineSimilarity(sbv, sbv2),
+               Catch::Matchers::WithinAbs(0.6666, 1e-4));
+  REQUIRE_THAT(KulczynskiSimilarity(sbv, sbv2),
+               Catch::Matchers::WithinAbs(0.6666, 1e-4));
+  REQUIRE_THAT(SokalSimilarity(sbv, sbv2),
+               Catch::Matchers::WithinAbs(0.3333, 1e-4));
+  REQUIRE_THAT(McConnaugheySimilarity(sbv, sbv2),
+               Catch::Matchers::WithinAbs(0.3333, 1e-4));
+  REQUIRE_THAT(BraunBlanquetSimilarity(sbv, sbv2),
+               Catch::Matchers::WithinAbs(0.6666, 1e-4));
+  REQUIRE_THAT(RusselSimilarity(sbv, sbv2),
+               Catch::Matchers::WithinAbs(0.4, 1e-4));
+  REQUIRE_THAT(RogotGoldbergSimilarity(sbv, sbv2),
+               Catch::Matchers::WithinAbs(0.5833, 1e-4));
+  REQUIRE_THAT(AllBitSimilarity(sbv, sbv2),
+               Catch::Matchers::WithinAbs(0.6, 1e-4));
 }
 
 TEST_CASE("test13BitVectAllOnes") {
@@ -1326,42 +1381,50 @@ TEST_CASE("test15BitmapOps") {
   {
     const unsigned char bv1[5] = {0x1, 0x1, 0x1, 0x1, 0x1};
     const unsigned char bv2[5] = {0x1, 0x1, 0x1, 0x1, 0x1};
-    REQUIRE(feq(CalcBitmapTanimoto(bv1, bv2, 5), 1.0));
+    REQUIRE_THAT(CalcBitmapTanimoto(bv1, bv2, 5),
+                 Catch::Matchers::WithinAbs(1.0, 1e-4));
   }
   {
     const unsigned char bv1[5] = {0x1, 0x1, 0x1, 0x1, 0x1};
     const unsigned char bv2[5] = {0x1, 0x1, 0x1, 0x0, 0x1};
-    REQUIRE(feq(CalcBitmapTanimoto(bv1, bv2, 5), 0.8));
+    REQUIRE_THAT(CalcBitmapTanimoto(bv1, bv2, 5),
+                 Catch::Matchers::WithinAbs(0.8, 1e-4));
   }
   {
     const unsigned char bv1[5] = {0x1, 0x1, 0x1, 0x1, 0x1};
     const unsigned char bv2[5] = {0x1, 0x1, 0x1, 0x1, 0x1};
-    REQUIRE(feq(CalcBitmapTversky(bv1, bv2, 5, 1., 1.), 1.0));
+    REQUIRE_THAT(CalcBitmapTversky(bv1, bv2, 5, 1., 1.),
+                 Catch::Matchers::WithinAbs(1.0, 1e-4));
   }
   {
     const unsigned char bv1[5] = {0x1, 0x1, 0x1, 0x1, 0x1};
     const unsigned char bv2[5] = {0x1, 0x1, 0x1, 0x0, 0x1};
-    REQUIRE(feq(CalcBitmapTversky(bv1, bv2, 5, 1., 1.), 0.8));
+    REQUIRE_THAT(CalcBitmapTversky(bv1, bv2, 5, 1., 1.),
+                 Catch::Matchers::WithinAbs(0.8, 1e-4));
   }
   {
     const unsigned char bv1[5] = {0x1, 0x1, 0x1, 0x1, 0x1};
     const unsigned char bv2[5] = {0x1, 0x1, 0x1, 0x1, 0x1};
-    REQUIRE(feq(CalcBitmapDice(bv1, bv2, 5), 1.0));
+    REQUIRE_THAT(CalcBitmapDice(bv1, bv2, 5),
+                 Catch::Matchers::WithinAbs(1.0, 1e-4));
   }
   {
     const unsigned char bv1[5] = {0x1, 0x1, 0x1, 0x1, 0x1};
     const unsigned char bv2[5] = {0x1, 0x1, 0x1, 0x0, 0x1};
-    REQUIRE(feq(CalcBitmapDice(bv1, bv2, 5), 8. / 9));
+    REQUIRE_THAT(CalcBitmapDice(bv1, bv2, 5),
+                 Catch::Matchers::WithinAbs(8. / 9, 1e-4));
   }
   {
     const unsigned char bv1[5] = {0x1, 0x1, 0x1, 0x1, 0x1};
     const unsigned char bv2[5] = {0x1, 0x1, 0x1, 0x1, 0x1};
-    REQUIRE(feq(CalcBitmapTversky(bv1, bv2, 5, 0.5, 0.5), 1.0));
+    REQUIRE_THAT(CalcBitmapTversky(bv1, bv2, 5, 0.5, 0.5),
+                 Catch::Matchers::WithinAbs(1.0, 1e-4));
   }
   {
     const unsigned char bv1[5] = {0x1, 0x1, 0x1, 0x1, 0x1};
     const unsigned char bv2[5] = {0x1, 0x1, 0x1, 0x0, 0x1};
-    REQUIRE(feq(CalcBitmapTversky(bv1, bv2, 5, 0.5, 0.5), 8. / 9));
+    REQUIRE_THAT(CalcBitmapTversky(bv1, bv2, 5, 0.5, 0.5),
+                 Catch::Matchers::WithinAbs(8. / 9, 1e-4));
   }
 
   {
@@ -1378,7 +1441,8 @@ TEST_CASE("test15BitmapOps") {
   {
     const unsigned char bv1[5] = {0x1, 0x0, 0x1, 0x0, 0x1};
     const unsigned char bv2[5] = {0x1, 0x1, 0x5, 0x1, 0x1};
-    REQUIRE(feq(CalcBitmapTversky(bv1, bv2, 5, 1.0, 0.), 1.0));
+    REQUIRE_THAT(CalcBitmapTversky(bv1, bv2, 5, 1.0, 0.0),
+                 Catch::Matchers::WithinAbs(1.0, 1e-4));
   }
 }
 
@@ -1440,11 +1504,11 @@ TEST_CASE("test14RealVect") {
   }
 
   REQUIRE(vect1.getLength() == 30);
-  REQUIRE(feq(vect1.getTotalVal(), 15.0));
+  REQUIRE_THAT(vect1.getTotalVal(), Catch::Matchers::WithinAbs(15.0, 1e-6));
   for (i = 0; i < vect1.getLength(); ++i) {
-    REQUIRE(feq(vect1.getVal(i), (i + 1) % 2));
+    REQUIRE_THAT(vect1.getVal(i),
+                 Catch::Matchers::WithinAbs((i + 1) % 2, 1e-6));
   }
-
   RealValueVect vect2(30);
   for (i = 0; i < vect2.getLength(); ++i) {
     vect2.setVal(i, double(1.0 / (i + 1.0)));
@@ -1452,19 +1516,21 @@ TEST_CASE("test14RealVect") {
 
   REQUIRE(vect2.getLength() == 30);
   for (i = 0; i < vect2.getLength(); ++i) {
-    REQUIRE(feq(vect2.getVal(i), double(1.0 / (i + 1.0))));
+    REQUIRE_THAT(vect2.getVal(i),
+                 Catch::Matchers::WithinAbs(double(1.0 / (i + 1.0)), 1e-6));
   }
 
   // test copy constructor and operator[]
   RealValueVect vect3(vect2);
   REQUIRE(vect3.getLength() == 30);
   for (i = 0; i < vect3.getLength(); ++i) {
-    REQUIRE(feq(vect3[i], double(1.0 / (i + 1.0))));
+    REQUIRE_THAT(vect3[i],
+                 Catch::Matchers::WithinAbs(double(1.0 / (i + 1.0)), 1e-6));
   }
 
   double Pi = 3.141592;
   RealValueVect vect4(60, Pi);
-  REQUIRE(feq(vect4.getTotalVal(), 60 * Pi));
+  REQUIRE_THAT(vect4.getTotalVal(), Catch::Matchers::WithinAbs(60 * Pi, 1e-6));
 }
 
 TEST_CASE("test15RealVectDists") {
@@ -1475,12 +1541,12 @@ TEST_CASE("test15RealVectDists") {
     v1.setVal(2 * i, 1.0);
     v2.setVal(2 * i, 1.0);
   }
-  REQUIRE(feq(computeL1Norm(v1, v2), 0));
+  REQUIRE_THAT(computeL1Norm(v1, v2), Catch::Matchers::WithinAbs(0, 1e-6));
   for (i = 0; i < 30; ++i) {
     v2.setVal(i, i % 2);
   }
 
-  REQUIRE(feq(computeL1Norm(v1, v2), 30.0));
+  REQUIRE_THAT(computeL1Norm(v1, v2), Catch::Matchers::WithinAbs(30.0, 1e-6));
 
   for (i = 0; i < 30; ++i) {
     if (i % 3 == 0) {
@@ -1490,14 +1556,14 @@ TEST_CASE("test15RealVectDists") {
     }
   }
 
-  REQUIRE(feq(computeL1Norm(v1, v2), 15.0));
+  REQUIRE_THAT(computeL1Norm(v1, v2), Catch::Matchers::WithinAbs(15.0, 1e-6));
 
   for (i = 0; i < 30; ++i) {
     v1.setVal(i, 0.0);
     v2.setVal(i, i / 10.0);
   }
 
-  REQUIRE(feq(computeL1Norm(v1, v2), 43.5));
+  REQUIRE_THAT(computeL1Norm(v1, v2), Catch::Matchers::WithinAbs(43.5, 1e-6));
 }
 
 TEST_CASE("test16RealVectPickles") {

--- a/Code/DataStructs/testDatastructs.cpp
+++ b/Code/DataStructs/testDatastructs.cpp
@@ -7,6 +7,8 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
+#include <catch2/catch_all.hpp>
+
 #include <RDGeneral/test.h>
 #include <cstdlib>
 #include <iostream>
@@ -50,7 +52,7 @@ void Test(T arg) {
   TXTMSG("Num:", t1.getNumBits());
   TXTMSG("NumOn:", t1.getNumOnBits());
   TXTMSG("NumOff:", t1.getNumOffBits());
-  TEST_ASSERT(t1 == t1);
+  REQUIRE(t1 == t1);
 
   IntVect onBits;
   t1.getOnBits(onBits);
@@ -63,7 +65,7 @@ void Test(T arg) {
   TXTMSG("t2[19]:", t2[19]);
   TXTMSG("t2[14]:", t2[14]);
 
-  TEST_ASSERT(t2 == t1);
+  REQUIRE(t2 == t1);
 
   t2 = t1;
   // onBits = t2.getOnBits();
@@ -72,7 +74,7 @@ void Test(T arg) {
   TXTMSG("t2[14]:", t2[14]);
   t2.setBit(15);
   t2.setBit(17);
-  TEST_ASSERT(t2 != t1);
+  REQUIRE(t2 != t1);
 
   std::cout << "t1: ";
   t1.getOnBits(onBits);
@@ -123,16 +125,16 @@ void Test(T arg) {
   }
 
   T t4(t1.toString());
-  TEST_ASSERT(t4 == t1);
-  TEST_ASSERT(feq(TanimotoSimilarity(t1, t4), 1.0));
+  REQUIRE(t4 == t1);
+  REQUIRE(feq(TanimotoSimilarity(t1, t4), 1.0));
 
   T *t5 = FoldFingerprint(t1);
-  TEST_ASSERT(t5->getNumBits() == t1.getNumBits() / 2);
-  TEST_ASSERT(t5->getBit(0));
-  TEST_ASSERT(t5->getBit(1));
-  TEST_ASSERT(t5->getBit(4));
-  TEST_ASSERT(!t5->getBit(2));
-  TEST_ASSERT(!t5->getBit(3));
+  REQUIRE(t5->getNumBits() == t1.getNumBits() / 2);
+  REQUIRE(t5->getBit(0));
+  REQUIRE(t5->getBit(1));
+  REQUIRE(t5->getBit(4));
+  REQUIRE(!t5->getBit(2));
+  REQUIRE(!t5->getBit(3));
   delete t5;
 
   std::string pkl = t1.toString();
@@ -140,7 +142,7 @@ void Test(T arg) {
   T t6(t1.getNumBits());
   t6.initFromText(pkl64, strlen(pkl64), true);
   delete[] pkl64;
-  TEST_ASSERT(t6 == t1);
+  REQUIRE(t6 == t1);
 }
 
 template <typename T>
@@ -162,17 +164,17 @@ void TaniTest(T &arg) {
       T v2(256);
       FromDaylightString(v2, fps[j]);
       double tani = TanimotoSimilarity(v1, v2);
-      TEST_ASSERT(feq(tani, dists[idx]));
+      REQUIRE(feq(tani, dists[idx]));
       tani = TverskySimilarity(v1, v2, 1., 1.);
-      TEST_ASSERT(feq(tani, dists[idx]));
+      REQUIRE(feq(tani, dists[idx]));
       tani = SimilarityWrapper(v1, v2, TanimotoSimilarity<T, T>);
-      TEST_ASSERT(feq(tani, dists[idx]));
+      REQUIRE(feq(tani, dists[idx]));
       tani = SimilarityWrapper(v1, v2, 1., 1., TverskySimilarity<T, T>);
-      TEST_ASSERT(feq(tani, dists[idx]));
+      REQUIRE(feq(tani, dists[idx]));
       tani = SimilarityWrapper(v1, v2, TanimotoSimilarity<T, T>, true);
-      TEST_ASSERT(feq(tani, 1. - dists[idx]));
+      REQUIRE(feq(tani, 1. - dists[idx]));
       tani = SimilarityWrapper(v1, v2, 1., 1., TverskySimilarity<T, T>, true);
-      TEST_ASSERT(feq(tani, 1. - dists[idx]));
+      REQUIRE(feq(tani, 1. - dists[idx]));
       idx++;
     }
   }
@@ -190,38 +192,34 @@ void ProbeTest(T &arg) {
     }
   }
   std::string pkl = t1.toString();
-  TEST_ASSERT(AllProbeBitsMatch(t1, pkl));
-  TEST_ASSERT(AllProbeBitsMatch(t2, pkl));
-  TEST_ASSERT(AllProbeBitsMatch(t1.toString(), pkl));
-  TEST_ASSERT(AllProbeBitsMatch(t2.toString(), pkl));
-  TEST_ASSERT(AllProbeBitsMatch(t1.toString().c_str(), pkl.c_str()));
-  TEST_ASSERT(AllProbeBitsMatch(t2.toString().c_str(), pkl.c_str()));
+  REQUIRE(AllProbeBitsMatch(t1, pkl));
+  REQUIRE(AllProbeBitsMatch(t2, pkl));
+  REQUIRE(AllProbeBitsMatch(t1.toString(), pkl));
+  REQUIRE(AllProbeBitsMatch(t2.toString(), pkl));
+  REQUIRE(AllProbeBitsMatch(t1.toString().c_str(), pkl.c_str()));
+  REQUIRE(AllProbeBitsMatch(t2.toString().c_str(), pkl.c_str()));
   pkl = t2.toString();
-  TEST_ASSERT(!AllProbeBitsMatch(t1, pkl));
-  TEST_ASSERT(AllProbeBitsMatch(t2, pkl));
-  TEST_ASSERT(!AllProbeBitsMatch(t1.toString(), pkl));
-  TEST_ASSERT(AllProbeBitsMatch(t2.toString(), pkl));
-  TEST_ASSERT(!AllProbeBitsMatch(t1.toString().c_str(), pkl.c_str()));
-  TEST_ASSERT(AllProbeBitsMatch(t2.toString().c_str(), pkl.c_str()));
+  REQUIRE(!AllProbeBitsMatch(t1, pkl));
+  REQUIRE(AllProbeBitsMatch(t2, pkl));
+  REQUIRE(!AllProbeBitsMatch(t1.toString(), pkl));
+  REQUIRE(AllProbeBitsMatch(t2.toString(), pkl));
+  REQUIRE(!AllProbeBitsMatch(t1.toString().c_str(), pkl.c_str()));
+  REQUIRE(AllProbeBitsMatch(t2.toString().c_str(), pkl.c_str()));
 }
 
-void test1DiscreteVect() {
+TEST_CASE("test1DiscreteVect") {
   DiscreteValueVect vect1(DiscreteValueVect::ONEBITVALUE, 30);
   unsigned int i;
   for (i = 0; i < 15; ++i) {
     vect1.setVal(2 * i, 1);
   }
 
-  TEST_ASSERT(vect1.getLength() == 30);
-  TEST_ASSERT(vect1.getTotalVal() == 15);
+  REQUIRE(vect1.getLength() == 30);
+  REQUIRE(vect1.getTotalVal() == 15);
   for (i = 0; i < vect1.getLength(); ++i) {
-    TEST_ASSERT(vect1.getVal(i) == (i + 1) % 2);
+    REQUIRE(vect1.getVal(i) == (i + 1) % 2);
   }
-  try {
-    vect1.setVal(28, 2);
-  } catch (ValueErrorException &dexp) {
-    BOOST_LOG(rdInfoLog) << "Expected failure: " << dexp.what() << "\n";
-  }
+  CHECK_THROWS_AS(vect1.setVal(28, 2), ValueErrorException);
 
   // all these tests should fail if unsigned int changes from being
   // 32 bits
@@ -231,14 +229,10 @@ void test1DiscreteVect() {
   }
 
   for (i = 0; i < vect2.getLength(); ++i) {
-    TEST_ASSERT(vect2.getVal(i) == i % 4);
+    REQUIRE(vect2.getVal(i) == i % 4);
   }
-  TEST_ASSERT(vect2.getTotalVal() == 43);
-  try {
-    vect2.setVal(28, 10);
-  } catch (ValueErrorException &dexp) {
-    BOOST_LOG(rdInfoLog) << "Expected failure: " << dexp.what() << "\n";
-  }
+  REQUIRE(vect2.getTotalVal() == 43);
+  CHECK_THROWS_AS(vect2.setVal(28, 10), ValueErrorException);
 
   DiscreteValueVect vect4(DiscreteValueVect::FOURBITVALUE, 30);
   for (i = 0; i < vect4.getLength(); ++i) {
@@ -246,14 +240,10 @@ void test1DiscreteVect() {
   }
 
   for (i = 0; i < vect4.getLength(); ++i) {
-    TEST_ASSERT(vect4.getVal(i) == i % 16);
+    REQUIRE(vect4.getVal(i) == i % 16);
   }
-  TEST_ASSERT(vect4.getTotalVal() == 211);
-  try {
-    vect4.setVal(28, 16);
-  } catch (ValueErrorException &dexp) {
-    BOOST_LOG(rdInfoLog) << "Expected failure: " << dexp.what() << "\n";
-  }
+  REQUIRE(vect4.getTotalVal() == 211);
+  CHECK_THROWS_AS(vect4.setVal(28, 16), ValueErrorException);
 
   DiscreteValueVect vect8(DiscreteValueVect::EIGHTBITVALUE, 32);
   for (i = 0; i < vect8.getLength(); ++i) {
@@ -261,14 +251,10 @@ void test1DiscreteVect() {
   }
 
   for (i = 0; i < vect8.getLength(); ++i) {
-    TEST_ASSERT(vect8.getVal(i) == i % 256);
+    REQUIRE(vect8.getVal(i) == i % 256);
   }
-  TEST_ASSERT(vect8.getTotalVal() == 496);
-  try {
-    vect8.setVal(28, 257);
-  } catch (ValueErrorException &dexp) {
-    BOOST_LOG(rdInfoLog) << "Expected failure: " << dexp.what() << "\n";
-  }
+  REQUIRE(vect8.getTotalVal() == 496);
+  CHECK_THROWS_AS(vect8.setVal(28, 257), ValueErrorException);
 
   DiscreteValueVect vect16(DiscreteValueVect::SIXTEENBITVALUE, 300);
   for (i = 0; i < vect16.getLength(); ++i) {
@@ -276,19 +262,15 @@ void test1DiscreteVect() {
   }
 
   for (i = 0; i < vect16.getLength(); ++i) {
-    TEST_ASSERT(vect16.getVal(i) == i % 300);
+    REQUIRE(vect16.getVal(i) == i % 300);
   }
 
-  TEST_ASSERT(vect16.getTotalVal() == 44850);
+  REQUIRE(vect16.getTotalVal() == 44850);
   vect16.setVal(28, 65535);
-  try {
-    vect16.setVal(28, 65536);
-  } catch (ValueErrorException &dexp) {
-    BOOST_LOG(rdInfoLog) << "Expected failure: " << dexp.what() << "\n";
-  }
+  CHECK_THROWS_AS(vect16.setVal(28, 65536), ValueErrorException);
 }
 
-void test2DiscreteVectDists() {
+TEST_CASE("test2DiscreteVectDists") {
   DiscreteValueVect v1(DiscreteValueVect::ONEBITVALUE, 30);
   DiscreteValueVect v2(DiscreteValueVect::ONEBITVALUE, 30);
   unsigned int i;
@@ -296,12 +278,12 @@ void test2DiscreteVectDists() {
     v1.setVal(2 * i, 1);
     v2.setVal(2 * i, 1);
   }
-  TEST_ASSERT(computeL1Norm(v1, v2) == 0);
+  REQUIRE(computeL1Norm(v1, v2) == 0);
   for (i = 0; i < 30; ++i) {
     v2.setVal(i, i % 2);
   }
 
-  TEST_ASSERT(computeL1Norm(v1, v2) == 30);
+  REQUIRE(computeL1Norm(v1, v2) == 30);
 
   for (i = 0; i < 30; ++i) {
     if (i % 3 == 0) {
@@ -311,7 +293,7 @@ void test2DiscreteVectDists() {
     }
   }
 
-  TEST_ASSERT(computeL1Norm(v1, v2) == 15);
+  REQUIRE(computeL1Norm(v1, v2) == 15);
 
   DiscreteValueVect v21(DiscreteValueVect::TWOBITVALUE, 30);
   DiscreteValueVect v22(DiscreteValueVect::TWOBITVALUE, 30);
@@ -319,11 +301,11 @@ void test2DiscreteVectDists() {
     v21.setVal(i, i % 4);
     v22.setVal(i, i % 4);
   }
-  TEST_ASSERT(computeL1Norm(v21, v22) == 0);
+  REQUIRE(computeL1Norm(v21, v22) == 0);
   for (i = 0; i < 30; ++i) {
     v22.setVal(i, (i + 1) % 4);
   }
-  TEST_ASSERT(computeL1Norm(v21, v22) == 44);
+  REQUIRE(computeL1Norm(v21, v22) == 44);
 
   DiscreteValueVect v41(DiscreteValueVect::FOURBITVALUE, 16);
   DiscreteValueVect v42(DiscreteValueVect::FOURBITVALUE, 16);
@@ -331,15 +313,15 @@ void test2DiscreteVectDists() {
     v41.setVal(i, i % 16);
     v42.setVal(i, i % 16);
   }
-  TEST_ASSERT(computeL1Norm(v41, v42) == 0);
+  REQUIRE(computeL1Norm(v41, v42) == 0);
 
   for (i = 0; i < 16; ++i) {
     v42.setVal(i, i % 5);
   }
-  TEST_ASSERT(computeL1Norm(v41, v42) == 90);
+  REQUIRE(computeL1Norm(v41, v42) == 90);
 
   DiscreteValueVect v43(v42);
-  TEST_ASSERT(computeL1Norm(v42, v43) == 0);
+  REQUIRE(computeL1Norm(v42, v43) == 0);
 
   DiscreteValueVect v81(DiscreteValueVect::EIGHTBITVALUE, 5);
   DiscreteValueVect v82(DiscreteValueVect::EIGHTBITVALUE, 5);
@@ -353,14 +335,14 @@ void test2DiscreteVectDists() {
   v82.setVal(3, 56);
   v81.setVal(4, 128);
   v82.setVal(4, 128);
-  TEST_ASSERT(computeL1Norm(v81, v82) == 0);
+  REQUIRE(computeL1Norm(v81, v82) == 0);
 
   v82.setVal(0, 14);
   v82.setVal(1, 67);
   v82.setVal(2, 103);
   v82.setVal(3, 6);
   v82.setVal(4, 228);
-  TEST_ASSERT(computeL1Norm(v81, v82) == 370);
+  REQUIRE(computeL1Norm(v81, v82) == 370);
 
   DiscreteValueVect v161(DiscreteValueVect::SIXTEENBITVALUE, 3);
   DiscreteValueVect v162(DiscreteValueVect::SIXTEENBITVALUE, 3);
@@ -370,36 +352,36 @@ void test2DiscreteVectDists() {
   v162.setVal(1, 64578);
   v161.setVal(2, 34);
   v162.setVal(2, 34);
-  TEST_ASSERT(computeL1Norm(v161, v162) == 0);
+  REQUIRE(computeL1Norm(v161, v162) == 0);
 
   v162.setVal(0, 1345);
   v162.setVal(1, 54578);
   v162.setVal(2, 10034);
-  TEST_ASSERT(computeL1Norm(v161, v162) == 21000);
+  REQUIRE(computeL1Norm(v161, v162) == 21000);
 }
 
-void test3DiscreteVectPickles() {
+TEST_CASE("test3DiscreteVectPickles") {
   DiscreteValueVect v1(DiscreteValueVect::ONEBITVALUE, 30);
   unsigned int i;
   for (i = 0; i < 15; ++i) {
     v1.setVal(2 * i, 1);
   }
   DiscreteValueVect v2(v1.toString());
-  TEST_ASSERT(computeL1Norm(v1, v2) == 0);
+  REQUIRE(computeL1Norm(v1, v2) == 0);
 
   DiscreteValueVect v21(DiscreteValueVect::TWOBITVALUE, 30);
   for (i = 0; i < 30; ++i) {
     v21.setVal(i, i % 4);
   }
   DiscreteValueVect v22(v21.toString());
-  TEST_ASSERT(computeL1Norm(v21, v22) == 0);
+  REQUIRE(computeL1Norm(v21, v22) == 0);
 
   DiscreteValueVect v41(DiscreteValueVect::FOURBITVALUE, 16);
   for (i = 0; i < 16; ++i) {
     v41.setVal(i, i % 16);
   }
   DiscreteValueVect v42(v41.toString());
-  TEST_ASSERT(computeL1Norm(v41, v42) == 0);
+  REQUIRE(computeL1Norm(v41, v42) == 0);
 
   DiscreteValueVect v81(DiscreteValueVect::EIGHTBITVALUE, 5);
   v81.setVal(0, 34);
@@ -408,145 +390,145 @@ void test3DiscreteVectPickles() {
   v81.setVal(3, 56);
   v81.setVal(4, 128);
   DiscreteValueVect v82(v81.toString());
-  TEST_ASSERT(computeL1Norm(v81, v82) == 0);
+  REQUIRE(computeL1Norm(v81, v82) == 0);
 
   DiscreteValueVect v161(DiscreteValueVect::SIXTEENBITVALUE, 3);
   v161.setVal(0, 2345);
   v161.setVal(1, 64578);
   v161.setVal(2, 34);
   DiscreteValueVect v162(v161.toString());
-  TEST_ASSERT(computeL1Norm(v161, v162) == 0);
+  REQUIRE(computeL1Norm(v161, v162) == 0);
 }
 
-void test4DiscreteVectOps1() {
+TEST_CASE("test4DiscreteVectOps1") {
   DiscreteValueVect vect1(DiscreteValueVect::ONEBITVALUE, 8);
   for (unsigned int i = 0; i < 4; ++i) {
     vect1.setVal(2 * i, 1);
   }
-  TEST_ASSERT(vect1.getLength() == 8);
-  TEST_ASSERT(vect1.getTotalVal() == 4);
+  REQUIRE(vect1.getLength() == 8);
+  REQUIRE(vect1.getTotalVal() == 4);
 
   DiscreteValueVect vect2(DiscreteValueVect::ONEBITVALUE, 8);
   for (unsigned int i = 0; i < 4; ++i) {
     vect2.setVal(2 * i + 1, 1);
   }
-  TEST_ASSERT(vect2.getTotalVal() == 4);
+  REQUIRE(vect2.getTotalVal() == 4);
 
   DiscreteValueVect vect3 = vect1 & vect2;
-  TEST_ASSERT(vect3.getLength() == 8);
-  TEST_ASSERT(vect3.getTotalVal() == 0);
+  REQUIRE(vect3.getLength() == 8);
+  REQUIRE(vect3.getTotalVal() == 0);
 
   DiscreteValueVect vect4 = vect1 | vect2;
-  TEST_ASSERT(vect4.getLength() == 8);
-  TEST_ASSERT(vect4.getTotalVal() == 8);
+  REQUIRE(vect4.getLength() == 8);
+  REQUIRE(vect4.getTotalVal() == 8);
 #if 0
   DiscreteValueVect vect5=~vect1;
-  TEST_ASSERT(vect5.getLength() == 8);
-  TEST_ASSERT(vect5.getTotalVal() == 4);
+  REQUIRE(vect5.getLength() == 8);
+  REQUIRE(vect5.getTotalVal() == 4);
 
-  TEST_ASSERT((vect5&vect1).getTotalVal()==0);
-  TEST_ASSERT((vect5&vect2).getTotalVal()==4);
+  REQUIRE((vect5&vect1).getTotalVal()==0);
+  REQUIRE((vect5&vect2).getTotalVal()==4);
 #endif
 }
 
-void test5DiscreteVectOps2() {
+TEST_CASE("test5DiscreteVectOps2") {
   DiscreteValueVect vect1(DiscreteValueVect::TWOBITVALUE, 8);
   for (unsigned int i = 0; i < 4; ++i) {
     vect1.setVal(2 * i, 2);
   }
-  TEST_ASSERT(vect1.getLength() == 8);
-  TEST_ASSERT(vect1.getTotalVal() == 8);
+  REQUIRE(vect1.getLength() == 8);
+  REQUIRE(vect1.getTotalVal() == 8);
 
   DiscreteValueVect vect2(DiscreteValueVect::TWOBITVALUE, 8);
   for (unsigned int i = 0; i < 4; ++i) {
     vect2.setVal(2 * i + 1, 2);
     vect2.setVal(2 * i, 1);
   }
-  TEST_ASSERT(vect2.getTotalVal() == 12);
+  REQUIRE(vect2.getTotalVal() == 12);
 
   DiscreteValueVect vect3 = vect1 & vect2;
-  TEST_ASSERT(vect3.getLength() == 8);
-  TEST_ASSERT(vect3.getTotalVal() == 4);
+  REQUIRE(vect3.getLength() == 8);
+  REQUIRE(vect3.getTotalVal() == 4);
 
   DiscreteValueVect vect4 = vect1 | vect2;
-  TEST_ASSERT(vect4.getLength() == 8);
-  TEST_ASSERT(vect4.getTotalVal() == 16);
+  REQUIRE(vect4.getLength() == 8);
+  REQUIRE(vect4.getTotalVal() == 16);
 
   DiscreteValueVect vect5 = vect1 + vect2;
-  TEST_ASSERT(vect5.getLength() == 8);
-  TEST_ASSERT(vect5.getTotalVal() == 20);
+  REQUIRE(vect5.getLength() == 8);
+  REQUIRE(vect5.getTotalVal() == 20);
 
   vect5 = vect1 - vect2;
-  TEST_ASSERT(vect5.getTotalVal() == 4);
+  REQUIRE(vect5.getTotalVal() == 4);
   vect5 = vect2 - vect1;
-  TEST_ASSERT(vect5.getTotalVal() == 8);
+  REQUIRE(vect5.getTotalVal() == 8);
 
 #if 0
   DiscreteValueVect vect5=~vect1;
-  TEST_ASSERT(vect5.getLength() == 8);
-  TEST_ASSERT(vect5.getTotalVal() == 16);
+  REQUIRE(vect5.getLength() == 8);
+  REQUIRE(vect5.getTotalVal() == 16);
 
-  TEST_ASSERT((vect5&vect1).getTotalVal()==4);
-  TEST_ASSERT((vect5&vect2).getTotalVal()==12);
+  REQUIRE((vect5&vect1).getTotalVal()==4);
+  REQUIRE((vect5&vect2).getTotalVal()==12);
 #endif
 }
 
-void test6SparseIntVect() {
+TEST_CASE("test6SparseIntVect") {
   SparseIntVect<int> iVect(255);
 
-  TEST_ASSERT(iVect.getLength() == 255);
-  TEST_ASSERT(iVect.getVal(23) == 0);
+  REQUIRE(iVect.getLength() == 255);
+  REQUIRE(iVect.getVal(23) == 0);
   iVect.setVal(23, 14);
-  TEST_ASSERT(iVect.getVal(23) == 14);
+  REQUIRE(iVect.getVal(23) == 14);
 
   SparseIntVect<int> oVect(iVect);
-  TEST_ASSERT(oVect.getLength() == 255);
-  TEST_ASSERT(oVect.getVal(23) == 14);
+  REQUIRE(oVect.getLength() == 255);
+  REQUIRE(oVect.getVal(23) == 14);
 
   std::vector<int> tmpV(3);
   tmpV[0] = 1;
   tmpV[1] = 5;
   tmpV[2] = 1;
-  TEST_ASSERT(iVect.getVal(1) == 0);
-  TEST_ASSERT(iVect[1] == 0);
-  TEST_ASSERT(iVect.getVal(5) == 0);
-  TEST_ASSERT(iVect[5] == 0);
+  REQUIRE(iVect.getVal(1) == 0);
+  REQUIRE(iVect[1] == 0);
+  REQUIRE(iVect.getVal(5) == 0);
+  REQUIRE(iVect[5] == 0);
   updateFromSequence(iVect, tmpV);
-  TEST_ASSERT(iVect.getVal(1) == 2);
-  TEST_ASSERT(iVect[1] == 2);
-  TEST_ASSERT(iVect.getVal(5) == 1);
-  TEST_ASSERT(iVect[5] == 1);
+  REQUIRE(iVect.getVal(1) == 2);
+  REQUIRE(iVect[1] == 2);
+  REQUIRE(iVect.getVal(5) == 1);
+  REQUIRE(iVect[5] == 1);
 
   iVect.setVal(3, -4);
-  TEST_ASSERT(iVect.getTotalVal() == 13);
+  REQUIRE(iVect.getTotalVal() == 13);
 
   try {
     iVect.setVal(-1, 13);
-    TEST_ASSERT(0);
+    REQUIRE(0);
   } catch (IndexErrorException &) {
     ;
   }
   try {
     iVect.setVal(255, 42);
-    TEST_ASSERT(0);
+    REQUIRE(0);
   } catch (IndexErrorException &) {
     ;
   }
   try {
     iVect.getVal(-1);
-    TEST_ASSERT(0);
+    REQUIRE(0);
   } catch (IndexErrorException &) {
     ;
   }
   try {
     iVect.getVal(255);
-    TEST_ASSERT(0);
+    REQUIRE(0);
   } catch (IndexErrorException &) {
     ;
   }
   try {
     iVect[-1];
-    TEST_ASSERT(0);
+    REQUIRE(0);
   } catch (IndexErrorException &) {
     ;
   }
@@ -557,17 +539,17 @@ void test6SparseIntVect() {
     iV1.setVal(0, 2);
     iV1.setVal(3, 1);
     auto iter = iV1.getNonzeroElements().begin();
-    TEST_ASSERT(iter->first == 0);
-    TEST_ASSERT(iter->second == 2);
+    REQUIRE(iter->first == 0);
+    REQUIRE(iter->second == 2);
     ++iter;
-    TEST_ASSERT(iter->first == 3);
-    TEST_ASSERT(iter->second == 1);
+    REQUIRE(iter->first == 3);
+    REQUIRE(iter->second == 1);
     ++iter;
-    TEST_ASSERT(iter->first == 4);
-    TEST_ASSERT(iter->second == 4);
+    REQUIRE(iter->first == 4);
+    REQUIRE(iter->second == 4);
     ++iter;
-    TEST_ASSERT(iter == iV1.getNonzeroElements().end());
-    TEST_ASSERT(feq(DiceSimilarity(iV1, iV1), 1.));
+    REQUIRE(iter == iV1.getNonzeroElements().end());
+    REQUIRE(feq(DiceSimilarity(iV1, iV1), 1.));
   }
 
   {  // iV1 &= iV2
@@ -582,33 +564,32 @@ void test6SparseIntVect() {
     iV2.setVal(3, 4);
     iV2.setVal(4, 6);
 
-    TEST_ASSERT(feq(DiceSimilarity(iV1, iV2), 18. / 26.));
+    REQUIRE(feq(DiceSimilarity(iV1, iV2), 18. / 26.));
 
     iV1 &= iV2;
-    TEST_ASSERT(iV1[0] == 0);
-    TEST_ASSERT(iV1[1] == 0);
-    TEST_ASSERT(iV1[2] == 1);
-    TEST_ASSERT(iV1[3] == 4);
-    TEST_ASSERT(iV1[4] == 4);
+    REQUIRE(iV1[0] == 0);
+    REQUIRE(iV1[1] == 0);
+    REQUIRE(iV1[2] == 1);
+    REQUIRE(iV1[3] == 4);
+    REQUIRE(iV1[4] == 4);
 
-    TEST_ASSERT(iV2[0] == 0);
-    TEST_ASSERT(iV2[1] == 2);
-    TEST_ASSERT(iV2[2] == 3);
-    TEST_ASSERT(iV2[3] == 4);
-    TEST_ASSERT(iV2[4] == 6);
+    REQUIRE(iV2[0] == 0);
+    REQUIRE(iV2[1] == 2);
+    REQUIRE(iV2[2] == 3);
+    REQUIRE(iV2[3] == 4);
+    REQUIRE(iV2[4] == 6);
 
-    TEST_ASSERT(feq(DiceSimilarity(iV1, iV2), 18. / 24.));
-    TEST_ASSERT(feq(TverskySimilarity(iV1, iV2, 0.5, 0.5, false), 9. / 12.));
-    TEST_ASSERT(feq(TverskySimilarity(iV1, iV2, 1.0, 1.0, false), 9. / 15.));
-    TEST_ASSERT(feq(TanimotoSimilarity(iV1, iV2), 9. / 15.));
-    TEST_ASSERT(
-        feq(TverskySimilarity(iV1, iV2, 0.333333333, 0.66666666667, false),
-            9. / 13.));
-    TEST_ASSERT(feq(TverskySimilarity(iV1, iV2, 1.0, 0.0, false), 9. / 9.));
+    REQUIRE(feq(DiceSimilarity(iV1, iV2), 18. / 24.));
+    REQUIRE(feq(TverskySimilarity(iV1, iV2, 0.5, 0.5, false), 9. / 12.));
+    REQUIRE(feq(TverskySimilarity(iV1, iV2, 1.0, 1.0, false), 9. / 15.));
+    REQUIRE(feq(TanimotoSimilarity(iV1, iV2), 9. / 15.));
+    REQUIRE(feq(TverskySimilarity(iV1, iV2, 0.333333333, 0.66666666667, false),
+                9. / 13.));
+    REQUIRE(feq(TverskySimilarity(iV1, iV2, 1.0, 0.0, false), 9. / 9.));
 
     try {
       iV1 &= iVect;
-      TEST_ASSERT(0);
+      REQUIRE(0);
     } catch (ValueErrorException &) {
       ;
     }
@@ -627,23 +608,23 @@ void test6SparseIntVect() {
     iV2.setVal(4, 6);
 
     iV3 = iV1 & iV2;
-    TEST_ASSERT(iV3[0] == 0);
-    TEST_ASSERT(iV3[1] == 0);
-    TEST_ASSERT(iV3[2] == 1);
-    TEST_ASSERT(iV3[3] == 4);
-    TEST_ASSERT(iV3[4] == 4);
+    REQUIRE(iV3[0] == 0);
+    REQUIRE(iV3[1] == 0);
+    REQUIRE(iV3[2] == 1);
+    REQUIRE(iV3[3] == 4);
+    REQUIRE(iV3[4] == 4);
 
-    TEST_ASSERT(iV1[0] == 2);
-    TEST_ASSERT(iV1[1] == 0);
-    TEST_ASSERT(iV1[2] == 1);
-    TEST_ASSERT(iV1[3] == 4);
-    TEST_ASSERT(iV1[4] == 4);
+    REQUIRE(iV1[0] == 2);
+    REQUIRE(iV1[1] == 0);
+    REQUIRE(iV1[2] == 1);
+    REQUIRE(iV1[3] == 4);
+    REQUIRE(iV1[4] == 4);
 
-    TEST_ASSERT(iV2[0] == 0);
-    TEST_ASSERT(iV2[1] == 2);
-    TEST_ASSERT(iV2[2] == 3);
-    TEST_ASSERT(iV2[3] == 4);
-    TEST_ASSERT(iV2[4] == 6);
+    REQUIRE(iV2[0] == 0);
+    REQUIRE(iV2[1] == 2);
+    REQUIRE(iV2[2] == 3);
+    REQUIRE(iV2[3] == 4);
+    REQUIRE(iV2[4] == 6);
   }
 
   {  // iV2 &= iV1
@@ -659,21 +640,21 @@ void test6SparseIntVect() {
     iV2.setVal(4, 6);
 
     iV2 &= iV1;
-    TEST_ASSERT(iV2[0] == 0);
-    TEST_ASSERT(iV2[1] == 0);
-    TEST_ASSERT(iV2[2] == 1);
-    TEST_ASSERT(iV2[3] == 4);
-    TEST_ASSERT(iV2[4] == 4);
+    REQUIRE(iV2[0] == 0);
+    REQUIRE(iV2[1] == 0);
+    REQUIRE(iV2[2] == 1);
+    REQUIRE(iV2[3] == 4);
+    REQUIRE(iV2[4] == 4);
 
-    TEST_ASSERT(iV1[0] == 2);
-    TEST_ASSERT(iV1[1] == 0);
-    TEST_ASSERT(iV1[2] == 1);
-    TEST_ASSERT(iV1[3] == 4);
-    TEST_ASSERT(iV1[4] == 4);
+    REQUIRE(iV1[0] == 2);
+    REQUIRE(iV1[1] == 0);
+    REQUIRE(iV1[2] == 1);
+    REQUIRE(iV1[3] == 4);
+    REQUIRE(iV1[4] == 4);
 
     try {
       iV2 &= iVect;
-      TEST_ASSERT(0);
+      REQUIRE(0);
     } catch (ValueErrorException &) {
       ;
     }
@@ -692,21 +673,21 @@ void test6SparseIntVect() {
     iV2.setVal(4, 6);
 
     iV1 |= iV2;
-    TEST_ASSERT(iV1[0] == 2);
-    TEST_ASSERT(iV1[1] == 2);
-    TEST_ASSERT(iV1[2] == 3);
-    TEST_ASSERT(iV1[3] == 4);
-    TEST_ASSERT(iV1[4] == 6);
+    REQUIRE(iV1[0] == 2);
+    REQUIRE(iV1[1] == 2);
+    REQUIRE(iV1[2] == 3);
+    REQUIRE(iV1[3] == 4);
+    REQUIRE(iV1[4] == 6);
 
-    TEST_ASSERT(iV2[0] == 0);
-    TEST_ASSERT(iV2[1] == 2);
-    TEST_ASSERT(iV2[2] == 3);
-    TEST_ASSERT(iV2[3] == 4);
-    TEST_ASSERT(iV2[4] == 6);
+    REQUIRE(iV2[0] == 0);
+    REQUIRE(iV2[1] == 2);
+    REQUIRE(iV2[2] == 3);
+    REQUIRE(iV2[3] == 4);
+    REQUIRE(iV2[4] == 6);
 
     try {
       iV1 |= iVect;
-      TEST_ASSERT(0);
+      REQUIRE(0);
     } catch (ValueErrorException &) {
       ;
     }
@@ -725,23 +706,23 @@ void test6SparseIntVect() {
     iV2.setVal(4, 6);
 
     iV3 = iV1 | iV2;
-    TEST_ASSERT(iV3[0] == 2);
-    TEST_ASSERT(iV3[1] == 2);
-    TEST_ASSERT(iV3[2] == 3);
-    TEST_ASSERT(iV3[3] == 4);
-    TEST_ASSERT(iV3[4] == 6);
+    REQUIRE(iV3[0] == 2);
+    REQUIRE(iV3[1] == 2);
+    REQUIRE(iV3[2] == 3);
+    REQUIRE(iV3[3] == 4);
+    REQUIRE(iV3[4] == 6);
 
-    TEST_ASSERT(iV1[0] == 2);
-    TEST_ASSERT(iV1[1] == 0);
-    TEST_ASSERT(iV1[2] == 1);
-    TEST_ASSERT(iV1[3] == 4);
-    TEST_ASSERT(iV1[4] == 4);
+    REQUIRE(iV1[0] == 2);
+    REQUIRE(iV1[1] == 0);
+    REQUIRE(iV1[2] == 1);
+    REQUIRE(iV1[3] == 4);
+    REQUIRE(iV1[4] == 4);
 
-    TEST_ASSERT(iV2[0] == 0);
-    TEST_ASSERT(iV2[1] == 2);
-    TEST_ASSERT(iV2[2] == 3);
-    TEST_ASSERT(iV2[3] == 4);
-    TEST_ASSERT(iV2[4] == 6);
+    REQUIRE(iV2[0] == 0);
+    REQUIRE(iV2[1] == 2);
+    REQUIRE(iV2[2] == 3);
+    REQUIRE(iV2[3] == 4);
+    REQUIRE(iV2[4] == 6);
   }
 
   {  // iV2 |= iV1
@@ -757,17 +738,17 @@ void test6SparseIntVect() {
     iV2.setVal(4, 6);
 
     iV2 |= iV1;
-    TEST_ASSERT(iV2[0] == 2);
-    TEST_ASSERT(iV2[1] == 2);
-    TEST_ASSERT(iV2[2] == 3);
-    TEST_ASSERT(iV2[3] == 4);
-    TEST_ASSERT(iV2[4] == 6);
+    REQUIRE(iV2[0] == 2);
+    REQUIRE(iV2[1] == 2);
+    REQUIRE(iV2[2] == 3);
+    REQUIRE(iV2[3] == 4);
+    REQUIRE(iV2[4] == 6);
 
-    TEST_ASSERT(iV1[0] == 2);
-    TEST_ASSERT(iV1[1] == 0);
-    TEST_ASSERT(iV1[2] == 1);
-    TEST_ASSERT(iV1[3] == 4);
-    TEST_ASSERT(iV1[4] == 4);
+    REQUIRE(iV1[0] == 2);
+    REQUIRE(iV1[1] == 0);
+    REQUIRE(iV1[2] == 1);
+    REQUIRE(iV1[3] == 4);
+    REQUIRE(iV1[4] == 4);
   }
 
   {  // iV1 += iV2
@@ -783,17 +764,17 @@ void test6SparseIntVect() {
     iV2.setVal(4, 6);
 
     iV1 += iV2;
-    TEST_ASSERT(iV1[0] == 2);
-    TEST_ASSERT(iV1[1] == 2);
-    TEST_ASSERT(iV1[2] == 4);
-    TEST_ASSERT(iV1[3] == 0);
-    TEST_ASSERT(iV1[4] == 10);
+    REQUIRE(iV1[0] == 2);
+    REQUIRE(iV1[1] == 2);
+    REQUIRE(iV1[2] == 4);
+    REQUIRE(iV1[3] == 0);
+    REQUIRE(iV1[4] == 10);
 
-    TEST_ASSERT(iV2[0] == 0);
-    TEST_ASSERT(iV2[1] == 2);
-    TEST_ASSERT(iV2[2] == 3);
-    TEST_ASSERT(iV2[3] == -4);
-    TEST_ASSERT(iV2[4] == 6);
+    REQUIRE(iV2[0] == 0);
+    REQUIRE(iV2[1] == 2);
+    REQUIRE(iV2[2] == 3);
+    REQUIRE(iV2[3] == -4);
+    REQUIRE(iV2[4] == 6);
   }
   {  // iV3 = IV1 + iV2
     SparseIntVect<int> iV1(5), iV2(5), iV3(5);
@@ -808,22 +789,22 @@ void test6SparseIntVect() {
     iV2.setVal(4, 6);
 
     iV3 = iV1 + iV2;
-    TEST_ASSERT(iV3[0] == 2);
-    TEST_ASSERT(iV3[1] == 2);
-    TEST_ASSERT(iV3[2] == 4);
-    TEST_ASSERT(iV3[3] == 0);
-    TEST_ASSERT(iV3[4] == 10);
+    REQUIRE(iV3[0] == 2);
+    REQUIRE(iV3[1] == 2);
+    REQUIRE(iV3[2] == 4);
+    REQUIRE(iV3[3] == 0);
+    REQUIRE(iV3[4] == 10);
 
-    TEST_ASSERT(iV1[0] == 2);
-    TEST_ASSERT(iV1[1] == 0);
-    TEST_ASSERT(iV1[2] == 1);
-    TEST_ASSERT(iV1[3] == 4);
-    TEST_ASSERT(iV1[4] == 4);
-    TEST_ASSERT(iV2[0] == 0);
-    TEST_ASSERT(iV2[1] == 2);
-    TEST_ASSERT(iV2[2] == 3);
-    TEST_ASSERT(iV2[3] == -4);
-    TEST_ASSERT(iV2[4] == 6);
+    REQUIRE(iV1[0] == 2);
+    REQUIRE(iV1[1] == 0);
+    REQUIRE(iV1[2] == 1);
+    REQUIRE(iV1[3] == 4);
+    REQUIRE(iV1[4] == 4);
+    REQUIRE(iV2[0] == 0);
+    REQUIRE(iV2[1] == 2);
+    REQUIRE(iV2[2] == 3);
+    REQUIRE(iV2[3] == -4);
+    REQUIRE(iV2[4] == 6);
   }
 
   {  // iV1 -= iV2
@@ -839,17 +820,17 @@ void test6SparseIntVect() {
     iV2.setVal(4, 6);
 
     iV1 -= iV2;
-    TEST_ASSERT(iV1[0] == 2);
-    TEST_ASSERT(iV1[1] == -2);
-    TEST_ASSERT(iV1[2] == -2);
-    TEST_ASSERT(iV1[3] == 0);
-    TEST_ASSERT(iV1[4] == -2);
+    REQUIRE(iV1[0] == 2);
+    REQUIRE(iV1[1] == -2);
+    REQUIRE(iV1[2] == -2);
+    REQUIRE(iV1[3] == 0);
+    REQUIRE(iV1[4] == -2);
 
-    TEST_ASSERT(iV2[0] == 0);
-    TEST_ASSERT(iV2[2] == 3);
-    TEST_ASSERT(iV2[1] == 2);
-    TEST_ASSERT(iV2[4] == 6);
-    TEST_ASSERT(iV2[3] == 4);
+    REQUIRE(iV2[0] == 0);
+    REQUIRE(iV2[2] == 3);
+    REQUIRE(iV2[1] == 2);
+    REQUIRE(iV2[4] == 6);
+    REQUIRE(iV2[3] == 4);
   }
   {  // iV3 = IV1 - iV2
     SparseIntVect<int> iV1(5), iV2(5), iV3(5);
@@ -864,22 +845,22 @@ void test6SparseIntVect() {
     iV2.setVal(2, 3);
 
     iV3 = iV1 - iV2;
-    TEST_ASSERT(iV3[0] == 2);
-    TEST_ASSERT(iV3[1] == -2);
-    TEST_ASSERT(iV3[2] == -2);
-    TEST_ASSERT(iV3[3] == 0);
-    TEST_ASSERT(iV3[4] == -2);
+    REQUIRE(iV3[0] == 2);
+    REQUIRE(iV3[1] == -2);
+    REQUIRE(iV3[2] == -2);
+    REQUIRE(iV3[3] == 0);
+    REQUIRE(iV3[4] == -2);
 
-    TEST_ASSERT(iV1[0] == 2);
-    TEST_ASSERT(iV1[1] == 0);
-    TEST_ASSERT(iV1[2] == 1);
-    TEST_ASSERT(iV1[3] == 4);
-    TEST_ASSERT(iV1[4] == 4);
-    TEST_ASSERT(iV2[0] == 0);
-    TEST_ASSERT(iV2[1] == 2);
-    TEST_ASSERT(iV2[2] == 3);
-    TEST_ASSERT(iV2[3] == 4);
-    TEST_ASSERT(iV2[4] == 6);
+    REQUIRE(iV1[0] == 2);
+    REQUIRE(iV1[1] == 0);
+    REQUIRE(iV1[2] == 1);
+    REQUIRE(iV1[3] == 4);
+    REQUIRE(iV1[4] == 4);
+    REQUIRE(iV2[0] == 0);
+    REQUIRE(iV2[1] == 2);
+    REQUIRE(iV2[2] == 3);
+    REQUIRE(iV2[3] == 4);
+    REQUIRE(iV2[4] == 6);
   }
 
   {  // operator== and operator!=
@@ -899,16 +880,16 @@ void test6SparseIntVect() {
     iV4.setVal(3, 4);
     iV4.setVal(4, 6);
 
-    TEST_ASSERT(iV1 == iV1);
-    TEST_ASSERT(iV2 == iV2);
-    TEST_ASSERT(iV3 == iV3);
-    TEST_ASSERT(iV1 != iV2);
-    TEST_ASSERT(iV1 != iV3);
-    TEST_ASSERT(iV2 != iV1);
-    TEST_ASSERT(iV3 != iV1);
-    TEST_ASSERT(iV1 != iV3);
-    TEST_ASSERT(iV1 != iV4);
-    TEST_ASSERT(iV2 == iV4);
+    REQUIRE(iV1 == iV1);
+    REQUIRE(iV2 == iV2);
+    REQUIRE(iV3 == iV3);
+    REQUIRE(iV1 != iV2);
+    REQUIRE(iV1 != iV3);
+    REQUIRE(iV2 != iV1);
+    REQUIRE(iV3 != iV1);
+    REQUIRE(iV1 != iV3);
+    REQUIRE(iV1 != iV4);
+    REQUIRE(iV2 == iV4);
   }
 
   {  // test negative values (was sf.net Issue 3295215)
@@ -923,11 +904,11 @@ void test6SparseIntVect() {
     iV2.setVal(3, -4);
     iV2.setVal(4, 6);
 
-    TEST_ASSERT(feq(DiceSimilarity(iV1, iV2), 18. / 26.));
+    REQUIRE(feq(DiceSimilarity(iV1, iV2), 18. / 26.));
   }
 }
 
-void test7SparseIntVectPickles() {
+TEST_CASE("test7SparseIntVectPickles") {
   {
     SparseIntVect<int> iV1(5), iV2(3);
     iV1.setVal(0, 2);
@@ -936,11 +917,11 @@ void test7SparseIntVectPickles() {
     iV1.setVal(4, 4);
 
     iV2.setVal(2, 3);
-    TEST_ASSERT(iV1 != iV2);
+    REQUIRE(iV1 != iV2);
     std::string pkl;
     pkl = iV1.toString();
     iV2.fromString(pkl);
-    TEST_ASSERT(iV1 == iV2);
+    REQUIRE(iV1 == iV2);
   }
 
   {
@@ -954,11 +935,11 @@ void test7SparseIntVectPickles() {
     std::string pkl;
     pkl = iV1.toString();
     iV2.fromString(pkl);
-    TEST_ASSERT(iV2.getLength() == iV1.getLength());
-    TEST_ASSERT(iV2[0] == 2)
-    TEST_ASSERT(iV2[1] == 0)
-    TEST_ASSERT(iV2[2] == 1)
-    TEST_ASSERT(iV2[3] == 4)
+    REQUIRE(iV2.getLength() == iV1.getLength());
+    REQUIRE(iV2[0] == 2);
+    REQUIRE(iV2[1] == 0);
+    REQUIRE(iV2[2] == 1);
+    REQUIRE(iV2[3] == 4);
   }
 
   {
@@ -972,14 +953,14 @@ void test7SparseIntVectPickles() {
     pkl = iV1.toString();
     try {
       iV2.fromString(pkl);
-      TEST_ASSERT(0);
+      REQUIRE(0);
     } catch (ValueErrorException &) {
       ;
     }
   }
 }
 
-void test8BitVectPickles() {
+TEST_CASE("test8BitVectPickles") {
 #if 0
   {
     std::string dirName = getenv("RDBASE");
@@ -1015,20 +996,20 @@ void test8BitVectPickles() {
     delete[] buff;
     ExplicitBitVect bv(pkl);
 
-    TEST_ASSERT(bv.getNumBits() == 32);
-    TEST_ASSERT(bv.getNumOnBits() == 16);
-    TEST_ASSERT(bv[0]);
-    TEST_ASSERT(!bv[1]);
+    REQUIRE(bv.getNumBits() == 32);
+    REQUIRE(bv.getNumOnBits() == 16);
+    REQUIRE(bv[0]);
+    REQUIRE(!bv[1]);
   }
 }
 
-void test9BitVectFPS() {
+TEST_CASE("test9BitVectFPS") {
   {
     ExplicitBitVect bv(32);
     std::string fps;
 
     fps = BitVectToFPSText(bv);
-    TEST_ASSERT(fps == "00000000");
+    REQUIRE(fps == "00000000");
 
     bv.setBit(0);
     bv.setBit(1);
@@ -1037,16 +1018,16 @@ void test9BitVectFPS() {
     bv.setBit(31);
 
     fps = BitVectToFPSText(bv);
-    TEST_ASSERT(fps == "03008280");
+    REQUIRE(fps == "03008280");
   }
   {
     ExplicitBitVect bv(32), bv2(32);
     std::string fps;
 
     fps = BitVectToFPSText(bv);
-    TEST_ASSERT(fps == "00000000");
+    REQUIRE(fps == "00000000");
     UpdateBitVectFromFPSText(bv2, fps);
-    TEST_ASSERT(bv == bv2);
+    REQUIRE(bv == bv2);
 
     bv.setBit(0);
     bv.setBit(1);
@@ -1057,29 +1038,29 @@ void test9BitVectFPS() {
 
     fps = BitVectToFPSText(bv);
     UpdateBitVectFromFPSText(bv2, fps);
-    TEST_ASSERT(bv == bv2);
+    REQUIRE(bv == bv2);
   }
   {
     ExplicitBitVect bv(33);
     std::string fps;
 
     fps = BitVectToFPSText(bv);
-    TEST_ASSERT(fps == "0000000000");
+    REQUIRE(fps == "0000000000");
 
     bv.setBit(0);
     bv.setBit(32);
 
     fps = BitVectToFPSText(bv);
-    TEST_ASSERT(fps == "0100000001");
+    REQUIRE(fps == "0100000001");
   }
   {
     ExplicitBitVect bv(33), bv2(33);
     std::string fps;
 
     fps = BitVectToFPSText(bv);
-    TEST_ASSERT(fps == "0000000000");
+    REQUIRE(fps == "0000000000");
     UpdateBitVectFromFPSText(bv2, fps);
-    TEST_ASSERT(bv == bv2);
+    REQUIRE(bv == bv2);
 
     bv.setBit(0);
     bv.setBit(1);
@@ -1090,19 +1071,19 @@ void test9BitVectFPS() {
 
     fps = BitVectToFPSText(bv);
     UpdateBitVectFromFPSText(bv2, fps);
-    TEST_ASSERT(bv == bv2);
+    REQUIRE(bv == bv2);
   }
 }
 
-void test10BitVectBinaryText() {
+TEST_CASE("test10BitVectBinaryText") {
   {
     ExplicitBitVect bv(32);
     std::string fps;
 
     fps = BitVectToBinaryText(bv);
-    TEST_ASSERT(fps.size() == 4);
+    REQUIRE(fps.size() == 4);
     for (char fp : fps) {
-      TEST_ASSERT(fp == 0);
+      REQUIRE(fp == 0);
     }
 
     bv.setBit(0);
@@ -1111,9 +1092,9 @@ void test10BitVectBinaryText() {
     bv.setBit(26);
 
     fps = BitVectToBinaryText(bv);
-    TEST_ASSERT(fps.size() == 4);
+    REQUIRE(fps.size() == 4);
     for (char fp : fps) {
-      TEST_ASSERT(fp != 0);
+      REQUIRE(fp != 0);
     }
   }
   {
@@ -1121,12 +1102,12 @@ void test10BitVectBinaryText() {
     std::string fps;
 
     fps = BitVectToBinaryText(bv);
-    TEST_ASSERT(fps.size() == 4);
+    REQUIRE(fps.size() == 4);
     for (char fp : fps) {
-      TEST_ASSERT(fp == 0);
+      REQUIRE(fp == 0);
     }
     UpdateBitVectFromBinaryText(bv2, fps);
-    TEST_ASSERT(bv == bv2);
+    REQUIRE(bv == bv2);
 
     bv.setBit(0);
     bv.setBit(1);
@@ -1137,37 +1118,37 @@ void test10BitVectBinaryText() {
 
     fps = BitVectToBinaryText(bv);
     UpdateBitVectFromBinaryText(bv2, fps);
-    TEST_ASSERT(bv == bv2);
+    REQUIRE(bv == bv2);
   }
   {
     ExplicitBitVect bv(33);
     std::string fps;
 
     fps = BitVectToBinaryText(bv);
-    TEST_ASSERT(fps.size() == 5);
+    REQUIRE(fps.size() == 5);
     for (char fp : fps) {
-      TEST_ASSERT(fp == 0);
+      REQUIRE(fp == 0);
     }
 
     bv.setBit(0);
     bv.setBit(32);
 
     fps = BitVectToBinaryText(bv);
-    TEST_ASSERT(fps.size() == 5);
-    TEST_ASSERT(fps[0] != 0);
+    REQUIRE(fps.size() == 5);
+    REQUIRE(fps[0] != 0);
     for (unsigned int i = 1; i < fps.size() - 1; ++i) {
-      TEST_ASSERT(fps[i] == 0);
+      REQUIRE(fps[i] == 0);
     }
-    TEST_ASSERT(fps[fps.size() - 1] != 0);
+    REQUIRE(fps[fps.size() - 1] != 0);
   }
   {
     ExplicitBitVect bv(33), bv2(33);
     std::string fps;
 
     fps = BitVectToBinaryText(bv);
-    TEST_ASSERT(fps.size() == 5);
+    REQUIRE(fps.size() == 5);
     UpdateBitVectFromBinaryText(bv2, fps);
-    TEST_ASSERT(bv == bv2);
+    REQUIRE(bv == bv2);
 
     bv.setBit(0);
     bv.setBit(1);
@@ -1178,11 +1159,11 @@ void test10BitVectBinaryText() {
 
     fps = BitVectToBinaryText(bv);
     UpdateBitVectFromBinaryText(bv2, fps);
-    TEST_ASSERT(bv == bv2);
+    REQUIRE(bv == bv2);
   }
 }
 
-void test11SimilaritiesBV() {
+TEST_CASE("test11SimilaritiesBV") {
   // similarity = 1.0
   ExplicitBitVect bv(10);
   bv.setBit(0);
@@ -1192,16 +1173,16 @@ void test11SimilaritiesBV() {
   bv.setBit(9);
   ExplicitBitVect bv2 = bv;
 
-  TEST_ASSERT(feq(TanimotoSimilarity(bv, bv2), 1.));
-  TEST_ASSERT(feq(DiceSimilarity(bv, bv2), 1.));
-  TEST_ASSERT(feq(CosineSimilarity(bv, bv2), 1.));
-  TEST_ASSERT(feq(KulczynskiSimilarity(bv, bv2), 1.));
-  TEST_ASSERT(feq(SokalSimilarity(bv, bv2), 1.));
-  TEST_ASSERT(feq(McConnaugheySimilarity(bv, bv2), 1.));
-  TEST_ASSERT(feq(BraunBlanquetSimilarity(bv, bv2), 1.));
-  TEST_ASSERT(feq(RusselSimilarity(bv, bv2), 0.5));
-  TEST_ASSERT(feq(RogotGoldbergSimilarity(bv, bv2), 1.));
-  TEST_ASSERT(feq(AllBitSimilarity(bv, bv2), 1.));
+  REQUIRE(feq(TanimotoSimilarity(bv, bv2), 1.));
+  REQUIRE(feq(DiceSimilarity(bv, bv2), 1.));
+  REQUIRE(feq(CosineSimilarity(bv, bv2), 1.));
+  REQUIRE(feq(KulczynskiSimilarity(bv, bv2), 1.));
+  REQUIRE(feq(SokalSimilarity(bv, bv2), 1.));
+  REQUIRE(feq(McConnaugheySimilarity(bv, bv2), 1.));
+  REQUIRE(feq(BraunBlanquetSimilarity(bv, bv2), 1.));
+  REQUIRE(feq(RusselSimilarity(bv, bv2), 0.5));
+  REQUIRE(feq(RogotGoldbergSimilarity(bv, bv2), 1.));
+  REQUIRE(feq(AllBitSimilarity(bv, bv2), 1.));
 
   // similarity = 0.0
   bv2 = ExplicitBitVect(10);
@@ -1211,16 +1192,16 @@ void test11SimilaritiesBV() {
   bv2.setBit(7);
   bv2.setBit(8);
 
-  TEST_ASSERT(feq(TanimotoSimilarity(bv, bv2), 0.));
-  TEST_ASSERT(feq(DiceSimilarity(bv, bv2), 0.));
-  TEST_ASSERT(feq(CosineSimilarity(bv, bv2), 0.));
-  TEST_ASSERT(feq(KulczynskiSimilarity(bv, bv2), 0.));
-  TEST_ASSERT(feq(SokalSimilarity(bv, bv2), 0.));
-  TEST_ASSERT(feq(McConnaugheySimilarity(bv, bv2), -1.));
-  TEST_ASSERT(feq(BraunBlanquetSimilarity(bv, bv2), 0.));
-  TEST_ASSERT(feq(RusselSimilarity(bv, bv2), 0.));
-  TEST_ASSERT(feq(RogotGoldbergSimilarity(bv, bv2), 0.));
-  TEST_ASSERT(feq(AllBitSimilarity(bv, bv2), 0.));
+  REQUIRE(feq(TanimotoSimilarity(bv, bv2), 0.));
+  REQUIRE(feq(DiceSimilarity(bv, bv2), 0.));
+  REQUIRE(feq(CosineSimilarity(bv, bv2), 0.));
+  REQUIRE(feq(KulczynskiSimilarity(bv, bv2), 0.));
+  REQUIRE(feq(SokalSimilarity(bv, bv2), 0.));
+  REQUIRE(feq(McConnaugheySimilarity(bv, bv2), -1.));
+  REQUIRE(feq(BraunBlanquetSimilarity(bv, bv2), 0.));
+  REQUIRE(feq(RusselSimilarity(bv, bv2), 0.));
+  REQUIRE(feq(RogotGoldbergSimilarity(bv, bv2), 0.));
+  REQUIRE(feq(AllBitSimilarity(bv, bv2), 0.));
 
   // similarity ~= 0.5
   bv.setBit(5);
@@ -1232,19 +1213,19 @@ void test11SimilaritiesBV() {
   bv2.setBit(8);
   bv2.setBit(9);
 
-  TEST_ASSERT(feq(TanimotoSimilarity(bv, bv2), 0.5));
-  TEST_ASSERT(feq(DiceSimilarity(bv, bv2), 0.6666));
-  TEST_ASSERT(feq(CosineSimilarity(bv, bv2), 0.6666));
-  TEST_ASSERT(feq(KulczynskiSimilarity(bv, bv2), 0.6666));
-  TEST_ASSERT(feq(SokalSimilarity(bv, bv2), 0.3333));
-  TEST_ASSERT(feq(McConnaugheySimilarity(bv, bv2), 0.3333));
-  TEST_ASSERT(feq(BraunBlanquetSimilarity(bv, bv2), 0.6666));
-  TEST_ASSERT(feq(RusselSimilarity(bv, bv2), 0.4));
-  TEST_ASSERT(feq(RogotGoldbergSimilarity(bv, bv2), 0.5833));
-  TEST_ASSERT(feq(AllBitSimilarity(bv, bv2), 0.6));
+  REQUIRE(feq(TanimotoSimilarity(bv, bv2), 0.5));
+  REQUIRE(feq(DiceSimilarity(bv, bv2), 0.6666));
+  REQUIRE(feq(CosineSimilarity(bv, bv2), 0.6666));
+  REQUIRE(feq(KulczynskiSimilarity(bv, bv2), 0.6666));
+  REQUIRE(feq(SokalSimilarity(bv, bv2), 0.3333));
+  REQUIRE(feq(McConnaugheySimilarity(bv, bv2), 0.3333));
+  REQUIRE(feq(BraunBlanquetSimilarity(bv, bv2), 0.6666));
+  REQUIRE(feq(RusselSimilarity(bv, bv2), 0.4));
+  REQUIRE(feq(RogotGoldbergSimilarity(bv, bv2), 0.5833));
+  REQUIRE(feq(AllBitSimilarity(bv, bv2), 0.6));
 }
 
-void test12SimilaritiesSparseBV() {
+TEST_CASE("test12SimilaritiesSparseBV") {
   // similarity = 1.0
   SparseBitVect sbv(10);
   sbv.setBit(0);
@@ -1254,16 +1235,16 @@ void test12SimilaritiesSparseBV() {
   sbv.setBit(9);
   SparseBitVect sbv2 = sbv;
 
-  TEST_ASSERT(feq(TanimotoSimilarity(sbv, sbv2), 1.));
-  TEST_ASSERT(feq(DiceSimilarity(sbv, sbv2), 1.));
-  TEST_ASSERT(feq(CosineSimilarity(sbv, sbv2), 1.));
-  TEST_ASSERT(feq(KulczynskiSimilarity(sbv, sbv2), 1.));
-  TEST_ASSERT(feq(SokalSimilarity(sbv, sbv2), 1.));
-  TEST_ASSERT(feq(McConnaugheySimilarity(sbv, sbv2), 1.));
-  TEST_ASSERT(feq(BraunBlanquetSimilarity(sbv, sbv2), 1.));
-  TEST_ASSERT(feq(RusselSimilarity(sbv, sbv2), 0.5));
-  TEST_ASSERT(feq(RogotGoldbergSimilarity(sbv, sbv2), 1.));
-  TEST_ASSERT(feq(AllBitSimilarity(sbv, sbv2), 1.));
+  REQUIRE(feq(TanimotoSimilarity(sbv, sbv2), 1.));
+  REQUIRE(feq(DiceSimilarity(sbv, sbv2), 1.));
+  REQUIRE(feq(CosineSimilarity(sbv, sbv2), 1.));
+  REQUIRE(feq(KulczynskiSimilarity(sbv, sbv2), 1.));
+  REQUIRE(feq(SokalSimilarity(sbv, sbv2), 1.));
+  REQUIRE(feq(McConnaugheySimilarity(sbv, sbv2), 1.));
+  REQUIRE(feq(BraunBlanquetSimilarity(sbv, sbv2), 1.));
+  REQUIRE(feq(RusselSimilarity(sbv, sbv2), 0.5));
+  REQUIRE(feq(RogotGoldbergSimilarity(sbv, sbv2), 1.));
+  REQUIRE(feq(AllBitSimilarity(sbv, sbv2), 1.));
 
   // similarity = 0.0
   sbv2 = SparseBitVect(10);
@@ -1273,16 +1254,16 @@ void test12SimilaritiesSparseBV() {
   sbv2.setBit(7);
   sbv2.setBit(8);
 
-  TEST_ASSERT(feq(TanimotoSimilarity(sbv, sbv2), 0.));
-  TEST_ASSERT(feq(DiceSimilarity(sbv, sbv2), 0.));
-  TEST_ASSERT(feq(CosineSimilarity(sbv, sbv2), 0.));
-  TEST_ASSERT(feq(KulczynskiSimilarity(sbv, sbv2), 0.));
-  TEST_ASSERT(feq(SokalSimilarity(sbv, sbv2), 0.));
-  TEST_ASSERT(feq(McConnaugheySimilarity(sbv, sbv2), -1.));
-  TEST_ASSERT(feq(BraunBlanquetSimilarity(sbv, sbv2), 0.));
-  TEST_ASSERT(feq(RusselSimilarity(sbv, sbv2), 0.));
-  TEST_ASSERT(feq(RogotGoldbergSimilarity(sbv, sbv2), 0.));
-  TEST_ASSERT(feq(AllBitSimilarity(sbv, sbv2), 0.));
+  REQUIRE(feq(TanimotoSimilarity(sbv, sbv2), 0.));
+  REQUIRE(feq(DiceSimilarity(sbv, sbv2), 0.));
+  REQUIRE(feq(CosineSimilarity(sbv, sbv2), 0.));
+  REQUIRE(feq(KulczynskiSimilarity(sbv, sbv2), 0.));
+  REQUIRE(feq(SokalSimilarity(sbv, sbv2), 0.));
+  REQUIRE(feq(McConnaugheySimilarity(sbv, sbv2), -1.));
+  REQUIRE(feq(BraunBlanquetSimilarity(sbv, sbv2), 0.));
+  REQUIRE(feq(RusselSimilarity(sbv, sbv2), 0.));
+  REQUIRE(feq(RogotGoldbergSimilarity(sbv, sbv2), 0.));
+  REQUIRE(feq(AllBitSimilarity(sbv, sbv2), 0.));
 
   // similarity ~= 0.5
   sbv.setBit(5);
@@ -1294,121 +1275,121 @@ void test12SimilaritiesSparseBV() {
   sbv2.setBit(8);
   sbv2.setBit(9);
 
-  TEST_ASSERT(feq(TanimotoSimilarity(sbv, sbv2), 0.5));
-  TEST_ASSERT(feq(DiceSimilarity(sbv, sbv2), 0.6666));
-  TEST_ASSERT(feq(CosineSimilarity(sbv, sbv2), 0.6666));
-  TEST_ASSERT(feq(KulczynskiSimilarity(sbv, sbv2), 0.6666));
-  TEST_ASSERT(feq(SokalSimilarity(sbv, sbv2), 0.3333));
-  TEST_ASSERT(feq(McConnaugheySimilarity(sbv, sbv2), 0.3333));
-  TEST_ASSERT(feq(BraunBlanquetSimilarity(sbv, sbv2), 0.6666));
-  TEST_ASSERT(feq(RusselSimilarity(sbv, sbv2), 0.4));
-  TEST_ASSERT(feq(RogotGoldbergSimilarity(sbv, sbv2), 0.5833));
-  TEST_ASSERT(feq(AllBitSimilarity(sbv, sbv2), 0.6));
+  REQUIRE(feq(TanimotoSimilarity(sbv, sbv2), 0.5));
+  REQUIRE(feq(DiceSimilarity(sbv, sbv2), 0.6666));
+  REQUIRE(feq(CosineSimilarity(sbv, sbv2), 0.6666));
+  REQUIRE(feq(KulczynskiSimilarity(sbv, sbv2), 0.6666));
+  REQUIRE(feq(SokalSimilarity(sbv, sbv2), 0.3333));
+  REQUIRE(feq(McConnaugheySimilarity(sbv, sbv2), 0.3333));
+  REQUIRE(feq(BraunBlanquetSimilarity(sbv, sbv2), 0.6666));
+  REQUIRE(feq(RusselSimilarity(sbv, sbv2), 0.4));
+  REQUIRE(feq(RogotGoldbergSimilarity(sbv, sbv2), 0.5833));
+  REQUIRE(feq(AllBitSimilarity(sbv, sbv2), 0.6));
 }
 
-void test13BitVectAllOnes() {
+TEST_CASE("test13BitVectAllOnes") {
   {
     ExplicitBitVect bv(32, false);
-    TEST_ASSERT(bv.getNumOnBits() == 0);
-    TEST_ASSERT(bv[0] == 0);
+    REQUIRE(bv.getNumOnBits() == 0);
+    REQUIRE(!bv[0]);
 
     ExplicitBitVect bv2(32, true);
-    TEST_ASSERT(bv2.getNumOnBits() == 32);
-    TEST_ASSERT(bv2[0] == 1);
+    REQUIRE(bv2.getNumOnBits() == 32);
+    REQUIRE(bv2[0]);
   }
 }
 
-void test14BitVectConcatenation() {
+TEST_CASE("test14BitVectConcatenation") {
   {
     ExplicitBitVect bv(32, false);
     ExplicitBitVect bv2(32, true);
     ExplicitBitVect bv3 = bv + bv2;
-    TEST_ASSERT(bv3.getNumBits() == 64);
-    TEST_ASSERT(bv3.getNumOnBits() == 32);
-    TEST_ASSERT(bv3.getNumOffBits() == 32);
+    REQUIRE(bv3.getNumBits() == 64);
+    REQUIRE(bv3.getNumOnBits() == 32);
+    REQUIRE(bv3.getNumOffBits() == 32);
   }
 }
 
-void test15BitmapOps() {
+TEST_CASE("test15BitmapOps") {
   {
     const unsigned char bv1[5] = {0x1, 0x1, 0x1, 0x1, 0x1};
-    TEST_ASSERT(CalcBitmapPopcount(bv1, 5) == 5);
+    REQUIRE(CalcBitmapPopcount(bv1, 5) == 5);
   }
   {
     const unsigned char bv1[5] = {0x1, 0x1, 0x3, 0x1, 0x1};
-    TEST_ASSERT(CalcBitmapPopcount(bv1, 5) == 6);
+    REQUIRE(CalcBitmapPopcount(bv1, 5) == 6);
   }
   {
     const unsigned char bv1[5] = {0x0, 0x0, 0x0, 0x0, 0x0};
-    TEST_ASSERT(CalcBitmapPopcount(bv1, 5) == 0);
+    REQUIRE(CalcBitmapPopcount(bv1, 5) == 0);
   }
   {
     const unsigned char bv1[5] = {0x1, 0x1, 0x1, 0x1, 0x1};
     const unsigned char bv2[5] = {0x1, 0x1, 0x1, 0x1, 0x1};
-    TEST_ASSERT(feq(CalcBitmapTanimoto(bv1, bv2, 5), 1.0));
+    REQUIRE(feq(CalcBitmapTanimoto(bv1, bv2, 5), 1.0));
   }
   {
     const unsigned char bv1[5] = {0x1, 0x1, 0x1, 0x1, 0x1};
     const unsigned char bv2[5] = {0x1, 0x1, 0x1, 0x0, 0x1};
-    TEST_ASSERT(feq(CalcBitmapTanimoto(bv1, bv2, 5), 0.8));
+    REQUIRE(feq(CalcBitmapTanimoto(bv1, bv2, 5), 0.8));
   }
   {
     const unsigned char bv1[5] = {0x1, 0x1, 0x1, 0x1, 0x1};
     const unsigned char bv2[5] = {0x1, 0x1, 0x1, 0x1, 0x1};
-    TEST_ASSERT(feq(CalcBitmapTversky(bv1, bv2, 5, 1., 1.), 1.0));
+    REQUIRE(feq(CalcBitmapTversky(bv1, bv2, 5, 1., 1.), 1.0));
   }
   {
     const unsigned char bv1[5] = {0x1, 0x1, 0x1, 0x1, 0x1};
     const unsigned char bv2[5] = {0x1, 0x1, 0x1, 0x0, 0x1};
-    TEST_ASSERT(feq(CalcBitmapTversky(bv1, bv2, 5, 1., 1.), 0.8));
+    REQUIRE(feq(CalcBitmapTversky(bv1, bv2, 5, 1., 1.), 0.8));
   }
   {
     const unsigned char bv1[5] = {0x1, 0x1, 0x1, 0x1, 0x1};
     const unsigned char bv2[5] = {0x1, 0x1, 0x1, 0x1, 0x1};
-    TEST_ASSERT(feq(CalcBitmapDice(bv1, bv2, 5), 1.0));
+    REQUIRE(feq(CalcBitmapDice(bv1, bv2, 5), 1.0));
   }
   {
     const unsigned char bv1[5] = {0x1, 0x1, 0x1, 0x1, 0x1};
     const unsigned char bv2[5] = {0x1, 0x1, 0x1, 0x0, 0x1};
-    TEST_ASSERT(feq(CalcBitmapDice(bv1, bv2, 5), 8. / 9));
+    REQUIRE(feq(CalcBitmapDice(bv1, bv2, 5), 8. / 9));
   }
   {
     const unsigned char bv1[5] = {0x1, 0x1, 0x1, 0x1, 0x1};
     const unsigned char bv2[5] = {0x1, 0x1, 0x1, 0x1, 0x1};
-    TEST_ASSERT(feq(CalcBitmapTversky(bv1, bv2, 5, 0.5, 0.5), 1.0));
+    REQUIRE(feq(CalcBitmapTversky(bv1, bv2, 5, 0.5, 0.5), 1.0));
   }
   {
     const unsigned char bv1[5] = {0x1, 0x1, 0x1, 0x1, 0x1};
     const unsigned char bv2[5] = {0x1, 0x1, 0x1, 0x0, 0x1};
-    TEST_ASSERT(feq(CalcBitmapTversky(bv1, bv2, 5, 0.5, 0.5), 8. / 9));
+    REQUIRE(feq(CalcBitmapTversky(bv1, bv2, 5, 0.5, 0.5), 8. / 9));
   }
 
   {
     const unsigned char bv1[5] = {0x1, 0x0, 0x1, 0x0, 0x1};
     const unsigned char bv2[5] = {0x1, 0x1, 0x5, 0x1, 0x1};
-    TEST_ASSERT(CalcBitmapAllProbeBitsMatch(bv1, bv2, 5));
+    REQUIRE(CalcBitmapAllProbeBitsMatch(bv1, bv2, 5));
   }
   {
     const unsigned char bv1[5] = {0x1, 0x0, 0x1, 0x0, 0x1};
     const unsigned char bv2[5] = {0x1, 0x1, 0x2, 0x1, 0x1};
-    TEST_ASSERT(!CalcBitmapAllProbeBitsMatch(bv1, bv2, 5));
+    REQUIRE(!CalcBitmapAllProbeBitsMatch(bv1, bv2, 5));
   }
 
   {
     const unsigned char bv1[5] = {0x1, 0x0, 0x1, 0x0, 0x1};
     const unsigned char bv2[5] = {0x1, 0x1, 0x5, 0x1, 0x1};
-    TEST_ASSERT(feq(CalcBitmapTversky(bv1, bv2, 5, 1.0, 0.), 1.0));
+    REQUIRE(feq(CalcBitmapTversky(bv1, bv2, 5, 1.0, 0.), 1.0));
   }
 }
 
-void test16BitVectProps() {
+TEST_CASE("test16BitVectProps") {
   ExplicitBitVect bv(32);
   for (int i = 0; i < 32; i += 2) {
     bv.setBit(i);
   }
 
   ExplicitBitVect bv2(bv.toString());
-  TEST_ASSERT(bv == bv2);
+  REQUIRE(bv == bv2);
 
   Dict d;
   d.setVal<ExplicitBitVect>("exp", bv);
@@ -1417,20 +1398,20 @@ void test16BitVectProps() {
   DataStructsExplicitBitVecPropHandler bv_handler;
   std::vector<CustomPropHandler *> handlers = {&bv_handler, bv_handler.clone()};
   for (auto handler : handlers) {
-    TEST_ASSERT(handler->canSerialize(value));
+    REQUIRE(handler->canSerialize(value));
     RDValue bad_value = 1;
-    TEST_ASSERT(!handler->canSerialize(bad_value));
+    REQUIRE(!handler->canSerialize(bad_value));
     std::stringstream ss;
-    TEST_ASSERT(handler->write(ss, value));
+    REQUIRE(handler->write(ss, value));
     RDValue newValue;
-    TEST_ASSERT(handler->read(ss, newValue));
-    TEST_ASSERT(from_rdvalue<ExplicitBitVect>(newValue) == bv);
+    REQUIRE(handler->read(ss, newValue));
+    REQUIRE(from_rdvalue<ExplicitBitVect>(newValue) == bv);
     newValue.destroy();
   }
   delete handlers[1];
 }
 
-void test17Github3994() {
+TEST_CASE("test17Github3994") {
   SparseIntVect<std::uint32_t> siv1(128);
   siv1.setVal(0, 3);
   siv1.setVal(100, 4);
@@ -1441,27 +1422,27 @@ void test17Github3994() {
   siv2.setVal(99, 4);
 
   auto siv3 = siv1;
-  TEST_ASSERT(siv3.getNonzeroElements().size() == 2);
-  TEST_ASSERT(siv3 == siv1);
-  TEST_ASSERT(siv3 != siv2);
+  REQUIRE(siv3.getNonzeroElements().size() == 2);
+  REQUIRE(siv3 == siv1);
+  REQUIRE(siv3 != siv2);
 
   siv1 = siv2;
-  TEST_ASSERT(siv1.getNonzeroElements().size() == 3);
-  TEST_ASSERT(siv1 != siv3);
-  TEST_ASSERT(siv1 == siv2);
+  REQUIRE(siv1.getNonzeroElements().size() == 3);
+  REQUIRE(siv1 != siv3);
+  REQUIRE(siv1 == siv2);
 }
 
-void test14RealVect() {
+TEST_CASE("test14RealVect") {
   RealValueVect vect1(30);
   unsigned int i;
   for (i = 0; i < 15; ++i) {
     vect1.setVal(2 * i, 1.0);
   }
 
-  TEST_ASSERT(vect1.getLength() == 30);
-  TEST_ASSERT(feq(vect1.getTotalVal(), 15.0));
+  REQUIRE(vect1.getLength() == 30);
+  REQUIRE(feq(vect1.getTotalVal(), 15.0));
   for (i = 0; i < vect1.getLength(); ++i) {
-    TEST_ASSERT(feq(vect1.getVal(i), (i + 1) % 2));
+    REQUIRE(feq(vect1.getVal(i), (i + 1) % 2));
   }
 
   RealValueVect vect2(30);
@@ -1469,24 +1450,24 @@ void test14RealVect() {
     vect2.setVal(i, double(1.0 / (i + 1.0)));
   }
 
-  TEST_ASSERT(vect2.getLength() == 30);
+  REQUIRE(vect2.getLength() == 30);
   for (i = 0; i < vect2.getLength(); ++i) {
-    TEST_ASSERT(feq(vect2.getVal(i), double(1.0 / (i + 1.0))));
+    REQUIRE(feq(vect2.getVal(i), double(1.0 / (i + 1.0))));
   }
 
   // test copy constructor and operator[]
   RealValueVect vect3(vect2);
-  TEST_ASSERT(vect3.getLength() == 30);
+  REQUIRE(vect3.getLength() == 30);
   for (i = 0; i < vect3.getLength(); ++i) {
-    TEST_ASSERT(feq(vect3[i], double(1.0 / (i + 1.0))));
+    REQUIRE(feq(vect3[i], double(1.0 / (i + 1.0))));
   }
 
   double Pi = 3.141592;
   RealValueVect vect4(60, Pi);
-  TEST_ASSERT(feq(vect4.getTotalVal(), 60 * Pi));
+  REQUIRE(feq(vect4.getTotalVal(), 60 * Pi));
 }
 
-void test15RealVectDists() {
+TEST_CASE("test15RealVectDists") {
   RealValueVect v1(30);
   RealValueVect v2(30);
   unsigned int i;
@@ -1494,12 +1475,12 @@ void test15RealVectDists() {
     v1.setVal(2 * i, 1.0);
     v2.setVal(2 * i, 1.0);
   }
-  TEST_ASSERT(feq(computeL1Norm(v1, v2), 0));
+  REQUIRE(feq(computeL1Norm(v1, v2), 0));
   for (i = 0; i < 30; ++i) {
     v2.setVal(i, i % 2);
   }
 
-  TEST_ASSERT(feq(computeL1Norm(v1, v2), 30.0));
+  REQUIRE(feq(computeL1Norm(v1, v2), 30.0));
 
   for (i = 0; i < 30; ++i) {
     if (i % 3 == 0) {
@@ -1509,62 +1490,61 @@ void test15RealVectDists() {
     }
   }
 
-  TEST_ASSERT(feq(computeL1Norm(v1, v2), 15.0));
+  REQUIRE(feq(computeL1Norm(v1, v2), 15.0));
 
   for (i = 0; i < 30; ++i) {
     v1.setVal(i, 0.0);
     v2.setVal(i, i / 10.0);
   }
 
-  TEST_ASSERT(feq(computeL1Norm(v1, v2), 43.5))
+  REQUIRE(feq(computeL1Norm(v1, v2), 43.5));
 }
 
-void test16RealVectPickles() {
+TEST_CASE("test16RealVectPickles") {
   RealValueVect v1(30);
   unsigned int i;
   for (i = 0; i < 15; ++i) {
     v1.setVal(2 * i, 1.1);
   }
   RealValueVect v2(v1.toString());
-  TEST_ASSERT(feq(computeL1Norm(v1, v2), 0.0));
+  CHECK_THAT(computeL1Norm(v1, v2), Catch::Matchers::WithinAbs(0.0, 0.001));
 }
 
-void test17RealVectOps() {
+TEST_CASE("test17RealVectOps") {
   RealValueVect vect1(8);
   for (unsigned int i = 0; i < 4; ++i) {
     vect1.setVal(2 * i, 2.1);
   }
-  TEST_ASSERT(vect1.getLength() == 8);
-  TEST_ASSERT(feq(vect1.getTotalVal(), 8.4));
+  REQUIRE(vect1.getLength() == 8);
+  CHECK_THAT(vect1.getTotalVal(), Catch::Matchers::WithinAbs(8.4, 0.001));
 
   RealValueVect vect2(8);
   for (unsigned int i = 0; i < 4; ++i) {
     vect2.setVal(2 * i + 1, 2.2);
     vect2.setVal(2 * i, 1.1);
   }
-  TEST_ASSERT(feq(vect2.getTotalVal(), 13.2));
+  CHECK_THAT(vect2.getTotalVal(), Catch::Matchers::WithinAbs(13.2, 0.001));
 
   RealValueVect vect3 = vect1 & vect2;
-  TEST_ASSERT(vect3.getLength() == 8);
-  TEST_ASSERT(feq(vect3.getTotalVal(), 4.4));
+  REQUIRE(vect3.getLength() == 8);
+  CHECK_THAT(vect3.getTotalVal(), Catch::Matchers::WithinAbs(4.4, 0.001));
 
   RealValueVect vect4 = vect1 | vect2;
-  TEST_ASSERT(vect4.getLength() == 8);
-  TEST_ASSERT(feq(vect4.getTotalVal(), 17.2));
+  REQUIRE(vect4.getLength() == 8);
+  CHECK_THAT(vect4.getTotalVal(), Catch::Matchers::WithinAbs(17.2, 0.001));
 
   RealValueVect vect5 = vect1 + vect2;
-  TEST_ASSERT(vect5.getLength() == 8);
-  TEST_ASSERT(feq(vect5.getTotalVal(), 21.6));
+  REQUIRE(vect5.getLength() == 8);
+  CHECK_THAT(vect5.getTotalVal(), Catch::Matchers::WithinAbs(21.6, 0.001));
 
   vect5 = vect1 - vect2;
-  TEST_ASSERT(feq(vect5.getTotalVal(), -4.8));
+  CHECK_THAT(vect5.getTotalVal(), Catch::Matchers::WithinAbs(-4.8, 0.001));
+
   vect5 = vect2 - vect1;
-  TEST_ASSERT(feq(vect5.getTotalVal(), 4.8));
+  CHECK_THAT(vect5.getTotalVal(), Catch::Matchers::WithinAbs(4.8, 0.001));
 }
 
-int main() {
-  RDLog::InitLogs();
-  boost::logging::enable_logs("rdApp.info");
+TEST_CASE("old main") {
   try {
     throw IndexErrorException(3);
   } catch (IndexErrorException &) {
@@ -1583,111 +1563,15 @@ int main() {
   TXTMSG("v3", v3);
   TXTMSG("v4", v4);
 
-  BOOST_LOG(rdInfoLog) << " SPARSE -----------------------------------"
-                       << std::endl;
-  SparseBitVect sparseFoo(10);
-  Test(sparseFoo);
-  TaniTest(sparseFoo);
-  ProbeTest(sparseFoo);
-  BOOST_LOG(rdInfoLog) << " Explicit ----------------------------------"
-                       << std::endl;
-  ExplicitBitVect explicitFoo(10);
-  Test(explicitFoo);
-  TaniTest(explicitFoo);
-  BOOST_LOG(rdInfoLog) << " Done" << std::endl;
-
-  BOOST_LOG(rdInfoLog)
-      << " Test DiscreteValue Vectors 1 ----------------------------" << endl;
-  test1DiscreteVect();
-  BOOST_LOG(rdInfoLog)
-      << " Test DiscreteValue Vectors 2 ------------------------------" << endl;
-  test2DiscreteVectDists();
-  BOOST_LOG(rdInfoLog)
-      << " Test DiscreteValue Vectors 3 ---------------------------" << endl;
-  test3DiscreteVectPickles();
-
-  BOOST_LOG(rdInfoLog)
-      << " Test DiscreteValue Operations -----------------------------" << endl;
-  test4DiscreteVectOps1();
-
-  BOOST_LOG(rdInfoLog)
-      << " Test DiscreteValue Operations 2 -------------------------- " << endl;
-  test5DiscreteVectOps2();
-
-  BOOST_LOG(rdInfoLog)
-      << " Test SparseIntVect  ------------------------------------"
-      << std::endl;
-  test6SparseIntVect();
-  BOOST_LOG(rdInfoLog)
-      << " Test SparseIntVect Serialization  --------------------------"
-      << std::endl;
-  test7SparseIntVectPickles();
-
-  BOOST_LOG(rdInfoLog)
-      << " Test BitVect Serialization  -------------------------------"
-      << std::endl;
-  test8BitVectPickles();
-
-  BOOST_LOG(rdInfoLog)
-      << " Test BitVect to FPS  -------------------------------" << std::endl;
-  test9BitVectFPS();
-
-  BOOST_LOG(rdInfoLog)
-      << " Test BitVect to binary string  -------------------------------"
-      << std::endl;
-  test10BitVectBinaryText();
-
-  BOOST_LOG(rdInfoLog)
-      << " Test Similarity Measures BitVect -------------------------------"
-      << std::endl;
-  test11SimilaritiesBV();
-
-  BOOST_LOG(rdInfoLog) << " Test Similarity Measures SparseBitVect "
-                          "-------------------------------"
-                       << std::endl;
-  test12SimilaritiesSparseBV();
-
-  BOOST_LOG(rdInfoLog)
-      << " Test BitVect with all ones -------------------------------"
-      << std::endl;
-  test13BitVectAllOnes();
-
-  BOOST_LOG(rdInfoLog) << " Test Explicit BitVects: Concatenation Operation  "
-                          "-------------------------------"
-                       << std::endl;
-  test14BitVectConcatenation();
-
-  BOOST_LOG(rdInfoLog) << " Test bitmap operations  "
-                          "-------------------------------"
-                       << std::endl;
-  test15BitmapOps();
-
-  BOOST_LOG(rdInfoLog) << " Test bitmaps as properties "
-                          "-------------------------------"
-                       << std::endl;
-  test16BitVectProps();
-
-  BOOST_LOG(rdInfoLog) << " Test #3944: SparseIntVect copy constructor and "
-                          "assignment operators not clearing existing data"
-                          "-------------------------------"
-                       << std::endl;
-  test17Github3994();
-
-  BOOST_LOG(rdInfoLog)
-      << " Test RealValue Vectors 1: Constructors and Accessing Values -------------------------------"
-      << std::endl;
-  test14RealVect();
-  BOOST_LOG(rdInfoLog)
-      << " Test RealValue Vectors 2: L1Norm -------------------------------"
-      << std::endl;
-  test15RealVectDists();
-  BOOST_LOG(rdInfoLog)
-      << " Test RealValue Vectors 3: Pickles -------------------------------"
-      << std::endl;
-  test16RealVectPickles();
-  BOOST_LOG(rdInfoLog)
-      << " Test RealValue Vectors 4: Vector Operations  -------------------------------"
-      << std::endl;
-  test17RealVectOps();
-  return 0;
+  SECTION("sparse") {
+    SparseBitVect sparseFoo(10);
+    Test(sparseFoo);
+    TaniTest(sparseFoo);
+    ProbeTest(sparseFoo);
+  }
+  SECTION("explicit") {
+    ExplicitBitVect explicitFoo(10);
+    Test(explicitFoo);
+    TaniTest(explicitFoo);
+  }
 }

--- a/Code/DataStructs/testFPB.cpp
+++ b/Code/DataStructs/testFPB.cpp
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2016 Greg Landrum
+//  Copyright (C) 2016-2025 Greg Landrum and other RDKit contributors
 //
 //  @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -7,12 +7,8 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
-#include <RDGeneral/test.h>
-#include <RDGeneral/Invariant.h>
-#include <RDGeneral/RDLog.h>
-#include <RDGeneral/Exceptions.h>
+#include <catch2/catch_all.hpp>
 #include <RDGeneral/utils.h>
-
 #include <DataStructs/ExplicitBitVect.h>
 #include <DataStructs/FPBReader.h>
 
@@ -20,67 +16,64 @@ using namespace RDKit;
 
 void _basicsTest(FPBReader &fps) {
   fps.init();
-  TEST_ASSERT(fps.length() == 100);
-  TEST_ASSERT(fps.nBits() == 2048);
+  REQUIRE(fps.length() == 100);
+  REQUIRE(fps.nBits() == 2048);
 
   {  // pop counts
     std::pair<unsigned int, unsigned int> offsets;
     offsets = fps.getFPIdsInCountRange(17, 17);
-    TEST_ASSERT(offsets.first == 0);
-    TEST_ASSERT(offsets.second == 1);
+    REQUIRE(offsets.first == 0);
+    REQUIRE(offsets.second == 1);
     offsets = fps.getFPIdsInCountRange(60, 65);
-    TEST_ASSERT(offsets.first == 96);
-    TEST_ASSERT(offsets.second == 100);
+    REQUIRE(offsets.first == 96);
+    REQUIRE(offsets.second == 100);
     offsets = fps.getFPIdsInCountRange(160, 165);
-    TEST_ASSERT(offsets.first == 100);
-    TEST_ASSERT(offsets.second == 100);
+    REQUIRE(offsets.first == 100);
+    REQUIRE(offsets.second == 100);
   }
   {  // get* version
     std::string nm = fps.getId(0);
-    // std::cerr << " nm: >" << nm << "<" << std::endl;
-    TEST_ASSERT(nm == "ZINC00902219");
+    REQUIRE(nm == "ZINC00902219");
     boost::shared_ptr<ExplicitBitVect> fp = fps.getFP(0);
-    TEST_ASSERT(fp);
-    TEST_ASSERT(fp->getNumBits() == 2048);
-    TEST_ASSERT(fp->getNumOnBits() == 17);
+    REQUIRE(fp);
+    REQUIRE(fp->getNumBits() == 2048);
+    REQUIRE(fp->getNumOnBits() == 17);
     unsigned int obs[17] = {1,   80,  183, 222,  227,  231,  482,  650, 807,
                             811, 831, 888, 1335, 1411, 1664, 1820, 1917};
     for (unsigned int i = 0; i < fp->getNumOnBits(); ++i) {
-      TEST_ASSERT(fp->getBit(obs[i]));
+      REQUIRE(fp->getBit(obs[i]));
     }
   }
   {  // operator[] version
     std::pair<boost::shared_ptr<ExplicitBitVect>, std::string> tpl = fps[0];
     boost::shared_ptr<ExplicitBitVect> fp = tpl.first;
-    TEST_ASSERT(fp);
-    TEST_ASSERT(fp->getNumBits() == 2048);
-    TEST_ASSERT(fp->getNumOnBits() == 17);
+    REQUIRE(fp);
+    REQUIRE(fp->getNumBits() == 2048);
+    REQUIRE(fp->getNumOnBits() == 17);
     unsigned int obs[17] = {1,   80,  183, 222,  227,  231,  482,  650, 807,
                             811, 831, 888, 1335, 1411, 1664, 1820, 1917};
     for (unsigned int i = 0; i < fp->getNumOnBits(); ++i) {
-      TEST_ASSERT(fp->getBit(obs[i]));
+      REQUIRE(fp->getBit(obs[i]));
     }
-    TEST_ASSERT(tpl.second == "ZINC00902219");
+    REQUIRE(tpl.second == "ZINC00902219");
   }
   {  // test another fp
     boost::shared_ptr<ExplicitBitVect> fp = fps.getFP(3);
-    TEST_ASSERT(fp);
-    TEST_ASSERT(fp->getNumBits() == 2048);
-    TEST_ASSERT(fp->getNumOnBits() == 20);
+    REQUIRE(fp);
+    REQUIRE(fp->getNumBits() == 2048);
+    REQUIRE(fp->getNumOnBits() == 20);
     unsigned int obs[20] = {1,   8,    80,   95,   222,  227, 457,
                             482, 650,  680,  715,  807,  831, 845,
                             888, 1226, 1556, 1711, 1917, 1982};
     for (unsigned int i = 0; i < fp->getNumOnBits(); ++i) {
-      TEST_ASSERT(fp->getBit(obs[i]));
+      REQUIRE(fp->getBit(obs[i]));
     }
     std::string nm = fps.getId(3);
-    TEST_ASSERT(nm == "ZINC04803506");
+    REQUIRE(nm == "ZINC04803506");
   }
 }
 
-void test1FPBReaderBasics() {
-  BOOST_LOG(rdInfoLog) << "-----------------------\n Testing FPBReader basics "
-                       << std::endl;
+TEST_CASE("FPBReader Basics") {
   std::string pathName = getenv("RDBASE");
   pathName += "/Code/DataStructs/testData/";
   {
@@ -89,13 +82,9 @@ void test1FPBReaderBasics() {
     _basicsTest(fps);
     fps.cleanup();  // make sure this doesn't cause problems
   }
-  BOOST_LOG(rdInfoLog) << "Finished" << std::endl;
 }
 
-void test9LazyFPBReaderBasics() {
-  BOOST_LOG(rdInfoLog)
-      << "-----------------------\n Testing Lazy FPBReader basics "
-      << std::endl;
+TEST_CASE("Lazy FPBReader Basics") {
   std::string pathName = getenv("RDBASE");
   pathName += "/Code/DataStructs/testData/";
   {
@@ -104,253 +93,233 @@ void test9LazyFPBReaderBasics() {
     _basicsTest(fps);
     fps.cleanup();  // make sure this doesn't cause problems
   }
-  BOOST_LOG(rdInfoLog) << "Finished" << std::endl;
 }
 
-void test2FPBReaderTanimoto() {
-  BOOST_LOG(rdInfoLog)
-      << "-----------------------\n Testing FPBReader tanimoto " << std::endl;
+TEST_CASE("FPBReader Tanimoto") {
   std::string pathName = getenv("RDBASE");
   pathName += "/Code/DataStructs/testData/";
   {
     std::string filename = pathName + "zim.head100.fpb";
     FPBReader fps(filename);
     fps.init();
-    TEST_ASSERT(fps.length() == 100);
+    REQUIRE(fps.length() == 100);
     {
       boost::shared_array<std::uint8_t> bytes = fps.getBytes(0);
-      TEST_ASSERT(bytes);
-      TEST_ASSERT(feq(fps.getTanimoto(0, bytes), 1.0));
-      TEST_ASSERT(feq(fps.getTanimoto(1, bytes), 0.3703));
+      REQUIRE(bytes);
+      REQUIRE(feq(fps.getTanimoto(0, bytes), 1.0));
+      REQUIRE(feq(fps.getTanimoto(1, bytes), 0.3703));
     }
     {
       boost::shared_array<std::uint8_t> bytes = fps.getBytes(1);
-      TEST_ASSERT(bytes);
-      TEST_ASSERT(feq(fps.getTanimoto(1, bytes), 1.0));
-      TEST_ASSERT(feq(fps.getTanimoto(0, bytes), 0.3703));
-      TEST_ASSERT(feq(fps.getTanimoto(2, bytes), 1.0));
-      TEST_ASSERT(feq(fps.getTanimoto(5, bytes), 0.2903));
+      REQUIRE(bytes);
+      REQUIRE(feq(fps.getTanimoto(1, bytes), 1.0));
+      REQUIRE(feq(fps.getTanimoto(0, bytes), 0.3703));
+      REQUIRE(feq(fps.getTanimoto(2, bytes), 1.0));
+      REQUIRE(feq(fps.getTanimoto(5, bytes), 0.2903));
     }
   }
-  BOOST_LOG(rdInfoLog) << "Finished" << std::endl;
 }
 
-void test3FPBReaderTanimotoNeighbors() {
-  BOOST_LOG(rdInfoLog)
-      << "-----------------------\n Testing FPBReader tanimoto neighbors"
-      << std::endl;
+TEST_CASE("FPBReader Tanimoto Neighbors") {
   std::string pathName = getenv("RDBASE");
   pathName += "/Code/DataStructs/testData/";
   {
     std::string filename = pathName + "zim.head100.fpb";
     FPBReader fps(filename);
     fps.init();
-    TEST_ASSERT(fps.length() == 100);
+    REQUIRE(fps.length() == 100);
     {
       boost::shared_array<std::uint8_t> bytes = fps.getBytes(0);
-      TEST_ASSERT(bytes);
+      REQUIRE(bytes);
       std::vector<std::pair<double, unsigned int>> nbrs =
           fps.getTanimotoNeighbors(bytes);
-      TEST_ASSERT(nbrs.size() == 1);
-      TEST_ASSERT(feq(nbrs[0].first, 1.));
-      TEST_ASSERT(nbrs[0].second == 0);
+      REQUIRE(nbrs.size() == 1);
+      REQUIRE(feq(nbrs[0].first, 1.));
+      REQUIRE(nbrs[0].second == 0);
     }
     {  // with a threshold
       boost::shared_array<std::uint8_t> bytes = fps.getBytes(0);
-      TEST_ASSERT(bytes);
+      REQUIRE(bytes);
       std::vector<std::pair<double, unsigned int>> nbrs =
           fps.getTanimotoNeighbors(bytes, 0.30);
-      TEST_ASSERT(nbrs.size() == 5);
-      TEST_ASSERT(feq(nbrs[0].first, 1.));
-      TEST_ASSERT(nbrs[0].second == 0);
-      TEST_ASSERT(feq(nbrs[1].first, 0.3703));
-      TEST_ASSERT(nbrs[1].second == 1);
+      REQUIRE(nbrs.size() == 5);
+      REQUIRE(feq(nbrs[0].first, 1.));
+      REQUIRE(nbrs[0].second == 0);
+      REQUIRE(feq(nbrs[1].first, 0.3703));
+      REQUIRE(nbrs[1].second == 1);
     }
     {  // with a threshold, no screen
       boost::shared_array<std::uint8_t> bytes = fps.getBytes(0);
-      TEST_ASSERT(bytes);
+      REQUIRE(bytes);
       std::vector<std::pair<double, unsigned int>> nbrs =
           fps.getTanimotoNeighbors(bytes, 0.30, false);
-      TEST_ASSERT(nbrs.size() == 5);
-      TEST_ASSERT(feq(nbrs[0].first, 1.));
-      TEST_ASSERT(nbrs[0].second == 0);
-      TEST_ASSERT(feq(nbrs[1].first, 0.3703));
-      TEST_ASSERT(nbrs[1].second == 1);
+      REQUIRE(nbrs.size() == 5);
+      REQUIRE(feq(nbrs[0].first, 1.));
+      REQUIRE(nbrs[0].second == 0);
+      REQUIRE(feq(nbrs[1].first, 0.3703));
+      REQUIRE(nbrs[1].second == 1);
     }
     {  // with a threshold
       boost::shared_array<std::uint8_t> bytes = fps.getBytes(95);
-      TEST_ASSERT(bytes);
+      REQUIRE(bytes);
       std::vector<std::pair<double, unsigned int>> nbrs =
           fps.getTanimotoNeighbors(bytes, 0.30);
-      TEST_ASSERT(nbrs.size() == 2);
-      TEST_ASSERT(feq(nbrs[0].first, 1.));
-      TEST_ASSERT(nbrs[0].second == 95);
-      TEST_ASSERT(feq(nbrs[1].first, 0.4125));
-      TEST_ASSERT(nbrs[1].second == 89);
+      REQUIRE(nbrs.size() == 2);
+      REQUIRE(feq(nbrs[0].first, 1.));
+      REQUIRE(nbrs[0].second == 95);
+      REQUIRE(feq(nbrs[1].first, 0.4125));
+      REQUIRE(nbrs[1].second == 89);
     }
   }
-  BOOST_LOG(rdInfoLog) << "Finished" << std::endl;
 }
 
-void test4LazyFPBReaderBasics() {
-  BOOST_LOG(rdInfoLog)
-      << "-----------------------\n Testing Lazy FPBReader basics "
-      << std::endl;
+TEST_CASE("Lazy FPBReader Basics 2") {
   std::string pathName = getenv("RDBASE");
   pathName += "/Code/DataStructs/testData/";
   {
     std::string filename = pathName + "zim.head100.fpb";
     FPBReader fps(filename, true);
     fps.init();
-    TEST_ASSERT(fps.length() == 100);
-    TEST_ASSERT(fps.nBits() == 2048);
+    REQUIRE(fps.length() == 100);
+    REQUIRE(fps.nBits() == 2048);
 
     {  // pop counts
       std::pair<unsigned int, unsigned int> offsets;
       offsets = fps.getFPIdsInCountRange(17, 17);
-      TEST_ASSERT(offsets.first == 0);
-      TEST_ASSERT(offsets.second == 1);
+      REQUIRE(offsets.first == 0);
+      REQUIRE(offsets.second == 1);
       offsets = fps.getFPIdsInCountRange(60, 65);
-      TEST_ASSERT(offsets.first == 96);
-      TEST_ASSERT(offsets.second == 100);
+      REQUIRE(offsets.first == 96);
+      REQUIRE(offsets.second == 100);
       offsets = fps.getFPIdsInCountRange(160, 165);
-      TEST_ASSERT(offsets.first == 100);
-      TEST_ASSERT(offsets.second == 100);
+      REQUIRE(offsets.first == 100);
+      REQUIRE(offsets.second == 100);
     }
     {  // get* version
       std::string nm = fps.getId(0);
-      TEST_ASSERT(nm == "ZINC00902219");
+      REQUIRE(nm == "ZINC00902219");
       boost::shared_ptr<ExplicitBitVect> fp = fps.getFP(0);
-      TEST_ASSERT(fp);
-      TEST_ASSERT(fp->getNumBits() == 2048);
-      TEST_ASSERT(fp->getNumOnBits() == 17);
+      REQUIRE(fp);
+      REQUIRE(fp->getNumBits() == 2048);
+      REQUIRE(fp->getNumOnBits() == 17);
       unsigned int obs[17] = {1,   80,  183, 222,  227,  231,  482,  650, 807,
                               811, 831, 888, 1335, 1411, 1664, 1820, 1917};
       for (unsigned int i = 0; i < fp->getNumOnBits(); ++i) {
-        TEST_ASSERT(fp->getBit(obs[i]));
+        REQUIRE(fp->getBit(obs[i]));
       }
     }
     {  // operator[] version
       std::pair<boost::shared_ptr<ExplicitBitVect>, std::string> tpl = fps[0];
       boost::shared_ptr<ExplicitBitVect> fp = tpl.first;
-      TEST_ASSERT(fp);
-      TEST_ASSERT(fp->getNumBits() == 2048);
-      TEST_ASSERT(fp->getNumOnBits() == 17);
+      REQUIRE(fp);
+      REQUIRE(fp->getNumBits() == 2048);
+      REQUIRE(fp->getNumOnBits() == 17);
       unsigned int obs[17] = {1,   80,  183, 222,  227,  231,  482,  650, 807,
                               811, 831, 888, 1335, 1411, 1664, 1820, 1917};
       for (unsigned int i = 0; i < fp->getNumOnBits(); ++i) {
-        TEST_ASSERT(fp->getBit(obs[i]));
+        REQUIRE(fp->getBit(obs[i]));
       }
-      TEST_ASSERT(tpl.second == "ZINC00902219");
+      REQUIRE(tpl.second == "ZINC00902219");
     }
     {  // test another fp
       boost::shared_ptr<ExplicitBitVect> fp = fps.getFP(3);
-      TEST_ASSERT(fp);
-      TEST_ASSERT(fp->getNumBits() == 2048);
-      TEST_ASSERT(fp->getNumOnBits() == 20);
+      REQUIRE(fp);
+      REQUIRE(fp->getNumBits() == 2048);
+      REQUIRE(fp->getNumOnBits() == 20);
       unsigned int obs[20] = {1,   8,    80,   95,   222,  227, 457,
                               482, 650,  680,  715,  807,  831, 845,
                               888, 1226, 1556, 1711, 1917, 1982};
       for (unsigned int i = 0; i < fp->getNumOnBits(); ++i) {
-        TEST_ASSERT(fp->getBit(obs[i]));
+        REQUIRE(fp->getBit(obs[i]));
       }
       std::string nm = fps.getId(3);
-      TEST_ASSERT(nm == "ZINC04803506");
+      REQUIRE(nm == "ZINC04803506");
     }
   }
-  BOOST_LOG(rdInfoLog) << "Finished" << std::endl;
 }
 
-void test5LazyFPBReaderTanimoto() {
-  BOOST_LOG(rdInfoLog)
-      << "-----------------------\n Testing Lazy FPBReader tanimoto "
-      << std::endl;
+TEST_CASE("Lazy FPBReader Tanimoto") {
   std::string pathName = getenv("RDBASE");
   pathName += "/Code/DataStructs/testData/";
   {
     std::string filename = pathName + "zim.head100.fpb";
     FPBReader fps(filename, true);
     fps.init();
-    TEST_ASSERT(fps.length() == 100);
+    REQUIRE(fps.length() == 100);
     {
       boost::shared_array<std::uint8_t> bytes = fps.getBytes(0);
-      TEST_ASSERT(bytes);
-      TEST_ASSERT(feq(fps.getTanimoto(0, bytes), 1.0));
-      TEST_ASSERT(feq(fps.getTanimoto(1, bytes), 0.3703));
+      REQUIRE(bytes);
+      REQUIRE(feq(fps.getTanimoto(0, bytes), 1.0));
+      REQUIRE(feq(fps.getTanimoto(1, bytes), 0.3703));
     }
     {
       boost::shared_ptr<ExplicitBitVect> ebv = fps.getFP(0);
-      TEST_ASSERT(ebv);
-      TEST_ASSERT(feq(fps.getTanimoto(0, *ebv.get()), 1.0));
-      TEST_ASSERT(feq(fps.getTanimoto(1, *ebv.get()), 0.3703));
+      REQUIRE(ebv);
+      REQUIRE(feq(fps.getTanimoto(0, *ebv.get()), 1.0));
+      REQUIRE(feq(fps.getTanimoto(1, *ebv.get()), 0.3703));
     }
     {
       boost::shared_array<std::uint8_t> bytes = fps.getBytes(1);
-      TEST_ASSERT(bytes);
-      TEST_ASSERT(feq(fps.getTanimoto(1, bytes), 1.0));
-      TEST_ASSERT(feq(fps.getTanimoto(0, bytes), 0.3703));
-      TEST_ASSERT(feq(fps.getTanimoto(2, bytes), 1.0));
-      TEST_ASSERT(feq(fps.getTanimoto(5, bytes), 0.2903));
+      REQUIRE(bytes);
+      REQUIRE(feq(fps.getTanimoto(1, bytes), 1.0));
+      REQUIRE(feq(fps.getTanimoto(0, bytes), 0.3703));
+      REQUIRE(feq(fps.getTanimoto(2, bytes), 1.0));
+      REQUIRE(feq(fps.getTanimoto(5, bytes), 0.2903));
     }
   }
-  BOOST_LOG(rdInfoLog) << "Finished" << std::endl;
 }
 
-void test6LazyFPBReaderTanimotoNeighbors() {
-  BOOST_LOG(rdInfoLog)
-      << "-----------------------\n Testing Lazy FPBReader tanimoto neighbors"
-      << std::endl;
+TEST_CASE("Lazy FPBReader Tanimoto Neighbors") {
   std::string pathName = getenv("RDBASE");
   pathName += "/Code/DataStructs/testData/";
   {
     std::string filename = pathName + "zim.head100.fpb";
     FPBReader fps(filename, true);
     fps.init();
-    TEST_ASSERT(fps.length() == 100);
+    REQUIRE(fps.length() == 100);
     {
       boost::shared_array<std::uint8_t> bytes = fps.getBytes(0);
-      TEST_ASSERT(bytes);
+      REQUIRE(bytes);
       std::vector<std::pair<double, unsigned int>> nbrs =
           fps.getTanimotoNeighbors(bytes);
-      TEST_ASSERT(nbrs.size() == 1);
-      TEST_ASSERT(feq(nbrs[0].first, 1.));
-      TEST_ASSERT(nbrs[0].second == 0);
+      REQUIRE(nbrs.size() == 1);
+      REQUIRE(feq(nbrs[0].first, 1.));
+      REQUIRE(nbrs[0].second == 0);
     }
     {  // with a threshold
       boost::shared_array<std::uint8_t> bytes = fps.getBytes(0);
-      TEST_ASSERT(bytes);
+      REQUIRE(bytes);
       std::vector<std::pair<double, unsigned int>> nbrs =
           fps.getTanimotoNeighbors(bytes, 0.30);
-      TEST_ASSERT(nbrs.size() == 5);
-      TEST_ASSERT(feq(nbrs[0].first, 1.));
-      TEST_ASSERT(nbrs[0].second == 0);
-      TEST_ASSERT(feq(nbrs[1].first, 0.3703));
-      TEST_ASSERT(nbrs[1].second == 1);
+      REQUIRE(nbrs.size() == 5);
+      REQUIRE(feq(nbrs[0].first, 1.));
+      REQUIRE(nbrs[0].second == 0);
+      REQUIRE(feq(nbrs[1].first, 0.3703));
+      REQUIRE(nbrs[1].second == 1);
     }
     {  // with a threshold
       boost::shared_array<std::uint8_t> bytes = fps.getBytes(95);
-      TEST_ASSERT(bytes);
+      REQUIRE(bytes);
       std::vector<std::pair<double, unsigned int>> nbrs =
           fps.getTanimotoNeighbors(bytes, 0.30);
-      TEST_ASSERT(nbrs.size() == 2);
-      TEST_ASSERT(feq(nbrs[0].first, 1.));
-      TEST_ASSERT(nbrs[0].second == 95);
-      TEST_ASSERT(feq(nbrs[1].first, 0.4125));
-      TEST_ASSERT(nbrs[1].second == 89);
+      REQUIRE(nbrs.size() == 2);
+      REQUIRE(feq(nbrs[0].first, 1.));
+      REQUIRE(nbrs[0].second == 95);
+      REQUIRE(feq(nbrs[1].first, 0.4125));
+      REQUIRE(nbrs[1].second == 89);
     }
     {  // ebv with a threshold
       boost::shared_ptr<ExplicitBitVect> ebv = fps.getFP(95);
-      TEST_ASSERT(ebv);
+      REQUIRE(ebv);
       std::vector<std::pair<double, unsigned int>> nbrs =
           fps.getTanimotoNeighbors(*ebv.get(), 0.30);
-      TEST_ASSERT(nbrs.size() == 2);
-      TEST_ASSERT(feq(nbrs[0].first, 1.));
-      TEST_ASSERT(nbrs[0].second == 95);
-      TEST_ASSERT(feq(nbrs[1].first, 0.4125));
-      TEST_ASSERT(nbrs[1].second == 89);
+      REQUIRE(nbrs.size() == 2);
+      REQUIRE(feq(nbrs[0].first, 1.));
+      REQUIRE(nbrs[0].second == 95);
+      REQUIRE(feq(nbrs[1].first, 0.4125));
+      REQUIRE(nbrs[1].second == 89);
     }
   }
-  BOOST_LOG(rdInfoLog) << "Finished" << std::endl;
 }
 
 // need forward declarations of some of the detail functions (doesn't make sense
@@ -363,7 +332,7 @@ boost::dynamic_bitset<> *bytesToBitset(const std::uint8_t *fpData,
 std::uint8_t *bitsetToBytes(const boost::dynamic_bitset<> &bitset);
 }  // namespace detail
 }  // namespace RDKit
-void test7BitsetDetails() {
+TEST_CASE("Bitset Details") {
   BOOST_LOG(rdInfoLog)
       << "-----------------------\n Testing some internal bitset details"
       << std::endl;
@@ -373,41 +342,40 @@ void test7BitsetDetails() {
     std::string filename = pathName + "zim.head100.fpb";
     FPBReader fps(filename, true);
     fps.init();
-    TEST_ASSERT(fps.length() == 100);
+    REQUIRE(fps.length() == 100);
     {
       boost::shared_array<std::uint8_t> bytes = fps.getBytes(0);
-      TEST_ASSERT(bytes);
+      REQUIRE(bytes);
 
       // -------------------
       // start with bytes -> a bitset
       boost::dynamic_bitset<> *dbs =
           RDKit::detail::bytesToBitset(bytes.get(), fps.nBits());
-      TEST_ASSERT(dbs);
-      TEST_ASSERT(dbs->size() == fps.nBits());
-      TEST_ASSERT(dbs->count() == 17);
+      REQUIRE(dbs);
+      REQUIRE(dbs->size() == fps.nBits());
+      REQUIRE(dbs->count() == 17);
 
       unsigned int obs[17] = {1,   80,  183, 222,  227,  231,  482,  650, 807,
                               811, 831, 888, 1335, 1411, 1664, 1820, 1917};
       for (unsigned int i = 0; i < dbs->count(); ++i) {
-        TEST_ASSERT((*dbs)[obs[i]]);
+        REQUIRE((*dbs)[obs[i]]);
       }
 
       // -------------------
       // and now go the other way
       std::uint8_t *newBytes = RDKit::detail::bitsetToBytes(*dbs);
-      TEST_ASSERT(newBytes);
+      REQUIRE(newBytes);
       for (unsigned int i = 0; i < fps.nBits() / 8; ++i) {
-        TEST_ASSERT(newBytes[i] == bytes[i]);
+        REQUIRE(newBytes[i] == bytes[i]);
       }
 
       delete dbs;
       delete[] newBytes;
     }
   }
-  BOOST_LOG(rdInfoLog) << "Finished" << std::endl;
 }
 
-void test8FPBReaderContains() {
+TEST_CASE("FPBReader Contains") {
   BOOST_LOG(rdInfoLog)
       << "-----------------------\n Testing FPBReader contains search"
       << std::endl;
@@ -417,153 +385,145 @@ void test8FPBReaderContains() {
     std::string filename = pathName + "zim.head100.fpb";
     FPBReader fps(filename);
     fps.init();
-    TEST_ASSERT(fps.length() == 100);
+    REQUIRE(fps.length() == 100);
     {
       boost::shared_array<std::uint8_t> bytes = fps.getBytes(0);
-      TEST_ASSERT(bytes);
+      REQUIRE(bytes);
       std::vector<unsigned int> nbrs = fps.getContainingNeighbors(bytes);
-      TEST_ASSERT(nbrs.size() == 1);
-      TEST_ASSERT(nbrs[0] == 0);
+      REQUIRE(nbrs.size() == 1);
+      REQUIRE(nbrs[0] == 0);
     }
     {
       boost::shared_array<std::uint8_t> bytes = fps.getBytes(1);
-      TEST_ASSERT(bytes);
+      REQUIRE(bytes);
       std::vector<unsigned int> nbrs = fps.getContainingNeighbors(bytes);
-      TEST_ASSERT(nbrs.size() == 4);
-      TEST_ASSERT(nbrs[0] == 1);
-      TEST_ASSERT(nbrs[1] == 2);
-      TEST_ASSERT(nbrs[2] == 3);
-      TEST_ASSERT(nbrs[3] == 4);
+      REQUIRE(nbrs.size() == 4);
+      REQUIRE(nbrs[0] == 1);
+      REQUIRE(nbrs[1] == 2);
+      REQUIRE(nbrs[2] == 3);
+      REQUIRE(nbrs[3] == 4);
     }
     {
       boost::shared_array<std::uint8_t> bytes = fps.getBytes(16);
-      TEST_ASSERT(bytes);
+      REQUIRE(bytes);
       std::vector<unsigned int> nbrs = fps.getContainingNeighbors(bytes);
-      TEST_ASSERT(nbrs.size() == 2);
-      TEST_ASSERT(nbrs[0] == 16);
-      TEST_ASSERT(nbrs[1] == 17);
+      REQUIRE(nbrs.size() == 2);
+      REQUIRE(nbrs[0] == 16);
+      REQUIRE(nbrs[1] == 17);
     }
     {
       boost::shared_array<std::uint8_t> bytes = fps.getBytes(87);
-      TEST_ASSERT(bytes);
+      REQUIRE(bytes);
       std::vector<unsigned int> nbrs = fps.getContainingNeighbors(bytes);
-      TEST_ASSERT(nbrs.size() == 4);
-      TEST_ASSERT(nbrs[0] == 85);
-      TEST_ASSERT(nbrs[1] == 86);
-      TEST_ASSERT(nbrs[2] == 87);
-      TEST_ASSERT(nbrs[3] == 88);
+      REQUIRE(nbrs.size() == 4);
+      REQUIRE(nbrs[0] == 85);
+      REQUIRE(nbrs[1] == 86);
+      REQUIRE(nbrs[2] == 87);
+      REQUIRE(nbrs[3] == 88);
     }
     {
       boost::shared_ptr<ExplicitBitVect> ebv = fps.getFP(87);
-      TEST_ASSERT(ebv);
+      REQUIRE(ebv);
       std::vector<unsigned int> nbrs = fps.getContainingNeighbors(*ebv.get());
-      TEST_ASSERT(nbrs.size() == 4);
-      TEST_ASSERT(nbrs[0] == 85);
-      TEST_ASSERT(nbrs[1] == 86);
-      TEST_ASSERT(nbrs[2] == 87);
-      TEST_ASSERT(nbrs[3] == 88);
+      REQUIRE(nbrs.size() == 4);
+      REQUIRE(nbrs[0] == 85);
+      REQUIRE(nbrs[1] == 86);
+      REQUIRE(nbrs[2] == 87);
+      REQUIRE(nbrs[3] == 88);
     }
   }
-  BOOST_LOG(rdInfoLog) << "Finished" << std::endl;
 }
 
-void test9FPBReaderTversky() {
-  BOOST_LOG(rdInfoLog) << "-----------------------\n Testing FPBReader Tversky "
-                       << std::endl;
+TEST_CASE("FPBReader Tversky") {
   std::string pathName = getenv("RDBASE");
   pathName += "/Code/DataStructs/testData/";
   {
     std::string filename = pathName + "zim.head100.fpb";
     FPBReader fps(filename);
     fps.init();
-    TEST_ASSERT(fps.length() == 100);
+    REQUIRE(fps.length() == 100);
     {
       boost::shared_array<std::uint8_t> bytes = fps.getBytes(0);
-      TEST_ASSERT(bytes);
-      TEST_ASSERT(feq(fps.getTversky(0, bytes, 1., 1.), 1.0));
-      TEST_ASSERT(feq(fps.getTversky(1, bytes, 1., 1.), 0.3703));
+      REQUIRE(bytes);
+      REQUIRE(feq(fps.getTversky(0, bytes, 1., 1.), 1.0));
+      REQUIRE(feq(fps.getTversky(1, bytes, 1., 1.), 0.3703));
     }
     {
       boost::shared_array<std::uint8_t> bytes = fps.getBytes(1);
-      TEST_ASSERT(bytes);
-      TEST_ASSERT(feq(fps.getTversky(1, bytes, 1., 1.), 1.0));
-      TEST_ASSERT(feq(fps.getTversky(0, bytes, 1., 1.), 0.3703));
-      TEST_ASSERT(feq(fps.getTversky(2, bytes, 1, 1.), 1.0));
-      TEST_ASSERT(feq(fps.getTversky(5, bytes, 1., 1.), 0.2903));
+      REQUIRE(bytes);
+      REQUIRE(feq(fps.getTversky(1, bytes, 1., 1.), 1.0));
+      REQUIRE(feq(fps.getTversky(0, bytes, 1., 1.), 0.3703));
+      REQUIRE(feq(fps.getTversky(2, bytes, 1, 1.), 1.0));
+      REQUIRE(feq(fps.getTversky(5, bytes, 1., 1.), 0.2903));
     }
   }
-  BOOST_LOG(rdInfoLog) << "Finished" << std::endl;
 }
 
-void test10FPBReaderTverskyNeighbors() {
-  BOOST_LOG(rdInfoLog)
-      << "-----------------------\n Testing FPBReader Tversky neighbors"
-      << std::endl;
+TEST_CASE("FPBReader Tversky Neighbors") {
   std::string pathName = getenv("RDBASE");
   pathName += "/Code/DataStructs/testData/";
   {
     std::string filename = pathName + "zim.head100.fpb";
     FPBReader fps(filename);
     fps.init();
-    TEST_ASSERT(fps.length() == 100);
+    REQUIRE(fps.length() == 100);
     {
       boost::shared_array<std::uint8_t> bytes = fps.getBytes(0);
-      TEST_ASSERT(bytes);
+      REQUIRE(bytes);
       std::vector<std::pair<double, unsigned int>> nbrs =
           fps.getTverskyNeighbors(bytes, 1., 1.);
-      TEST_ASSERT(nbrs.size() == 1);
-      TEST_ASSERT(feq(nbrs[0].first, 1.));
-      TEST_ASSERT(nbrs[0].second == 0);
+      REQUIRE(nbrs.size() == 1);
+      REQUIRE(feq(nbrs[0].first, 1.));
+      REQUIRE(nbrs[0].second == 0);
     }
     {  // with a threshold
       boost::shared_array<std::uint8_t> bytes = fps.getBytes(0);
-      TEST_ASSERT(bytes);
+      REQUIRE(bytes);
       std::vector<std::pair<double, unsigned int>> nbrs =
           fps.getTverskyNeighbors(bytes, 1., 1., 0.3);
-      TEST_ASSERT(nbrs.size() == 5);
-      TEST_ASSERT(feq(nbrs[0].first, 1.));
-      TEST_ASSERT(nbrs[0].second == 0);
-      TEST_ASSERT(feq(nbrs[1].first, 0.3703));
-      TEST_ASSERT(nbrs[1].second == 1);
+      REQUIRE(nbrs.size() == 5);
+      REQUIRE(feq(nbrs[0].first, 1.));
+      REQUIRE(nbrs[0].second == 0);
+      REQUIRE(feq(nbrs[1].first, 0.3703));
+      REQUIRE(nbrs[1].second == 1);
     }
     {  // with a threshold, asymmetric
       boost::shared_array<std::uint8_t> bytes = fps.getBytes(0);
-      TEST_ASSERT(bytes);
+      REQUIRE(bytes);
       std::vector<std::pair<double, unsigned int>> nbrs =
           fps.getTverskyNeighbors(bytes, 1., 0.5, 0.3);
-      TEST_ASSERT(nbrs.size() == 5);
-      TEST_ASSERT(feq(nbrs[0].first, 1.));
-      TEST_ASSERT(nbrs[0].second == 0);
-      TEST_ASSERT(feq(nbrs[1].first, 0.4255));
-      TEST_ASSERT(nbrs[1].second == 1);
+      REQUIRE(nbrs.size() == 5);
+      REQUIRE(feq(nbrs[0].first, 1.));
+      REQUIRE(nbrs[0].second == 0);
+      REQUIRE(feq(nbrs[1].first, 0.4255));
+      REQUIRE(nbrs[1].second == 1);
     }
     {  // with a threshold,  no screen
       boost::shared_array<std::uint8_t> bytes = fps.getBytes(0);
-      TEST_ASSERT(bytes);
+      REQUIRE(bytes);
       std::vector<std::pair<double, unsigned int>> nbrs =
           fps.getTverskyNeighbors(bytes, 1., 1., 0.3, false);
-      TEST_ASSERT(nbrs.size() == 5);
-      TEST_ASSERT(feq(nbrs[0].first, 1.));
-      TEST_ASSERT(nbrs[0].second == 0);
-      TEST_ASSERT(feq(nbrs[1].first, 0.3703));
-      TEST_ASSERT(nbrs[1].second == 1);
+      REQUIRE(nbrs.size() == 5);
+      REQUIRE(feq(nbrs[0].first, 1.));
+      REQUIRE(nbrs[0].second == 0);
+      REQUIRE(feq(nbrs[1].first, 0.3703));
+      REQUIRE(nbrs[1].second == 1);
     }
     {  // with a threshold, asymmetric, no screen
       boost::shared_array<std::uint8_t> bytes = fps.getBytes(0);
-      TEST_ASSERT(bytes);
+      REQUIRE(bytes);
       std::vector<std::pair<double, unsigned int>> nbrs =
           fps.getTverskyNeighbors(bytes, 1., 0.5, 0.3, false);
-      TEST_ASSERT(nbrs.size() == 5);
-      TEST_ASSERT(feq(nbrs[0].first, 1.));
-      TEST_ASSERT(nbrs[0].second == 0);
-      TEST_ASSERT(feq(nbrs[1].first, 0.4255));
-      TEST_ASSERT(nbrs[1].second == 1);
+      REQUIRE(nbrs.size() == 5);
+      REQUIRE(feq(nbrs[0].first, 1.));
+      REQUIRE(nbrs[0].second == 0);
+      REQUIRE(feq(nbrs[1].first, 0.4255));
+      REQUIRE(nbrs[1].second == 1);
     }
   }
-  BOOST_LOG(rdInfoLog) << "Finished" << std::endl;
 }
 
-void testGithub1118() {
+TEST_CASE("Github Issue 1118") {
   BOOST_LOG(rdInfoLog) << "-----------------------\n Testing github issue "
                           "1118: deleting non-initialized FPBReader causes seg "
                           "fault"
@@ -588,22 +548,4 @@ void testGithub1118() {
   BOOST_LOG(rdInfoLog) << "Finished" << std::endl;
 }
 
-int main() {
-  RDLog::InitLogs();
-
-  test1FPBReaderBasics();
-  test9LazyFPBReaderBasics();
-
-  test2FPBReaderTanimoto();
-  test3FPBReaderTanimotoNeighbors();
-  test8FPBReaderContains();
-  test4LazyFPBReaderBasics();
-  test5LazyFPBReaderTanimoto();
-  test6LazyFPBReaderTanimotoNeighbors();
-  test7BitsetDetails();
-
-  test9FPBReaderTversky();
-  test10FPBReaderTverskyNeighbors();
-  testGithub1118();
-  return 0;
-}
+int main(int argc, char *argv[]) { return Catch::Session().run(argc, argv); }

--- a/Code/DataStructs/testMultiFPB.cpp
+++ b/Code/DataStructs/testMultiFPB.cpp
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2016 Greg Landrum
+//  Copyright (C) 2016-2025 Greg Landrum and other RDKit contributors
 //
 //  @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -7,12 +7,8 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
-#include <RDGeneral/test.h>
-#include <RDGeneral/Invariant.h>
-#include <RDGeneral/RDLog.h>
-#include <RDGeneral/Exceptions.h>
+#include <catch2/catch_all.hpp>
 #include <RDGeneral/utils.h>
-
 #include <DataStructs/ExplicitBitVect.h>
 #include <DataStructs/FPBReader.h>
 #include <DataStructs/MultiFPBReader.h>
@@ -20,10 +16,7 @@
 
 using namespace RDKit;
 
-void test1MultiFPBReaderBasics() {
-  BOOST_LOG(rdInfoLog)
-      << "-----------------------\n Testing MultiFPBReader basics "
-      << std::endl;
+TEST_CASE("MultiFPBReader Basics") {
   std::string pathName = getenv("RDBASE");
   pathName += "/Code/DataStructs/testData/";
   {
@@ -34,29 +27,26 @@ void test1MultiFPBReaderBasics() {
     rdrs.push_back(&fps2);
     MultiFPBReader mfps(rdrs);
     mfps.init();
-    TEST_ASSERT(mfps.length() == 2);
-    TEST_ASSERT(mfps.getReader(0));
-    TEST_ASSERT(mfps.getReader(0)->nBits() == mfps.nBits());
+    REQUIRE(mfps.length() == 2);
+    REQUIRE(mfps.getReader(0));
+    REQUIRE(mfps.getReader(0)->nBits() == mfps.nBits());
   }
   {
     std::string filename = pathName + "zim.head100.fpb";
     FPBReader fps1(filename), fps2(filename);
     MultiFPBReader mfps;
-    TEST_ASSERT(mfps.addReader(&fps1) == 1);
-    TEST_ASSERT(mfps.addReader(&fps2) == 2);
+    REQUIRE(mfps.addReader(&fps1) == 1);
+    REQUIRE(mfps.addReader(&fps2) == 2);
     mfps.init();
-    TEST_ASSERT(mfps.length() == 2);
-    TEST_ASSERT(mfps.getReader(0));
-    TEST_ASSERT(mfps.getReader(0)->nBits() == mfps.nBits());
-    TEST_ASSERT(mfps.getReader(0));
-    TEST_ASSERT(mfps.getReader(0)->nBits() == mfps.nBits());
+    REQUIRE(mfps.length() == 2);
+    REQUIRE(mfps.getReader(0));
+    REQUIRE(mfps.getReader(0)->nBits() == mfps.nBits());
+    REQUIRE(mfps.getReader(0));
+    REQUIRE(mfps.getReader(0)->nBits() == mfps.nBits());
   }
-  BOOST_LOG(rdInfoLog) << "Finished" << std::endl;
 }
-void test2MultiFPBReaderTanimoto() {
-  BOOST_LOG(rdInfoLog)
-      << "-----------------------\n Testing MultiFPBReader Tanimoto "
-      << std::endl;
+
+TEST_CASE("MultiFPBReader Tanimoto") {
   std::string pathName = getenv("RDBASE");
   pathName += "/Code/DataStructs/testData/";
   {
@@ -67,61 +57,57 @@ void test2MultiFPBReaderTanimoto() {
     rdrs.push_back(&fps2);
     MultiFPBReader mfps(rdrs);
     mfps.init();
-    TEST_ASSERT(mfps.length() == 2);
+    REQUIRE(mfps.length() == 2);
 
     {
       boost::shared_array<std::uint8_t> bytes = mfps.getReader(0)->getBytes(0);
-      TEST_ASSERT(bytes);
+      REQUIRE(bytes);
       std::vector<MultiFPBReader::ResultTuple> nbrs =
           mfps.getTanimotoNeighbors(bytes);
-      TEST_ASSERT(nbrs.size() == 2);
-      TEST_ASSERT(feq(std::get<0>(nbrs[0]), 1.));
-      TEST_ASSERT(std::get<1>(nbrs[0]) == 0);
-      TEST_ASSERT(std::get<2>(nbrs[0]) == 0);
-      TEST_ASSERT(feq(std::get<0>(nbrs[1]), 1.));
-      TEST_ASSERT(std::get<1>(nbrs[1]) == 0);
-      TEST_ASSERT(std::get<2>(nbrs[1]) == 1);
+      REQUIRE(nbrs.size() == 2);
+      REQUIRE(feq(std::get<0>(nbrs[0]), 1.));
+      REQUIRE(std::get<1>(nbrs[0]) == 0);
+      REQUIRE(std::get<2>(nbrs[0]) == 0);
+      REQUIRE(feq(std::get<0>(nbrs[1]), 1.));
+      REQUIRE(std::get<1>(nbrs[1]) == 0);
+      REQUIRE(std::get<2>(nbrs[1]) == 1);
     }
     {  // with a threshold
       boost::shared_array<std::uint8_t> bytes = mfps.getReader(0)->getBytes(0);
-      TEST_ASSERT(bytes);
+      REQUIRE(bytes);
       std::vector<MultiFPBReader::ResultTuple> nbrs =
           mfps.getTanimotoNeighbors(bytes, 0.30);
-      TEST_ASSERT(nbrs.size() == 10);
-      TEST_ASSERT(feq(std::get<0>(nbrs[0]), 1.));
-      TEST_ASSERT(std::get<1>(nbrs[0]) == 0);
-      TEST_ASSERT(std::get<2>(nbrs[0]) == 0);
-      TEST_ASSERT(feq(std::get<0>(nbrs[1]), 1.));
-      TEST_ASSERT(std::get<1>(nbrs[1]) == 0);
-      TEST_ASSERT(std::get<2>(nbrs[1]) == 1);
-      TEST_ASSERT(feq(std::get<0>(nbrs[2]), 0.3703));
-      TEST_ASSERT(std::get<1>(nbrs[2]) == 1);
-      TEST_ASSERT(std::get<2>(nbrs[2]) == 0);
+      REQUIRE(nbrs.size() == 10);
+      REQUIRE(feq(std::get<0>(nbrs[0]), 1.));
+      REQUIRE(std::get<1>(nbrs[0]) == 0);
+      REQUIRE(std::get<2>(nbrs[0]) == 0);
+      REQUIRE(feq(std::get<0>(nbrs[1]), 1.));
+      REQUIRE(std::get<1>(nbrs[1]) == 0);
+      REQUIRE(std::get<2>(nbrs[1]) == 1);
+      REQUIRE(feq(std::get<0>(nbrs[2]), 0.3703));
+      REQUIRE(std::get<1>(nbrs[2]) == 1);
+      REQUIRE(std::get<2>(nbrs[2]) == 0);
     }
     {  // with a threshold
       boost::shared_array<std::uint8_t> bytes = mfps.getReader(0)->getBytes(95);
-      TEST_ASSERT(bytes);
+      REQUIRE(bytes);
       std::vector<MultiFPBReader::ResultTuple> nbrs =
           mfps.getTanimotoNeighbors(bytes, 0.30);
-      TEST_ASSERT(nbrs.size() == 4);
-      TEST_ASSERT(feq(std::get<0>(nbrs[0]), 1.));
-      TEST_ASSERT(std::get<1>(nbrs[0]) == 95);
-      TEST_ASSERT(std::get<2>(nbrs[0]) == 0);
-      TEST_ASSERT(feq(std::get<0>(nbrs[1]), 1.));
-      TEST_ASSERT(std::get<1>(nbrs[1]) == 95);
-      TEST_ASSERT(std::get<2>(nbrs[1]) == 1);
-      TEST_ASSERT(feq(std::get<0>(nbrs[2]), 0.4125));
-      TEST_ASSERT(std::get<1>(nbrs[2]) == 89);
-      TEST_ASSERT(std::get<2>(nbrs[2]) == 0);
+      REQUIRE(nbrs.size() == 4);
+      REQUIRE(feq(std::get<0>(nbrs[0]), 1.));
+      REQUIRE(std::get<1>(nbrs[0]) == 95);
+      REQUIRE(std::get<2>(nbrs[0]) == 0);
+      REQUIRE(feq(std::get<0>(nbrs[1]), 1.));
+      REQUIRE(std::get<1>(nbrs[1]) == 95);
+      REQUIRE(std::get<2>(nbrs[1]) == 1);
+      REQUIRE(feq(std::get<0>(nbrs[2]), 0.4125));
+      REQUIRE(std::get<1>(nbrs[2]) == 89);
+      REQUIRE(std::get<2>(nbrs[2]) == 0);
     }
   }
-  BOOST_LOG(rdInfoLog) << "Finished" << std::endl;
 }
 
-void test3MultiFPBReaderTversky() {
-  BOOST_LOG(rdInfoLog)
-      << "-----------------------\n Testing MultiFPBReader Tversky "
-      << std::endl;
+TEST_CASE("MultiFPBReader Tversky") {
   std::string pathName = getenv("RDBASE");
   pathName += "/Code/DataStructs/testData/";
   {
@@ -132,61 +118,57 @@ void test3MultiFPBReaderTversky() {
     rdrs.push_back(&fps2);
     MultiFPBReader mfps(rdrs);
     mfps.init();
-    TEST_ASSERT(mfps.length() == 2);
+    REQUIRE(mfps.length() == 2);
 
     {
       boost::shared_array<std::uint8_t> bytes = mfps.getReader(0)->getBytes(0);
-      TEST_ASSERT(bytes);
+      REQUIRE(bytes);
       std::vector<MultiFPBReader::ResultTuple> nbrs =
           mfps.getTverskyNeighbors(bytes, 1., 1.);
-      TEST_ASSERT(nbrs.size() == 2);
-      TEST_ASSERT(feq(std::get<0>(nbrs[0]), 1.));
-      TEST_ASSERT(std::get<1>(nbrs[0]) == 0);
-      TEST_ASSERT(std::get<2>(nbrs[0]) == 0);
-      TEST_ASSERT(feq(std::get<0>(nbrs[1]), 1.));
-      TEST_ASSERT(std::get<1>(nbrs[1]) == 0);
-      TEST_ASSERT(std::get<2>(nbrs[1]) == 1);
+      REQUIRE(nbrs.size() == 2);
+      REQUIRE(feq(std::get<0>(nbrs[0]), 1.));
+      REQUIRE(std::get<1>(nbrs[0]) == 0);
+      REQUIRE(std::get<2>(nbrs[0]) == 0);
+      REQUIRE(feq(std::get<0>(nbrs[1]), 1.));
+      REQUIRE(std::get<1>(nbrs[1]) == 0);
+      REQUIRE(std::get<2>(nbrs[1]) == 1);
     }
     {  // with a threshold
       boost::shared_array<std::uint8_t> bytes = mfps.getReader(0)->getBytes(0);
-      TEST_ASSERT(bytes);
+      REQUIRE(bytes);
       std::vector<MultiFPBReader::ResultTuple> nbrs =
           mfps.getTverskyNeighbors(bytes, 1., 1., 0.30);
-      TEST_ASSERT(nbrs.size() == 10);
-      TEST_ASSERT(feq(std::get<0>(nbrs[0]), 1.));
-      TEST_ASSERT(std::get<1>(nbrs[0]) == 0);
-      TEST_ASSERT(std::get<2>(nbrs[0]) == 0);
-      TEST_ASSERT(feq(std::get<0>(nbrs[1]), 1.));
-      TEST_ASSERT(std::get<1>(nbrs[1]) == 0);
-      TEST_ASSERT(std::get<2>(nbrs[1]) == 1);
-      TEST_ASSERT(feq(std::get<0>(nbrs[2]), 0.3703));
-      TEST_ASSERT(std::get<1>(nbrs[2]) == 1);
-      TEST_ASSERT(std::get<2>(nbrs[2]) == 0);
+      REQUIRE(nbrs.size() == 10);
+      REQUIRE(feq(std::get<0>(nbrs[0]), 1.));
+      REQUIRE(std::get<1>(nbrs[0]) == 0);
+      REQUIRE(std::get<2>(nbrs[0]) == 0);
+      REQUIRE(feq(std::get<0>(nbrs[1]), 1.));
+      REQUIRE(std::get<1>(nbrs[1]) == 0);
+      REQUIRE(std::get<2>(nbrs[1]) == 1);
+      REQUIRE(feq(std::get<0>(nbrs[2]), 0.3703));
+      REQUIRE(std::get<1>(nbrs[2]) == 1);
+      REQUIRE(std::get<2>(nbrs[2]) == 0);
     }
     {  // with a threshold, asymmetric
       boost::shared_array<std::uint8_t> bytes = mfps.getReader(0)->getBytes(0);
-      TEST_ASSERT(bytes);
+      REQUIRE(bytes);
       std::vector<MultiFPBReader::ResultTuple> nbrs =
           mfps.getTverskyNeighbors(bytes, 1., 0.5, 0.30);
-      TEST_ASSERT(nbrs.size() == 10);
-      TEST_ASSERT(feq(std::get<0>(nbrs[0]), 1.));
-      TEST_ASSERT(std::get<1>(nbrs[0]) == 0);
-      TEST_ASSERT(std::get<2>(nbrs[0]) == 0);
-      TEST_ASSERT(feq(std::get<0>(nbrs[1]), 1.));
-      TEST_ASSERT(std::get<1>(nbrs[1]) == 0);
-      TEST_ASSERT(std::get<2>(nbrs[1]) == 1);
-      TEST_ASSERT(feq(std::get<0>(nbrs[2]), 0.4255));
-      TEST_ASSERT(std::get<1>(nbrs[2]) == 1);
-      TEST_ASSERT(std::get<2>(nbrs[2]) == 0);
+      REQUIRE(nbrs.size() == 10);
+      REQUIRE(feq(std::get<0>(nbrs[0]), 1.));
+      REQUIRE(std::get<1>(nbrs[0]) == 0);
+      REQUIRE(std::get<2>(nbrs[0]) == 0);
+      REQUIRE(feq(std::get<0>(nbrs[1]), 1.));
+      REQUIRE(std::get<1>(nbrs[1]) == 0);
+      REQUIRE(std::get<2>(nbrs[1]) == 1);
+      REQUIRE(feq(std::get<0>(nbrs[2]), 0.4255));
+      REQUIRE(std::get<1>(nbrs[2]) == 1);
+      REQUIRE(std::get<2>(nbrs[2]) == 0);
     }
   }
-  BOOST_LOG(rdInfoLog) << "Finished" << std::endl;
 }
 
-void test4MultiFPBReaderContains() {
-  BOOST_LOG(rdInfoLog)
-      << "-----------------------\n Testing MultiFPBReader contains search"
-      << std::endl;
+TEST_CASE("MultiFPBReader Contains") {
   std::string pathName = getenv("RDBASE");
   pathName += "/Code/DataStructs/testData/";
   {
@@ -197,43 +179,39 @@ void test4MultiFPBReaderContains() {
     rdrs.push_back(&fps2);
     MultiFPBReader mfps(rdrs);
     mfps.init();
-    TEST_ASSERT(mfps.length() == 2);
+    REQUIRE(mfps.length() == 2);
     {
       boost::shared_array<std::uint8_t> bytes = mfps.getReader(0)->getBytes(0);
-      TEST_ASSERT(bytes);
+      REQUIRE(bytes);
       std::vector<std::pair<unsigned int, unsigned int>> nbrs =
           mfps.getContainingNeighbors(bytes);
-      TEST_ASSERT(nbrs.size() == 2);
-      TEST_ASSERT(nbrs[0].first == 0);
-      TEST_ASSERT(nbrs[0].second == 0);
-      TEST_ASSERT(nbrs[1].first == 0);
-      TEST_ASSERT(nbrs[1].second == 1);
+      REQUIRE(nbrs.size() == 2);
+      REQUIRE(nbrs[0].first == 0);
+      REQUIRE(nbrs[0].second == 0);
+      REQUIRE(nbrs[1].first == 0);
+      REQUIRE(nbrs[1].second == 1);
     }
     {
       boost::shared_array<std::uint8_t> bytes = mfps.getReader(0)->getBytes(1);
-      TEST_ASSERT(bytes);
+      REQUIRE(bytes);
       std::vector<std::pair<unsigned int, unsigned int>> nbrs =
           mfps.getContainingNeighbors(bytes);
-      TEST_ASSERT(nbrs.size() == 8);
-      TEST_ASSERT(nbrs[0].first == 1);
-      TEST_ASSERT(nbrs[0].second == 0);
-      TEST_ASSERT(nbrs[2].first == 2);
-      TEST_ASSERT(nbrs[4].first == 3);
-      TEST_ASSERT(nbrs[6].first == 4);
-      TEST_ASSERT(nbrs[1].first == 1);
-      TEST_ASSERT(nbrs[1].second == 1);
-      TEST_ASSERT(nbrs[3].first == 2);
-      TEST_ASSERT(nbrs[5].first == 3);
-      TEST_ASSERT(nbrs[7].first == 4);
+      REQUIRE(nbrs.size() == 8);
+      REQUIRE(nbrs[0].first == 1);
+      REQUIRE(nbrs[0].second == 0);
+      REQUIRE(nbrs[2].first == 2);
+      REQUIRE(nbrs[4].first == 3);
+      REQUIRE(nbrs[6].first == 4);
+      REQUIRE(nbrs[1].first == 1);
+      REQUIRE(nbrs[1].second == 1);
+      REQUIRE(nbrs[3].first == 2);
+      REQUIRE(nbrs[5].first == 3);
+      REQUIRE(nbrs[7].first == 4);
     }
   }
-  BOOST_LOG(rdInfoLog) << "Finished" << std::endl;
 }
 
-void test5MultiFPBReaderThreaded() {
-  BOOST_LOG(rdInfoLog)
-      << "-----------------------\n Testing MultiFPBReader Similarity Threaded"
-      << std::endl;
+TEST_CASE("MultiFPBReader Similarity Threaded") {
   std::string pathName = getenv("RDBASE");
   pathName += "/Code/DataStructs/testData/";
   {
@@ -249,7 +227,7 @@ void test5MultiFPBReaderThreaded() {
     rdrs.push_back(&fps4);
     MultiFPBReader mfps(rdrs);
     mfps.init();
-    TEST_ASSERT(mfps.length() == 4);
+    REQUIRE(mfps.length() == 4);
     std::string fps =
         "0000000000404000100000001000040000300040222000002004000240000020000000"
         "8200010200000090000024040860070044003214820000220401054008018000226000"
@@ -261,89 +239,85 @@ void test5MultiFPBReaderThreaded() {
     {
       std::vector<MultiFPBReader::ResultTuple> nbrs =
           mfps.getTanimotoNeighbors(qbv, 0.6);
-      TEST_ASSERT(nbrs.size() == 6);
+      REQUIRE(nbrs.size() == 6);
       // for (unsigned int i = 0; i < nbrs.size(); ++i) {
       //   std::cerr << i << ": " << std::get<0>(nbrs[i]) << " " <<
       //   std::get<1>(nbrs[i])
       //             << " " << std::get<2>(nbrs[i]) << " " << std::endl;
       // }
-      TEST_ASSERT(feq(std::get<0>(nbrs[0]), 0.66412));
-      TEST_ASSERT(std::get<1>(nbrs[0]) == 0);
-      TEST_ASSERT(std::get<2>(nbrs[0]) == 3);
-      TEST_ASSERT(feq(std::get<0>(nbrs[1]), 0.65289));
-      TEST_ASSERT(std::get<1>(nbrs[1]) == 1);
-      TEST_ASSERT(std::get<2>(nbrs[1]) == 2);
-      TEST_ASSERT(feq(std::get<0>(nbrs[2]), 0.64341));
-      TEST_ASSERT(std::get<1>(nbrs[2]) == 2);
-      TEST_ASSERT(std::get<2>(nbrs[2]) == 1);
-      TEST_ASSERT(feq(std::get<0>(nbrs[3]), 0.61940));
-      TEST_ASSERT(std::get<1>(nbrs[3]) == 1);
-      TEST_ASSERT(std::get<2>(nbrs[3]) == 0);
-      TEST_ASSERT(feq(std::get<0>(nbrs[4]), 0.61905));
-      TEST_ASSERT(std::get<1>(nbrs[4]) == 0);
-      TEST_ASSERT(std::get<2>(nbrs[4]) == 0);
-      TEST_ASSERT(feq(std::get<0>(nbrs[5]), 0.61344));
-      TEST_ASSERT(std::get<1>(nbrs[5]) == 0);
-      TEST_ASSERT(std::get<2>(nbrs[5]) == 1);
+      REQUIRE(feq(std::get<0>(nbrs[0]), 0.66412));
+      REQUIRE(std::get<1>(nbrs[0]) == 0);
+      REQUIRE(std::get<2>(nbrs[0]) == 3);
+      REQUIRE(feq(std::get<0>(nbrs[1]), 0.65289));
+      REQUIRE(std::get<1>(nbrs[1]) == 1);
+      REQUIRE(std::get<2>(nbrs[1]) == 2);
+      REQUIRE(feq(std::get<0>(nbrs[2]), 0.64341));
+      REQUIRE(std::get<1>(nbrs[2]) == 2);
+      REQUIRE(std::get<2>(nbrs[2]) == 1);
+      REQUIRE(feq(std::get<0>(nbrs[3]), 0.61940));
+      REQUIRE(std::get<1>(nbrs[3]) == 1);
+      REQUIRE(std::get<2>(nbrs[3]) == 0);
+      REQUIRE(feq(std::get<0>(nbrs[4]), 0.61905));
+      REQUIRE(std::get<1>(nbrs[4]) == 0);
+      REQUIRE(std::get<2>(nbrs[4]) == 0);
+      REQUIRE(feq(std::get<0>(nbrs[5]), 0.61344));
+      REQUIRE(std::get<1>(nbrs[5]) == 0);
+      REQUIRE(std::get<2>(nbrs[5]) == 1);
     }
 
 #ifdef RDK_TEST_MULTITHREADED
     {
       std::vector<MultiFPBReader::ResultTuple> nbrs =
           mfps.getTanimotoNeighbors(qbv, 0.6, 4);
-      TEST_ASSERT(nbrs.size() == 6);
-      TEST_ASSERT(feq(std::get<0>(nbrs[0]), 0.66412));
-      TEST_ASSERT(std::get<1>(nbrs[0]) == 0);
-      TEST_ASSERT(std::get<2>(nbrs[0]) == 3);
-      TEST_ASSERT(feq(std::get<0>(nbrs[1]), 0.65289));
-      TEST_ASSERT(std::get<1>(nbrs[1]) == 1);
-      TEST_ASSERT(std::get<2>(nbrs[1]) == 2);
-      TEST_ASSERT(feq(std::get<0>(nbrs[2]), 0.64341));
-      TEST_ASSERT(std::get<1>(nbrs[2]) == 2);
-      TEST_ASSERT(std::get<2>(nbrs[2]) == 1);
-      TEST_ASSERT(feq(std::get<0>(nbrs[3]), 0.61940));
-      TEST_ASSERT(std::get<1>(nbrs[3]) == 1);
-      TEST_ASSERT(std::get<2>(nbrs[3]) == 0);
-      TEST_ASSERT(feq(std::get<0>(nbrs[4]), 0.61905));
-      TEST_ASSERT(std::get<1>(nbrs[4]) == 0);
-      TEST_ASSERT(std::get<2>(nbrs[4]) == 0);
-      TEST_ASSERT(feq(std::get<0>(nbrs[5]), 0.61344));
-      TEST_ASSERT(std::get<1>(nbrs[5]) == 0);
-      TEST_ASSERT(std::get<2>(nbrs[5]) == 1);
+      REQUIRE(nbrs.size() == 6);
+      REQUIRE(feq(std::get<0>(nbrs[0]), 0.66412));
+      REQUIRE(std::get<1>(nbrs[0]) == 0);
+      REQUIRE(std::get<2>(nbrs[0]) == 3);
+      REQUIRE(feq(std::get<0>(nbrs[1]), 0.65289));
+      REQUIRE(std::get<1>(nbrs[1]) == 1);
+      REQUIRE(std::get<2>(nbrs[1]) == 2);
+      REQUIRE(feq(std::get<0>(nbrs[2]), 0.64341));
+      REQUIRE(std::get<1>(nbrs[2]) == 2);
+      REQUIRE(std::get<2>(nbrs[2]) == 1);
+      REQUIRE(feq(std::get<0>(nbrs[3]), 0.61940));
+      REQUIRE(std::get<1>(nbrs[3]) == 1);
+      REQUIRE(std::get<2>(nbrs[3]) == 0);
+      REQUIRE(feq(std::get<0>(nbrs[4]), 0.61905));
+      REQUIRE(std::get<1>(nbrs[4]) == 0);
+      REQUIRE(std::get<2>(nbrs[4]) == 0);
+      REQUIRE(feq(std::get<0>(nbrs[5]), 0.61344));
+      REQUIRE(std::get<1>(nbrs[5]) == 0);
+      REQUIRE(std::get<2>(nbrs[5]) == 1);
     }
     {  // request more threads than we have readers, this shouldn't be a problem
       std::vector<MultiFPBReader::ResultTuple> nbrs =
           mfps.getTanimotoNeighbors(qbv, 0.6, 8);
-      TEST_ASSERT(nbrs.size() == 6);
-      TEST_ASSERT(feq(std::get<0>(nbrs[0]), 0.66412));
-      TEST_ASSERT(std::get<1>(nbrs[0]) == 0);
-      TEST_ASSERT(std::get<2>(nbrs[0]) == 3);
-      TEST_ASSERT(feq(std::get<0>(nbrs[1]), 0.65289));
-      TEST_ASSERT(std::get<1>(nbrs[1]) == 1);
-      TEST_ASSERT(std::get<2>(nbrs[1]) == 2);
-      TEST_ASSERT(feq(std::get<0>(nbrs[2]), 0.64341));
-      TEST_ASSERT(std::get<1>(nbrs[2]) == 2);
-      TEST_ASSERT(std::get<2>(nbrs[2]) == 1);
-      TEST_ASSERT(feq(std::get<0>(nbrs[3]), 0.61940));
-      TEST_ASSERT(std::get<1>(nbrs[3]) == 1);
-      TEST_ASSERT(std::get<2>(nbrs[3]) == 0);
-      TEST_ASSERT(feq(std::get<0>(nbrs[4]), 0.61905));
-      TEST_ASSERT(std::get<1>(nbrs[4]) == 0);
-      TEST_ASSERT(std::get<2>(nbrs[4]) == 0);
-      TEST_ASSERT(feq(std::get<0>(nbrs[5]), 0.61344));
-      TEST_ASSERT(std::get<1>(nbrs[5]) == 0);
-      TEST_ASSERT(std::get<2>(nbrs[5]) == 1);
+      REQUIRE(nbrs.size() == 6);
+      REQUIRE(feq(std::get<0>(nbrs[0]), 0.66412));
+      REQUIRE(std::get<1>(nbrs[0]) == 0);
+      REQUIRE(std::get<2>(nbrs[0]) == 3);
+      REQUIRE(feq(std::get<0>(nbrs[1]), 0.65289));
+      REQUIRE(std::get<1>(nbrs[1]) == 1);
+      REQUIRE(std::get<2>(nbrs[1]) == 2);
+      REQUIRE(feq(std::get<0>(nbrs[2]), 0.64341));
+      REQUIRE(std::get<1>(nbrs[2]) == 2);
+      REQUIRE(std::get<2>(nbrs[2]) == 1);
+      REQUIRE(feq(std::get<0>(nbrs[3]), 0.61940));
+      REQUIRE(std::get<1>(nbrs[3]) == 1);
+      REQUIRE(std::get<2>(nbrs[3]) == 0);
+      REQUIRE(feq(std::get<0>(nbrs[4]), 0.61905));
+      REQUIRE(std::get<1>(nbrs[4]) == 0);
+      REQUIRE(std::get<2>(nbrs[4]) == 0);
+      REQUIRE(feq(std::get<0>(nbrs[5]), 0.61344));
+      REQUIRE(std::get<1>(nbrs[5]) == 0);
+      REQUIRE(std::get<2>(nbrs[5]) == 1);
     }
 
 #endif
   }
-  BOOST_LOG(rdInfoLog) << "Finished" << std::endl;
 }
 
-void test6MultiFPBReaderContainsThreaded() {
-  BOOST_LOG(rdInfoLog)
-      << "-----------------------\n Testing MultiFPBReader Contains Threaded"
-      << std::endl;
+TEST_CASE("MultiFPBReader Contains Threaded") {
   std::string pathName = getenv("RDBASE");
   pathName += "/Code/DataStructs/testData/";
   {
@@ -359,7 +333,7 @@ void test6MultiFPBReaderContainsThreaded() {
     rdrs.push_back(&fps4);
     MultiFPBReader mfps(rdrs);
     mfps.init();
-    TEST_ASSERT(mfps.length() == 4);
+    REQUIRE(mfps.length() == 4);
     std::string fps =
         "40081010824820021000500010110410003000402b20285000a4040240010030050000"
         "080001420040009000003d04086007080c03b31d920004220400074008098010206080"
@@ -371,84 +345,84 @@ void test6MultiFPBReaderContainsThreaded() {
     {
       std::vector<std::pair<unsigned int, unsigned int>> nbrs =
           mfps.getContainingNeighbors(qbv);
-      TEST_ASSERT(nbrs.size() == 9);
+      REQUIRE(nbrs.size() == 9);
       // for (unsigned int i = 0; i < nbrs.size(); ++i) {
       //   std::cerr << i << ": " << nbrs[i].first << " " << nbrs[i].second
       //             << std::endl;
       // }
-      TEST_ASSERT(nbrs[0].first == 160);
-      TEST_ASSERT(nbrs[0].second == 0);
-      TEST_ASSERT(nbrs[1].first == 163);
-      TEST_ASSERT(nbrs[1].second == 0);
-      TEST_ASSERT(nbrs[2].first == 170);
-      TEST_ASSERT(nbrs[2].second == 0);
-      TEST_ASSERT(nbrs[3].first == 180);
-      TEST_ASSERT(nbrs[3].second == 2);
-      TEST_ASSERT(nbrs[4].first == 182);
-      TEST_ASSERT(nbrs[4].second == 3);
-      TEST_ASSERT(nbrs[5].first == 185);
-      TEST_ASSERT(nbrs[5].second == 0);
-      TEST_ASSERT(nbrs[6].first == 189);
-      TEST_ASSERT(nbrs[6].second == 0);
-      TEST_ASSERT(nbrs[7].first == 192);
-      TEST_ASSERT(nbrs[7].second == 3);
-      TEST_ASSERT(nbrs[8].first == 193);
-      TEST_ASSERT(nbrs[8].second == 0);
+      REQUIRE(nbrs[0].first == 160);
+      REQUIRE(nbrs[0].second == 0);
+      REQUIRE(nbrs[1].first == 163);
+      REQUIRE(nbrs[1].second == 0);
+      REQUIRE(nbrs[2].first == 170);
+      REQUIRE(nbrs[2].second == 0);
+      REQUIRE(nbrs[3].first == 180);
+      REQUIRE(nbrs[3].second == 2);
+      REQUIRE(nbrs[4].first == 182);
+      REQUIRE(nbrs[4].second == 3);
+      REQUIRE(nbrs[5].first == 185);
+      REQUIRE(nbrs[5].second == 0);
+      REQUIRE(nbrs[6].first == 189);
+      REQUIRE(nbrs[6].second == 0);
+      REQUIRE(nbrs[7].first == 192);
+      REQUIRE(nbrs[7].second == 3);
+      REQUIRE(nbrs[8].first == 193);
+      REQUIRE(nbrs[8].second == 0);
     }
 #ifdef RDK_TEST_MULTITHREADED
     {
       std::vector<std::pair<unsigned int, unsigned int>> nbrs =
           mfps.getContainingNeighbors(qbv, 4);
-      TEST_ASSERT(nbrs.size() == 9);
+      REQUIRE(nbrs.size() == 9);
       // for (unsigned int i = 0; i < nbrs.size(); ++i) {
       //   std::cerr << i << ": " << nbrs[i].first << " " << nbrs[i].second
       //             << std::endl;
       // }
-      TEST_ASSERT(nbrs[0].first == 160);
-      TEST_ASSERT(nbrs[0].second == 0);
-      TEST_ASSERT(nbrs[1].first == 163);
-      TEST_ASSERT(nbrs[1].second == 0);
-      TEST_ASSERT(nbrs[2].first == 170);
-      TEST_ASSERT(nbrs[2].second == 0);
-      TEST_ASSERT(nbrs[3].first == 180);
-      TEST_ASSERT(nbrs[3].second == 2);
-      TEST_ASSERT(nbrs[4].first == 182);
-      TEST_ASSERT(nbrs[4].second == 3);
-      TEST_ASSERT(nbrs[5].first == 185);
-      TEST_ASSERT(nbrs[5].second == 0);
-      TEST_ASSERT(nbrs[6].first == 189);
-      TEST_ASSERT(nbrs[6].second == 0);
-      TEST_ASSERT(nbrs[7].first == 192);
-      TEST_ASSERT(nbrs[7].second == 3);
-      TEST_ASSERT(nbrs[8].first == 193);
-      TEST_ASSERT(nbrs[8].second == 0);
+      REQUIRE(nbrs[0].first == 160);
+      REQUIRE(nbrs[0].second == 0);
+      REQUIRE(nbrs[1].first == 163);
+      REQUIRE(nbrs[1].second == 0);
+      REQUIRE(nbrs[2].first == 170);
+      REQUIRE(nbrs[2].second == 0);
+      REQUIRE(nbrs[3].first == 180);
+      REQUIRE(nbrs[3].second == 2);
+      REQUIRE(nbrs[4].first == 182);
+      REQUIRE(nbrs[4].second == 3);
+      REQUIRE(nbrs[5].first == 185);
+      REQUIRE(nbrs[5].second == 0);
+      REQUIRE(nbrs[6].first == 189);
+      REQUIRE(nbrs[6].second == 0);
+      REQUIRE(nbrs[7].first == 192);
+      REQUIRE(nbrs[7].second == 3);
+      REQUIRE(nbrs[8].first == 193);
+      REQUIRE(nbrs[8].second == 0);
     }
     {  // request more threads than we have readers, this shouldn't be a problem
       std::vector<std::pair<unsigned int, unsigned int>> nbrs =
           mfps.getContainingNeighbors(qbv, 8);
-      TEST_ASSERT(nbrs.size() == 9);
+      REQUIRE(nbrs.size() == 9);
       // for (unsigned int i = 0; i < nbrs.size(); ++i) {
       //   std::cerr << i << ": " << nbrs[i].first << " " << nbrs[i].second
       //             << std::endl;
       // }
-      TEST_ASSERT(nbrs[0].first == 160);
-      TEST_ASSERT(nbrs[0].second == 0);
-      TEST_ASSERT(nbrs[1].first == 163);
-      TEST_ASSERT(nbrs[1].second == 0);
-      TEST_ASSERT(nbrs[2].first == 170);
-      TEST_ASSERT(nbrs[2].second == 0);
-      TEST_ASSERT(nbrs[3].first == 180);
-      TEST_ASSERT(nbrs[3].second == 2);
-      TEST_ASSERT(nbrs[4].first == 182);
-      TEST_ASSERT(nbrs[4].second == 3);
-      TEST_ASSERT(nbrs[5].first == 185);
-      TEST_ASSERT(nbrs[5].second == 0);
-      TEST_ASSERT(nbrs[6].first == 189);
-      TEST_ASSERT(nbrs[6].second == 0);
-      TEST_ASSERT(nbrs[7].first == 192);
-      TEST_ASSERT(nbrs[7].second == 3);
-      TEST_ASSERT(nbrs[8].first == 193);
-      TEST_ASSERT(nbrs[8].second == 0);
+      REQUIRE(nbrs[0].first == 160);
+      REQUIRE(nbrs[0].second == 0);
+      REQUIRE(nbrs[1].first == 163);
+      REQUIRE(nbrs[1].second == 0);
+      REQUIRE(nbrs[2].first == 170);
+      REQUIRE(nbrs[2].second == 0);
+      REQUIRE(nbrs[3].first == 180);
+      REQUIRE(nbrs[3].second == 2);
+      REQUIRE(nbrs[4].first == 182);
+      REQUIRE(nbrs[4].second == 3);
+      REQUIRE(nbrs[5].first == 185);
+      REQUIRE(nbrs[5].second == 0);
+      REQUIRE(nbrs[6].first == 189);
+      REQUIRE(nbrs[6].second == 0);
+      REQUIRE(nbrs[7].first == 192);
+      REQUIRE(nbrs[7].second == 3);
+      REQUIRE(nbrs[8].first == 193);
+      REQUIRE(nbrs[8].second == 0);
     }
 #endif
   }
@@ -476,57 +450,57 @@ void test6MultiFPBReaderContainsThreaded() {
     {
       std::vector<std::pair<unsigned int, unsigned int>> nbrs =
           mfps.getContainingNeighbors(qbv);
-      TEST_ASSERT(nbrs.size() == 9);
+      REQUIRE(nbrs.size() == 9);
       // for (unsigned int i = 0; i < nbrs.size(); ++i) {
       //   std::cerr << i << ": " << nbrs[i].first << " " << nbrs[i].second
       //             << std::endl;
       // }
-      TEST_ASSERT(nbrs[0].first == 160);
-      TEST_ASSERT(nbrs[0].second == 0);
-      TEST_ASSERT(nbrs[1].first == 163);
-      TEST_ASSERT(nbrs[1].second == 0);
-      TEST_ASSERT(nbrs[2].first == 170);
-      TEST_ASSERT(nbrs[2].second == 0);
-      TEST_ASSERT(nbrs[3].first == 180);
-      TEST_ASSERT(nbrs[3].second == 2);
-      TEST_ASSERT(nbrs[4].first == 182);
-      TEST_ASSERT(nbrs[4].second == 3);
-      TEST_ASSERT(nbrs[5].first == 185);
-      TEST_ASSERT(nbrs[5].second == 0);
-      TEST_ASSERT(nbrs[6].first == 189);
-      TEST_ASSERT(nbrs[6].second == 0);
-      TEST_ASSERT(nbrs[7].first == 192);
-      TEST_ASSERT(nbrs[7].second == 3);
-      TEST_ASSERT(nbrs[8].first == 193);
-      TEST_ASSERT(nbrs[8].second == 0);
+      REQUIRE(nbrs[0].first == 160);
+      REQUIRE(nbrs[0].second == 0);
+      REQUIRE(nbrs[1].first == 163);
+      REQUIRE(nbrs[1].second == 0);
+      REQUIRE(nbrs[2].first == 170);
+      REQUIRE(nbrs[2].second == 0);
+      REQUIRE(nbrs[3].first == 180);
+      REQUIRE(nbrs[3].second == 2);
+      REQUIRE(nbrs[4].first == 182);
+      REQUIRE(nbrs[4].second == 3);
+      REQUIRE(nbrs[5].first == 185);
+      REQUIRE(nbrs[5].second == 0);
+      REQUIRE(nbrs[6].first == 189);
+      REQUIRE(nbrs[6].second == 0);
+      REQUIRE(nbrs[7].first == 192);
+      REQUIRE(nbrs[7].second == 3);
+      REQUIRE(nbrs[8].first == 193);
+      REQUIRE(nbrs[8].second == 0);
     }
 #else
     {
       std::vector<std::pair<unsigned int, unsigned int>> nbrs =
           mfps.getContainingNeighbors(qbv, 4);
-      TEST_ASSERT(nbrs.size() == 9);
+      REQUIRE(nbrs.size() == 9);
       // for (unsigned int i = 0; i < nbrs.size(); ++i) {
       //   std::cerr << i << ": " << nbrs[i].first << " " << nbrs[i].second
       //             << std::endl;
       // }
-      TEST_ASSERT(nbrs[0].first == 160);
-      TEST_ASSERT(nbrs[0].second == 0);
-      TEST_ASSERT(nbrs[1].first == 163);
-      TEST_ASSERT(nbrs[1].second == 0);
-      TEST_ASSERT(nbrs[2].first == 170);
-      TEST_ASSERT(nbrs[2].second == 0);
-      TEST_ASSERT(nbrs[3].first == 180);
-      TEST_ASSERT(nbrs[3].second == 2);
-      TEST_ASSERT(nbrs[4].first == 182);
-      TEST_ASSERT(nbrs[4].second == 3);
-      TEST_ASSERT(nbrs[5].first == 185);
-      TEST_ASSERT(nbrs[5].second == 0);
-      TEST_ASSERT(nbrs[6].first == 189);
-      TEST_ASSERT(nbrs[6].second == 0);
-      TEST_ASSERT(nbrs[7].first == 192);
-      TEST_ASSERT(nbrs[7].second == 3);
-      TEST_ASSERT(nbrs[8].first == 193);
-      TEST_ASSERT(nbrs[8].second == 0);
+      REQUIRE(nbrs[0].first == 160);
+      REQUIRE(nbrs[0].second == 0);
+      REQUIRE(nbrs[1].first == 163);
+      REQUIRE(nbrs[1].second == 0);
+      REQUIRE(nbrs[2].first == 170);
+      REQUIRE(nbrs[2].second == 0);
+      REQUIRE(nbrs[3].first == 180);
+      REQUIRE(nbrs[3].second == 2);
+      REQUIRE(nbrs[4].first == 182);
+      REQUIRE(nbrs[4].second == 3);
+      REQUIRE(nbrs[5].first == 185);
+      REQUIRE(nbrs[5].second == 0);
+      REQUIRE(nbrs[6].first == 189);
+      REQUIRE(nbrs[6].second == 0);
+      REQUIRE(nbrs[7].first == 192);
+      REQUIRE(nbrs[7].second == 3);
+      REQUIRE(nbrs[8].first == 193);
+      REQUIRE(nbrs[8].second == 0);
     }
 #endif
   }
@@ -534,7 +508,7 @@ void test6MultiFPBReaderContainsThreaded() {
   BOOST_LOG(rdInfoLog) << "Finished" << std::endl;
 }
 
-void test7MultiFPBReaderEdges() {
+TEST_CASE("MultiFPBReader edge cases") {
   BOOST_LOG(rdInfoLog)
       << "-----------------------\n Testing MultiFPBReader edge cases "
       << std::endl;
@@ -553,27 +527,15 @@ void test7MultiFPBReaderEdges() {
     {
       std::vector<std::pair<unsigned int, unsigned int>> nbrs =
           mfps.getContainingNeighbors(qbv);
-      TEST_ASSERT(nbrs.size() == 0);
+      REQUIRE(nbrs.size() == 0);
     }
     {
       std::vector<MultiFPBReader::ResultTuple> nbrs =
           mfps.getTanimotoNeighbors(qbv, 0.01);
-      TEST_ASSERT(nbrs.size() == 0);
+      REQUIRE(nbrs.size() == 0);
     }
   }
   BOOST_LOG(rdInfoLog) << "Finished" << std::endl;
 }
 
-int main() {
-  RDLog::InitLogs();
-
-  test1MultiFPBReaderBasics();
-  test2MultiFPBReaderTanimoto();
-  test3MultiFPBReaderTversky();
-  test4MultiFPBReaderContains();
-  test5MultiFPBReaderThreaded();
-  test6MultiFPBReaderContainsThreaded();
-  test7MultiFPBReaderEdges();
-
-  return 0;
-}
+int main(int argc, char *argv[]) { return Catch::Session().run(argc, argv); }

--- a/Code/DistGeom/CMakeLists.txt
+++ b/Code/DistGeom/CMakeLists.txt
@@ -15,7 +15,7 @@ rdkit_headers(BoundsMatrix.h
               FourthDimContribs.h
               TriangleSmooth.h DEST DistGeom)
 
-rdkit_test(testDistGeom testDistGeom.cpp 
+rdkit_catch_test(testDistGeom testDistGeom.cpp 
 LINK_LIBRARIES DistGeometry )
 
 if(RDK_BUILD_PYTHON_WRAPPERS)

--- a/Code/DistGeom/testDistGeom.cpp
+++ b/Code/DistGeom/testDistGeom.cpp
@@ -1,6 +1,5 @@
-// $Id$
 //
-// Copyright (C)  2004-2006 Rational Discovery LLC
+// Copyright (C)  2004-2025 Greg Landrum and other RDKit contributors
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -9,7 +8,7 @@
 //  of the RDKit source tree.
 //
 
-#include <RDGeneral/test.h>
+#include <catch2/catch_all.hpp>
 #include "BoundsMatrix.h"
 #include "TriangleSmooth.h"
 #include <iostream>
@@ -22,8 +21,7 @@
 using namespace DistGeom;
 using namespace RDNumeric;
 
-void test1() {
-  // test triangle smoothing
+TEST_CASE("test1") {
   unsigned int npt = 5;
   double x = sqrt(3.0);
   auto *mmat = new BoundsMatrix(npt);
@@ -52,26 +50,46 @@ void test1() {
   BoundsMatPtr mptr(mmat);
 
   triangleSmoothBounds(mptr);
-  CHECK_INVARIANT(RDKit::feq(mmat->getUpperBound(0, 1), 1.0, 0.001), "");
-  CHECK_INVARIANT(RDKit::feq(mmat->getLowerBound(0, 1), 1.0, 0.001), "");
-  CHECK_INVARIANT(RDKit::feq(mmat->getUpperBound(0, 2), 1.732, 0.001), "");
-  CHECK_INVARIANT(RDKit::feq(mmat->getLowerBound(0, 2), 1.732, 0.001), "");
-  CHECK_INVARIANT(RDKit::feq(mmat->getUpperBound(0, 3), 2.732, 0.001), "");
-  CHECK_INVARIANT(RDKit::feq(mmat->getLowerBound(0, 3), 0.732, 0.001), "");
-  CHECK_INVARIANT(RDKit::feq(mmat->getUpperBound(0, 4), 3.464, 0.001), "");
-  CHECK_INVARIANT(RDKit::feq(mmat->getLowerBound(0, 4), 0.0, 0.001), "");
-  CHECK_INVARIANT(RDKit::feq(mmat->getUpperBound(1, 2), 1.0, 0.001), "");
-  CHECK_INVARIANT(RDKit::feq(mmat->getLowerBound(1, 2), 1.0, 0.001), "");
-  CHECK_INVARIANT(RDKit::feq(mmat->getUpperBound(1, 3), 1.732, 0.001), "");
-  CHECK_INVARIANT(RDKit::feq(mmat->getLowerBound(1, 3), 1.732, 0.001), "");
-  CHECK_INVARIANT(RDKit::feq(mmat->getUpperBound(1, 4), 2.732, 0.001), "");
-  CHECK_INVARIANT(RDKit::feq(mmat->getLowerBound(1, 4), 0.732, 0.001), "");
-  CHECK_INVARIANT(RDKit::feq(mmat->getUpperBound(2, 3), 1.0, 0.001), "");
-  CHECK_INVARIANT(RDKit::feq(mmat->getLowerBound(2, 3), 1.0, 0.001), "");
-  CHECK_INVARIANT(RDKit::feq(mmat->getUpperBound(2, 4), 1.732, 0.001), "");
-  CHECK_INVARIANT(RDKit::feq(mmat->getLowerBound(2, 4), 1.732, 0.001), "");
-  CHECK_INVARIANT(RDKit::feq(mmat->getUpperBound(3, 4), 1.0, 0.001), "");
-  CHECK_INVARIANT(RDKit::feq(mmat->getLowerBound(3, 4), 1.0, 0.001), "");
+  REQUIRE_THAT(mmat->getUpperBound(0, 1),
+               Catch::Matchers::WithinAbs(1.0, 0.001));
+  REQUIRE_THAT(mmat->getLowerBound(0, 1),
+               Catch::Matchers::WithinAbs(1.0, 0.001));
+  REQUIRE_THAT(mmat->getUpperBound(0, 2),
+               Catch::Matchers::WithinAbs(1.732, 0.001));
+  REQUIRE_THAT(mmat->getLowerBound(0, 2),
+               Catch::Matchers::WithinAbs(1.732, 0.001));
+  REQUIRE_THAT(mmat->getUpperBound(0, 3),
+               Catch::Matchers::WithinAbs(2.732, 0.001));
+  REQUIRE_THAT(mmat->getLowerBound(0, 3),
+               Catch::Matchers::WithinAbs(0.732, 0.001));
+  REQUIRE_THAT(mmat->getUpperBound(0, 4),
+               Catch::Matchers::WithinAbs(3.464, 0.001));
+  REQUIRE_THAT(mmat->getLowerBound(0, 4),
+               Catch::Matchers::WithinAbs(0.0, 0.001));
+  REQUIRE_THAT(mmat->getUpperBound(1, 2),
+               Catch::Matchers::WithinAbs(1.0, 0.001));
+  REQUIRE_THAT(mmat->getLowerBound(1, 2),
+               Catch::Matchers::WithinAbs(1.0, 0.001));
+  REQUIRE_THAT(mmat->getUpperBound(1, 3),
+               Catch::Matchers::WithinAbs(1.732, 0.001));
+  REQUIRE_THAT(mmat->getLowerBound(1, 3),
+               Catch::Matchers::WithinAbs(1.732, 0.001));
+  REQUIRE_THAT(mmat->getUpperBound(1, 4),
+               Catch::Matchers::WithinAbs(2.732, 0.001));
+  REQUIRE_THAT(mmat->getLowerBound(1, 4),
+               Catch::Matchers::WithinAbs(0.732, 0.001));
+  REQUIRE_THAT(mmat->getUpperBound(2, 3),
+               Catch::Matchers::WithinAbs(1.0, 0.001));
+  REQUIRE_THAT(mmat->getLowerBound(2, 3),
+               Catch::Matchers::WithinAbs(1.0, 0.001));
+  REQUIRE_THAT(mmat->getUpperBound(2, 4),
+               Catch::Matchers::WithinAbs(1.732, 0.001));
+  REQUIRE_THAT(mmat->getLowerBound(2, 4),
+               Catch::Matchers::WithinAbs(1.732, 0.001));
+  REQUIRE_THAT(mmat->getUpperBound(3, 4),
+               Catch::Matchers::WithinAbs(1.0, 0.001));
+  REQUIRE_THAT(mmat->getLowerBound(3, 4),
+               Catch::Matchers::WithinAbs(1.0, 0.001));
 
   DoubleSymmMatrix dmat(npt, 0.0);
   RDKit::rng_type generator(42u);
@@ -84,10 +102,10 @@ void test1() {
   for (unsigned int i = 0; i < dmat.getDataSize(); i++) {
     sumElem += dmat.getData()[i];
   }
-  CHECK_INVARIANT(RDKit::feq(sumElem, 14.3079, 0.001), "");
+  REQUIRE_THAT(sumElem, Catch::Matchers::WithinAbs(14.3079, 0.001));
 }
 
-void testIssue216() {
+TEST_CASE("testIssue216") {
   RDNumeric::DoubleSymmMatrix dmat(4);
   dmat.setVal(0, 0, 0.0);
   dmat.setVal(0, 1, 1.0);
@@ -108,29 +126,17 @@ void testIssue216() {
   }
 
   bool gotCoords = DistGeom::computeInitialCoords(dmat, pos);
-  CHECK_INVARIANT(gotCoords, "");
+  REQUIRE(gotCoords);
 
   for (int i = 1; i < 4; i++) {
     RDGeom::Point3D pti = *(RDGeom::Point3D *)pos[i];
     for (int j = 0; j < i; j++) {
       RDGeom::Point3D ptj = *(RDGeom::Point3D *)pos[j];
       ptj -= pti;
-      CHECK_INVARIANT(RDKit::feq(ptj.length(), 1.0, 0.02), "");
+      REQUIRE_THAT(ptj.length(), Catch::Matchers::WithinAbs(1.0, 0.02));
     }
   }
   for (int i = 0; i < 4; i++) {
     delete pos[i];
   }
-}
-int main() {
-  std::cout << "***********************************************************\n";
-  std::cout << "   test1 \n";
-  test1();
-
-  std::cout << "***********************************************************\n";
-  std::cout << "   testIssue216 \n";
-  testIssue216();
-  std::cout
-      << "***********************************************************\n\n";
-  return 0;
 }

--- a/Code/Features/CMakeLists.txt
+++ b/Code/Features/CMakeLists.txt
@@ -1,5 +1,5 @@
 rdkit_headers(Feature.h
               DEST Features)
 
-rdkit_test(testBaseFeatures testFeatures.cpp 
+rdkit_catch_test(testBaseFeatures testFeatures.cpp 
 LINK_LIBRARIES RDGeneral RDGeometryLib )

--- a/Code/Features/testFeatures.cpp
+++ b/Code/Features/testFeatures.cpp
@@ -1,5 +1,5 @@
 //
-// Copyright (C)  2004-2040 Greg Landrum and other RDKit contributors
+// Copyright (C)  2004-2025 Greg Landrum and other RDKit contributors
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -7,7 +7,7 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
-#include <RDGeneral/test.h>
+#include <catch2/catch_all.hpp>
 #include <iostream>
 #include <RDGeneral/Invariant.h>
 #include <RDGeneral/utils.h>
@@ -26,125 +26,104 @@ typedef enum {
   grnType,
 } TypeMarker;
 
-void test1() {
-  std::cerr << "-------------------------------------" << std::endl;
-  std::cerr << "Basics for ExplicitFeatures." << std::endl;
-
+TEST_CASE("Basics for ExplicitFeatures") {
   ExplicitFeature<TypeMarker> f1;
   f1.setFamily(bazType);
-  TEST_ASSERT(f1.getFamily() == bazType);
+  REQUIRE(f1.getFamily() == bazType);
   f1.setType(grnType);
-  TEST_ASSERT(f1.getType() == grnType);
-  TEST_ASSERT(feq(f1.getLoc().x, 0.0));
-  TEST_ASSERT(feq(f1.getLoc().y, 0.0));
-  TEST_ASSERT(feq(f1.getLoc().z, 0.0));
-  TEST_ASSERT(f1.getDirs().size() == 0);
+  REQUIRE(f1.getType() == grnType);
+  REQUIRE_THAT(f1.getLoc().x, Catch::Matchers::WithinAbs(0.0, 1e-4));
+  REQUIRE_THAT(f1.getLoc().y, Catch::Matchers::WithinAbs(0.0, 1e-4));
+  REQUIRE_THAT(f1.getLoc().z, Catch::Matchers::WithinAbs(0.0, 1e-4));
+  REQUIRE(f1.getDirs().size() == 0);
 
   f1 = ExplicitFeature<TypeMarker>(barType, fooType);
-  TEST_ASSERT(f1.getFamily() == barType);
-  TEST_ASSERT(f1.getType() == fooType);
-  TEST_ASSERT(feq(f1.getLoc().x, 0.0));
-  TEST_ASSERT(feq(f1.getLoc().y, 0.0));
-  TEST_ASSERT(feq(f1.getLoc().z, 0.0));
-  TEST_ASSERT(f1.getDirs().size() == 0);
+  REQUIRE(f1.getFamily() == barType);
+  REQUIRE(f1.getType() == fooType);
+  REQUIRE_THAT(f1.getLoc().x, Catch::Matchers::WithinAbs(0.0, 1e-4));
+  REQUIRE_THAT(f1.getLoc().y, Catch::Matchers::WithinAbs(0.0, 1e-4));
+  REQUIRE_THAT(f1.getLoc().z, Catch::Matchers::WithinAbs(0.0, 1e-4));
+  REQUIRE(f1.getDirs().size() == 0);
 
   f1 = ExplicitFeature<TypeMarker>(barType, fooType, Point3D(1.0, 2.0, 3.0));
-  TEST_ASSERT(f1.getFamily() == barType);
-  TEST_ASSERT(f1.getType() == fooType);
-  TEST_ASSERT(feq(f1.getLoc().x, 1.0));
-  TEST_ASSERT(feq(f1.getLoc().y, 2.0));
-  TEST_ASSERT(feq(f1.getLoc().z, 3.0));
-  TEST_ASSERT(f1.getDirs().size() == 0);
+  REQUIRE(f1.getFamily() == barType);
+  REQUIRE(f1.getType() == fooType);
+  REQUIRE_THAT(f1.getLoc().x, Catch::Matchers::WithinAbs(1.0, 1e-4));
+  REQUIRE_THAT(f1.getLoc().y, Catch::Matchers::WithinAbs(2.0, 1e-4));
+  REQUIRE_THAT(f1.getLoc().z, Catch::Matchers::WithinAbs(3.0, 1e-4));
+  REQUIRE(f1.getDirs().size() == 0);
 
   f1.setLoc(Point3D(-1.0, -2.0, -3.0));
-  TEST_ASSERT(feq(f1.getLoc().x, -1.0));
-  TEST_ASSERT(feq(f1.getLoc().y, -2.0));
-  TEST_ASSERT(feq(f1.getLoc().z, -3.0));
-  TEST_ASSERT(f1.getDirs().size() == 0);
-
-  std::cerr << "  done" << std::endl;
+  REQUIRE_THAT(f1.getLoc().x, Catch::Matchers::WithinAbs(-1.0, 1e-4));
+  REQUIRE_THAT(f1.getLoc().y, Catch::Matchers::WithinAbs(-2.0, 1e-4));
+  REQUIRE_THAT(f1.getLoc().z, Catch::Matchers::WithinAbs(-3.0, 1e-4));
+  REQUIRE(f1.getDirs().size() == 0);
 }
 
-void test2() {
-  std::cerr << "-------------------------------------" << std::endl;
-  std::cerr << "Basics for ImplicitFeatures." << std::endl;
-
+TEST_CASE("Basics for ImplicitFeatures") {
   ImplicitFeature<TypeMarker> f1;
   f1.setType(fooType);
-  TEST_ASSERT(f1.getType() == fooType);
+  REQUIRE(f1.getType() == fooType);
   f1.setType(grnType);
-  TEST_ASSERT(f1.getType() == grnType);
-  TEST_ASSERT(feq(f1.getLoc().x, 0.0));
-  TEST_ASSERT(feq(f1.getLoc().y, 0.0));
-  TEST_ASSERT(feq(f1.getLoc().z, 0.0));
-  TEST_ASSERT(f1.getDirs().size() == 0);
+  REQUIRE(f1.getType() == grnType);
+  REQUIRE_THAT(f1.getLoc().x, Catch::Matchers::WithinAbs(0.0, 1e-4));
+  REQUIRE_THAT(f1.getLoc().y, Catch::Matchers::WithinAbs(0.0, 1e-4));
+  REQUIRE_THAT(f1.getLoc().z, Catch::Matchers::WithinAbs(0.0, 1e-4));
+  REQUIRE(f1.getDirs().size() == 0);
 
   f1 = ImplicitFeature<TypeMarker>(barType, fooType);
-  TEST_ASSERT(f1.getFamily() == barType);
-  TEST_ASSERT(f1.getType() == fooType);
-  TEST_ASSERT(feq(f1.getLoc().x, 0.0));
-  TEST_ASSERT(feq(f1.getLoc().y, 0.0));
-  TEST_ASSERT(feq(f1.getLoc().z, 0.0));
-  TEST_ASSERT(f1.getDirs().size() == 0);
+  REQUIRE(f1.getFamily() == barType);
+  REQUIRE(f1.getType() == fooType);
+  REQUIRE_THAT(f1.getLoc().x, Catch::Matchers::WithinAbs(0.0, 1e-4));
+  REQUIRE_THAT(f1.getLoc().y, Catch::Matchers::WithinAbs(0.0, 1e-4));
+  REQUIRE_THAT(f1.getLoc().z, Catch::Matchers::WithinAbs(0.0, 1e-4));
+  REQUIRE(f1.getDirs().size() == 0);
 
   Point3D p1(0, 0, 0), p2(1, 0, 0), p3(0, 1, 0);
   f1.addPoint(&p1);
   f1.addPoint(&p2);
-  TEST_ASSERT(feq(f1.getLoc().x, 0.50));
-  TEST_ASSERT(feq(f1.getLoc().y, 0.0));
-  TEST_ASSERT(feq(f1.getLoc().z, 0.0));
+  REQUIRE_THAT(f1.getLoc().x, Catch::Matchers::WithinAbs(0.50, 1e-4));
+  REQUIRE_THAT(f1.getLoc().y, Catch::Matchers::WithinAbs(0.0, 1e-4));
+  REQUIRE_THAT(f1.getLoc().z, Catch::Matchers::WithinAbs(0.0, 1e-4));
 
   f1.addPoint(&p3);
-  TEST_ASSERT(feq(f1.getLoc().x, 0.3333));
-  TEST_ASSERT(feq(f1.getLoc().y, 0.3333));
-  TEST_ASSERT(feq(f1.getLoc().z, 0.0));
+  REQUIRE_THAT(f1.getLoc().x, Catch::Matchers::WithinAbs(0.3333, 1e-4));
+  REQUIRE_THAT(f1.getLoc().y, Catch::Matchers::WithinAbs(0.3333, 1e-4));
+  REQUIRE_THAT(f1.getLoc().z, Catch::Matchers::WithinAbs(0.0, 1e-4));
 
   f1.reset();
-  TEST_ASSERT(feq(f1.getLoc().x, 0.0));
-  TEST_ASSERT(feq(f1.getLoc().y, 0.0));
-  TEST_ASSERT(feq(f1.getLoc().z, 0.0));
-
-  std::cerr << "  done" << std::endl;
+  REQUIRE_THAT(f1.getLoc().x, Catch::Matchers::WithinAbs(0.0, 1e-4));
+  REQUIRE_THAT(f1.getLoc().y, Catch::Matchers::WithinAbs(0.0, 1e-4));
+  REQUIRE_THAT(f1.getLoc().z, Catch::Matchers::WithinAbs(0.0, 1e-4));
 }
 
-void test3() {
-  std::cerr << "-------------------------------------" << std::endl;
-  std::cerr << "ExplicitFeatures 2D, string type." << std::endl;
-
+TEST_CASE("ExplicitFeatures 2D, string type.") {
   typedef ExplicitFeature<std::string, std::string, Point2D> LocalFeature;
   LocalFeature f1;
   f1.setType("foo");
-  TEST_ASSERT(f1.getType() == "foo");
+  REQUIRE(f1.getType() == "foo");
   f1.setFamily("foob");
-  TEST_ASSERT(f1.getFamily() == "foob");
-  TEST_ASSERT(feq(f1.getLoc().x, 0.0));
-  TEST_ASSERT(feq(f1.getLoc().y, 0.0));
-  TEST_ASSERT(f1.getDirs().size() == 0);
+  REQUIRE(f1.getFamily() == "foob");
+  REQUIRE_THAT(f1.getLoc().x, Catch::Matchers::WithinAbs(0.0, 1e-4));
+  REQUIRE_THAT(f1.getLoc().y, Catch::Matchers::WithinAbs(0.0, 1e-4));
+  REQUIRE(f1.getDirs().size() == 0);
 
   f1 = LocalFeature("foo", "bar");
-  TEST_ASSERT(f1.getFamily() == "foo");
-  TEST_ASSERT(f1.getType() == "bar");
-  TEST_ASSERT(feq(f1.getLoc().x, 0.0));
-  TEST_ASSERT(feq(f1.getLoc().y, 0.0));
-  TEST_ASSERT(f1.getDirs().size() == 0);
+  REQUIRE(f1.getFamily() == "foo");
+  REQUIRE(f1.getType() == "bar");
+  REQUIRE_THAT(f1.getLoc().x, Catch::Matchers::WithinAbs(0.0, 1e-4));
+  REQUIRE_THAT(f1.getLoc().y, Catch::Matchers::WithinAbs(0.0, 1e-4));
+  REQUIRE(f1.getDirs().size() == 0);
 
   f1 = LocalFeature("grm", "grn", Point2D(1.0, 2.0));
-  TEST_ASSERT(f1.getFamily() == "grm");
-  TEST_ASSERT(f1.getType() == "grn");
-  TEST_ASSERT(feq(f1.getLoc().x, 1.0));
-  TEST_ASSERT(feq(f1.getLoc().y, 2.0));
-  TEST_ASSERT(f1.getDirs().size() == 0);
+  REQUIRE(f1.getFamily() == "grm");
+  REQUIRE(f1.getType() == "grn");
+  REQUIRE_THAT(f1.getLoc().x, Catch::Matchers::WithinAbs(1.0, 1e-4));
+  REQUIRE_THAT(f1.getLoc().y, Catch::Matchers::WithinAbs(2.0, 1e-4));
+  REQUIRE(f1.getDirs().size() == 0);
 
   f1.setLoc(Point2D(-1.0, -2.0));
-  TEST_ASSERT(feq(f1.getLoc().x, -1.0));
-  TEST_ASSERT(feq(f1.getLoc().y, -2.0));
-  TEST_ASSERT(f1.getDirs().size() == 0);
-
-  std::cerr << "  done" << std::endl;
-}
-
-int main() {
-  test1();
-  test2();
-  test3();
+  REQUIRE_THAT(f1.getLoc().x, Catch::Matchers::WithinAbs(-1.0, 1e-4));
+  REQUIRE_THAT(f1.getLoc().y, Catch::Matchers::WithinAbs(-2.0, 1e-4));
+  REQUIRE(f1.getDirs().size() == 0);
 }

--- a/Code/Geometry/CMakeLists.txt
+++ b/Code/Geometry/CMakeLists.txt
@@ -16,7 +16,7 @@ rdkit_headers(Grid3D.h
               UniformRealValueGrid3D.h
               Utils.h DEST Geometry)
 
-rdkit_test(testTransforms testTransforms.cpp LINK_LIBRARIES RDGeometryLib )
+rdkit_catch_test(testTransforms testTransforms.cpp LINK_LIBRARIES RDGeometryLib )
 rdkit_catch_test(testGrid testGrid.cpp LINK_LIBRARIES RDGeometryLib)
 rdkit_test(testRealValueGrid testRealValueGrid.cpp LINK_LIBRARIES RDGeometryLib DataStructs RDGeneral)
 rdkit_catch_test(geometryTestsCatch catch_tests.cpp

--- a/Code/Geometry/CMakeLists.txt
+++ b/Code/Geometry/CMakeLists.txt
@@ -18,7 +18,7 @@ rdkit_headers(Grid3D.h
 
 rdkit_catch_test(testTransforms testTransforms.cpp LINK_LIBRARIES RDGeometryLib )
 rdkit_catch_test(testGrid testGrid.cpp LINK_LIBRARIES RDGeometryLib)
-rdkit_test(testRealValueGrid testRealValueGrid.cpp LINK_LIBRARIES RDGeometryLib DataStructs RDGeneral)
+rdkit_catch_test(testRealValueGrid testRealValueGrid.cpp LINK_LIBRARIES RDGeometryLib DataStructs RDGeneral)
 rdkit_catch_test(geometryTestsCatch catch_tests.cpp
            LINK_LIBRARIES RDGeometryLib)
 

--- a/Code/Geometry/CMakeLists.txt
+++ b/Code/Geometry/CMakeLists.txt
@@ -17,7 +17,7 @@ rdkit_headers(Grid3D.h
               Utils.h DEST Geometry)
 
 rdkit_test(testTransforms testTransforms.cpp LINK_LIBRARIES RDGeometryLib )
-rdkit_test(testGrid testGrid.cpp LINK_LIBRARIES RDGeometryLib)
+rdkit_catch_test(testGrid testGrid.cpp LINK_LIBRARIES RDGeometryLib)
 rdkit_test(testRealValueGrid testRealValueGrid.cpp LINK_LIBRARIES RDGeometryLib DataStructs RDGeneral)
 rdkit_catch_test(geometryTestsCatch catch_tests.cpp
            LINK_LIBRARIES RDGeometryLib)

--- a/Code/Geometry/testGrid.cpp
+++ b/Code/Geometry/testGrid.cpp
@@ -1,6 +1,5 @@
-//  $Id$
 //
-//   Copyright (C) 2005-2013 Greg Landrum and Rational Discovery LLC
+//   Copyright (C) 2005-2025 Greg Landrum and other RDKit contributors
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -8,7 +7,7 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
-#include <RDGeneral/test.h>
+#include <catch2/catch_all.hpp>
 #include "UniformGrid3D.h"
 #include <DataStructs/DiscreteValueVect.h>
 #include "point.h"
@@ -24,133 +23,128 @@
 using namespace RDGeom;
 using namespace RDKit;
 
-void testUniformGrid1() {
+TEST_CASE("testUniformGrid1") {
   UniformGrid3D grd(6.0, 5.0, 4.0);
-  CHECK_INVARIANT(grd.getSize() == 960, "");
-  CHECK_INVARIANT(RDKit::feq(grd.getSpacing(), .5), "");
-  CHECK_INVARIANT(grd.getNumX() == 12, "");
-  CHECK_INVARIANT(grd.getNumY() == 10, "");
-  CHECK_INVARIANT(grd.getNumZ() == 8, "");
+  REQUIRE(grd.getSize() == 960);
+  REQUIRE_THAT(grd.getSpacing(), Catch::Matchers::WithinAbs(.5, 1e-6));
+  REQUIRE(grd.getNumX() == 12);
+  REQUIRE(grd.getNumY() == 10);
+  REQUIRE(grd.getNumZ() == 8);
 
   grd.setSphereOccupancy(Point3D(0.0, 0.0, 0.0), 1.5, 0.25);
-  CHECK_INVARIANT(grd.getOccupancyVect()->getTotalVal() == 523, "");
-  // writeGridToFile(grd, "junk.grd");
+  REQUIRE(grd.getOccupancyVect()->getTotalVal() == 523);
 
   UniformGrid3D grd2(grd);
-  CHECK_INVARIANT(grd2.getSize() == 960, "");
-  CHECK_INVARIANT(RDKit::feq(grd2.getSpacing(), .5), "");
-  CHECK_INVARIANT(grd2.getNumX() == 12, "");
-  CHECK_INVARIANT(grd2.getNumY() == 10, "");
-  CHECK_INVARIANT(grd2.getNumZ() == 8, "");
-  CHECK_INVARIANT(grd2.getOccupancyVect()->getTotalVal() == 523, "");
+  REQUIRE(grd2.getSize() == 960);
+  REQUIRE_THAT(grd2.getSpacing(), Catch::Matchers::WithinAbs(.5, 1e-6));
+  REQUIRE(grd2.getNumX() == 12);
+  REQUIRE(grd2.getNumY() == 10);
+  REQUIRE(grd2.getNumZ() == 8);
+  REQUIRE(grd2.getOccupancyVect()->getTotalVal() == 523);
 
-  // make sure the data are actually decoupled:
   grd.setSphereOccupancy(Point3D(1.0, 1.0, 0.0), 1.5, 0.25);
-  CHECK_INVARIANT(grd.getOccupancyVect()->getTotalVal() > 523, "");
-  CHECK_INVARIANT(grd2.getOccupancyVect()->getTotalVal() == 523, "");
+  REQUIRE(grd.getOccupancyVect()->getTotalVal() > 523);
+  REQUIRE(grd2.getOccupancyVect()->getTotalVal() == 523);
 }
 
-void testUniformGrid2() {
-  // test distance metrics:
+TEST_CASE("testUniformGrid2") {
   UniformGrid3D grd(10.0, 10.0, 10.0);
   grd.setSphereOccupancy(Point3D(-2.0, -2.0, 0.0), 1.5, 0.25);
   grd.setSphereOccupancy(Point3D(-2.0, 2.0, 0.0), 1.5, 0.25);
   grd.setSphereOccupancy(Point3D(2.0, -2.0, 0.0), 1.5, 0.25);
   grd.setSphereOccupancy(Point3D(2.0, 2.0, 0.0), 1.5, 0.25);
-  writeGridToFile(grd, "junk.grd");
   double dist = tanimotoDistance(grd, grd);
-  CHECK_INVARIANT(RDKit::feq(dist, 0.0), "");
+  REQUIRE_THAT(dist, Catch::Matchers::WithinAbs(0.0, 1e-6));
   dist = tverskyIndex(grd, grd, 1.0, 1.0);
-  CHECK_INVARIANT(RDKit::feq(dist, 1.0), "");
+  REQUIRE_THAT(dist, Catch::Matchers::WithinAbs(1.0, 1e-6));
   dist = tverskyIndex(grd, grd, 1.0, 0.0);
-  CHECK_INVARIANT(RDKit::feq(dist, 1.0), "");
+  REQUIRE_THAT(dist, Catch::Matchers::WithinAbs(1.0, 1e-6));
   dist = tverskyIndex(grd, grd, 0.0, 1.0);
-  CHECK_INVARIANT(RDKit::feq(dist, 1.0), "");
+  REQUIRE_THAT(dist, Catch::Matchers::WithinAbs(1.0, 1e-6));
   dist = tverskyIndex(grd, grd, 0.25, 0.75);
-  CHECK_INVARIANT(RDKit::feq(dist, 1.0), "");
+  REQUIRE_THAT(dist, Catch::Matchers::WithinAbs(1.0, 1e-6));
   dist = tverskyIndex(grd, grd, 0.75, 0.25);
-  CHECK_INVARIANT(RDKit::feq(dist, 1.0), "");
+  REQUIRE_THAT(dist, Catch::Matchers::WithinAbs(1.0, 1e-6));
 
   UniformGrid3D grd2(10.0, 10.0, 10.0);
   grd2.setSphereOccupancy(Point3D(-2.0, -2.0, 0.0), 1.5, 0.25);
   grd2.setSphereOccupancy(Point3D(-2.0, 2.0, 0.0), 1.5, 0.25);
   grd2.setSphereOccupancy(Point3D(2.0, -2.0, 0.0), 1.5, 0.25);
   dist = tanimotoDistance(grd, grd2);
-  CHECK_INVARIANT(RDKit::feq(dist, 0.25), "");
+  REQUIRE_THAT(dist, Catch::Matchers::WithinAbs(0.25, 1e-6));
   dist = tverskyIndex(grd, grd2, 1.0, 1.0);
-  CHECK_INVARIANT(RDKit::feq(dist, 0.75), "");
+  REQUIRE_THAT(dist, Catch::Matchers::WithinAbs(0.75, 1e-6));
   dist = tverskyIndex(grd, grd2, 1.0, 0.0);
-  CHECK_INVARIANT(RDKit::feq(dist, 0.75), "");
+  REQUIRE_THAT(dist, Catch::Matchers::WithinAbs(0.75, 1e-6));
   dist = tverskyIndex(grd, grd2, 0.0, 1.0);
-  CHECK_INVARIANT(RDKit::feq(dist, 1.0), "");
+  REQUIRE_THAT(dist, Catch::Matchers::WithinAbs(1.0, 1e-6));
   dist = tverskyIndex(grd, grd2, 0.25, 0.75);
-  CHECK_INVARIANT(RDKit::feq(dist, 0.923), "");
+  REQUIRE_THAT(dist, Catch::Matchers::WithinAbs(0.923, 1e-3));
   dist = tverskyIndex(grd, grd2, 0.75, 0.25);
-  CHECK_INVARIANT(RDKit::feq(dist, 0.8), "");
+  REQUIRE_THAT(dist, Catch::Matchers::WithinAbs(0.8, 1e-6));
   dist = protrudeDistance(grd, grd2);
-  CHECK_INVARIANT(RDKit::feq(dist, 0.25), "");
+  REQUIRE_THAT(dist, Catch::Matchers::WithinAbs(0.25, 1e-6));
   dist = protrudeDistance(grd2, grd);
-  CHECK_INVARIANT(RDKit::feq(dist, 0.0), "");
+  REQUIRE_THAT(dist, Catch::Matchers::WithinAbs(0.0, 1e-6));
 
   UniformGrid3D grd3(10.0, 10.0, 10.0);
   grd3.setSphereOccupancy(Point3D(-2.0, -2.0, 0.0), 1.5, 0.25);
   grd3.setSphereOccupancy(Point3D(-2.0, 2.0, 0.0), 1.5, 0.25);
   dist = tanimotoDistance(grd, grd3);
-  CHECK_INVARIANT(RDKit::feq(dist, 0.5), "");
+  REQUIRE_THAT(dist, Catch::Matchers::WithinAbs(0.5, 1e-6));
   dist = tverskyIndex(grd, grd3, 1.0, 1.0);
-  CHECK_INVARIANT(RDKit::feq(dist, 0.5), "");
+  REQUIRE_THAT(dist, Catch::Matchers::WithinAbs(0.5, 1e-6));
   dist = tverskyIndex(grd, grd3, 1.0, 0.0);
-  CHECK_INVARIANT(RDKit::feq(dist, 0.5), "");
+  REQUIRE_THAT(dist, Catch::Matchers::WithinAbs(0.5, 1e-6));
   dist = tverskyIndex(grd, grd3, 0.0, 1.0);
-  CHECK_INVARIANT(RDKit::feq(dist, 1.0), "");
+  REQUIRE_THAT(dist, Catch::Matchers::WithinAbs(1.0, 1e-6));
   dist = tverskyIndex(grd, grd3, 0.25, 0.75);
-  CHECK_INVARIANT(RDKit::feq(dist, 0.8), "");
+  REQUIRE_THAT(dist, Catch::Matchers::WithinAbs(0.8, 1e-6));
   dist = tverskyIndex(grd, grd3, 0.75, 0.25);
-  CHECK_INVARIANT(RDKit::feq(dist, 0.5714), "");
+  REQUIRE_THAT(dist, Catch::Matchers::WithinAbs(0.5714, 1e-4));
   dist = protrudeDistance(grd, grd3);
-  CHECK_INVARIANT(RDKit::feq(dist, 0.5), "");
+  REQUIRE_THAT(dist, Catch::Matchers::WithinAbs(0.5, 1e-6));
   dist = protrudeDistance(grd3, grd);
-  CHECK_INVARIANT(RDKit::feq(dist, 0.0), "");
+  REQUIRE_THAT(dist, Catch::Matchers::WithinAbs(0.0, 1e-6));
 
   UniformGrid3D grd4(10.0, 10.0, 10.0);
   grd4.setSphereOccupancy(Point3D(2.0, 2.0, 0.0), 1.5, 0.25);
   grd4.setSphereOccupancy(Point3D(2.0, -2.0, 0.0), 1.5, 0.25);
   dist = tanimotoDistance(grd3, grd4);
-  CHECK_INVARIANT(RDKit::feq(dist, 1.0), "");
+  REQUIRE_THAT(dist, Catch::Matchers::WithinAbs(1.0, 1e-6));
   dist = tverskyIndex(grd3, grd4, 1.0, 1.0);
-  CHECK_INVARIANT(RDKit::feq(dist, 0.0), "");
+  REQUIRE_THAT(dist, Catch::Matchers::WithinAbs(0.0, 1e-6));
   dist = tverskyIndex(grd3, grd4, 1.0, 0.0);
-  CHECK_INVARIANT(RDKit::feq(dist, 0.0), "");
+  REQUIRE_THAT(dist, Catch::Matchers::WithinAbs(0.0, 1e-6));
   dist = tverskyIndex(grd3, grd4, 0.0, 1.0);
-  CHECK_INVARIANT(RDKit::feq(dist, 0.0), "");
+  REQUIRE_THAT(dist, Catch::Matchers::WithinAbs(0.0, 1e-6));
   dist = tverskyIndex(grd3, grd4, 0.25, 0.75);
-  CHECK_INVARIANT(RDKit::feq(dist, 0.0), "");
+  REQUIRE_THAT(dist, Catch::Matchers::WithinAbs(0.0, 1e-6));
   dist = tverskyIndex(grd3, grd4, 0.75, 0.25);
-  CHECK_INVARIANT(RDKit::feq(dist, 0.0), "");
+  REQUIRE_THAT(dist, Catch::Matchers::WithinAbs(0.0, 1e-6));
 
   UniformGrid3D grd5(10.0, 10.0, 10.0);
   grd5.setSphereOccupancy(Point3D(-2.0, -2.0, 0.0), 1.5, 0.25);
   dist = tanimotoDistance(grd, grd5);
-  CHECK_INVARIANT(RDKit::feq(dist, 0.75), "");
+  REQUIRE_THAT(dist, Catch::Matchers::WithinAbs(0.75, 1e-6));
   dist = tverskyIndex(grd, grd5, 1.0, 1.0);
-  CHECK_INVARIANT(RDKit::feq(dist, 0.25), "");
+  REQUIRE_THAT(dist, Catch::Matchers::WithinAbs(0.25, 1e-6));
   dist = tverskyIndex(grd, grd5, 1.0, 0.0);
-  CHECK_INVARIANT(RDKit::feq(dist, 0.25), "");
+  REQUIRE_THAT(dist, Catch::Matchers::WithinAbs(0.25, 1e-6));
   dist = tverskyIndex(grd, grd5, 0.0, 1.0);
-  CHECK_INVARIANT(RDKit::feq(dist, 1.0), "");
+  REQUIRE_THAT(dist, Catch::Matchers::WithinAbs(1.0, 1e-6));
   dist = tverskyIndex(grd, grd5, 0.25, 0.75);
-  CHECK_INVARIANT(RDKit::feq(dist, 0.5714), "");
+  REQUIRE_THAT(dist, Catch::Matchers::WithinAbs(0.5714, 1e-4));
   dist = tverskyIndex(grd, grd5, 0.75, 0.25);
-  CHECK_INVARIANT(RDKit::feq(dist, 0.3077), "");
+  REQUIRE_THAT(dist, Catch::Matchers::WithinAbs(0.3077, 1e-4));
   dist = protrudeDistance(grd, grd5);
-  CHECK_INVARIANT(RDKit::feq(dist, 0.75), "");
+  REQUIRE_THAT(dist, Catch::Matchers::WithinAbs(0.75, 1e-6));
   dist = protrudeDistance(grd5, grd);
-  CHECK_INVARIANT(RDKit::feq(dist, 0.00), "");
+  REQUIRE_THAT(dist, Catch::Matchers::WithinAbs(0.00, 1e-6));
 }
 
-void testUniformGridPickling() {
+TEST_CASE("testUniformGridPickling") {
   {
-    // test tanimoto distance
     UniformGrid3D grd(10.0, 10.0, 10.0);
     grd.setSphereOccupancy(Point3D(-2.0, -2.0, 0.0), 1.5, 0.25);
     grd.setSphereOccupancy(Point3D(-2.0, 2.0, 0.0), 1.5, 0.25);
@@ -158,7 +152,7 @@ void testUniformGridPickling() {
     grd.setSphereOccupancy(Point3D(2.0, 2.0, 0.0), 1.5, 0.25);
     UniformGrid3D grd2(grd.toString());
     double dist = tanimotoDistance(grd, grd2);
-    CHECK_INVARIANT(RDKit::feq(dist, 0.0), "");
+    REQUIRE_THAT(dist, Catch::Matchers::WithinAbs(0.0, 1e-6));
   }
 
   {
@@ -186,20 +180,20 @@ void testUniformGridPickling() {
     grd2.setSphereOccupancy(Point3D(2.0, 2.0, 0.0), 1.5, 0.25);
 
     std::string pkl2 = grd2.toString();
-    TEST_ASSERT(pkl2.length() == pkl.length());
-    TEST_ASSERT(pkl2 == pkl);
+    REQUIRE(pkl2.length() == pkl.length());
+    REQUIRE(pkl2 == pkl);
 
-    TEST_ASSERT(grd.getSize() == grd2.getSize());
-    TEST_ASSERT(grd.getNumX() == grd2.getNumX());
-    TEST_ASSERT(grd.getNumY() == grd2.getNumY());
-    TEST_ASSERT(grd.getNumZ() == grd2.getNumZ());
-    TEST_ASSERT(grd.compareParams(grd2));
+    REQUIRE(grd.getSize() == grd2.getSize());
+    REQUIRE(grd.getNumX() == grd2.getNumX());
+    REQUIRE(grd.getNumY() == grd2.getNumY());
+    REQUIRE(grd.getNumZ() == grd2.getNumZ());
+    REQUIRE(grd.compareParams(grd2));
     double dist = tanimotoDistance(grd, grd2);
-    TEST_ASSERT(RDKit::feq(dist, 0.0));
+    REQUIRE_THAT(dist, Catch::Matchers::WithinAbs(0.0, 1e-6));
   }
 }
 
-void testUniformGridOps() {
+TEST_CASE("testUniformGridOps") {
   UniformGrid3D grd(10.0, 10.0, 10.0);
   grd.setSphereOccupancy(Point3D(-2.0, -2.0, 0.0), 1.0, 0.25);
   grd.setSphereOccupancy(Point3D(-2.0, 2.0, 0.0), 1.0, 0.25);
@@ -209,15 +203,15 @@ void testUniformGridOps() {
   grd2.setSphereOccupancy(Point3D(2.0, 2.0, 0.0), 1.0, 0.25);
 
   double dist = tanimotoDistance(grd, grd2);
-  CHECK_INVARIANT(RDKit::feq(dist, 1.0), "");
+  REQUIRE_THAT(dist, Catch::Matchers::WithinAbs(1.0, 1e-6));
 
   UniformGrid3D grd3(grd);
   grd3 |= grd2;
 
   dist = tanimotoDistance(grd3, grd);
-  CHECK_INVARIANT(RDKit::feq(dist, 0.5), "");
+  REQUIRE_THAT(dist, Catch::Matchers::WithinAbs(0.5, 1e-6));
   dist = tanimotoDistance(grd3, grd2);
-  CHECK_INVARIANT(RDKit::feq(dist, 0.5), "");
+  REQUIRE_THAT(dist, Catch::Matchers::WithinAbs(0.5, 1e-6));
 
   UniformGrid3D grd4(10.0, 10.0, 10.0);
   grd4.setSphereOccupancy(Point3D(-2.0, -2.0, 0.0), 1.0, 0.25);
@@ -228,13 +222,12 @@ void testUniformGridOps() {
   grd5 &= grd2;
 
   dist = tanimotoDistance(grd5, grd);
-  CHECK_INVARIANT(RDKit::feq(dist, 1.0), "");
+  REQUIRE_THAT(dist, Catch::Matchers::WithinAbs(1.0, 1e-6));
   dist = tanimotoDistance(grd5, grd2);
-  CHECK_INVARIANT(RDKit::feq(dist, 0.5), "");
+  REQUIRE_THAT(dist, Catch::Matchers::WithinAbs(0.5, 1e-6));
 }
 
-void testUniformGridIndexing() {
-  // test distance metrics:
+TEST_CASE("testUniformGridIndexing") {
   UniformGrid3D grd(5.0, 5.0, 5.0);
 
   {
@@ -242,71 +235,44 @@ void testUniformGridIndexing() {
     unsigned int idx = grd.getGridIndex(xi, yi, zi);
     unsigned int nxi, nyi, nzi;
     grd.getGridIndices(idx, nxi, nyi, nzi);
-    TEST_ASSERT(nxi == xi);
-    TEST_ASSERT(nyi == yi);
-    TEST_ASSERT(nzi == zi);
+    REQUIRE(nxi == xi);
+    REQUIRE(nyi == yi);
+    REQUIRE(nzi == zi);
   }
   {
     unsigned int xi = 3, yi = 3, zi = 5;
     unsigned int idx = grd.getGridIndex(xi, yi, zi);
     unsigned int nxi, nyi, nzi;
     grd.getGridIndices(idx, nxi, nyi, nzi);
-    TEST_ASSERT(nxi == xi);
-    TEST_ASSERT(nyi == yi);
-    TEST_ASSERT(nzi == zi);
+    REQUIRE(nxi == xi);
+    REQUIRE(nyi == yi);
+    REQUIRE(nzi == zi);
   }
   {
     unsigned int xi = 3, yi = 6, zi = 3;
     unsigned int idx = grd.getGridIndex(xi, yi, zi);
     unsigned int nxi, nyi, nzi;
     grd.getGridIndices(idx, nxi, nyi, nzi);
-    TEST_ASSERT(nxi == xi);
-    TEST_ASSERT(nyi == yi);
-    TEST_ASSERT(nzi == zi);
+    REQUIRE(nxi == xi);
+    REQUIRE(nyi == yi);
+    REQUIRE(nzi == zi);
   }
   {
     unsigned int xi = 0, yi = 0, zi = 0;
     unsigned int idx = grd.getGridIndex(xi, yi, zi);
     unsigned int nxi, nyi, nzi;
     grd.getGridIndices(idx, nxi, nyi, nzi);
-    TEST_ASSERT(nxi == xi);
-    TEST_ASSERT(nyi == yi);
-    TEST_ASSERT(nzi == zi);
+    REQUIRE(nxi == xi);
+    REQUIRE(nyi == yi);
+    REQUIRE(nzi == zi);
   }
   {
     unsigned int xi = 8, yi = 2, zi = 1;
     unsigned int idx = grd.getGridIndex(xi, yi, zi);
     unsigned int nxi, nyi, nzi;
     grd.getGridIndices(idx, nxi, nyi, nzi);
-    TEST_ASSERT(nxi == xi);
-    TEST_ASSERT(nyi == yi);
-    TEST_ASSERT(nzi == zi);
+    REQUIRE(nxi == xi);
+    REQUIRE(nyi == yi);
+    REQUIRE(nzi == zi);
   }
-}
-
-int main() {
-  std::cout << "***********************************************************\n";
-  std::cout << "Testing Grid\n";
-
-  std::cout << "\t---------------------------------\n";
-  std::cout << "\t testUniformGrid1 \n\n";
-  testUniformGrid1();
-
-  std::cout << "\t---------------------------------\n";
-  std::cout << "\t testUniformGrid2 \n\n";
-  testUniformGrid2();
-
-  std::cout << "\t---------------------------------\n";
-  std::cout << "\t testUniformGridPickling \n\n";
-  testUniformGridPickling();
-
-  std::cout << "\t---------------------------------\n";
-  std::cout << "\t testGridOps \n\n";
-  testUniformGridOps();
-
-  std::cout << "\t---------------------------------\n";
-  std::cout << "\t testUniformGridIndexing \n\n";
-  testUniformGridIndexing();
-
-  return 0;
 }

--- a/Code/Geometry/testRealValueGrid.cpp
+++ b/Code/Geometry/testRealValueGrid.cpp
@@ -1,5 +1,5 @@
 //
-//  Copyright (c) 2014-2024, Novartis Institutes for BioMedical Research and
+//  Copyright (c) 2014-2025, Novartis Institutes for BioMedical Research and
 //  other RDKit contributors
 //
 //   @@ All Rights Reserved @@
@@ -8,6 +8,7 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
+#include <catch2/catch_all.hpp>
 #include "UniformRealValueGrid3D.h"
 #include <GraphMol/GraphMol.h>
 #include <Geometry/point.h>
@@ -25,106 +26,102 @@
 using namespace RDGeom;
 using namespace RDKit;
 
-void test1UniformRealValueGrid3D() {
+TEST_CASE("test1UniformRealValueGrid3D") {
   RDGeom::UniformRealValueGrid3D grd(6.0, 5.0, 4.0);
-  CHECK_INVARIANT(grd.getSize() == 960, "");
-  CHECK_INVARIANT(RDKit::feq(grd.getSpacing(), .5), "");
-  CHECK_INVARIANT(grd.getNumX() == 12, "");
-  CHECK_INVARIANT(grd.getNumY() == 10, "");
-  CHECK_INVARIANT(grd.getNumZ() == 8, "");
+  REQUIRE(grd.getSize() == 960);
+  REQUIRE_THAT(grd.getSpacing(), Catch::Matchers::WithinAbs(.5, 1e-4));
+  REQUIRE(grd.getNumX() == 12);
+  REQUIRE(grd.getNumY() == 10);
+  REQUIRE(grd.getNumZ() == 8);
 
   RDGeom::UniformRealValueGrid3D grd2(grd);
-  CHECK_INVARIANT(grd2.getSize() == 960, "");
-  CHECK_INVARIANT(RDKit::feq(grd2.getSpacing(), .5), "");
-  CHECK_INVARIANT(grd2.getNumX() == 12, "");
-  CHECK_INVARIANT(grd2.getNumY() == 10, "");
-  CHECK_INVARIANT(grd2.getNumZ() == 8, "");
-  CHECK_INVARIANT(grd2.getOccupancyVect()->getTotalVal() == 0, "");
-  TEST_ASSERT(grd.compareVectors(grd2));
-  TEST_ASSERT(grd.compareParams(grd2));
+  REQUIRE(grd2.getSize() == 960);
+  REQUIRE_THAT(grd2.getSpacing(), Catch::Matchers::WithinAbs(.5, 1e-4));
+  REQUIRE(grd2.getNumX() == 12);
+  REQUIRE(grd2.getNumY() == 10);
+  REQUIRE(grd2.getNumZ() == 8);
+  REQUIRE(grd2.getOccupancyVect()->getTotalVal() == 0);
+  REQUIRE(grd.compareVectors(grd2));
+  REQUIRE(grd.compareParams(grd2));
 
   grd.setVal(1, 1.0);
-  TEST_ASSERT(!grd.compareVectors(grd2));
-  TEST_ASSERT(grd.compareParams(grd2))
-  // make sure the data are actually decoupled:
-  // grd.setSphereOccupancy(Point3D(1.0, 1.0, 0.0), 1.5, 0.25);
-  // CHECK_INVARIANT(grd.getOccupancyVect()->getTotalVal()>523, "" );
-  // CHECK_INVARIANT(grd2.getOccupancyVect()->getTotalVal() == 523, "" );
+  REQUIRE(!grd.compareVectors(grd2));
+  REQUIRE(grd.compareParams(grd2));
 }
 
-void test2UniformRealValueGrid3DPickling() {
+TEST_CASE("test2UniformRealValueGrid3DPickling") {
   RDGeom::UniformRealValueGrid3D grd(5.0, 5.0, 5.0, 0.1);
   grd.setVal(50, 2.3);
   const std::string pkl = grd.toString();
 
   RDGeom::UniformRealValueGrid3D grd2(pkl);
-  TEST_ASSERT(grd.compareVectors(grd2));
-  TEST_ASSERT(grd.compareParams(grd2));
+  REQUIRE(grd.compareVectors(grd2));
+  REQUIRE(grd.compareParams(grd2));
 }
 
-void test3UniformRealValueGrid3DIndexing() {
+TEST_CASE("test3UniformRealValueGrid3DIndexing") {
   RDGeom::UniformRealValueGrid3D grd(5.0, 5.0, 5.0, 0.1);
   {
     unsigned int xi = 3, yi = 3, zi = 3;
     unsigned int idx = grd.getGridIndex(xi, yi, zi);
     unsigned int nxi, nyi, nzi;
     grd.getGridIndices(idx, nxi, nyi, nzi);
-    TEST_ASSERT(nxi == xi);
-    TEST_ASSERT(nyi == yi);
-    TEST_ASSERT(nzi == zi);
+    REQUIRE(nxi == xi);
+    REQUIRE(nyi == yi);
+    REQUIRE(nzi == zi);
   }
   {
     unsigned int xi = 3, yi = 3, zi = 5;
     unsigned int idx = grd.getGridIndex(xi, yi, zi);
     unsigned int nxi, nyi, nzi;
     grd.getGridIndices(idx, nxi, nyi, nzi);
-    TEST_ASSERT(nxi == xi);
-    TEST_ASSERT(nyi == yi);
-    TEST_ASSERT(nzi == zi);
+    REQUIRE(nxi == xi);
+    REQUIRE(nyi == yi);
+    REQUIRE(nzi == zi);
   }
   {
     unsigned int xi = 3, yi = 6, zi = 3;
     unsigned int idx = grd.getGridIndex(xi, yi, zi);
     unsigned int nxi, nyi, nzi;
     grd.getGridIndices(idx, nxi, nyi, nzi);
-    TEST_ASSERT(nxi == xi);
-    TEST_ASSERT(nyi == yi);
-    TEST_ASSERT(nzi == zi);
+    REQUIRE(nxi == xi);
+    REQUIRE(nyi == yi);
+    REQUIRE(nzi == zi);
   }
   {
     unsigned int xi = 0, yi = 0, zi = 0;
     unsigned int idx = grd.getGridIndex(xi, yi, zi);
     unsigned int nxi, nyi, nzi;
     grd.getGridIndices(idx, nxi, nyi, nzi);
-    TEST_ASSERT(nxi == xi);
-    TEST_ASSERT(nyi == yi);
-    TEST_ASSERT(nzi == zi);
+    REQUIRE(nxi == xi);
+    REQUIRE(nyi == yi);
+    REQUIRE(nzi == zi);
   }
   {
     unsigned int xi = 8, yi = 2, zi = 1;
     unsigned int idx = grd.getGridIndex(xi, yi, zi);
     unsigned int nxi, nyi, nzi;
     grd.getGridIndices(idx, nxi, nyi, nzi);
-    TEST_ASSERT(nxi == xi);
-    TEST_ASSERT(nyi == yi);
-    TEST_ASSERT(nzi == zi);
+    REQUIRE(nxi == xi);
+    REQUIRE(nyi == yi);
+    REQUIRE(nzi == zi);
   }
 
   RDGeom::Point3D pt = grd.getOffset();
   grd.setVal(pt, 2.3);
   unsigned int id = grd.getGridPointIndex(pt);
 
-  TEST_ASSERT(RDKit::feq(grd.getVal(pt), 2.3));
-  TEST_ASSERT(id == 0);
-  TEST_ASSERT(RDKit::feq(grd.getVal(id), 2.3));
+  REQUIRE_THAT(grd.getVal(pt), Catch::Matchers::WithinAbs(2.3, 1e-4));
+  REQUIRE(id == 0);
+  REQUIRE_THAT(grd.getVal(id), Catch::Matchers::WithinAbs(2.3, 1e-4));
 
   RDGeom::Point3D pt2 = grd.getGridPointLoc(id);
-  TEST_ASSERT(RDKit::feq(pt.x, pt2.x));
-  TEST_ASSERT(RDKit::feq(pt.y, pt2.y));
-  TEST_ASSERT(RDKit::feq(pt.z, pt2.z));
+  REQUIRE_THAT(pt.x, Catch::Matchers::WithinAbs(pt2.x, 1e-4));
+  REQUIRE_THAT(pt.y, Catch::Matchers::WithinAbs(pt2.y, 1e-4));
+  REQUIRE_THAT(pt.z, Catch::Matchers::WithinAbs(pt2.z, 1e-4));
 }
 
-void test4UniformRealValueGrid3DOps() {
+TEST_CASE("test4UniformRealValueGrid3DOps") {
   RDGeom::UniformRealValueGrid3D grd1(5.0, 5.0, 5.0, 0.1);
   RDGeom::UniformRealValueGrid3D grd2(5.0, 5.0, 5.0, 0.1);
 
@@ -133,53 +130,30 @@ void test4UniformRealValueGrid3DOps() {
   RDGeom::UniformRealValueGrid3D grd3(grd2);
 
   grd1 |= grd2;
-  TEST_ASSERT(RDKit::feq(grd1.getVal(50), 37.37));
-  TEST_ASSERT(RDKit::feq(grd2.getVal(50), 1.03));
+  REQUIRE_THAT(grd1.getVal(50), Catch::Matchers::WithinAbs(37.37, 1e-4));
+  REQUIRE_THAT(grd2.getVal(50), Catch::Matchers::WithinAbs(1.03, 1e-4));
 
   grd2 = grd2 | grd1;
-  TEST_ASSERT(RDKit::feq(grd1.getVal(50), 37.37));
-  TEST_ASSERT(RDKit::feq(grd2.getVal(50), 37.37));
+  REQUIRE_THAT(grd1.getVal(50), Catch::Matchers::WithinAbs(37.37, 1e-4));
+  REQUIRE_THAT(grd2.getVal(50), Catch::Matchers::WithinAbs(37.37, 1e-4));
 
   grd2 = grd2 & grd3;
-  TEST_ASSERT(RDKit::feq(grd2.getVal(50), 1.03));
-  TEST_ASSERT(RDKit::feq(grd3.getVal(50), 1.03));
+  REQUIRE_THAT(grd2.getVal(50), Catch::Matchers::WithinAbs(1.03, 1e-4));
+  REQUIRE_THAT(grd3.getVal(50), Catch::Matchers::WithinAbs(1.03, 1e-4));
 
   grd3 &= grd1;
-  TEST_ASSERT(RDKit::feq(grd1.getVal(50), 37.37));
-  TEST_ASSERT(RDKit::feq(grd3.getVal(50), 1.03));
+  REQUIRE_THAT(grd1.getVal(50), Catch::Matchers::WithinAbs(37.37, 1e-4));
+  REQUIRE_THAT(grd3.getVal(50), Catch::Matchers::WithinAbs(1.03, 1e-4));
 
   grd1 += grd2;
-  TEST_ASSERT(RDKit::feq(grd1.getVal(50), 38.40));
-  TEST_ASSERT(RDKit::feq(grd2.getVal(50), 1.03));
+  REQUIRE_THAT(grd1.getVal(50), Catch::Matchers::WithinAbs(38.40, 1e-4));
+  REQUIRE_THAT(grd2.getVal(50), Catch::Matchers::WithinAbs(1.03, 1e-4));
 
   grd1 -= grd2;
-  TEST_ASSERT(RDKit::feq(grd1.getVal(50), 37.37));
-  TEST_ASSERT(RDKit::feq(grd2.getVal(50), 1.03));
+  REQUIRE_THAT(grd1.getVal(50), Catch::Matchers::WithinAbs(37.37, 1e-4));
+  REQUIRE_THAT(grd2.getVal(50), Catch::Matchers::WithinAbs(1.03, 1e-4));
 
   grd2 = grd2 - grd1;
-  TEST_ASSERT(RDKit::feq(grd1.getVal(50), 37.37));
-  TEST_ASSERT(RDKit::feq(grd2.getVal(50), -36.34));
-}
-
-int main() {
-  std::cout << "***********************************************************\n";
-  std::cout << "Testing RealValueGrid3D\n";
-
-  std::cout << "\t---------------------------------\n";
-  std::cout << "\t test1UniformRealValueGrid3D \n\n";
-  test1UniformRealValueGrid3D();
-
-  std::cout << "\t---------------------------------\n";
-  std::cout << "\t test2UniformRealValueGrid3DPickling \n\n";
-  test2UniformRealValueGrid3DPickling();
-
-  std::cout << "\t---------------------------------\n";
-  std::cout << "\t test3UniformRealValueGrid3DIndexing \n\n";
-  test3UniformRealValueGrid3DIndexing();
-
-  std::cout << "\t---------------------------------\n";
-  std::cout << "\t test4UniformRealValueGrid3DOps \n\n";
-  test4UniformRealValueGrid3DOps();
-
-  return 0;
+  REQUIRE_THAT(grd1.getVal(50), Catch::Matchers::WithinAbs(37.37, 1e-4));
+  REQUIRE_THAT(grd2.getVal(50), Catch::Matchers::WithinAbs(-36.34, 1e-4));
 }

--- a/Code/Geometry/testTransforms.cpp
+++ b/Code/Geometry/testTransforms.cpp
@@ -1,6 +1,5 @@
-//  $Id$
 //
-//   Copyright (C) 2005-2006 Rational Discovery LLC
+//   Copyright (C) 2005-2025 Greg Landrum and other RDKit contributors
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -9,7 +8,7 @@
 //  of the RDKit source tree.
 //
 
-#include <RDGeneral/test.h>
+#include <catch2/catch_all.hpp>
 #include <RDGeneral/types.h>
 #include <RDGeneral/Invariant.h>
 #include <RDGeneral/utils.h>
@@ -23,12 +22,16 @@ using namespace RDGeom;
 using namespace std;
 
 bool ptEq(const Point3D pt1, const Point3D pt2, double val = 1.e-8) {
-  return ((fabs(pt1.x - pt2.x) < val) && (fabs(pt1.y - pt2.y) < val) &&
-          (fabs(pt1.z - pt2.z) < val));
+  REQUIRE_THAT(pt1.x, Catch::Matchers::WithinAbs(pt2.x, val));
+  REQUIRE_THAT(pt1.y, Catch::Matchers::WithinAbs(pt2.y, val));
+  REQUIRE_THAT(pt1.z, Catch::Matchers::WithinAbs(pt2.z, val));
+  return true;
 }
 
 bool ptEq(const Point2D pt1, const Point2D pt2, double val = 1.e-8) {
-  return ((fabs(pt1.x - pt2.x) < val) && (fabs(pt1.y - pt2.y) < val));
+  REQUIRE_THAT(pt1.x, Catch::Matchers::WithinAbs(pt2.x, val));
+  REQUIRE_THAT(pt1.y, Catch::Matchers::WithinAbs(pt2.y, val));
+  return true;
 }
 
 double randNum(double x = 5) {
@@ -38,115 +41,115 @@ double randNum(double x = 5) {
   return res;
 }
 
-void testPointND() {
+TEST_CASE("testPointND") {
   PointND pt(5);
-  TEST_ASSERT(pt.dimension() == 5);
+  REQUIRE(pt.dimension() == 5);
   unsigned int i;
   for (i = 0; i < 5; ++i) {
     pt[i] = i + 1.0;
   }
   pt.normalize();
-  double ep[5];
-  ep[0] = 0.13484;
-  ep[1] = 0.26968;
-  ep[2] = 0.40452;
-  ep[3] = 0.53936;
-  ep[4] = 0.6742;
+  double ep[5] = {0.13484, 0.26968, 0.40452, 0.53936, 0.6742};
 
   for (i = 0; i < 5; ++i) {
-    TEST_ASSERT(fabs(pt[i] - ep[i]) < 1.e-4);
+    REQUIRE_THAT(pt[i], Catch::Matchers::WithinAbs(ep[i], 1.e-4));
   }
 
   PointND pt2(pt);
   for (i = 0; i < 5; ++i) {
-    TEST_ASSERT(fabs(pt2[i] - ep[i]) < 1.e-4);
+    REQUIRE_THAT(pt2[i], Catch::Matchers::WithinAbs(ep[i], 1.e-4));
   }
 
   pt2 += pt;
   for (i = 0; i < 5; ++i) {
-    TEST_ASSERT(fabs(pt2[i] - 2 * ep[i]) < 1.e-4);
+    REQUIRE_THAT(pt2[i], Catch::Matchers::WithinAbs(2 * ep[i], 1.e-4));
   }
 
   pt2 /= 2.0;
   for (i = 0; i < 5; ++i) {
-    TEST_ASSERT(fabs(pt2[i] - ep[i]) < 1.e-4);
+    REQUIRE_THAT(pt2[i], Catch::Matchers::WithinAbs(ep[i], 1.e-4));
   }
 
   pt2 -= pt;
   for (i = 0; i < 5; ++i) {
-    TEST_ASSERT(fabs(pt2[i] - 0.0) < 1.e-4);
+    REQUIRE_THAT(pt2[i], Catch::Matchers::WithinAbs(0.0, 1.e-4));
   }
   pt2 = pt;
   pt2 *= 2.;
   for (i = 0; i < 5; ++i) {
-    TEST_ASSERT(fabs(pt2[i] - 2 * ep[i]) < 1.e-4);
+    REQUIRE_THAT(pt2[i], Catch::Matchers::WithinAbs(2 * ep[i], 1.e-4));
   }
 
   double dp = pt.dotProduct(pt2);
-  TEST_ASSERT(fabs(dp - 2.0) < 1.e-4);
+  REQUIRE_THAT(dp, Catch::Matchers::WithinAbs(2.0, 1.e-4));
 
   double angle = pt.angleTo(pt2);
-  TEST_ASSERT(fabs(angle - 0.0) < 1.e-4);
+  REQUIRE_THAT(angle, Catch::Matchers::WithinAbs(0.0, 1.e-4));
 }
 
-void testPointOps3D() {
+TEST_CASE("testPointOps3D") {
   Point3D pt0(1, 0, 0);
   Point3D pt1(0, 1, 0);
   Point3D pt2(-1, 0, 0);
   Point3D pt3(0, -1, 0);
 
-  TEST_ASSERT(fabs(pt0.angleTo(pt0)) < 1e-4);
-  TEST_ASSERT(fabs(pt0.angleTo(pt1) - M_PI / 2.) < 1e-4);
-  TEST_ASSERT(fabs(pt0.angleTo(pt2) - M_PI) < 1e-4);
-  TEST_ASSERT(fabs(pt0.angleTo(pt3) - M_PI / 2.) < 1e-4);
+  REQUIRE_THAT(pt0.angleTo(pt0), Catch::Matchers::WithinAbs(0.0, 1e-4));
+  REQUIRE_THAT(pt0.angleTo(pt1), Catch::Matchers::WithinAbs(M_PI / 2., 1e-4));
+  REQUIRE_THAT(pt0.angleTo(pt2), Catch::Matchers::WithinAbs(M_PI, 1e-4));
+  REQUIRE_THAT(pt0.angleTo(pt3), Catch::Matchers::WithinAbs(M_PI / 2., 1e-4));
 
-  TEST_ASSERT(fabs(pt1.angleTo(pt0) - M_PI / 2.) < 1e-4);
-  TEST_ASSERT(fabs(pt1.angleTo(pt1)) < 1e-4);
-  TEST_ASSERT(fabs(pt1.angleTo(pt2) - M_PI / 2.) < 1e-4);
-  TEST_ASSERT(fabs(pt1.angleTo(pt3) - M_PI) < 1e-4);
+  REQUIRE_THAT(pt1.angleTo(pt0), Catch::Matchers::WithinAbs(M_PI / 2., 1e-4));
+  REQUIRE_THAT(pt1.angleTo(pt1), Catch::Matchers::WithinAbs(0.0, 1e-4));
+  REQUIRE_THAT(pt1.angleTo(pt2), Catch::Matchers::WithinAbs(M_PI / 2., 1e-4));
+  REQUIRE_THAT(pt1.angleTo(pt3), Catch::Matchers::WithinAbs(M_PI, 1e-4));
 
-  TEST_ASSERT(fabs(pt0.signedAngleTo(pt0)) < 1e-4);
-  TEST_ASSERT(fabs(pt0.signedAngleTo(pt1) - M_PI / 2.) < 1e-4);
-  TEST_ASSERT(fabs(pt0.signedAngleTo(pt2) - M_PI) < 1e-4);
-  TEST_ASSERT(fabs(pt0.signedAngleTo(pt3) - 3. * M_PI / 2.) < 1e-4);
+  REQUIRE_THAT(pt0.signedAngleTo(pt0), Catch::Matchers::WithinAbs(0.0, 1e-4));
+  REQUIRE_THAT(pt0.signedAngleTo(pt1),
+               Catch::Matchers::WithinAbs(M_PI / 2., 1e-4));
+  REQUIRE_THAT(pt0.signedAngleTo(pt2), Catch::Matchers::WithinAbs(M_PI, 1e-4));
+  REQUIRE_THAT(pt0.signedAngleTo(pt3),
+               Catch::Matchers::WithinAbs(3. * M_PI / 2., 1e-4));
 
   Point3D diffPt = pt0.directionVector(pt1);
   Point3D ref(-sqrt(2.) / 2., sqrt(2.) / 2., 0);
-  TEST_ASSERT(ptEq(diffPt, ref));
+  REQUIRE(ptEq(diffPt, ref));
 }
-void testPointOps2D() {
+
+TEST_CASE("testPointOps2D") {
   Point2D pt0(1, 0);
   Point2D pt1(0, 1);
   Point2D pt2(-1, 0);
   Point2D pt3(0, -1);
 
-  TEST_ASSERT(fabs(pt0.angleTo(pt0)) < 1e-4);
-  TEST_ASSERT(fabs(pt0.angleTo(pt1) - M_PI / 2.) < 1e-4);
-  TEST_ASSERT(fabs(pt0.angleTo(pt2) - M_PI) < 1e-4);
-  TEST_ASSERT(fabs(pt0.angleTo(pt3) - M_PI / 2.) < 1e-4);
+  REQUIRE_THAT(pt0.angleTo(pt0), Catch::Matchers::WithinAbs(0.0, 1e-4));
+  REQUIRE_THAT(pt0.angleTo(pt1), Catch::Matchers::WithinAbs(M_PI / 2., 1e-4));
+  REQUIRE_THAT(pt0.angleTo(pt2), Catch::Matchers::WithinAbs(M_PI, 1e-4));
+  REQUIRE_THAT(pt0.angleTo(pt3), Catch::Matchers::WithinAbs(M_PI / 2., 1e-4));
 
-  TEST_ASSERT(fabs(pt1.angleTo(pt0) - M_PI / 2.) < 1e-4);
-  TEST_ASSERT(fabs(pt1.angleTo(pt1)) < 1e-4);
-  TEST_ASSERT(fabs(pt1.angleTo(pt2) - M_PI / 2.) < 1e-4);
-  TEST_ASSERT(fabs(pt1.angleTo(pt3) - M_PI) < 1e-4);
+  REQUIRE_THAT(pt1.angleTo(pt0), Catch::Matchers::WithinAbs(M_PI / 2., 1e-4));
+  REQUIRE_THAT(pt1.angleTo(pt1), Catch::Matchers::WithinAbs(0.0, 1e-4));
+  REQUIRE_THAT(pt1.angleTo(pt2), Catch::Matchers::WithinAbs(M_PI / 2., 1e-4));
+  REQUIRE_THAT(pt1.angleTo(pt3), Catch::Matchers::WithinAbs(M_PI, 1e-4));
 
-  TEST_ASSERT(fabs(pt0.signedAngleTo(pt0)) < 1e-4);
-  TEST_ASSERT(fabs(pt0.signedAngleTo(pt1) - M_PI / 2.) < 1e-4);
-  TEST_ASSERT(fabs(pt0.signedAngleTo(pt2) - M_PI) < 1e-4);
-  TEST_ASSERT(fabs(pt0.signedAngleTo(pt3) - 3. * M_PI / 2.) < 1e-4);
+  REQUIRE_THAT(pt0.signedAngleTo(pt0), Catch::Matchers::WithinAbs(0.0, 1e-4));
+  REQUIRE_THAT(pt0.signedAngleTo(pt1),
+               Catch::Matchers::WithinAbs(M_PI / 2., 1e-4));
+  REQUIRE_THAT(pt0.signedAngleTo(pt2), Catch::Matchers::WithinAbs(M_PI, 1e-4));
+  REQUIRE_THAT(pt0.signedAngleTo(pt3),
+               Catch::Matchers::WithinAbs(3. * M_PI / 2., 1e-4));
 
   Point2D diffPt = pt0.directionVector(pt1);
   Point2D ref(-sqrt(2.) / 2., sqrt(2.) / 2.);
-  TEST_ASSERT(ptEq(diffPt, ref));
+  REQUIRE(ptEq(diffPt, ref));
 }
 
-void test12D() {
+TEST_CASE("test12D") {
   Point2D pt(1.0, 2.0);
   Transform2D trans;
   trans.TransformPoint(pt);
 
-  CHECK_INVARIANT(fabs(pt.x - 1.0) < 1.e-8, "");
-  CHECK_INVARIANT(fabs(pt.y - 2.0) < 1.e-8, "");
+  REQUIRE(fabs(pt.x - 1.0) < 1.e-8);
+  REQUIRE(fabs(pt.y - 2.0) < 1.e-8);
 
   Point2D ref1(randNum(), randNum());
   Point2D ref2(randNum(), randNum());
@@ -166,8 +169,8 @@ void test12D() {
 
   // make sure pt1 overlaps ref1
   Point2D dif1 = pt1 - ref1;
-  CHECK_INVARIANT(fabs(dif1.x) < 1.e-8, "");
-  CHECK_INVARIANT(fabs(dif1.y) < 1.e-8, "");
+  REQUIRE(fabs(dif1.x) < 1.e-8);
+  REQUIRE(fabs(dif1.y) < 1.e-8);
 
   // now check that the angle between the two vectors (ref2 - ref1) and
   // (pt2 - pt1) is zero
@@ -176,7 +179,7 @@ void test12D() {
   rvec.normalize();
   pvec.normalize();
   double pdot = rvec.dotProduct(pvec);
-  CHECK_INVARIANT(fabs(pdot - 1.0) < 1.e-8, "");
+  REQUIRE(fabs(pdot - 1.0) < 1.e-8);
 
   // compute the reverse transform and make sure we are basically getting the
   // identity
@@ -185,8 +188,8 @@ void test12D() {
   tdi.TransformPoint(pt1);
   tdi.TransformPoint(pt2);
 
-  CHECK_INVARIANT(ptEq(pt1, pt1o), "");
-  CHECK_INVARIANT(ptEq(pt2, pt2o), "");
+  REQUIRE(ptEq(pt1, pt1o));
+  REQUIRE(ptEq(pt2, pt2o));
 
   // the following product should result in an identity matrix
   tdi *= t2d;
@@ -194,8 +197,8 @@ void test12D() {
   tdi.TransformPoint(pt1);
   tdi.TransformPoint(pt2);
 
-  CHECK_INVARIANT(ptEq(pt1, pt1o), "");
-  CHECK_INVARIANT(ptEq(pt2, pt2o), "");
+  REQUIRE(ptEq(pt1, pt1o));
+  REQUIRE(ptEq(pt2, pt2o));
 
   Point2D npt1(1.0, 0.0);
   Point2D npt2(5.0, 0.0);
@@ -206,44 +209,44 @@ void test12D() {
   ntd.TransformPoint(npt1);
   ntd.TransformPoint(npt2);
 
-  CHECK_INVARIANT(ptEq(npt1, opt1), "");
-  CHECK_INVARIANT(ptEq(npt2, opt2), "");
+  REQUIRE(ptEq(npt1, opt1));
+  REQUIRE(ptEq(npt2, opt2));
 }
 
-void test23D() {
+TEST_CASE("test23D") {
   Point3D pt(1.0, 0.0, 0.0);
   Point3D tpt = pt;
   Transform3D trans;
   trans.SetRotation(M_PI / 2., X_Axis);
   trans.TransformPoint(pt);
-  CHECK_INVARIANT(ptEq(tpt, pt), "");
+  REQUIRE(ptEq(tpt, pt));
 
   Point3D pt2(0.0, 1.0, 0.0);
   Point3D tpt2(0.0, 0.0, 1.0);
   trans.TransformPoint(pt2);
-  CHECK_INVARIANT(ptEq(tpt2, pt2), "");
+  REQUIRE(ptEq(tpt2, pt2));
 
   Point3D pt3(0.0, 0.0, 1.0);
   Point3D tpt3(0.0, -1.0, 0.0);
   trans.TransformPoint(pt3);
-  CHECK_INVARIANT(ptEq(tpt3, pt3), "");
+  REQUIRE(ptEq(tpt3, pt3));
 
   // rotate around y-axis
   Transform3D transy;
   transy.SetRotation(M_PI / 2., Y_Axis);
   transy.TransformPoint(pt);
   Point3D tpt4(0.0, 0.0, -1.0);
-  CHECK_INVARIANT(ptEq(tpt4, pt), "");
+  REQUIRE(ptEq(tpt4, pt));
 
   Point3D pt5(0.0, 1.0, 0.0);
   Point3D tpt5(0.0, 1.0, 0.0);
   transy.TransformPoint(pt5);
-  CHECK_INVARIANT(ptEq(tpt5, pt5), "");
+  REQUIRE(ptEq(tpt5, pt5));
 
   Point3D pt6(0.0, 0.0, 1.0);
   Point3D tpt6(1.0, 0.0, 0.0);
   transy.TransformPoint(pt6);
-  CHECK_INVARIANT(ptEq(tpt6, pt6), "");
+  REQUIRE(ptEq(tpt6, pt6));
 
   // z-axis
   Transform3D transz;
@@ -251,20 +254,20 @@ void test23D() {
   Point3D pt7(1.0, 0.0, 0.0);
   Point3D tpt7(0.0, 1.0, 0.0);
   transz.TransformPoint(pt7);
-  CHECK_INVARIANT(ptEq(tpt7, pt7), "");
+  REQUIRE(ptEq(tpt7, pt7));
 
   Point3D pt8(0.0, 1.0, 0.0);
   Point3D tpt8(-1.0, 0.0, 0.0);
   transz.TransformPoint(pt8);
-  CHECK_INVARIANT(ptEq(tpt8, pt8), "");
+  REQUIRE(ptEq(tpt8, pt8));
 
   Point3D pt9(0.0, 0.0, 1.0);
   Point3D tpt9(0.0, 0.0, 1.0);
   transz.TransformPoint(pt9);
-  CHECK_INVARIANT(ptEq(tpt9, pt9), "");
+  REQUIRE(ptEq(tpt9, pt9));
 }
 
-void test3MatMultiply() {
+TEST_CASE("test3MatMultiply") {
   // start with line on the axis starting at 1.0,
   // transform it into a line on z-axis starting at 3.0
   Point3D pt1(1.0, 0.0, 0.0);
@@ -314,17 +317,16 @@ void test3MatMultiply() {
   t3.TransformPoint(pt1);
   t3.TransformPoint(pt2);
   std::cout << "Pt1: " << pt1 << " Pt2: " << pt2 << "\n";
-  // check the transformed points align with the new points on z-axis
-  CHECK_INVARIANT(ptEq(pt1, npt1), "");
-  CHECK_INVARIANT(ptEq(pt2, npt2), "");
+  REQUIRE(ptEq(pt1, npt1));
+  REQUIRE(ptEq(pt2, npt2));
 
   t4.TransformPoint(opt1);
   t4.TransformPoint(opt2);
-  CHECK_INVARIANT(ptEq(opt1, npt1), "");
-  CHECK_INVARIANT(ptEq(opt2, npt2), "");
+  REQUIRE(ptEq(opt1, npt1));
+  REQUIRE(ptEq(opt2, npt2));
 }
 
-void testFromQuaternion() {
+TEST_CASE("testFromQuaternion") {
   double qt[4];
   qt[0] = cos(M_PI / 6);
   qt[1] = -sin(M_PI / 6);
@@ -338,41 +340,7 @@ void testFromQuaternion() {
 
   for (unsigned int i = 0; i < 4; i++) {
     for (unsigned int j = 0; j < 4; j++) {
-      CHECK_INVARIANT(RDKit::feq(trans.getVal(i, j), ntrans.getVal(i, j)), "");
+      REQUIRE(RDKit::feq(trans.getVal(i, j), ntrans.getVal(i, j)));
     }
   }
-}
-
-int main() {
-  srand(time(nullptr));
-
-  std::cout << "****************************************\n";
-  std::cout << "testPointND\n";
-  testPointND();
-
-  std::cout << "****************************************\n";
-  std::cout << "testPointOps3D\n";
-  testPointOps3D();
-
-  std::cout << "****************************************\n";
-  std::cout << "testPointOps2D\n";
-  testPointOps2D();
-
-  std::cout << "****************************************\n";
-  std::cout << "test12D\n";
-  test12D();
-
-  std::cout << "****************************************\n";
-  std::cout << "test23D\n";
-  test23D();
-
-  std::cout << "****************************************\n";
-  std::cout << "test3MatMultiply\n";
-  test3MatMultiply();
-
-  std::cout << "****************************************\n";
-  std::cout << "testFromQuaternion\n";
-  testFromQuaternion();
-  std::cout << "****************************************\n";
-  return 0;
 }

--- a/Code/Numerics/Alignment/CMakeLists.txt
+++ b/Code/Numerics/Alignment/CMakeLists.txt
@@ -4,7 +4,7 @@ target_compile_definitions(Alignment PRIVATE RDKIT_ALIGNMENT_BUILD)
 
 rdkit_headers(AlignPoints.h DEST Numerics/Alignment)
 
-rdkit_test(testAlignment testAlignment.cpp LINK_LIBRARIES Alignment )
+rdkit_catch_test(testAlignment testAlignment.cpp LINK_LIBRARIES Alignment )
 
 if(RDK_BUILD_PYTHON_WRAPPERS)
 add_subdirectory(Wrap)

--- a/Code/Numerics/Alignment/testAlignment.cpp
+++ b/Code/Numerics/Alignment/testAlignment.cpp
@@ -1,5 +1,4 @@
-// $Id$
-//  Copyright (C) 2004-2008 Greg Landrum and Rational Discovery LLC
+//  Copyright (C) 2004-2025 Greg Landrum and other RDKit contributors
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -7,7 +6,7 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
-#include <RDGeneral/test.h>
+#include <catch2/catch_all.hpp>
 #include "AlignPoints.h"
 #include <Numerics/Vector.h>
 #include <RDGeneral/utils.h>
@@ -20,7 +19,7 @@
 using namespace RDNumeric;
 using namespace RDNumeric::Alignments;
 
-void testBasic() {
+TEST_CASE("testBasic") {
   RDGeom::Point3DConstPtrVect rpts;
   RDGeom::Point3D rpt1(0.0, 0.0, 0.0);
   rpts.push_back(&rpt1);
@@ -35,18 +34,18 @@ void testBasic() {
 
   RDGeom::Transform3D trans;
   double ssr = AlignPoints(rpts, qpts, trans);
-  CHECK_INVARIANT(RDKit::feq(ssr, 0.0), "");
+  REQUIRE_THAT(ssr, Catch::Matchers::WithinAbs(0.0, 1e-4));
 
   // transform qpts and see if we match the rpts
   trans.TransformPoint(qpt1);
   trans.TransformPoint(qpt2);
   qpt1 -= rpt1;
   qpt2 -= rpt2;
-  CHECK_INVARIANT(RDKit::feq(qpt1.length(), 0.0), "");
-  CHECK_INVARIANT(RDKit::feq(qpt2.length(), 0.0), "");
+  REQUIRE_THAT(qpt1.length(), Catch::Matchers::WithinAbs(0.0, 1e-4));
+  REQUIRE_THAT(qpt2.length(), Catch::Matchers::WithinAbs(0.0, 1e-4));
 }
 
-void testTraingle() {
+TEST_CASE("testTriangle") {
   // try 3 point two equilateral triangles of different edge lengths
   RDGeom::Point3DConstPtrVect rpts;
   RDGeom::Point3D rpt1(-cos(M_PI / 6), -sin(M_PI / 6), 0.0);
@@ -66,7 +65,7 @@ void testTraingle() {
 
   RDGeom::Transform3D trans;
   double ssr = AlignPoints(rpts, qpts, trans);
-  CHECK_INVARIANT(RDKit::feq(ssr, 3.0), "");
+  REQUIRE_THAT(ssr, Catch::Matchers::WithinAbs(3.0, 1e-4));
   RDGeom::Point3D nqpt1, nqpt2, nqpt3;
   nqpt1 = qpt1;
   nqpt2 = qpt2;
@@ -78,16 +77,16 @@ void testTraingle() {
   nqpt2 -= rpt2;
   nqpt3 -= rpt3;
 
-  CHECK_INVARIANT(RDKit::feq(nqpt1.length(), 1.0), "");
-  CHECK_INVARIANT(RDKit::feq(nqpt2.length(), 1.0), "");
-  CHECK_INVARIANT(RDKit::feq(nqpt3.length(), 1.0), "");
+  REQUIRE_THAT(nqpt1.length(), Catch::Matchers::WithinAbs(1.0, 1e-4));
+  REQUIRE_THAT(nqpt2.length(), Catch::Matchers::WithinAbs(1.0, 1e-4));
+  REQUIRE_THAT(nqpt3.length(), Catch::Matchers::WithinAbs(1.0, 1e-4));
 
   DoubleVector wts(3);
   wts.setVal(0, 1.0);
   wts.setVal(1, 1.0);
   wts.setVal(2, 2.0);
   ssr = AlignPoints(rpts, qpts, trans, &wts);
-  CHECK_INVARIANT(RDKit::feq(ssr, 3.75), "");
+  REQUIRE_THAT(ssr, Catch::Matchers::WithinAbs(3.75, 1e-4));
   nqpt1 = qpt1;
   nqpt2 = qpt2;
   nqpt3 = qpt3;
@@ -99,16 +98,16 @@ void testTraingle() {
   nqpt2 -= rpt2;
   nqpt3 -= rpt3;
 
-  CHECK_INVARIANT(RDKit::feq(nqpt1.length(), 1.14564), "");
-  CHECK_INVARIANT(RDKit::feq(nqpt2.length(), 1.14564), "");
-  CHECK_INVARIANT(RDKit::feq(nqpt3.length(), 0.75), "");
+  REQUIRE_THAT(nqpt1.length(), Catch::Matchers::WithinAbs(1.14564, 1e-4));
+  REQUIRE_THAT(nqpt2.length(), Catch::Matchers::WithinAbs(1.14564, 1e-4));
+  REQUIRE_THAT(nqpt3.length(), Catch::Matchers::WithinAbs(0.75, 1e-4));
 
   wts.setVal(0, 1.0);
   wts.setVal(1, 2.0);
   wts.setVal(2, 2.0);
 
   ssr = AlignPoints(rpts, qpts, trans, &wts);
-  CHECK_INVARIANT(RDKit::feq(ssr, 4.8), "");
+  REQUIRE_THAT(ssr, Catch::Matchers::WithinAbs(4.8, 1e-4));
   nqpt1 = qpt1;
   nqpt2 = qpt2;
   nqpt3 = qpt3;
@@ -121,12 +120,12 @@ void testTraingle() {
   nqpt1 -= rpt1;
   nqpt2 -= rpt2;
   nqpt3 -= rpt3;
-  CHECK_INVARIANT(RDKit::feq(nqpt1.length(), 1.2), "");
-  CHECK_INVARIANT(RDKit::feq(nqpt2.length(), 0.9165), "");
-  CHECK_INVARIANT(RDKit::feq(nqpt3.length(), 0.9165), "");
+  REQUIRE_THAT(nqpt1.length(), Catch::Matchers::WithinAbs(1.2, 1e-4));
+  REQUIRE_THAT(nqpt2.length(), Catch::Matchers::WithinAbs(0.9165, 1e-4));
+  REQUIRE_THAT(nqpt3.length(), Catch::Matchers::WithinAbs(0.9165, 1e-4));
 }
 
-void testFourPts() {
+TEST_CASE("testFourPts") {
   // lets test most point 4 points
   RDGeom::Point3DConstPtrVect rpts;
   RDGeom::Point3D rpt1(0.0, 0.0, 0.0);
@@ -150,7 +149,7 @@ void testFourPts() {
 
   RDGeom::Transform3D trans;
   double ssr = AlignPoints(rpts, qpts, trans);
-  CHECK_INVARIANT(RDKit::feq(ssr, 0.0), "");
+  REQUIRE_THAT(ssr, Catch::Matchers::WithinAbs(0.0, 1e-4));
   trans.TransformPoint(qpt1);
   trans.TransformPoint(qpt2);
   trans.TransformPoint(qpt3);
@@ -159,13 +158,13 @@ void testFourPts() {
   qpt2 -= rpt2;
   qpt3 -= rpt3;
   qpt4 -= rpt4;
-  CHECK_INVARIANT(RDKit::feq(qpt1.length(), 0.0), "");
-  CHECK_INVARIANT(RDKit::feq(qpt2.length(), 0.0), "");
-  CHECK_INVARIANT(RDKit::feq(qpt3.length(), 0.0), "");
-  CHECK_INVARIANT(RDKit::feq(qpt4.length(), 0.0), "");
+  REQUIRE_THAT(qpt1.length(), Catch::Matchers::WithinAbs(0.0, 1e-4));
+  REQUIRE_THAT(qpt2.length(), Catch::Matchers::WithinAbs(0.0, 1e-4));
+  REQUIRE_THAT(qpt3.length(), Catch::Matchers::WithinAbs(0.0, 1e-4));
+  REQUIRE_THAT(qpt4.length(), Catch::Matchers::WithinAbs(0.0, 1e-4));
 }
 
-void testReflection() {
+TEST_CASE("testReflection") {
   // lets test most point 4 points
   RDGeom::Point3DConstPtrVect rpts;
   RDGeom::Point3D rpt1(0.0, 0.0, 0.0);
@@ -189,10 +188,10 @@ void testReflection() {
 
   RDGeom::Transform3D trans;
   double ssr = AlignPoints(rpts, qpts, trans);
-  CHECK_INVARIANT(RDKit::feq(ssr, 1.0), "");
+  REQUIRE_THAT(ssr, Catch::Matchers::WithinAbs(1.0, 1e-4));
 
   ssr = AlignPoints(rpts, qpts, trans, nullptr, true);
-  CHECK_INVARIANT(RDKit::feq(ssr, 0.0), "");
+  REQUIRE_THAT(ssr, Catch::Matchers::WithinAbs(0.0, 1e-4));
 
   trans.TransformPoint(qpt1);
   trans.TransformPoint(qpt2);
@@ -203,31 +202,8 @@ void testReflection() {
   qpt3 -= rpt3;
   qpt4 -= rpt4;
 
-  CHECK_INVARIANT(RDKit::feq(qpt1.length(), 0.0), "");
-  CHECK_INVARIANT(RDKit::feq(qpt2.length(), 0.0), "");
-  CHECK_INVARIANT(RDKit::feq(qpt3.length(), 0.0), "");
-  CHECK_INVARIANT(RDKit::feq(qpt4.length(), 0.0), "");
-}
-
-int main() {
-  std::cout << "-----------------------------------------\n";
-  std::cout << "Testing Alignment Code\n";
-
-  std::cout << "---------------------------------------\n";
-  std::cout << "\t testBasic\n";
-  testBasic();
-
-  std::cout << "---------------------------------------\n";
-  std::cout << "\t testTriangle\n";
-  testTraingle();
-
-  std::cout << "---------------------------------------\n";
-  std::cout << "\t testFourPts\n";
-  testFourPts();
-
-  std::cout << "---------------------------------------\n";
-  std::cout << "\t testReflection\n";
-  testReflection();
-  std::cout << "---------------------------------------\n";
-  return (0);
+  REQUIRE_THAT(qpt1.length(), Catch::Matchers::WithinAbs(0.0, 1e-4));
+  REQUIRE_THAT(qpt2.length(), Catch::Matchers::WithinAbs(0.0, 1e-4));
+  REQUIRE_THAT(qpt3.length(), Catch::Matchers::WithinAbs(0.0, 1e-4));
+  REQUIRE_THAT(qpt4.length(), Catch::Matchers::WithinAbs(0.0, 1e-4));
 }

--- a/Code/Numerics/CMakeLists.txt
+++ b/Code/Numerics/CMakeLists.txt
@@ -8,5 +8,5 @@ rdkit_headers(Matrix.h
               Vector.h 
               Conrec.h DEST Numerics)
 
-rdkit_test(testMatrices testMatrices.cpp LINK_LIBRARIES RDGeneral)
+rdkit_catch_test(testMatrices testMatrices.cpp LINK_LIBRARIES RDGeneral)
 rdkit_catch_test(testConrec testConrec.cpp LINK_LIBRARIES RDGeometryLib )

--- a/Code/Numerics/Optimizer/CMakeLists.txt
+++ b/Code/Numerics/Optimizer/CMakeLists.txt
@@ -6,6 +6,6 @@ target_compile_definitions(Optimizer PRIVATE RDKIT_OPTIMIZER_BUILD)
 
 rdkit_headers(BFGSOpt.h DEST Numerics/Optimizer)
 
-rdkit_test(testOptimizer testOptimizer.cpp LINK_LIBRARIES Optimizer )
+rdkit_catch_test(testOptimizer testOptimizer.cpp LINK_LIBRARIES Optimizer )
 
 

--- a/Code/Numerics/Optimizer/testOptimizer.cpp
+++ b/Code/Numerics/Optimizer/testOptimizer.cpp
@@ -1,6 +1,5 @@
-// $Id$
 //
-// Copyright (C)  2004-2006 Rational Discovery LLC
+// Copyright (C)  2004-2025 Greg Landrum and other RDKit contributors
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -12,6 +11,7 @@
 #include <iostream>
 #include <cmath>
 #include <RDGeneral/Invariant.h>
+#include <catch2/catch_all.hpp>
 
 #include "BFGSOpt.h"
 
@@ -64,10 +64,7 @@ double grad2(double *v, double *grad) {
   return 1.0;
 }
 
-void test1() {
-  std::cerr << "-------------------------------------" << std::endl;
-  std::cerr << "Testing linear search." << std::endl;
-
+TEST_CASE("testLinearSearch") {
   int dim = 2;
   double oLoc[2], oVal;
   double grad[2], dir[2];
@@ -81,57 +78,51 @@ void test1() {
   oLoc[0] = 0;
   oLoc[1] = 1.0;
   oVal = func(oLoc);
-  TEST_ASSERT(fabs(oVal - 1.0) < 1e-4);
+  REQUIRE_THAT(oVal, Catch::Matchers::WithinAbs(1.0, 1e-4));
   gradFunc(oLoc, grad);
   dir[0] = 0;
   dir[1] = -.5;
 
   BFGSOpt::linearSearch(dim, oLoc, oVal, grad, dir, nLoc, nVal, func, 0.5,
                         resCode);
-  TEST_ASSERT(resCode == 0);
-  TEST_ASSERT(fabs(nVal - 0.25) < 1e-4);
-  TEST_ASSERT(fabs(nLoc[0]) < 1e-4);
-  TEST_ASSERT(fabs(nLoc[1] - 0.5) < 1e-4);
+  REQUIRE(resCode == 0);
+  REQUIRE_THAT(nVal, Catch::Matchers::WithinAbs(0.25, 1e-4));
+  REQUIRE_THAT(nLoc[0], Catch::Matchers::WithinAbs(0.0, 1e-4));
+  REQUIRE_THAT(nLoc[1], Catch::Matchers::WithinAbs(0.5, 1e-4));
 
   oLoc[0] = 1.0;
   oLoc[1] = 1.0;
   oVal = func(oLoc);
-  TEST_ASSERT(fabs(oVal - 2.0) < 1e-4);
+  REQUIRE_THAT(oVal, Catch::Matchers::WithinAbs(2.0, 1e-4));
   gradFunc(oLoc, grad);
   dir[0] = -.5;
   dir[1] = -.5;
 
   BFGSOpt::linearSearch(dim, oLoc, oVal, grad, dir, nLoc, nVal, func, 1.0,
                         resCode);
-  TEST_ASSERT(resCode == 0);
-  TEST_ASSERT(fabs(nVal - 0.5) < 1e-4);
-  TEST_ASSERT(fabs(nLoc[0] - 0.5) < 1e-4);
-  TEST_ASSERT(fabs(nLoc[1] - 0.5) < 1e-4);
+  REQUIRE(resCode == 0);
+  REQUIRE_THAT(nVal, Catch::Matchers::WithinAbs(0.5, 1e-4));
+  REQUIRE_THAT(nLoc[0], Catch::Matchers::WithinAbs(0.5, 1e-4));
+  REQUIRE_THAT(nLoc[1], Catch::Matchers::WithinAbs(0.5, 1e-4));
 
-  // we go hugely too far, but the dir gets cut in half, so we
-  // immediately hit the minimum
   func = circ_0_0;
   oLoc[0] = 0;
   oLoc[1] = 1.0;
   oVal = func(oLoc);
-  TEST_ASSERT(fabs(oVal - 1.0) < 1e-4);
+  REQUIRE_THAT(oVal, Catch::Matchers::WithinAbs(1.0, 1e-4));
   gradFunc(oLoc, grad);
   dir[0] = 0;
   dir[1] = -2;
 
   BFGSOpt::linearSearch(dim, oLoc, oVal, grad, dir, nLoc, nVal, func, 2.0,
                         resCode);
-  TEST_ASSERT(resCode == 0);
-  TEST_ASSERT(fabs(nVal) < 1e-4);
-  TEST_ASSERT(fabs(nLoc[0]) < 1e-4);
-  TEST_ASSERT(fabs(nLoc[1]) < 1e-4);
-  std::cerr << "  done" << std::endl;
+  REQUIRE(resCode == 0);
+  REQUIRE_THAT(nVal, Catch::Matchers::WithinAbs(0.0, 1e-4));
+  REQUIRE_THAT(nLoc[0], Catch::Matchers::WithinAbs(0.0, 1e-4));
+  REQUIRE_THAT(nLoc[1], Catch::Matchers::WithinAbs(0.0, 1e-4));
 }
 
-void test2() {
-  std::cerr << "-------------------------------------" << std::endl;
-  std::cerr << "Testing BFGS optimization." << std::endl;
-
+TEST_CASE("testBFGSOptimization") {
   unsigned int dim = 2;
   double oLoc[2], oVal;
   double nVal;
@@ -144,37 +135,27 @@ void test2() {
   oLoc[0] = 0;
   oLoc[1] = 1.0;
   oVal = func(oLoc);
-  TEST_ASSERT(fabs(oVal - 1.0) < 1e-4);
+  REQUIRE_THAT(oVal, Catch::Matchers::WithinAbs(1.0, 1e-4));
 
   BFGSOpt::minimize(dim, oLoc, 1e-4, nIters, nVal, func, gradFunc);
-  TEST_ASSERT(nIters = 1);
-  TEST_ASSERT(fabs(nVal) < 1e-4);
-  TEST_ASSERT(fabs(oLoc[0]) < 1e-4);
-  TEST_ASSERT(fabs(oLoc[1]) < 1e-4);
+  REQUIRE(nIters == 1);
+  REQUIRE_THAT(nVal, Catch::Matchers::WithinAbs(0.0, 1e-4));
+  REQUIRE_THAT(oLoc[0], Catch::Matchers::WithinAbs(0.0, 1e-4));
+  REQUIRE_THAT(oLoc[1], Catch::Matchers::WithinAbs(0.0, 1e-4));
 
   func = func2;
   gradFunc = grad2;
   oLoc[0] = 2.0;
   oLoc[1] = 0.5;
   BFGSOpt::minimize(dim, oLoc, 1e-4, nIters, nVal, func, gradFunc);
-  // TEST_ASSERT(nIters=1);
-  TEST_ASSERT(fabs(nVal) < 1e-4);
-  TEST_ASSERT(fabs(oLoc[0] - 1) < 1e-3);
-  TEST_ASSERT(fabs(oLoc[1]) < 1e-3);
+  REQUIRE_THAT(nVal, Catch::Matchers::WithinAbs(0.0, 1e-4));
+  REQUIRE_THAT(oLoc[0], Catch::Matchers::WithinAbs(1.0, 1e-3));
+  REQUIRE_THAT(oLoc[1], Catch::Matchers::WithinAbs(0.0, 1e-3));
 
-  // up the tolerance:
   oLoc[0] = 2.0;
   oLoc[1] = 0.5;
   BFGSOpt::minimize(dim, oLoc, 1e-4, nIters, nVal, func, gradFunc, 1e-8);
-  // TEST_ASSERT(nIters=1);
-  TEST_ASSERT(fabs(nVal) < 1e-4);
-  TEST_ASSERT(fabs(oLoc[0] - 1) < 1e-4);
-  TEST_ASSERT(fabs(oLoc[1]) < 1e-4);
-
-  std::cerr << "  done" << std::endl;
-}
-
-int main() {
-  test1();
-  test2();
+  REQUIRE_THAT(nVal, Catch::Matchers::WithinAbs(0.0, 1e-4));
+  REQUIRE_THAT(oLoc[0], Catch::Matchers::WithinAbs(1.0, 1e-4));
+  REQUIRE_THAT(oLoc[1], Catch::Matchers::WithinAbs(0.0, 1e-4));
 }

--- a/Code/Numerics/testMatrices.cpp
+++ b/Code/Numerics/testMatrices.cpp
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2004-2019 Rational Discovery LLC
+//  Copyright (C) 2004-2025 Greg Landrum and other RDKit contributors
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -7,7 +7,7 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
-#include <RDGeneral/test.h>
+#include <catch2/catch_all.hpp>
 #include "Matrix.h"
 #include "SquareMatrix.h"
 #include "SymmMatrix.h"
@@ -19,17 +19,17 @@
 
 using namespace RDNumeric;
 
-void test1Vector() {
+TEST_CASE("test1Vector") {
   Vector<double> v1(3, 1.0);
   v1.setVal(0, 2.0);
   v1.setVal(2, -4.0);
-  CHECK_INVARIANT(RDKit::feq(v1.normL1(), 7.0), "");
-  CHECK_INVARIANT(RDKit::feq(v1.normLinfinity(), 4.0), "");
-  CHECK_INVARIANT(RDKit::feq(v1.normL2(), sqrt(21.0)), "");
+  REQUIRE_THAT(v1.normL1(), Catch::Matchers::WithinAbs(7.0, 1e-4));
+  REQUIRE_THAT(v1.normLinfinity(), Catch::Matchers::WithinAbs(4.0, 1e-4));
+  REQUIRE_THAT(v1.normL2(), Catch::Matchers::WithinAbs(sqrt(21.0), 1e-4));
 
   v1.setVal(1, 2.0);
-  CHECK_INVARIANT(RDKit::feq(v1.getVal(1), 2.0), "");
-  CHECK_INVARIANT(RDKit::feq(v1.normL1(), 8.0), "");
+  REQUIRE_THAT(v1.getVal(1), Catch::Matchers::WithinAbs(2.0, 1e-4));
+  REQUIRE_THAT(v1.normL1(), Catch::Matchers::WithinAbs(8.0, 1e-4));
 
   auto *data = new double[3];
   data[0] = 1.0;
@@ -37,25 +37,24 @@ void test1Vector() {
   data[2] = 3.0;
   Vector<double>::DATA_SPTR sdata(data);
   Vector<double> *v2 = new Vector<double>(3, sdata);
-  CHECK_INVARIANT(RDKit::feq(v2->normL1(), 6.0), "");
+  REQUIRE_THAT(v2->normL1(), Catch::Matchers::WithinAbs(6.0, 1e-4));
   Vector<double> v3(v1);
   unsigned int i;
   for (i = 0; i < v1.size(); i++) {
-    CHECK_INVARIANT(RDKit::feq(v1.getVal(i), v3.getVal(i)), "");
+    REQUIRE_THAT(v1.getVal(i), Catch::Matchers::WithinAbs(v3.getVal(i), 1e-4));
   }
 
   delete v2;
-  // delete [] data;
 
   Vector<double> vr1(5);
   Vector<double> vr2(5);
   vr1.setToRandom();
-  CHECK_INVARIANT(RDKit::feq(vr1.normL2(), 1.0), "");
+  REQUIRE_THAT(vr1.normL2(), Catch::Matchers::WithinAbs(1.0, 1e-4));
   vr2.setToRandom(120);
-  CHECK_INVARIANT(RDKit::feq(vr2.normL2(), 1.0), "");
+  REQUIRE_THAT(vr2.normL2(), Catch::Matchers::WithinAbs(1.0, 1e-4));
 }
 
-void test2Matrix() {
+TEST_CASE("test2Matrix") {
   Matrix<double> A(2, 3);
   A.setVal(0, 0, 1.0);
   A.setVal(0, 1, 0.5);
@@ -70,73 +69,74 @@ void test2Matrix() {
 
   Vector<double> v2(2);
   multiply(A, v1, v2);
-  CHECK_INVARIANT(RDKit::feq(v2.getVal(0), 8.0), "");
-  CHECK_INVARIANT(RDKit::feq(v2.getVal(1), 11.5), "");
+  REQUIRE_THAT(v2.getVal(0), Catch::Matchers::WithinAbs(8.0, 1e-4));
+  REQUIRE_THAT(v2.getVal(1), Catch::Matchers::WithinAbs(11.5, 1e-4));
 
   double *data = A.getData();
   data[2] = 3.0;
-  CHECK_INVARIANT(RDKit::feq(A.getVal(0, 2), 3.0), "");
+  REQUIRE_THAT(A.getVal(0, 2), Catch::Matchers::WithinAbs(3.0, 1e-4));
   multiply(A, v1, v2);
-  CHECK_INVARIANT(RDKit::feq(v2.getVal(0), 11.0), "");
-  CHECK_INVARIANT(RDKit::feq(v2.getVal(1), 11.5), "");
+  REQUIRE_THAT(v2.getVal(0), Catch::Matchers::WithinAbs(11.0, 1e-4));
+  REQUIRE_THAT(v2.getVal(1), Catch::Matchers::WithinAbs(11.5, 1e-4));
 
   data = new double[6];
   Matrix<double> *B = new Matrix<double>(2, 3, Matrix<double>::DATA_SPTR(data));
-  Matrix<double> E(A);  //(*B) = A;
+  Matrix<double> E(A);
   multiply(E, v1, v2);
-  CHECK_INVARIANT(RDKit::feq(v2.getVal(0), 11.0), "");
-  CHECK_INVARIANT(RDKit::feq(v2.getVal(1), 11.5), "");
+  REQUIRE_THAT(v2.getVal(0), Catch::Matchers::WithinAbs(11.0, 1e-4));
+  REQUIRE_THAT(v2.getVal(1), Catch::Matchers::WithinAbs(11.5, 1e-4));
   delete B;
-  // delete [] data;
 
   Matrix<double> D(3, 2);
   A.transpose(D);
   Matrix<double> C(2, 2);
   multiply(A, D, C);
 
-  CHECK_INVARIANT(RDKit::feq(C.getVal(0, 0), 10.25), "");
-  CHECK_INVARIANT(RDKit::feq(C.getVal(0, 1), 10), "");
-  CHECK_INVARIANT(RDKit::feq(C.getVal(1, 0), 10), "");
-  CHECK_INVARIANT(RDKit::feq(C.getVal(1, 1), 10.25), "");
+  REQUIRE_THAT(C.getVal(0, 0), Catch::Matchers::WithinAbs(10.25, 1e-4));
+  REQUIRE_THAT(C.getVal(0, 1), Catch::Matchers::WithinAbs(10.0, 1e-4));
+  REQUIRE_THAT(C.getVal(1, 0), Catch::Matchers::WithinAbs(10.0, 1e-4));
+  REQUIRE_THAT(C.getVal(1, 1), Catch::Matchers::WithinAbs(10.25, 1e-4));
 
   auto Ccp(C);
   Ccp += C;
-  CHECK_INVARIANT(RDKit::feq(Ccp.getVal(0, 0), 20.5), "");
-  CHECK_INVARIANT(RDKit::feq(Ccp.getVal(0, 1), 20), "");
-  CHECK_INVARIANT(RDKit::feq(Ccp.getVal(1, 0), 20), "");
-  CHECK_INVARIANT(RDKit::feq(Ccp.getVal(1, 1), 20.5), "");
+  REQUIRE_THAT(Ccp.getVal(0, 0), Catch::Matchers::WithinAbs(20.5, 1e-4));
+  REQUIRE_THAT(Ccp.getVal(0, 1), Catch::Matchers::WithinAbs(20.0, 1e-4));
+  REQUIRE_THAT(Ccp.getVal(1, 0), Catch::Matchers::WithinAbs(20.0, 1e-4));
+  REQUIRE_THAT(Ccp.getVal(1, 1), Catch::Matchers::WithinAbs(20.5, 1e-4));
 
   Ccp -= C;
-  CHECK_INVARIANT(RDKit::feq(Ccp.getVal(0, 0), 10.25), "");
-  CHECK_INVARIANT(RDKit::feq(Ccp.getVal(0, 1), 10), "");
-  CHECK_INVARIANT(RDKit::feq(Ccp.getVal(1, 0), 10), "");
-  CHECK_INVARIANT(RDKit::feq(Ccp.getVal(1, 1), 10.25), "");
+  REQUIRE_THAT(Ccp.getVal(0, 0), Catch::Matchers::WithinAbs(10.25, 1e-4));
+  REQUIRE_THAT(Ccp.getVal(0, 1), Catch::Matchers::WithinAbs(10.0, 1e-4));
+  REQUIRE_THAT(Ccp.getVal(1, 0), Catch::Matchers::WithinAbs(10.0, 1e-4));
+  REQUIRE_THAT(Ccp.getVal(1, 1), Catch::Matchers::WithinAbs(10.25, 1e-4));
 
   C *= 2.;
-  CHECK_INVARIANT(RDKit::feq(C.getVal(0, 0), 20.5), "");
-  CHECK_INVARIANT(RDKit::feq(C.getVal(0, 1), 20), "");
-  CHECK_INVARIANT(RDKit::feq(C.getVal(1, 0), 20), "");
-  CHECK_INVARIANT(RDKit::feq(C.getVal(1, 1), 20.5), "");
+  REQUIRE_THAT(C.getVal(0, 0), Catch::Matchers::WithinAbs(20.5, 1e-4));
+  REQUIRE_THAT(C.getVal(0, 1), Catch::Matchers::WithinAbs(20.0, 1e-4));
+  REQUIRE_THAT(C.getVal(1, 0), Catch::Matchers::WithinAbs(20.0, 1e-4));
+  REQUIRE_THAT(C.getVal(1, 1), Catch::Matchers::WithinAbs(20.5, 1e-4));
 
   C /= 2.;
-  CHECK_INVARIANT(RDKit::feq(C.getVal(0, 0), 10.25), "");
-  CHECK_INVARIANT(RDKit::feq(C.getVal(0, 1), 10), "");
-  CHECK_INVARIANT(RDKit::feq(C.getVal(1, 0), 10), "");
-  CHECK_INVARIANT(RDKit::feq(C.getVal(1, 1), 10.25), "");
+  REQUIRE_THAT(C.getVal(0, 0), Catch::Matchers::WithinAbs(10.25, 1e-4));
+  REQUIRE_THAT(C.getVal(0, 1), Catch::Matchers::WithinAbs(10.0, 1e-4));
+  REQUIRE_THAT(C.getVal(1, 0), Catch::Matchers::WithinAbs(10.0, 1e-4));
+  REQUIRE_THAT(C.getVal(1, 1), Catch::Matchers::WithinAbs(10.25, 1e-4));
 
   Vector<double> tRow(A.numCols());
   A.getRow(1, tRow);
   for (unsigned int i = 0; i < A.numCols(); ++i) {
-    TEST_ASSERT(RDKit::feq(A.getVal(1, i), tRow.getVal(i)));
+    REQUIRE_THAT(A.getVal(1, i),
+                 Catch::Matchers::WithinAbs(tRow.getVal(i), 1e-4));
   }
   Vector<double> tCol(A.numRows());
   A.getCol(1, tCol);
   for (unsigned int i = 0; i < A.numRows(); ++i) {
-    TEST_ASSERT(RDKit::feq(A.getVal(i, 1), tCol.getVal(i)));
+    REQUIRE_THAT(A.getVal(i, 1),
+                 Catch::Matchers::WithinAbs(tCol.getVal(i), 1e-4));
   }
 }
 
-void test3SquareMatrix() {
+TEST_CASE("test3SquareMatrix") {
   SquareMatrix<double> A(2);
   A.setVal(0, 0, 1.0);
   A.setVal(0, 1, 2.0);
@@ -145,15 +145,15 @@ void test3SquareMatrix() {
   SquareMatrix<double> B(A), C(2);
 
   multiply(A, B, C);
-  CHECK_INVARIANT(RDKit::feq(C.getVal(0, 0), 7.0), "");
-  CHECK_INVARIANT(RDKit::feq(C.getVal(0, 1), 10.0), "");
-  CHECK_INVARIANT(RDKit::feq(C.getVal(1, 0), 15.0), "");
-  CHECK_INVARIANT(RDKit::feq(C.getVal(1, 1), 22.0), "");
+  REQUIRE_THAT(C.getVal(0, 0), Catch::Matchers::WithinAbs(7.0, 1e-4));
+  REQUIRE_THAT(C.getVal(0, 1), Catch::Matchers::WithinAbs(10.0, 1e-4));
+  REQUIRE_THAT(C.getVal(1, 0), Catch::Matchers::WithinAbs(15.0, 1e-4));
+  REQUIRE_THAT(C.getVal(1, 1), Catch::Matchers::WithinAbs(22.0, 1e-4));
   B *= A;
-  CHECK_INVARIANT(RDKit::feq(B.getVal(0, 0), 7.0), "");
-  CHECK_INVARIANT(RDKit::feq(B.getVal(0, 1), 10.0), "");
-  CHECK_INVARIANT(RDKit::feq(B.getVal(1, 0), 15.0), "");
-  CHECK_INVARIANT(RDKit::feq(B.getVal(1, 1), 22.0), "");
+  REQUIRE_THAT(B.getVal(0, 0), Catch::Matchers::WithinAbs(7.0, 1e-4));
+  REQUIRE_THAT(B.getVal(0, 1), Catch::Matchers::WithinAbs(10.0, 1e-4));
+  REQUIRE_THAT(B.getVal(1, 0), Catch::Matchers::WithinAbs(15.0, 1e-4));
+  REQUIRE_THAT(B.getVal(1, 1), Catch::Matchers::WithinAbs(22.0, 1e-4));
 
   auto *data = new double[4];
   data[0] = 1.0;
@@ -168,19 +168,19 @@ void test3SquareMatrix() {
   unsigned int i, j;
   for (i = 0; i < 2; i++) {
     for (j = 0; j < 2; j++) {
-      CHECK_INVARIANT(RDKit::feq(B.getVal(i, j), A.getVal(i, j)), "");
+      REQUIRE_THAT(B.getVal(i, j),
+                   Catch::Matchers::WithinAbs(A.getVal(i, j), 1e-4));
     }
   }
   D->transposeInplace();
-  CHECK_INVARIANT(RDKit::feq(D->getVal(0, 0), 1.0), "");
-  CHECK_INVARIANT(RDKit::feq(D->getVal(0, 1), 3.0), "");
-  CHECK_INVARIANT(RDKit::feq(D->getVal(1, 0), 2.0), "");
-  CHECK_INVARIANT(RDKit::feq(D->getVal(1, 1), 4.0), "");
+  REQUIRE_THAT(D->getVal(0, 0), Catch::Matchers::WithinAbs(1.0, 1e-4));
+  REQUIRE_THAT(D->getVal(0, 1), Catch::Matchers::WithinAbs(3.0, 1e-4));
+  REQUIRE_THAT(D->getVal(1, 0), Catch::Matchers::WithinAbs(2.0, 1e-4));
+  REQUIRE_THAT(D->getVal(1, 1), Catch::Matchers::WithinAbs(4.0, 1e-4));
   delete D;
-  // delete [] data;
 }
 
-void test4SymmMatrix() {
+TEST_CASE("test4SymmMatrix") {
   SymmMatrix<double> A(3);
   A.setVal(0, 0, 1.0);
   A.setVal(0, 1, 2.0);
@@ -201,7 +201,8 @@ void test4SymmMatrix() {
   unsigned int i, j;
   for (i = 0; i < 3; i++) {
     for (j = 0; j < 3; j++) {
-      CHECK_INVARIANT(RDKit::feq(B.getVal(i, j), C.getVal(i, j)), "");
+      REQUIRE_THAT(B.getVal(i, j),
+                   Catch::Matchers::WithinAbs(C.getVal(i, j), 1e-4));
     }
   }
 
@@ -212,43 +213,19 @@ void test4SymmMatrix() {
 
   multiply(A, x, y);
 
-  CHECK_INVARIANT(RDKit::feq(y.getVal(0), 9.5), "");
-  CHECK_INVARIANT(RDKit::feq(y.getVal(1), 13.0), "");
-  CHECK_INVARIANT(RDKit::feq(y.getVal(2), 10.5), "");
+  REQUIRE_THAT(y.getVal(0), Catch::Matchers::WithinAbs(9.5, 1e-4));
+  REQUIRE_THAT(y.getVal(1), Catch::Matchers::WithinAbs(13.0, 1e-4));
+  REQUIRE_THAT(y.getVal(2), Catch::Matchers::WithinAbs(10.5, 1e-4));
 
-  CHECK_INVARIANT(A.getDataSize() == 6, "");
+  REQUIRE(A.getDataSize() == 6);
   A.setToIdentity();
   for (i = 0; i < 3; i++) {
     for (j = 0; j < 3; j++) {
       if (i != j) {
-        CHECK_INVARIANT(RDKit::feq(A.getVal(i, j), 0.0, 0.000001), "");
+        REQUIRE_THAT(A.getVal(i, j), Catch::Matchers::WithinAbs(0.0, 1e-6));
       } else {
-        CHECK_INVARIANT(RDKit::feq(A.getVal(i, j), 1.0, 0.000001), "");
+        REQUIRE_THAT(A.getVal(i, j), Catch::Matchers::WithinAbs(1.0, 1e-6));
       }
     }
   }
-}
-
-int main() {
-  RDLog::InitLogs();
-
-  BOOST_LOG(rdErrorLog) << "-----------------------------------------\n";
-  BOOST_LOG(rdErrorLog) << "Testing RDNumerics: vectors and matrices Code\n";
-
-  BOOST_LOG(rdErrorLog) << "---------------------------------------\n";
-  BOOST_LOG(rdErrorLog) << "\t test1Vector\n";
-  test1Vector();
-
-  BOOST_LOG(rdErrorLog) << "---------------------------------------\n";
-  BOOST_LOG(rdErrorLog) << "\t test2Matrix\n";
-  test2Matrix();
-
-  BOOST_LOG(rdErrorLog) << "---------------------------------------\n";
-  BOOST_LOG(rdErrorLog) << "\t test3SquareMatrix\n";
-  test3SquareMatrix();
-
-  BOOST_LOG(rdErrorLog) << "---------------------------------------\n";
-  BOOST_LOG(rdErrorLog) << "\t test4SymmMatrix\n";
-  test4SymmMatrix();
-  return 0;
 }

--- a/Code/Query/CMakeLists.txt
+++ b/Code/Query/CMakeLists.txt
@@ -12,5 +12,5 @@ rdkit_headers(AndQuery.h
               SetQuery.h
               XOrQuery.h DEST Query)
 
-rdkit_test(testQuery test.cpp LINK_LIBRARIES RDGeneral)
+rdkit_catch_test(testQuery test.cpp LINK_LIBRARIES RDGeneral)
 

--- a/Code/Query/test.cpp
+++ b/Code/Query/test.cpp
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2003-2020 Greg Landrum and Rational Discovery LLC
+// Copyright (c) 2003-2025 Greg Landrum and other RDKit contributors
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -8,7 +8,7 @@
 //  of the RDKit source tree.
 //
 
-#include <RDGeneral/test.h>
+#include <catch2/catch_all.hpp>
 #include "QueryObjects.h"
 #include <iostream>
 #include <cmath>
@@ -17,60 +17,157 @@
 using namespace std;
 using namespace Queries;
 
-void test1() {
-  cout << "Float" << endl;
+int foofun(double bar) { return int(floor(bar)); };
+
+bool matchF(int v) { return v == 3; }
+
+int dataF(float v) { return int(floor(v)) * 3; }
+
+bool cmp(int v) { return v < 3; }
+
+TEST_CASE("basics1_Query") {
+  Query<int, float, true> q;
+  q.setMatchFunc(matchF);
+  q.setDataFunc(dataF);
+
+  REQUIRE(!q.Match(0.0));
+  REQUIRE(q.Match(1.0));
+  REQUIRE(q.Match(1.1));
+  REQUIRE(!q.Match(-2.0));
+
+  REQUIRE(!q.getMatchFunc()(0));
+  REQUIRE(q.getMatchFunc()(3));
+  REQUIRE(q.getDataFunc()(1.0) == dataF(1.0));
+}
+
+TEST_CASE("basics1_Query2") {
+  Query<bool, int, true> q2;
+  q2.setDataFunc(cmp);
+
+  REQUIRE(q2.Match(0));
+  REQUIRE(q2.Match(1));
+  REQUIRE(!q2.Match(3));
+  REQUIRE(!q2.Match(4));
+  REQUIRE(!q2.Match(4.0));
+}
+
+TEST_CASE("basics2_Equality") {
+  EqualityQuery<int> q2;
+  q2.setVal(3);
+
+  REQUIRE(!q2.Match(0));
+  REQUIRE(!q2.Match(1));
+  REQUIRE(q2.Match(3));
+  REQUIRE(!q2.Match(-3));
+}
+
+TEST_CASE("basics2_Greater") {
+  GreaterQuery<int> q3;
+  q3.setVal(3);
+
+  REQUIRE(q3.Match(0));
+  REQUIRE(q3.Match(1));
+  REQUIRE(!q3.Match(3));
+  REQUIRE(!q3.Match(5));
+}
+
+TEST_CASE("basics2_GreaterEqual") {
+  GreaterEqualQuery<int> q4(3);
+
+  REQUIRE(q4.Match(0));
+  REQUIRE(q4.Match(1));
+  REQUIRE(q4.Match(3));
+  REQUIRE(!q4.Match(5));
+}
+
+TEST_CASE("basics2_Less") {
+  LessQuery<int> q5;
+  q5.setVal(3);
+
+  REQUIRE(!q5.Match(0));
+  REQUIRE(!q5.Match(1));
+  REQUIRE(!q5.Match(3));
+  REQUIRE(q5.Match(5));
+}
+
+TEST_CASE("basics2_LessEqual") {
+  LessEqualQuery<int> q6(3);
+
+  REQUIRE(!q6.Match(0));
+  REQUIRE(!q6.Match(1));
+  REQUIRE(q6.Match(3));
+  REQUIRE(q6.Match(5));
+}
+
+TEST_CASE("basics2_OpenRange") {
+  RangeQuery<int> q7(0, 3);
+
+  REQUIRE(!q7.Match(0));
+  REQUIRE(q7.Match(1));
+  REQUIRE(!q7.Match(3));
+  REQUIRE(!q7.Match(5));
+}
+
+TEST_CASE("basics2_ClosedRange") {
+  RangeQuery<int> q7(0, 3);
+  q7.setEndsOpen(false, false);
+
+  REQUIRE(q7.Match(0));
+  REQUIRE(q7.Match(1));
+  REQUIRE(q7.Match(3));
+  REQUIRE(!q7.Match(5));
+}
+
+TEST_CASE("testFloatEquality") {
   EqualityQuery<double> q(1.0);
 
-  TEST_ASSERT(!q.Match(0.0));
-  TEST_ASSERT(q.Match(1.0));
-  TEST_ASSERT(!q.Match(1.001));
-  TEST_ASSERT(!q.Match(1.1));
-  TEST_ASSERT(!q.Match(-2));
+  REQUIRE(!q.Match(0.0));
+  REQUIRE(q.Match(1.0));
+  REQUIRE(!q.Match(1.001));
+  REQUIRE(!q.Match(1.1));
+  REQUIRE(!q.Match(-2));
 
-  cout << "With Tolerance" << endl;
   q.setTol(0.002);
-  TEST_ASSERT(!q.Match(0.0));
-  TEST_ASSERT(q.Match(1.0));
-  TEST_ASSERT(q.Match(1.001));
-  TEST_ASSERT(!q.Match(1.1));
-  TEST_ASSERT(!q.Match(-2));
-  TEST_ASSERT(q.getTypeLabel().empty());
+  REQUIRE(!q.Match(0.0));
+  REQUIRE(q.Match(1.0));
+  REQUIRE(q.Match(1.001));
+  REQUIRE(!q.Match(1.1));
+  REQUIRE(!q.Match(-2));
+  REQUIRE(q.getTypeLabel().empty());
   q.setTypeLabel("FloatEquality");
 
   Query<double> *newQ;
   newQ = q.copy();
-  TEST_ASSERT(!newQ->Match(0.0));
-  TEST_ASSERT(newQ->Match(1.0));
-  TEST_ASSERT(newQ->Match(1.001));
-  TEST_ASSERT(!newQ->Match(1.1));
-  TEST_ASSERT(!newQ->Match(-2));
-  TEST_ASSERT(newQ->getTypeLabel() == "FloatEquality");
+  REQUIRE(!newQ->Match(0.0));
+  REQUIRE(newQ->Match(1.0));
+  REQUIRE(newQ->Match(1.001));
+  REQUIRE(!newQ->Match(1.1));
+  REQUIRE(!newQ->Match(-2));
+  REQUIRE(newQ->getTypeLabel() == "FloatEquality");
   delete newQ;
 }
 
-void test2() {
-  cout << "Set" << endl;
+TEST_CASE("testSetQuery") {
   SetQuery<int> q;
   q.insert(1);
   q.insert(3);
   q.insert(5);
 
-  TEST_ASSERT(!q.Match(0));
-  TEST_ASSERT(q.Match(1));
-  TEST_ASSERT(q.Match(3));
-  TEST_ASSERT(!q.Match(-3));
+  REQUIRE(!q.Match(0));
+  REQUIRE(q.Match(1));
+  REQUIRE(q.Match(3));
+  REQUIRE(!q.Match(-3));
 
   Query<int> *newQ;
   newQ = q.copy();
-  TEST_ASSERT(!newQ->Match(0));
-  TEST_ASSERT(newQ->Match(1));
-  TEST_ASSERT(newQ->Match(3));
-  TEST_ASSERT(!newQ->Match(-3));
+  REQUIRE(!newQ->Match(0));
+  REQUIRE(newQ->Match(1));
+  REQUIRE(newQ->Match(3));
+  REQUIRE(!newQ->Match(-3));
   delete newQ;
 }
 
-void test3() {
-  cout << "And" << endl;
+TEST_CASE("testAndQuery") {
   auto *q = new AndQuery<int>;
   auto *l = new LessQuery<int>;
   l->setVal(0);
@@ -80,24 +177,23 @@ void test3() {
   q->addChild(Query<int>::CHILD_TYPE(l));
   q->addChild(Query<int>::CHILD_TYPE(g));
 
-  TEST_ASSERT(!q->Match(0));
-  TEST_ASSERT(q->Match(1));
-  TEST_ASSERT(q->Match(3));
-  TEST_ASSERT(!q->Match(-3));
+  REQUIRE(!q->Match(0));
+  REQUIRE(q->Match(1));
+  REQUIRE(q->Match(3));
+  REQUIRE(!q->Match(-3));
 
   Query<int> *newQ;
   newQ = q->copy();
-  TEST_ASSERT(!newQ->Match(0));
-  TEST_ASSERT(newQ->Match(1));
-  TEST_ASSERT(newQ->Match(3));
-  TEST_ASSERT(!newQ->Match(-3));
+  REQUIRE(!newQ->Match(0));
+  REQUIRE(newQ->Match(1));
+  REQUIRE(newQ->Match(3));
+  REQUIRE(!newQ->Match(-3));
 
   delete newQ;
   delete q;
 }
 
-void test4() {
-  cout << "Or" << endl;
+TEST_CASE("testOrQuery") {
   auto *q = new OrQuery<int>;
   auto *l = new LessQuery<int>;
   l->setVal(0);
@@ -107,24 +203,23 @@ void test4() {
   q->addChild(Query<int>::CHILD_TYPE(l));
   q->addChild(Query<int>::CHILD_TYPE(g));
 
-  TEST_ASSERT(q->Match(0));
-  TEST_ASSERT(q->Match(1));
-  TEST_ASSERT(q->Match(3));
-  TEST_ASSERT(q->Match(-3));
+  REQUIRE(q->Match(0));
+  REQUIRE(q->Match(1));
+  REQUIRE(q->Match(3));
+  REQUIRE(q->Match(-3));
 
   Query<int> *newQ;
   newQ = q->copy();
-  TEST_ASSERT(newQ->Match(0));
-  TEST_ASSERT(newQ->Match(1));
-  TEST_ASSERT(newQ->Match(3));
-  TEST_ASSERT(newQ->Match(-3));
+  REQUIRE(newQ->Match(0));
+  REQUIRE(newQ->Match(1));
+  REQUIRE(newQ->Match(3));
+  REQUIRE(newQ->Match(-3));
 
   delete newQ;
   delete q;
 }
 
-void test5() {
-  cout << "XOr" << endl;
+TEST_CASE("testXOrQuery") {
   auto *q = new XOrQuery<int>;
   auto *l = new LessQuery<int>;
   l->setVal(0);
@@ -134,176 +229,73 @@ void test5() {
   q->addChild(Query<int>::CHILD_TYPE(l));
   q->addChild(Query<int>::CHILD_TYPE(g));
 
-  TEST_ASSERT(q->Match(-1));
-  TEST_ASSERT(q->Match(0));
-  TEST_ASSERT(!q->Match(1));
-  TEST_ASSERT(!q->Match(3));
-  TEST_ASSERT(q->Match(-3));
+  REQUIRE(q->Match(-1));
+  REQUIRE(q->Match(0));
+  REQUIRE(!q->Match(1));
+  REQUIRE(!q->Match(3));
+  REQUIRE(q->Match(-3));
 
   Query<int> *newQ;
   newQ = q->copy();
-  TEST_ASSERT(newQ->Match(-1));
-  TEST_ASSERT(newQ->Match(0));
-  TEST_ASSERT(!newQ->Match(1));
-  TEST_ASSERT(!newQ->Match(3));
-  TEST_ASSERT(newQ->Match(-3));
+  REQUIRE(newQ->Match(-1));
+  REQUIRE(newQ->Match(0));
+  REQUIRE(!newQ->Match(1));
+  REQUIRE(!newQ->Match(3));
+  REQUIRE(newQ->Match(-3));
 
   delete newQ;
   delete q;
 }
 
-int foofun(double bar) { return int(floor(bar)); };
-
-void test6() {
-  cout << "pointer and copy foo" << endl;
+TEST_CASE("testPointerAndCopyFoo") {
   EqualityQuery<int, double, true> q;
   q.setDataFunc(foofun);
   q.setVal(6);
-  TEST_ASSERT(q.Match(6.0));
-  TEST_ASSERT(q.Match(6.1));
-  TEST_ASSERT(!q.Match(5.0));
+  REQUIRE(q.Match(6.0));
+  REQUIRE(q.Match(6.1));
+  REQUIRE(!q.Match(5.0));
 
   Query<int, double, true> *newQ;
   newQ = q.copy();
-  TEST_ASSERT(newQ->Match(6.0));
-  TEST_ASSERT(newQ->Match(6.1));
-  TEST_ASSERT(!newQ->Match(5.0));
+  REQUIRE(newQ->Match(6.0));
+  REQUIRE(newQ->Match(6.1));
+  REQUIRE(!newQ->Match(5.0));
 
   Query<int, double, true> *newQ2 = &q;
-  TEST_ASSERT(newQ2->Match(6.0));
-  TEST_ASSERT(newQ2->Match(6.1));
-  TEST_ASSERT(!newQ2->Match(5.0));
+  REQUIRE(newQ2->Match(6.0));
+  REQUIRE(newQ2->Match(6.1));
+  REQUIRE(!newQ2->Match(5.0));
 
   Query<int, double, true> *newQ3;
   newQ3 = newQ2->copy();
-  TEST_ASSERT(newQ3->Match(6.0));
-  TEST_ASSERT(newQ3->Match(6.1));
-  TEST_ASSERT(!newQ3->Match(5.0));
+  REQUIRE(newQ3->Match(6.0));
+  REQUIRE(newQ3->Match(6.1));
+  REQUIRE(!newQ3->Match(5.0));
 
   delete newQ;
   delete newQ3;
 }
 
-bool matchF(int v) { return v == 3; }
-
-int dataF(float v) { return int(floor(v)) * 3; }
-
-bool cmp(int v) { return v < 3; }
-
-void basics1() {
-  cout << "Query" << endl;
-  Query<int, float, true> q;
-  q.setMatchFunc(matchF);
-  q.setDataFunc(dataF);
-
-  TEST_ASSERT(!q.Match(0.0));
-  TEST_ASSERT(q.Match(1.0));
-  TEST_ASSERT(q.Match(1.1));
-  TEST_ASSERT(!q.Match(-2.0));
-
-  TEST_ASSERT(!q.getMatchFunc()(0));
-  TEST_ASSERT(q.getMatchFunc()(3));
-  TEST_ASSERT(q.getDataFunc()(1.0) == dataF(1.0));
-
-  cout << "Query2" << endl;
-  Query<bool, int, true> q2;
-  q2.setDataFunc(cmp);
-  TEST_ASSERT(q2.Match(0));
-  TEST_ASSERT(q2.Match(1));
-  TEST_ASSERT(!q2.Match(3));
-  TEST_ASSERT(!q2.Match(4));
-  TEST_ASSERT(!q2.Match(4.0));
-}
-
-void basics2() {
-  cout << "Equality" << endl;
-  EqualityQuery<int> q2;
-  q2.setVal(3);
-  TEST_ASSERT(!q2.Match(0));
-  TEST_ASSERT(!q2.Match(1));
-  TEST_ASSERT(q2.Match(3));
-  TEST_ASSERT(!q2.Match(-3));
-
-  cout << "Greater" << endl;
-  GreaterQuery<int> q3;
-  q3.setVal(3);
-  TEST_ASSERT(q3.Match(0));
-  TEST_ASSERT(q3.Match(1));
-  TEST_ASSERT(!q3.Match(3));
-  TEST_ASSERT(!q3.Match(5));
-
-  cout << "GreaterEqual" << endl;
-  GreaterEqualQuery<int> q4(3);
-  TEST_ASSERT(q4.Match(0));
-  TEST_ASSERT(q4.Match(1));
-  TEST_ASSERT(q4.Match(3));
-  TEST_ASSERT(!q4.Match(5));
-
-  cout << "Less" << endl;
-  LessQuery<int> q5;
-  q5.setVal(3);
-  TEST_ASSERT(!q5.Match(0));
-  TEST_ASSERT(!q5.Match(1));
-  TEST_ASSERT(!q5.Match(3));
-  TEST_ASSERT(q5.Match(5));
-
-  cout << "LessEqual" << endl;
-  LessEqualQuery<int> q6(3);
-
-  TEST_ASSERT(!q6.Match(0));
-  TEST_ASSERT(!q6.Match(1));
-  TEST_ASSERT(q6.Match(3));
-  TEST_ASSERT(q6.Match(5));
-
-  cout << "Open Range" << endl;
-  RangeQuery<int> q7(0, 3);
-  TEST_ASSERT(!q7.Match(0));
-  TEST_ASSERT(q7.Match(1));
-  TEST_ASSERT(!q7.Match(3));
-  TEST_ASSERT(!q7.Match(5));
-
-  cout << "Closed Range" << endl;
-  q7.setEndsOpen(false, false);
-  TEST_ASSERT(q7.Match(0));
-  TEST_ASSERT(q7.Match(1));
-  TEST_ASSERT(q7.Match(3));
-  TEST_ASSERT(!q7.Match(5));
-}
-
 int convFunc(const char *arg) { return boost::lexical_cast<int>(arg); };
 
-void test7() {
-  cout << "Set2" << endl;
+TEST_CASE("testSetQueryWithDataFunc") {
   SetQuery<int, const char *, true> q;
   q.setDataFunc(convFunc);
   q.insert(1);
   q.insert(3);
   q.insert(5);
 
-  TEST_ASSERT(!q.Match("0"));
-  TEST_ASSERT(q.Match("1"));
-  TEST_ASSERT(q.Match("3"));
-  TEST_ASSERT(!q.Match("-3"));
+  REQUIRE(!q.Match("0"));
+  REQUIRE(q.Match("1"));
+  REQUIRE(q.Match("3"));
+  REQUIRE(!q.Match("-3"));
 
   Query<int, const char *, true> *newQ;
   newQ = q.copy();
-  TEST_ASSERT(!newQ->Match("0"));
-  TEST_ASSERT(newQ->Match("1"));
-  TEST_ASSERT(newQ->Match("3"));
-  TEST_ASSERT(!newQ->Match("-3"));
+  REQUIRE(!newQ->Match("0"));
+  REQUIRE(newQ->Match("1"));
+  REQUIRE(newQ->Match("3"));
+  REQUIRE(!newQ->Match("-3"));
 
   delete newQ;
-}
-
-int main() {
-  basics1();
-  basics2();
-
-  test1();
-  test2();
-  test3();
-  test4();
-  test5();
-  test6();
-  test7();
 }

--- a/Code/RDGeneral/CMakeLists.txt
+++ b/Code/RDGeneral/CMakeLists.txt
@@ -58,8 +58,8 @@ if (NOT RDK_INSTALL_INTREE)
     install(DIRECTORY hash DESTINATION ${RDKit_HdrDir}/RDGeneral)
 endif (NOT RDK_INSTALL_INTREE)
 
-rdkit_test(testDict testDict.cpp LINK_LIBRARIES RDGeneral)
-rdkit_test(testRDValue testRDValue.cpp LINK_LIBRARIES RDGeneral)
+rdkit_catch_test(testDict testDict.cpp LINK_LIBRARIES RDGeneral)
+rdkit_catch_test(testRDValue testRDValue.cpp LINK_LIBRARIES RDGeneral)
 
 if (RDK_BUILD_THREADSAFE_SSS)
     rdkit_test(testConcurrentQueue testConcurrentQueue.cpp LINK_LIBRARIES RDGeneral)

--- a/Code/RDGeneral/CMakeLists.txt
+++ b/Code/RDGeneral/CMakeLists.txt
@@ -62,7 +62,7 @@ rdkit_catch_test(testDict testDict.cpp LINK_LIBRARIES RDGeneral)
 rdkit_catch_test(testRDValue testRDValue.cpp LINK_LIBRARIES RDGeneral)
 
 if (RDK_BUILD_THREADSAFE_SSS)
-    rdkit_test(testConcurrentQueue testConcurrentQueue.cpp LINK_LIBRARIES RDGeneral)
+    rdkit_catch_test(testConcurrentQueue testConcurrentQueue.cpp LINK_LIBRARIES RDGeneral)
 endif (RDK_BUILD_THREADSAFE_SSS)
 
 if (RDK_BUILD_CPP_TESTS)

--- a/Code/RDGeneral/testConcurrentQueue.cpp
+++ b/Code/RDGeneral/testConcurrentQueue.cpp
@@ -1,5 +1,5 @@
 #ifdef RDK_BUILD_THREADSAFE_SSS
-#include <RDGeneral/Invariant.h>
+#include <catch2/catch_all.hpp>
 #include <RDGeneral/RDLog.h>
 
 #include <functional>
@@ -10,27 +10,26 @@
 
 using namespace RDKit;
 
-//! method for testing basic ConcurrentQueue operations
-void testPushAndPop() {
+TEST_CASE("testPushAndPop") {
   ConcurrentQueue<int> *q = new ConcurrentQueue<int>(4);
   int e1, e2, e3;
-  TEST_ASSERT(q->isEmpty());
+  REQUIRE(q->isEmpty());
 
   q->push(1);
   q->push(2);
   q->push(3);
 
-  TEST_ASSERT(!q->isEmpty());
+  REQUIRE(!q->isEmpty());
 
-  TEST_ASSERT(q->pop(e1));
-  TEST_ASSERT(q->pop(e2));
-  TEST_ASSERT(q->pop(e3));
+  REQUIRE(q->pop(e1));
+  REQUIRE(q->pop(e2));
+  REQUIRE(q->pop(e3));
 
-  TEST_ASSERT(e1 == 1);
-  TEST_ASSERT(e2 == 2);
-  TEST_ASSERT(e3 == 3);
+  REQUIRE(e1 == 1);
+  REQUIRE(e2 == 2);
+  REQUIRE(e3 == 3);
 
-  TEST_ASSERT(q->isEmpty());
+  REQUIRE(q->isEmpty());
 
   delete (q);
 }
@@ -52,7 +51,7 @@ void consume(ConcurrentQueue<int> &q, std::vector<int> &result) {
 bool testProducerConsumer(const int numProducerThreads,
                           const int numConsumerThreads) {
   ConcurrentQueue<int> q(5);
-  TEST_ASSERT(q.isEmpty());
+  REQUIRE(q.isEmpty());
 
   const int numToProduce = 10;
 
@@ -77,7 +76,7 @@ bool testProducerConsumer(const int numProducerThreads,
 
   std::for_each(consumers.begin(), consumers.end(),
                 std::mem_fn(&std::thread::join));
-  TEST_ASSERT(q.isEmpty());
+  REQUIRE(q.isEmpty());
 
   std::vector<int> frequency(numToProduce, 0);
   for (auto &result : results) {
@@ -93,47 +92,26 @@ bool testProducerConsumer(const int numProducerThreads,
   return true;
 }
 
-void testMultipleTimes() {
+TEST_CASE("testMultipleTimes") {
   const int trials = 10000;
   //! Single Producer, Single Consumer
   for (int i = 0; i < trials; i++) {
-    bool result = testProducerConsumer(1, 1);
-    TEST_ASSERT(result);
+    REQUIRE(testProducerConsumer(1, 1));
   }
 
   //! Single Producer, Multiple Consumer
   for (int i = 0; i < trials; i++) {
-    bool result = testProducerConsumer(1, 5);
-    TEST_ASSERT(result);
+    REQUIRE(testProducerConsumer(1, 5));
   }
 
   //! Multiple Producer, Single Consumer
   for (int i = 0; i < trials; i++) {
-    bool result = testProducerConsumer(5, 1);
-    TEST_ASSERT(result);
+    REQUIRE(testProducerConsumer(5, 1));
   }
 
   //! Multiple Producer, Multiple Consumer
   for (int i = 0; i < trials; i++) {
-    bool result = testProducerConsumer(2, 4);
-    TEST_ASSERT(result);
+    REQUIRE(testProducerConsumer(2, 4));
   }
 }
-
-int main() {
-  RDLog::InitLogs();
-
-  BOOST_LOG(rdErrorLog) << "\n-----------------------------------------\n";
-  testPushAndPop();
-  BOOST_LOG(rdErrorLog) << "Finished: testPushAndPop() \n";
-  BOOST_LOG(rdErrorLog) << "\n-----------------------------------------\n";
-#ifdef RDK_TEST_MULTITHREADED
-  BOOST_LOG(rdErrorLog) << "\n-----------------------------------------\n";
-  testMultipleTimes();
-  BOOST_LOG(rdErrorLog) << "Finished: testMultipleTimes() \n";
-  BOOST_LOG(rdErrorLog) << "\n-----------------------------------------\n";
-#endif
-  return 0;
-}
-
 #endif

--- a/Code/RDGeneral/testDict.cpp
+++ b/Code/RDGeneral/testDict.cpp
@@ -1,6 +1,5 @@
 //
-// Copyright 2001-2008 Randal M. Henne, Greg Landrum and
-//                     Rational Discovery LLC
+// Copyright 2001-2025 Randal M. Henne and other RDKit contributors
 //
 //  @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -10,7 +9,7 @@
 //
 //
 
-#include <RDGeneral/test.h>
+#include <catch2/catch_all.hpp>
 #include "types.h"
 #include "StreamOps.h"
 #include <RDGeneral/Invariant.h>
@@ -30,13 +29,10 @@ struct Foo {
   float baz{0.f};
   Foo() {}
   Foo(int bar, float baz) : bar(bar), baz(baz) {}
-  ~Foo() { std::cerr << "deleted!" << std::endl; }
+  ~Foo() {}
 };
 
-void testGithub940() {
-  BOOST_LOG(rdErrorLog)
-      << "Testing Github940: property dictionaries leaking memory" << std::endl;
-
+TEST_CASE("testGithub940") {
   // a couple small tests to check for memory leaks. Only useful with valgrind
   {  // tests computed props
     STR_VECT computed;
@@ -55,12 +51,12 @@ void testGithub940() {
     d->clearVal(RDKit::detail::computedPropName);
     delete d;
   }
-  BOOST_LOG(rdErrorLog) << "\tdone" << std::endl;
 }
 
-void testRDAny() {
-  std::cerr << "Testing RDValue" << std::endl;
-  { RDAny v(-2147450880); }
+TEST_CASE("testRDValue") {
+  {
+    RDAny v(-2147450880);
+  }
 
   {
     int vi = 0;
@@ -68,36 +64,35 @@ void testRDAny() {
     for (int i = 0; i < 100; ++i) {
       vi += i;
       v = rdvalue_cast<int>(v) + i;
-      TEST_ASSERT(vi == rdvalue_cast<int>(v));
+      REQUIRE(vi == rdvalue_cast<int>(v));
     }
   }
-  std::cerr << "Testing RDAny" << std::endl;
   {
     RDAny a(1);
     RDAny b = a;
-    TEST_ASSERT(rdany_cast<int>(a) == 1);
-    TEST_ASSERT(rdany_cast<int>(b) == 1);
+    REQUIRE(rdany_cast<int>(a) == 1);
+    REQUIRE(rdany_cast<int>(b) == 1);
   }
 
   {
     RDAny a(1);
     RDAny b = a;
-    TEST_ASSERT(rdany_cast<int>(a) == 1);
-    TEST_ASSERT(rdany_cast<int>(b) == rdany_cast<int>(a));
+    REQUIRE(rdany_cast<int>(a) == 1);
+    REQUIRE(rdany_cast<int>(b) == rdany_cast<int>(a));
     std::map<std::string, RDAny> foo;
     foo["foo"] = a;
     foo["bar"] = std::string("This is a test");
-    TEST_ASSERT(rdany_cast<int>(foo["foo"]) == 1);
-    TEST_ASSERT(rdany_cast<int>(foo["foo"]) == rdany_cast<int>(a));
-    TEST_ASSERT(rdany_cast<std::string>(foo["bar"]) == "This is a test");
+    REQUIRE(rdany_cast<int>(foo["foo"]) == 1);
+    REQUIRE(rdany_cast<int>(foo["foo"]) == rdany_cast<int>(a));
+    REQUIRE(rdany_cast<std::string>(foo["bar"]) == "This is a test");
   }
 
   {
     bool a = true;
     RDValue v(a);
-    TEST_ASSERT(rdvalue_cast<bool>(v) == true);
+    REQUIRE(rdvalue_cast<bool>(v) == true);
     v = (int)10;
-    TEST_ASSERT(rdvalue_cast<int>(v) == 10);
+    REQUIRE(rdvalue_cast<int>(v) == 10);
   }
 
   {
@@ -114,39 +109,35 @@ void testRDAny() {
     computed.push_back("foo");
     d.setVal(RDKit::detail::computedPropName, computed);
     STR_VECT computed2 = d.getVal<STR_VECT>(RDKit::detail::computedPropName);
-    TEST_ASSERT(computed2[0] == "foo");
+    REQUIRE(computed2[0] == "foo");
     Dict d2(d);
     computed2 = d2.getVal<STR_VECT>(RDKit::detail::computedPropName);
-    TEST_ASSERT(computed2[0] == "foo");
+    REQUIRE(computed2[0] == "foo");
   }
 
   {
     Dict d;
     // int v=1;
     // d.setVal("foo", v);
-    // TEST_ASSERT(d.getVal<int>("foo") == 1, "bad getval");
+    // REQUIRE(d.getVal<int>("foo") == 1, "bad getval");
 
     std::vector<int> fooV;
     fooV.resize(3);
     fooV[0] = 1;
     fooV[1] = 2;
     fooV[2] = 3;
-    if (0) {
+    if (1) {
       std::vector<int> fooV2;
-      std::cerr << "send int vect" << std::endl;
       RDAny a(fooV);
-      std::cerr << "retrieve int vect" << std::endl;
       fooV2 = rdany_cast<std::vector<int>>(a);
-      TEST_ASSERT(fooV == fooV2);
+      REQUIRE(fooV == fooV2);
     }
 
     {
       std::vector<int> fooV2;
-      std::cerr << "dict set int vect" << std::endl;
       d.setVal("bar", fooV);
-      std::cerr << "dict get int vect" << std::endl;
       d.getVal("bar", fooV2);
-      TEST_ASSERT(fooV == fooV2);
+      REQUIRE(fooV == fooV2);
     }
   }
 
@@ -161,9 +152,9 @@ void testRDAny() {
     RDAny baz(foo);
 
     for (int i = 0; i < 4; ++i) {
-      TEST_ASSERT(rdany_cast<std::vector<int>>(foo)[i] == i);
-      TEST_ASSERT(rdany_cast<std::vector<int>>(bar)[i] == i);
-      TEST_ASSERT(rdany_cast<std::vector<int>>(baz)[i] == i);
+      REQUIRE(rdany_cast<std::vector<int>>(foo)[i] == i);
+      REQUIRE(rdany_cast<std::vector<int>>(bar)[i] == i);
+      REQUIRE(rdany_cast<std::vector<int>>(baz)[i] == i);
     }
   }
 
@@ -176,13 +167,13 @@ void testRDAny() {
     RDAny foo(v);
 
     for (int i = 0; i < 4; ++i) {
-      TEST_ASSERT(rdany_cast<std::vector<double>>(foo)[i] == i);
+      REQUIRE(rdany_cast<std::vector<double>>(foo)[i] == i);
     }
 
     RDAny b = foo;
 
     for (int i = 0; i < 4; ++i) {
-      TEST_ASSERT(rdany_cast<std::vector<double>>(b)[i] == i);
+      REQUIRE(rdany_cast<std::vector<double>>(b)[i] == i);
     }
   }
 
@@ -272,17 +263,17 @@ void testRDAny() {
 
   {  // checks replacement with vector
     RDAny vv(2.0);
-    TEST_ASSERT(rdany_cast<double>(vv) == 2.0);
+    REQUIRE(rdany_cast<double>(vv) == 2.0);
 
     std::vector<int> vect;
     vect.push_back(1);
     vv = vect;
-    TEST_ASSERT(rdany_cast<std::vector<int>>(vv)[0] == 1);
+    REQUIRE(rdany_cast<std::vector<int>>(vv)[0] == 1);
 
     // tests copy
     RDAny vvv(vv);
 
-    TEST_ASSERT(rdany_cast<std::vector<int>>(vvv)[0] == 1);
+    REQUIRE(rdany_cast<std::vector<int>>(vvv)[0] == 1);
   }
 
   {
@@ -290,22 +281,21 @@ void testRDAny() {
     std::vector<std::pair<int, int>> pvect;
     pvect.push_back(std::make_pair<int, int>(2, 2));
     std::any any1(pvect);
-    std::any_cast<std::vector<std::pair<int, int>>>(any1);
-    std::any_cast<std::vector<std::pair<int, int>> &>(any1);
-    std::any_cast<const std::vector<std::pair<int, int>> &>(any1);
+    auto a1 = std::any_cast<std::vector<std::pair<int, int>>>(any1);
+    auto a2 = std::any_cast<std::vector<std::pair<int, int>> &>(any1);
+    auto a3 = std::any_cast<const std::vector<std::pair<int, int>> &>(any1);
 
     RDAny vv(pvect);
     auto &any = rdany_cast<std::any &>(vv);
-    std::any_cast<std::vector<std::pair<int, int>>>(any);
-    std::any_cast<std::vector<std::pair<int, int>> &>(any);
-    std::any_cast<const std::vector<std::pair<int, int>> &>(any);
+    auto a4 = std::any_cast<std::vector<std::pair<int, int>>>(any);
+    auto a5 = std::any_cast<std::vector<std::pair<int, int>> &>(any);
+    auto a6 = std::any_cast<const std::vector<std::pair<int, int>> &>(any);
 
     const std::vector<std::pair<int, int>> &pv =
         rdany_cast<std::vector<std::pair<int, int>>>(vv);
-    TEST_ASSERT(pv[0].first == 2);
+    REQUIRE(pv[0].first == 2);
     RDAny vvv(vv);
-    TEST_ASSERT(
-        (rdany_cast<std::vector<std::pair<int, int>>>(vvv)[0].first == 2));
+    REQUIRE((rdany_cast<std::vector<std::pair<int, int>>>(vvv)[0].first == 2));
   }
 
   {
@@ -314,16 +304,10 @@ void testRDAny() {
     p->push_back(100);
     RDAny v(p);
     RDAny vv(v);
-    try {
-      rdany_cast<std::vector<int>>(v);
-#ifndef UNSAFE_RDVALUE
-      PRECONDITION(0, "Should throw bad cast");
-#endif
-    } catch (std::bad_any_cast &) {
-    }
+    REQUIRE_THROWS_AS(rdany_cast<std::vector<int>>(v), std::bad_any_cast);
 
-    TEST_ASSERT((*rdany_cast<std::vector<int> *>(vv))[0] == 100);
-    TEST_ASSERT((*rdany_cast<std::vector<int> *>((const RDAny &)vv))[0] == 100);
+    REQUIRE((*rdany_cast<std::vector<int> *>(vv))[0] == 100);
+    REQUIRE((*rdany_cast<std::vector<int> *>((const RDAny &)vv))[0] == 100);
     delete p;
 
     auto *m = new std::map<int, int>();
@@ -331,7 +315,7 @@ void testRDAny() {
     RDAny mv(m);
     // leaks
     auto *anym = rdany_cast<std::map<int, int> *>(mv);
-    TEST_ASSERT(anym->find(0) != anym->end());
+    REQUIRE(anym->find(0) != anym->end());
     delete anym;
   }
 
@@ -342,9 +326,9 @@ void testRDAny() {
     p->push_back(100);
     RDAny v(p);
     RDAny vv(v);
-    TEST_ASSERT((*rdany_cast<vptr>(v))[0] == 100);
-    TEST_ASSERT((*rdany_cast<vptr>(vv))[0] == 100);
-    TEST_ASSERT((*rdany_cast<vptr>((const RDAny &)vv))[0] == 100);
+    REQUIRE((*rdany_cast<vptr>(v))[0] == 100);
+    REQUIRE((*rdany_cast<vptr>(vv))[0] == 100);
+    REQUIRE((*rdany_cast<vptr>((const RDAny &)vv))[0] == 100);
 
     typedef boost::shared_ptr<std::map<int, int>> mptr;
     mptr m(new std::map<int, int>());
@@ -352,10 +336,10 @@ void testRDAny() {
     RDAny mv(m);
     // leaks
     mptr anym = rdany_cast<mptr>(mv);
-    TEST_ASSERT(anym->find(0) != anym->end());
+    REQUIRE(anym->find(0) != anym->end());
 
     RDAny any3(boost::shared_ptr<Foo>(new Foo(1, 2.f)));
-    TEST_ASSERT(any3.m_value.getTag() == RDTypeTag::AnyTag);
+    REQUIRE(any3.m_value.getTag() == RDTypeTag::AnyTag);
   }
 }
 
@@ -373,9 +357,7 @@ class DictCon {
   Dict d;
 };
 
-void testStringVals() {
-  BOOST_LOG(rdErrorLog) << "-------------------------------------" << std::endl;
-  BOOST_LOG(rdErrorLog) << "Testing String Pickle Roundtrips." << std::endl;
+TEST_CASE("testStringPickleRoundtrips") {
   {
     Dict d;
     std::string sv;
@@ -383,14 +365,14 @@ void testStringVals() {
     d.setVal("foo", sv);
     int iv;
     d.getVal("foo", iv);
-    TEST_ASSERT(iv == 1);
+    REQUIRE(iv == 1);
   }
   {
     Dict d;
     d.setVal("foo", "1");
     int iv;
     d.getVal("foo", iv);
-    TEST_ASSERT(iv == 1);
+    REQUIRE(iv == 1);
   }
   {
     Dict d;
@@ -399,7 +381,7 @@ void testStringVals() {
     d.setVal("foo", sv);
     double dv;
     d.getVal("foo", dv);
-    TEST_ASSERT(feq(dv, 1.3));
+    REQUIRE(feq(dv, 1.3));
   }
 
   {
@@ -408,17 +390,13 @@ void testStringVals() {
     d.setVal("foo", iv);
     std::string sv;
     d.getVal("foo", sv);
-    TEST_ASSERT(sv == "1");
+    REQUIRE(sv == "1");
     sv = d.getVal<std::string>("foo");
-    TEST_ASSERT(sv == "1");
+    REQUIRE(sv == "1");
   }
-
-  BOOST_LOG(rdErrorLog) << "\tdone" << std::endl;
 }
 
-void testVectToString() {
-  BOOST_LOG(rdErrorLog) << "-------------------------------------" << std::endl;
-  BOOST_LOG(rdErrorLog) << "Testing conversion of vect to string." << std::endl;
+TEST_CASE("testVectToString") {
   {
     Dict d;
     std::vector<int> v;
@@ -427,7 +405,7 @@ void testVectToString() {
     d.setVal("foo", v);
     std::string sv;
     d.getVal("foo", sv);
-    TEST_ASSERT(sv == "[1,0]");
+    REQUIRE(sv == "[1,0]");
   }
   {
     Dict d;
@@ -437,9 +415,9 @@ void testVectToString() {
     d.setVal("foo", v);
     std::string sv;
     d.getVal("foo", sv);
-    TEST_ASSERT(sv == "[1,0]");
+    REQUIRE(sv == "[1,0]");
     sv = d.getVal<std::string>("foo");
-    TEST_ASSERT(sv == "[1,0]");
+    REQUIRE(sv == "[1,0]");
   }
   {
     Dict d;
@@ -449,9 +427,9 @@ void testVectToString() {
     d.setVal("foo", v);
     std::string sv;
     d.getVal("foo", sv);
-    TEST_ASSERT(sv == "[1.2,0]");
+    REQUIRE(sv == "[1.2,0]");
     sv = d.getVal<std::string>("foo");
-    TEST_ASSERT(sv == "[1.2,0]");
+    REQUIRE(sv == "[1.2,0]");
   }
   {
     Dict d;
@@ -461,24 +439,20 @@ void testVectToString() {
     d.setVal("foo", v);
     std::string sv;
     d.getVal("foo", sv);
-    TEST_ASSERT(sv == "[10001,0]");
+    REQUIRE(sv == "[10001,0]");
     sv = d.getVal<std::string>("foo");
-    TEST_ASSERT(sv == "[10001,0]");
+    REQUIRE(sv == "[10001,0]");
   }
-
-  BOOST_LOG(rdErrorLog) << "\tdone" << std::endl;
 }
 
-void testConstReturns() {
-  BOOST_LOG(rdErrorLog) << "-------------------------------------" << std::endl;
-  BOOST_LOG(rdErrorLog) << "Testing returning const references." << std::endl;
+TEST_CASE("testConstReturns") {
   {
     std::string v = "foo";
     RDAny anyv(v);
 
     std::string tgt = rdany_cast<std::string>(anyv);
     const std::string &ctgt = rdany_cast<std::string>(anyv);
-    TEST_ASSERT(ctgt != "");
+    REQUIRE(ctgt != "");
   }
 
   {
@@ -488,7 +462,7 @@ void testConstReturns() {
 
     // const std::string nv=d.getVal<const std::string &>("foo");
     std::string nv = d.getVal<std::string>("foo");
-    TEST_ASSERT(nv == "foo");
+    REQUIRE(nv == "foo");
   }
 
   {
@@ -502,7 +476,6 @@ void testConstReturns() {
     std::clock_t start, end;
 
     double ls = 0;
-    BOOST_LOG(rdErrorLog) << "any cast" << std::endl;
     start = std::clock();
     for (int i = 0; i < nreps; ++i) {
       const std::string &nv = rdany_cast<std::string>(anyv);
@@ -514,7 +487,6 @@ void testConstReturns() {
                           << ls << std::endl;
 
     ls = 0;
-    BOOST_LOG(rdErrorLog) << "copy" << std::endl;
     start = std::clock();
     for (int i = 0; i < nreps; ++i) {
       std::string nv = rdany_cast<std::string>(anyv);
@@ -526,7 +498,6 @@ void testConstReturns() {
                           << ls << std::endl;
 
     ls = 0;
-    BOOST_LOG(rdErrorLog) << "ref" << std::endl;
     start = std::clock();
     for (int i = 0; i < nreps; ++i) {
       const std::string &nv = rdany_cast<std::string>(anyv);
@@ -538,7 +509,6 @@ void testConstReturns() {
                           << ls << std::endl;
 
     ls = 0;
-    BOOST_LOG(rdErrorLog) << "dict" << std::endl;
     start = std::clock();
     for (int i = 0; i < nreps; ++i) {
       const std::string &nv = d.getVal<std::string>("foo");
@@ -550,7 +520,6 @@ void testConstReturns() {
                           << ls << std::endl;
 
     ls = 0;
-    BOOST_LOG(rdErrorLog) << "ref with hasVal" << std::endl;
     start = std::clock();
     std::string k = "foo";
     for (int i = 0; i < nreps; ++i) {
@@ -566,14 +535,9 @@ void testConstReturns() {
 
     // std::string nv=d.getVal<std::string>("foo");
   }
-
-  BOOST_LOG(rdErrorLog) << "\tdone" << std::endl;
 }
 
-void testUpdate() {
-  BOOST_LOG(rdErrorLog) << "-------------------------------------" << std::endl;
-  BOOST_LOG(rdErrorLog) << "Testing dict update." << std::endl;
-
+TEST_CASE("testUpdate") {
   {
     Dict d;
     std::string sv;
@@ -588,10 +552,10 @@ void testUpdate() {
 
     Dict d2;
     d2.update(d);
-    TEST_ASSERT(d.getVal<std::string>("foo") == d2.getVal<std::string>("foo"));
-    TEST_ASSERT(d.getVal<double>("foo2") == d2.getVal<double>("foo2"));
-    TEST_ASSERT(d.getVal<std::vector<int>>("foo3") ==
-                d2.getVal<std::vector<int>>("foo3"));
+    REQUIRE(d.getVal<std::string>("foo") == d2.getVal<std::string>("foo"));
+    REQUIRE(d.getVal<double>("foo2") == d2.getVal<double>("foo2"));
+    REQUIRE(d.getVal<std::vector<int>>("foo3") ==
+            d2.getVal<std::vector<int>>("foo3"));
   }
 
   {  // a few tests to make sure copying/updating with nonPOD data is ok
@@ -609,29 +573,28 @@ void testUpdate() {
       Dict d2;
       d2.setVal("foo", 1);
       d2.update(d, true);
-      TEST_ASSERT(d2.getVal<std::string>("foo") == "1.3");
-      TEST_ASSERT(d.getVal<double>("foo2") == d2.getVal<double>("foo2"));
-      TEST_ASSERT(d.getVal<std::vector<int>>("foo3") ==
-                  d2.getVal<std::vector<int>>("foo3"));
+      REQUIRE(d2.getVal<std::string>("foo") == "1.3");
+      REQUIRE(d.getVal<double>("foo2") == d2.getVal<double>("foo2"));
+      REQUIRE(d.getVal<std::vector<int>>("foo3") ==
+              d2.getVal<std::vector<int>>("foo3"));
     }
 
     {
       Dict d2 = d;
       d2.setVal("foo", 1);
-      TEST_ASSERT(1 == d2.getVal<int>("foo"));
-      TEST_ASSERT(d.getVal<double>("foo2") == d2.getVal<double>("foo2"));
-      TEST_ASSERT(d.getVal<std::vector<int>>("foo3") ==
-                  d2.getVal<std::vector<int>>("foo3"));
+      REQUIRE(1 == d2.getVal<int>("foo"));
+      REQUIRE(d.getVal<double>("foo2") == d2.getVal<double>("foo2"));
+      REQUIRE(d.getVal<std::vector<int>>("foo3") ==
+              d2.getVal<std::vector<int>>("foo3"));
     }
 
     {
       Dict d2(d);
-      TEST_ASSERT(d.getVal<double>("foo2") == d2.getVal<double>("foo2"));
-      TEST_ASSERT(d.getVal<std::vector<int>>("foo3") ==
-                  d2.getVal<std::vector<int>>("foo3"));
+      REQUIRE(d.getVal<double>("foo2") == d2.getVal<double>("foo2"));
+      REQUIRE(d.getVal<std::vector<int>>("foo3") ==
+              d2.getVal<std::vector<int>>("foo3"));
     }
   }
-  BOOST_LOG(rdErrorLog) << "\tdone" << std::endl;
 }
 
 class FooHandler : public CustomPropHandler {
@@ -666,7 +629,7 @@ class FooHandler : public CustomPropHandler {
   CustomPropHandler *clone() const override { return new FooHandler; }
 };
 
-void testCustomProps() {
+TEST_CASE("testCustomProps") {
   Foo f(1, 2.f);
   Dict d;
   d.setVal<Foo>("foo", f);
@@ -675,21 +638,21 @@ void testCustomProps() {
   std::vector<CustomPropHandler *> handlers = {&foo_handler,
                                                foo_handler.clone()};
   for (auto handler : handlers) {
-    TEST_ASSERT(handler->canSerialize(value));
+    REQUIRE(handler->canSerialize(value));
     RDValue bad_value = 1;
-    TEST_ASSERT(!handler->canSerialize(bad_value));
+    REQUIRE(!handler->canSerialize(bad_value));
     std::stringstream ss;
-    TEST_ASSERT(handler->write(ss, value));
+    REQUIRE(handler->write(ss, value));
     RDValue newValue;
-    TEST_ASSERT(handler->read(ss, newValue));
-    TEST_ASSERT(from_rdvalue<const Foo &>(newValue).bar == f.bar);
-    TEST_ASSERT(from_rdvalue<const Foo &>(newValue).baz == f.baz);
+    REQUIRE(handler->read(ss, newValue));
+    REQUIRE(from_rdvalue<const Foo &>(newValue).bar == f.bar);
+    REQUIRE(from_rdvalue<const Foo &>(newValue).baz == f.baz);
     newValue.destroy();
   }
   delete handlers[1];
 }
 
-void testGithub2910() {
+TEST_CASE("testGithub2910") {
   Dict d;
   d.setVal("foo", 1.0);
   d.clearVal("foo");
@@ -697,98 +660,85 @@ void testGithub2910() {
   d.clearVal("foo");
 }
 
-int main() {
-  RDLog::InitLogs();
-  testGithub940();
-
-  testRDAny();
+TEST_CASE("basics") {
   Dict d;
   INT_VECT fooV;
   fooV.resize(3);
-  BOOST_LOG(rdInfoLog) << "dict test" << std::endl;
-  TEST_ASSERT(!d.hasVal("foo"));
+  REQUIRE(!d.hasVal("foo"));
   int x = 1;
   d.setVal("foo", x);
-  TEST_ASSERT(d.hasVal("foo"));
-  TEST_ASSERT(!d.hasVal("bar"));
+  REQUIRE(d.hasVal("foo"));
+  REQUIRE(!d.hasVal("bar"));
   int v, v2;
   d.getVal("foo", v);
-  TEST_ASSERT(v == 1);
+  REQUIRE(v == 1);
   v2 = d.getVal<int>("foo");
-  TEST_ASSERT(v2 == v);
+  REQUIRE(v2 == v);
   d.setVal("bar", fooV);
   d.getVal("foo", v);
-  TEST_ASSERT(v == 1);
+  REQUIRE(v == 1);
   v2 = d.getVal<int>("foo");
-  TEST_ASSERT(v2 == v);
+  REQUIRE(v2 == v);
   INT_VECT fooV2, fooV3;
   d.getVal("bar", fooV2);
   fooV3 = d.getVal<INT_VECT>("bar");
-  TEST_ASSERT(fooV == fooV2);
-  TEST_ASSERT(fooV2 == fooV3);
+  REQUIRE(fooV == fooV2);
+  REQUIRE(fooV2 == fooV3);
 
   VECT_INT_VECT fooV4;
   fooV4.resize(3);
-  TEST_ASSERT(!d.hasVal("baz"));
+  REQUIRE(!d.hasVal("baz"));
   d.setVal("baz", fooV4);
-  TEST_ASSERT(d.hasVal("baz"));
+  REQUIRE(d.hasVal("baz"));
 
   DictCon dc1;
-  TEST_ASSERT(!dc1.getDict()->hasVal("foo"));
+  REQUIRE(!dc1.getDict()->hasVal("foo"));
   int y = 1;
   dc1.getDict()->setVal("foo", y);
-  TEST_ASSERT(dc1.getDict()->hasVal("foo"));
-  TEST_ASSERT(!dc1.getDict()->hasVal("bar"));
+  REQUIRE(dc1.getDict()->hasVal("foo"));
+  REQUIRE(!dc1.getDict()->hasVal("bar"));
   dc1.getDict()->setVal("bar", fooV);
   dc1.getDict()->getVal("foo", v);
-  TEST_ASSERT(v == 1);
+  REQUIRE(v == 1);
   dc1.getDict()->getVal("bar", fooV2);
-  TEST_ASSERT(fooV == fooV2);
+  REQUIRE(fooV == fooV2);
   fooV4.resize(3);
-  TEST_ASSERT(!dc1.getDict()->hasVal("baz"));
+  REQUIRE(!dc1.getDict()->hasVal("baz"));
   dc1.getDict()->setVal("baz", fooV4);
-  TEST_ASSERT(dc1.getDict()->hasVal("baz"));
+  REQUIRE(dc1.getDict()->hasVal("baz"));
 
   dc1.getDict()->reset();
 
   DictCon dc2 = dc1;
-  TEST_ASSERT(!dc2.getDict()->hasVal("foo"));
+  REQUIRE(!dc2.getDict()->hasVal("foo"));
   int z = 1;
   dc2.getDict()->setVal("foo", z);
-  TEST_ASSERT(dc2.getDict()->hasVal("foo"));
-  TEST_ASSERT(!dc2.getDict()->hasVal("bar"));
+  REQUIRE(dc2.getDict()->hasVal("foo"));
+  REQUIRE(!dc2.getDict()->hasVal("bar"));
   dc2.getDict()->setVal("bar", fooV);
   dc2.getDict()->getVal("foo", v);
-  TEST_ASSERT(v == 1);
+  REQUIRE(v == 1);
   dc2.getDict()->getVal("bar", fooV2);
-  TEST_ASSERT(fooV == fooV2);
+  REQUIRE(fooV == fooV2);
   fooV4.resize(3);
-  TEST_ASSERT(!dc2.getDict()->hasVal("baz"));
+  REQUIRE(!dc2.getDict()->hasVal("baz"));
   dc2.getDict()->setVal("baz", fooV4);
-  TEST_ASSERT(dc2.getDict()->hasVal("baz"));
+  REQUIRE(dc2.getDict()->hasVal("baz"));
 
   DictCon dc3(dc2);
-  TEST_ASSERT(dc3.getDict()->hasVal("foo"));
+  REQUIRE(dc3.getDict()->hasVal("foo"));
   dc3.getDict()->getVal("foo", v);
-  TEST_ASSERT(v == 1);
+  REQUIRE(v == 1);
   dc3.getDict()->getVal("bar", fooV2);
-  TEST_ASSERT(fooV == fooV2);
+  REQUIRE(fooV == fooV2);
   fooV4.resize(3);
-  TEST_ASSERT(dc3.getDict()->hasVal("baz"));
+  REQUIRE(dc3.getDict()->hasVal("baz"));
 
-  TEST_ASSERT(dc3.getDict()->hasVal("foo"));
+  REQUIRE(dc3.getDict()->hasVal("foo"));
   dc3.getDict()->getVal("foo", v);
-  TEST_ASSERT(v == 1);
+  REQUIRE(v == 1);
   dc3.getDict()->getVal("bar", fooV2);
-  TEST_ASSERT(fooV == fooV2);
+  REQUIRE(fooV == fooV2);
   fooV4.resize(3);
-  TEST_ASSERT(dc3.getDict()->hasVal("baz"));
-
-  testStringVals();
-  testVectToString();
-  testConstReturns();
-  testUpdate();
-  testCustomProps();
-  testGithub2910();
-  return 0;
+  REQUIRE(dc3.getDict()->hasVal("baz"));
 }

--- a/Code/RDGeneral/testRDValue.cpp
+++ b/Code/RDGeneral/testRDValue.cpp
@@ -1,4 +1,4 @@
-#include <RDGeneral/test.h>
+#include <catch2/catch_all.hpp>
 #include "RDValue.h"
 #include "RDProps.h"
 #include "Invariant.h"
@@ -17,50 +17,58 @@ using namespace RDKit;
 
 template <class T>
 void testLimits() {
-  BOOST_LOG(rdErrorLog) << "Test limits" << std::endl;
   // check numeric limits
   {
     RDValue v(std::numeric_limits<T>::min());
     std::cerr << "min: " << std::numeric_limits<T>::min() << " "
               << rdvalue_cast<T>(v) << std::endl;
-    CHECK_INVARIANT(rdvalue_cast<T>(v) == std::numeric_limits<T>::min(),
-                    "bad min");
-    CHECK_INVARIANT(
-        rdvalue_cast<T>(RDValue(v)) == std::numeric_limits<T>::min(),
-        "bad min");
+    REQUIRE(rdvalue_cast<T>(v) == std::numeric_limits<T>::min());
+    REQUIRE(rdvalue_cast<T>(RDValue(v)) == std::numeric_limits<T>::min());
     v = std::numeric_limits<T>::max();
-    CHECK_INVARIANT(rdvalue_cast<T>(v) == std::numeric_limits<T>::max(),
-                    "bad max");
-    CHECK_INVARIANT(
-        rdvalue_cast<T>(RDValue(v)) == std::numeric_limits<T>::max(),
-        "bad max");
+    REQUIRE(rdvalue_cast<T>(v) == std::numeric_limits<T>::max());
+    REQUIRE(rdvalue_cast<T>(RDValue(v)) == std::numeric_limits<T>::max());
   }
   {
     RDValue v(std::numeric_limits<T>::max());
-    CHECK_INVARIANT(rdvalue_cast<T>(v) == std::numeric_limits<T>::max(),
-                    "bad max");
+    REQUIRE(rdvalue_cast<T>(v) == std::numeric_limits<T>::max());
     RDValue vv(v);
-    CHECK_INVARIANT(rdvalue_cast<T>(vv) == std::numeric_limits<T>::max(),
-                    "bad max");
+    REQUIRE(rdvalue_cast<T>(vv) == std::numeric_limits<T>::max());
 
     v = std::numeric_limits<T>::min();
     RDValue vvv(v);
-    CHECK_INVARIANT(rdvalue_cast<T>(v) == std::numeric_limits<T>::min(),
-                    "bad min");
-    CHECK_INVARIANT(rdvalue_cast<T>(vvv) == std::numeric_limits<T>::min(),
-                    "bad min");
+    REQUIRE(rdvalue_cast<T>(v) == std::numeric_limits<T>::min());
+    REQUIRE(rdvalue_cast<T>(vvv) == std::numeric_limits<T>::min());
   }
-  BOOST_LOG(rdErrorLog) << "..done" << std::endl;
 }
 
-void testPOD() {
-  BOOST_LOG(rdErrorLog) << "Test POD" << std::endl;
+TEST_CASE("testLimits") {
+  {
+    RDValue v(std::numeric_limits<int>::min());
+    REQUIRE(rdvalue_cast<int>(v) == std::numeric_limits<int>::min());
+    REQUIRE(rdvalue_cast<int>(RDValue(v)) == std::numeric_limits<int>::min());
+    v = std::numeric_limits<int>::max();
+    REQUIRE(rdvalue_cast<int>(v) == std::numeric_limits<int>::max());
+    REQUIRE(rdvalue_cast<int>(RDValue(v)) == std::numeric_limits<int>::max());
+  }
+  {
+    RDValue v(std::numeric_limits<int>::max());
+    REQUIRE(rdvalue_cast<int>(v) == std::numeric_limits<int>::max());
+    RDValue vv(v);
+    REQUIRE(rdvalue_cast<int>(vv) == std::numeric_limits<int>::max());
+
+    v = std::numeric_limits<int>::min();
+    RDValue vvv(v);
+    REQUIRE(rdvalue_cast<int>(v) == std::numeric_limits<int>::min());
+    REQUIRE(rdvalue_cast<int>(vvv) == std::numeric_limits<int>::min());
+  }
+}
+
+TEST_CASE("testPOD") {
   testLimits<int>();
   testLimits<unsigned int>();
   testLimits<double>();
   testLimits<float>();
   testLimits<bool>();
-  BOOST_LOG(rdErrorLog) << "..done" << std::endl;
 }
 
 template <class T>
@@ -73,63 +81,53 @@ void testVector() {
   data.push_back(T());
 
   RDValue v(data);
-  CHECK_INVARIANT(rdvalue_cast<std::vector<T>>(v) == data, "bad vec");
+  REQUIRE(rdvalue_cast<std::vector<T>>(v) == data);
   RDValue vv;
   copy_rdvalue(vv, v);
-  CHECK_INVARIANT(rdvalue_cast<std::vector<T>>(vv) == data,
-                  "bad copy constructor");
+  REQUIRE(rdvalue_cast<std::vector<T>>(vv) == data);
   RDValue::cleanup_rdvalue(v);  // desctructor...
   RDValue::cleanup_rdvalue(vv);
 }
 
-void testPODVectors() {
-  BOOST_LOG(rdErrorLog) << "Test String Vect" << std::endl;
+TEST_CASE("testPODVectors") {
   testVector<int>();
   testVector<unsigned int>();
   testVector<double>();
   testVector<float>();
   testVector<long double>();  // stored in anys
-  BOOST_LOG(rdErrorLog) << "..done" << std::endl;
 }
 
-void testStringVect() {
-  BOOST_LOG(rdErrorLog) << "Test String Vect" << std::endl;
+TEST_CASE("testStringVect") {
   std::vector<std::string> vecs;
   vecs.emplace_back("my");
   vecs.emplace_back("dog");
   vecs.emplace_back("has");
   vecs.emplace_back("fleas");
   RDValue v(vecs);
-  CHECK_INVARIANT(rdvalue_cast<std::vector<std::string>>(v) == vecs,
-                  "bad vect");
+  REQUIRE(rdvalue_cast<std::vector<std::string>>(v) == vecs);
   RDValue vc;
   copy_rdvalue(vc, v);
-  CHECK_INVARIANT(rdvalue_cast<std::vector<std::string>>(vc) == vecs,
-                  "bad vect");
+  REQUIRE(rdvalue_cast<std::vector<std::string>>(vc) == vecs);
   RDValue vv = vecs;
   RDValue vvc;
   copy_rdvalue(vvc, vv);
-  CHECK_INVARIANT(rdvalue_cast<std::vector<std::string>>(vv) == vecs,
-                  "bad vect");
-  CHECK_INVARIANT(rdvalue_cast<std::vector<std::string>>(vvc) == vecs,
-                  "bad vect");
+  REQUIRE(rdvalue_cast<std::vector<std::string>>(vv) == vecs);
+  REQUIRE(rdvalue_cast<std::vector<std::string>>(vvc) == vecs);
 
-  RDValue::cleanup_rdvalue(v);    // desctructor...
-  RDValue::cleanup_rdvalue(vc);   // desctructor...
-  RDValue::cleanup_rdvalue(vv);   // desctructor...
-  RDValue::cleanup_rdvalue(vvc);  // desctructor...
-  BOOST_LOG(rdErrorLog) << "..done" << std::endl;
+  RDValue::cleanup_rdvalue(v);
+  RDValue::cleanup_rdvalue(vc);
+  RDValue::cleanup_rdvalue(vv);
+  RDValue::cleanup_rdvalue(vvc);
 }
 
-void testMapsAndLists() {
-  BOOST_LOG(rdErrorLog) << "Test Maps And Lists" << std::endl;
+TEST_CASE("testMapsAndLists") {
   {
     typedef std::map<std::string, int> listtype;
     listtype m;
     m["foo"] = 1;
     m["bar"] = 2;
     RDValue v(m);
-    CHECK_INVARIANT(rdvalue_cast<listtype>(v) == m, "bad map cast");
+    REQUIRE(rdvalue_cast<listtype>(v) == m);
     RDValue::cleanup_rdvalue(v);
   }
   {
@@ -137,27 +135,20 @@ void testMapsAndLists() {
     m.emplace_back("foo");
     m.emplace_back("bar");
     RDValue v(m);
-    CHECK_INVARIANT(rdvalue_cast<std::list<std::string>>(v) == m,
-                    "bad map cast");
+    REQUIRE(rdvalue_cast<std::list<std::string>>(v) == m);
     RDValue::cleanup_rdvalue(v);
   }
-  BOOST_LOG(rdErrorLog) << "..done" << std::endl;
 }
 
-void testNaN() {
-  // make a NaN
-  BOOST_LOG(rdErrorLog) << "Test NaN" << std::endl;
+TEST_CASE("testNaN") {
   double nan = sqrt(-1.0);
   RDValue v(nan);
-  TEST_ASSERT(v.getTag() == RDTypeTag::DoubleTag);
-
-  CHECK_INVARIANT(std::isnan(rdvalue_cast<double>(v)),
-                  "Oops, can't store NaNs!");
+  REQUIRE(v.getTag() == RDTypeTag::DoubleTag);
+  REQUIRE(std::isnan(rdvalue_cast<double>(v)));
 
   RDValue vv(2.0);
-  TEST_ASSERT(rdvalue_is<double>(vv));
-  TEST_ASSERT(vv.getTag() == RDTypeTag::DoubleTag);
-  BOOST_LOG(rdErrorLog) << "..done" << std::endl;
+  REQUIRE(rdvalue_is<double>(vv));
+  REQUIRE(vv.getTag() == RDTypeTag::DoubleTag);
 }
 
 template <class T>
@@ -189,19 +180,12 @@ void testProp(T val) {
   }
 };
 
-void testPropertyPickler() {
-  BOOST_LOG(rdErrorLog) << "Test Property Pickler" << std::endl;
-  std::cerr << "== int" << std::endl;
+TEST_CASE("testPropertyPickler") {
   testProp<int>(1234);
-  std::cerr << "== double" << std::endl;
   testProp<double>(1234.);
-  std::cerr << "== float" << std::endl;
   testProp<float>(1234.0f);
-  std::cerr << "== unsigned int" << std::endl;
   testProp<unsigned int>(1234u);
-  std::cerr << "== bool" << std::endl;
   testProp<bool>(true);
-  std::cerr << "== std::string" << std::endl;
   testProp<std::string>(
       std::string("the quick brown fox jumps over the lazy dog"));
 
@@ -210,28 +194,9 @@ void testPropertyPickler() {
   testProp(0.0f);
   testProp(0u);
   testProp(false);
-
-  /*
-  testProp(makeVec<int>());
-  testProp(makeVec<int>());
-  testProp(makeVec<int>());
-  testProp(makeVec<unsigned int>());
-
-  {
-    std::vector<std::string> v;
-    v.push_back("a");
-    v.push_back("b");
-    v.push_back("c");
-    v.push_back("d");
-    v.push_back("e");
-    testProp(v);
-  }
-  */
-  BOOST_LOG(rdErrorLog) << "..done" << std::endl;
 }
 
-void testPickleBinaryString() {
-  BOOST_LOG(rdErrorLog) << "Pickle Binary String" << std::endl;
+TEST_CASE("testPickleBinaryString") {
   char buf[10];
   for (int i = 0; i < 10; ++i) {
     buf[i] = (char)i;
@@ -242,18 +207,17 @@ void testPickleBinaryString() {
   {
     RDProps p;
     p.setProp<std::string>("foo", str);
-    TEST_ASSERT(streamWriteProps(ss, p));
+    REQUIRE(streamWriteProps(ss, p));
   }
 
   {
     RDProps p2;
     streamReadProps(ss, p2);
-    TEST_ASSERT(p2.getProp<std::string>("foo") == str);
+    REQUIRE(p2.getProp<std::string>("foo") == str);
   }
-  BOOST_LOG(rdErrorLog) << "..done" << std::endl;
 }
 
-void testIntConversions() {
+TEST_CASE("testIntConversions") {
   RDProps p;
   p.setProp<int>("foo", 1);
   p.getProp<std::int64_t>("foo");
@@ -271,7 +235,6 @@ void testIntConversions() {
 
   p.getProp<std::int16_t>("foo");
 
-  // Test that min/max values of smaller types do not under/overflow
   p.setProp<unsigned int>("foo", 0);
   p.getProp<std::uint8_t>("foo");
   p.getProp<std::uint16_t>("foo");
@@ -294,51 +257,22 @@ void testIntConversions() {
   p.setProp<int>("foo", 32767);
   p.getProp<std::int16_t>("foo");
 
-  // Test some overflows
   p.setProp<int>("foo", 32767 + 1);
-  try {
-    p.getProp<std::int8_t>("foo");  // should fail
-    TEST_ASSERT(0);
-  } catch (boost::numeric::positive_overflow &) {
-  }
-  try {
-    p.getProp<std::uint8_t>("foo");  // should fail
-    TEST_ASSERT(0);
-  } catch (boost::numeric::positive_overflow &) {
-  }
-  try {
-    p.getProp<std::int16_t>("foo");  // should fail
-    TEST_ASSERT(0);
-  } catch (boost::numeric::positive_overflow &) {
-  }
+  REQUIRE_THROWS_AS(p.getProp<std::int8_t>("foo"),
+                    boost::numeric::positive_overflow);
+  REQUIRE_THROWS_AS(p.getProp<std::uint8_t>("foo"),
+                    boost::numeric::positive_overflow);
+  REQUIRE_THROWS_AS(p.getProp<std::int16_t>("foo"),
+                    boost::numeric::positive_overflow);
   p.setProp<int>("foo", 65535 + 1);
-  try {
-    p.getProp<std::uint16_t>("foo");  // should fail
-    TEST_ASSERT(0);
-  } catch (boost::numeric::positive_overflow &) {
-  }
+  REQUIRE_THROWS_AS(p.getProp<std::uint16_t>("foo"),
+                    boost::numeric::positive_overflow);
 
   p.setProp<int>("foo", -1);
-  try {
-    p.getProp<std::uint8_t>("foo");  // should fail
-    TEST_ASSERT(0);
-  } catch (boost::numeric::negative_overflow &) {
-  }
+  REQUIRE_THROWS_AS(p.getProp<std::uint8_t>("foo"),
+                    boost::numeric::negative_overflow);
 
-  p.getProp<std::int16_t>("foo");  // should pass
-  try {
-    p.getProp<std::uint16_t>("foo");  // should fail
-    TEST_ASSERT(0);
-  } catch (boost::numeric::negative_overflow &) {
-  }
-}
-int main() {
-  std::cerr << "-- running tests -- " << std::endl;
-  testPOD();
-  testPODVectors();
-  testStringVect();
-  testNaN();
-  testPropertyPickler();
-  testPickleBinaryString();
-  testIntConversions();
+  p.getProp<std::int16_t>("foo");
+  REQUIRE_THROWS_AS(p.getProp<std::uint16_t>("foo"),
+                    boost::numeric::negative_overflow);
 }


### PR DESCRIPTION
The RDKit C++ tests are a mix of catch2 tests and a bunch written using an internal "framework". The catch2 tests are easier to write, debug failures with, and do better reporting, so it would be nice to migrate all of the C++ testing to use catch2.

This PR is a start at that; it migrates a bunch of tests to catch2.

I did a couple of these manually, but the majority were done with copilot followed by a manual review and cleanup.
 
This is the prompt I used in the copilot chat in VS Code:
```
Convert this entire file to use v3 of the catch2 test framework, do not use tags. convert all uses of feq to use catch2 matchers and WithinAbs
``` 

The next time I have the motivation/time to do so, I will start doing the same thing in the `GraphMol` directory.