### PR TITLE
Explicitly pass D__isascii when building InChi

### DIFF
--- a/External/INCHI-API/CMakeLists.txt
+++ b/External/INCHI-API/CMakeLists.txt
@@ -71,10 +71,10 @@ if(RDK_BUILD_INCHI_SUPPORT)
   endif()
 
      if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-      set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-comment -Wno-parentheses -Wno-logical-op-parentheses -Wno-pointer-bool-conversion -Wno-unused-value -Wno-unsequenced -Wno-constant-logical-operand")
+      set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-comment -Wno-parentheses -Wno-logical-op-parentheses -Wno-pointer-bool-conversion -Wno-unused-value -Wno-unsequenced -Wno-constant-logical-operand -D__isascii=isascii")
      endif()
      if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-      set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wformat-overflow=0 -Wformat=0 -Wno-format-security")
+      set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wformat-overflow=0 -Wformat=0 -Wno-format-security -D__isascii=isascii")
      endif()
 
 


### PR DESCRIPTION
RDKit's InChi build tries to guess whether the C compiler provides isascii() (which is the standard) or __isascii(), but it guesses wrong for Emscripten builds (which I do during sketcher compilation). This change passes -D__isascii=isascii when building InChi, which means that the wrong guess will still wind up with the right function name.