### PR TITLE
expose exceeded timeout failure to python

### DIFF
--- a/Code/GraphMol/DistGeomHelpers/Wrap/rdDistGeom.cpp
+++ b/Code/GraphMol/DistGeomHelpers/Wrap/rdDistGeom.cpp
@@ -480,6 +480,8 @@ BOOST_PYTHON_MODULE(rdDistGeom) {
              RDKit::DGeomHelpers::EmbedFailureCauses::BAD_DOUBLE_BOND_STEREO)
       .value("CHECK_CHIRAL_CENTERS2",
              RDKit::DGeomHelpers::EmbedFailureCauses::CHECK_CHIRAL_CENTERS2)
+      .value("EXCEEDED_TIMEOUT",
+             RDKit::DGeomHelpers::EmbedFailureCauses::EXCEEDED_TIMEOUT)
       .export_values();
 
   python::class_<PyEmbedParameters, boost::noncopyable>(


### PR DESCRIPTION
Fixes #8806 

The EXCEEDED_TIMEOUT failure was never added to the python enum.
