### PR TITLE
Document Options in RGroupDcompose and other minor docs fixes

### DIFF
--- a/Code/GraphMol/RGroupDecomposition/Wrap/rdRGroupComposition.cpp
+++ b/Code/GraphMol/RGroupDecomposition/Wrap/rdRGroupComposition.cpp
@@ -398,7 +398,7 @@ struct rgroupdecomp_wrapper {
              "       columns[rgroup_label] = [ mols_or_smiles ]\n");
 
     docString =
-        "Decompose a collecion of molecules into their Rgroups\n"
+        "Decompose a collection of molecules into their Rgroups\n"
         "  ARGUMENTS:\n"
         "    - cores: a set of cores from most to least specific.\n"
         "             See RGroupDecompositionParameters for more details\n"
@@ -408,6 +408,9 @@ struct rgroupdecomp_wrapper {
         "molecules [default: False]\n"
         "    - asRows: return the results as rows (default) otherwise return "
         "columns\n"
+        "    - options: RGroupDecompositionParameters object that defines "
+        "the decomposition.\n"
+        "             See RGroupDecompositionParameters for defaults\n"
         "\n"
         "  RETURNS: row_or_column_results, unmatched\n"
         "\n"

--- a/Code/GraphMol/RGroupDecomposition/Wrap/rdRGroupComposition.cpp
+++ b/Code/GraphMol/RGroupDecomposition/Wrap/rdRGroupComposition.cpp
@@ -224,7 +224,7 @@ struct rgroupdecomp_wrapper {
         .export_values();
 
     python::enum_<RDKit::RGroupCoreAlignment>("RGroupCoreAlignment")
-        // DEPRECATED, remove the folowing line in release 2021.03
+        // DEPRECATED, remove the following line in release 2021.03
         .value("None", RDKit::NoAlignment)
         .value("NoAlignment", RDKit::NoAlignment)
         .value("MCS", RDKit::MCS)
@@ -237,7 +237,7 @@ struct rgroupdecomp_wrapper {
 
     docString =
         "RGroupDecompositionParameters controls how the RGroupDecomposition "
-        "sets labelling and matches structures\n"
+        "sets labeling and matches structures\n"
         "  OPTIONS:\n"
         "    - RGroupCoreAlignment: can be one of RGroupCoreAlignment.None_ or "
         "RGroupCoreAlignment.MCS\n"

--- a/Docs/Book/GettingStartedWithContributing.md
+++ b/Docs/Book/GettingStartedWithContributing.md
@@ -270,8 +270,10 @@ The RDKit docs support inclusion of Sphinx doctests to allow the result of a cod
 
 #### Build the Documentation
 
-To preview your changes to the RDKit documentation, build the docs locally. First set up your development environment by following the instructions in [Building RDKit for Development](#building-rdkit-for-development). Then change to the directory `Docs/Book`:
+To preview your changes to the RDKit documentation, build the docs locally. First set up your development environment by following the instructions in [Building RDKit for Development](#building-rdkit-for-development). Then configure `doxygen` before changing to the directory `Docs/Book`:
   ```
+  # Configure doxygen
+  cd $RDBASE/Code/ && doxygen doxygen/doxygen.config
   cd $RDBASE/Docs/Book
   ```
 

--- a/Docs/Book/Makefile
+++ b/Docs/Book/Makefile
@@ -8,7 +8,7 @@ PAPER         =
 BUILDDIR      = _build
 
 # Created by running doxygen in the $RDBASE/Code directory as follows:
-#  doxygen doxygen.config
+#  doxygen doxygen/doxygen.config
 CPPAPIDOCSHOME   = $(RDBASE)/Code/docs
 
 # Internal variables.

--- a/Docs/Book_jp/Makefile
+++ b/Docs/Book_jp/Makefile
@@ -8,7 +8,7 @@ PAPER         =
 BUILDDIR      = _build
 
 # Created by running doxygen in the $RDBASE/Code directory as follows:
-#  doxygen doxygen.config
+#  doxygen doxygen/doxygen.config
 CPPAPIDOCSHOME   = $(RDBASE)/Code/docs
 
 # Internal variables.


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! 
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->
N/A

#### What does this implement/fix? Explain your changes.
Adds missing parameter in docstring of RGroupDecompose, fixes typos and adds note about configuring doxygen.

