### PR TITLE
Include <cstdint> for a couple of headers for windows compilation

### DIFF
--- a/Code/ForceField/MMFF/StretchBend.h
+++ b/Code/ForceField/MMFF/StretchBend.h
@@ -10,6 +10,7 @@
 #ifndef __RD_MMFFSTRETCHBEND_H__
 #define __RD_MMFFSTRETCHBEND_H__
 
+#include <cstdint>
 #include <utility>
 #include <vector>
 

--- a/Code/ForceField/MMFF/TorsionAngle.h
+++ b/Code/ForceField/MMFF/TorsionAngle.h
@@ -12,6 +12,7 @@
 #define RD_MMFFTORSIONANGLE_H
 
 #include <ForceField/Contrib.h>
+#include <cstdint>
 #include <tuple>
 #include <vector>
 


### PR DESCRIPTION
When building RDKit on Windows Server 2022 (the windows-latest GitHub runner) a couple of headers needed #include <cstdint> to compile properly.