### PR TITLE
Explicitly set COMPOSE_BAKE to false

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,6 +17,7 @@ jobs:
       dockerComposeFile: './Code/MinimalLib/docker/docker_compose_build_minimallib.yml'
       dockerComposeFileArgs: |
         GET_SRC=copy_from_local
+        COMPOSE_BAKE=false
 - job: Ubuntu_x64
   timeoutInMinutes: 120
   pool:


### PR DESCRIPTION
Apparently the default for `COMPOSE_BAKE` has changed to `true` and this change broke the `minimallib` build.
This change should restore the build functionality.