### PR TITLE
support bond property lists in SDF 

### DIFF
--- a/Code/GraphMol/FileParsers/FileParserUtils.h
+++ b/Code/GraphMol/FileParsers/FileParserUtils.h
@@ -154,6 +154,7 @@ void applyMolListProp(ROMol &mol, const std::string &pn,
 
 //! applies a particular property to the atoms as an atom property list
 template <typename T>
+[[deprecated("use applyMolListProp instead")]]
 void applyMolListPropToAtoms(ROMol &mol, const std::string &pn,
                              const std::string &prefix,
                              const std::string &missingValueMarker = "n/a") {
@@ -175,6 +176,7 @@ void applyMolListProps(ROMol &mol, const std::string &prefix, size_t nItems,
 //! applies all properties matching a particular prefix as an atom property
 //! list
 template <typename T>
+[[deprecated("use applyMolListProps instead")]]
 void applyMolListPropsToAtoms(ROMol &mol, const std::string &prefix,
                               const std::string missingValueMarker = "n/a") {
   auto getter = [&mol](size_t which) { return mol.getAtomWithIdx(which); };

--- a/Code/GraphMol/FileParsers/testPropertyLists.cpp
+++ b/Code/GraphMol/FileParsers/testPropertyLists.cpp
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2019 Greg Landrum
+//  Copyright (C) 2019-2025 Greg Landrum and other RDKit contributors
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
 //  The contents are covered by the terms of the BSD license
@@ -18,15 +18,17 @@
 
 using namespace RDKit;
 
-TEST_CASE("Property list conversion", "[atom_list_properties]") {
+TEST_CASE("Property list conversion") {
+  auto m = "COC"_smiles;
+  REQUIRE(m);
+  auto getter = [&m](size_t which) { return m->getAtomWithIdx(which); };
   SECTION("basics: iprops") {
-    auto m = "COC"_smiles;
-    REQUIRE(m);
     m->setProp("atom.iprop.foo1", "1   6 9");
     m->setProp("atom.iprop.foo2", "3 n/a   9");
     m->setProp("atom.iprop.foo3", "[?]  5 1 ?");
     m->setProp("atom.iprop.foo4", "[foo] 3 foo   9");
-    FileParserUtils::applyMolListPropsToAtoms<std::int64_t>(*m, "atom.iprop.");
+    FileParserUtils::applyMolListProps<std::int64_t>(*m, "atom.iprop.",
+                                                     m->getNumAtoms(), getter);
     CHECK(m->getAtomWithIdx(0)->hasProp("foo1"));
     CHECK(m->getAtomWithIdx(1)->hasProp("foo1"));
     CHECK(m->getAtomWithIdx(2)->hasProp("foo1"));
@@ -45,12 +47,11 @@ TEST_CASE("Property list conversion", "[atom_list_properties]") {
     CHECK(m->getAtomWithIdx(1)->getProp<std::string>("foo3") == "1");
   }
   SECTION("basics: dprops") {
-    auto m = "COC"_smiles;
-    REQUIRE(m);
     m->setProp("atom.dprop.foo1", "1   6 9");
     m->setProp("atom.dprop.foo2", "3 n/a   9");
     m->setProp("atom.dprop.foo3", "[?]  5 1 ?");
-    FileParserUtils::applyMolListPropsToAtoms<double>(*m, "atom.dprop.");
+    FileParserUtils::applyMolListProps<double>(*m, "atom.dprop.",
+                                               m->getNumAtoms(), getter);
     CHECK(m->getAtomWithIdx(0)->hasProp("foo1"));
     CHECK(m->getAtomWithIdx(1)->hasProp("foo1"));
     CHECK(m->getAtomWithIdx(2)->hasProp("foo1"));
@@ -65,12 +66,11 @@ TEST_CASE("Property list conversion", "[atom_list_properties]") {
     CHECK(m->getAtomWithIdx(1)->getProp<double>("foo3") == 1);
   }
   SECTION("basics: props") {
-    auto m = "COC"_smiles;
-    REQUIRE(m);
     m->setProp("atom.prop.foo1", "1   6 9");
     m->setProp("atom.prop.foo2", "3 n/a   9");
     m->setProp("atom.prop.foo3", "[?]  5 1 ?");
-    FileParserUtils::applyMolListPropsToAtoms<std::string>(*m, "atom.prop.");
+    FileParserUtils::applyMolListProps<std::string>(*m, "atom.prop.",
+                                                    m->getNumAtoms(), getter);
     CHECK(m->getAtomWithIdx(0)->hasProp("foo1"));
     CHECK(m->getAtomWithIdx(1)->hasProp("foo1"));
     CHECK(m->getAtomWithIdx(2)->hasProp("foo1"));
@@ -85,12 +85,11 @@ TEST_CASE("Property list conversion", "[atom_list_properties]") {
     CHECK(m->getAtomWithIdx(1)->getProp<std::string>("foo3") == "1");
   }
   SECTION("basics: bprops") {
-    auto m = "COC"_smiles;
-    REQUIRE(m);
     m->setProp("atom.bprop.foo1", "1   0 0");
     m->setProp("atom.bprop.foo2", "0 n/a   1");
     m->setProp("atom.bprop.foo3", "[?]  0 1 ?");
-    FileParserUtils::applyMolListPropsToAtoms<bool>(*m, "atom.bprop.");
+    FileParserUtils::applyMolListProps<bool>(*m, "atom.bprop.",
+                                             m->getNumAtoms(), getter);
     CHECK(m->getAtomWithIdx(0)->hasProp("foo1"));
     CHECK(m->getAtomWithIdx(1)->hasProp("foo1"));
     CHECK(m->getAtomWithIdx(2)->hasProp("foo1"));
@@ -104,8 +103,25 @@ TEST_CASE("Property list conversion", "[atom_list_properties]") {
     CHECK(m->getAtomWithIdx(2)->getProp<bool>("foo2") == true);
     CHECK(m->getAtomWithIdx(1)->getProp<bool>("foo3") == true);
   }
+  SECTION("basics: bond props") {
+    auto bgetter = [&m](size_t which) { return m->getBondWithIdx(which); };
+
+    m->setProp("bond.prop.foo1", "1   6");
+    m->setProp("bond.prop.foo2", "3 n/a");
+    m->setProp("bond.prop.foo3", "[?]  ? 5");
+    FileParserUtils::applyMolListProps<std::string>(*m, "bond.prop.",
+                                                    m->getNumBonds(), bgetter);
+    CHECK(m->getBondWithIdx(0)->hasProp("foo1"));
+    CHECK(m->getBondWithIdx(1)->hasProp("foo1"));
+    CHECK(m->getBondWithIdx(0)->hasProp("foo2"));
+    CHECK(!m->getBondWithIdx(1)->hasProp("foo2"));
+    CHECK(!m->getBondWithIdx(0)->hasProp("foo3"));
+    CHECK(m->getBondWithIdx(1)->hasProp("foo3"));
+    CHECK(m->getBondWithIdx(1)->getProp<std::string>("foo1") == "6");
+    CHECK(m->getBondWithIdx(1)->getProp<std::string>("foo3") == "5");
+  }
 }
-TEST_CASE("processMolPropertyLists", "[atom_list_properties]") {
+TEST_CASE("processMolPropertyLists") {
   SECTION("basics") {
     auto m = "COC"_smiles;
     REQUIRE(m);
@@ -133,7 +149,7 @@ TEST_CASE("processMolPropertyLists", "[atom_list_properties]") {
   }
 }
 
-TEST_CASE("basic SDF handling", "[SDF][atom_list_properties]") {
+TEST_CASE("basic SDF handling") {
   std::string sdf = R"SDF(
      RDKit  2D
 
@@ -184,7 +200,7 @@ $$$$
   }
 }
 
-TEST_CASE("createAtomPropertyLists", "[atom_list_properties]") {
+TEST_CASE("createAtomPropertyLists") {
   SECTION("basics") {
     auto m = "COC"_smiles;
     REQUIRE(m);
@@ -217,6 +233,7 @@ TEST_CASE("createAtomPropertyLists", "[atom_list_properties]") {
   SECTION("long lines") {
     auto m = "COC"_smiles;
     REQUIRE(m);
+    auto getter = [&m](size_t which) { return m->getAtomWithIdx(which); };
     m->getAtomWithIdx(0)->setProp<std::string>("foo1", std::string(80, 'a'));
     m->getAtomWithIdx(1)->setProp<std::string>("foo1", std::string(80, 'b'));
     m->getAtomWithIdx(2)->setProp<std::string>("foo1", std::string(80, 'c'));
@@ -228,7 +245,8 @@ TEST_CASE("createAtomPropertyLists", "[atom_list_properties]") {
     for (auto &atom : m->atoms()) {
       atom->clearProp("foo1");
     }
-    FileParserUtils::applyMolListPropsToAtoms<std::string>(*m, "atom.prop.");
+    FileParserUtils::applyMolListProps<std::string>(*m, "atom.prop.",
+                                                    m->getNumAtoms(), getter);
     CHECK(m->getAtomWithIdx(0)->getProp<std::string>("foo1") ==
           std::string(80, 'a'));
     CHECK(m->getAtomWithIdx(1)->getProp<std::string>("foo1") ==

--- a/Code/GraphMol/Wrap/rdmolfiles.cpp
+++ b/Code/GraphMol/Wrap/rdmolfiles.cpp
@@ -740,12 +740,15 @@ python::object MolsFromCDXMLFile(const std::string &filename, bool sanitize,
   return python::tuple(res);
 }
 
-python::tuple MolsFromCDXMLHelper(python::object cdxml, python::object pyParams) {
+python::tuple MolsFromCDXMLHelper(python::object cdxml,
+                                  python::object pyParams) {
   RDKit::v2::CDXMLParser::CDXMLParserParams params;
   if (pyParams) {
-    params = python::extract<RDKit::v2::CDXMLParser::CDXMLParserParams>(pyParams);
+    params =
+        python::extract<RDKit::v2::CDXMLParser::CDXMLParserParams>(pyParams);
   }
-  auto mols = RDKit::v2::CDXMLParser::MolsFromCDXML(pyObjectToString(cdxml), params);
+  auto mols =
+      RDKit::v2::CDXMLParser::MolsFromCDXML(pyObjectToString(cdxml), params);
   python::list res;
   for (auto &mol : mols) {
     // take ownership of the data from the unique_ptr
@@ -755,12 +758,13 @@ python::tuple MolsFromCDXMLHelper(python::object cdxml, python::object pyParams)
   return python::tuple(res);
 }
 
- python::object MolsFromCDXMLFileHelper(const std::string &filename,
-					python::object pyParams) {
-   RDKit::v2::CDXMLParser::CDXMLParserParams params(
-		       true, true, RDKit::v2::CDXMLParser::CDXMLFormat::Auto);
+python::object MolsFromCDXMLFileHelper(const std::string &filename,
+                                       python::object pyParams) {
+  RDKit::v2::CDXMLParser::CDXMLParserParams params(
+      true, true, RDKit::v2::CDXMLParser::CDXMLFormat::Auto);
   if (pyParams) {
-    params = python::extract<RDKit::v2::CDXMLParser::CDXMLParserParams>(pyParams);
+    params =
+        python::extract<RDKit::v2::CDXMLParser::CDXMLParserParams>(pyParams);
   }
   std::vector<std::unique_ptr<RWMol>> mols;
   try {
@@ -1221,7 +1225,7 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
       .def_readwrite(
           "precision", &RDKit::MolWriterParams::precision,
           "precision of coordinates (only available in V3000)(default=false)")
-      .def("__setattr__",&safeSetattr);
+      .def("__setattr__", &safeSetattr);
 
   python::class_<RDKit::v2::FileParsers::MolFromSCSRParams, boost::noncopyable>(
       "MolFromSCSRParams",
@@ -1781,10 +1785,9 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
       .def_readwrite(
           "includeDativeBonds", &RDKit::SmilesWriteParams::includeDativeBonds,
           "include the RDKit extension for dative bonds. Otherwise dative bonds will be written as single bonds")
-      .def_readwrite(
-          "ignoreAtomMapNumbers",
-          &RDKit::SmilesWriteParams::ignoreAtomMapNumbers,
-          "ignore atom map numbers when canonicalizing the molecule")
+      .def_readwrite("ignoreAtomMapNumbers",
+                     &RDKit::SmilesWriteParams::ignoreAtomMapNumbers,
+                     "ignore atom map numbers when canonicalizing the molecule")
       .def("__setattr__", &safeSetattr);
 
   python::def("MolToSmiles",
@@ -2515,6 +2518,33 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
       "values");
 
   python::def(
+      "CreateBondIntPropertyList", FileParserUtils::createBondIntPropertyList,
+      (python::arg("mol"), python::arg("propName"),
+       python::arg("missingValueMarker") = "", python::arg("lineSize") = 190),
+      "creates a list property on the molecule from individual bond property "
+      "values");
+  python::def(
+      "CreateBondDoublePropertyList",
+      FileParserUtils::createBondDoublePropertyList,
+      (python::arg("mol"), python::arg("propName"),
+       python::arg("missingValueMarker") = "", python::arg("lineSize") = 190),
+      "creates a list property on the molecule from individual bond property "
+      "values");
+  python::def(
+      "CreateBondBoolPropertyList", FileParserUtils::createBondBoolPropertyList,
+      (python::arg("mol"), python::arg("propName"),
+       python::arg("missingValueMarker") = "", python::arg("lineSize") = 190),
+      "creates a list property on the molecule from individual bond property "
+      "values");
+  python::def(
+      "CreateBondStringPropertyList",
+      FileParserUtils::createBondStringPropertyList,
+      (python::arg("mol"), python::arg("propName"),
+       python::arg("missingValueMarker") = "", python::arg("lineSize") = 190),
+      "creates a list property on the molecule from individual bond property "
+      "values");
+
+  python::def(
       "MolToRandomSmilesVect", RDKit::MolToRandomSmilesHelper,
       (python::arg("mol"), python::arg("numSmiles"),
        python::arg("randomSeed") = 0, python::arg("isomericSmiles") = true,
@@ -2639,34 +2669,29 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
                python::arg("removeHs") = true),
               docString.c_str());
 
-    python::enum_<RDKit::v2::CDXMLParser::CDXMLFormat>("CDXMLFormat")
-      .value("CDXML",
-             RDKit::v2::CDXMLParser::CDXMLFormat::CDXML)
-      .value("CDX",
-             RDKit::v2::CDXMLParser::CDXMLFormat::CDX)
+  python::enum_<RDKit::v2::CDXMLParser::CDXMLFormat>("CDXMLFormat")
+      .value("CDXML", RDKit::v2::CDXMLParser::CDXMLFormat::CDXML)
+      .value("CDX", RDKit::v2::CDXMLParser::CDXMLFormat::CDX)
       .value("Auto", RDKit::v2::CDXMLParser::CDXMLFormat::Auto);
 
   python::class_<RDKit::v2::CDXMLParser::CDXMLParserParams, boost::noncopyable>(
       "CDXMLParserParams",
       "Parameters controlling conversion of a CDXML document to molecules",
       python::init<>(python::args("self"), "Construct a default CDXMLFormat"))
-    .def(python::init<bool, bool, RDKit::v2::CDXMLParser::CDXMLFormat>(
-        python::args("self", "sanitize", "removeHs", "format")))
+      .def(python::init<bool, bool, RDKit::v2::CDXMLParser::CDXMLFormat>(
+          python::args("self", "sanitize", "removeHs", "format")))
+      .def_readwrite("sanitize",
+                     &RDKit::v2::CDXMLParser::CDXMLParserParams::sanitize,
+                     "controls whether or not the molecule is sanitized before "
+                     "being returned")
+      .def_readwrite("removeHs",
+                     &RDKit::v2::CDXMLParser::CDXMLParserParams::removeHs,
+                     "controls whether or not Hs are removed before the "
+                     "molecule is returned")
       .def_readwrite(
-          "sanitize",
-          &RDKit::v2::CDXMLParser::CDXMLParserParams::sanitize,
-	  "controls whether or not the molecule is sanitized before "
-	  "being returned")
-      .def_readwrite(
-          "removeHs",
-          &RDKit::v2::CDXMLParser::CDXMLParserParams::removeHs,
-	  "controls whether or not Hs are removed before the "
-	  "molecule is returned")
-      .def_readwrite(
-          "format",
-          &RDKit::v2::CDXMLParser::CDXMLParserParams::format,
+          "format", &RDKit::v2::CDXMLParser::CDXMLParserParams::format,
           "ChemDraw format One of Auto, CDXML, CDX.  For data streams, Auto defaults to CDXML");
-  
+
   docString =
       R"DOC(Construct a molecule from a cdxml file.
 
@@ -2688,8 +2713,7 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
        a tuple  of parsed Mol objects.)DOC";
 
   python::def("MolsFromCDXMLFile", MolsFromCDXMLFileHelper,
-              (python::arg("filename"),
-	       python::arg("params")),
+              (python::arg("filename"), python::arg("params")),
               docString.c_str());
 
   docString =
@@ -2711,12 +2735,11 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
        a tuple of parsed Mol objects.)DOC";
 
   python::def("MolsFromCDXML", MolsFromCDXMLHelper,
-              (python::arg("cdxml"),
-	       python::arg("params")),
-              docString.c_str());
+              (python::arg("cdxml"), python::arg("params")), docString.c_str());
 
   docString = "Returns true if the RDKit is built with ChemDraw CDX support";
-  python::def("HasChemDrawCDXSupport", RDKit::v2::CDXMLParser::hasChemDrawCDXSupport, docString.c_str());
+  python::def("HasChemDrawCDXSupport",
+              RDKit::v2::CDXMLParser::hasChemDrawCDXSupport, docString.c_str());
 
 #ifdef RDK_USE_BOOST_IOSTREAMS
   docString =


### PR DESCRIPTION
This is exactly analogous to the way atom property lists are supported and is something I should have done with the initial PR.

There's a bit of refactoring to simplify the code/avoid duplicate code.

Fixes #8777 too