### PR TITLE
Fix offsets for DrawMoleculeWithHighlights.

### DIFF
--- a/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2D.cpp
@@ -163,6 +163,7 @@ void MolDraw2D::drawMoleculeWithHighlights(
       break;
   }
   drawMols_.emplace_back(dm);
+  drawMols_.back()->setOffsets(x_offset_, y_offset_);
   drawMols_.back()->createDrawObjects();
   fixVariableDimensions(*drawMols_.back());
   ++activeMolIdx_;

--- a/Code/GraphMol/MolDraw2D/catch_tests.cpp
+++ b/Code/GraphMol/MolDraw2D/catch_tests.cpp
@@ -10848,7 +10848,7 @@ TEST_CASE("Github 8679 - DrawMoleculesWithHighlights doesn't offset") {
   REQUIRE(mol1);
   auto mol2 = "c1ccccc1Br"_smiles;
   REQUIRE(mol2);
-  MolDraw2DSVG drawer(600, 300, 300, 300);
+  MolDraw2DSVG drawer(600, 300, 300, 300, true);
   drawer.drawOptions().addAtomIndices = true;
   std::map<int, std::vector<DrawColour>> atomCols;
   std::map<int, double> atomRads;
@@ -10866,7 +10866,7 @@ TEST_CASE("Github 8679 - DrawMoleculesWithHighlights doesn't offset") {
   outs << text;
   outs.close();
   const static std::regex atom6(
-      "<path class='atom-6' d='M (\\d+\\.\\d+) (\\d+\\.\\d+)");
+      "<text x='(\\d+\\.\\d+)' y='(\\d+\\.\\d+)' class='atom-6'.*</text>");
   std::ptrdiff_t const match_count(
       std::distance(std::sregex_iterator(text.begin(), text.end(), atom6),
                     std::sregex_iterator()));

--- a/Code/GraphMol/MolDraw2D/catch_tests.cpp
+++ b/Code/GraphMol/MolDraw2D/catch_tests.cpp
@@ -369,6 +369,7 @@ const std::map<std::string, std::hash_result_t> SVG_HASHES = {
     {"testStandardColoursHighlightedAtoms_1.svg", 4265528904U},
     {"testStandardColoursHighlightedAtoms_2.svg", 2285000572U},
     {"testArrowheads.svg", 3318006834U},
+    {"testOffsetHighlightedMols.svg", 3147614756U},
 };
 
 // These PNG hashes aren't completely reliable due to floating point cruft,
@@ -10754,7 +10755,7 @@ TEST_CASE("Solid arrowhead in wrong place (Github 8500)") {
 }
 
 TEST_CASE("Show all CIP codes (Github 8561)") {
-    auto m = R"CTAB(
+  auto m = R"CTAB(
      RDKit          2D
 
   0  0  0  0  0  0  0  0  0  0999 V3000
@@ -10810,40 +10811,77 @@ M  V30 END COLLECTION
 M  V30 END CTAB
 M  END
 )CTAB"_ctab;
-    REQUIRE(m);
-    CIPLabeler::assignCIPLabels(*m);
-    MolDraw2DSVG drawer(350, 300);
-    drawer.drawOptions().addStereoAnnotation = true;
-    drawer.drawOptions().showAllCIPCodes = true;
-    drawer.drawMolecule(*m);
-    drawer.finishDrawing();
-    auto text = drawer.getDrawingText();
-    std::ofstream outs("testShowAllCIPLabels.svg");
-    outs << text;
-    outs.close();
+  REQUIRE(m);
+  CIPLabeler::assignCIPLabels(*m);
+  MolDraw2DSVG drawer(350, 300);
+  drawer.drawOptions().addStereoAnnotation = true;
+  drawer.drawOptions().showAllCIPCodes = true;
+  drawer.drawMolecule(*m);
+  drawer.finishDrawing();
+  auto text = drawer.getDrawingText();
+  std::ofstream outs("testShowAllCIPLabels.svg");
+  outs << text;
+  outs.close();
 
-    // Check for Blue (M) CIP label on Bond
-    TEST_ASSERT(
-        text.find("class='CIP_Code'") !=
-        std::string::npos);
+  // Check for Blue (M) CIP label on Bond
+  TEST_ASSERT(text.find("class='CIP_Code'") != std::string::npos);
 
-    //try again, this tiem using JSON to set options
-    const char *json =
-      "{\"addStereoAnnotation\":true, \"showAllCIPCodes\":true}";
-    MolDraw2DSVG drawer2(350, 300);
-    MolDrawOptions opts;
-    MolDraw2DUtils::updateMolDrawOptionsFromJSON(opts, json);
-    drawer2.drawOptions() = opts;
-    drawer2.drawMolecule(*m);
-    drawer2.finishDrawing();
-    auto text2 = drawer2.getDrawingText();
-    std::ofstream outs2("testShowAllCIPLabels2.svg");
-    outs2 << text2;
-    outs2.close();
+  // try again, this tiem using JSON to set options
+  const char *json = "{\"addStereoAnnotation\":true, \"showAllCIPCodes\":true}";
+  MolDraw2DSVG drawer2(350, 300);
+  MolDrawOptions opts;
+  MolDraw2DUtils::updateMolDrawOptionsFromJSON(opts, json);
+  drawer2.drawOptions() = opts;
+  drawer2.drawMolecule(*m);
+  drawer2.finishDrawing();
+  auto text2 = drawer2.getDrawingText();
+  std::ofstream outs2("testShowAllCIPLabels2.svg");
+  outs2 << text2;
+  outs2.close();
 
-    // Check for Blue (M) CIP label on Bond
-    TEST_ASSERT(
-        text2.find("class='CIP_Code'") !=
-        std::string::npos);
-  }
+  // Check for Blue (M) CIP label on Bond
+  TEST_ASSERT(text2.find("class='CIP_Code'") != std::string::npos);
+}
 
+TEST_CASE("Github 8679 - DrawMoleculesWithHighlights doesn't offset") {
+  auto mol1 = "c1ccccc1Cl"_smiles;
+  REQUIRE(mol1);
+  auto mol2 = "c1ccccc1Br"_smiles;
+  REQUIRE(mol2);
+  MolDraw2DSVG drawer(600, 300, 300, 300);
+  drawer.drawOptions().addAtomIndices = true;
+  std::map<int, std::vector<DrawColour>> atomCols;
+  std::map<int, double> atomRads;
+  std::map<int, int> bondMults;
+  std::map<int, std::vector<DrawColour>> bondCols;
+
+  drawer.drawMoleculeWithHighlights(*mol1, "", atomCols, bondCols, atomRads,
+                                    bondMults);
+  drawer.setOffset(300, 0);
+  drawer.drawMoleculeWithHighlights(*mol2, "", atomCols, bondCols, atomRads,
+                                    bondMults);
+  drawer.finishDrawing();
+  auto text = drawer.getDrawingText();
+  std::ofstream outs("testOffsetHighlightedMols.svg");
+  outs << text;
+  outs.close();
+  const static std::regex atom6(
+      "<path class='atom-6' d='M (\\d+\\.\\d+) (\\d+\\.\\d+)");
+  std::ptrdiff_t const match_count(
+      std::distance(std::sregex_iterator(text.begin(), text.end(), atom6),
+                    std::sregex_iterator()));
+
+  // There are 4 characters for the 2 atom 6s.  Check that the 1st and 3rd
+  // are in different panels, by x coord.
+  CHECK(match_count == 4);
+  auto match_begin = std::sregex_iterator(text.begin(), text.end(), atom6);
+  std::smatch match = *match_begin;
+  double x1 = stod(match[1]);
+  CHECK(x1 < 300.0);
+  ++match_begin;
+  ++match_begin;
+  match = *match_begin;
+  double x2 = stod(match[1]);
+  CHECK((x2 > 300.0 && x2 < 600.0));
+  check_file_hash("testOffsetHighlightedMols.svg");
+}


### PR DESCRIPTION

#### Reference Issue
Fixes #8679 


#### What does this implement/fix? Explain your changes.
Adds the offset before doing the drawing, in the same manner as DrawMolecule().

#### Any other comments?
clang-format has changed the previous test in catch_tests.cpp.  I didn't change anything else in that test.
