### PR TITLE
Mem fixes

### DIFF
--- a/Code/GraphMol/EnumerateStereoisomers/Wrap/rdEnumerateStereoisomers.cpp
+++ b/Code/GraphMol/EnumerateStereoisomers/Wrap/rdEnumerateStereoisomers.cpp
@@ -42,7 +42,7 @@ class LocalStereoEnumerator {
     if (!iso) {
       return boost::shared_ptr<RDKit::ROMol>();
     }
-    return boost::shared_ptr<RDKit::ROMol>(new RDKit::ROMol(*iso.release()));
+    return boost::shared_ptr<RDKit::ROMol>(iso.release());
   }
 
   unsigned int GetStereoisomerCount() {

--- a/Code/GraphMol/FileParsers/MultithreadedMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/MultithreadedMolSupplier.cpp
@@ -20,12 +20,13 @@ namespace FileParsers {
 void MultithreadedMolSupplier::close() {
   df_forceStop = true;
   d_outputQueue->setDone();
-  
-  if(df_started) {
+
+  if (df_started) {
     // Clear the queues until they are empty
     //  d_inputQueue->clear is not thread-safe
     std::tuple<std::string, unsigned int, unsigned int> r;
-    while (d_inputQueue->pop(r)) {}
+    while (d_inputQueue->pop(r)) {
+    }
     // clear the output queues, they might be full
     //  and blocking the writer threads, note
     //  that while ending threads the writers may
@@ -38,7 +39,7 @@ void MultithreadedMolSupplier::close() {
   }
 
   endThreads();
-  
+
   // notify the queue again that it is done in case
   //  anyone is waiting on it
   d_outputQueue->setDone();
@@ -55,9 +56,9 @@ void MultithreadedMolSupplier::close() {
     }
   } else {
     // destroy all objects in the output queue
-    if(d_outputQueue) d_outputQueue->clear();
+    if (d_outputQueue) d_outputQueue->clear();
   }
-  
+
   // close external streams if any
   //  destructors are called child to parent, however the threads
   //  need to be ended before shutting down streams, so override this
@@ -65,7 +66,7 @@ void MultithreadedMolSupplier::close() {
   closeStreams();
   df_started = false;
 }
-    
+
 void MultithreadedMolSupplier::reader() {
   std::string record;
   unsigned int lineNum, index;
@@ -97,7 +98,7 @@ void MultithreadedMolSupplier::writer() {
       }
       auto temp = std::tuple<RWMol *, std::string, unsigned int>{
           mol.release(), std::get<0>(r), std::get<2>(r)};
-      
+
       d_outputQueue->push(temp);
     } catch (...) {
       // fill the queue wih a null value
@@ -131,15 +132,15 @@ std::unique_ptr<RWMol> MultithreadedMolSupplier::next() {
     startThreads();
   }
   std::tuple<RWMol *, std::string, unsigned int> r;
-  if (!df_forceStop  && d_outputQueue->pop(r)) {
+  if (!df_forceStop && d_outputQueue->pop(r)) {
     d_lastItemText = std::get<1>(r);
     d_lastRecordId = std::get<2>(r);
     std::unique_ptr<RWMol> res{std::get<0>(r)};
     if (res && nextCallback) {
       try {
-	nextCallback(*res, *this);
+        nextCallback(*res, *this);
       } catch (...) {
-	// Ignore exception and proceed with mol as is.
+        // Ignore exception and proceed with mol as is.
       }
     }
     return res;
@@ -154,14 +155,13 @@ void MultithreadedMolSupplier::endThreads() {
   if (!df_started) {
     return;
   }
-  
+
   // stop the writers before stopping the readers
   //  otherwise there might be a deadlock
   for (auto &thread : d_writerThreads) {
     thread.join();
   }
   d_readerThread.join();
-    
 }
 
 void MultithreadedMolSupplier::startThreads() {

--- a/Code/GraphMol/FileParsers/MultithreadedMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/MultithreadedMolSupplier.cpp
@@ -33,8 +33,7 @@ void MultithreadedMolSupplier::close() {
     //  put a few more items back in the queue
     std::tuple<RWMol *, std::string, unsigned int> mol_r;
     while (d_outputQueue->pop(mol_r)) {
-      RWMol *m = std::get<0>(mol_r);
-      delete m;
+      delete std::get<0>(mol_r);
     }
   }
 
@@ -49,14 +48,14 @@ void MultithreadedMolSupplier::close() {
   //  the threads were endings
   if (df_started) {
     d_inputQueue->clear();
+  }
+
+  if (d_outputQueue) {
+    // destroy all objects in the output queue
     std::tuple<RWMol *, std::string, unsigned int> r;
     while (d_outputQueue->pop(r)) {
-      RWMol *m = std::get<0>(r);
-      delete m;
+      delete std::get<0>(r);
     }
-  } else {
-    // destroy all objects in the output queue
-    if (d_outputQueue) d_outputQueue->clear();
   }
 
   // close external streams if any

--- a/Code/RDGeneral/ConcurrentQueue.h
+++ b/Code/RDGeneral/ConcurrentQueue.h
@@ -65,8 +65,7 @@ void ConcurrentQueue<E>::push(const E &element) {
   std::unique_lock<std::mutex> lk(d_lock);
   //! concurrent queue is full so we wait until
   //! it is not full
-  if(d_done) return;
-  
+
   while (d_head + d_capacity == d_tail) {
     d_notFull.wait(lk);
   }


### PR DESCRIPTION
I ran asan again, and found a couple leaks in code, both of them leaking complete mols:

- in `rdEnumerateStereoisomers.cpp`, we release a `ROMol` to make a copy of it, which is then wrapped into a `shared_ptr`... but the released `ROMol`is never cleaned up. The fix is trivial: we don´t need the copy at all, since the released pointer is already a `ROMol`.

- The leak in `MultithreadedMolSupplier` is trickier. When we parse the text into mols, these are stored in the output queue as raw pointers, which are either extracted from the queue when they are written out, or cleaned up when the output queue is deleted. The problem is that when the `MultithreadedMolSupplier` shuts down, one of the first things we do in `MultithreadedMolSupplier::close()` is telling the output queue to stop accepting elements. Due to the `if(d_done) return;`added to `Code/RDGeneral/ConcurrentQueue.h`in #8556, this means that anything that we try to put into the output queue after that point is sliently discarded, leaking the mol pointers. This is easily fixed by removing the "return" line again and allowing mols to go into the output queue while the threads are being terminated. I also updated `MultithreadedMolSupplier::close()`  to make sure mols in the output queue are cleaned up also when `df_started == false`.
