### PR TITLE
Fix 8664

### DIFF
--- a/Code/GraphMol/SmilesParse/CXSmilesOps.cpp
+++ b/Code/GraphMol/SmilesParse/CXSmilesOps.cpp
@@ -2026,7 +2026,8 @@ std::string get_atom_props_block(const ROMol &mol,
                                  const std::vector<unsigned int> &atomOrder) {
   std::vector<std::string> skip = {common_properties::atomLabel,
                                    common_properties::molFileValue,
-                                   common_properties::molParity};
+                                   common_properties::molParity,
+                                   common_properties::molAtomMapNumber};
   std::string res = "";
   unsigned int which = 0;
   for (auto idx : atomOrder) {

--- a/Code/GraphMol/SmilesParse/catch_tests.cpp
+++ b/Code/GraphMol/SmilesParse/catch_tests.cpp
@@ -3303,3 +3303,15 @@ TEST_CASE(
           "O=C(N[C@H]1C[C@@H](C(=O)O)[C@@H]2C[C@@H]21)C1CC(=O)N(Cc2ccccn2)C1");
   }
 }
+
+TEST_CASE(
+    "github #8664: RDKit CXSMiles includes map number as an atom property") {
+  SECTION("as reported") {
+    auto m =
+        "CC[OH:2]"_smiles;
+    REQUIRE(m);
+    auto smi = MolToCXSmiles(*m);
+    CHECK(smi ==
+          "CC[OH:2]");
+  }
+}


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! 
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->
Fixes #8664.


#### What does this implement/fix? Explain your changes.
The atom map number property is now skipped when gathering the atom properties block for CXSmiles. 


#### Any other comments?

