### PR TITLE
Fixes CI: Force conda-forge channel, ignore defaults/anaconda repos

### DIFF
--- a/.azure-pipelines/linux_build.yml
+++ b/.azure-pipelines/linux_build.yml
@@ -9,17 +9,21 @@ steps:
     conda config --add channels conda-forge
     conda config --set solver libmamba
     conda info -a
-    conda create --name rdkit_build -c conda-forge $(python) cmake \
+    conda create --name rdkit_build -c conda-forge --override-channels  $(python) cmake \
         boost-cpp=$(boost_version) \
         boost=$(boost_version) \
         numpy pillow eigen pandas=2.0 matplotlib-base=3.8 \
         qt=5 cairo
     conda activate rdkit_build
-    conda install -c conda-forge pytest nbval ipykernel>=6.0
+    conda config --env --add channels conda-forge
+    conda config --env --set channel_priority strict
+    conda install -c conda-forge --override-channels  pytest nbval ipykernel>=6.0
   displayName: Setup build environment
 - bash: |
     source ${CONDA}/etc/profile.d/conda.sh
     conda activate rdkit_build
+    conda config --env --add channels conda-forge
+    conda config --env --set channel_priority strict
     export CXXFLAGS="${CXXFLAGS} -Wall -Werror"
     mkdir build && cd build && \
     cmake .. \
@@ -54,12 +58,16 @@ steps:
 - bash: |
     source ${CONDA}/etc/profile.d/conda.sh
     conda activate rdkit_build
+    conda config --env --add channels conda-forge
+    conda config --env --set channel_priority strict
     cd build
     make -j $( $(number_of_cores) ) install
   displayName: Build
 - bash: |
     source ${CONDA}/etc/profile.d/conda.sh
     conda activate rdkit_build
+    conda config --env --add channels conda-forge
+    conda config --env --set channel_priority strict
     export RDBASE=`pwd`
     export PYTHONPATH=${RDBASE}:${PYTHONPATH}
     export LD_LIBRARY_PATH=${RDBASE}/lib:${CONDA_PREFIX}/lib:${LD_LIBRARY_PATH}
@@ -71,7 +79,9 @@ steps:
 - bash: |
     source ${CONDA}/etc/profile.d/conda.sh
     conda activate rdkit_build
-    conda install -c conda-forge ipython=8.12 sphinx myst-parser
+    conda config --env --add channels conda-forge
+    conda config --env --set channel_priority strict
+    conda install -c conda-forge --override-channels  ipython=8.12 sphinx myst-parser
     export RDBASE=`pwd`
     export PYTHONPATH=${RDBASE}:${PYTHONPATH}
     export LD_LIBRARY_PATH=${RDBASE}/lib:${LD_LIBRARY_PATH}

--- a/.azure-pipelines/linux_build_cartridge.yml
+++ b/.azure-pipelines/linux_build_cartridge.yml
@@ -10,16 +10,20 @@ steps:
     conda config --set always_yes yes --set changeps1 no
     conda update -q conda
     conda info -a
-    conda create --name rdkit_build -c conda-forge cmake \
+    conda create --name rdkit_build -c conda-forge --override-channels  cmake \
         boost-cpp=$(boost_version) \
         boost=$(boost_version) \
         eigen \
         cairo
     conda activate rdkit_build
+    conda config --env --add channels conda-forge
+    conda config --env --set channel_priority strict
   displayName: Setup build environment
 - bash: |
     source ${CONDA}/etc/profile.d/conda.sh
     conda activate rdkit_build
+    conda config --env --add channels conda-forge
+    conda config --env --set channel_priority strict
     mkdir build && cd build && \
     cmake .. \
     -DCMAKE_BUILD_TYPE=Release \
@@ -41,6 +45,8 @@ steps:
 - bash: |
     source ${CONDA}/etc/profile.d/conda.sh
     conda activate rdkit_build
+    conda config --env --add channels conda-forge
+    conda config --env --set channel_priority strict
     cd build
     make -j $( $(number_of_cores) ) install
     sudo sh ./Code/PgSQL/rdkit/pgsql_install.sh
@@ -48,6 +54,8 @@ steps:
 - bash: |
     source ${CONDA}/etc/profile.d/conda.sh
     conda activate rdkit_build
+    conda config --env --add channels conda-forge
+    conda config --env --set channel_priority strict
     cd build
     sh ./Code/PgSQL/rdkit/pgsql_regress.sh
     if [ -e ./Code/PgSQL/rdkit/regression.diffs ]

--- a/.azure-pipelines/linux_build_fuzzer.yml
+++ b/.azure-pipelines/linux_build_fuzzer.yml
@@ -14,6 +14,8 @@ steps:
 - bash: |
     source ${CONDA}/etc/profile.d/conda.sh
     conda activate rdkit_build
+    conda config --env --add channels conda-forge
+    conda config --env --set channel_priority strict
 
     export CC="clang-9"
     export CXX="clang++-9"
@@ -41,12 +43,16 @@ steps:
 - bash: |
     source ${CONDA}/etc/profile.d/conda.sh
     conda activate rdkit_build
+    conda config --env --add channels conda-forge
+    conda config --env --set channel_priority strict
     cd build
     make -j $( $(number_of_cores) ) install
   displayName: Build
 - bash: |
     source ${CONDA}/etc/profile.d/conda.sh
     conda activate rdkit_build
+    conda config --env --add channels conda-forge
+    conda config --env --set channel_priority strict
     corpora=$(find . -type d -name "*_fuzzer")
     for corpus in $corpora; do
       corpus_basename=$(basename $corpus)

--- a/.azure-pipelines/linux_build_java.yml
+++ b/.azure-pipelines/linux_build_java.yml
@@ -6,7 +6,7 @@ steps:
     conda config --set always_yes yes --set changeps1 no
     conda update -q conda
     conda info -a
-    conda create --name rdkit_build -c conda-forge cmake \
+    conda create --name rdkit_build -c conda-forge --override-channels  cmake \
         libboost=$(boost_version) \
         libboost-devel=$(boost_version) \
         swig=4.2
@@ -14,6 +14,8 @@ steps:
 - bash: |
     source ${CONDA}/etc/profile.d/conda.sh
     conda activate rdkit_build
+    conda config --env --add channels conda-forge
+    conda config --env --set channel_priority strict
     mkdir build && cd build && \
     cmake .. \
     -DSWIG_EXECUTABLE=${CONDA_PREFIX}/bin/swig \
@@ -39,12 +41,16 @@ steps:
 - bash: |
     source ${CONDA}/etc/profile.d/conda.sh
     conda activate rdkit_build
+    conda config --env --add channels conda-forge
+    conda config --env --set channel_priority strict
     cd build
     make -j $( $(number_of_cores) ) install
   displayName: Build
 - bash: |
     source ${CONDA}/etc/profile.d/conda.sh
     conda activate rdkit_build
+    conda config --env --add channels conda-forge
+    conda config --env --set channel_priority strict
     export RDBASE=`pwd`
     export PYTHONPATH=${RDBASE}:${PYTHONPATH}
     export LD_LIBRARY_PATH=${RDBASE}/lib:${CONDA_PREFIX}/lib:${LD_LIBRARY_PATH}

--- a/.azure-pipelines/linux_build_limitexternal.yml
+++ b/.azure-pipelines/linux_build_limitexternal.yml
@@ -9,16 +9,20 @@ steps:
     conda config --add channels conda-forge
     conda config --set solver libmamba
     conda info -a
-    conda create --name rdkit_build $(python) cmake \
+    conda create --name rdkit_build -c conda-forge --override-channels $(python) cmake \
         libboost=$(boost_version) libboost-devel=$(boost_version) \
         libboost-python=$(boost_version) libboost-python-devel=$(boost_version) \
         numpy pillow eigen pandas=2.1 \
         qt pytest
     conda activate rdkit_build
+    conda config --env --add channels conda-forge
+    conda config --env --set channel_priority strict
   displayName: Setup build environment
 - bash: |
     source ${CONDA}/etc/profile.d/conda.sh
     conda activate rdkit_build
+    conda config --env --add channels conda-forge
+    conda config --env --set channel_priority strict
     mkdir build && cd build && \
     cmake .. \
     -DCMAKE_BUILD_TYPE=Release \
@@ -46,12 +50,16 @@ steps:
 - bash: |
     source ${CONDA}/etc/profile.d/conda.sh
     conda activate rdkit_build
+    conda config --env --add channels conda-forge
+    conda config --env --set channel_priority strict
     cd build
     make -j $( $(number_of_cores) ) install
   displayName: Build
 - bash: |
     source ${CONDA}/etc/profile.d/conda.sh
     conda activate rdkit_build
+    conda config --env --add channels conda-forge
+    conda config --env --set channel_priority strict
     export RDBASE=`pwd`
     export PYTHONPATH=${RDBASE}:${PYTHONPATH}
     export LD_LIBRARY_PATH=${RDBASE}/lib:${CONDA_PREFIX}/lib:${LD_LIBRARY_PATH}

--- a/.azure-pipelines/linux_build_py311.yml
+++ b/.azure-pipelines/linux_build_py311.yml
@@ -6,17 +6,21 @@ steps:
     conda config --set always_yes yes --set changeps1 no
     conda update -q conda
     conda info -a
-    conda create --name rdkit_build -c conda-forge $(python) cmake \
+    conda create --name rdkit_build -c conda-forge --override-channels  $(python) cmake \
         boost-cpp=$(boost_version) \
         boost=$(boost_version) \
         numpy=1.24.3 pillow eigen pandas=2.1 matplotlib-base=3.8 \
         cairo
     conda activate rdkit_build
-    conda install -c conda-forge ipython=8.20 jupyter nbval ipykernel>=6.0
+    conda config --env --add channels conda-forge
+    conda config --env --set channel_priority strict
+    conda install -c conda-forge --override-channels  ipython=8.20 jupyter nbval ipykernel>=6.0
   displayName: Setup build environment (no Qt due to versioning problems)
 - bash: |
     source ${CONDA}/etc/profile.d/conda.sh
     conda activate rdkit_build
+    conda config --env --add channels conda-forge
+    conda config --env --set channel_priority strict
     export CXXFLAGS="${CXXFLAGS} -Wall -Werror -Wextra"
     mkdir build && cd build && \
     cmake .. \
@@ -50,12 +54,16 @@ steps:
 - bash: |
     source ${CONDA}/etc/profile.d/conda.sh
     conda activate rdkit_build
+    conda config --env --add channels conda-forge
+    conda config --env --set channel_priority strict
     cd build
     make -j $( $(number_of_cores) ) install
   displayName: Build
 - bash: |
     source ${CONDA}/etc/profile.d/conda.sh
     conda activate rdkit_build
+    conda config --env --add channels conda-forge
+    conda config --env --set channel_priority strict
     export RDBASE=`pwd`
     export PYTHONPATH=${RDBASE}:${PYTHONPATH}
     export LD_LIBRARY_PATH=${RDBASE}/lib:${CONDA_PREFIX}/lib:${LD_LIBRARY_PATH}
@@ -67,7 +75,9 @@ steps:
 - bash: |
     source ${CONDA}/etc/profile.d/conda.sh
     conda activate rdkit_build
-    conda install -c conda-forge sphinx myst-parser
+    conda config --env --add channels conda-forge
+    conda config --env --set channel_priority strict
+    conda install -c conda-forge --override-channels  sphinx myst-parser
     export RDBASE=`pwd`
     export PYTHONPATH=${RDBASE}:${PYTHONPATH}
     export LD_LIBRARY_PATH=${RDBASE}/lib:${LD_LIBRARY_PATH}

--- a/.azure-pipelines/mac_build.yml
+++ b/.azure-pipelines/mac_build.yml
@@ -1,5 +1,5 @@
 steps:
-- bash: | 
+- bash: |
     export CONDA=/tmp/miniforge
     wget https://github.com/conda-forge/miniforge/releases/download/24.9.0-0/Miniforge3-24.9.0-0-MacOSX-x86_64.sh
     bash Miniforge3-24.9.0-0-MacOSX-x86_64.sh -b -p ${CONDA}
@@ -33,10 +33,12 @@ steps:
     export CONDA=/tmp/miniforge
     source ${CONDA}/etc/profile.d/conda.sh
     conda activate rdkit_build
+    conda config --env --add channels conda-forge
+    conda config --env --set channel_priority strict
     ls -l /Library
     ls -l /Library/Developer
     ls -l /Library/Developer/CommandLineTools
-    ls -l /Library/Developer/CommandLineTools/SDKs    
+    ls -l /Library/Developer/CommandLineTools/SDKs
     export SDKROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX$(target_platform).sdk
     export CONDA_BUILD_SYSROOT=${SDKROOT}
     export CXXFLAGS="${CXXFLAGS} -Wall -Wextra -Werror"
@@ -70,6 +72,8 @@ steps:
     export CONDA=/tmp/miniforge
     source ${CONDA}/etc/profile.d/conda.sh
     conda activate rdkit_build
+    conda config --env --add channels conda-forge
+    conda config --env --set channel_priority strict
     export SDKROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX$(target_platform).sdk
     export CONDA_BUILD_SYSROOT=${SDKROOT}
     cd build
@@ -79,6 +83,8 @@ steps:
     export CONDA=/tmp/miniforge
     source ${CONDA}/etc/profile.d/conda.sh
     conda activate rdkit_build
+    conda config --env --add channels conda-forge
+    conda config --env --set channel_priority strict
     export RDBASE=`pwd`
     export PYTHONPATH=${RDBASE}:${PYTHONPATH}
     export DYLD_FALLBACK_LIBRARY_PATH=${RDBASE}/lib:${RDBASE}/rdkit:${CONDA_PREFIX}/lib:${DYLD_FALLBACK_LIBRARY_PATH}

--- a/.azure-pipelines/mac_build_java.yml
+++ b/.azure-pipelines/mac_build_java.yml
@@ -1,5 +1,5 @@
 steps:
-- bash: | 
+- bash: |
     export CONDA=/tmp/miniforge
     wget https://github.com/conda-forge/miniforge/releases/download/24.9.0-0/Miniforge3-24.9.0-0-MacOSX-x86_64.sh
     bash Miniforge3-24.9.0-0-MacOSX-x86_64.sh -b -p ${CONDA}
@@ -19,21 +19,25 @@ steps:
     echo -e "backend: TkAgg\n" > $HOME/.matplotlib/matplotlibrc
     conda config --set always_yes yes --set changeps1 no
     conda update -q conda
-    conda create --name rdkit_build  -c conda-forge $(compiler) \
+    conda create --name rdkit_build  -c conda-forge --override-channels  $(compiler) \
         libcxx=$(compiler_version) cmake=3.26 \
         libboost=$(boost_version) \
         libboost-devel=$(boost_version) \
         cairo eigen swig=4.2 make
     conda activate rdkit_build
+    conda config --env --add channels conda-forge
+    conda config --env --set channel_priority strict
   displayName: Setup build environment
 - bash: |
     export CONDA=/tmp/miniforge
     source ${CONDA}/etc/profile.d/conda.sh
     conda activate rdkit_build
+    conda config --env --add channels conda-forge
+    conda config --env --set channel_priority strict
     ls -l /Library
     ls -l /Library/Developer
     ls -l /Library/Developer/CommandLineTools
-    ls -l /Library/Developer/CommandLineTools/SDKs    
+    ls -l /Library/Developer/CommandLineTools/SDKs
     export SDKROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX$(target_platform).sdk
     export CONDA_BUILD_SYSROOT=${SDKROOT}
     mkdir build && cd build && \
@@ -61,6 +65,8 @@ steps:
     export CONDA=/tmp/miniforge
     source ${CONDA}/etc/profile.d/conda.sh
     conda activate rdkit_build
+    conda config --env --add channels conda-forge
+    conda config --env --set channel_priority strict
     export SDKROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX$(target_platform).sdk
     export CONDA_BUILD_SYSROOT=${SDKROOT}
     cd build
@@ -70,6 +76,8 @@ steps:
     export CONDA=/tmp/miniforge
     source ${CONDA}/etc/profile.d/conda.sh
     conda activate rdkit_build
+    conda config --env --add channels conda-forge
+    conda config --env --set channel_priority strict
     export RDBASE=`pwd`
     export PYTHONPATH=${RDBASE}:${PYTHONPATH}
     export DYLD_FALLBACK_LIBRARY_PATH=${RDBASE}/lib:${RDBASE}/rdkit:${CONDA_PREFIX}/lib:${DYLD_FALLBACK_LIBRARY_PATH}

--- a/.azure-pipelines/vs_build.yml
+++ b/.azure-pipelines/vs_build.yml
@@ -6,15 +6,17 @@ steps:
     conda info -a
     conda install -n base conda-libmamba-solver
     conda config --set solver libmamba
-    conda create --name rdkit_build -c conda-forge $(python) ^
+    conda create --name rdkit_build -c conda-forge --override-channels  $(python) ^
         boost=$(boost_version) boost-cpp=$(boost_version) ^
         libboost-python-devel=(boost_version) ^
         libboost=$(boost_version) ^
         libboost-devel=$(boost_version) ^
         numpy matplotlib cairo pillow eigen pandas=2.1
     call activate rdkit_build
-    conda install -c conda-forge sphinx myst-parser ipython jupyter pytest nbval
-    conda install -c conda-forge cmake
+    conda config --env --add channels conda-forge
+    conda config --env --set channel_priority strict
+    conda install -c conda-forge --override-channels  sphinx myst-parser ipython jupyter pytest nbval
+    conda install -c conda-forge --override-channels  cmake
   displayName: Install dependencies
 - script: |
     set Boost_ROOT=
@@ -52,6 +54,8 @@ steps:
   displayName: Build
 - script: |
     call activate rdkit_build
+    conda config --env --add channels conda-forge
+    conda config --env --set channel_priority strict
     set RDBASE=%cd%
     set PYTHONPATH=%RDBASE%;%PYTHONPATH%
     set PATH=%RDBASE%\lib;%PATH%
@@ -60,7 +64,9 @@ steps:
   displayName: Run tests
 - script: |
     call activate rdkit_build
-    conda install -c conda-forge sphinx myst-parser
+    conda config --env --add channels conda-forge
+    conda config --env --set channel_priority strict
+    conda install -c conda-forge --override-channels  sphinx myst-parser
     set RDBASE=%cd%
     set PYTHONPATH=%RDBASE%;%PYTHONPATH%
     set PATH=%RDBASE%\lib;%PATH%

--- a/.azure-pipelines/vs_build_dll.yml
+++ b/.azure-pipelines/vs_build_dll.yml
@@ -6,14 +6,16 @@ steps:
     conda info -a
     conda install -n base conda-libmamba-solver
     conda config --set solver libmamba
-    conda create --name rdkit_build -c conda-forge $(python) ^
+    conda create --name rdkit_build -c conda-forge --override-channels  $(python) ^
         boost=$(boost_version) boost-cpp=$(boost_version) ^
         libboost-python-devel=(boost_version) ^
         libboost=$(boost_version) ^
         libboost-devel=$(boost_version) ^
         numpy matplotlib cairo pillow eigen pandas=2.1
     call activate rdkit_build
-    conda install -c conda-forge cmake ipython pytest nbval
+    conda config --env --add channels conda-forge
+    conda config --env --set channel_priority strict
+    conda install -c conda-forge --override-channels  cmake ipython pytest nbval
   displayName: Install dependencies
 - script: |
     set Boost_ROOT=

--- a/.azure-pipelines/vs_build_swig.yml
+++ b/.azure-pipelines/vs_build_swig.yml
@@ -11,12 +11,14 @@ steps:
     conda info -a
     conda install -n base conda-libmamba-solver
     conda config --set solver libmamba
-    conda create --name rdkit_build -c conda-forge ^
+    conda create --name rdkit_build -c conda-forge --override-channels  ^
         cmake=3.26 ^
         libboost=$(boost_version) ^
         libboost-devel=$(boost_version) ^
         cairo eigen swig=4.2
     call activate rdkit_build
+    conda config --env --add channels conda-forge
+    conda config --env --set channel_priority strict
   displayName: Install dependencies
 - script: |
     set Boost_ROOT=
@@ -45,7 +47,7 @@ steps:
     -DRDK_BUILD_SWIG_CSHARP_WRAPPER=ON ^
     -DRDK_BUILD_CFFI_LIB=OFF ^
     -DRDK_SWIG_STATIC=ON ^
-    -DRDK_TEST_MULTITHREADED=ON 
+    -DRDK_TEST_MULTITHREADED=ON
   displayName: Configure build (Run CMake)
 - script: |
     call activate rdkit_build
@@ -58,7 +60,7 @@ steps:
     set PYTHONPATH=%RDBASE%;%PYTHONPATH%
     set PATH=%RDBASE%\lib;%PATH%
     cd build
-    ctest -R CSharpTests -C Release -T test --output-on-failure --verbose 
+    ctest -R CSharpTests -C Release -T test --output-on-failure --verbose
   displayName: Run tests
 - task: PublishTestResults@2
   inputs:


### PR DESCRIPTION
Anaconda is forcing CI builds to accept their TOS when using the anaconda repo, this removes the repos
completely from the build.

There are still some warnings in setup, but these are not fatal anymore

```
CondaToSNonInteractiveError: Terms of Service have not been accepted for the following channels. Please accept or remove them before proceeding:
    • https://repo.anaconda.com/pkgs/main
    • https://repo.anaconda.com/pkgs/r

To accept a channel's Terms of Service, run the following and replace `CHANNEL` with the channel name/URL:
    ‣ conda tos accept --override-channels --channel CHANNEL

To remove channels with rejected Terms of Service, run the following and replace `CHANNEL` with the channel name/URL:
    ‣ conda config --remove channels CHANNEL
```