### PR TITLE
Fixes #8801

### DIFF
--- a/External/ChemDraw/CMakeLists.txt
+++ b/External/ChemDraw/CMakeLists.txt
@@ -95,6 +95,10 @@ endif()
       endif(RDK_INSTALL_STATIC_LIBS)
   endif()
 
+  if(TARGET ChemDraw_static)
+    target_link_libraries(ChemDraw_static PUBLIC expat)
+  endif()
+
   install(TARGETS ChemDraw DESTINATION ${RDKit_LibDir})
 
   if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")


### PR DESCRIPTION
Fixes #8801 

This should fix it. The issue is that RDKFuncs.so is being linked with the dynamic and static versions of the dependencies.

The dynamic libs are not a problem, they are already being linked against expat. But the static libaries are not linked, they are just collections of objects, so you need to transitively provide all dependencies. And there's the problem: the `expat` dependency is not linked against the static ChemDraw lib. This patch specifies this dependency.

I don't know why the static libs are necessary for the C# wrappers, though.