### PR TITLE
run clang-tidy and clang-format on the chemdraw files

### DIFF
--- a/External/ChemDraw/ChemDrawStartInclude.h
+++ b/External/ChemDraw/ChemDrawStartInclude.h
@@ -34,7 +34,7 @@
 #pragma GCC diagnostic ignored "-Wsign-compare"
 #pragma GCC diagnostic ignored "-Wconversion"
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-//#pragma GCC diagnostic ignored "-Wmacro-redefined"
+// #pragma GCC diagnostic ignored "-Wmacro-redefined"
 #pragma GCC diagnostic ignored "-Wunknown-pragmas"
 #pragma GCC diagnostic ignored "-Wignored-qualifiers"
 #pragma GCC diagnostic ignored "-Wextra"

--- a/External/ChemDraw/bond.cpp
+++ b/External/ChemDraw/bond.cpp
@@ -28,7 +28,7 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-//#include "node.h"
+// #include "node.h"
 #include "utils.h"
 #include "fragment.h"
 
@@ -171,8 +171,9 @@ bool parseBond(RWMol &mol, unsigned int fragmentId, CDXBond &bond,
   unsigned int bondIdx = 0;
   auto startIdx = start_atom->getIdx();
   auto endIdx = end_atom->getIdx();
-  if (swap_bond_ends) { std::swap(startIdx, endIdx);
-}
+  if (swap_bond_ends) {
+    std::swap(startIdx, endIdx);
+  }
 
   if (qb) {
     qb->setBeginAtomIdx(startIdx);
@@ -224,5 +225,5 @@ bool parseBond(RWMol &mol, unsigned int fragmentId, CDXBond &bond,
   }
   return true;
 }
-}
+}  // namespace ChemDraw
 }  // namespace RDKit

--- a/External/ChemDraw/bond.cpp
+++ b/External/ChemDraw/bond.cpp
@@ -171,7 +171,8 @@ bool parseBond(RWMol &mol, unsigned int fragmentId, CDXBond &bond,
   unsigned int bondIdx = 0;
   auto startIdx = start_atom->getIdx();
   auto endIdx = end_atom->getIdx();
-  if (swap_bond_ends) std::swap(startIdx, endIdx);
+  if (swap_bond_ends) { std::swap(startIdx, endIdx);
+}
 
   if (qb) {
     qb->setBeginAtomIdx(startIdx);

--- a/External/ChemDraw/bond.h
+++ b/External/ChemDraw/bond.h
@@ -48,5 +48,5 @@ namespace ChemDraw {
 bool parseBond(RWMol &mol, unsigned int fragmentId, CDXBond &bond,
                PageData &pagedata);
 }
-}
+}  // namespace RDKit
 #endif

--- a/External/ChemDraw/bracket.cpp
+++ b/External/ChemDraw/bracket.cpp
@@ -28,7 +28,7 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-//#include "node.h"
+// #include "node.h"
 #include "utils.h"
 #include "bracket.h"
 
@@ -36,20 +36,20 @@ namespace RDKit {
 namespace ChemDraw {
 // This is currently unimplemented waiting on full bracket support in the rdkit
 //  or support for expansion inside the RDChemDrawLib
-bool parseBracket(CDXBracketedGroup &bracket, PageData &/*pagedata*/) {
+bool parseBracket(CDXBracketedGroup &bracket, PageData & /*pagedata*/) {
   // Get the contained atoms/bonds in the bracket
   for (auto &attachment : bracket.ContainedObjects()) {
     auto childid = (CDXDatumID)attachment.second->GetTag();
     if (childid == kCDXObj_BracketAttachment) {
-      auto &bracketattachment =
-          (CDXBracketAttachment &)(*attachment.second);
+      auto &bracketattachment = (CDXBracketAttachment &)(*attachment.second);
       for (auto &bracketdata : bracketattachment.ContainedObjects()) {
         auto bracketid = (CDXDatumID)bracketdata.second->GetTag();
         if (bracketid == kCDXObj_CrossingBond) {
-          //CDXCrossingBond &crossingbond =
-          //    (CDXCrossingBond &)(*attachment.second);
-          // XX unimplmented crossingbond.m_bondID;       // bond that crosses brackets
-          // XX unimplmented crossingbond.m_innerAtomID;  // atom within brackets
+          // CDXCrossingBond &crossingbond =
+          //     (CDXCrossingBond &)(*attachment.second);
+          //  XX unimplmented crossingbond.m_bondID;       // bond that crosses
+          //  brackets XX unimplmented crossingbond.m_innerAtomID;  // atom
+          //  within brackets
         }
       }
     }
@@ -102,5 +102,5 @@ bool parseBracket(CDXBracketedGroup &bracket, PageData &/*pagedata*/) {
   }
   return true;
 }
-}
+}  // namespace ChemDraw
 }  // namespace RDKit

--- a/External/ChemDraw/bracket.cpp
+++ b/External/ChemDraw/bracket.cpp
@@ -39,12 +39,12 @@ namespace ChemDraw {
 bool parseBracket(CDXBracketedGroup &bracket, PageData &/*pagedata*/) {
   // Get the contained atoms/bonds in the bracket
   for (auto &attachment : bracket.ContainedObjects()) {
-    CDXDatumID childid = (CDXDatumID)attachment.second->GetTag();
+    auto childid = (CDXDatumID)attachment.second->GetTag();
     if (childid == kCDXObj_BracketAttachment) {
-      CDXBracketAttachment &bracketattachment =
+      auto &bracketattachment =
           (CDXBracketAttachment &)(*attachment.second);
       for (auto &bracketdata : bracketattachment.ContainedObjects()) {
-        CDXDatumID bracketid = (CDXDatumID)bracketdata.second->GetTag();
+        auto bracketid = (CDXDatumID)bracketdata.second->GetTag();
         if (bracketid == kCDXObj_CrossingBond) {
           //CDXCrossingBond &crossingbond =
           //    (CDXCrossingBond &)(*attachment.second);

--- a/External/ChemDraw/bracket.h
+++ b/External/ChemDraw/bracket.h
@@ -47,6 +47,6 @@ namespace RDKit {
 namespace ChemDraw {
 bool parseBracket(CDXBracketedGroup &bracket, PageData &pagedata);
 }
-}
+}  // namespace RDKit
 
 #endif

--- a/External/ChemDraw/chemdraw.cpp
+++ b/External/ChemDraw/chemdraw.cpp
@@ -87,7 +87,7 @@ void visit_children(
   molzip_params.enforceValenceRules = false;
 
   for (auto frag : node.ContainedObjects()) {
-    CDXDatumID id = (CDXDatumID)frag.second->GetTag();
+    auto id = (CDXDatumID)frag.second->GetTag();
     if (id == kCDXObj_Fragment) {
       std::unique_ptr<RWMol> mol = std::make_unique<RWMol>();
       if (!parseFragment(*mol, (CDXFragment &)(*frag.second), pagedata,
@@ -131,7 +131,7 @@ void visit_children(
 
         if (atm->hasProp(CDX_ATOM_POS)) {
           hasConf = true;
-          const std::vector<double> coord =
+          const auto coord =
               atm->getProp<std::vector<double>>(CDX_ATOM_POS);
 
           p.x = coord[0];
@@ -208,7 +208,7 @@ void visit_children(
         MolOps::detectBondStereochemistry(*res);
       }
     } else if (id == kCDXObj_ReactionScheme) {  // get the reaction info
-      CDXReactionScheme &scheme = (CDXReactionScheme &)(*frag.second);
+      auto &scheme = (CDXReactionScheme &)(*frag.second);
       pagedata.schemes.emplace_back(scheme);
       /*
       int scheme_id = scheme.GetObjectID();   //frag.second.template
@@ -226,12 +226,12 @@ void visit_children(
       }
       */
     } else if (id == kCDXObj_Group) {
-      CDXGroup &group = (CDXGroup &)(*frag.second);
+      auto &group = (CDXGroup &)(*frag.second);
       group_id = frag.second->GetObjectID();
       visit_children(group, pagedata, missing_frag_id, bondLength, params,
                      group_id);
     } else if (id == kCDXObj_BracketedGroup) {
-      CDXBracketedGroup &bracketgroup = (CDXBracketedGroup &)(*frag.second);
+      auto &bracketgroup = (CDXBracketedGroup &)(*frag.second);
       parseBracket(bracketgroup, pagedata);
     }
   }
@@ -320,7 +320,7 @@ std::vector<std::unique_ptr<RWMol>> molsFromCDXMLDataStream(
 
   int missing_frag_id = -1;
   for (auto node : document->ContainedObjects()) {
-    CDXDatumID id = (CDXDatumID)node.second->GetTag();
+    auto id = (CDXDatumID)node.second->GetTag();
     switch (id) {
       case kCDXObj_Page:
         visit_children(*node.second, pagedata, missing_frag_id, bondLength,
@@ -350,9 +350,9 @@ std::unique_ptr<CDXDocument> ChemDrawToDocument(const std::string &filename) {
   std::fstream chemdrawfile(filename);
   std::string ext = std::filesystem::path(filename).extension().string();
   boost::algorithm::to_lower(ext);
-  if (ext == ".cdxml")
+  if (ext == ".cdxml") {
     return streamToCDXDocument(chemdrawfile, CDXFormat::CDXML);
-  else if (ext == ".cdx") {
+  } else if (ext == ".cdx") {
     return streamToCDXDocument(chemdrawfile, CDXFormat::CDX);
   }
   std::string msg =

--- a/External/ChemDraw/chemdraw.cpp
+++ b/External/ChemDraw/chemdraw.cpp
@@ -131,8 +131,7 @@ void visit_children(
 
         if (atm->hasProp(CDX_ATOM_POS)) {
           hasConf = true;
-          const auto coord =
-              atm->getProp<std::vector<double>>(CDX_ATOM_POS);
+          const auto coord = atm->getProp<std::vector<double>>(CDX_ATOM_POS);
 
           p.x = coord[0];
           p.y = -1 * coord[1];  // CDXML uses an inverted coordinate

--- a/External/ChemDraw/chemdraw.h
+++ b/External/ChemDraw/chemdraw.h
@@ -49,26 +49,29 @@ struct RDKIT_RDCHEMDRAWLIB_EXPORT ChemDrawParserParams {
   bool sanitize;
   bool removeHs;
   CDXFormat format;
-  ChemDrawParserParams() : sanitize(true), removeHs(true), format(CDXFormat::AUTO) {}
-  ChemDrawParserParams(bool sanitize, bool removeHs, CDXFormat format) :
-     sanitize(sanitize), removeHs(removeHs), format(format) {}
-  
+  ChemDrawParserParams()
+      : sanitize(true), removeHs(true), format(CDXFormat::AUTO) {}
+  ChemDrawParserParams(bool sanitize, bool removeHs, CDXFormat format)
+      : sanitize(sanitize), removeHs(removeHs), format(format) {}
 };
 
 std::vector<std::unique_ptr<RWMol>> RDKIT_RDCHEMDRAWLIB_EXPORT
-MolsFromChemDrawDataStream(std::istream &inStream,
-               const ChemDrawParserParams &params = ChemDrawParserParams());
+MolsFromChemDrawDataStream(
+    std::istream &inStream,
+    const ChemDrawParserParams &params = ChemDrawParserParams());
 
 std::vector<std::unique_ptr<RWMol>> RDKIT_RDCHEMDRAWLIB_EXPORT
-MolsFromChemDrawFile(const std::string &filename,
-               const ChemDrawParserParams &params = ChemDrawParserParams());
+MolsFromChemDrawFile(
+    const std::string &filename,
+    const ChemDrawParserParams &params = ChemDrawParserParams());
 
 std::vector<std::unique_ptr<RWMol>> RDKIT_RDCHEMDRAWLIB_EXPORT
-MolsFromChemDrawBlock(const std::string &block,
-               const ChemDrawParserParams &params = ChemDrawParserParams());
+MolsFromChemDrawBlock(
+    const std::string &block,
+    const ChemDrawParserParams &params = ChemDrawParserParams());
 
 std::string RDKIT_RDCHEMDRAWLIB_EXPORT
 MolToChemDrawBlock(const ROMol &mol, CDXFormat format = CDXFormat::CDXML);
-}
+}  // namespace v2
 }  // namespace RDKit
 #endif

--- a/External/ChemDraw/chemdraw_doc.h
+++ b/External/ChemDraw/chemdraw_doc.h
@@ -46,6 +46,6 @@ ChemDrawToDocument(std::istream &inStream, v2::CDXFormat format);
 std::unique_ptr<CDXDocument> RDKIT_RDCHEMDRAWLIB_EXPORT
 ChemDrawToDocument(const std::string &filename);
 
-}
+}  // namespace ChemDraw
 }  // namespace RDKit
 #endif

--- a/External/ChemDraw/chemdrawreaction.cpp
+++ b/External/ChemDraw/chemdrawreaction.cpp
@@ -69,7 +69,7 @@ namespace v2 {
 //! Parse a text stream with ChemDraw data into a ChemicalReaction
 std::vector<std::unique_ptr<ChemicalReaction>>
 ChemDrawDataStreamToChemicalReactions(std::istream &inStream, bool sanitize,
-                                   bool removeHs) {
+                                      bool removeHs) {
   ChemDrawParserParams params;
   params.sanitize = sanitize;
   params.removeHs = removeHs;
@@ -162,6 +162,6 @@ std::vector<std::unique_ptr<ChemicalReaction>> ChemDrawFileToChemicalReactions(
   }
   return res;
 }
-  
-}  
+
+}  // namespace v2
 }  // namespace RDKit

--- a/External/ChemDraw/chemdrawreaction.cpp
+++ b/External/ChemDraw/chemdrawreaction.cpp
@@ -97,7 +97,7 @@ ChemDrawDataStreamToChemicalReactions(std::istream &inStream, bool sanitize,
   }
   for (const auto &scheme : schemes) {
     // convert atoms to queries:
-    ChemicalReaction *res = new ChemicalReaction;
+    auto *res = new ChemicalReaction;
     result.push_back(std::unique_ptr<ChemicalReaction>(res));
     for (auto idx : scheme.second) {
       CHECK_INVARIANT(

--- a/External/ChemDraw/chemdrawreaction.h
+++ b/External/ChemDraw/chemdrawreaction.h
@@ -37,27 +37,31 @@
 #include <GraphMol/ChemReactions/Reaction.h>
 #include <string>
 
-namespace RDKit
-{
+namespace RDKit {
 namespace v2 {
 //---------------------------------------------------------------------------
 //! \name Chemdraw rxn Support
 ///@{
 
 //! Parse text in ChemDraw rxn format into a vector of ChemicalReactions
-RDKIT_RDCHEMDRAWREACTIONLIB_EXPORT std::vector<std::unique_ptr<ChemicalReaction>>
-ChemDrawToChemicalReactions(const std::string &rxnBlock, bool sanitize = false,
-			    bool removeHs = false);
+RDKIT_RDCHEMDRAWREACTIONLIB_EXPORT
+    std::vector<std::unique_ptr<ChemicalReaction>>
+    ChemDrawToChemicalReactions(const std::string &rxnBlock,
+                                bool sanitize = false, bool removeHs = false);
 //! Parse a file in ChemDraw rxn format into a vector of ChemicalReactions
-RDKIT_RDCHEMDRAWREACTIONLIB_EXPORT std::vector<std::unique_ptr<ChemicalReaction>>
-ChemDrawFileToChemicalReactions(const std::string &fileName, bool sanitize = false,
-				bool removeHs = false);
-//! Parse a text stream in ChemDraw rxn format into a vector of ChemicalReactions
-RDKIT_RDCHEMDRAWREACTIONLIB_EXPORT std::vector<std::unique_ptr<ChemicalReaction>>
-ChemDrawDataStreamToChemicalReactions(std::istream &rxnStream,
-				      bool sanitize = false,
-				      bool removeHs = false);
+RDKIT_RDCHEMDRAWREACTIONLIB_EXPORT
+    std::vector<std::unique_ptr<ChemicalReaction>>
+    ChemDrawFileToChemicalReactions(const std::string &fileName,
+                                    bool sanitize = false,
+                                    bool removeHs = false);
+//! Parse a text stream in ChemDraw rxn format into a vector of
+//! ChemicalReactions
+RDKIT_RDCHEMDRAWREACTIONLIB_EXPORT
+    std::vector<std::unique_ptr<ChemicalReaction>>
+    ChemDrawDataStreamToChemicalReactions(std::istream &rxnStream,
+                                          bool sanitize = false,
+                                          bool removeHs = false);
 
-}
+}  // namespace v2
 }  // namespace RDKit
 #endif

--- a/External/ChemDraw/fragment.cpp
+++ b/External/ChemDraw/fragment.cpp
@@ -109,458 +109,910 @@ bool parseFragment(RWMol &mol, CDXFragment &fragment, PageData &pagedata,
           break;
         }
       }
-      case kCDXProp_EndObject: break;
-      case kCDXProp_CreationUserName: break;
-      case kCDXProp_CreationDate: break;
-      case kCDXProp_CreationProgram: break;
-      case kCDXProp_ModificationUserName: break;
-      case kCDXProp_ModificationDate: break;
-      case kCDXProp_ModificationProgram: break;
-      case kCDXProp_Unused1: break;
-      case kCDXProp_Name: break;
-      case kCDXProp_Comment: break;
-      case kCDXProp_ZOrder: break;
-      case kCDXProp_RegistryNumber: break;
-      case kCDXProp_RegistryAuthority: break;
-      case kCDXProp_Unused2: break;
-      case kCDXProp_RepresentsProperty: break;
-      case kCDXProp_IgnoreWarnings: break;
-      case kCDXProp_ChemicalWarning: break;
-      case kCDXProp_Visible: break;
-      case kCDXProp_Transparent: break;
-      case kCDXProp_SupersededBy: break;
-      case kCDXProp_StructurePerspective: break;
-      case kCDXProp_FontTable: break;
-      case kCDXProp_2DPosition: break;
-      case kCDXProp_3DPosition: break;
-      case kCDXProp_2DExtent: break;
-      case kCDXProp_3DExtent: break;
-      case kCDXProp_BoundingBox: break;
-      case kCDXProp_RotationAngle: break;
-      case kCDXProp_BoundsInParent: break;
-      case kCDXProp_3DHead: break;
-      case kCDXProp_3DTail: break;
-      case kCDXProp_TopLeft: break;
-      case kCDXProp_TopRight: break;
-      case kCDXProp_BottomRight: break;
-      case kCDXProp_BottomLeft: break;
-      case kCDXProp_3DCenter: break;
-      case kCDXProp_3DMajorAxisEnd: break;
-      case kCDXProp_3DMinorAxisEnd: break;
-      case kCDXProp_ColorTable: break;
-      case kCDXProp_ForegroundColor: break;
-      case kCDXProp_BackgroundColor: break;
-      case kCDXProp_FadePercent: break;
-      case kCDXProp_Unused8: break;
-      case kCDXProp_Unused9: break;
-      case kCDXProp_ForegroundAlpha: break;
-      case kCDXProp_BackgroundAlpha: break;
-      case kCDXProp_HighlightColor: break;
-      case kCDXProp_Node_Type: break;
-      case kCDXProp_Node_LabelDisplay: break;
-      case kCDXProp_Node_Element: break;
-      case kCDXProp_Atom_ElementList: break;
-      case kCDXProp_Atom_Formula: break;
-      case kCDXProp_Atom_Isotope: break;
-      case kCDXProp_Atom_Charge: break;
-      case kCDXProp_Atom_Radical: break;
-      case kCDXProp_Atom_RestrictFreeSites: break;
-      case kCDXProp_Atom_RestrictImplicitHydrogens: break;
-      case kCDXProp_Atom_RestrictRingBondCount: break;
-      case kCDXProp_Atom_RestrictUnsaturatedBonds: break;
-      case kCDXProp_Atom_RestrictRxnChange: break;
-      case kCDXProp_Atom_RestrictRxnStereo: break;
-      case kCDXProp_Atom_AbnormalValence: break;
-      case kCDXProp_Unused3: break;
-      case kCDXProp_Atom_NumHydrogens: break;
-      case kCDXProp_Unused4: break;
-      case kCDXProp_Unused5: break;
-      case kCDXProp_Atom_HDot: break;
-      case kCDXProp_Atom_HDash: break;
-      case kCDXProp_Atom_Geometry: break;
-      case kCDXProp_Atom_BondOrdering: break;
-      case kCDXProp_Node_Attachments: break;
-      case kCDXProp_Atom_GenericNickname: break;
-      case kCDXProp_Atom_AltGroupID: break;
-      case kCDXProp_Atom_RestrictSubstituentsUpTo: break;
-      case kCDXProp_Atom_RestrictSubstituentsExactly: break;
-      case kCDXProp_Atom_CIPStereochemistry: break;
-      case kCDXProp_Atom_Translation: break;
-      case kCDXProp_Atom_AtomNumber: break;
-      case kCDXProp_Atom_ShowQuery: break;
-      case kCDXProp_Atom_ShowStereo: break;
-      case kCDXProp_Atom_ShowAtomNumber: break;
-      case kCDXProp_Atom_LinkCountLow: break;
-      case kCDXProp_Atom_LinkCountHigh: break;
-      case kCDXProp_Atom_IsotopicAbundance: break;
-      case kCDXProp_Atom_ExternalConnectionType: break;
-      case kCDXProp_Atom_GenericList: break;
-      case kCDXProp_Atom_ShowTerminalCarbonLabels: break;
-      case kCDXProp_Atom_ShowNonTerminalCarbonLabels: break;
-      case kCDXProp_Atom_HideImplicitHydrogens: break;
-      case kCDXProp_Atom_ShowEnhancedStereo: break;
-      case kCDXProp_Atom_EnhancedStereoType: break;
-      case kCDXProp_Atom_EnhancedStereoGroupNum: break;
-      case kCDXProp_Node_NeedsClean: break;
-      case kCDXProp_Atom_ResidueID: break;
-      case kCDXProp_Atom_ShowResidueID: break;
-      case kCDXProp_Atom_ExternalConnectionNum: break;
-      case kCDXProp_Atom_ShowAtomID: break;
-      case kCDXProp_Atom_AtomID: break;
-      case kCDXProp_Node_HydrogenBondAttachmentAtoms: break;
-      case kCDXProp_Node_HydrogenBonds: break;
-      case kCDXProp_Mole_Racemic: break;
-      case kCDXProp_Mole_Absolute: break;
-      case kCDXProp_Mole_Relative: break;
-      case kCDXProp_Mole_Formula: break;
-      case kCDXProp_Mole_Weight: break;
-      case kCDXProp_Frag_ConnectionOrder: break;
-      case kCDXProp_Frag_SequenceType: break;
-      case kCDXProp_Frag_IsFromGuidedStereo: break;
-      case kCDXProp_Frag_IsComplement: break;
-      case kCDXProp_Bond_Order: break;
-      case kCDXProp_Bond_Display: break;
-      case kCDXProp_Bond_Display2: break;
-      case kCDXProp_Bond_DoublePosition: break;
-      case kCDXProp_Bond_Begin: break;
-      case kCDXProp_Bond_End: break;
-      case kCDXProp_Bond_RestrictTopology: break;
-      case kCDXProp_Bond_RestrictRxnParticipation: break;
-      case kCDXProp_Bond_BeginAttach: break;
-      case kCDXProp_Bond_EndAttach: break;
-      case kCDXProp_Bond_CIPStereochemistry: break;
-      case kCDXProp_Bond_BondOrdering: break;
-      case kCDXProp_Bond_ShowQuery: break;
-      case kCDXProp_Bond_ShowStereo: break;
-      case kCDXProp_Bond_CrossingBonds: break;
-      case kCDXProp_Bond_ShowRxn: break;
-      case kCDXProp_Bond_Connectivity: break;
-      case kCDXProp_Bond_BeginExternalNum: break;
-      case kCDXProp_Bond_EndExternalNum: break;
-      case kCDXProp_Bond_Connectivity_Routed: break;
-      case kCDXProp_Text: break;
-      case kCDXProp_Justification: break;
-      case kCDXProp_LineHeight: break;
-      case kCDXProp_WordWrapWidth: break;
-      case kCDXProp_LineStarts: break;
-      case kCDXProp_LabelAlignment: break;
-      case kCDXProp_LabelLineHeight: break;
-      case kCDXProp_CaptionLineHeight: break;
-      case kCDXProp_InterpretChemically: break;
-      case kCDXProp_UTF8Text: break;
-      case kCDXProp_MacPrintInfo: break;
-      case kCDXProp_WinPrintInfo: break;
-      case kCDXProp_PrintMargins: break;
-      case kCDXProp_ChainAngle: break;
-      case kCDXProp_BondSpacing: break;
-      case kCDXProp_BondLength: break;
-      case kCDXProp_BoldWidth: break;
-      case kCDXProp_LineWidth: break;
-      case kCDXProp_MarginWidth: break;
-      case kCDXProp_HashSpacing: break;
-      case kCDXProp_LabelStyle: break;
-      case kCDXProp_CaptionStyle: break;
-      case kCDXProp_CaptionJustification: break;
-      case kCDXProp_FractionalWidths: break;
-      case kCDXProp_Magnification: break;
-      case kCDXProp_WidthPages: break;
-      case kCDXProp_HeightPages: break;
-      case kCDXProp_DrawingSpaceType: break;
-      case kCDXProp_Width: break;
-      case kCDXProp_Height: break;
-      case kCDXProp_PageOverlap: break;
-      case kCDXProp_Header: break;
-      case kCDXProp_HeaderPosition: break;
-      case kCDXProp_Footer: break;
-      case kCDXProp_FooterPosition: break;
-      case kCDXProp_PrintTrimMarks: break;
-      case kCDXProp_LabelStyleFont: break;
-      case kCDXProp_CaptionStyleFont: break;
-      case kCDXProp_LabelStyleSize: break;
-      case kCDXProp_CaptionStyleSize: break;
-      case kCDXProp_LabelStyleFace: break;
-      case kCDXProp_CaptionStyleFace: break;
-      case kCDXProp_LabelStyleColor: break;
-      case kCDXProp_CaptionStyleColor: break;
-      case kCDXProp_BondSpacingAbs: break;
-      case kCDXProp_LabelJustification: break;
-      case kCDXProp_FixInplaceExtent: break;
-      case kCDXProp_Side: break;
-      case kCDXProp_FixInplaceGap: break;
-      case kCDXProp_CartridgeData: break;
-      case kCDXProp_AminoAcidTermini: break;
-      case kCDXProp_ShowSequenceTermini: break;
-      case kCDXProp_ShowSequenceBonds: break;
-      case kCDXProp_ResidueWrapCount: break;
-      case kCDXProp_ResidueBlockCount: break;
-      case kCDXProp_Unused10: break;
-      case kCDXProp_Unused11: break;
-      case kCDXProp_BondSpacingType: break;
-      case kCDXProp_LabelStyleFontName: break;
-      case kCDXProp_CaptionStyleFontName: break;
-      case kCDXProp_ShowSequenceUnlinkedBranches: break;
-      case kCDXProp_MonomerRenderingStyle: break;
-      case kCDXProp_Window_IsZoomed: break;
-      case kCDXProp_Window_Position: break;
-      case kCDXProp_Window_Size: break;
-      case kCDXProp_Graphic_Type: break;
-      case kCDXProp_Line_Type: break;
-      case kCDXProp_Arrow_Type: break;
-      case kCDXProp_Rectangle_Type: break;
-      case kCDXProp_Oval_Type: break;
-      case kCDXProp_Orbital_Type: break;
-      case kCDXProp_Bracket_Type: break;
-      case kCDXProp_Symbol_Type: break;
-      case kCDXProp_Curve_Type: break;
-      case kCDXProp_Arrowhead_Size: break;
-      case kCDXProp_Arc_AngularSize: break;
-      case kCDXProp_Bracket_LipSize: break;
-      case kCDXProp_Curve_Points: break;
-      case kCDXProp_Bracket_Usage: break;
-      case kCDXProp_Polymer_RepeatPattern: break;
-      case kCDXProp_Polymer_FlipType: break;
-      case kCDXProp_BracketedObjects: break;
-      case kCDXProp_Bracket_RepeatCount: break;
-      case kCDXProp_Bracket_ComponentOrder: break;
-      case kCDXProp_Bracket_SRULabel: break;
-      case kCDXProp_Bracket_GraphicID: break;
-      case kCDXProp_Bracket_BondID: break;
-      case kCDXProp_Bracket_InnerAtomID: break;
-      case kCDXProp_Curve_Points3D: break;
-      case kCDXProp_Arrowhead_Type: break;
-      case kCDXProp_Arrowhead_CenterSize: break;
-      case kCDXProp_Arrowhead_Width: break;
-      case kCDXProp_ShadowSize: break;
-      case kCDXProp_Arrow_ShaftSpacing: break;
-      case kCDXProp_Arrow_EquilibriumRatio: break;
-      case kCDXProp_Arrowhead_Head: break;
-      case kCDXProp_Arrowhead_Tail: break;
-      case kCDXProp_Fill_Type: break;
-      case kCDXProp_Curve_Spacing: break;
-      case kCDXProp_Closed: break;
-      case kCDXProp_Arrow_Dipole: break;
-      case kCDXProp_Arrow_NoGo: break;
-      case kCDXProp_CornerRadius: break;
-      case kCDXProp_Frame_Type: break;
-      case kCDXProp_Arrow_SourceID: break;
-      case kCDXProp_Arrow_TargetID: break;
-      case kCDXProp_Arrow_IsSmart_Deleted: break;
-      case kCDXProp_Picture_Edition: break;
-      case kCDXProp_Picture_EditionAlias: break;
-      case kCDXProp_MacPICT: break;
-      case kCDXProp_WindowsMetafile: break;
-      case kCDXProp_OLEObject: break;
-      case kCDXProp_EnhancedMetafile: break;
-      case kCDXProp_Compressed_MacPICT: break;
-      case kCDXProp_Compressed_WindowsMetafile: break;
-      case kCDXProp_Compressed_OLEObject: break;
-      case kCDXProp_Compressed_EnhancedMetafile: break;
-      case kCDXProp_Uncompressed_MacPICT_Size: break;
-      case kCDXProp_Uncompressed_WindowsMetafile_Size: break;
-      case kCDXProp_Uncompressed_OLEObject_Size: break;
-      case kCDXProp_Uncompressed_EnhancedMetafile_Size: break;
-      case kCDXProp_GIF: break;
-      case kCDXProp_TIFF: break;
-      case kCDXProp_PNG: break;
-      case kCDXProp_JPEG: break;
-      case kCDXProp_BMP: break;
-      case kCDXProp_PDF: break;
-      case kCDXProp_Spectrum_XSpacing: break;
-      case kCDXProp_Spectrum_XLow: break;
-      case kCDXProp_Spectrum_XType: break;
-      case kCDXProp_Spectrum_YType: break;
-      case kCDXProp_Spectrum_XAxisLabel: break;
-      case kCDXProp_Spectrum_YAxisLabel: break;
-      case kCDXProp_Spectrum_DataPoint: break;
-      case kCDXProp_Spectrum_Class: break;
-      case kCDXProp_Spectrum_YLow: break;
-      case kCDXProp_Spectrum_YScale: break;
-      case kCDXProp_TLC_OriginFraction: break;
-      case kCDXProp_TLC_SolventFrontFraction: break;
-      case kCDXProp_TLC_ShowOrigin: break;
-      case kCDXProp_TLC_ShowSolventFront: break;
-      case kCDXProp_ShowBorders: break;
-      case kCDXProp_TLC_ShowSideTicks: break;
-      case kCDXProp_TLC_Rf: break;
-      case kCDXProp_TLC_Tail: break;
-      case kCDXProp_TLC_ShowRf: break;
-      case kCDXProp_GEP_ShowScale: break;
-      case kCDXProp_GEP_ScaleUnit: break;
-      case kCDXProp_GEP_StartRange: break;
-      case kCDXProp_GEP_EndRange: break;
-      case kCDXProp_GEP_ShowValue: break;
-      case kCDXProp_GEP_Value: break;
-      case kCDXProp_GEP_LaneLabelsAngle: break;
-      case kCDXProp_GEP_AxisWidth: break;
-      case kCDXProp_BioShape_Type: break;
-      case kCDXProp_1SubstrateEnzyme_ReceptorSize: break;
-      case kCDXProp_Receptor_NeckWidth: break;
-      case kCDXProp_HelixProtein_CylinderWidth: break;
-      case kCDXProp_HelixProtein_CylinderHeight: break;
-      case kCDXProp_HelixProtein_CylinderDistance: break;
-      case kCDXProp_HelixProtein_PipeWidth: break;
-      case kCDXProp_HelixProtein_Extra: break;
-      case kCDXProp_Membrane_ElementSize: break;
-      case kCDXProp_Membrane_StartAngle: break;
-      case kCDXProp_Membrane_EndAngle: break;
-      case kCDXProp_DNA_WaveLength: break;
-      case kCDXProp_DNA_WaveWidth: break;
-      case kCDXProp_DNA_Offset: break;
-      case kCDXProp_DNA_WaveHeight: break;
-      case kCDXProp_Gprotein_UpperHeight: break;
-      case kCDXProp_NamedAlternativeGroup_TextFrame: break;
-      case kCDXProp_NamedAlternativeGroup_GroupFrame: break;
-      case kCDXProp_NamedAlternativeGroup_Valence: break;
-      case kCDXProp_GeometricFeature: break;
-      case kCDXProp_RelationValue: break;
-      case kCDXProp_BasisObjects: break;
-      case kCDXProp_ConstraintType: break;
-      case kCDXProp_ConstraintMin: break;
-      case kCDXProp_ConstraintMax: break;
-      case kCDXProp_IgnoreUnconnectedAtoms: break;
-      case kCDXProp_DihedralIsChiral: break;
-      case kCDXProp_PointIsDirected: break;
-      case kCDXProp_ChemicalPropertyType: break;
-      case kCDXProp_ChemicalPropertyDisplayID: break;
-      case kCDXProp_ChemicalPropertyIsActive: break;
-      case kCDXProp_ChemicalPropertyUnknown: break;
-      case kCDXProp_ChemicalPropertyName: break;
-      case kCDXProp_ChemicalPropertyFormula: break;
-      case kCDXProp_ChemicalPropertyExactMass: break;
-      case kCDXProp_ChemicalPropertyMolWeight: break;
-      case kCDXProp_ChemicalPropertyMOverZ: break;
-      case kCDXProp_ChemicalPropertyAnalysis: break;
-      case kCDXProp_ChemicalPropertyBoilingPoint: break;
-      case kCDXProp_ChemicalPropertyMeltingPoint: break;
-      case kCDXProp_ChemicalPropertyCriticalTemp: break;
-      case kCDXProp_ChemicalPropertyCriticalPressure: break;
-      case kCDXProp_ChemicalPropertyCriticalVolume: break;
-      case kCDXProp_ChemicalPropertyGibbsEnergy: break;
-      case kCDXProp_ChemicalPropertyLogP: break;
-      case kCDXProp_ChemicalPropertyMR: break;
-      case kCDXProp_ChemicalPropertyHenrysLaw: break;
-      case kCDXProp_ChemicalPropertyHeatOfForm: break;
-      case kCDXProp_ChemicalPropertytPSA: break;
-      case kCDXProp_ChemicalPropertyCLogP: break;
-      case kCDXProp_ChemicalPropertyCMR: break;
-      case kCDXProp_ChemicalPropertyLogS: break;
-      case kCDXProp_ChemicalPropertyPKa: break;
-      case kCDXProp_ChemicalPropertyID: break;
-      case kCDXProp_ChemicalPropertyFragmentLabel: break;
-      case kCDXProp_ChemicalPropertyTypeIUPACAtomNumber: break;
-      case kCDXProp_ChemicalPropertyIsChemicallySignificant: break;
-      case kCDXProp_ChemicalPropertyExternalBonds: break;
-      case kCDXProp_ReactionStep_Atom_Map: break;
-      case kCDXProp_ReactionStep_Reactants: break;
-      case kCDXProp_ReactionStep_Products: break;
-      case kCDXProp_ReactionStep_Plusses: break;
-      case kCDXProp_ReactionStep_Arrows: break;
-      case kCDXProp_ReactionStep_ObjectsAboveArrow: break;
-      case kCDXProp_ReactionStep_ObjectsBelowArrow: break;
-      case kCDXProp_ReactionStep_Atom_Map_Manual: break;
-      case kCDXProp_ReactionStep_Atom_Map_Auto: break;
-      case kCDXProp_RxnAutonumber_Style: break;
-      case kCDXProp_RxnAutonumber_Conditions: break;
-      case kCDXProp_RxnAutonumber_Start: break;
-      case kCDXProp_RxnAutonumber_Format: break;
-      case kCDXProp_ObjectTag_Type: break;
-      case kCDXProp_Unused6: break;
-      case kCDXProp_Unused7: break;
-      case kCDXProp_ObjectTag_Tracking: break;
-      case kCDXProp_ObjectTag_Persistent: break;
-      case kCDXProp_ObjectTag_Value: break;
-      case kCDXProp_Positioning: break;
-      case kCDXProp_PositioningAngle: break;
-      case kCDXProp_PositioningOffset: break;
-      case kCDXProp_Sequence_Identifier: break;
-      case kCDXProp_CrossReference_Container: break;
-      case kCDXProp_CrossReference_Document: break;
-      case kCDXProp_CrossReference_Identifier: break;
-      case kCDXProp_CrossReference_Sequence: break;
-      case kCDXProp_Template_PaneHeight: break;
-      case kCDXProp_Template_NumRows: break;
-      case kCDXProp_Template_NumColumns: break;
-      case kCDXProp_Group_Integral: break;
-      case kCDXProp_SG_DataType: break;
-      case kCDXProp_SG_PropertyType: break;
-      case kCDXProp_SG_DataValue: break;
-      case kCDXProp_SG_ComponentIsReactant: break;
-      case kCDXProp_SG_ComponentIsHeader: break;
-      case kCDXProp_IsHidden: break;
-      case kCDXProp_IsReadOnly: break;
-      case kCDXProp_IsEdited: break;
-      case kCDXProp_SG_ComponentReferenceID: break;
-      case kCDXProp_PlasmidMap_NumberBasePairs: break;
-      case kCDXProp_PlasmidMap_MarkerStart: break;
-      case kCDXProp_PlasmidMap_MarkerOffset: break;
-      case kCDXProp_PlasmidMap_MarkerAngle: break;
-      case kCDXProp_PlasmidMap_RegionStart: break;
-      case kCDXProp_PlasmidMap_RegionEnd: break;
-      case kCDXProp_PlasmidMap_RegionOffset: break;
-      case kCDXProp_PlasmidMap_RingRadius: break;
-      case kCDXProp_RLogic_Group: break;
-      case kCDXProp_RLogic_Occurrence: break;
-      case kCDXProp_RLogic_RestH: break;
-      case kCDXProp_RLogic_IfThenGroup: break;
-      case kCDXProp_Annotation_Keyword: break;
-      case kCDXProp_Annotation_Content: break;
-      case kCDXProp_SplitterPositions: break;
-      case kCDXProp_PageDefinition: break;
-      case kCDXProp_Property_Rule: break;
-      case kCDXProp_Property_DataType: break;
-      case kCDXProp_Property_Value: break;
-      case kCDXUser_TemporaryBegin: break;
-      case kCDXUser_TemporaryEnd: break;
-      case kCDXObj_Document: break;
-      case kCDXObj_Page: break;
-      case kCDXObj_Group: break;
-      case kCDXObj_Fragment: break;
-      case kCDXObj_Text: break;
-      case kCDXObj_Graphic: break;
-      case kCDXObj_Curve: break;
-      case kCDXObj_EmbeddedObject: break;
-      case kCDXObj_NamedAlternativeGroup: break;
-      case kCDXObj_TemplateGrid: break;
-      case kCDXObj_RegistryNumber: break;
-      case kCDXObj_ReactionScheme: break;
-      case kCDXObj_ReactionStep: break;
-      case kCDXObj_ObjectDefinition: break;
-      case kCDXObj_Spectrum: break;
-      case kCDXObj_ObjectTag: break;
-      case kCDXObj_OleClientItem: break;
-      case kCDXObj_Sequence: break;
-      case kCDXObj_CrossReference: break;
-      case kCDXObj_Splitter: break;
-      case kCDXObj_Table: break;
-      case kCDXObj_BracketedGroup: break;
-      case kCDXObj_BracketAttachment: break;
-      case kCDXObj_CrossingBond: break;
-      case kCDXObj_Border: break;
-      case kCDXObj_Geometry: break;
-      case kCDXObj_Constraint: break;
-      case kCDXObj_TLCPlate: break;
-      case kCDXObj_TLCLane: break;
-      case kCDXObj_TLCSpot: break;
-      case kCDXObj_ChemicalProperty: break;
-      case kCDXObj_Arrow: break;
-      case kCDXObj_StoichiometryGrid: break;
-      case kCDXObj_SGComponent: break;
-      case kCDXObj_SGDatum: break;
-      case kCDXObj_BioShape: break;
-      case kCDXObj_PlasmidMap: break;
-      case kCDXObj_PlasmidMarker: break;
-      case kCDXObj_PlasmidRegion: break;
-      case kCDXObj_RLogic: break;
-      case kCDXObj_RLogicItem: break;
-      case kCDXObj_Annotation: break;
-      case kCDXObj_GEPPlate: break;
-      case kCDXObj_GEPBand: break;
-      case kCDXObj_Marker: break;
-      case kCDXObj_GEPLane: break;
-      case kCDXObj_DocumentProperties: break;
-      case kCDXObj_Property: break;
-      case kCDXObj_ColoredMolecularArea: break;
-      case kCDXObj_UnknownObject: break;       
+      case kCDXProp_EndObject:
+        break;
+      case kCDXProp_CreationUserName:
+        break;
+      case kCDXProp_CreationDate:
+        break;
+      case kCDXProp_CreationProgram:
+        break;
+      case kCDXProp_ModificationUserName:
+        break;
+      case kCDXProp_ModificationDate:
+        break;
+      case kCDXProp_ModificationProgram:
+        break;
+      case kCDXProp_Unused1:
+        break;
+      case kCDXProp_Name:
+        break;
+      case kCDXProp_Comment:
+        break;
+      case kCDXProp_ZOrder:
+        break;
+      case kCDXProp_RegistryNumber:
+        break;
+      case kCDXProp_RegistryAuthority:
+        break;
+      case kCDXProp_Unused2:
+        break;
+      case kCDXProp_RepresentsProperty:
+        break;
+      case kCDXProp_IgnoreWarnings:
+        break;
+      case kCDXProp_ChemicalWarning:
+        break;
+      case kCDXProp_Visible:
+        break;
+      case kCDXProp_Transparent:
+        break;
+      case kCDXProp_SupersededBy:
+        break;
+      case kCDXProp_StructurePerspective:
+        break;
+      case kCDXProp_FontTable:
+        break;
+      case kCDXProp_2DPosition:
+        break;
+      case kCDXProp_3DPosition:
+        break;
+      case kCDXProp_2DExtent:
+        break;
+      case kCDXProp_3DExtent:
+        break;
+      case kCDXProp_BoundingBox:
+        break;
+      case kCDXProp_RotationAngle:
+        break;
+      case kCDXProp_BoundsInParent:
+        break;
+      case kCDXProp_3DHead:
+        break;
+      case kCDXProp_3DTail:
+        break;
+      case kCDXProp_TopLeft:
+        break;
+      case kCDXProp_TopRight:
+        break;
+      case kCDXProp_BottomRight:
+        break;
+      case kCDXProp_BottomLeft:
+        break;
+      case kCDXProp_3DCenter:
+        break;
+      case kCDXProp_3DMajorAxisEnd:
+        break;
+      case kCDXProp_3DMinorAxisEnd:
+        break;
+      case kCDXProp_ColorTable:
+        break;
+      case kCDXProp_ForegroundColor:
+        break;
+      case kCDXProp_BackgroundColor:
+        break;
+      case kCDXProp_FadePercent:
+        break;
+      case kCDXProp_Unused8:
+        break;
+      case kCDXProp_Unused9:
+        break;
+      case kCDXProp_ForegroundAlpha:
+        break;
+      case kCDXProp_BackgroundAlpha:
+        break;
+      case kCDXProp_HighlightColor:
+        break;
+      case kCDXProp_Node_Type:
+        break;
+      case kCDXProp_Node_LabelDisplay:
+        break;
+      case kCDXProp_Node_Element:
+        break;
+      case kCDXProp_Atom_ElementList:
+        break;
+      case kCDXProp_Atom_Formula:
+        break;
+      case kCDXProp_Atom_Isotope:
+        break;
+      case kCDXProp_Atom_Charge:
+        break;
+      case kCDXProp_Atom_Radical:
+        break;
+      case kCDXProp_Atom_RestrictFreeSites:
+        break;
+      case kCDXProp_Atom_RestrictImplicitHydrogens:
+        break;
+      case kCDXProp_Atom_RestrictRingBondCount:
+        break;
+      case kCDXProp_Atom_RestrictUnsaturatedBonds:
+        break;
+      case kCDXProp_Atom_RestrictRxnChange:
+        break;
+      case kCDXProp_Atom_RestrictRxnStereo:
+        break;
+      case kCDXProp_Atom_AbnormalValence:
+        break;
+      case kCDXProp_Unused3:
+        break;
+      case kCDXProp_Atom_NumHydrogens:
+        break;
+      case kCDXProp_Unused4:
+        break;
+      case kCDXProp_Unused5:
+        break;
+      case kCDXProp_Atom_HDot:
+        break;
+      case kCDXProp_Atom_HDash:
+        break;
+      case kCDXProp_Atom_Geometry:
+        break;
+      case kCDXProp_Atom_BondOrdering:
+        break;
+      case kCDXProp_Node_Attachments:
+        break;
+      case kCDXProp_Atom_GenericNickname:
+        break;
+      case kCDXProp_Atom_AltGroupID:
+        break;
+      case kCDXProp_Atom_RestrictSubstituentsUpTo:
+        break;
+      case kCDXProp_Atom_RestrictSubstituentsExactly:
+        break;
+      case kCDXProp_Atom_CIPStereochemistry:
+        break;
+      case kCDXProp_Atom_Translation:
+        break;
+      case kCDXProp_Atom_AtomNumber:
+        break;
+      case kCDXProp_Atom_ShowQuery:
+        break;
+      case kCDXProp_Atom_ShowStereo:
+        break;
+      case kCDXProp_Atom_ShowAtomNumber:
+        break;
+      case kCDXProp_Atom_LinkCountLow:
+        break;
+      case kCDXProp_Atom_LinkCountHigh:
+        break;
+      case kCDXProp_Atom_IsotopicAbundance:
+        break;
+      case kCDXProp_Atom_ExternalConnectionType:
+        break;
+      case kCDXProp_Atom_GenericList:
+        break;
+      case kCDXProp_Atom_ShowTerminalCarbonLabels:
+        break;
+      case kCDXProp_Atom_ShowNonTerminalCarbonLabels:
+        break;
+      case kCDXProp_Atom_HideImplicitHydrogens:
+        break;
+      case kCDXProp_Atom_ShowEnhancedStereo:
+        break;
+      case kCDXProp_Atom_EnhancedStereoType:
+        break;
+      case kCDXProp_Atom_EnhancedStereoGroupNum:
+        break;
+      case kCDXProp_Node_NeedsClean:
+        break;
+      case kCDXProp_Atom_ResidueID:
+        break;
+      case kCDXProp_Atom_ShowResidueID:
+        break;
+      case kCDXProp_Atom_ExternalConnectionNum:
+        break;
+      case kCDXProp_Atom_ShowAtomID:
+        break;
+      case kCDXProp_Atom_AtomID:
+        break;
+      case kCDXProp_Node_HydrogenBondAttachmentAtoms:
+        break;
+      case kCDXProp_Node_HydrogenBonds:
+        break;
+      case kCDXProp_Mole_Racemic:
+        break;
+      case kCDXProp_Mole_Absolute:
+        break;
+      case kCDXProp_Mole_Relative:
+        break;
+      case kCDXProp_Mole_Formula:
+        break;
+      case kCDXProp_Mole_Weight:
+        break;
+      case kCDXProp_Frag_ConnectionOrder:
+        break;
+      case kCDXProp_Frag_SequenceType:
+        break;
+      case kCDXProp_Frag_IsFromGuidedStereo:
+        break;
+      case kCDXProp_Frag_IsComplement:
+        break;
+      case kCDXProp_Bond_Order:
+        break;
+      case kCDXProp_Bond_Display:
+        break;
+      case kCDXProp_Bond_Display2:
+        break;
+      case kCDXProp_Bond_DoublePosition:
+        break;
+      case kCDXProp_Bond_Begin:
+        break;
+      case kCDXProp_Bond_End:
+        break;
+      case kCDXProp_Bond_RestrictTopology:
+        break;
+      case kCDXProp_Bond_RestrictRxnParticipation:
+        break;
+      case kCDXProp_Bond_BeginAttach:
+        break;
+      case kCDXProp_Bond_EndAttach:
+        break;
+      case kCDXProp_Bond_CIPStereochemistry:
+        break;
+      case kCDXProp_Bond_BondOrdering:
+        break;
+      case kCDXProp_Bond_ShowQuery:
+        break;
+      case kCDXProp_Bond_ShowStereo:
+        break;
+      case kCDXProp_Bond_CrossingBonds:
+        break;
+      case kCDXProp_Bond_ShowRxn:
+        break;
+      case kCDXProp_Bond_Connectivity:
+        break;
+      case kCDXProp_Bond_BeginExternalNum:
+        break;
+      case kCDXProp_Bond_EndExternalNum:
+        break;
+      case kCDXProp_Bond_Connectivity_Routed:
+        break;
+      case kCDXProp_Text:
+        break;
+      case kCDXProp_Justification:
+        break;
+      case kCDXProp_LineHeight:
+        break;
+      case kCDXProp_WordWrapWidth:
+        break;
+      case kCDXProp_LineStarts:
+        break;
+      case kCDXProp_LabelAlignment:
+        break;
+      case kCDXProp_LabelLineHeight:
+        break;
+      case kCDXProp_CaptionLineHeight:
+        break;
+      case kCDXProp_InterpretChemically:
+        break;
+      case kCDXProp_UTF8Text:
+        break;
+      case kCDXProp_MacPrintInfo:
+        break;
+      case kCDXProp_WinPrintInfo:
+        break;
+      case kCDXProp_PrintMargins:
+        break;
+      case kCDXProp_ChainAngle:
+        break;
+      case kCDXProp_BondSpacing:
+        break;
+      case kCDXProp_BondLength:
+        break;
+      case kCDXProp_BoldWidth:
+        break;
+      case kCDXProp_LineWidth:
+        break;
+      case kCDXProp_MarginWidth:
+        break;
+      case kCDXProp_HashSpacing:
+        break;
+      case kCDXProp_LabelStyle:
+        break;
+      case kCDXProp_CaptionStyle:
+        break;
+      case kCDXProp_CaptionJustification:
+        break;
+      case kCDXProp_FractionalWidths:
+        break;
+      case kCDXProp_Magnification:
+        break;
+      case kCDXProp_WidthPages:
+        break;
+      case kCDXProp_HeightPages:
+        break;
+      case kCDXProp_DrawingSpaceType:
+        break;
+      case kCDXProp_Width:
+        break;
+      case kCDXProp_Height:
+        break;
+      case kCDXProp_PageOverlap:
+        break;
+      case kCDXProp_Header:
+        break;
+      case kCDXProp_HeaderPosition:
+        break;
+      case kCDXProp_Footer:
+        break;
+      case kCDXProp_FooterPosition:
+        break;
+      case kCDXProp_PrintTrimMarks:
+        break;
+      case kCDXProp_LabelStyleFont:
+        break;
+      case kCDXProp_CaptionStyleFont:
+        break;
+      case kCDXProp_LabelStyleSize:
+        break;
+      case kCDXProp_CaptionStyleSize:
+        break;
+      case kCDXProp_LabelStyleFace:
+        break;
+      case kCDXProp_CaptionStyleFace:
+        break;
+      case kCDXProp_LabelStyleColor:
+        break;
+      case kCDXProp_CaptionStyleColor:
+        break;
+      case kCDXProp_BondSpacingAbs:
+        break;
+      case kCDXProp_LabelJustification:
+        break;
+      case kCDXProp_FixInplaceExtent:
+        break;
+      case kCDXProp_Side:
+        break;
+      case kCDXProp_FixInplaceGap:
+        break;
+      case kCDXProp_CartridgeData:
+        break;
+      case kCDXProp_AminoAcidTermini:
+        break;
+      case kCDXProp_ShowSequenceTermini:
+        break;
+      case kCDXProp_ShowSequenceBonds:
+        break;
+      case kCDXProp_ResidueWrapCount:
+        break;
+      case kCDXProp_ResidueBlockCount:
+        break;
+      case kCDXProp_Unused10:
+        break;
+      case kCDXProp_Unused11:
+        break;
+      case kCDXProp_BondSpacingType:
+        break;
+      case kCDXProp_LabelStyleFontName:
+        break;
+      case kCDXProp_CaptionStyleFontName:
+        break;
+      case kCDXProp_ShowSequenceUnlinkedBranches:
+        break;
+      case kCDXProp_MonomerRenderingStyle:
+        break;
+      case kCDXProp_Window_IsZoomed:
+        break;
+      case kCDXProp_Window_Position:
+        break;
+      case kCDXProp_Window_Size:
+        break;
+      case kCDXProp_Graphic_Type:
+        break;
+      case kCDXProp_Line_Type:
+        break;
+      case kCDXProp_Arrow_Type:
+        break;
+      case kCDXProp_Rectangle_Type:
+        break;
+      case kCDXProp_Oval_Type:
+        break;
+      case kCDXProp_Orbital_Type:
+        break;
+      case kCDXProp_Bracket_Type:
+        break;
+      case kCDXProp_Symbol_Type:
+        break;
+      case kCDXProp_Curve_Type:
+        break;
+      case kCDXProp_Arrowhead_Size:
+        break;
+      case kCDXProp_Arc_AngularSize:
+        break;
+      case kCDXProp_Bracket_LipSize:
+        break;
+      case kCDXProp_Curve_Points:
+        break;
+      case kCDXProp_Bracket_Usage:
+        break;
+      case kCDXProp_Polymer_RepeatPattern:
+        break;
+      case kCDXProp_Polymer_FlipType:
+        break;
+      case kCDXProp_BracketedObjects:
+        break;
+      case kCDXProp_Bracket_RepeatCount:
+        break;
+      case kCDXProp_Bracket_ComponentOrder:
+        break;
+      case kCDXProp_Bracket_SRULabel:
+        break;
+      case kCDXProp_Bracket_GraphicID:
+        break;
+      case kCDXProp_Bracket_BondID:
+        break;
+      case kCDXProp_Bracket_InnerAtomID:
+        break;
+      case kCDXProp_Curve_Points3D:
+        break;
+      case kCDXProp_Arrowhead_Type:
+        break;
+      case kCDXProp_Arrowhead_CenterSize:
+        break;
+      case kCDXProp_Arrowhead_Width:
+        break;
+      case kCDXProp_ShadowSize:
+        break;
+      case kCDXProp_Arrow_ShaftSpacing:
+        break;
+      case kCDXProp_Arrow_EquilibriumRatio:
+        break;
+      case kCDXProp_Arrowhead_Head:
+        break;
+      case kCDXProp_Arrowhead_Tail:
+        break;
+      case kCDXProp_Fill_Type:
+        break;
+      case kCDXProp_Curve_Spacing:
+        break;
+      case kCDXProp_Closed:
+        break;
+      case kCDXProp_Arrow_Dipole:
+        break;
+      case kCDXProp_Arrow_NoGo:
+        break;
+      case kCDXProp_CornerRadius:
+        break;
+      case kCDXProp_Frame_Type:
+        break;
+      case kCDXProp_Arrow_SourceID:
+        break;
+      case kCDXProp_Arrow_TargetID:
+        break;
+      case kCDXProp_Arrow_IsSmart_Deleted:
+        break;
+      case kCDXProp_Picture_Edition:
+        break;
+      case kCDXProp_Picture_EditionAlias:
+        break;
+      case kCDXProp_MacPICT:
+        break;
+      case kCDXProp_WindowsMetafile:
+        break;
+      case kCDXProp_OLEObject:
+        break;
+      case kCDXProp_EnhancedMetafile:
+        break;
+      case kCDXProp_Compressed_MacPICT:
+        break;
+      case kCDXProp_Compressed_WindowsMetafile:
+        break;
+      case kCDXProp_Compressed_OLEObject:
+        break;
+      case kCDXProp_Compressed_EnhancedMetafile:
+        break;
+      case kCDXProp_Uncompressed_MacPICT_Size:
+        break;
+      case kCDXProp_Uncompressed_WindowsMetafile_Size:
+        break;
+      case kCDXProp_Uncompressed_OLEObject_Size:
+        break;
+      case kCDXProp_Uncompressed_EnhancedMetafile_Size:
+        break;
+      case kCDXProp_GIF:
+        break;
+      case kCDXProp_TIFF:
+        break;
+      case kCDXProp_PNG:
+        break;
+      case kCDXProp_JPEG:
+        break;
+      case kCDXProp_BMP:
+        break;
+      case kCDXProp_PDF:
+        break;
+      case kCDXProp_Spectrum_XSpacing:
+        break;
+      case kCDXProp_Spectrum_XLow:
+        break;
+      case kCDXProp_Spectrum_XType:
+        break;
+      case kCDXProp_Spectrum_YType:
+        break;
+      case kCDXProp_Spectrum_XAxisLabel:
+        break;
+      case kCDXProp_Spectrum_YAxisLabel:
+        break;
+      case kCDXProp_Spectrum_DataPoint:
+        break;
+      case kCDXProp_Spectrum_Class:
+        break;
+      case kCDXProp_Spectrum_YLow:
+        break;
+      case kCDXProp_Spectrum_YScale:
+        break;
+      case kCDXProp_TLC_OriginFraction:
+        break;
+      case kCDXProp_TLC_SolventFrontFraction:
+        break;
+      case kCDXProp_TLC_ShowOrigin:
+        break;
+      case kCDXProp_TLC_ShowSolventFront:
+        break;
+      case kCDXProp_ShowBorders:
+        break;
+      case kCDXProp_TLC_ShowSideTicks:
+        break;
+      case kCDXProp_TLC_Rf:
+        break;
+      case kCDXProp_TLC_Tail:
+        break;
+      case kCDXProp_TLC_ShowRf:
+        break;
+      case kCDXProp_GEP_ShowScale:
+        break;
+      case kCDXProp_GEP_ScaleUnit:
+        break;
+      case kCDXProp_GEP_StartRange:
+        break;
+      case kCDXProp_GEP_EndRange:
+        break;
+      case kCDXProp_GEP_ShowValue:
+        break;
+      case kCDXProp_GEP_Value:
+        break;
+      case kCDXProp_GEP_LaneLabelsAngle:
+        break;
+      case kCDXProp_GEP_AxisWidth:
+        break;
+      case kCDXProp_BioShape_Type:
+        break;
+      case kCDXProp_1SubstrateEnzyme_ReceptorSize:
+        break;
+      case kCDXProp_Receptor_NeckWidth:
+        break;
+      case kCDXProp_HelixProtein_CylinderWidth:
+        break;
+      case kCDXProp_HelixProtein_CylinderHeight:
+        break;
+      case kCDXProp_HelixProtein_CylinderDistance:
+        break;
+      case kCDXProp_HelixProtein_PipeWidth:
+        break;
+      case kCDXProp_HelixProtein_Extra:
+        break;
+      case kCDXProp_Membrane_ElementSize:
+        break;
+      case kCDXProp_Membrane_StartAngle:
+        break;
+      case kCDXProp_Membrane_EndAngle:
+        break;
+      case kCDXProp_DNA_WaveLength:
+        break;
+      case kCDXProp_DNA_WaveWidth:
+        break;
+      case kCDXProp_DNA_Offset:
+        break;
+      case kCDXProp_DNA_WaveHeight:
+        break;
+      case kCDXProp_Gprotein_UpperHeight:
+        break;
+      case kCDXProp_NamedAlternativeGroup_TextFrame:
+        break;
+      case kCDXProp_NamedAlternativeGroup_GroupFrame:
+        break;
+      case kCDXProp_NamedAlternativeGroup_Valence:
+        break;
+      case kCDXProp_GeometricFeature:
+        break;
+      case kCDXProp_RelationValue:
+        break;
+      case kCDXProp_BasisObjects:
+        break;
+      case kCDXProp_ConstraintType:
+        break;
+      case kCDXProp_ConstraintMin:
+        break;
+      case kCDXProp_ConstraintMax:
+        break;
+      case kCDXProp_IgnoreUnconnectedAtoms:
+        break;
+      case kCDXProp_DihedralIsChiral:
+        break;
+      case kCDXProp_PointIsDirected:
+        break;
+      case kCDXProp_ChemicalPropertyType:
+        break;
+      case kCDXProp_ChemicalPropertyDisplayID:
+        break;
+      case kCDXProp_ChemicalPropertyIsActive:
+        break;
+      case kCDXProp_ChemicalPropertyUnknown:
+        break;
+      case kCDXProp_ChemicalPropertyName:
+        break;
+      case kCDXProp_ChemicalPropertyFormula:
+        break;
+      case kCDXProp_ChemicalPropertyExactMass:
+        break;
+      case kCDXProp_ChemicalPropertyMolWeight:
+        break;
+      case kCDXProp_ChemicalPropertyMOverZ:
+        break;
+      case kCDXProp_ChemicalPropertyAnalysis:
+        break;
+      case kCDXProp_ChemicalPropertyBoilingPoint:
+        break;
+      case kCDXProp_ChemicalPropertyMeltingPoint:
+        break;
+      case kCDXProp_ChemicalPropertyCriticalTemp:
+        break;
+      case kCDXProp_ChemicalPropertyCriticalPressure:
+        break;
+      case kCDXProp_ChemicalPropertyCriticalVolume:
+        break;
+      case kCDXProp_ChemicalPropertyGibbsEnergy:
+        break;
+      case kCDXProp_ChemicalPropertyLogP:
+        break;
+      case kCDXProp_ChemicalPropertyMR:
+        break;
+      case kCDXProp_ChemicalPropertyHenrysLaw:
+        break;
+      case kCDXProp_ChemicalPropertyHeatOfForm:
+        break;
+      case kCDXProp_ChemicalPropertytPSA:
+        break;
+      case kCDXProp_ChemicalPropertyCLogP:
+        break;
+      case kCDXProp_ChemicalPropertyCMR:
+        break;
+      case kCDXProp_ChemicalPropertyLogS:
+        break;
+      case kCDXProp_ChemicalPropertyPKa:
+        break;
+      case kCDXProp_ChemicalPropertyID:
+        break;
+      case kCDXProp_ChemicalPropertyFragmentLabel:
+        break;
+      case kCDXProp_ChemicalPropertyTypeIUPACAtomNumber:
+        break;
+      case kCDXProp_ChemicalPropertyIsChemicallySignificant:
+        break;
+      case kCDXProp_ChemicalPropertyExternalBonds:
+        break;
+      case kCDXProp_ReactionStep_Atom_Map:
+        break;
+      case kCDXProp_ReactionStep_Reactants:
+        break;
+      case kCDXProp_ReactionStep_Products:
+        break;
+      case kCDXProp_ReactionStep_Plusses:
+        break;
+      case kCDXProp_ReactionStep_Arrows:
+        break;
+      case kCDXProp_ReactionStep_ObjectsAboveArrow:
+        break;
+      case kCDXProp_ReactionStep_ObjectsBelowArrow:
+        break;
+      case kCDXProp_ReactionStep_Atom_Map_Manual:
+        break;
+      case kCDXProp_ReactionStep_Atom_Map_Auto:
+        break;
+      case kCDXProp_RxnAutonumber_Style:
+        break;
+      case kCDXProp_RxnAutonumber_Conditions:
+        break;
+      case kCDXProp_RxnAutonumber_Start:
+        break;
+      case kCDXProp_RxnAutonumber_Format:
+        break;
+      case kCDXProp_ObjectTag_Type:
+        break;
+      case kCDXProp_Unused6:
+        break;
+      case kCDXProp_Unused7:
+        break;
+      case kCDXProp_ObjectTag_Tracking:
+        break;
+      case kCDXProp_ObjectTag_Persistent:
+        break;
+      case kCDXProp_ObjectTag_Value:
+        break;
+      case kCDXProp_Positioning:
+        break;
+      case kCDXProp_PositioningAngle:
+        break;
+      case kCDXProp_PositioningOffset:
+        break;
+      case kCDXProp_Sequence_Identifier:
+        break;
+      case kCDXProp_CrossReference_Container:
+        break;
+      case kCDXProp_CrossReference_Document:
+        break;
+      case kCDXProp_CrossReference_Identifier:
+        break;
+      case kCDXProp_CrossReference_Sequence:
+        break;
+      case kCDXProp_Template_PaneHeight:
+        break;
+      case kCDXProp_Template_NumRows:
+        break;
+      case kCDXProp_Template_NumColumns:
+        break;
+      case kCDXProp_Group_Integral:
+        break;
+      case kCDXProp_SG_DataType:
+        break;
+      case kCDXProp_SG_PropertyType:
+        break;
+      case kCDXProp_SG_DataValue:
+        break;
+      case kCDXProp_SG_ComponentIsReactant:
+        break;
+      case kCDXProp_SG_ComponentIsHeader:
+        break;
+      case kCDXProp_IsHidden:
+        break;
+      case kCDXProp_IsReadOnly:
+        break;
+      case kCDXProp_IsEdited:
+        break;
+      case kCDXProp_SG_ComponentReferenceID:
+        break;
+      case kCDXProp_PlasmidMap_NumberBasePairs:
+        break;
+      case kCDXProp_PlasmidMap_MarkerStart:
+        break;
+      case kCDXProp_PlasmidMap_MarkerOffset:
+        break;
+      case kCDXProp_PlasmidMap_MarkerAngle:
+        break;
+      case kCDXProp_PlasmidMap_RegionStart:
+        break;
+      case kCDXProp_PlasmidMap_RegionEnd:
+        break;
+      case kCDXProp_PlasmidMap_RegionOffset:
+        break;
+      case kCDXProp_PlasmidMap_RingRadius:
+        break;
+      case kCDXProp_RLogic_Group:
+        break;
+      case kCDXProp_RLogic_Occurrence:
+        break;
+      case kCDXProp_RLogic_RestH:
+        break;
+      case kCDXProp_RLogic_IfThenGroup:
+        break;
+      case kCDXProp_Annotation_Keyword:
+        break;
+      case kCDXProp_Annotation_Content:
+        break;
+      case kCDXProp_SplitterPositions:
+        break;
+      case kCDXProp_PageDefinition:
+        break;
+      case kCDXProp_Property_Rule:
+        break;
+      case kCDXProp_Property_DataType:
+        break;
+      case kCDXProp_Property_Value:
+        break;
+      case kCDXUser_TemporaryBegin:
+        break;
+      case kCDXUser_TemporaryEnd:
+        break;
+      case kCDXObj_Document:
+        break;
+      case kCDXObj_Page:
+        break;
+      case kCDXObj_Group:
+        break;
+      case kCDXObj_Fragment:
+        break;
+      case kCDXObj_Text:
+        break;
+      case kCDXObj_Graphic:
+        break;
+      case kCDXObj_Curve:
+        break;
+      case kCDXObj_EmbeddedObject:
+        break;
+      case kCDXObj_NamedAlternativeGroup:
+        break;
+      case kCDXObj_TemplateGrid:
+        break;
+      case kCDXObj_RegistryNumber:
+        break;
+      case kCDXObj_ReactionScheme:
+        break;
+      case kCDXObj_ReactionStep:
+        break;
+      case kCDXObj_ObjectDefinition:
+        break;
+      case kCDXObj_Spectrum:
+        break;
+      case kCDXObj_ObjectTag:
+        break;
+      case kCDXObj_OleClientItem:
+        break;
+      case kCDXObj_Sequence:
+        break;
+      case kCDXObj_CrossReference:
+        break;
+      case kCDXObj_Splitter:
+        break;
+      case kCDXObj_Table:
+        break;
+      case kCDXObj_BracketedGroup:
+        break;
+      case kCDXObj_BracketAttachment:
+        break;
+      case kCDXObj_CrossingBond:
+        break;
+      case kCDXObj_Border:
+        break;
+      case kCDXObj_Geometry:
+        break;
+      case kCDXObj_Constraint:
+        break;
+      case kCDXObj_TLCPlate:
+        break;
+      case kCDXObj_TLCLane:
+        break;
+      case kCDXObj_TLCSpot:
+        break;
+      case kCDXObj_ChemicalProperty:
+        break;
+      case kCDXObj_Arrow:
+        break;
+      case kCDXObj_StoichiometryGrid:
+        break;
+      case kCDXObj_SGComponent:
+        break;
+      case kCDXObj_SGDatum:
+        break;
+      case kCDXObj_BioShape:
+        break;
+      case kCDXObj_PlasmidMap:
+        break;
+      case kCDXObj_PlasmidMarker:
+        break;
+      case kCDXObj_PlasmidRegion:
+        break;
+      case kCDXObj_RLogic:
+        break;
+      case kCDXObj_RLogicItem:
+        break;
+      case kCDXObj_Annotation:
+        break;
+      case kCDXObj_GEPPlate:
+        break;
+      case kCDXObj_GEPBand:
+        break;
+      case kCDXObj_Marker:
+        break;
+      case kCDXObj_GEPLane:
+        break;
+      case kCDXObj_DocumentProperties:
+        break;
+      case kCDXObj_Property:
+        break;
+      case kCDXObj_ColoredMolecularArea:
+        break;
+      case kCDXObj_UnknownObject:
+        break;
     }
   }
 
@@ -582,5 +1034,5 @@ bool parseFragment(RWMol &mol, CDXFragment &fragment, PageData &pagedata,
 
   return !skip_fragment;
 }
-}
+}  // namespace ChemDraw
 }  // namespace RDKit

--- a/External/ChemDraw/fragment.cpp
+++ b/External/ChemDraw/fragment.cpp
@@ -89,13 +89,13 @@ bool parseFragment(RWMol &mol, CDXFragment &fragment, PageData &pagedata,
       false;  // is there an irrecoverable error for this fragment
 
   for (auto child : fragment.ContainedObjects()) {
-    CDXDatumID id = (CDXDatumID)child.second->GetTag();
+    auto id = (CDXDatumID)child.second->GetTag();
 #ifdef DEBUG
     std::cerr << "Data Type: " << id << std::endl;
 #endif
     switch (id) {
       case kCDXObj_Node: {
-        CDXNode &node = (CDXNode &)(*child.second);
+        auto &node = (CDXNode &)(*child.second);
         if (!parseNode(mol, frag_id, node, pagedata, sgroups, missingFragId,
                        externalAttachment)) {
           skip_fragment = true;
@@ -103,7 +103,7 @@ bool parseFragment(RWMol &mol, CDXFragment &fragment, PageData &pagedata,
         break;
       }
       case kCDXObj_Bond: {
-        CDXBond &bond = (CDXBond &)(*child.second);
+        auto &bond = (CDXBond &)(*child.second);
         if (!parseBond(mol, frag_id, bond, pagedata)) {
           skip_fragment = true;
           break;

--- a/External/ChemDraw/fragment.h
+++ b/External/ChemDraw/fragment.h
@@ -59,10 +59,9 @@ struct PageData {
   std::map<unsigned int, Atom *> atomIds;
   std::map<unsigned int, Bond *> bondIds;
   std::vector<std::unique_ptr<RWMol>> mols;  // All molecules found in the doc
-  std::map<unsigned int, size_t>
-      fragmentLookup;  // fragment.id->molecule index
+  std::map<unsigned int, size_t> fragmentLookup;  // fragment.id->molecule index
   std::map<unsigned int, std::vector<int>>
-      groupedFragments;              // grouped.id -> [fragment.id]
+      groupedFragments;               // grouped.id -> [fragment.id]
   std::vector<ReactionInfo> schemes;  // reaction schemes found
 
   void clearCDXProps() {
@@ -90,7 +89,7 @@ struct PageData {
 //!                   external node's are normally NickNames or  new Fragments
 bool parseFragment(RWMol &mol, CDXFragment &fragment, PageData &pagedata,
                    int &missingFragId, int externalAttachment = -1);
-}
+}  // namespace ChemDraw
 }  // namespace RDKit
 
 #endif

--- a/External/ChemDraw/node.cpp
+++ b/External/ChemDraw/node.cpp
@@ -45,10 +45,11 @@ bool parseNode(
       node.m_numHydrogens == kNumHydrogenUnspecified ? 0 : node.m_numHydrogens;
   bool explicitHs = node.m_numHydrogens != kNumHydrogenUnspecified;
   int charge = 0;
-  if ((node.m_charge & 0x00FFFFFF) == 0)
+  if ((node.m_charge & 0x00FFFFFF) == 0) {
     charge = node.m_charge >> 24;
-  else
+  } else {
     charge = node.m_charge;
+}
   int atommap = 0;
   int rgroup_num = -1;
   int isotope = node.m_isotope;
@@ -144,20 +145,23 @@ bool parseNode(
       const std::string &text = ((CDXText *)child.second)->GetText().str();
       if (text.size() > 0 && text[0] == 'R') {
         try {
-          if (checkForRGroup)
+          if (checkForRGroup) {
             rgroup_num = text.size() > 1 ? stoi(text.substr(1)) : 0;
-          else
+          } else {
             isotope = text.size() > 1 ? stoi(text.substr(1)) : 0;
+}
         } catch (const std::invalid_argument &e) {
-          if (rgroup_num)
+          if (rgroup_num) {
             BOOST_LOG(rdWarningLog)
                 << "RGroupError: Invalid argument - Cannot convert '" << text
                 << "' to an integer." << std::endl;
+}
         } catch (const std::out_of_range &e) {
-          if (rgroup_num)
+          if (rgroup_num) {
             BOOST_LOG(rdWarningLog)
                 << "RGroupError: Out of range - The number '" << text
                 << "' is too large or too small." << std::endl;
+}
         }
       }
     }

--- a/External/ChemDraw/node.cpp
+++ b/External/ChemDraw/node.cpp
@@ -28,7 +28,7 @@
 // THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-//#include "node.h"
+// #include "node.h"
 #include "fragment.h"
 #include "utils.h"
 
@@ -49,7 +49,7 @@ bool parseNode(
     charge = node.m_charge >> 24;
   } else {
     charge = node.m_charge;
-}
+  }
   int atommap = 0;
   int rgroup_num = -1;
   int isotope = node.m_isotope;
@@ -149,19 +149,19 @@ bool parseNode(
             rgroup_num = text.size() > 1 ? stoi(text.substr(1)) : 0;
           } else {
             isotope = text.size() > 1 ? stoi(text.substr(1)) : 0;
-}
+          }
         } catch (const std::invalid_argument &e) {
           if (rgroup_num) {
             BOOST_LOG(rdWarningLog)
                 << "RGroupError: Invalid argument - Cannot convert '" << text
                 << "' to an integer." << std::endl;
-}
+          }
         } catch (const std::out_of_range &e) {
           if (rgroup_num) {
             BOOST_LOG(rdWarningLog)
                 << "RGroupError: Out of range - The number '" << text
                 << "' is too large or too small." << std::endl;
-}
+          }
         }
       }
     }
@@ -203,7 +203,7 @@ bool parseNode(
       rd_atom->setProp<char>(CDX_IMPLICIT_HYDROGEN_STEREO, 'h');
       break;
   }
-  
+
   if (node.m_bondOrdering) {
     // This node may be completely replaced by the fragment
     // i.e. [*:1]C[*:1].C[*:1]C => CCC
@@ -323,5 +323,5 @@ bool parseNode(
   }
   return true;
 }
-}
+}  // namespace ChemDraw
 }  // namespace RDKit

--- a/External/ChemDraw/node.h
+++ b/External/ChemDraw/node.h
@@ -50,5 +50,5 @@ bool parseNode(
     std::map<std::pair<int, StereoGroupType>, StereoGroupInfo> &sgroups,
     int &missingFragId, int externalAttachment);
 }
-}
+}  // namespace RDKit
 #endif

--- a/External/ChemDraw/reaction.cpp
+++ b/External/ChemDraw/reaction.cpp
@@ -120,9 +120,9 @@ void ReactionStepInfo::set_reaction_step(
 ReactionInfo::ReactionInfo(CDXReactionScheme &scheme)
     : scheme_id(static_cast<unsigned int>(scheme.GetObjectID())) {
   for (auto &rxnNode : scheme.ContainedObjects()) {
-    CDXDatumID type_id = (CDXDatumID)rxnNode.second->GetTag();
+    auto type_id = (CDXDatumID)rxnNode.second->GetTag();
     if (type_id == kCDXObj_ReactionStep) {
-      CDXReactionStep &step = (CDXReactionStep &)(*rxnNode.second);
+      auto &step = (CDXReactionStep &)(*rxnNode.second);
       auto step_id = step.GetObjectID();
       steps.emplace_back(ReactionStepInfo());
       ReactionStepInfo &scheme = steps.back();
@@ -150,7 +150,7 @@ void ReactionInfo::set_reaction_steps(
       auto idx = mol->getProp<unsigned int>(CDX_FRAG_ID);
       fragments[idx] = mol_idx++;
       for (auto &atom : mol->atoms()) {
-        unsigned int idx = atom->getProp<unsigned int>(CDX_ATOM_ID);
+        auto idx = atom->getProp<unsigned int>(CDX_ATOM_ID);
         atoms[idx] = atom;
       }
     }

--- a/External/ChemDraw/reaction.cpp
+++ b/External/ChemDraw/reaction.cpp
@@ -161,5 +161,5 @@ void ReactionInfo::set_reaction_steps(
     }
   }
 }
-}  
+}  // namespace ChemDraw
 }  // namespace RDKit

--- a/External/ChemDraw/reaction.h
+++ b/External/ChemDraw/reaction.h
@@ -81,7 +81,7 @@ class ReactionInfo {
       std::map<unsigned int, std::vector<int>> &grouped_fragments,
       const std::vector<std::unique_ptr<RWMol>> &mols) const;
 };
-}
+}  // namespace ChemDraw
 }  // namespace RDKit
 
 #endif

--- a/External/ChemDraw/test-chiral.cpp
+++ b/External/ChemDraw/test-chiral.cpp
@@ -54,7 +54,7 @@ TEST_CASE("Geometry") {
       std::string(getenv("RDBASE")) + "/External/ChemDraw/test_data/";
   SECTION("R/S Tetrahedral") {
     //_sleep(10 * 1000);
-    
+
     {
       auto fname = path + "geometry-tetrahedral.cdxml";
       auto mols = MolsFromChemDrawFile(fname);
@@ -71,11 +71,11 @@ TEST_CASE("Geometry") {
       auto smi = MolToSmiles(*mol);
       REQUIRE(smi == MolToSmiles(*mols[0]));
     }
-    
+
     {
       auto fname = path + "geometry-tetrahedral-3.cdxml";
       auto mols = MolsFromChemDrawFile(fname);
-      REQUIRE(mols.size()); 
+      REQUIRE(mols.size());
       auto mol = "C1CC[C@H]2CCCC[C@@H]2C1"_smiles;
       auto smi = MolToSmiles(*mol);
       REQUIRE(smi == MolToSmiles(*mols[0]));
@@ -86,7 +86,8 @@ TEST_CASE("Geometry") {
       auto fname = path + "geometry-tetrahedral-4.cdxml";
       auto mols = MolsFromChemDrawFile(fname);
       REQUIRE(mols.size());
-      auto mol = "CC(S[C@@H]1CC2=C([H])C(CC[C@]2(C)[C@@]3([H])CC([H])([H])[C@]4(C)[C@](OC5=O)(CC5([H])[H])CC[C@@]4([H])[C@]13[H])=O)=O"_smiles;
+      auto mol =
+    "CC(S[C@@H]1CC2=C([H])C(CC[C@]2(C)[C@@]3([H])CC([H])([H])[C@]4(C)[C@](OC5=O)(CC5([H])[H])CC[C@@]4([H])[C@]13[H])=O)=O"_smiles;
       auto smi = MolToSmiles(*mol);
       std::cerr << "** " << smi << std::endl;
       REQUIRE(smi == MolToSmiles(*mols[0]));

--- a/External/ChemDraw/test-reactions.cpp
+++ b/External/ChemDraw/test-reactions.cpp
@@ -41,7 +41,6 @@
 #include <GraphMol/ChemReactions/SanitizeRxn.h>
 #include <GraphMol/SmilesParse/SmilesWrite.h>
 
-
 #include <filesystem>
 using namespace RDKit;
 using namespace RDKit::v2;
@@ -161,4 +160,3 @@ M  END
           ChemicalReactionToRxnSmarts(*rxn_mb));
   }
 }
-

--- a/External/ChemDraw/test.cpp
+++ b/External/ChemDraw/test.cpp
@@ -1300,9 +1300,11 @@ TEST_CASE("Round TRIP") {
     RDLog::LogStateSetter blocker;
     for (const auto &entry :
          std::filesystem::recursive_directory_iterator(code_path)) {
-      if (entry.path().string().find("ChemDraw") != std::string::npos)
+      if (entry.path().string().find("ChemDraw") != std::string::npos) {
         continue;  // Skip ChemDraw directory
-      if (entry.path().string().find("build") != std::string::npos) continue;
+}
+      if (entry.path().string().find("build") != std::string::npos) { continue;
+}
       if (entry.is_regular_file() &&
           entry.path().extension().string() == ".mol") {
         if (exceptions.find(entry.path().filename().string()) !=

--- a/External/ChemDraw/test.cpp
+++ b/External/ChemDraw/test.cpp
@@ -1302,9 +1302,10 @@ TEST_CASE("Round TRIP") {
          std::filesystem::recursive_directory_iterator(code_path)) {
       if (entry.path().string().find("ChemDraw") != std::string::npos) {
         continue;  // Skip ChemDraw directory
-}
-      if (entry.path().string().find("build") != std::string::npos) { continue;
-}
+      }
+      if (entry.path().string().find("build") != std::string::npos) {
+        continue;
+      }
       if (entry.is_regular_file() &&
           entry.path().extension().string() == ".mol") {
         if (exceptions.find(entry.path().filename().string()) !=

--- a/External/ChemDraw/test_3d.cpp
+++ b/External/ChemDraw/test_3d.cpp
@@ -52,8 +52,10 @@ TEST_CASE("Round TRIP") {
       std::string(getenv("RDBASE")) + "/Code/GraphMol/test_data/";
   std::string code_path = std::string(getenv("RDBASE"));
 
-  // Eventually this catch test is to see if round tripping mol 3d -> chemdraw returns
-  //  reasonable coords, however chemdraw seems to forget about the original scale
+  // Eventually this catch test is to see if round tripping mol 3d -> chemdraw
+  // returns
+  //  reasonable coords, however chemdraw seems to forget about the original
+  //  scale
   //   and converts to pixel drawing coords, so this test is kind of meaningless
   SECTION("3D structs") {
     auto fname =

--- a/External/ChemDraw/test_6k.cpp
+++ b/External/ChemDraw/test_6k.cpp
@@ -59,8 +59,9 @@ std::string replace(std::string &istr, const std::string &from,
                     const std::string &to) {
   std::string str(istr);
   size_t start_pos = str.find(from);
-  if (start_pos == std::string::npos) { return str;
-}
+  if (start_pos == std::string::npos) {
+    return str;
+  }
   str.replace(start_pos, from.length(), to);
   return str;
 }
@@ -71,8 +72,8 @@ bool hasNonSupportedFeatures(CDXDocument &document, const std::string &fname) {
   std::stringstream xml;
   xml << ifs.rdbuf();
   // We should be able to figure this out from the node but...
-  if(xml.str().find("monomerAttachmentStructure_") != std::string::npos ||
-     xml.str().find("Name=\"monomerAttachments") != std::string::npos) {
+  if (xml.str().find("monomerAttachmentStructure_") != std::string::npos ||
+      xml.str().find("Name=\"monomerAttachments") != std::string::npos) {
     return true;
   }
 
@@ -84,9 +85,11 @@ bool hasNonSupportedFeatures(CDXDocument &document, const std::string &fname) {
           auto id = (CDXDatumID)frag.second->GetTag();
           if (id == kCDXObj_Fragment) {
             auto &fragment = (CDXFragment &)(*frag.second);
-            if (fragment.m_sequenceType == kCDXSeqType_Unknown) { return true;
-}
-          } else if (id == kCDXObj_BracketAttachment || id == kCDXObj_BracketedGroup) {
+            if (fragment.m_sequenceType == kCDXSeqType_Unknown) {
+              return true;
+            }
+          } else if (id == kCDXObj_BracketAttachment ||
+                     id == kCDXObj_BracketedGroup) {
             return true;
           }
         }
@@ -94,7 +97,7 @@ bool hasNonSupportedFeatures(CDXDocument &document, const std::string &fname) {
       case kCDXObj_ObjectTag: {
         CDXObject &object = *((CDXObject *)node.second);
         id = (CDXDatumID)object.GetTag();
-	// Check for monomers
+        // Check for monomers
         break;
       }
       default:
@@ -115,7 +118,7 @@ TEST_CASE("Round TRIP") {
 
   SECTION("round trip") {
     // if we can't find the CDXML6K path, then don't run the test
-    if(!std::filesystem::exists(path)) {
+    if (!std::filesystem::exists(path)) {
       return;
     }
     int failed = 0;
@@ -138,43 +141,82 @@ TEST_CASE("Round TRIP") {
     std::string nomolpath = path + "NOMOL/";
     std::string badparsepath = path + "BADPARSE/";
     std::string sanitizationpath = path + "SANI/";
-    
+
     std::set<std::string> known_failures{
-      "INDMUMLL1117_2025-01-24-17-23-14_304.cdxml",  // Dative oxygen gets set to a radical
-      "INDMUMLL1117_2025-01-24-17-26-06_1010.cdxml", // The next batch has a type of stereochem I don't know how to parse yet
-      "INDMUMLL1117_2025-01-24-17-26-06_1012.cdxml",
-      "INDMUMLL1117_2025-01-24-17-26-06_1022.cdxml",
-      "INDMUMLL1117_2025-01-24-17-26-06_1024.cdxml",
-      "INDMUMLL1117_2025-01-24-17-26-06_1026.cdxml",
-      "INDMUMLL1117_2025-01-24-17-26-06_1032.cdxml",
-      "INDMUMLL1117_2025-01-24-17-26-06_1034.cdxml",
-      "INDMUMLL1117_2025-01-24-17-26-06_1036.cdxml",
-      "INDMUMLL1117_2025-01-24-17-26-06_1040.cdxml",
-      "INDMUMLL1117_2025-01-24-17-26-06_1042.cdxml",
-      "INDMUMLL1117_2025-01-24-17-26-06_1048.cdxml", // Stereo chem batch ends here
-      "INDMUMLL1117_2025-01-24-17-26-13_1690.cdxml", // RDKit shows a radical for the dative ->[O]
-      "INDMUMLL1117_2025-01-24-17-27-11_6877.cdxml", // The next batch has a type of stereochem I don't know how to parse yet (same as before)
-      "INDMUMLL1117_2025-01-24-17-27-11_6878.cdxml",
-      "INDMUMLL1117_2025-01-24-17-27-11_6883.cdxml",
-      "INDMUMLL1117_2025-01-24-17-27-11_6884.cdxml",
-      "INDMUMLL1117_2025-01-24-17-27-11_6889.cdxml",
-      "INDMUMLL1117_2025-01-24-17-27-11_6896.cdxml",
-      "INDMUMLL1117_2025-01-24-17-27-30_8574.cdxml", // Stereo chem batch ends here
-      "INDMUMLL1117_2025-01-24-17-27-31_8633.cdxml", // RDkit is missing a dummy atom molecule
-      "INDMUMLL1117_2025-01-24-17-27-31_8651.cdxml", // RDkit is missing a dummy atom molecule
-      "INDMUMLL1117_2025-01-24-17-27-53_10330.cdxml",// 2D projection of 3D stereo, we fail this one
-      "INDMUMLL1117_2025-01-24-17-27-53_10332.cdxml",// 2D projection of 3D stereo, we fail this one
-      "INDMUMLL1117_2025-01-24-17-27-54_10336.cdxml",// RDKit Smiles keeps any bonds ~, ChemDraw doesn't
-      "INDMUMLL1117_2025-01-24-17-28-02_10942.cdxml",// Chemdraw smiles doesn't support quadruple bond $
-      "INDMUMLL1117_2025-01-24-17-28-15_11666.cdxml",// RDKit Smiles keeps any bonds ~, ChemDraw doesn't
-      "INDMUMLL1117_2025-01-24-17-28-20_12011.cdxml",// RDKit gets stereo from the 3D data and the wedging
-      "INDMUMLL1117_2025-01-24-17-28-20_12012.cdxml",// RDKit gets stereo from the 3D data and the wedging
-      "INDMUMLL1117_2025-01-24-17-28-21_12031.cdxml",// 2D projection of 3D stereo, we fail this one
-      "INDMUMLL1117_2025-01-24-17-28-30_12568.cdxml",// 2D projection of 3D stereo, we fail this one
-      "INDMUMLL1117_2025-01-24-17-29-06_14654.cdxml",// Dative oxygen gets set to a radical
-      "INDMUMLL1117_2025-01-24-17-29-08_14775.cdxml",// RDKit Smiles keeps any bonds ~, ChemDraw doesn't
-      "INDMUMLL1117_2025-01-24-17-29-09_14896.cdxml",// We apparently do a bit of a better job than chemdraw here in parsing R/S
-      "INDMUMLL1117_2025-01-24-17-29-09_14897.cdxml" // RDKit just gets very different stereo chem, no idea why
+        "INDMUMLL1117_2025-01-24-17-23-14_304.cdxml",  // Dative oxygen gets set
+                                                       // to a radical
+        "INDMUMLL1117_2025-01-24-17-26-06_1010.cdxml",  // The next batch has a
+                                                        // type of stereochem I
+                                                        // don't know how to
+                                                        // parse yet
+        "INDMUMLL1117_2025-01-24-17-26-06_1012.cdxml",
+        "INDMUMLL1117_2025-01-24-17-26-06_1022.cdxml",
+        "INDMUMLL1117_2025-01-24-17-26-06_1024.cdxml",
+        "INDMUMLL1117_2025-01-24-17-26-06_1026.cdxml",
+        "INDMUMLL1117_2025-01-24-17-26-06_1032.cdxml",
+        "INDMUMLL1117_2025-01-24-17-26-06_1034.cdxml",
+        "INDMUMLL1117_2025-01-24-17-26-06_1036.cdxml",
+        "INDMUMLL1117_2025-01-24-17-26-06_1040.cdxml",
+        "INDMUMLL1117_2025-01-24-17-26-06_1042.cdxml",
+        "INDMUMLL1117_2025-01-24-17-26-06_1048.cdxml",  // Stereo chem batch
+                                                        // ends here
+        "INDMUMLL1117_2025-01-24-17-26-13_1690.cdxml",  // RDKit shows a radical
+                                                        // for the dative ->[O]
+        "INDMUMLL1117_2025-01-24-17-27-11_6877.cdxml",  // The next batch has a
+                                                        // type of stereochem I
+                                                        // don't know how to
+                                                        // parse yet (same as
+                                                        // before)
+        "INDMUMLL1117_2025-01-24-17-27-11_6878.cdxml",
+        "INDMUMLL1117_2025-01-24-17-27-11_6883.cdxml",
+        "INDMUMLL1117_2025-01-24-17-27-11_6884.cdxml",
+        "INDMUMLL1117_2025-01-24-17-27-11_6889.cdxml",
+        "INDMUMLL1117_2025-01-24-17-27-11_6896.cdxml",
+        "INDMUMLL1117_2025-01-24-17-27-30_8574.cdxml",   // Stereo chem batch
+                                                         // ends here
+        "INDMUMLL1117_2025-01-24-17-27-31_8633.cdxml",   // RDkit is missing a
+                                                         // dummy atom molecule
+        "INDMUMLL1117_2025-01-24-17-27-31_8651.cdxml",   // RDkit is missing a
+                                                         // dummy atom molecule
+        "INDMUMLL1117_2025-01-24-17-27-53_10330.cdxml",  // 2D projection of 3D
+                                                         // stereo, we fail this
+                                                         // one
+        "INDMUMLL1117_2025-01-24-17-27-53_10332.cdxml",  // 2D projection of 3D
+                                                         // stereo, we fail this
+                                                         // one
+        "INDMUMLL1117_2025-01-24-17-27-54_10336.cdxml",  // RDKit Smiles keeps
+                                                         // any bonds ~,
+                                                         // ChemDraw doesn't
+        "INDMUMLL1117_2025-01-24-17-28-02_10942.cdxml",  // Chemdraw smiles
+                                                         // doesn't support
+                                                         // quadruple bond $
+        "INDMUMLL1117_2025-01-24-17-28-15_11666.cdxml",  // RDKit Smiles keeps
+                                                         // any bonds ~,
+                                                         // ChemDraw doesn't
+        "INDMUMLL1117_2025-01-24-17-28-20_12011.cdxml",  // RDKit gets stereo
+                                                         // from the 3D data and
+                                                         // the wedging
+        "INDMUMLL1117_2025-01-24-17-28-20_12012.cdxml",  // RDKit gets stereo
+                                                         // from the 3D data and
+                                                         // the wedging
+        "INDMUMLL1117_2025-01-24-17-28-21_12031.cdxml",  // 2D projection of 3D
+                                                         // stereo, we fail this
+                                                         // one
+        "INDMUMLL1117_2025-01-24-17-28-30_12568.cdxml",  // 2D projection of 3D
+                                                         // stereo, we fail this
+                                                         // one
+        "INDMUMLL1117_2025-01-24-17-29-06_14654.cdxml",  // Dative oxygen gets
+                                                         // set to a radical
+        "INDMUMLL1117_2025-01-24-17-29-08_14775.cdxml",  // RDKit Smiles keeps
+                                                         // any bonds ~,
+                                                         // ChemDraw doesn't
+        "INDMUMLL1117_2025-01-24-17-29-09_14896.cdxml",  // We apparently do a
+                                                         // bit of a better job
+                                                         // than chemdraw here
+                                                         // in parsing R/S
+        "INDMUMLL1117_2025-01-24-17-29-09_14897.cdxml"   // RDKit just gets very
+                                                         // different stereo
+                                                         // chem, no idea why
     };
 
     for (auto p : {failpath, nomolpath, badparsepath, sanitizationpath}) {
@@ -191,25 +233,25 @@ TEST_CASE("Round TRIP") {
         // issue here - graphite nanotube
         if (fname == "INDMUMLL1117_2025-01-24-17-28-02_10946.cdxml") {
           continue;  // nanotube takes forever
-}
+        }
         auto molfname = molpath + replace(fname, ".cdxml", ".mol");
         auto smifname = smipath + replace(fname, ".cdxml", ".smi");
         // if chemscript couldn't make an output, ignore it
-	total++;
+        total++;
 
         if (!std::filesystem::exists(molfname) ||
             !std::filesystem::exists(smifname)) {
-	  no_mol_in_doc++;
+          no_mol_in_doc++;
           continue;
         }
-	
-	// Get the ChemScript mol and smiles
+
+        // Get the ChemScript mol and smiles
         std::unique_ptr<RWMol> mol;
         //= nullptr;
         try {
           mol.reset(MolFileToMol(molfname));
         } catch (...) {
-	  bad_chemdraw_mol++;
+          bad_chemdraw_mol++;
           continue;
         }
         // REQUIRE(mols.size());
@@ -230,8 +272,8 @@ TEST_CASE("Round TRIP") {
             smiles = smiles_in;
           }
         }
-	
-	parseable++;
+
+        parseable++;
         // Read the cdxml
         std::vector<std::unique_ptr<RWMol>> mols;
         bool santizationFailure = false;
@@ -244,22 +286,20 @@ TEST_CASE("Round TRIP") {
             santizationFailure = true;
           }
           if (!mols.size()) {
-	    if (smiles.size() == 0) {
-	      // At least we match the chemscript non-mol
-	      success++;
-	    }
-            else if (hasNonSupportedFeatures(entry.path().string())) {
-              //std::cerr << "[NOMOL (Unsupported)]: " << entry.path().string()
-              //          << std::endl;
+            if (smiles.size() == 0) {
+              // At least we match the chemscript non-mol
+              success++;
+            } else if (hasNonSupportedFeatures(entry.path().string())) {
+              // std::cerr << "[NOMOL (Unsupported)]: " << entry.path().string()
+              //           << std::endl;
               nonSupported++;
             } else {
-	      std::cerr << "[NOMOL]: " << entry.path().string()
-                        << std::endl;
+              std::cerr << "[NOMOL]: " << entry.path().string() << std::endl;
               std::filesystem::copy(
                   entry.path().string(),
                   nomolpath + entry.path().filename().string());
-	      nomol++;
-	    }
+              nomol++;
+            }
             continue;
           }
         } catch (...) {
@@ -295,10 +335,11 @@ TEST_CASE("Round TRIP") {
                 sanitizationpath + entry.path().filename().string());
             saniFailed++;
           } else {
-            if(known_failures.find(entry.path().filename().string()) != known_failures.end()) {
-              continue; // we know this failure and it's ok for now
-}
-            
+            if (known_failures.find(entry.path().filename().string()) !=
+                known_failures.end()) {
+              continue;  // we know this failure and it's ok for now
+            }
+
             std::cerr << "[FAIL]: " << entry.path() << std::endl;
             std::filesystem::copy(entry.path(),
                                   failpath + entry.path().filename().string());
@@ -319,8 +360,7 @@ TEST_CASE("Round TRIP") {
     std::cerr << "Success:" << success + smimatches << std::endl;
     std::cerr << "skipped (non supported features):" << nonSupported
               << std::endl;
-    std::cerr << "skipped (no mol in doc):" << no_mol_in_doc
-              << std::endl;
+    std::cerr << "skipped (no mol in doc):" << no_mol_in_doc << std::endl;
     std::cerr << "Chemscript smiles matches not chemscript mol: " << smimatches
               << std::endl;
     std::cerr << "Failed:" << failed << std::endl;

--- a/External/ChemDraw/test_6k.cpp
+++ b/External/ChemDraw/test_6k.cpp
@@ -59,7 +59,8 @@ std::string replace(std::string &istr, const std::string &from,
                     const std::string &to) {
   std::string str(istr);
   size_t start_pos = str.find(from);
-  if (start_pos == std::string::npos) return str;
+  if (start_pos == std::string::npos) { return str;
+}
   str.replace(start_pos, from.length(), to);
   return str;
 }
@@ -76,14 +77,15 @@ bool hasNonSupportedFeatures(CDXDocument &document, const std::string &fname) {
   }
 
   for (auto node : document.ContainedObjects()) {
-    CDXDatumID id = (CDXDatumID)node.second->GetTag();
+    auto id = (CDXDatumID)node.second->GetTag();
     switch (id) {
       case kCDXObj_Page:
         for (auto frag : node.second->ContainedObjects()) {
-          CDXDatumID id = (CDXDatumID)frag.second->GetTag();
+          auto id = (CDXDatumID)frag.second->GetTag();
           if (id == kCDXObj_Fragment) {
-            CDXFragment &fragment = (CDXFragment &)(*frag.second);
-            if (fragment.m_sequenceType == kCDXSeqType_Unknown) return true;
+            auto &fragment = (CDXFragment &)(*frag.second);
+            if (fragment.m_sequenceType == kCDXSeqType_Unknown) { return true;
+}
           } else if (id == kCDXObj_BracketAttachment || id == kCDXObj_BracketedGroup) {
             return true;
           }
@@ -187,8 +189,9 @@ TEST_CASE("Round TRIP") {
       if (entry.is_regular_file()) {
         std::string fname = entry.path().filename().string();
         // issue here - graphite nanotube
-        if (fname == "INDMUMLL1117_2025-01-24-17-28-02_10946.cdxml")
+        if (fname == "INDMUMLL1117_2025-01-24-17-28-02_10946.cdxml") {
           continue;  // nanotube takes forever
+}
         auto molfname = molpath + replace(fname, ".cdxml", ".mol");
         auto smifname = smipath + replace(fname, ".cdxml", ".smi");
         // if chemscript couldn't make an output, ignore it
@@ -217,9 +220,9 @@ TEST_CASE("Round TRIP") {
         {
           try {
             auto smimol = SmilesToMol(smiles_in);
-            if (!smimol)
+            if (!smimol) {
               smiles = smiles_in;
-            else {
+            } else {
               smiles = MolToSmiles(*smimol);
               delete smimol;
             }
@@ -292,8 +295,9 @@ TEST_CASE("Round TRIP") {
                 sanitizationpath + entry.path().filename().string());
             saniFailed++;
           } else {
-            if(known_failures.find(entry.path().filename().string()) != known_failures.end())
+            if(known_failures.find(entry.path().filename().string()) != known_failures.end()) {
               continue; // we know this failure and it's ok for now
+}
             
             std::cerr << "[FAIL]: " << entry.path() << std::endl;
             std::filesystem::copy(entry.path(),

--- a/External/ChemDraw/utils.cpp
+++ b/External/ChemDraw/utils.cpp
@@ -241,7 +241,7 @@ Atom::ChiralType getChirality(ROMol &mol, Atom *center_atom, Conformer &conf) {
     if (center_atom->hasProp(CDX_IMPLICIT_HYDROGEN_STEREO) &&
         center_atom->getProp<char>(CDX_IMPLICIT_HYDROGEN_STEREO) == 'w') {
       nswaps++;
-}
+    }
 
     if (nswaps % 2) {
       return Atom::ChiralType::CHI_TETRAHEDRAL_CCW;
@@ -282,25 +282,25 @@ void checkChemDrawTetrahedralGeometries(RWMol &mol) {
         case kCDXCIPAtom_R:
           if (!chiralityChanged) {
             atom->setChiralTag(Atom::ChiralType::CHI_TETRAHEDRAL_CW);
-}
+          }
           unsetTetrahedralAtoms.push_back(std::make_pair('R', atom));
           break;
         case kCDXCIPAtom_r:
           if (!chiralityChanged) {
             atom->setChiralTag(Atom::ChiralType::CHI_TETRAHEDRAL_CW);
-}
+          }
           unsetTetrahedralAtoms.push_back(std::make_pair('r', atom));
           break;
         case kCDXCIPAtom_S:
           if (!chiralityChanged) {
             atom->setChiralTag(Atom::ChiralType::CHI_TETRAHEDRAL_CW);
-}
+          }
           unsetTetrahedralAtoms.push_back(std::make_pair('S', atom));
           break;
         case kCDXCIPAtom_s:
           if (!chiralityChanged) {
             atom->setChiralTag(Atom::ChiralType::CHI_TETRAHEDRAL_CCW);
-}
+          }
           unsetTetrahedralAtoms.push_back(std::make_pair('s', atom));
           break;
         default:

--- a/External/ChemDraw/utils.cpp
+++ b/External/ChemDraw/utils.cpp
@@ -186,7 +186,7 @@ bool replaceFragments(RWMol &mol) {
 namespace {
 Atom::ChiralType getChirality(ROMol &mol, Atom *center_atom, Conformer &conf) {
   if (center_atom->hasProp(CDX_BOND_ORDERING)) {
-    std::vector<int> bond_ordering =
+    auto bond_ordering =
         center_atom->getProp<std::vector<int>>(CDX_BOND_ORDERING);
     if (bond_ordering.size() < 3) {
       return Atom::ChiralType::CHI_UNSPECIFIED;
@@ -239,8 +239,9 @@ Atom::ChiralType getChirality(ROMol &mol, Atom *center_atom, Conformer &conf) {
     // This is supports the HDot and HDash available in chemdraw
     //  one is an implicit wedged hydrogen and one is a dashed hydrogen
     if (center_atom->hasProp(CDX_IMPLICIT_HYDROGEN_STEREO) &&
-        center_atom->getProp<char>(CDX_IMPLICIT_HYDROGEN_STEREO) == 'w')
+        center_atom->getProp<char>(CDX_IMPLICIT_HYDROGEN_STEREO) == 'w') {
       nswaps++;
+}
 
     if (nswaps % 2) {
       return Atom::ChiralType::CHI_TETRAHEDRAL_CCW;
@@ -279,23 +280,27 @@ void checkChemDrawTetrahedralGeometries(RWMol &mol) {
       //  I currently don't understand that well enough.
       switch (cip) {
         case kCDXCIPAtom_R:
-          if (!chiralityChanged)
+          if (!chiralityChanged) {
             atom->setChiralTag(Atom::ChiralType::CHI_TETRAHEDRAL_CW);
+}
           unsetTetrahedralAtoms.push_back(std::make_pair('R', atom));
           break;
         case kCDXCIPAtom_r:
-          if (!chiralityChanged)
+          if (!chiralityChanged) {
             atom->setChiralTag(Atom::ChiralType::CHI_TETRAHEDRAL_CW);
+}
           unsetTetrahedralAtoms.push_back(std::make_pair('r', atom));
           break;
         case kCDXCIPAtom_S:
-          if (!chiralityChanged)
+          if (!chiralityChanged) {
             atom->setChiralTag(Atom::ChiralType::CHI_TETRAHEDRAL_CW);
+}
           unsetTetrahedralAtoms.push_back(std::make_pair('S', atom));
           break;
         case kCDXCIPAtom_s:
-          if (!chiralityChanged)
+          if (!chiralityChanged) {
             atom->setChiralTag(Atom::ChiralType::CHI_TETRAHEDRAL_CCW);
+}
           unsetTetrahedralAtoms.push_back(std::make_pair('s', atom));
           break;
         default:

--- a/External/ChemDraw/utils.h
+++ b/External/ChemDraw/utils.h
@@ -104,7 +104,7 @@ struct StereoGroupInfo {
 // check to see if we have a tetrahedral flag and ChemDraw CIP set but no
 //  stereo assigned, if so check the bond ordering for CW and CCW
 void checkChemDrawTetrahedralGeometries(RWMol &mol);
-}
+}  // namespace ChemDraw
 }  // namespace RDKit
 
 #endif

--- a/External/ChemDraw/writer.cpp
+++ b/External/ChemDraw/writer.cpp
@@ -76,10 +76,10 @@ std::string MolToChemDrawBlock(const ROMol &mol, CDXFormat format) {
 
   CDXObjectID object_id = 1;
   CDXDocument document(object_id++);
-  CDXPage *page = new CDXPage(object_id++);
+  auto *page = new CDXPage(object_id++);
   document.m_bondLength = DEFAULT_CDX_BOND_LENGTH;
   document.m_flags |= CDXDocument::CDXDocumentProperty1::has_bondLength;
-  CDXFragment *fragment = new CDXFragment(object_id++);
+  auto *fragment = new CDXFragment(object_id++);
   page->AddChild(fragment);
   std::vector<CDXNode *> nodes;
   nodes.reserve(trmol.getNumAtoms());
@@ -108,7 +108,7 @@ std::string MolToChemDrawBlock(const ROMol &mol, CDXFormat format) {
   auto wedgeBonds = Chirality::pickBondsToWedge(trmol, nullptr, conf);
 
   for (auto &atom : trmol.atoms()) {
-    CDXNode *node = new CDXNode(object_id + atom->getIdx());
+    auto *node = new CDXNode(object_id + atom->getIdx());
     auto pos = conf->getAtomPos(atom->getIdx());
     if (is3D) {
       node->Position3D(CDXPoint3D(CDXCoordinatefromPoints(pos.x),
@@ -173,7 +173,7 @@ std::string MolToChemDrawBlock(const ROMol &mol, CDXFormat format) {
   }
 
   for (auto &bond : trmol.bonds()) {
-    CDXBond *cdxbond =
+    auto *cdxbond =
         new CDXBond(object_id + mol.getNumAtoms() + bond->getIdx());
 
     int dirCode = 0;
@@ -271,8 +271,9 @@ std::string MolToChemDrawBlock(const ROMol &mol, CDXFormat format) {
     }
 
     if (bond->getBondDir() == Bond::BondDir::EITHERDOUBLE ||
-        bond->getBondDir() == Bond::BondDir::UNKNOWN)
+        bond->getBondDir() == Bond::BondDir::UNKNOWN) {
       cdxbond->m_display = kCDXBondDisplay_Wavy;
+}
 
     fragment->AddChild(cdxbond);
   }

--- a/External/ChemDraw/writer.cpp
+++ b/External/ChemDraw/writer.cpp
@@ -38,7 +38,6 @@
 #include "chemdraw/CDXStdObjects.h"
 #include "ChemDrawEndInclude.h"
 
-
 namespace RDKit {
 namespace v2 {
 const double DEFAULT_CDX_BOND_LENGTH = 14.4;
@@ -173,8 +172,7 @@ std::string MolToChemDrawBlock(const ROMol &mol, CDXFormat format) {
   }
 
   for (auto &bond : trmol.bonds()) {
-    auto *cdxbond =
-        new CDXBond(object_id + mol.getNumAtoms() + bond->getIdx());
+    auto *cdxbond = new CDXBond(object_id + mol.getNumAtoms() + bond->getIdx());
 
     int dirCode = 0;
     bool reverse = false;
@@ -273,7 +271,7 @@ std::string MolToChemDrawBlock(const ROMol &mol, CDXFormat format) {
     if (bond->getBondDir() == Bond::BondDir::EITHERDOUBLE ||
         bond->getBondDir() == Bond::BondDir::UNKNOWN) {
       cdxbond->m_display = kCDXBondDisplay_Wavy;
-}
+    }
 
     fragment->AddChild(cdxbond);
   }
@@ -281,9 +279,9 @@ std::string MolToChemDrawBlock(const ROMol &mol, CDXFormat format) {
   document.AddChild(page);
   document.m_colorTable.m_colors
       .clear();  // if this isn't empty something fails.
-  
+
   std::ostringstream os;
-  if(format == CDXFormat::CDXML) {
+  if (format == CDXFormat::CDXML) {
     os << kCDXML_HeaderString;
     XMLDataSink ds(os);
     document.XMLWrite(ds);
@@ -293,5 +291,5 @@ std::string MolToChemDrawBlock(const ROMol &mol, CDXFormat format) {
   }
   return os.str();
 }
-}
+}  // namespace v2
 }  // namespace RDKit


### PR DESCRIPTION
This is just a run of clang-tidy-18 and then clang-format-18 across the .cpp and .h files in External/ChemDraw 

For reviewing: I would suggest just looking at the changes from the first commit (the clang-tidy run)
The second one is just clang-format changes.