### PR TITLE
Implement #8793

### DIFF
--- a/rdkit/Chem/PandasTools.py
+++ b/rdkit/Chem/PandasTools.py
@@ -543,21 +543,22 @@ def SaveXlsxFromFrame(frame, outFile, molCol='ROMol', size=(300, 300), formats=N
     worksheet.write_string(0, col_idx, col)
 
   for row_idx, (_, row) in enumerate(frame.iterrows()):
+    have_img = False
     row_idx_actual = row_idx + 1
-
-    worksheet.set_row(row_idx_actual, height=size[1])  # looks like height is not in px?
-
     for col_idx, col in enumerate(cols):
       if col_idx in molCol_indices:
         image_data = BytesIO()
         m = row[col]
-        img = Draw.MolToImage(m if isinstance(m, Chem.Mol) else Chem.Mol(), size=size,
-                              options=drawOptions)
-        img.save(image_data, format='PNG')
-        worksheet.insert_image(row_idx_actual, col_idx, "f", {'image_data': image_data})
-        worksheet.set_column(col_idx, col_idx,
-                             width=size[0] / 6.)  # looks like height is not in px?
-      elif str(dataTypes[col]) == "object":
+        if isinstance(m, Chem.Mol):
+          have_img = True
+          img = Draw.MolToImage(m if isinstance(m, Chem.Mol) else Chem.Mol(), size=size,
+                                options=drawOptions)
+          img.save(image_data, format='PNG')
+          worksheet.insert_image(row_idx_actual, col_idx, "f", {'image_data': image_data})
+          worksheet.set_column(col_idx, col_idx,
+                              width=size[0] / 6.)  # looks like height is not in px?
+          continue
+      if str(dataTypes[col]) == "object":
         # string length is limited in xlsx
         worksheet.write_string(row_idx_actual, col_idx,
                                str(row[col])[:32000], cell_formats['write_string'])
@@ -566,6 +567,8 @@ def SaveXlsxFromFrame(frame, outFile, molCol='ROMol', size=(300, 300), formats=N
           worksheet.write_number(row_idx_actual, col_idx, row[col], cell_formats['write_number'])
       elif 'datetime' in str(dataTypes[col]):
         worksheet.write_datetime(row_idx_actual, col_idx, row[col], cell_formats['write_datetime'])
+    if have_img:
+      worksheet.set_row(row_idx_actual, height=size[1])  # looks like height is not in px?
 
   workbook.close()
   image_data.close()


### PR DESCRIPTION
`SaveXlsxFromFrame` already supports a list of `molCol` strings as opposed to a single `molCol` string.
However, currently it does not support mixed-type columns. With this PR it becomes possible to select all `DataFrame` columns as `molCol` and have all molecules rendered as molecules.

See below for an example:
```
from rdkit import Chem
from rdkit.Chem import PandasTools
import pandas as pd

df = pd.DataFrame({
    "mol": [Chem.MolFromSmiles(smi) for smi in [
        "CC1([C@@H](N2[C@H](S1)[C@@H](C2=O)NC(=O)[C@@H](C3=CC=C(C=C3)O)N)C(=O)O)C",
        "CC1=C(C(=NO1)C2=C(C=CC=C2Cl)F)C(=O)N[C@H]3[C@@H]4N(C3=O)[C@H](C(S4)(C)C)C(=O)O",
        "CCO/N=C(/C1=NSC(=N1)N)\C(=O)N[C@H]2[C@@H]3N(C2=O)C(=C(CS3)SC4=NC(=CS4)C5=CC=[N+](C=C5)C)C(=O)[O-]"
    ]] + ["This is not a molecule"],
    "name": ["Amoxicillin", "Flucloxacillin", "Ceftaroline"] + [Chem.MolFromMolBlock("\n     RDKit          2D\n\n 17 18  0  0  0  0  0  0  0  0999 V2000\n    0.5936    2.5907    0.0000 S   0  0  0  0  0  0  0  0  0  0  0  0\n   -0.2493    1.2937    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n    0.4525   -0.0850    0.0000 N   0  0  0  0  0  0  0  0  0  0  0  0\n    1.9969   -0.1663    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n    2.8401    1.1304    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n    2.1383    2.5091    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n   -1.6279    0.5920    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n   -0.9261   -0.7867    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n   -3.0990    1.0707    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n   -4.2489    0.0359    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n   -5.7199    0.5146    0.0000 R#  0  0  0  0  0  0  0  0  0  0  0  0\n   -3.9278   -1.4773    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0\n    4.3847    1.0488    0.0000 R#  0  0  0  0  0  0  0  0  0  0  0  0\n    2.6986   -1.5448    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n    1.8557   -2.8418    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0\n    4.2432   -1.6265    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0\n   -1.4048   -2.2576    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0\n  4  5  2  0\n  5  6  1  0\n  2  7  1  0\n  7  8  1  0\n  2  3  1  0\n  3  4  1  0\n  3  8  1  0\n  1  2  1  0\n  1  6  1  0\n  7  9  1  1\n  9 10  1  0\n 10 12  2  0\n 10 11  1  0\n  5 13  1  0\n  4 14  1  0\n 14 15  2  0\n 14 16  1  0\n  8 17  2  0\nM  RGP  2  11   1  13   2\nV   11 *\nV   13 *\nM  END\n")],
    "smarts": [Chem.MolFromSmarts(sma) for sma in ["N1C(=O)CC1", "N1C(=O)CC1", "N1C(=O)CC1"]] + ["This is not a SMARTS"],
    "no mols here": [1, 2, 3, 4]
})
PandasTools.SaveXlsxFromFrame(df, "df_with_mols.xlsx", molCol=df.columns, size=(200, 100))
PandasTools.RenderImagesInAllDataFrames()
df
```
<img width="760" height="885" alt="image" src="https://github.com/user-attachments/assets/9003e3a3-6265-414b-bc78-433b6c93b350" />
The resulting Excel sheet `df_with_mols.xlsx` is:
<img width="863" height="573" alt="image" src="https://github.com/user-attachments/assets/472fa475-6181-4d4a-bb80-44e53ac70962" />

Fixes #8793 