### PR TITLE
Fixes #8712

### DIFF
--- a/Code/GraphMol/FindStereo.cpp
+++ b/Code/GraphMol/FindStereo.cpp
@@ -836,21 +836,16 @@ bool updateAtoms(ROMol &mol, const std::vector<unsigned int> &aranks,
                 const auto &aring = mol.getRingInfo()->atomRings()[ridx];
                 unsigned int nHere = 0;
                 for (auto raidx : aring) {
-                  if (possibleRingStereoAtoms[raidx]) {
-                    --possibleRingStereoAtoms[raidx];
-                    if (possibleRingStereoAtoms[raidx]) {
-                      ++nHere;
-                    } else {
-                      // In case there's no possible ring stereo anymore,
-                      // un-fix these atoms so we can recheck them in the next
-                      // iteration, for the case that they are no longer chiral
-                      // after removing the current chirality
-                      fixedAtoms[raidx] = false;
-                    }
-                  }
+                  // Ring stereo changed, so un-fix atoms in this ring so we can
+                  // recheck them in the next iteration, for the case that they
+                  // are no longer after the current atom was declared
+                  // non-chiral
+                  fixedAtoms[raidx] = false;
+                  nHere += (possibleRingStereoAtoms[raidx] > 0);
                 }
                 if (nHere <= 1) {
-                  // update the bondstereo counts too
+                  // if the ring can't transmit stereo anymore, update the
+                  // counts
                   for (auto rbidx : mol.getRingInfo()->bondRings()[ridx]) {
                     if (possibleRingStereoBonds[rbidx]) {
                       --possibleRingStereoBonds[rbidx];

--- a/Code/GraphMol/FindStereo.cpp
+++ b/Code/GraphMol/FindStereo.cpp
@@ -846,6 +846,16 @@ bool updateAtoms(ROMol &mol, const std::vector<unsigned int> &aranks,
                 if (nHere <= 1) {
                   // if the ring can't transmit stereo anymore, update the
                   // counts
+                  if (nHere == 1) {
+                    // update the last potential ring stereo atom in the ring,
+                    // since it can't have ring stereo alone.
+                    for (auto raidx : aring) {
+                      if (possibleRingStereoAtoms[raidx]) {
+                        --possibleRingStereoAtoms[raidx];
+                        break;
+                      }
+                    }
+                  }
                   for (auto rbidx : mol.getRingInfo()->bondRings()[ridx]) {
                     if (possibleRingStereoBonds[rbidx]) {
                       --possibleRingStereoBonds[rbidx];

--- a/Code/GraphMol/FindStereo.cpp
+++ b/Code/GraphMol/FindStereo.cpp
@@ -820,7 +820,7 @@ bool updateAtoms(ROMol &mol, const std::vector<unsigned int> &aranks,
           sinfos.push_back(std::move(sinfo));
         } else {
           // Only do another round if we change anything here
-          needAnotherRound = possibleAtoms[aidx];
+          needAnotherRound |= possibleAtoms[aidx];
           possibleAtoms[aidx] = 0;
           atomSymbols[aidx] = getAtomCompareSymbol(*atom);
 

--- a/Code/GraphMol/FindStereo.cpp
+++ b/Code/GraphMol/FindStereo.cpp
@@ -818,15 +818,17 @@ bool updateAtoms(ROMol &mol, const std::vector<unsigned int> &aranks,
             needAnotherRound = true;
           }
           sinfos.push_back(std::move(sinfo));
-        } else if (possibleAtoms[aidx]) {
+        } else {
+          // Only do another round if we change anything here
+          needAnotherRound = possibleAtoms[aidx];
           possibleAtoms[aidx] = 0;
           atomSymbols[aidx] = getAtomCompareSymbol(*atom);
-          needAnotherRound = true;
 
           // if this was creating possible ring stereo, update that info now
           if (possibleRingStereoAtoms[aidx]) {
             --possibleRingStereoAtoms[aidx];
             if (!possibleRingStereoAtoms[aidx]) {
+              needAnotherRound = true;
               // we're no longer in any ring with possible ring stereo. Go
               // update all the other atoms/bonds in rings that we're in:
               for (unsigned int ridx = 0;
@@ -838,6 +840,12 @@ bool updateAtoms(ROMol &mol, const std::vector<unsigned int> &aranks,
                     --possibleRingStereoAtoms[raidx];
                     if (possibleRingStereoAtoms[raidx]) {
                       ++nHere;
+                    } else {
+                      // In case there's no possible ring stereo anymore,
+                      // un-fix these atoms so we can recheck them in the next
+                      // iteration, for the case that they are no longer chiral
+                      // after removing the current chirality
+                      fixedAtoms[raidx] = false;
                     }
                   }
                 }

--- a/Code/GraphMol/catch_chirality.cpp
+++ b/Code/GraphMol/catch_chirality.cpp
@@ -2149,7 +2149,7 @@ TEST_CASE(
   RDLog::LogStateSetter setter;  // disable irritating warning messages
   auto molblock = R"CTAB(
      RDKit          3D
-     
+
   0  0  0  0  0  0  0  0  0  0999 V3000
 M  V30 BEGIN CTAB
 M  V30 COUNTS 5 4 0 0 0
@@ -2679,7 +2679,7 @@ TEST_CASE("useLegacyStereoPerception feature flag") {
     CHECK(m->getAtomWithIdx(9)->getChiralTag() != Atom::CHI_UNSPECIFIED);
   }
   std::string molblock = R"CTAB(
-  Mrv2108 05202206352D          
+  Mrv2108 05202206352D
 
   0  0  0     0  0            999 V3000
 M  V30 BEGIN CTAB
@@ -2797,7 +2797,7 @@ M  END
 TEST_CASE("github 5307: AssignAtomChiralTagsFromStructure ignores Hydrogens") {
   std::string mb = R"CTAB(
      RDKit          3D
-     
+
   0  0  0  0  0  0  0  0  0  0999 V3000
 M  V30 BEGIN CTAB
 M  V30 COUNTS 5 4 0 0 0
@@ -3317,7 +3317,7 @@ void testStereoValidationFromMol(std::string molBlock,
 }
 
 std::string validateStereoMolBlockSpiro = R"(
-  Mrv2308 06232316112D          
+  Mrv2308 06232316112D
 
   0  0  0     0  0            999 V3000
 M  V30 BEGIN CTAB
@@ -3359,7 +3359,7 @@ M  END
   )";
 
 std::string validateStereoMolBlockDoubleBondNoStereo = R"(
-  Mrv2308 06232316392D          
+  Mrv2308 06232316392D
 
   0  0  0     0  0            999 V3000
 M  V30 BEGIN CTAB
@@ -3391,7 +3391,7 @@ M  END
   )";
 
 std::string validateStereoMolBlockDoubleBondNoStereo2 = R"(
-  Mrv0541 07011416342D          
+  Mrv0541 07011416342D
 
  21 22  0  0  0  0            999 V2000
    -1.9814    1.4834    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
@@ -3449,7 +3449,7 @@ $$$$
 )";
 
 std::string validateStereoError1 = R"(
-  -ISIS-  -- StrEd -- 
+  -ISIS-  -- StrEd --
 
  29 32  0  0  0  0  0  0  0  0999 V2000
    -1.2050   -4.7172    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
@@ -3525,7 +3525,7 @@ $$$$
 )";
 
 std::string validateStereoUniq1 = R"(
-  Mrv0541 06301412152D          
+  Mrv0541 06301412152D
 
  15 15  0  0  0  0            999 V2000
     1.0464   -0.3197    0.0000 N   0  0  0  0  0  0  0  0  0  0  0  0
@@ -3764,7 +3764,7 @@ TEST_CASE(
   }
   SECTION("ensure we can enumerate stereo on either double bonds") {
     auto mol = R"CTAB(
-  Mrv2004 11072316002D          
+  Mrv2004 11072316002D
 
   0  0  0     0  0            999 V3000
 M  V30 BEGIN CTAB
@@ -3807,7 +3807,7 @@ M  END)CTAB"_ctab;
 TEST_CASE("adding two wedges to chiral centers") {
   SECTION("basics") {
     auto mol = R"CTAB(
-  Mrv2219 02112315062D          
+  Mrv2219 02112315062D
 
   0  0  0     0  0            999 V3000
 M  V30 BEGIN CTAB
@@ -4102,7 +4102,7 @@ TEST_CASE("zero bond-length chirality cases") {
   SECTION("basics") {
     {
       auto m = R"CTAB(derived from CHEMBL3183068
-  Mrv2211 07202306222D          
+  Mrv2211 07202306222D
 
   0  0  0     0  0            999 V3000
 M  V30 BEGIN CTAB
@@ -4140,7 +4140,7 @@ M  END
     }
     {
       auto m = R"CTAB(derived from CHEMBL3183068
-  Mrv2211 07202306222D          
+  Mrv2211 07202306222D
 
   0  0  0     0  0            999 V3000
 M  V30 BEGIN CTAB
@@ -4255,7 +4255,7 @@ M  END
   SECTION("four-coordinate") {
     {
       auto m = R"CTAB(
-  Mrv2211 07202306492D          
+  Mrv2211 07202306492D
 
   0  0  0     0  0            999 V3000
 M  V30 BEGIN CTAB
@@ -4282,7 +4282,7 @@ M  END
     }
     {
       auto m = R"CTAB(
-  Mrv2211 07202306492D          
+  Mrv2211 07202306492D
 
   0  0  0     0  0            999 V3000
 M  V30 BEGIN CTAB
@@ -4309,7 +4309,7 @@ M  END
     }
     {
       auto m = R"CTAB(
-  Mrv2211 07202306492D          
+  Mrv2211 07202306492D
 
   0  0  0     0  0            999 V3000
 M  V30 BEGIN CTAB
@@ -4470,7 +4470,7 @@ M  END
     auto m =
         R"CTAB(derived from CHEMBL2373651. This was wrong in the RDKit implementation
   Mrv2211 07212313282D
-            
+
   0  0  0     0  0            999 V3000
 M  V30 BEGIN CTAB
 M  V30 COUNTS 7 7 0 0 1
@@ -4666,7 +4666,7 @@ M  V30 BEGIN BOND
 M  V30 1 1 2 1 CFG=1
 M  V30 2 1 3 2
 M  V30 3 1 4 6
-M  V30 4 1 5 3 
+M  V30 4 1 5 3
 M  V30 5 1 6 2
 M  V30 6 1 5 7 CFG=1
 M  V30 7 1 2 8 CFG=3
@@ -4925,7 +4925,7 @@ TEST_CASE(
   UseLegacyStereoPerceptionFixture reset_stereo_perception(legacy_stereo);
 
   auto m = R"CTAB(
-  Mrv2311 12122315472D          
+  Mrv2311 12122315472D
 
   0  0  0     0  0            999 V3000
 M  V30 BEGIN CTAB
@@ -4961,7 +4961,7 @@ TEST_CASE(
     UseLegacyStereoPerceptionFixture reset_stereo_perception(legacy_stereo);
 
     auto m = R"CTAB(
-  Mrv2211 01252410552D          
+  Mrv2211 01252410552D
 
  10  9  0  0  0  0            999 V2000
     0.0000   -1.4364    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
@@ -5237,7 +5237,7 @@ M  END
   }
   SECTION("cage") {
     auto m = R"CTAB(
-  Mrv2305 03052406362D          
+  Mrv2305 03052406362D
 
   0  0  0     0  0            999 V3000
 M  V30 BEGIN CTAB
@@ -5535,7 +5535,7 @@ M  END
   }
   SECTION("favor larger rings") {
     auto m = R"CTAB(
-  Mrv2401 04262410272D          
+  Mrv2401 04262410272D
 
   0  0  0     0  0            999 V3000
 M  V30 BEGIN CTAB
@@ -6020,7 +6020,7 @@ TEST_CASE(
 TEST_CASE("Github issue #7983: stereogroup lost on chiral sulfoxide") {
   SECTION("basics") {
     auto m = R"CTAB(
-  Mrv2317 02032512242D          
+  Mrv2317 02032512242D
 
   0  0  0     0  0            999 V3000
 M  V30 BEGIN CTAB
@@ -6151,7 +6151,7 @@ TEST_CASE("Github #8420: imines and crossed bonds") {
   UseLegacyStereoPerceptionFixture reset_stereo_perception(useLegacy);
   SECTION("as reported") {
     std::string ctab = R"CTAB(
-  MJ250100                      
+  MJ250100
 
   7  7  0  0  1  0  0  0  0  0999 V2000
     0.6961    0.4995    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
@@ -6173,4 +6173,73 @@ M  END)CTAB";
     REQUIRE(m);
     CHECK(m->getBondWithIdx(0)->getStereo() == Bond::BondStereo::STEREONONE);
   }
+}
+
+TEST_CASE(
+    "Github #8712: Modern stereo + 3D SD file leads to bad stereo detection for some molecules") {
+  UseLegacyStereoPerceptionFixture reset_stereo_perception(false);
+  std::string ctab = R"CTAB(
+     RDKit          3D
+
+  0  0  0  0  0  0  0  0  0  0999 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 23 23 0 0 0
+M  V30 BEGIN ATOM
+M  V30 1 C 2.628222 -0.014974 0.390914 0
+M  V30 2 N 1.918195 0.260032 -0.835284 0
+M  V30 3 C 0.487110 0.206615 -0.681308 0
+M  V30 4 C 0.079788 -1.165009 -0.217881 0
+M  V30 5 C -1.428295 -1.378335 -0.390798 0
+M  V30 6 S -2.156694 -0.136366 0.671587 0
+M  V30 7 O -1.585579 -0.347357 2.045208 0
+M  V30 8 O -3.651696 -0.172351 0.647489 0
+M  V30 9 C -1.519569 1.415993 0.067834 0
+M  V30 10 C -0.010801 1.307036 0.207366 0
+M  V30 11 H 1.988100 -0.320407 1.230786 0
+M  V30 12 H 3.238742 0.867078 0.711200 0
+M  V30 13 H 3.359131 -0.825206 0.185242 0
+M  V30 14 H 2.223613 -0.317010 -1.647727 0
+M  V30 15 H 0.041778 0.347830 -1.688472 0
+M  V30 16 H 0.284353 -1.370499 0.832996 0
+M  V30 17 H 0.580676 -1.905979 -0.844599 0
+M  V30 18 H -1.673500 -2.379109 -0.016810 0
+M  V30 19 H -1.696056 -1.195326 -1.452807 0
+M  V30 20 H -1.827609 1.481487 -0.996993 0
+M  V30 21 H -1.921584 2.283368 0.626641 0
+M  V30 22 H 0.172726 1.108075 1.288878 0
+M  V30 23 H 0.468947 2.250412 -0.133459 0
+M  V30 END ATOM
+M  V30 BEGIN BOND
+M  V30 1 1 1 2
+M  V30 2 1 2 3
+M  V30 3 1 3 4
+M  V30 4 1 4 5
+M  V30 5 1 5 6
+M  V30 6 2 6 7
+M  V30 7 2 6 8
+M  V30 8 1 6 9
+M  V30 9 1 9 10
+M  V30 10 1 10 3
+M  V30 11 1 1 11
+M  V30 12 1 1 12
+M  V30 13 1 1 13
+M  V30 14 1 2 14
+M  V30 15 1 3 15
+M  V30 16 1 4 16
+M  V30 17 1 4 17
+M  V30 18 1 5 18
+M  V30 19 1 5 19
+M  V30 20 1 9 20
+M  V30 21 1 9 21
+M  V30 22 1 10 22
+M  V30 23 1 10 23
+M  V30 END BOND
+M  V30 END CTAB
+M  END
+)CTAB";
+  auto m = v2::FileParsers::MolFromMolBlock(ctab);
+  REQUIRE(m);
+
+  auto smiles = MolToSmiles(*m);
+  CHECK(smiles.find('@') == std::string::npos);
 }

--- a/Code/GraphMol/catch_chirality.cpp
+++ b/Code/GraphMol/catch_chirality.cpp
@@ -6178,7 +6178,8 @@ M  END)CTAB";
 TEST_CASE(
     "Github #8712: Modern stereo + 3D SD file leads to bad stereo detection for some molecules") {
   UseLegacyStereoPerceptionFixture reset_stereo_perception(false);
-  std::string ctab = R"CTAB(
+  SECTION("as reported") {
+    std::string ctab = R"CTAB(
      RDKit          3D
 
   0  0  0  0  0  0  0  0  0  0999 V3000
@@ -6237,9 +6238,21 @@ M  V30 END BOND
 M  V30 END CTAB
 M  END
 )CTAB";
-  auto m = v2::FileParsers::MolFromMolBlock(ctab);
-  REQUIRE(m);
+    auto m = v2::FileParsers::MolFromMolBlock(ctab);
+    REQUIRE(m);
 
-  auto smiles = MolToSmiles(*m);
-  CHECK(smiles.find('@') == std::string::npos);
+    auto smiles = MolToSmiles(*m);
+    CHECK(smiles.find('@') == std::string::npos);
+  }
+  SECTION("counterexample from the doc tests") {
+    // Do not break this one!
+    // I'm adding it here because it seems we don't have this case
+    // in any other C++ test.
+    auto m = R"SMI(C1C[C@H](C)[C@H](C)[C@H](C)C1)SMI"_smiles;
+    REQUIRE(m);
+    for (auto i : {2, 4, 6}) {
+      CHECK(m->getAtomWithIdx(i)->getChiralTag() !=
+            Atom::ChiralType::CHI_UNSPECIFIED);
+    }
+  }
 }

--- a/Code/GraphMol/catch_chirality.cpp
+++ b/Code/GraphMol/catch_chirality.cpp
@@ -6178,6 +6178,10 @@ M  END)CTAB";
 TEST_CASE(
     "Github #8712: Modern stereo + 3D SD file leads to bad stereo detection for some molecules") {
   UseLegacyStereoPerceptionFixture reset_stereo_perception(false);
+
+  constexpr bool cleanUpStereo = false;
+  constexpr bool flagPossibleCenters = true;
+
   SECTION("as reported") {
     std::string ctab = R"CTAB(
      RDKit          3D
@@ -6241,18 +6245,29 @@ M  END
     auto m = v2::FileParsers::MolFromMolBlock(ctab);
     REQUIRE(m);
 
-    auto smiles = MolToSmiles(*m);
-    CHECK(smiles.find('@') == std::string::npos);
+    auto centers =
+        Chirality::findPotentialStereo(*m, cleanUpStereo, flagPossibleCenters);
+    CHECK(centers.empty());
   }
-  SECTION("counterexample from the doc tests") {
+  SECTION("overcorrection #1") {
     // Do not break this one!
-    // I'm adding it here because it seems we don't have this case
-    // in any other C++ test.
+    // This one comes from the doctests. I'm adding it here because it seems we
+    // don't have this case in any other C++ test.
     auto m = R"SMI(C1C[C@H](C)[C@H](C)[C@H](C)C1)SMI"_smiles;
     REQUIRE(m);
-    for (auto i : {2, 4, 6}) {
-      CHECK(m->getAtomWithIdx(i)->getChiralTag() !=
-            Atom::ChiralType::CHI_UNSPECIFIED);
-    }
+    auto centers =
+        Chirality::findPotentialStereo(*m, cleanUpStereo, flagPossibleCenters);
+    CHECK(centers.size() == 3);
+  }
+  SECTION("overcorrection #2") {
+    // Do not break this one either!
+    // This case seems to be related to the order of the atoms, since I haven't
+    // been able to reproduce with the equivalent SMILES with explicit Hs.
+    auto m = R"SMI(C[C@H]1C[C@@H](C)C1)SMI"_smiles;
+    REQUIRE(m);
+    MolOps::addHs(*m);  // This only manifests if Hs are present
+    auto centers =
+        Chirality::findPotentialStereo(*m, cleanUpStereo, flagPossibleCenters);
+    CHECK(centers.size() == 2);
   }
 }


### PR DESCRIPTION
Fixes #8712

There's multiple factors converging here that cause the issue.

First of all, this only happens with the new stereo algoritm. The reason why it doesn't happen with the legacy one is that the legacy stereo implementation doesn't support across-the-ring stereo dependency, which plays a role here.

Second, this was observed on structures with 3D coordinates, but we would hit it exactly the same in 2D structures with wedges on the wrong places (i.e. coming out of the S atom and the C on the opposite side of the ring), or SMILES with parities for such atoms :
```
m = Chem.MolFromSmiles('CN[C@@H]1CC[S@](=O)(=O)CC1')
print(Chem.MolToSmiles(m))
# CN[C@@H]1CCS(=O)(=O)CC1
```

This is because when parsing a 3D molblock we add parities for anything that looks like a reasonable tetrahedron. We do this before calculating stereo, so we don't have priority rankings for the neighbors (we might never have them, if we called parsing without sanitization). Since we don't have priorities, we can't check if two or more have the same priority (as in the case of the sulfonyl group) to discard potential chirality for the atom and not set the parity.

So, we end up with a lot of parities that we might not need at all. When we run stereo calculation, these parities are examined, and those are set on non-chiral atoms end up being cleaned up. Except in this case.

The reason this case wasn't being cleaned up is that the new stereo algorithm marks atoms with parities as atoms "known" chiralities. Those are currently exempt from being examined from ring stereo in `updateAtoms()`: we "know" these atoms are chiral, so they shouldn't depend on ring stereo to be chiral. But they do, as in this case.

This patch subjects "known" atoms that have been found to have neighbors with the same parity to the same ring stereo scrutiny as atoms we only suspect might be chiral.

Also, during this clean up, if one of these "known" atoms is found not to be really chiral, and the removal of this atom removes across-the-ring stereo possibility, atoms that may depend on this possibility are unmarked as fixed, so that they can be reexamined in the next iteration of the loop.

Finally, we need to patch the flag that indicates that the stereo calculation loop should continue, since "un-fixed" "known" atoms will keep being re-examined until they are marked as "fixed" (which would prevent them from being cleaned up in `cleanMolStereo()`). For this reason, we only keep the cycle going in `updateAtoms()` if we actually changed anything.

[EDIT]: there was one more issue that needed to be fixed. This is reflected by the "overcorrection #2" test I added: when one potentially chiral atom involved in ring stereo is proven non-chiral, the whole ring may be marked as non ring-stereo capable, possibly throwing out valid chiral atoms. The new patch addresses this by only removing atoms from ring stereo one by one, and forcing re-examination of the remaining ring atoms when one ring member is discovered as not ring stereo capable.

Please run as many additional testing on this as you can imagine: it already happened twice that this passed all tests and I still was able to find issues with the fix I had!

