### PR TITLE
fix: -Wdeprecated-literal-operator

### DIFF
--- a/Code/GraphMol/ChemReactions/ReactionParser.h
+++ b/Code/GraphMol/ChemReactions/ReactionParser.h
@@ -388,8 +388,8 @@ inline std::string addChemicalReactionToPNGFile(const ChemicalReaction &rxn,
 }
 //! @}
 
-inline std::unique_ptr<ChemicalReaction> operator"" _rxnsmarts(const char *text,
-                                                               size_t len) {
+inline std::unique_ptr<ChemicalReaction> operator""_rxnsmarts(const char *text,
+                                                              size_t len) {
   std::string sma(text, len);
   std::unique_ptr<ChemicalReaction> ptr;
   try {
@@ -399,8 +399,8 @@ inline std::unique_ptr<ChemicalReaction> operator"" _rxnsmarts(const char *text,
   }
   return ptr;
 }
-inline std::unique_ptr<ChemicalReaction> operator"" _rxnsmiles(const char *text,
-                                                               size_t len) {
+inline std::unique_ptr<ChemicalReaction> operator""_rxnsmiles(const char *text,
+                                                              size_t len) {
   std::string sma(text, len);
   std::unique_ptr<ChemicalReaction> ptr;
   try {

--- a/Code/GraphMol/FileParsers/FileParsers.h
+++ b/Code/GraphMol/FileParsers/FileParsers.h
@@ -489,8 +489,8 @@ RDKIT_FILEPARSERS_EXPORT RWMol *RDKitSVGToMol(std::istream *instream,
                                               bool sanitize = true,
                                               bool removeHs = true);
 
-inline std::unique_ptr<RDKit::RWMol> operator"" _ctab(const char *text,
-                                                      size_t len) {
+inline std::unique_ptr<RDKit::RWMol> operator""_ctab(const char *text,
+                                                     size_t len) {
   std::string data(text, len);
   try {
     return v2::FileParsers::MolFromMolBlock(data);
@@ -498,8 +498,8 @@ inline std::unique_ptr<RDKit::RWMol> operator"" _ctab(const char *text,
     return nullptr;
   }
 }
-inline std::unique_ptr<RDKit::RWMol> operator"" _mol2(const char *text,
-                                                      size_t len) {
+inline std::unique_ptr<RDKit::RWMol> operator""_mol2(const char *text,
+                                                     size_t len) {
   std::string data(text, len);
   try {
     return v2::FileParsers::MolFromMol2Block(data);
@@ -508,8 +508,8 @@ inline std::unique_ptr<RDKit::RWMol> operator"" _mol2(const char *text,
   }
 }
 
-inline std::unique_ptr<RDKit::RWMol> operator"" _pdb(const char *text,
-                                                     size_t len) {
+inline std::unique_ptr<RDKit::RWMol> operator""_pdb(const char *text,
+                                                    size_t len) {
   std::string data(text, len);
   try {
     return v2::FileParsers::MolFromPDBBlock(data);

--- a/Code/GraphMol/SmilesParse/SmilesParse.h
+++ b/Code/GraphMol/SmilesParse/SmilesParse.h
@@ -234,8 +234,8 @@ inline Bond *SmartsToBond(const std::string &sma) {
 }
 }  // namespace v1
 
-inline std::unique_ptr<RDKit::RWMol> operator"" _smiles(const char *text,
-                                                        size_t len) {
+inline std::unique_ptr<RDKit::RWMol> operator""_smiles(const char *text,
+                                                       size_t len) {
   std::string smi(text, len);
   try {
     return v2::SmilesParse::MolFromSmiles(smi);
@@ -243,8 +243,8 @@ inline std::unique_ptr<RDKit::RWMol> operator"" _smiles(const char *text,
     return nullptr;
   }
 }
-inline std::unique_ptr<RDKit::RWMol> operator"" _smarts(const char *text,
-                                                        size_t len) {
+inline std::unique_ptr<RDKit::RWMol> operator""_smarts(const char *text,
+                                                       size_t len) {
   std::string smi(text, len);
   return v2::SmilesParse::MolFromSmarts(smi);
 }


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! 
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.

<https://cplusplus.github.io/CWG/issues/2521.html>

> The form of User Defined Literals that permits a space between the quotes and the name of the literal should be deprecated, and eventually removed.

#### Any other comments?

