### PR TITLE
ForceFieldHelpers: fix “No Python class registered for C++ class ForceFields::PyForceField” error #8754

### DIFF
--- a/Code/GraphMol/ForceFieldHelpers/Wrap/rdForceFields.cpp
+++ b/Code/GraphMol/ForceFieldHelpers/Wrap/rdForceFields.cpp
@@ -248,6 +248,8 @@ PyObject *getUFFVdWParams(const RDKit::ROMol &mol, const unsigned int idx1,
 }  // namespace ForceFields
 
 BOOST_PYTHON_MODULE(rdForceFieldHelpers) {
+   boost::python::import("rdkit.ForceField.rdForceField");
+
   python::scope().attr("__doc__") =
       "Module containing functions to handle force fields";
 

--- a/Code/GraphMol/ForceFieldHelpers/Wrap/testHelpers.py
+++ b/Code/GraphMol/ForceFieldHelpers/Wrap/testHelpers.py
@@ -5,7 +5,7 @@ import numpy
 
 from rdkit import Chem, RDConfig
 from rdkit.Chem import ChemicalForceFields, rdDistGeom
-
+from rdkit.Chem.rdForceFieldHelpers import UFFGetMoleculeForceField
 
 def feq(v1, v2, tol2=1e-4):
   return abs(v1 - v2) <= tol2
@@ -406,6 +406,15 @@ M  END"""
     posa = m.GetConformer().GetAtomPosition(0)
     posb = m.GetConformer().GetAtomPosition(1)
     self.assertAlmostEqual((posa - posb).Length(), 100, delta=10e-5)
+
+
+  def test_uff_get_forcefield_runs(self):
+      mol = Chem.MolFromSmiles("CCO")
+      mol = Chem.AddHs(mol)
+      rdDistGeom.EmbedMolecule(mol, randomSeed=42)
+      ff = UFFGetMoleculeForceField(mol, ignoreInterfragInteractions=False)
+      self.assertIsNotNone(ff)
+      self.assertTrue(hasattr(ff, "CalcEnergy"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes github issue #8754

* UFFGetMoleculeForceField was returning PyForceField* before the class was registered via rdForceField, which caused “No Python class registered” errors in Python when using multiple conformers.

* This patch forces rdForceField to be imported during rdForceFieldHelpers module init, ensuring the class is always registered before helper functions are used.

* Add unit test