### PR TITLE
Add safeSetattr to more params / options objects

### DIFF
--- a/Code/GraphMol/ChemReactions/Wrap/rdChemReactions.cpp
+++ b/Code/GraphMol/ChemReactions/Wrap/rdChemReactions.cpp
@@ -559,7 +559,8 @@ BOOST_PYTHON_MODULE(rdChemReactions) {
       .def_readwrite("agentWeight",
                      &RDKit::ReactionFingerprintParams::agentWeight)
       .def_readwrite("includeAgents",
-                     &RDKit::ReactionFingerprintParams::includeAgents);
+                     &RDKit::ReactionFingerprintParams::includeAgents)
+      .def("__setattr__", &safeSetattr);
 
   std::string docString =
       R"DOC(A class for storing and applying chemical reactions.

--- a/Code/GraphMol/Depictor/Wrap/rdDepictor.cpp
+++ b/Code/GraphMol/Depictor/Wrap/rdDepictor.cpp
@@ -328,7 +328,8 @@ BOOST_PYTHON_MODULE(rdDepictor) {
           "adjustMolBlockWedging is True")
       .def_readwrite(
           "useRingTemplates", &ConstrainedDepictionParams::useRingTemplates,
-          "use templates to generate coordinates of complex ring systems");
+          "use templates to generate coordinates of complex ring systems")
+      .def("__setattr__", &safeSetattr);
 
   std::string docString;
   docString =

--- a/Code/GraphMol/Descriptors/Wrap/rdMolDescriptors.cpp
+++ b/Code/GraphMol/Descriptors/Wrap/rdMolDescriptors.cpp
@@ -991,7 +991,8 @@ BOOST_PYTHON_MODULE(rdMolDescriptors) {
       .setattr("atomTypes", atomPairTypes)
       .setattr("numPathBits", RDKit::AtomPairs::numPathBits)
       .setattr("numAtomPairFingerprintBits",
-               RDKit::AtomPairs::numAtomPairFingerprintBits);
+               RDKit::AtomPairs::numAtomPairFingerprintBits)
+      .def("__setattr__", &safeSetattr);
   docString = "Returns the atom code (hash) for an atom";
   python::def("GetAtomPairAtomCode", RDKit::AtomPairs::getAtomCode,
               (python::arg("atom"), python::arg("branchSubtract") = 0,

--- a/Code/GraphMol/FMCS/Wrap/rdFMCS.cpp
+++ b/Code/GraphMol/FMCS/Wrap/rdFMCS.cpp
@@ -762,7 +762,9 @@ BOOST_PYTHON_MODULE(rdFMCS) {
                     "SMILES string to be used as the seed of the MCS")
       .add_property("StoreAll", &RDKit::PyMCSParameters::getStoreAll,
                     &RDKit::PyMCSParameters::setStoreAll,
-                    "toggles storage of degenerate MCSs");
+                    "toggles storage of degenerate MCSs")
+      .def("__setattr__", &safeSetattr);
+      
 
   python::class_<RDKit::MCSAtomCompareParameters, boost::noncopyable>(
       "MCSAtomCompareParameters",
@@ -787,7 +789,8 @@ BOOST_PYTHON_MODULE(rdFMCS) {
                      "results cannot include lone ring atoms")
       .def_readwrite("MatchIsotope",
                      &RDKit::MCSAtomCompareParameters::MatchIsotope,
-                     "use isotope atom queries in MCSResults");
+                     "use isotope atom queries in MCSResults")
+      .def("__setattr__", &safeSetattr);
 
   python::class_<RDKit::MCSBondCompareParameters, boost::noncopyable>(
       "MCSBondCompareParameters",
@@ -811,7 +814,8 @@ BOOST_PYTHON_MODULE(rdFMCS) {
           "won't match cyclodecane")
       .def_readwrite("MatchStereo",
                      &RDKit::MCSBondCompareParameters::MatchStereo,
-                     "include bond stereo in the comparison");
+                     "include bond stereo in the comparison")
+      .def("__setattr__", &safeSetattr);
 
   python::class_<RDKit::PyMCSProgress, boost::noncopyable>(
       "MCSProgress",

--- a/Code/GraphMol/MolDraw2D/Wrap/rdMolDraw2D.cpp
+++ b/Code/GraphMol/MolDraw2D/Wrap/rdMolDraw2D.cpp
@@ -1388,7 +1388,9 @@ BOOST_PYTHON_MODULE(rdMolDraw2D) {
       .def("setContourColour", &RDKit::setContourColour,
            (python::arg("self"), python::arg("colour")))
       .def("setColourMap", &RDKit::setColoursHelper,
-           (python::arg("self"), python::arg("colours")));
+           (python::arg("self"), python::arg("colours")))
+      .def("__setattr__", &safeSetattr);
+
   docString = R"DOC(Generates and draws contours for a set of gaussians
 
   - drawer: the MolDraw2D object to use

--- a/Code/GraphMol/MolEnumerator/Wrap/rdMolEnumerator.cpp
+++ b/Code/GraphMol/MolEnumerator/Wrap/rdMolEnumerator.cpp
@@ -11,6 +11,8 @@
 #include <RDBoost/python.h>
 #include <GraphMol/MolEnumerator/MolEnumerator.h>
 
+#include <RDBoost/Wrap.h>
+
 namespace python = boost::python;
 using namespace RDKit;
 namespace {
@@ -78,7 +80,8 @@ BOOST_PYTHON_MODULE(rdMolEnumerator) {
                      "seed for the random enumeration (not yet implemented")
       .def("SetEnumerationOperator", &setEnumerationHelper,
            python::args("self", "typ"),
-           "set the operator to be used for enumeration");
+           "set the operator to be used for enumeration")
+      .def("__setattr__", &safeSetattr);
   python::def("Enumerate", &enumerateHelper1,
               (python::arg("mol"), python::arg("maxPerOperation") = 0),
               python::return_value_policy<python::manage_new_object>(),

--- a/Code/GraphMol/MolInterchange/Wrap/rdMolInterchange.cpp
+++ b/Code/GraphMol/MolInterchange/Wrap/rdMolInterchange.cpp
@@ -87,7 +87,8 @@ BOOST_PYTHON_MODULE(rdMolInterchange) {
       .def_readwrite("useHCounts",
                      &RDKit::MolInterchange::JSONParseParameters::useHCounts,
                      "use atomic H counts from the JSON. You may want to set "
-                     "this to False when parsing queries.");
+                     "this to False when parsing queries.")
+      .def("__setattr__", &safeSetattr);
 
   python::class_<RDKit::MolInterchange::JSONWriteParameters,
                  boost::noncopyable>("JSONWriteParameters",
@@ -95,7 +96,8 @@ BOOST_PYTHON_MODULE(rdMolInterchange) {
       .def_readwrite(
           "useRDKitExtensions",
           &RDKit::MolInterchange::JSONWriteParameters::useRDKitExtensions,
-          "use RDKit extensions to the commonchem format");
+          "use RDKit extensions to the commonchem format")
+      .def("__setattr__", &safeSetattr);
 
   std::string docString;
   docString =

--- a/Code/GraphMol/MolProcessing/Wrap/rdMolProcessing.cpp
+++ b/Code/GraphMol/MolProcessing/Wrap/rdMolProcessing.cpp
@@ -76,7 +76,8 @@ BOOST_PYTHON_MODULE(rdMolProcessing) {
       .def_readwrite("confId2D", &GeneralMolSupplier::SupplierOptions::confId2D,
                      "used for TDT files")
       .def_readwrite("confId3D", &GeneralMolSupplier::SupplierOptions::confId3D,
-                     "used for TDT files");
+                     "used for TDT files")
+      .def("__setattr__", &safeSetattr);
 
   python::def(
       "GetFingerprintsForMolsInFile",

--- a/Code/GraphMol/MolStandardize/Wrap/rdMolStandardize.cpp
+++ b/Code/GraphMol/MolStandardize/Wrap/rdMolStandardize.cpp
@@ -460,7 +460,8 @@ BOOST_PYTHON_MODULE(rdMolStandardize) {
                      &RDKit::MolStandardize::CleanupParameters::
                          largestFragmentChooserCountHeavyAtomsOnly,
                      "whether LargestFragmentChooser should only count "
-                     "heavy atoms (defaults to False)");
+                     "heavy atoms (defaults to False)")
+      .def("__setattr__", &safeSetattr);
 
   python::def("UpdateParamsFromJSON",
               &RDKit::MolStandardize::updateCleanupParamsFromJSON,

--- a/Code/GraphMol/RGroupDecomposition/Wrap/rdRGroupComposition.cpp
+++ b/Code/GraphMol/RGroupDecomposition/Wrap/rdRGroupComposition.cpp
@@ -347,7 +347,8 @@ struct rgroupdecomp_wrapper {
             &RDKit::RGroupDecompositionParameters::substructmatchParams)
         .def_readwrite(
             "includeTargetMolInResults",
-            &RDKit::RGroupDecompositionParameters::includeTargetMolInResults);
+            &RDKit::RGroupDecompositionParameters::includeTargetMolInResults)
+        .def("__setattr__", &safeSetattr);
 
     python::class_<RDKit::RGroupDecompositionHelper, boost::noncopyable>(
         "RGroupDecomposition",

--- a/Code/GraphMol/RascalMCES/Wrap/rdRascalMCES.cpp
+++ b/Code/GraphMol/RascalMCES/Wrap/rdRascalMCES.cpp
@@ -244,7 +244,8 @@ BOOST_PYTHON_MODULE(rdRascalMCES) {
                      " is > 0, it will over-ride the"
                      " similarityThreshold."
                      "  Note that this refers to the"
-                     " minimum number of BONDS in the MCES. Default=0.");
+                     " minimum number of BONDS in the MCES. Default=0.")
+      .def("__setattr__", &safeSetattr);
 
   docString =
       "Find one or more MCESs between the 2 molecules given.  Returns a list of "
@@ -290,7 +291,8 @@ BOOST_PYTHON_MODULE(rdRascalMCES) {
       .def_readwrite(
           "clusterMergeSim",
           &RDKit::RascalMCES::RascalClusterOptions::clusterMergeSim,
-          "Two clusters are merged if the fraction of molecules they have in common is greater than this.  Default=0.6.");
+          "Two clusters are merged if the fraction of molecules they have in common is greater than this.  Default=0.6.")
+      .def("__setattr__", &safeSetattr);
 
   docString =
       "Use the RASCAL MCES similarity metric to do fuzzy clustering.  Returns a list of lists "

--- a/Code/GraphMol/ScaffoldNetwork/Wrap/rdScaffoldNetwork.cpp
+++ b/Code/GraphMol/ScaffoldNetwork/Wrap/rdScaffoldNetwork.cpp
@@ -128,7 +128,8 @@ BOOST_PYTHON_MODULE(rdScaffoldNetwork) {
       .def_readwrite("collectMolCounts",
                      &ScaffoldNetwork::ScaffoldNetworkParams::collectMolCounts,
                      "keep track of the number of molecules each scaffold was "
-                     "found in");
+                     "found in")
+      .def("__setattr__", &safeSetattr);
 
   python::enum_<ScaffoldNetwork::EdgeType>("EdgeType")
       .value("Fragment", ScaffoldNetwork::EdgeType::Fragment)

--- a/Code/GraphMol/Wrap/rdmolfiles.cpp
+++ b/Code/GraphMol/Wrap/rdmolfiles.cpp
@@ -1247,7 +1247,8 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
       .def_readwrite(
           "scsrBaseHbondOptions",
           &RDKit::v2::FileParsers::MolFromSCSRParams::scsrBaseHbondOptions,
-          "One of Ignore, UseSapAll(default) , UseSapOne, Auto");
+          "One of Ignore, UseSapAll(default) , UseSapOne, Auto")
+      .def("__setattr__", &safeSetattr);
 
   docString =
       "Construct a molecule from an SCSR Mol block.\n\n\
@@ -2580,8 +2581,9 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
           "choose CXSMILES fields to be included in the CXSMILES string (default=rdkit.Chem.rdmolfiles.CXSmilesFields.CX_ALL)")
       .def_readwrite(
           "restoreBondDirs", &RDKit::PNGMetadataParams::restoreBondDirs,
-          "choose what to do with bond dirs in the CXSMILES string (default=rdkit.Chem.rdmolfiles.RestoreBondDirOption.RestoreBondDirOptionClear)");
-
+          "choose what to do with bond dirs in the CXSMILES string (default=rdkit.Chem.rdmolfiles.RestoreBondDirOption.RestoreBondDirOptionClear)")
+      .def("__setattr__", &safeSetattr);
+      
   docString =
       R"DOC(Construct a molecule from metadata in a PNG string.
 
@@ -2696,7 +2698,8 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
                      "molecule is returned")
       .def_readwrite(
           "format", &RDKit::v2::CDXMLParser::CDXMLParserParams::format,
-          "ChemDraw format One of Auto, CDXML, CDX.  For data streams, Auto defaults to CDXML");
+          "ChemDraw format One of Auto, CDXML, CDX.  For data streams, Auto defaults to CDXML")
+      .def("__setattr__", &safeSetattr);
 
   docString =
       R"DOC(Construct a molecule from a cdxml file.

--- a/External/CoordGen/Wrap/rdCoordGen.cpp
+++ b/External/CoordGen/Wrap/rdCoordGen.cpp
@@ -16,6 +16,7 @@
 #include <RDGeneral/Exceptions.h>
 #include <GraphMol/RDKitBase.h>
 #include <CoordGen/CoordGen.h>
+#include <RDBoost/Wrap.h>
 
 namespace python = boost::python;
 
@@ -91,7 +92,9 @@ struct coordgen_wrapper {
                        "controls sketcher precision")
         .def_readwrite(
             "treatNonterminalBondsToMetalAsZOBs",
-            &CoordGen::CoordGenParams::treatNonterminalBondsToMetalAsZeroOrder);
+            &CoordGen::CoordGenParams::treatNonterminalBondsToMetalAsZeroOrder)
+        .def("__setattr__", &safeSetattr);
+
     python::def("SetDefaultTemplateFileDir", SetDefaultTemplateFileDir,
                 python::args("dir"));
     docString =

--- a/External/FreeSASA/Wrap/rdFreeSASA.cpp
+++ b/External/FreeSASA/Wrap/rdFreeSASA.cpp
@@ -111,7 +111,8 @@ struct freesasa_wrapper {
             python::args("self", "alg", "cls", "pr")))
         .def_readwrite("algorithm", &FreeSASA::SASAOpts::algorithm)
         .def_readwrite("classifier", &FreeSASA::SASAOpts::classifier)
-        .def_readwrite("probeRadius", &FreeSASA::SASAOpts::probeRadius);
+        .def_readwrite("probeRadius", &FreeSASA::SASAOpts::probeRadius)
+        .def("__setattr__", &safeSetattr);
 
     docString =
         "Classify the atoms in the molecule returning their radii if "


### PR DESCRIPTION
Fixes no specific issue.

Scanned through the `rd*.cpp` files for parameter and options objects and added the `safeSetattr` to the ones not having it.



