### PR TITLE
Create a function to extract some specified atoms from a ROMol as a new ROMol by creating new graph (#8742)

### DIFF
--- a/Code/GraphMol/MolOps.cpp
+++ b/Code/GraphMol/MolOps.cpp
@@ -47,6 +47,15 @@ const int ci_LOCAL_INF = static_cast<int>(1e8);
 namespace RDKit {
 namespace MolOps {
 namespace {
+
+// Helper api to hold atom selection data for ExtractMolFragment
+struct [[nodiscard]] SelectedAtomInfo {
+    std::vector<bool> selected_atoms;
+    std::vector<bool> selected_bonds;
+    std::unordered_map<unsigned int, unsigned int> atom_mapping;
+    std::unordered_map<unsigned int, unsigned int> bond_mapping;
+};
+
 void nitrogenCleanup(RWMol &mol, Atom *atom) {
   // conversions here:
   // - neutral 5 coordinate Ns with double bonds to Os to the
@@ -1337,5 +1346,190 @@ void collapseAttachmentPoints(RWMol &mol, bool markedOnly) {
     mol.commitBatchEdit();
   }
 }
+
+static void copySelectedAtomsAndBonds(::RDKit::RWMol& extracted_mol,
+                                          const RDKit::ROMol& reference_mol,
+                                          SelectedAtomInfo& selection_info)
+{
+    auto& [selected_atoms, selected_bonds, atom_mapping, bond_mapping] =
+        selection_info;
+    for (const auto& ref_atom : reference_mol.atoms()) {
+        if (!selected_atoms[ref_atom->getIdx()]) {
+            continue;
+        }
+
+        std::unique_ptr<::RDKit::Atom> extracted_atom{ref_atom->copy()};
+
+        static constinit bool updateLabel = true;
+        static constinit bool takeOwnership = true;
+        atom_mapping[ref_atom->getIdx()] = extracted_mol.addAtom(
+            extracted_atom.release(), updateLabel, takeOwnership);
+    }
+
+    for (const auto& ref_bond : reference_mol.bonds()) {
+        if (!selected_bonds[ref_bond->getIdx()]) {
+            continue;
+        }
+
+        std::unique_ptr<::RDKit::Bond> extracted_bond{ref_bond->copy()};
+        extracted_bond->setBeginAtomIdx(
+            atom_mapping[ref_bond->getBeginAtomIdx()]);
+        extracted_bond->setEndAtomIdx(atom_mapping[ref_bond->getEndAtomIdx()]);
+
+        static constinit bool takeOwnership = true;
+        auto num_bonds =
+            extracted_mol.addBond(extracted_bond.release(), takeOwnership);
+        bond_mapping[ref_bond->getIdx()] = num_bonds - 1;
+    }
+}
+
+[[nodiscard]] static bool
+is_selected_sgroup(const ::RDKit::SubstanceGroup& sgroup,
+                   const SelectedAtomInfo& selection_info)
+{
+    auto is_selected_component = [](auto& indices, auto& selection_test) {
+        return indices.empty() ||
+               std::all_of(indices.begin(), indices.end(), selection_test);
+    };
+
+    // clang-format off
+    auto atom_test = [&](int idx) { return selection_info.selected_atoms[idx]; };
+    auto bond_test = [&](int idx) { return selection_info.selected_bonds[idx]; };
+    return is_selected_component(sgroup.getAtoms(), atom_test) &&
+           is_selected_component(sgroup.getBonds(), bond_test) &&
+           is_selected_component(sgroup.getParentAtoms(), atom_test);
+    // clang-format on
+}
+
+static void
+copySelectedSubstanceGroups(::RDKit::RWMol& extracted_mol,
+                               const RDKit::ROMol& reference_mol,
+                               const SelectedAtomInfo& selection_info)
+{
+    auto update_indices = [](auto& sgroup, auto getter, auto setter,
+                             auto& mapping) {
+        auto indices = getter(sgroup);
+        std::for_each(indices.begin(), indices.end(),
+                      [&](auto& idx) { idx = mapping.at(idx); });
+        setter(sgroup, std::move(indices));
+    };
+
+    const auto& [selected_atoms, selected_bonds, atom_mapping, bond_mapping] =
+        selection_info;
+    for (const auto& sgroup : ::RDKit::getSubstanceGroups(reference_mol)) {
+        if (!is_selected_sgroup(sgroup, selection_info)) {
+            continue;
+        }
+
+        ::RDKit::SubstanceGroup extracted_sgroup(sgroup);
+        extracted_sgroup.setOwningMol(&extracted_mol);
+
+        update_indices(
+            extracted_sgroup, std::mem_fn(&::RDKit::SubstanceGroup::getAtoms),
+            std::mem_fn(&::RDKit::SubstanceGroup::setAtoms), atom_mapping);
+        update_indices(extracted_sgroup,
+                       std::mem_fn(&::RDKit::SubstanceGroup::getParentAtoms),
+                       std::mem_fn(&::RDKit::SubstanceGroup::setParentAtoms),
+                       atom_mapping);
+        update_indices(
+            extracted_sgroup, std::mem_fn(&::RDKit::SubstanceGroup::getBonds),
+            std::mem_fn(&::RDKit::SubstanceGroup::setBonds), bond_mapping);
+
+        ::RDKit::addSubstanceGroup(extracted_mol, std::move(extracted_sgroup));
+    }
+}
+
+static void
+copySelectedStereoGroups(::RDKit::RWMol& extracted_mol,
+                            const RDKit::ROMol& reference_mol,
+                            const SelectedAtomInfo& selection_info)
+{
+    auto is_selected_component = [](auto& objects, auto& selected_indices) {
+        return objects.empty() ||
+               std::all_of(objects.begin(), objects.end(), [&](auto& object) {
+                   return selected_indices[object->getIdx()];
+               });
+    };
+
+    auto is_selected_stereo_group = [&](const auto& stereo_group) {
+        return is_selected_component(stereo_group.getAtoms(),
+                                     selection_info.selected_atoms) &&
+               is_selected_component(stereo_group.getBonds(),
+                                     selection_info.selected_bonds);
+    };
+
+    std::vector<::RDKit::Atom*> extracted_atoms(extracted_mol.getNumAtoms());
+    for (const auto& atom : extracted_mol.atoms()) {
+        extracted_atoms[atom->getIdx()] = atom;
+    }
+
+    std::vector<::RDKit::Bond*> extracted_bonds(extracted_mol.getNumBonds());
+    for (const auto& bond : extracted_mol.bonds()) {
+        extracted_bonds[bond->getIdx()] = bond;
+    }
+
+    const auto& [selected_atoms, selected_bonds, atom_mapping, bond_mapping] =
+        selection_info;
+    std::vector<::RDKit::StereoGroup> extracted_stereo_groups;
+    for (const auto& stereo_group : reference_mol.getStereoGroups()) {
+        if (!is_selected_stereo_group(stereo_group)) {
+            continue;
+        }
+
+        std::vector<::RDKit::Atom*> atoms;
+        for (const auto& atom : stereo_group.getAtoms()) {
+            atoms.push_back(extracted_atoms[atom_mapping.at(atom->getIdx())]);
+        }
+
+        std::vector<::RDKit::Bond*> bonds;
+        for (const auto& bond : stereo_group.getBonds()) {
+            bonds.push_back(extracted_bonds[bond_mapping.at(bond->getIdx())]);
+        }
+
+        extracted_stereo_groups.push_back({stereo_group.getGroupType(),
+                                           std::move(atoms), std::move(bonds),
+                                           stereo_group.getReadId()});
+        extracted_stereo_groups.back().setWriteId(stereo_group.getWriteId());
+    }
+
+    extracted_mol.setStereoGroups(std::move(extracted_stereo_groups));
+}
+
+boost::shared_ptr<RDKit::RWMol>
+ExtractMolFragment(const RDKit::ROMol& mol,
+                   const std::vector<unsigned int>& atom_ids, bool sanitize)
+{
+
+    const auto num_atoms = mol.getNumAtoms();
+    SelectedAtomInfo selection_info{.selected_atoms=std::vector<bool>(num_atoms),
+                                    .selected_bonds=std::vector<bool>(mol.getNumBonds()),
+                                    .atom_mapping={},
+                                    .bond_mapping={}};
+    auto& [selected_atoms, selected_bonds, atom_mapping, bond_mapping] =
+        selection_info;
+    for (const auto& atom_idx : atom_ids) {
+        if (atom_idx < num_atoms) {
+            selected_atoms[atom_idx] = true;
+        }
+    }
+    for (const auto& bond : mol.bonds()) {
+        if (selected_atoms[bond->getBeginAtomIdx()] &&
+            selected_atoms[bond->getEndAtomIdx()]) {
+            selected_bonds[bond->getIdx()] = true;
+        }
+    }
+
+    auto extracted_mol = std::make_unique<::RDKit::RWMol>();
+    copySelectedAtomsAndBonds(*extracted_mol, mol, selection_info);
+    copySelectedSubstanceGroups(*extracted_mol, mol, selection_info);
+    copySelectedStereoGroups(*extracted_mol, mol, selection_info);
+    if (sanitize) {
+        ::RDKit::MolOps::sanitizeMol(*extracted_mol);
+    }
+
+    // NOTE: Bookmarks are currently not copied
+    return extracted_mol;
+}
+
 }  // end of namespace MolOps
 }  // end of namespace RDKit

--- a/Code/GraphMol/MolOps.cpp
+++ b/Code/GraphMol/MolOps.cpp
@@ -50,10 +50,10 @@ namespace {
 
 // Helper api to hold atom selection data for ExtractMolFragment
 struct [[nodiscard]] SelectedAtomInfo {
-    std::vector<bool> selected_atoms;
-    std::vector<bool> selected_bonds;
-    std::unordered_map<unsigned int, unsigned int> atom_mapping;
-    std::unordered_map<unsigned int, unsigned int> bond_mapping;
+  std::vector<bool> selected_atoms;
+  std::vector<bool> selected_bonds;
+  std::unordered_map<unsigned int, unsigned int> atom_mapping;
+  std::unordered_map<unsigned int, unsigned int> bond_mapping;
 };
 
 void nitrogenCleanup(RWMol &mol, Atom *atom) {
@@ -110,7 +110,7 @@ void nitrogenCleanup(RWMol &mol, Atom *atom) {
         break;
       }
     }  // end of loop over the first neigh
-  }  // if this atom is 5 coordinate nitrogen
+  }    // if this atom is 5 coordinate nitrogen
   // force a recalculation of the explicit valence here
   atom->setIsAromatic(aromHolder);
   atom->calcExplicitValence(false);
@@ -1347,188 +1347,179 @@ void collapseAttachmentPoints(RWMol &mol, bool markedOnly) {
   }
 }
 
-static void copySelectedAtomsAndBonds(::RDKit::RWMol& extracted_mol,
-                                          const RDKit::ROMol& reference_mol,
-                                          SelectedAtomInfo& selection_info)
-{
-    auto& [selected_atoms, selected_bonds, atom_mapping, bond_mapping] =
-        selection_info;
-    for (const auto& ref_atom : reference_mol.atoms()) {
-        if (!selected_atoms[ref_atom->getIdx()]) {
-            continue;
-        }
-
-        std::unique_ptr<::RDKit::Atom> extracted_atom{ref_atom->copy()};
-
-        static constinit bool updateLabel = true;
-        static constinit bool takeOwnership = true;
-        atom_mapping[ref_atom->getIdx()] = extracted_mol.addAtom(
-            extracted_atom.release(), updateLabel, takeOwnership);
+static void copySelectedAtomsAndBonds(::RDKit::RWMol &extracted_mol,
+                                      const RDKit::ROMol &reference_mol,
+                                      SelectedAtomInfo &selection_info) {
+  auto &[selected_atoms, selected_bonds, atom_mapping, bond_mapping] =
+      selection_info;
+  for (const auto &ref_atom : reference_mol.atoms()) {
+    if (!selected_atoms[ref_atom->getIdx()]) {
+      continue;
     }
 
-    for (const auto& ref_bond : reference_mol.bonds()) {
-        if (!selected_bonds[ref_bond->getIdx()]) {
-            continue;
-        }
+    std::unique_ptr<::RDKit::Atom> extracted_atom{ref_atom->copy()};
 
-        std::unique_ptr<::RDKit::Bond> extracted_bond{ref_bond->copy()};
-        extracted_bond->setBeginAtomIdx(
-            atom_mapping[ref_bond->getBeginAtomIdx()]);
-        extracted_bond->setEndAtomIdx(atom_mapping[ref_bond->getEndAtomIdx()]);
+    static constinit bool updateLabel = true;
+    static constinit bool takeOwnership = true;
+    atom_mapping[ref_atom->getIdx()] = extracted_mol.addAtom(
+        extracted_atom.release(), updateLabel, takeOwnership);
+  }
 
-        static constinit bool takeOwnership = true;
-        auto num_bonds =
-            extracted_mol.addBond(extracted_bond.release(), takeOwnership);
-        bond_mapping[ref_bond->getIdx()] = num_bonds - 1;
+  for (const auto &ref_bond : reference_mol.bonds()) {
+    if (!selected_bonds[ref_bond->getIdx()]) {
+      continue;
     }
+
+    std::unique_ptr<::RDKit::Bond> extracted_bond{ref_bond->copy()};
+    extracted_bond->setBeginAtomIdx(atom_mapping[ref_bond->getBeginAtomIdx()]);
+    extracted_bond->setEndAtomIdx(atom_mapping[ref_bond->getEndAtomIdx()]);
+
+    static constinit bool takeOwnership = true;
+    auto num_bonds =
+        extracted_mol.addBond(extracted_bond.release(), takeOwnership);
+    bond_mapping[ref_bond->getIdx()] = num_bonds - 1;
+  }
 }
 
-[[nodiscard]] static bool
-is_selected_sgroup(const ::RDKit::SubstanceGroup& sgroup,
-                   const SelectedAtomInfo& selection_info)
-{
-    auto is_selected_component = [](auto& indices, auto& selection_test) {
-        return indices.empty() ||
-               std::all_of(indices.begin(), indices.end(), selection_test);
-    };
+[[nodiscard]] static bool is_selected_sgroup(
+    const ::RDKit::SubstanceGroup &sgroup,
+    const SelectedAtomInfo &selection_info) {
+  auto is_selected_component = [](auto &indices, auto &selection_test) {
+    return indices.empty() ||
+           std::all_of(indices.begin(), indices.end(), selection_test);
+  };
 
-    // clang-format off
+  // clang-format off
     auto atom_test = [&](int idx) { return selection_info.selected_atoms[idx]; };
     auto bond_test = [&](int idx) { return selection_info.selected_bonds[idx]; };
     return is_selected_component(sgroup.getAtoms(), atom_test) &&
            is_selected_component(sgroup.getBonds(), bond_test) &&
            is_selected_component(sgroup.getParentAtoms(), atom_test);
-    // clang-format on
+  // clang-format on
 }
 
-static void
-copySelectedSubstanceGroups(::RDKit::RWMol& extracted_mol,
-                               const RDKit::ROMol& reference_mol,
-                               const SelectedAtomInfo& selection_info)
-{
-    auto update_indices = [](auto& sgroup, auto getter, auto setter,
-                             auto& mapping) {
-        auto indices = getter(sgroup);
-        std::for_each(indices.begin(), indices.end(),
-                      [&](auto& idx) { idx = mapping.at(idx); });
-        setter(sgroup, std::move(indices));
-    };
+static void copySelectedSubstanceGroups(
+    ::RDKit::RWMol &extracted_mol, const RDKit::ROMol &reference_mol,
+    const SelectedAtomInfo &selection_info) {
+  auto update_indices = [](auto &sgroup, auto getter, auto setter,
+                           auto &mapping) {
+    auto indices = getter(sgroup);
+    std::for_each(indices.begin(), indices.end(),
+                  [&](auto &idx) { idx = mapping.at(idx); });
+    setter(sgroup, std::move(indices));
+  };
 
-    const auto& [selected_atoms, selected_bonds, atom_mapping, bond_mapping] =
-        selection_info;
-    for (const auto& sgroup : ::RDKit::getSubstanceGroups(reference_mol)) {
-        if (!is_selected_sgroup(sgroup, selection_info)) {
-            continue;
-        }
-
-        ::RDKit::SubstanceGroup extracted_sgroup(sgroup);
-        extracted_sgroup.setOwningMol(&extracted_mol);
-
-        update_indices(
-            extracted_sgroup, std::mem_fn(&::RDKit::SubstanceGroup::getAtoms),
-            std::mem_fn(&::RDKit::SubstanceGroup::setAtoms), atom_mapping);
-        update_indices(extracted_sgroup,
-                       std::mem_fn(&::RDKit::SubstanceGroup::getParentAtoms),
-                       std::mem_fn(&::RDKit::SubstanceGroup::setParentAtoms),
-                       atom_mapping);
-        update_indices(
-            extracted_sgroup, std::mem_fn(&::RDKit::SubstanceGroup::getBonds),
-            std::mem_fn(&::RDKit::SubstanceGroup::setBonds), bond_mapping);
-
-        ::RDKit::addSubstanceGroup(extracted_mol, std::move(extracted_sgroup));
+  const auto &[selected_atoms, selected_bonds, atom_mapping, bond_mapping] =
+      selection_info;
+  for (const auto &sgroup : ::RDKit::getSubstanceGroups(reference_mol)) {
+    if (!is_selected_sgroup(sgroup, selection_info)) {
+      continue;
     }
+
+    ::RDKit::SubstanceGroup extracted_sgroup(sgroup);
+    extracted_sgroup.setOwningMol(&extracted_mol);
+
+    update_indices(
+        extracted_sgroup, std::mem_fn(&::RDKit::SubstanceGroup::getAtoms),
+        std::mem_fn(&::RDKit::SubstanceGroup::setAtoms), atom_mapping);
+    update_indices(
+        extracted_sgroup, std::mem_fn(&::RDKit::SubstanceGroup::getParentAtoms),
+        std::mem_fn(&::RDKit::SubstanceGroup::setParentAtoms), atom_mapping);
+    update_indices(
+        extracted_sgroup, std::mem_fn(&::RDKit::SubstanceGroup::getBonds),
+        std::mem_fn(&::RDKit::SubstanceGroup::setBonds), bond_mapping);
+
+    ::RDKit::addSubstanceGroup(extracted_mol, std::move(extracted_sgroup));
+  }
 }
 
-static void
-copySelectedStereoGroups(::RDKit::RWMol& extracted_mol,
-                            const RDKit::ROMol& reference_mol,
-                            const SelectedAtomInfo& selection_info)
-{
-    auto is_selected_component = [](auto& objects, auto& selected_indices) {
-        return objects.empty() ||
-               std::all_of(objects.begin(), objects.end(), [&](auto& object) {
-                   return selected_indices[object->getIdx()];
-               });
-    };
+static void copySelectedStereoGroups(::RDKit::RWMol &extracted_mol,
+                                     const RDKit::ROMol &reference_mol,
+                                     const SelectedAtomInfo &selection_info) {
+  auto is_selected_component = [](auto &objects, auto &selected_indices) {
+    return objects.empty() ||
+           std::all_of(objects.begin(), objects.end(), [&](auto &object) {
+             return selected_indices[object->getIdx()];
+           });
+  };
 
-    auto is_selected_stereo_group = [&](const auto& stereo_group) {
-        return is_selected_component(stereo_group.getAtoms(),
-                                     selection_info.selected_atoms) &&
-               is_selected_component(stereo_group.getBonds(),
-                                     selection_info.selected_bonds);
-    };
+  auto is_selected_stereo_group = [&](const auto &stereo_group) {
+    return is_selected_component(stereo_group.getAtoms(),
+                                 selection_info.selected_atoms) &&
+           is_selected_component(stereo_group.getBonds(),
+                                 selection_info.selected_bonds);
+  };
 
-    std::vector<::RDKit::Atom*> extracted_atoms(extracted_mol.getNumAtoms());
-    for (const auto& atom : extracted_mol.atoms()) {
-        extracted_atoms[atom->getIdx()] = atom;
+  std::vector<::RDKit::Atom *> extracted_atoms(extracted_mol.getNumAtoms());
+  for (const auto &atom : extracted_mol.atoms()) {
+    extracted_atoms[atom->getIdx()] = atom;
+  }
+
+  std::vector<::RDKit::Bond *> extracted_bonds(extracted_mol.getNumBonds());
+  for (const auto &bond : extracted_mol.bonds()) {
+    extracted_bonds[bond->getIdx()] = bond;
+  }
+
+  const auto &[selected_atoms, selected_bonds, atom_mapping, bond_mapping] =
+      selection_info;
+  std::vector<::RDKit::StereoGroup> extracted_stereo_groups;
+  for (const auto &stereo_group : reference_mol.getStereoGroups()) {
+    if (!is_selected_stereo_group(stereo_group)) {
+      continue;
     }
 
-    std::vector<::RDKit::Bond*> extracted_bonds(extracted_mol.getNumBonds());
-    for (const auto& bond : extracted_mol.bonds()) {
-        extracted_bonds[bond->getIdx()] = bond;
+    std::vector<::RDKit::Atom *> atoms;
+    for (const auto &atom : stereo_group.getAtoms()) {
+      atoms.push_back(extracted_atoms[atom_mapping.at(atom->getIdx())]);
     }
 
-    const auto& [selected_atoms, selected_bonds, atom_mapping, bond_mapping] =
-        selection_info;
-    std::vector<::RDKit::StereoGroup> extracted_stereo_groups;
-    for (const auto& stereo_group : reference_mol.getStereoGroups()) {
-        if (!is_selected_stereo_group(stereo_group)) {
-            continue;
-        }
-
-        std::vector<::RDKit::Atom*> atoms;
-        for (const auto& atom : stereo_group.getAtoms()) {
-            atoms.push_back(extracted_atoms[atom_mapping.at(atom->getIdx())]);
-        }
-
-        std::vector<::RDKit::Bond*> bonds;
-        for (const auto& bond : stereo_group.getBonds()) {
-            bonds.push_back(extracted_bonds[bond_mapping.at(bond->getIdx())]);
-        }
-
-        extracted_stereo_groups.push_back({stereo_group.getGroupType(),
-                                           std::move(atoms), std::move(bonds),
-                                           stereo_group.getReadId()});
-        extracted_stereo_groups.back().setWriteId(stereo_group.getWriteId());
+    std::vector<::RDKit::Bond *> bonds;
+    for (const auto &bond : stereo_group.getBonds()) {
+      bonds.push_back(extracted_bonds[bond_mapping.at(bond->getIdx())]);
     }
 
-    extracted_mol.setStereoGroups(std::move(extracted_stereo_groups));
+    extracted_stereo_groups.push_back({stereo_group.getGroupType(),
+                                       std::move(atoms), std::move(bonds),
+                                       stereo_group.getReadId()});
+    extracted_stereo_groups.back().setWriteId(stereo_group.getWriteId());
+  }
+
+  extracted_mol.setStereoGroups(std::move(extracted_stereo_groups));
 }
 
-boost::shared_ptr<RDKit::RWMol>
-ExtractMolFragment(const RDKit::ROMol& mol,
-                   const std::vector<unsigned int>& atom_ids, bool sanitize)
-{
-
-    const auto num_atoms = mol.getNumAtoms();
-    SelectedAtomInfo selection_info{.selected_atoms=std::vector<bool>(num_atoms),
-                                    .selected_bonds=std::vector<bool>(mol.getNumBonds()),
-                                    .atom_mapping={},
-                                    .bond_mapping={}};
-    auto& [selected_atoms, selected_bonds, atom_mapping, bond_mapping] =
-        selection_info;
-    for (const auto& atom_idx : atom_ids) {
-        if (atom_idx < num_atoms) {
-            selected_atoms[atom_idx] = true;
-        }
+boost::shared_ptr<RDKit::RWMol> ExtractMolFragment(
+    const RDKit::ROMol &mol, const std::vector<unsigned int> &atom_ids,
+    bool sanitize) {
+  const auto num_atoms = mol.getNumAtoms();
+  SelectedAtomInfo selection_info{
+      .selected_atoms = std::vector<bool>(num_atoms),
+      .selected_bonds = std::vector<bool>(mol.getNumBonds()),
+      .atom_mapping = {},
+      .bond_mapping = {}};
+  auto &[selected_atoms, selected_bonds, atom_mapping, bond_mapping] =
+      selection_info;
+  for (const auto &atom_idx : atom_ids) {
+    if (atom_idx < num_atoms) {
+      selected_atoms[atom_idx] = true;
     }
-    for (const auto& bond : mol.bonds()) {
-        if (selected_atoms[bond->getBeginAtomIdx()] &&
-            selected_atoms[bond->getEndAtomIdx()]) {
-            selected_bonds[bond->getIdx()] = true;
-        }
+  }
+  for (const auto &bond : mol.bonds()) {
+    if (selected_atoms[bond->getBeginAtomIdx()] &&
+        selected_atoms[bond->getEndAtomIdx()]) {
+      selected_bonds[bond->getIdx()] = true;
     }
+  }
 
-    auto extracted_mol = std::make_unique<::RDKit::RWMol>();
-    copySelectedAtomsAndBonds(*extracted_mol, mol, selection_info);
-    copySelectedSubstanceGroups(*extracted_mol, mol, selection_info);
-    copySelectedStereoGroups(*extracted_mol, mol, selection_info);
-    if (sanitize) {
-        ::RDKit::MolOps::sanitizeMol(*extracted_mol);
-    }
+  auto extracted_mol = std::make_unique<::RDKit::RWMol>();
+  copySelectedAtomsAndBonds(*extracted_mol, mol, selection_info);
+  copySelectedSubstanceGroups(*extracted_mol, mol, selection_info);
+  copySelectedStereoGroups(*extracted_mol, mol, selection_info);
+  if (sanitize) {
+    ::RDKit::MolOps::sanitizeMol(*extracted_mol);
+  }
 
-    // NOTE: Bookmarks are currently not copied
-    return extracted_mol;
+  // NOTE: Bookmarks are currently not copied
+  return extracted_mol;
 }
 
 }  // end of namespace MolOps

--- a/Code/GraphMol/MolOps.h
+++ b/Code/GraphMol/MolOps.h
@@ -297,16 +297,17 @@ RDKIT_GRAPHMOL_EXPORT void setTerminalAtomCoords(ROMol &mol, unsigned int idx,
        - the caller is responsible for <tt>delete</tt>ing the pointer this
    returns.
 */
-[[deprecated("Please use the version with RemoveHsParameters")]]
-RDKIT_GRAPHMOL_EXPORT ROMol *removeHs(const ROMol &mol, bool implicitOnly,
-                                      bool updateExplicitCount = false,
-                                      bool sanitize = true);
+[[deprecated(
+    "Please use the version with RemoveHsParameters")]] RDKIT_GRAPHMOL_EXPORT
+    ROMol *
+    removeHs(const ROMol &mol, bool implicitOnly,
+             bool updateExplicitCount = false, bool sanitize = true);
 //! \overload
 /// modifies the molecule in place
-[[deprecated("Please use the version with RemoveHsParameters")]]
-RDKIT_GRAPHMOL_EXPORT void removeHs(RWMol &mol, bool implicitOnly,
-                                    bool updateExplicitCount = false,
-                                    bool sanitize = true);
+[[deprecated(
+    "Please use the version with RemoveHsParameters")]] RDKIT_GRAPHMOL_EXPORT void
+removeHs(RWMol &mol, bool implicitOnly, bool updateExplicitCount = false,
+         bool sanitize = true);
 struct RDKIT_GRAPHMOL_EXPORT RemoveHsParameters {
   bool removeDegreeZero = false;    /**< hydrogens that have no bonds */
   bool removeHigherDegrees = false; /**< hydrogens with two (or more) bonds */
@@ -1375,10 +1376,9 @@ RDKIT_GRAPHMOL_EXPORT bool isAttachmentPoint(const Atom *atom,
  * NOTE: Bookmarks are currently not copied
  *
  */
-RDKIT_GRAPHMOL_EXPORT boost::shared_ptr<RDKit::RWMol>
-ExtractMolFragment(const RDKit::ROMol& mol,
-                   const std::vector<unsigned int>& atom_ids,
-                   bool sanitize = true);
+RDKIT_GRAPHMOL_EXPORT boost::shared_ptr<RDKit::RWMol> ExtractMolFragment(
+    const RDKit::ROMol &mol, const std::vector<unsigned int> &atom_ids,
+    bool sanitize = true);
 
 }  // namespace MolOps
 }  // namespace RDKit

--- a/Code/GraphMol/MolOps.h
+++ b/Code/GraphMol/MolOps.h
@@ -1361,6 +1361,25 @@ RDKIT_GRAPHMOL_EXPORT bool isAttachmentPoint(const Atom *atom,
 
 }  // namespace details
 
+//!
+/*
+ * Helper api to extract a subgraph from an ROMol. Bonds, substance groups and
+ * stereo groups are only extracted to the subgraph if all participant atoms
+ * are selected by the `atom_ids` parameter.
+ *
+ * @param mol starting mol
+ * @param atom_ids the indices of atoms to extract. If an atom index falls
+ *                 outside of the acceptable atom indices, it is ignored.
+ * @param sanitize whether to sanitize the extracted mol.
+ *
+ * NOTE: Bookmarks are currently not copied
+ *
+ */
+RDKIT_GRAPHMOL_EXPORT boost::shared_ptr<RDKit::RWMol>
+ExtractMolFragment(const RDKit::ROMol& mol,
+                   const std::vector<unsigned int>& atom_ids,
+                   bool sanitize = true);
+
 }  // namespace MolOps
 }  // namespace RDKit
 

--- a/Code/GraphMol/catch_molops.cpp
+++ b/Code/GraphMol/catch_molops.cpp
@@ -416,3 +416,246 @@ M  END)CTAB";
           Bond::BondType::SINGLE);
   }
 }
+
+// helper api to get test data for ExtractMolFragment
+struct SelectedComponents {
+  std::vector<bool> selected_atoms;
+  std::vector<bool> selected_bonds;
+};
+
+// helper api to get test mol for ExtractMolFragment api.
+[[nodiscard]] static std::unique_ptr<RDKit::RWMol> get_test_mol()
+{
+  std::unique_ptr<RDKit::RWMol> mol{RDKit::SmilesToMol("CCCCCCCCCCCCCCC")};
+  for (auto& atom : mol->atoms()) {
+    atom->setProp("orig_idx", atom->getIdx());
+  }
+
+  for (auto& bond : mol->bonds()) {
+    bond->setProp("orig_idx", bond->getIdx());
+  }
+
+  return mol;
+}
+
+// Helper api to get the included atoms and bonds from test atom indices.
+[[nodiscard]] static SelectedComponents
+get_selected_components(::RDKit::RWMol& mol,
+		                        const std::vector<unsigned int>& atom_ids)
+{
+  const auto num_atoms = mol.getNumAtoms();
+  std::vector<bool> selected_atoms(num_atoms);
+
+  for (auto& atom_idx : atom_ids) {
+    if (atom_idx < num_atoms) {
+      selected_atoms[atom_idx] = true;
+    }
+  }
+
+  std::vector<bool> selected_bonds(mol.getNumBonds());
+  for (auto& bond : mol.bonds()) {
+    if (selected_atoms[bond->getBeginAtomIdx()] &&
+      selected_atoms[bond->getEndAtomIdx()]) {
+      selected_bonds[bond->getIdx()] = true;
+    }
+  }
+
+  return {std::move(selected_atoms), std::move(selected_bonds)};
+}
+
+// This test makes sure we correctly extract atoms
+TEST_CASE("test_extract_atoms", "[ExtractMolFragment]") {
+  auto selected_atoms = GENERATE(
+    // unique values
+    std::vector<unsigned int>{0, 2, 4, 6, 8, 10, 12},
+    // duplicate values
+    std::vector<unsigned int>{0, 0, 2, 2, 4, 4, 6, 6, 8, 8, 10, 10, 12, 12},
+    // values outside of atom indices
+    std::vector<unsigned int>{0, 2, 4, 6, 8, 10, 12, 100, 200, 300}
+  );
+
+  std::vector<unsigned int> expected_atoms{0, 2, 4, 6, 8, 10, 12};
+
+  auto mol = get_test_mol();
+  auto extracted_mol = MolOps::ExtractMolFragment(*mol, selected_atoms);
+  REQUIRE(extracted_mol->getNumAtoms() == expected_atoms.size());
+
+  std::vector<unsigned int> extracted_atoms;
+  for (auto& atom : extracted_mol->atoms()) {
+    extracted_atoms.push_back(atom->template getProp<unsigned int>("orig_idx"));
+  }
+
+  CHECK(extracted_atoms == expected_atoms);
+}
+
+// This test makes sure we correctly extract atoms
+TEST_CASE("test_extract_bonds", "[ExtractMolFragment]")
+{
+  auto test_mol = get_test_mol();
+
+  for (auto& bond : test_mol->bonds()) {
+    bond->setProp("test_prop", true);
+  }
+
+  for (auto& bond : test_mol->bonds()) {
+    auto begin_idx = bond->getBeginAtomIdx();
+    auto end_idx = bond->getEndAtomIdx();
+    auto m = MolOps::ExtractMolFragment(*test_mol, {begin_idx, end_idx});
+
+    REQUIRE(m->getNumBonds() == 1);
+    CHECK(m->getBondWithIdx(0)->getProp<bool>("test_prop") == true);
+    CHECK(m->getNumAtoms() == 2);
+    CHECK(m->getAtomWithIdx(0)->getProp<unsigned int>("orig_idx") == begin_idx);
+    CHECK(m->getAtomWithIdx(1)->getProp<unsigned int>("orig_idx") == end_idx);
+  }
+}
+
+// This test makes sure we correctly extract substance groups
+TEST_CASE("test_extract_substance_groups", "[ExtractMolFragment]") {
+  auto mol = get_test_mol();
+  ::RDKit::SubstanceGroup sgroup{mol.get(), "COP"};
+
+  auto test_sgroup_atoms = GENERATE(
+     std::vector<unsigned int>{},
+     std::vector<unsigned int>{0, 1, 2, 3, 4},
+     std::vector<unsigned int>{9, 10, 11}
+  );
+  sgroup.setAtoms(test_sgroup_atoms);
+
+  auto test_sgroup_bonds = GENERATE(
+     std::vector<unsigned int>{},
+     std::vector<unsigned int>{0, 1, 2},
+     std::vector<unsigned int>{3, 4, 5}
+  );
+  sgroup.setBonds(test_sgroup_bonds);
+
+  auto test_sgroup_patoms = GENERATE(
+     std::vector<unsigned int>{},
+     std::vector<unsigned int>{3, 4},
+     std::vector<unsigned int>{5, 6}
+  );
+  sgroup.setParentAtoms(test_sgroup_patoms);
+
+  ::RDKit::addSubstanceGroup(*mol, std::move(sgroup));
+
+  auto has_selected_components = [&](auto& components, auto& ref_bitset) {
+   return components.empty() ||
+     std::ranges::all_of(components, [&](auto& idx) {
+         return idx < ref_bitset.size() && ref_bitset[idx];
+       });
+  };
+
+  auto test_selected_atoms = GENERATE(
+     std::vector<unsigned int>{0, 1, 2, 3, 4, 5},
+     std::vector<unsigned int>{0, 2, 4, 6, 8, 10, 12},
+     std::vector<unsigned int>{0, 0, 2, 2, 4, 4, 6, 6, 8, 8, 10, 10, 12, 12},
+     std::vector<unsigned int>{0, 2, 4, 6, 8, 10, 12, 100, 200, 300}
+  );
+
+  auto extracted_mol = MolOps::ExtractMolFragment(*mol, test_selected_atoms);
+
+  auto [selected_atoms, selected_bonds] = get_selected_components(*mol, test_selected_atoms);
+  // sgroup should only be copied if all components are selected
+  auto flag = ::RDKit::getSubstanceGroups(*extracted_mol).size() == 1;
+  REQUIRE(flag ==
+             (has_selected_components(test_sgroup_atoms, selected_atoms) &&
+              has_selected_components(test_sgroup_patoms, selected_atoms) &&
+              has_selected_components(test_sgroup_bonds, selected_bonds)));
+
+  // now make sure we copied the correct components
+  if (flag) {
+      auto& extracted_sgroup = ::RDKit::getSubstanceGroups(*extracted_mol)[0];
+      for (auto& idx : extracted_sgroup.getAtoms()) {
+          auto atom = extracted_mol->getAtomWithIdx(idx);
+          CHECK(
+              selected_atoms[atom->template getProp<unsigned int>("orig_idx")] ==
+              true);
+      }
+
+      for (auto& idx : extracted_sgroup.getParentAtoms()) {
+          auto atom = extracted_mol->getAtomWithIdx(idx);
+          CHECK(
+              selected_atoms[atom->template getProp<unsigned int>("orig_idx")] ==
+              true);
+      }
+
+      for (auto& idx : extracted_sgroup.getBonds()) {
+          auto bond = extracted_mol->getBondWithIdx(idx);
+          CHECK(
+              selected_bonds[bond->template getProp<unsigned int>("orig_idx")] ==
+              true);
+      }
+  }
+}
+
+// This test makes sure we correctly extract stereo groups
+TEST_CASE("test_extract_stereo_groups", "[ExtractMolFragment]") {
+  auto mol = get_test_mol();
+
+  auto test_stereo_group_atoms = GENERATE(
+     std::vector<unsigned int>{},
+     std::vector<unsigned int>{0, 1, 2, 3, 4},
+     std::vector<unsigned int>{9, 10, 11}
+  );
+
+  std::vector<::RDKit::Atom*> sg_atoms;
+  for (auto& idx : test_stereo_group_atoms) {
+      sg_atoms.push_back(mol->getAtomWithIdx(idx));
+  }
+
+  auto test_stereo_group_bonds = GENERATE(
+     std::vector<unsigned int>{},
+     std::vector<unsigned int>{0, 1, 2},
+     std::vector<unsigned int>{3, 4, 5}
+  );
+
+  std::vector<::RDKit::Bond*> sg_bonds;
+  for (auto& idx : test_stereo_group_bonds) {
+      sg_bonds.push_back(mol->getBondWithIdx(idx));
+  }
+
+  ::RDKit::StereoGroup stereo_group{::RDKit::StereoGroupType::STEREO_ABSOLUTE,
+                                    std::move(sg_atoms), std::move(sg_bonds)};
+  mol->setStereoGroups({std::move(stereo_group)});
+
+  auto has_selected_components = [&](auto& components, auto& ref_bitset) {
+      return components.empty() ||
+             std::ranges::all_of(components, [&](auto& idx) {
+                     return idx < ref_bitset.size() && ref_bitset[idx];
+                 });
+  };
+
+  auto test_selected_atoms = GENERATE(
+     std::vector<unsigned int>{0, 1, 2, 3, 4, 5},
+     std::vector<unsigned int>{0, 2, 4, 6, 8, 10, 12},
+     std::vector<unsigned int>{0, 0, 2, 2, 4, 4, 6, 6, 8, 8, 10, 10, 12, 12},
+     std::vector<unsigned int>{0, 2, 4, 6, 8, 10, 12, 100, 200, 300}
+  );
+
+  auto extracted_mol = MolOps::ExtractMolFragment(*mol, test_selected_atoms);
+
+  auto [selected_atoms, selected_bonds] =
+      get_selected_components(*mol, test_selected_atoms);
+
+  // stereo group should only be copied if all components are selected
+  auto flag = extracted_mol->getStereoGroups().size() == 1;
+  REQUIRE(flag ==
+             (has_selected_components(test_stereo_group_atoms, selected_atoms) &&
+              has_selected_components(test_stereo_group_bonds, selected_bonds)));
+
+  // now make sure we copied the correct components
+  if (flag) {
+      auto& extracted_stereo_group = extracted_mol->getStereoGroups()[0];
+      for (auto& atom : extracted_stereo_group.getAtoms()) {
+          CHECK(
+              selected_atoms[atom->template getProp<int>("orig_idx")] ==
+              true);
+      }
+
+      for (auto& bond : extracted_stereo_group.getBonds()) {
+          CHECK(
+              selected_bonds[bond->template getProp<int>("orig_idx")] ==
+              true);
+      }
+  }
+}

--- a/Code/GraphMol/catch_molops.cpp
+++ b/Code/GraphMol/catch_molops.cpp
@@ -424,14 +424,13 @@ struct SelectedComponents {
 };
 
 // helper api to get test mol for ExtractMolFragment api.
-[[nodiscard]] static std::unique_ptr<RDKit::RWMol> get_test_mol()
-{
+[[nodiscard]] static std::unique_ptr<RDKit::RWMol> get_test_mol() {
   std::unique_ptr<RDKit::RWMol> mol{RDKit::SmilesToMol("CCCCCCCCCCCCCCC")};
-  for (auto& atom : mol->atoms()) {
+  for (auto &atom : mol->atoms()) {
     atom->setProp("orig_idx", atom->getIdx());
   }
 
-  for (auto& bond : mol->bonds()) {
+  for (auto &bond : mol->bonds()) {
     bond->setProp("orig_idx", bond->getIdx());
   }
 
@@ -439,23 +438,21 @@ struct SelectedComponents {
 }
 
 // Helper api to get the included atoms and bonds from test atom indices.
-[[nodiscard]] static SelectedComponents
-get_selected_components(::RDKit::RWMol& mol,
-		                        const std::vector<unsigned int>& atom_ids)
-{
+[[nodiscard]] static SelectedComponents get_selected_components(
+    ::RDKit::RWMol &mol, const std::vector<unsigned int> &atom_ids) {
   const auto num_atoms = mol.getNumAtoms();
   std::vector<bool> selected_atoms(num_atoms);
 
-  for (auto& atom_idx : atom_ids) {
+  for (auto &atom_idx : atom_ids) {
     if (atom_idx < num_atoms) {
       selected_atoms[atom_idx] = true;
     }
   }
 
   std::vector<bool> selected_bonds(mol.getNumBonds());
-  for (auto& bond : mol.bonds()) {
+  for (auto &bond : mol.bonds()) {
     if (selected_atoms[bond->getBeginAtomIdx()] &&
-      selected_atoms[bond->getEndAtomIdx()]) {
+        selected_atoms[bond->getEndAtomIdx()]) {
       selected_bonds[bond->getIdx()] = true;
     }
   }
@@ -466,13 +463,12 @@ get_selected_components(::RDKit::RWMol& mol,
 // This test makes sure we correctly extract atoms
 TEST_CASE("test_extract_atoms", "[ExtractMolFragment]") {
   auto selected_atoms = GENERATE(
-    // unique values
-    std::vector<unsigned int>{0, 2, 4, 6, 8, 10, 12},
-    // duplicate values
-    std::vector<unsigned int>{0, 0, 2, 2, 4, 4, 6, 6, 8, 8, 10, 10, 12, 12},
-    // values outside of atom indices
-    std::vector<unsigned int>{0, 2, 4, 6, 8, 10, 12, 100, 200, 300}
-  );
+      // unique values
+      std::vector<unsigned int>{0, 2, 4, 6, 8, 10, 12},
+      // duplicate values
+      std::vector<unsigned int>{0, 0, 2, 2, 4, 4, 6, 6, 8, 8, 10, 10, 12, 12},
+      // values outside of atom indices
+      std::vector<unsigned int>{0, 2, 4, 6, 8, 10, 12, 100, 200, 300});
 
   std::vector<unsigned int> expected_atoms{0, 2, 4, 6, 8, 10, 12};
 
@@ -481,7 +477,7 @@ TEST_CASE("test_extract_atoms", "[ExtractMolFragment]") {
   REQUIRE(extracted_mol->getNumAtoms() == expected_atoms.size());
 
   std::vector<unsigned int> extracted_atoms;
-  for (auto& atom : extracted_mol->atoms()) {
+  for (auto &atom : extracted_mol->atoms()) {
     extracted_atoms.push_back(atom->template getProp<unsigned int>("orig_idx"));
   }
 
@@ -489,15 +485,14 @@ TEST_CASE("test_extract_atoms", "[ExtractMolFragment]") {
 }
 
 // This test makes sure we correctly extract atoms
-TEST_CASE("test_extract_bonds", "[ExtractMolFragment]")
-{
+TEST_CASE("test_extract_bonds", "[ExtractMolFragment]") {
   auto test_mol = get_test_mol();
 
-  for (auto& bond : test_mol->bonds()) {
+  for (auto &bond : test_mol->bonds()) {
     bond->setProp("test_prop", true);
   }
 
-  for (auto& bond : test_mol->bonds()) {
+  for (auto &bond : test_mol->bonds()) {
     auto begin_idx = bond->getBeginAtomIdx();
     auto end_idx = bond->getEndAtomIdx();
     auto m = MolOps::ExtractMolFragment(*test_mol, {begin_idx, end_idx});
@@ -515,76 +510,67 @@ TEST_CASE("test_extract_substance_groups", "[ExtractMolFragment]") {
   auto mol = get_test_mol();
   ::RDKit::SubstanceGroup sgroup{mol.get(), "COP"};
 
-  auto test_sgroup_atoms = GENERATE(
-     std::vector<unsigned int>{},
-     std::vector<unsigned int>{0, 1, 2, 3, 4},
-     std::vector<unsigned int>{9, 10, 11}
-  );
+  auto test_sgroup_atoms = GENERATE(std::vector<unsigned int>{},
+                                    std::vector<unsigned int>{0, 1, 2, 3, 4},
+                                    std::vector<unsigned int>{9, 10, 11});
   sgroup.setAtoms(test_sgroup_atoms);
 
-  auto test_sgroup_bonds = GENERATE(
-     std::vector<unsigned int>{},
-     std::vector<unsigned int>{0, 1, 2},
-     std::vector<unsigned int>{3, 4, 5}
-  );
+  auto test_sgroup_bonds =
+      GENERATE(std::vector<unsigned int>{}, std::vector<unsigned int>{0, 1, 2},
+               std::vector<unsigned int>{3, 4, 5});
   sgroup.setBonds(test_sgroup_bonds);
 
-  auto test_sgroup_patoms = GENERATE(
-     std::vector<unsigned int>{},
-     std::vector<unsigned int>{3, 4},
-     std::vector<unsigned int>{5, 6}
-  );
+  auto test_sgroup_patoms =
+      GENERATE(std::vector<unsigned int>{}, std::vector<unsigned int>{3, 4},
+               std::vector<unsigned int>{5, 6});
   sgroup.setParentAtoms(test_sgroup_patoms);
 
   ::RDKit::addSubstanceGroup(*mol, std::move(sgroup));
 
-  auto has_selected_components = [&](auto& components, auto& ref_bitset) {
-   return components.empty() ||
-     std::ranges::all_of(components, [&](auto& idx) {
-         return idx < ref_bitset.size() && ref_bitset[idx];
-       });
+  auto has_selected_components = [&](auto &components, auto &ref_bitset) {
+    return components.empty() ||
+           std::ranges::all_of(components, [&](auto &idx) {
+             return idx < ref_bitset.size() && ref_bitset[idx];
+           });
   };
 
   auto test_selected_atoms = GENERATE(
-     std::vector<unsigned int>{0, 1, 2, 3, 4, 5},
-     std::vector<unsigned int>{0, 2, 4, 6, 8, 10, 12},
-     std::vector<unsigned int>{0, 0, 2, 2, 4, 4, 6, 6, 8, 8, 10, 10, 12, 12},
-     std::vector<unsigned int>{0, 2, 4, 6, 8, 10, 12, 100, 200, 300}
-  );
+      std::vector<unsigned int>{0, 1, 2, 3, 4, 5},
+      std::vector<unsigned int>{0, 2, 4, 6, 8, 10, 12},
+      std::vector<unsigned int>{0, 0, 2, 2, 4, 4, 6, 6, 8, 8, 10, 10, 12, 12},
+      std::vector<unsigned int>{0, 2, 4, 6, 8, 10, 12, 100, 200, 300});
 
   auto extracted_mol = MolOps::ExtractMolFragment(*mol, test_selected_atoms);
 
-  auto [selected_atoms, selected_bonds] = get_selected_components(*mol, test_selected_atoms);
+  auto [selected_atoms, selected_bonds] =
+      get_selected_components(*mol, test_selected_atoms);
   // sgroup should only be copied if all components are selected
   auto flag = ::RDKit::getSubstanceGroups(*extracted_mol).size() == 1;
   REQUIRE(flag ==
-             (has_selected_components(test_sgroup_atoms, selected_atoms) &&
-              has_selected_components(test_sgroup_patoms, selected_atoms) &&
-              has_selected_components(test_sgroup_bonds, selected_bonds)));
+          (has_selected_components(test_sgroup_atoms, selected_atoms) &&
+           has_selected_components(test_sgroup_patoms, selected_atoms) &&
+           has_selected_components(test_sgroup_bonds, selected_bonds)));
 
   // now make sure we copied the correct components
   if (flag) {
-      auto& extracted_sgroup = ::RDKit::getSubstanceGroups(*extracted_mol)[0];
-      for (auto& idx : extracted_sgroup.getAtoms()) {
-          auto atom = extracted_mol->getAtomWithIdx(idx);
-          CHECK(
-              selected_atoms[atom->template getProp<unsigned int>("orig_idx")] ==
-              true);
-      }
+    auto &extracted_sgroup = ::RDKit::getSubstanceGroups(*extracted_mol)[0];
+    for (auto &idx : extracted_sgroup.getAtoms()) {
+      auto atom = extracted_mol->getAtomWithIdx(idx);
+      CHECK(selected_atoms[atom->template getProp<unsigned int>("orig_idx")] ==
+            true);
+    }
 
-      for (auto& idx : extracted_sgroup.getParentAtoms()) {
-          auto atom = extracted_mol->getAtomWithIdx(idx);
-          CHECK(
-              selected_atoms[atom->template getProp<unsigned int>("orig_idx")] ==
-              true);
-      }
+    for (auto &idx : extracted_sgroup.getParentAtoms()) {
+      auto atom = extracted_mol->getAtomWithIdx(idx);
+      CHECK(selected_atoms[atom->template getProp<unsigned int>("orig_idx")] ==
+            true);
+    }
 
-      for (auto& idx : extracted_sgroup.getBonds()) {
-          auto bond = extracted_mol->getBondWithIdx(idx);
-          CHECK(
-              selected_bonds[bond->template getProp<unsigned int>("orig_idx")] ==
-              true);
-      }
+    for (auto &idx : extracted_sgroup.getBonds()) {
+      auto bond = extracted_mol->getBondWithIdx(idx);
+      CHECK(selected_bonds[bond->template getProp<unsigned int>("orig_idx")] ==
+            true);
+    }
   }
 }
 
@@ -593,44 +579,39 @@ TEST_CASE("test_extract_stereo_groups", "[ExtractMolFragment]") {
   auto mol = get_test_mol();
 
   auto test_stereo_group_atoms = GENERATE(
-     std::vector<unsigned int>{},
-     std::vector<unsigned int>{0, 1, 2, 3, 4},
-     std::vector<unsigned int>{9, 10, 11}
-  );
+      std::vector<unsigned int>{}, std::vector<unsigned int>{0, 1, 2, 3, 4},
+      std::vector<unsigned int>{9, 10, 11});
 
-  std::vector<::RDKit::Atom*> sg_atoms;
-  for (auto& idx : test_stereo_group_atoms) {
-      sg_atoms.push_back(mol->getAtomWithIdx(idx));
+  std::vector<::RDKit::Atom *> sg_atoms;
+  for (auto &idx : test_stereo_group_atoms) {
+    sg_atoms.push_back(mol->getAtomWithIdx(idx));
   }
 
-  auto test_stereo_group_bonds = GENERATE(
-     std::vector<unsigned int>{},
-     std::vector<unsigned int>{0, 1, 2},
-     std::vector<unsigned int>{3, 4, 5}
-  );
+  auto test_stereo_group_bonds =
+      GENERATE(std::vector<unsigned int>{}, std::vector<unsigned int>{0, 1, 2},
+               std::vector<unsigned int>{3, 4, 5});
 
-  std::vector<::RDKit::Bond*> sg_bonds;
-  for (auto& idx : test_stereo_group_bonds) {
-      sg_bonds.push_back(mol->getBondWithIdx(idx));
+  std::vector<::RDKit::Bond *> sg_bonds;
+  for (auto &idx : test_stereo_group_bonds) {
+    sg_bonds.push_back(mol->getBondWithIdx(idx));
   }
 
   ::RDKit::StereoGroup stereo_group{::RDKit::StereoGroupType::STEREO_ABSOLUTE,
                                     std::move(sg_atoms), std::move(sg_bonds)};
   mol->setStereoGroups({std::move(stereo_group)});
 
-  auto has_selected_components = [&](auto& components, auto& ref_bitset) {
-      return components.empty() ||
-             std::ranges::all_of(components, [&](auto& idx) {
-                     return idx < ref_bitset.size() && ref_bitset[idx];
-                 });
+  auto has_selected_components = [&](auto &components, auto &ref_bitset) {
+    return components.empty() ||
+           std::ranges::all_of(components, [&](auto &idx) {
+             return idx < ref_bitset.size() && ref_bitset[idx];
+           });
   };
 
   auto test_selected_atoms = GENERATE(
-     std::vector<unsigned int>{0, 1, 2, 3, 4, 5},
-     std::vector<unsigned int>{0, 2, 4, 6, 8, 10, 12},
-     std::vector<unsigned int>{0, 0, 2, 2, 4, 4, 6, 6, 8, 8, 10, 10, 12, 12},
-     std::vector<unsigned int>{0, 2, 4, 6, 8, 10, 12, 100, 200, 300}
-  );
+      std::vector<unsigned int>{0, 1, 2, 3, 4, 5},
+      std::vector<unsigned int>{0, 2, 4, 6, 8, 10, 12},
+      std::vector<unsigned int>{0, 0, 2, 2, 4, 4, 6, 6, 8, 8, 10, 10, 12, 12},
+      std::vector<unsigned int>{0, 2, 4, 6, 8, 10, 12, 100, 200, 300});
 
   auto extracted_mol = MolOps::ExtractMolFragment(*mol, test_selected_atoms);
 
@@ -640,22 +621,18 @@ TEST_CASE("test_extract_stereo_groups", "[ExtractMolFragment]") {
   // stereo group should only be copied if all components are selected
   auto flag = extracted_mol->getStereoGroups().size() == 1;
   REQUIRE(flag ==
-             (has_selected_components(test_stereo_group_atoms, selected_atoms) &&
-              has_selected_components(test_stereo_group_bonds, selected_bonds)));
+          (has_selected_components(test_stereo_group_atoms, selected_atoms) &&
+           has_selected_components(test_stereo_group_bonds, selected_bonds)));
 
   // now make sure we copied the correct components
   if (flag) {
-      auto& extracted_stereo_group = extracted_mol->getStereoGroups()[0];
-      for (auto& atom : extracted_stereo_group.getAtoms()) {
-          CHECK(
-              selected_atoms[atom->template getProp<int>("orig_idx")] ==
-              true);
-      }
+    auto &extracted_stereo_group = extracted_mol->getStereoGroups()[0];
+    for (auto &atom : extracted_stereo_group.getAtoms()) {
+      CHECK(selected_atoms[atom->template getProp<int>("orig_idx")] == true);
+    }
 
-      for (auto& bond : extracted_stereo_group.getBonds()) {
-          CHECK(
-              selected_bonds[bond->template getProp<int>("orig_idx")] ==
-              true);
-      }
+    for (auto &bond : extracted_stereo_group.getBonds()) {
+      CHECK(selected_bonds[bond->template getProp<int>("orig_idx")] == true);
+    }
   }
 }


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! 
-->
#### Reference Issue
Implements #8742


#### What does this implement/fix? Explain your changes.
This adds a new api, `RDKit::MolOps::ExtractMolFragment`, to allow efficient
extractions of mol fragments from large mols. Compared to the approach where
we delete "unwanted" atoms/bonds from the input mol, this api is faster for
small mols (about 2x faster) and at least 3x faster for big mols (was 10x faster for "CCC"*1000).

#### Any other comments?

