### PR TITLE
Avoid CMake warning due to mismatching if()..endif()

### DIFF
--- a/Code/JavaWrappers/gmwrapper/CMakeLists.txt
+++ b/Code/JavaWrappers/gmwrapper/CMakeLists.txt
@@ -346,7 +346,7 @@ if (RDK_BUILD_CHEMDRAW_SUPPORT)
        java -Djava.library.path=${CMAKE_CURRENT_SOURCE_DIR}
        	-cp "${JUNIT_JAR}${PATH_SEP}${CMAKE_JAVA_TEST_OUTDIR}${PATH_SEP}${CMAKE_CURRENT_SOURCE_DIR}/org.RDKit.jar"
 		org.RDKit.ChemDrawTest)
-endif (RDK_BUILD_INCHI_SUPPORT)
+endif (RDK_BUILD_CHEMDRAW_SUPPORT)
 
 #ADD_TEST(JavaMemoryTests
 #    java -Djava.library.path=${CMAKE_CURRENT_SOURCE_DIR}


### PR DESCRIPTION
Small PR to fix a warning caused by a copy/paste typo.