### PR TITLE
Trim spaces from RDProp strings to simulate reading from SDFiles

### DIFF
--- a/Code/GraphMol/Wrap/Atom.cpp
+++ b/Code/GraphMol/Wrap/Atom.cpp
@@ -446,12 +446,12 @@ struct atom_wrapper {
               python::arg("includeComputed") = true,
               python::arg("autoConvertStrings") = true),
              "Returns a dictionary of the properties set on the Atom.\n"
+	     "When possible, string values will be trimmed and converted to integers and doubles\n"
              " n.b. some properties cannot be converted to python types.\n")
 
         .def("UpdatePropertyCache", &Atom::updatePropertyCache,
              (python::arg("self"), python::arg("strict") = true),
-             "Regenerates computed properties like implicit valence and ring "
-             "information.\n\n")
+	     getPropsAsDictDocString.c_str())
 
         .def("NeedsUpdatePropertyCache", &Atom::needsUpdatePropertyCache,
              (python::arg("self")),

--- a/Code/GraphMol/Wrap/Atom.cpp
+++ b/Code/GraphMol/Wrap/Atom.cpp
@@ -445,13 +445,13 @@ struct atom_wrapper {
              (python::arg("self"), python::arg("includePrivate") = true,
               python::arg("includeComputed") = true,
               python::arg("autoConvertStrings") = true),
-             "Returns a dictionary of the properties set on the Atom.\n"
-	     "When possible, string values will be trimmed and converted to integers and doubles\n"
-             " n.b. some properties cannot be converted to python types.\n")
+	     getPropsAsDictDocString.c_str())
 
         .def("UpdatePropertyCache", &Atom::updatePropertyCache,
              (python::arg("self"), python::arg("strict") = true),
-	     getPropsAsDictDocString.c_str())
+	     "Regenerates computed properties like implicit valence and ring "
+             "information.\n\n")
+
 
         .def("NeedsUpdatePropertyCache", &Atom::needsUpdatePropertyCache,
              (python::arg("self")),

--- a/Code/GraphMol/Wrap/Bond.cpp
+++ b/Code/GraphMol/Wrap/Bond.cpp
@@ -301,9 +301,7 @@ struct bond_wrapper {
              (python::arg("self"), python::arg("includePrivate") = true,
               python::arg("includeComputed") = true,
               python::arg("autoConvertStrings") = true),
-             "Returns a dictionary of the properties set on the Bond.\n"
-             " n.b. some properties cannot be converted to python types.\n")
-
+	     getPropsAsDictDocString.c_str())
         ;
 
     python::enum_<Bond::BondType>("BondType")

--- a/Code/GraphMol/Wrap/Conformer.cpp
+++ b/Code/GraphMol/Wrap/Conformer.cpp
@@ -294,17 +294,7 @@ struct conformer_wrapper {
              (python::arg("self"), python::arg("includePrivate") = false,
               python::arg("includeComputed") = false,
               python::arg("autoConvertStrings") = true),
-             "Returns a dictionary populated with the conformer's properties.\n"
-             " n.b. Some properties are not able to be converted to python "
-             "types.\n\n"
-             "  ARGUMENTS:\n"
-             "    - includePrivate: (optional) toggles inclusion of private "
-             "properties in the result set.\n"
-             "                      Defaults to False.\n"
-             "    - includeComputed: (optional) toggles inclusion of computed "
-             "properties in the result set.\n"
-             "                      Defaults to False.\n\n"
-             "  RETURNS: a dictionary\n");
+	     getPropsAsDictDocString.c_str());
   };
 };
 }  // namespace RDKit

--- a/Code/GraphMol/Wrap/Mol.cpp
+++ b/Code/GraphMol/Wrap/Mol.cpp
@@ -797,17 +797,7 @@ struct mol_wrapper {
              (python::arg("self"), python::arg("includePrivate") = false,
               python::arg("includeComputed") = false,
               python::arg("autoConvertStrings") = true),
-             "Returns a dictionary populated with the molecules properties.\n"
-             " n.b. Some properties are not able to be converted to python "
-             "types.\n\n"
-             "  ARGUMENTS:\n"
-             "    - includePrivate: (optional) toggles inclusion of private "
-             "properties in the result set.\n"
-             "                      Defaults to False.\n"
-             "    - includeComputed: (optional) toggles inclusion of computed "
-             "properties in the result set.\n"
-             "                      Defaults to False.\n\n"
-             "  RETURNS: a dictionary\n")
+	     getPropsAsDictDocString.c_str())
 
         .def("GetAromaticAtoms", MolGetAromaticAtoms,
              python::return_value_policy<

--- a/Code/GraphMol/Wrap/props.hpp
+++ b/Code/GraphMol/Wrap/props.hpp
@@ -76,6 +76,20 @@ bool AddToDict(const U &ob, boost::python::dict &dict, const std::string &key) {
   return true;
 }
 
+const std::string getPropsAsDictDocString = "Returns a dictionary populated with the conformer's properties.\n"
+  "When possible, string values will be trimmed and converted to integers and doubles\n"
+  
+  " n.b. Some properties are not able to be converted to python "
+  "types.\n\n"
+  "  ARGUMENTS:\n"
+  "    - includePrivate: (optional) toggles inclusion of private "
+  "properties in the result set.\n"
+  "                      Defaults to False.\n"
+  "    - includeComputed: (optional) toggles inclusion of computed "
+  "properties in the result set.\n"
+  "                      Defaults to False.\n\n"
+  "  RETURNS: a dictionary\n";
+  
 template <class T>
 boost::python::dict GetPropsAsDict(const T &obj, bool includePrivate,
                                    bool includeComputed,

--- a/Code/GraphMol/Wrap/props.hpp
+++ b/Code/GraphMol/Wrap/props.hpp
@@ -36,6 +36,7 @@
 #include <RDBoost/Wrap.h>
 #include <RDGeneral/Dict.h>
 #include <algorithm>
+#include <boost/algorithm/string.hpp>
 
 namespace RDKit {
 
@@ -98,6 +99,7 @@ boost::python::dict GetPropsAsDict(const T &obj, bool includePrivate,
           break;
         case RDTypeTag::StringTag: {
           auto value = from_rdvalue<std::string>(rdvalue.val);
+	  boost::trim(value);
           if (autoConvertStrings) {
             // Auto convert strings to ints and double if possible
             int ivalue;

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -613,7 +613,9 @@ class TestCase(unittest.TestCase):
     m = Chem.MolFromSmiles('C1=CN=CC=C1')
     m.SetProp("int", "1000")
     m.SetProp("double", "10000.123")
-    self.assertEqual(m.GetPropsAsDict(), {"int": 1000, "double": 10000.123})
+    m.SetProp("double spaces", " 10000.123 ")
+    self.assertEqual(m.GetPropsAsDict(), {
+      "int": 1000, "double": 10000.123, "double spaces": 10000.123 })
 
     self.assertEqual(type(m.GetPropsAsDict()['int']), int)
     self.assertEqual(type(m.GetPropsAsDict()['double']), float)

--- a/Code/RDGeneral/RDValue.h
+++ b/Code/RDGeneral/RDValue.h
@@ -39,6 +39,8 @@
 #include "RDValue-taggedunion.h"
 #endif
 
+#include <boost/algorithm/string.hpp>
+
 namespace RDKit {
 //  Common Casts (POD Casts are implementation dependent)
 // string casts
@@ -274,7 +276,11 @@ typename boost::enable_if<boost::is_arithmetic<T>, T>::type from_rdvalue(
       res = rdvalue_cast<T>(arg);
     } catch (const std::bad_any_cast &exc) {
       try {
-        res = boost::lexical_cast<T>(rdvalue_cast<std::string>(arg));
+	std::string val = rdvalue_cast<std::string>(arg);
+	// trim only the right characters, this mimics how SD values
+	//  work on read, they will be trimmed by the MolFile parser
+	boost::trim_right(val);
+        res = boost::lexical_cast<T>(val);
       } catch (...) {
         throw exc;
       }

--- a/Code/RDGeneral/testRDValue.cpp
+++ b/Code/RDGeneral/testRDValue.cpp
@@ -276,3 +276,13 @@ TEST_CASE("testIntConversions") {
   REQUIRE_THROWS_AS(p.getProp<std::uint16_t>("foo"),
                     boost::numeric::negative_overflow);
 }
+
+TEST_CASE("testStringToDouble") {
+  RDProps p;
+  p.setProp<std::string>("foo", "123.0 ");
+  p.setProp<std::string>("bar", " 123.0 ");
+  REQUIRE(p.getProp<double>("foo") == 123.0);
+  REQUIRE(p.getProp<float>("foo") == 123.0f);
+  REQUIRE_THROWS_AS(p.getProp<double>("bar"),
+		    std::bad_any_cast);
+}


### PR DESCRIPTION
Fixes #8546 

By default, when converting to double/floats this trims the right hand white space.  This simulates round tripping through SDFiles which automatically do this.

When converting to a python dictionary, the rdkit will be more aggressive and trim all spaces.

```
mol.SetDoubleProp("foo", "123.0 ")
mol.GetDoubleProp("foo") == 123.
mol.SetDoubleProp("bar", " 123.0 ")
mol.GetDoubleProp("bar) # throws exception
mol.GetPropsAsDict()["bar"] == 123.
```
