### PR TITLE
Refactor iostreams includes

### DIFF
--- a/Code/Catalogs/CatalogEntry.h
+++ b/Code/Catalogs/CatalogEntry.h
@@ -11,7 +11,6 @@
 #ifndef __RD_CATALOGENTRY_H__
 #define __RD_CATALOGENTRY_H__
 
-#include <iostream>
 #include <string>
 
 namespace RDCatalog {

--- a/Code/DataManip/MetricMatrixCalc/testMatCalc.cpp
+++ b/Code/DataManip/MetricMatrixCalc/testMatCalc.cpp
@@ -14,6 +14,7 @@
 
 #include <cstdlib>
 #include <ctime>
+#include <iostream>
 
 using namespace RDDataManip;
 int main() {

--- a/Code/DataStructs/DiscreteDistMat.cpp
+++ b/Code/DataStructs/DiscreteDistMat.cpp
@@ -10,7 +10,6 @@
 //
 #include "DiscreteDistMat.h"
 #include "DiscreteValueVect.h"
-#include <iostream>
 #include "DatastructsException.h"
 
 namespace RDKit {

--- a/Code/DataStructs/ExplicitBitVect.cpp
+++ b/Code/DataStructs/ExplicitBitVect.cpp
@@ -9,7 +9,6 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
-#include <iostream>
 #include <RDGeneral/Exceptions.h>
 #include "ExplicitBitVect.h"
 #include <RDGeneral/StreamOps.h>

--- a/Code/DataStructs/FPBReader.h
+++ b/Code/DataStructs/FPBReader.h
@@ -18,7 +18,6 @@
      in future releases.
 */
 
-#include <iostream>
 #include <fstream>
 #include <sstream>
 #include <string>

--- a/Code/DataStructs/Utils.cpp
+++ b/Code/DataStructs/Utils.cpp
@@ -11,7 +11,6 @@
 #include "BitVects.h"
 #include "BitVectUtils.h"
 #include <RDGeneral/Invariant.h>
-#include <iostream>
 
 //! Convert a SparseBitVector to an ExplicitBitVector
 ExplicitBitVect *convertToExplicit(const SparseBitVect *sbv) {

--- a/Code/DataStructs/base64.cpp
+++ b/Code/DataStructs/base64.cpp
@@ -8,7 +8,6 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
-#include <iostream>
 #include <cstring>
 #include "base64.h"
 // Encoding table from RFC 2045

--- a/Code/DistGeom/BoundsMatrix.h
+++ b/Code/DistGeom/BoundsMatrix.h
@@ -13,7 +13,6 @@
 
 #include <RDGeneral/Invariant.h>
 #include <boost/smart_ptr.hpp>
-#include <iostream>
 #include <iomanip>
 #include <Numerics/SquareMatrix.h>
 

--- a/Code/DistGeom/testDistGeom.cpp
+++ b/Code/DistGeom/testDistGeom.cpp
@@ -11,7 +11,6 @@
 #include <catch2/catch_all.hpp>
 #include "BoundsMatrix.h"
 #include "TriangleSmooth.h"
-#include <iostream>
 #include <boost/smart_ptr.hpp>
 #include <cmath>
 #include <Numerics/SymmMatrix.h>

--- a/Code/Features/testFeatures.cpp
+++ b/Code/Features/testFeatures.cpp
@@ -8,7 +8,6 @@
 //  of the RDKit source tree.
 //
 #include <catch2/catch_all.hpp>
-#include <iostream>
 #include <RDGeneral/Invariant.h>
 #include <RDGeneral/utils.h>
 #include <Geometry/point.h>

--- a/Code/ForceField/AngleConstraints.h
+++ b/Code/ForceField/AngleConstraints.h
@@ -12,7 +12,6 @@
 #ifndef RD_ANGLECONSTRAINTS_H
 #define RD_ANGLECONSTRAINTS_H
 #include <vector>
-#include <iostream>
 #include "ForceField.h"
 #include "Contrib.h"
 

--- a/Code/ForceField/DistanceConstraints.h
+++ b/Code/ForceField/DistanceConstraints.h
@@ -12,7 +12,6 @@
 #ifndef RD_DISTANCECONSTRAINTS_H
 #define RD_DISTANCECONSTRAINTS_H
 #include <vector>
-#include <iostream>
 #include "Contrib.h"
 
 namespace ForceFields {

--- a/Code/ForceField/MMFF/Params.cpp
+++ b/Code/ForceField/MMFF/Params.cpp
@@ -16,7 +16,6 @@
 #include <cmath>
 #include "Params.h"
 
-#include <iostream>
 #include <sstream>
 #include <RDGeneral/StreamOps.h>
 #include <boost/lexical_cast.hpp>

--- a/Code/ForceField/MMFF/Params.h
+++ b/Code/ForceField/MMFF/Params.h
@@ -19,7 +19,6 @@
 #include <vector>
 #include <algorithm>
 #include <map>
-#include <iostream>
 #include <cstdint>
 
 #ifndef M_PI

--- a/Code/ForceField/MMFF/testMMFFForceField.cpp
+++ b/Code/ForceField/MMFF/testMMFFForceField.cpp
@@ -24,7 +24,6 @@
 #include <GraphMol/DistGeomHelpers/Embedder.h>
 #include <GraphMol/MolTransforms/MolTransforms.h>
 #include <ForceField/ForceField.h>
-#include <iostream>
 #include <iomanip>
 #include <fstream>
 #include <sstream>

--- a/Code/ForceField/UFF/Params.cpp
+++ b/Code/ForceField/UFF/Params.cpp
@@ -13,7 +13,6 @@
 #include <cmath>
 #include "Params.h"
 
-#include <iostream>
 #include <sstream>
 #include <RDGeneral/StreamOps.h>
 #include <boost/lexical_cast.hpp>

--- a/Code/ForceField/UFF/testUFFForceField.cpp
+++ b/Code/ForceField/UFF/testUFFForceField.cpp
@@ -8,7 +8,6 @@
 //  of the RDKit source tree.
 //
 #include <RDGeneral/test.h>
-#include <iostream>
 #include <iomanip>
 #include <cmath>
 #include <RDGeneral/Invariant.h>

--- a/Code/Fuzz/smiles_string_to_mol_fuzzer.cc
+++ b/Code/Fuzz/smiles_string_to_mol_fuzzer.cc
@@ -14,8 +14,6 @@
 
 #include <fuzzer/FuzzedDataProvider.h>
 
-#include <iostream>
-
 #include <GraphMol/GraphMol.h>
 #include <GraphMol/SmilesParse/SmilesParse.h>
 

--- a/Code/Fuzz/standalone_fuzz_target_runner.cpp
+++ b/Code/Fuzz/standalone_fuzz_target_runner.cpp
@@ -9,7 +9,6 @@
 // e.g. the one that comes from a bug report.
 
 #include <cassert>
-#include <iostream>
 #include <fstream>
 #include <vector>
 

--- a/Code/Geometry/UniformGrid3D.h
+++ b/Code/Geometry/UniformGrid3D.h
@@ -14,7 +14,6 @@
 #include "point.h"
 #include <DataStructs/DiscreteValueVect.h>
 #include "Grid3D.h"
-#include <iostream>
 
 namespace RDGeom {
 class RDKIT_RDGEOMETRYLIB_EXPORT UniformGrid3D

--- a/Code/Geometry/point.h
+++ b/Code/Geometry/point.h
@@ -11,7 +11,6 @@
 #include <RDGeneral/export.h>
 #ifndef __RD_POINT_H__
 #define __RD_POINT_H__
-#include <iostream>
 #include <cmath>
 #include <vector>
 #include <map>

--- a/Code/Geometry/testGrid.cpp
+++ b/Code/Geometry/testGrid.cpp
@@ -14,7 +14,6 @@
 #include <RDGeneral/Invariant.h>
 #include <RDGeneral/utils.h>
 #include "GridUtils.h"
-#include <iostream>
 #include <sstream>
 #include <fstream>
 #include <ios>

--- a/Code/Geometry/testRealValueGrid.cpp
+++ b/Code/Geometry/testRealValueGrid.cpp
@@ -17,7 +17,6 @@
 #include <RDGeneral/RDLog.h>
 #include <RDGeneral/types.h>
 #include <algorithm>
-#include <iostream>
 #include <sstream>
 #include <fstream>
 #include <ios>

--- a/Code/GraphMol/Abbreviations/Abbreviations.cpp
+++ b/Code/GraphMol/Abbreviations/Abbreviations.cpp
@@ -13,7 +13,6 @@
 #include <RDGeneral/Invariant.h>
 
 #include <boost/dynamic_bitset.hpp>
-#include <iostream>
 
 namespace RDKit {
 

--- a/Code/GraphMol/Atom.h
+++ b/Code/GraphMol/Atom.h
@@ -16,9 +16,6 @@
 #ifndef _RD_ATOM_H
 #define _RD_ATOM_H
 
-// Std stuff
-#include <iostream>
-
 // ours
 #include <RDGeneral/Invariant.h>
 #include <Query/QueryObjects.h>

--- a/Code/GraphMol/Basement/FeatTrees/testFeatTrees.cpp
+++ b/Code/GraphMol/Basement/FeatTrees/testFeatTrees.cpp
@@ -13,7 +13,6 @@
 #include <boost/log/functions.hpp>
 #include <GraphMol/RDKitBase.h>
 #include <string>
-#include <iostream>
 #include <GraphMol/FeatTrees/FeatTree.h>
 #include <GraphMol/FeatTrees/FeatTreeUtils.h>
 #include <GraphMol/SmilesParse/SmilesParse.h>

--- a/Code/GraphMol/Bond.h
+++ b/Code/GraphMol/Bond.h
@@ -12,7 +12,6 @@
 #define RD_BOND_H
 
 // std stuff
-#include <iostream>
 #include <utility>
 
 // Ours

--- a/Code/GraphMol/ChemReactions/ReactionParser.h
+++ b/Code/GraphMol/ChemReactions/ReactionParser.h
@@ -37,7 +37,6 @@
 #define RD_REACTIONPARSER_H_21Aug2006
 
 #include <string>
-#include <iostream>
 #include <fstream>
 #include <map>
 #include <sstream>
@@ -150,8 +149,9 @@ inline std::string ChemicalReactionToRxnSmiles(const ChemicalReaction &rxn,
 }
 
 //! returns the reaction SMARTS for a reaction with CX extension
-RDKIT_CHEMREACTIONS_EXPORT std::string ChemicalReactionToCXRxnSmarts(const ChemicalReaction &rxn,
-                                        const SmilesWriteParams &params, std::uint32_t flags = SmilesWrite::CXSmilesFields::CX_ALL);
+RDKIT_CHEMREACTIONS_EXPORT std::string ChemicalReactionToCXRxnSmarts(
+    const ChemicalReaction &rxn, const SmilesWriteParams &params,
+    std::uint32_t flags = SmilesWrite::CXSmilesFields::CX_ALL);
 //! \overload
 inline std::string ChemicalReactionToCXRxnSmarts(const ChemicalReaction &rxn) {
   SmilesWriteParams params;
@@ -160,10 +160,12 @@ inline std::string ChemicalReactionToCXRxnSmarts(const ChemicalReaction &rxn) {
 }
 
 //! returns the reaction SMILES for a reaction with CX extension
-RDKIT_CHEMREACTIONS_EXPORT std::string ChemicalReactionToCXRxnSmiles(const ChemicalReaction &rxn,
-                                        const SmilesWriteParams &params, std::uint32_t flags = SmilesWrite::CXSmilesFields::CX_ALL);
+RDKIT_CHEMREACTIONS_EXPORT std::string ChemicalReactionToCXRxnSmiles(
+    const ChemicalReaction &rxn, const SmilesWriteParams &params,
+    std::uint32_t flags = SmilesWrite::CXSmilesFields::CX_ALL);
 //! \overload
-inline std::string ChemicalReactionToCXRxnSmiles(const ChemicalReaction &rxn, bool canonical = true) {
+inline std::string ChemicalReactionToCXRxnSmiles(const ChemicalReaction &rxn,
+                                                 bool canonical = true) {
   SmilesWriteParams params;
   params.canonical = canonical;
   return ChemicalReactionToCXRxnSmiles(rxn, params);

--- a/Code/GraphMol/ChemReactions/ReactionPickler.h
+++ b/Code/GraphMol/ChemReactions/ReactionPickler.h
@@ -14,7 +14,6 @@
 
 #include <GraphMol/MolPickler.h>
 // Std stuff
-#include <iostream>
 #include <string>
 #include <exception>
 #ifdef WIN32

--- a/Code/GraphMol/ChemReactions/testReaction.cpp
+++ b/Code/GraphMol/ChemReactions/testReaction.cpp
@@ -36,7 +36,6 @@
 #include <RDGeneral/utils.h>
 #include <GraphMol/RDKitBase.h>
 #include <string>
-#include <iostream>
 #include <Geometry/point.h>
 #include <GraphMol/SmilesParse/SmilesParse.h>
 #include <GraphMol/SmilesParse/SmilesWrite.h>

--- a/Code/GraphMol/ChemReactions/testReactionFingerprints.cpp
+++ b/Code/GraphMol/ChemReactions/testReactionFingerprints.cpp
@@ -35,7 +35,6 @@
 #include <RDGeneral/utils.h>
 #include <GraphMol/RDKitBase.h>
 #include <string>
-#include <iostream>
 #include <GraphMol/ChemReactions/Reaction.h>
 #include <GraphMol/ChemReactions/ReactionParser.h>
 #include "GraphMol/ChemReactions/ReactionFingerprints.h"

--- a/Code/GraphMol/ChemTransforms/ChemTransforms.cpp
+++ b/Code/GraphMol/ChemTransforms/ChemTransforms.cpp
@@ -23,7 +23,6 @@
 #include <RDGeneral/BoostEndInclude.h>
 #include <vector>
 #include <algorithm>
-#include <iostream>
 #include <fstream>
 #include <sstream>
 #include <GraphMol/SmilesParse/SmilesParse.h>

--- a/Code/GraphMol/ChemTransforms/ChemTransforms.h
+++ b/Code/GraphMol/ChemTransforms/ChemTransforms.h
@@ -13,7 +13,6 @@
 
 #include <boost/smart_ptr.hpp>
 #include <vector>
-#include <iostream>
 
 #include <GraphMol/Substruct/SubstructMatch.h>
 #include "MolFragmenter.h"

--- a/Code/GraphMol/ChemTransforms/testChemTransforms.cpp
+++ b/Code/GraphMol/ChemTransforms/testChemTransforms.cpp
@@ -12,7 +12,6 @@
 #include <RDGeneral/utils.h>
 #include <GraphMol/RDKitBase.h>
 #include <string>
-#include <iostream>
 #include <GraphMol/SmilesParse/SmilesParse.h>
 #include <GraphMol/SmilesParse/SmilesWrite.h>
 #include <GraphMol/SmilesParse/SmartsWrite.h>

--- a/Code/GraphMol/Depictor/Basement/depictTest.cpp
+++ b/Code/GraphMol/Depictor/Basement/depictTest.cpp
@@ -12,7 +12,6 @@
 #include <RDGeneral/Invariant.h>
 #include <RDGeneral/RDLog.h>
 #include "Depictor.h"
-#include <iostream>
 #include <GraphMol/RDKitBase.h>
 #include <GraphMol/FileParsers/FileParsers.h>
 #include <GraphMol/SmilesParse/SmilesParse.h>

--- a/Code/GraphMol/Depictor/DepictUtils.cpp
+++ b/Code/GraphMol/Depictor/DepictUtils.cpp
@@ -11,7 +11,6 @@
 #include <cmath>
 #include <Geometry/point.h>
 #include "DepictUtils.h"
-#include <iostream>
 #include <RDGeneral/Invariant.h>
 #include <GraphMol/Chirality.h>
 #include <algorithm>

--- a/Code/GraphMol/Depictor/EmbeddedFrag.cpp
+++ b/Code/GraphMol/Depictor/EmbeddedFrag.cpp
@@ -17,7 +17,6 @@
 #include "EmbeddedFrag.h"
 #include "DepictUtils.h"
 #include "Templates.h"
-#include <iostream>
 #include <GraphMol/ROMol.h>
 #include <GraphMol/Bond.h>
 #include "RDDepictor.h"

--- a/Code/GraphMol/Depictor/RDDepictor.cpp
+++ b/Code/GraphMol/Depictor/RDDepictor.cpp
@@ -31,7 +31,6 @@
 #include <GraphMol/Chirality.h>
 #include "EmbeddedFrag.h"
 #include "DepictUtils.h"
-#include <iostream>
 #include <boost/dynamic_bitset.hpp>
 #include <algorithm>
 

--- a/Code/GraphMol/Depictor/Templates.h
+++ b/Code/GraphMol/Depictor/Templates.h
@@ -14,7 +14,6 @@
 
 #include "TemplateSmiles.h"
 
-#include <iostream>
 #include <fstream>
 #include <unordered_map>
 

--- a/Code/GraphMol/Depictor/testDepictor.cpp
+++ b/Code/GraphMol/Depictor/testDepictor.cpp
@@ -12,7 +12,6 @@
 #include <RDGeneral/RDLog.h>
 #include <GraphMol/RDKitBase.h>
 #include <string>
-#include <iostream>
 #include <GraphMol/FileParsers/MolWriters.h>
 #include <GraphMol/FileParsers/FileParsers.h>
 #include <GraphMol/FileParsers/MolSupplier.h>

--- a/Code/GraphMol/Descriptors/AUTOCORR2D.cpp
+++ b/Code/GraphMol/Descriptors/AUTOCORR2D.cpp
@@ -36,7 +36,6 @@
 #include "AUTOCORR2D.h"
 #include "MolData3Ddescriptors.h"
 #include <cmath>
-#include <iostream>
 
 namespace RDKit {
 namespace Descriptors {

--- a/Code/GraphMol/Descriptors/AUTOCORR3D.cpp
+++ b/Code/GraphMol/Descriptors/AUTOCORR3D.cpp
@@ -37,7 +37,6 @@
 #include "MolData3Ddescriptors.h"
 
 #include <cmath>
-#include <iostream>
 
 #include <Eigen/Core>
 #include <Eigen/Dense>

--- a/Code/GraphMol/Descriptors/AtomFeat.cpp
+++ b/Code/GraphMol/Descriptors/AtomFeat.cpp
@@ -22,7 +22,6 @@
 // Adding ATOM FEATURES descriptors by Guillaume Godin
 
 #include <GraphMol/RDKitBase.h>
-#include <iostream>
 
 #include "AtomFeat.h"
 

--- a/Code/GraphMol/Descriptors/Crippen.cpp
+++ b/Code/GraphMol/Descriptors/Crippen.cpp
@@ -15,7 +15,6 @@
 #include <GraphMol/Substruct/SubstructMatch.h>
 #include "MolDescriptors.h"
 #include "Crippen.h"
-#include <iostream>
 #include <sstream>
 #include <RDGeneral/StreamOps.h>
 #include <boost/lexical_cast.hpp>

--- a/Code/GraphMol/Descriptors/DCLV.cpp
+++ b/Code/GraphMol/Descriptors/DCLV.cpp
@@ -10,7 +10,6 @@
 /*=================================================================*/
 #define _USE_MATH_DEFINES
 
-#include <iostream>
 #include <limits>
 #include <string>
 #include <list>
@@ -44,7 +43,7 @@ static bool checkExcludedAtoms(const Atom *atm, bool includeLigand) {
 
     switch (resName[0]) {
       case 'D':
-        if (resName == "DOD" || resName == "D20"){
+        if (resName == "DOD" || resName == "D20") {
           return true;
         }
         break;
@@ -56,7 +55,7 @@ static bool checkExcludedAtoms(const Atom *atm, bool includeLigand) {
       case 'S':
         if (resName == "SOL" || resName == "SO4" || resName == "SUL") {
           return true;
-       }
+        }
         break;
       case 'W':
         if (resName == "WAT") {
@@ -78,14 +77,14 @@ static bool checkExcludedAtoms(const Atom *atm, bool includeLigand) {
     if (!includeLigand &&
         static_cast<const AtomPDBResidueInfo *>(info)->getIsHeteroAtom()) {
       return true;
-    } 
+    }
   }
 
   return false;
 }
 
-static bool includeAsPolar(const Atom *atm, const ROMol &mol,
-                         bool includeSandP, bool includeHs) {
+static bool includeAsPolar(const Atom *atm, const ROMol &mol, bool includeSandP,
+                           bool includeHs) {
   // using Peter Ertl definition, polar atoms = O, N, P, S and attached Hs
 
   switch (atm->getAtomicNum()) {
@@ -105,8 +104,7 @@ static bool includeAsPolar(const Atom *atm, const ROMol &mol,
     case 1: {
       if (!includeHs) {
         return false;
-      } 
-      else {
+      } else {
         for (const auto nbr : mol.atomNeighbors(atm)) {
           if (includeAsPolar(nbr, mol, includeSandP, includeHs)) {
             return true;
@@ -130,7 +128,7 @@ struct State {
   double voxU = 0.0;
   double voxV = 0.0;
   double voxW = 0.0;
-  
+
   std::vector<unsigned int> grid[VOXORDER][VOXORDER][VOXORDER];
 
   void createVoxelGrid(const Point3D &minXYZ, const Point3D &maxXYZ,
@@ -205,11 +203,11 @@ struct State {
             for (auto idx : grid[x][y][z]) {
               if (idx != atm_idx) {
                 auto dist = range + radii_[idx];
-                if ((pos - positions[idx]).lengthSq() < (dist * dist)){
+                if ((pos - positions[idx]).lengthSq() < (dist * dist)) {
                   atomNeighbours.push_back(idx);
                 }
               }
-            }                           
+            }
           }
         }
       }
@@ -220,12 +218,9 @@ struct State {
 };
 
 // constructor definition
-DoubleCubicLatticeVolume::DoubleCubicLatticeVolume(const ROMol &mol,
-                                                   std::vector<double> radii,
-                                                   bool isProtein,
-                                                   bool includeLigand,
-                                                   double probeRadius,
-                                                   int confId)
+DoubleCubicLatticeVolume::DoubleCubicLatticeVolume(
+    const ROMol &mol, std::vector<double> radii, bool isProtein,
+    bool includeLigand, double probeRadius, int confId)
     : mol(mol),
       radii_(std::move(radii)),
       isProtein(isProtein),
@@ -356,7 +351,6 @@ bool DoubleCubicLatticeVolume::testPoint(
 }
 
 double DoubleCubicLatticeVolume::getAtomSurfaceArea(unsigned int atomIdx) {
-
   // surface area for single atom
 
   const auto rad = radii_[atomIdx];
@@ -420,7 +414,8 @@ double DoubleCubicLatticeVolume::getPartialSurfaceArea(
   return area;
 }
 
-double DoubleCubicLatticeVolume::getPolarSurfaceArea(bool includeSandP, bool includeHs) {
+double DoubleCubicLatticeVolume::getPolarSurfaceArea(bool includeSandP,
+                                                     bool includeHs) {
   boost::dynamic_bitset<> polarAtoms(mol.getNumAtoms());
   for (const auto atom : mol.atoms()) {
     if (includeAsPolar(atom, mol, includeSandP, includeHs)) {
@@ -430,7 +425,8 @@ double DoubleCubicLatticeVolume::getPolarSurfaceArea(bool includeSandP, bool inc
   return getPartialSurfaceArea(polarAtoms);
 }
 
-std::map<unsigned int, std::vector<RDGeom::Point3D>> &DoubleCubicLatticeVolume::getSurfacePoints() {
+std::map<unsigned int, std::vector<RDGeom::Point3D>> &
+DoubleCubicLatticeVolume::getSurfacePoints() {
   if (!surfacePoints.empty()) {
     return surfacePoints;
   }
@@ -540,7 +536,8 @@ double DoubleCubicLatticeVolume::getPartialVolume(
   return vol;
 }
 
-double DoubleCubicLatticeVolume::getPolarVolume(bool includeSandP, bool includeHs) {
+double DoubleCubicLatticeVolume::getPolarVolume(bool includeSandP,
+                                                bool includeHs) {
   boost::dynamic_bitset<> polarAtoms(mol.getNumAtoms());
   for (const auto atom : mol.atoms()) {
     if (includeAsPolar(atom, mol, includeSandP, includeHs)) {

--- a/Code/GraphMol/Descriptors/DCLV.h
+++ b/Code/GraphMol/Descriptors/DCLV.h
@@ -12,7 +12,6 @@
 #ifndef RDKIT_DCLV_H
 #define RDKIT_DCLV_H
 
-#include <iostream>
 #include <string>
 #include <list>
 #include <cmath>
@@ -28,7 +27,7 @@ namespace RDKit {
 namespace Descriptors {
 
 class RDKIT_DESCRIPTORS_EXPORT DoubleCubicLatticeVolume {
-  public:
+ public:
   /*!
 
     \param mol: input molecule or protein
@@ -51,12 +50,11 @@ class RDKIT_DESCRIPTORS_EXPORT DoubleCubicLatticeVolume {
   bool includeLigand = true;
   double probeRadius = 1.4;
   int confId = -1;
-  double maxRadius = 1.7; // treat default max radius as Carbon
+  double maxRadius = 1.7;  // treat default max radius as Carbon
 
-
-DoubleCubicLatticeVolume(const ROMol &mol, std::vector<double> radii,
-                         bool isProtein = false, bool includeLigand = true, 
-                         double probeRadius = 1.4, int confId = -1);
+  DoubleCubicLatticeVolume(const ROMol &mol, std::vector<double> radii,
+                           bool isProtein = false, bool includeLigand = true,
+                           double probeRadius = 1.4, int confId = -1);
   //! Class for calculation of the Shrake and Rupley surface area and volume
   //! using the Double Cubic Lattice Method.
   //!
@@ -89,7 +87,7 @@ DoubleCubicLatticeVolume(const ROMol &mol, std::vector<double> radii,
   /*! \return van der Waals Volume */
   double getVDWVolume();
 
-   /*! \return Polar Volume */
+  /*! \return Polar Volume */
   double getPolarVolume(bool includeSandP, bool includeHs);
 
   /*! \return Volume from specified atoms */

--- a/Code/GraphMol/Descriptors/Data3Ddescriptors.cpp
+++ b/Code/GraphMol/Descriptors/Data3Ddescriptors.cpp
@@ -1,5 +1,4 @@
 #include <cstdlib>
-#include <iostream>
 #include "Data3Ddescriptors.h"
 
 using namespace std;

--- a/Code/GraphMol/Descriptors/GETAWAY.cpp
+++ b/Code/GraphMol/Descriptors/GETAWAY.cpp
@@ -49,7 +49,6 @@
 #include <cmath>
 #include <Eigen/Dense>
 #include <Eigen/SVD>
-#include <iostream>
 #include <deque>
 #include <Eigen/Core>
 #include <Eigen/QR>

--- a/Code/GraphMol/Descriptors/MolData3Ddescriptors.cpp
+++ b/Code/GraphMol/Descriptors/MolData3Ddescriptors.cpp
@@ -1,5 +1,4 @@
 #include <cstdlib>
-#include <iostream>
 #include "MolData3Ddescriptors.h"
 #include <GraphMol/RDKitBase.h>
 

--- a/Code/GraphMol/Descriptors/test.cpp
+++ b/Code/GraphMol/Descriptors/test.cpp
@@ -9,7 +9,6 @@
 //
 
 #include <RDGeneral/test.h>
-#include <iostream>
 #include <fstream>
 
 #include <RDGeneral/BoostStartInclude.h>

--- a/Code/GraphMol/Descriptors/test3D.cpp
+++ b/Code/GraphMol/Descriptors/test3D.cpp
@@ -14,7 +14,6 @@
 #endif
 
 #include <RDGeneral/test.h>
-#include <iostream>
 #include <fstream>
 
 #include <RDGeneral/BoostStartInclude.h>

--- a/Code/GraphMol/DetermineBonds/catch_tests.cpp
+++ b/Code/GraphMol/DetermineBonds/catch_tests.cpp
@@ -8,7 +8,6 @@
 #include <GraphMol/SmilesParse/SmilesParse.h>
 #include <GraphMol/SmilesParse/SmilesWrite.h>
 #include <GraphMol/AddHs.cpp>
-#include <iostream>
 #include <fstream>
 #include <algorithm>
 #include <GraphMol/Resonance.h>

--- a/Code/GraphMol/DistGeomHelpers/testDgeomHelpers.cpp
+++ b/Code/GraphMol/DistGeomHelpers/testDgeomHelpers.cpp
@@ -13,14 +13,12 @@
 #include <GraphMol/RDKitBase.h>
 #include <string>
 #include <vector>
-#include <iostream>
 #include <DistGeom/BoundsMatrix.h>
 #include <DistGeom/DistGeomUtils.h>
 #include <DistGeom/TriangleSmooth.h>
 #include <GraphMol/SmilesParse/SmilesParse.h>
 #include <GraphMol/SmilesParse/SmilesWrite.h>
 #include <GraphMol/FileParsers/FileParsers.h>
-#include <iostream>
 #include "BoundsMatrixBuilder.h"
 #include "Embedder.h"
 #include <cstdlib>

--- a/Code/GraphMol/FMCS/DebugTrace.h
+++ b/Code/GraphMol/FMCS/DebugTrace.h
@@ -13,7 +13,6 @@
 #include <cstring>
 #include <cstddef>
 #include <ctime>
-#include <iostream>
 #ifdef _MSC_VER
 #define _CRT_SECURE_NO_WARNINGS
 #define NOMINMAX

--- a/Code/GraphMol/FMCS/FMCS.cpp
+++ b/Code/GraphMol/FMCS/FMCS.cpp
@@ -16,7 +16,6 @@
 #include <boost/property_tree/json_parser.hpp>
 #include <RDGeneral/BoostEndInclude.h>
 
-#include <iostream>
 #include <sstream>
 #include "SubstructMatchCustom.h"
 #include "MaximumCommonSubgraph.h"

--- a/Code/GraphMol/FMCS/Test/testFMCS.cpp
+++ b/Code/GraphMol/FMCS/Test/testFMCS.cpp
@@ -43,7 +43,6 @@
 #include <cstring>
 #include <ctime>
 #include <string>
-#include <iostream>
 #include "../../RDKitBase.h"
 #include "../../FileParsers/FileParsers.h"  //MOL single molecule !
 #include "../../FileParsers/MolSupplier.h"  //SDF
@@ -1687,7 +1686,6 @@ int main(int argc, const char *argv[]) {
   _CrtMemCheckpoint(&_ms);
 #endif
   // while(1)   // check memory leaks in TaskManager or 'top -p ...'
-  {}
 #ifdef _DEBUG  // check memory leaks
   _CrtMemDumpAllObjectsSince(&_ms);
 #endif

--- a/Code/GraphMol/FMCS/testFMCS_Unit.cpp
+++ b/Code/GraphMol/FMCS/testFMCS_Unit.cpp
@@ -42,7 +42,6 @@
 #include <cstring>
 #include <ctime>
 #include <string>
-#include <iostream>
 #include <RDGeneral/RDLog.h>
 #include <RDGeneral/utils.h>
 #include "../RDKitBase.h"

--- a/Code/GraphMol/FileParsers/CDXMLParser.h
+++ b/Code/GraphMol/FileParsers/CDXMLParser.h
@@ -13,7 +13,6 @@
 
 #include <RDGeneral/types.h>
 #include <string>
-#include <iostream>
 #include <vector>
 
 namespace RDKit {
@@ -35,10 +34,10 @@ struct RDKIT_FILEPARSERS_EXPORT CDXMLParserParams {
   bool sanitize = true;
   bool removeHs = true;
   CDXMLFormat format = CDXMLFormat::Auto;
-  
+
   CDXMLParserParams() = default;
-  CDXMLParserParams(bool sanitize, bool removeHs, CDXMLFormat format) :
-    sanitize(sanitize), removeHs(removeHs), format(format) {}
+  CDXMLParserParams(bool sanitize, bool removeHs, CDXMLFormat format)
+      : sanitize(sanitize), removeHs(removeHs), format(format) {}
 };
 
 //! \brief construct molecules from a CDXML file
@@ -68,7 +67,8 @@ MolsFromCDXMLDataStream(std::istream &inStream,
  */
 RDKIT_FILEPARSERS_EXPORT std::vector<std::unique_ptr<RWMol>> MolsFromCDXMLFile(
     const std::string &filename,
-    const CDXMLParserParams &params = CDXMLParserParams(true, true, CDXMLFormat::Auto));
+    const CDXMLParserParams &params = CDXMLParserParams(true, true,
+                                                        CDXMLFormat::Auto));
 
 //! \brief construct molecules from a CDXML block
 //! The RDKit is optionally built with the Revvity ChemDraw parser
@@ -84,7 +84,8 @@ RDKIT_FILEPARSERS_EXPORT std::vector<std::unique_ptr<RWMol>> MolsFromCDXMLFile(
  */
 RDKIT_FILEPARSERS_EXPORT std::vector<std::unique_ptr<RWMol>> MolsFromCDXML(
     const std::string &cdxml,
-    const CDXMLParserParams &params = CDXMLParserParams(true, true, v2::CDXMLParser::CDXMLFormat::Auto));
+    const CDXMLParserParams &params =
+        CDXMLParserParams(true, true, v2::CDXMLParser::CDXMLFormat::Auto));
 }  // namespace CDXMLParser
 }  // namespace v2
 
@@ -106,8 +107,8 @@ inline namespace v1 {
  */
 inline std::vector<std::unique_ptr<RWMol>> CDXMLDataStreamToMols(
     std::istream &inStream, bool sanitize = true, bool removeHs = true) {
-  v2::CDXMLParser::CDXMLParserParams params(
-      sanitize, removeHs, v2::CDXMLParser::CDXMLFormat::Auto);
+  v2::CDXMLParser::CDXMLParserParams params(sanitize, removeHs,
+                                            v2::CDXMLParser::CDXMLFormat::Auto);
   return v2::CDXMLParser::MolsFromCDXMLDataStream(inStream, params);
 }
 
@@ -116,8 +117,8 @@ inline std::vector<std::unique_ptr<RWMol>> CDXMLDataStreamToMols(
 //!  full functionality, just the base ones required for molecule and
 //!  reaction parsing.
 //! Note: If the ChemDraw extensions are available,
-//!   This function uses the file extension to determine the file type, .cdx or .cdxml
-//!   If not, it defaults to CDXML
+//!   This function uses the file extension to determine the file type, .cdx or
+//!   .cdxml If not, it defaults to CDXML
 /*!
  *   \param fileName - cdxml fileName
  *   \param sanitize - toggles sanitization and stereochemistry
@@ -154,7 +155,7 @@ inline std::vector<std::unique_ptr<RWMol>> CDXMLToMols(const std::string &cdxml,
   v2::CDXMLParser::CDXMLParserParams params;
   params.sanitize = sanitize;
   params.removeHs = removeHs;
-  params.format = v2::CDXMLParser::CDXMLFormat::Auto;  
+  params.format = v2::CDXMLParser::CDXMLFormat::Auto;
   return v2::CDXMLParser::MolsFromCDXML(cdxml, params);
 }
 }  // namespace v1

--- a/Code/GraphMol/FileParsers/FileParserUtils.h
+++ b/Code/GraphMol/FileParsers/FileParserUtils.h
@@ -12,7 +12,6 @@
 #define RD_FILEPARSERUTILS_H
 
 #include <string>
-#include <iostream>
 #include <RDGeneral/BoostStartInclude.h>
 #include <boost/lexical_cast.hpp>
 #include <boost/algorithm/string.hpp>

--- a/Code/GraphMol/FileParsers/FileParsers.h
+++ b/Code/GraphMol/FileParsers/FileParsers.h
@@ -17,7 +17,6 @@
 #include "CDXMLParser.h"
 #include <string>
 #include <string_view>
-#include <iostream>
 #include <vector>
 #include <exception>
 

--- a/Code/GraphMol/FileParsers/ForwardSDMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/ForwardSDMolSupplier.cpp
@@ -21,7 +21,6 @@
 #include "FileParserUtils.h"
 
 #include <fstream>
-#include <iostream>
 #include <sstream>
 #include <string>
 

--- a/Code/GraphMol/FileParsers/GeneralFileReader.h
+++ b/Code/GraphMol/FileParsers/GeneralFileReader.h
@@ -13,7 +13,6 @@
 #include <RDStreams/streams.h>
 
 #include <boost/algorithm/string.hpp>
-#include <iostream>
 #include <memory>
 #include <string>
 #include <vector>

--- a/Code/GraphMol/FileParsers/MaeMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/MaeMolSupplier.cpp
@@ -8,7 +8,6 @@
 //  of the RDKit source tree.
 //
 #include <cstring>
-#include <iostream>
 #include <fstream>
 
 #include <boost/unordered_set.hpp>
@@ -39,7 +38,10 @@ namespace FileParsers {
 namespace {
 
 // Flag for parsing chirality labels
-enum class [[nodiscard]] ChiralityLabelStatus{VALID, INVALID};
+enum class [[nodiscard]] ChiralityLabelStatus {
+  VALID,
+  INVALID
+};
 
 class PDBInfo {
  public:

--- a/Code/GraphMol/FileParsers/MolFileWriter.cpp
+++ b/Code/GraphMol/FileParsers/MolFileWriter.cpp
@@ -25,7 +25,6 @@
 #include <vector>
 #include <algorithm>
 #include <fstream>
-#include <iostream>
 #include <iomanip>
 #include <cstdio>
 
@@ -586,7 +585,7 @@ void GetMolFileAtomProperties(const Atom *atom, const Conformer *conf,
       parityFlag = getAtomParityFlag(atom, conf);
     }
   }
-  
+
   if (hasNonDefaultValence(atom)) {
     if (atom->getTotalDegree() == 0) {
       // Specify zero valence for elements/metals without neighbors
@@ -609,12 +608,13 @@ const std::string GetMolFileAtomLine(const Atom *atom, const Conformer *conf,
   GetMolFileAtomProperties(atom, conf, totValence, atomMapNumber, parityFlag, x,
                            y, z);
 
-  if( (x >= MAX_V2000_COORD || x <= MIN_V2000_COORD) ||
+  if ((x >= MAX_V2000_COORD || x <= MIN_V2000_COORD) ||
       (y >= MAX_V2000_COORD || y <= MIN_V2000_COORD) ||
-      (z >= MAX_V2000_COORD || z <= MIN_V2000_COORD) ) {
-    throw ValueErrorException("MolFile coordinates must be in (-100000, 1000000)");
+      (z >= MAX_V2000_COORD || z <= MIN_V2000_COORD)) {
+    throw ValueErrorException(
+        "MolFile coordinates must be in (-100000, 1000000)");
   }
-  
+
   int massDiff, chg, stereoCare, hCount, rxnComponentType, rxnComponentNumber,
       inversionFlag, exactChangeFlag;
   massDiff = 0;
@@ -1273,24 +1273,23 @@ std::string outputMolToMolBlock(const RWMol &tmol, int confId,
   }
 
   bool coordMagnitudeTooLargeForV2K = false;
-  if(conf) {
-    for(auto &pos : conf->getPositions()) {
-      if( (pos.x >= MAX_V2000_COORD || pos.x <= MIN_V2000_COORD) ||
-	        (pos.y >= MAX_V2000_COORD || pos.y <= MIN_V2000_COORD) ||
-	        (pos.z >= MAX_V2000_COORD || pos.z <= MIN_V2000_COORD) ) {
-	          coordMagnitudeTooLargeForV2K = true;
+  if (conf) {
+    for (auto &pos : conf->getPositions()) {
+      if ((pos.x >= MAX_V2000_COORD || pos.x <= MIN_V2000_COORD) ||
+          (pos.y >= MAX_V2000_COORD || pos.y <= MIN_V2000_COORD) ||
+          (pos.z >= MAX_V2000_COORD || pos.z <= MIN_V2000_COORD)) {
+        coordMagnitudeTooLargeForV2K = true;
       }
     }
   }
 
   if (whichFormat == MolFileFormat::V2000 && coordMagnitudeTooLargeForV2K) {
     throw ValueErrorException(
-			      "V2000 format does not support atom positions <= " +
-			      std::to_string((int)MIN_V2000_COORD) +
-			      " or >= " + std::to_string((int)MAX_V2000_COORD) );
+        "V2000 format does not support atom positions <= " +
+        std::to_string((int)MIN_V2000_COORD) +
+        " or >= " + std::to_string((int)MAX_V2000_COORD));
   }
 
-  
   std::string text;
   if (tmol.getPropIfPresent(common_properties::_Name, text)) {
     res += text;
@@ -1332,7 +1331,8 @@ std::string outputMolToMolBlock(const RWMol &tmol, int confId,
   if (whichFormat == MolFileFormat::V3000) {
     isV3000 = true;
   } else if (whichFormat == MolFileFormat::unspecified &&
-             (coordMagnitudeTooLargeForV2K || hasDative || nAtoms > 999 || nBonds > 999 || nSGroups > 999 ||
+             (coordMagnitudeTooLargeForV2K || hasDative || nAtoms > 999 ||
+              nBonds > 999 || nSGroups > 999 ||
               !tmol.getStereoGroups().empty())) {
     isV3000 = true;
   }

--- a/Code/GraphMol/FileParsers/MolSupplier.h
+++ b/Code/GraphMol/FileParsers/MolSupplier.h
@@ -18,7 +18,6 @@
 #include <list>
 #include <memory>
 #include <vector>
-#include <iostream>
 #include <fstream>
 #include <GraphMol/ROMol.h>
 #include <RDGeneral/BadFileException.h>

--- a/Code/GraphMol/FileParsers/MolWriters.h
+++ b/Code/GraphMol/FileParsers/MolWriters.h
@@ -14,7 +14,6 @@
 
 #include <RDGeneral/types.h>
 
-#include <iostream>
 #include <memory>
 #include <string>
 

--- a/Code/GraphMol/FileParsers/PDBParser.cpp
+++ b/Code/GraphMol/FileParsers/PDBParser.cpp
@@ -10,7 +10,6 @@
 #include <cstring>
 #include <cstdio>
 #include <string>
-#include <iostream>
 #include <fstream>
 #include <RDGeneral/BoostStartInclude.h>
 #include <boost/lexical_cast.hpp>

--- a/Code/GraphMol/FileParsers/PDBWriter.cpp
+++ b/Code/GraphMol/FileParsers/PDBWriter.cpp
@@ -9,7 +9,6 @@
 //
 #include <algorithm>
 #include <fstream>
-#include <iostream>
 #include <map>
 #include <string>
 #include <vector>

--- a/Code/GraphMol/FileParsers/SDMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/SDMolSupplier.cpp
@@ -18,7 +18,6 @@
 #include "FileParsers.h"
 
 #include <fstream>
-#include <iostream>
 #include <sstream>
 #include <string>
 

--- a/Code/GraphMol/FileParsers/SDWriter.cpp
+++ b/Code/GraphMol/FileParsers/SDWriter.cpp
@@ -9,7 +9,6 @@
 //
 
 #include <fstream>
-#include <iostream>
 #include <sstream>
 #include <string>
 

--- a/Code/GraphMol/FileParsers/SmilesMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/SmilesMolSupplier.cpp
@@ -17,7 +17,6 @@
 typedef boost::tokenizer<boost::char_separator<char>> tokenizer;
 
 #include <fstream>
-#include <iostream>
 #include <sstream>
 #include <string>
 #include <cstdlib>

--- a/Code/GraphMol/FileParsers/SmilesWriter.cpp
+++ b/Code/GraphMol/FileParsers/SmilesWriter.cpp
@@ -9,7 +9,6 @@
 //  of the RDKit source tree.
 //
 #include <fstream>
-#include <iostream>
 #include <sstream>
 #include <string>
 

--- a/Code/GraphMol/FileParsers/TDTMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/TDTMolSupplier.cpp
@@ -22,7 +22,6 @@
 #include <RDGeneral/LocaleSwitcher.h>
 
 #include <fstream>
-#include <iostream>
 #include <sstream>
 #include <string>
 

--- a/Code/GraphMol/FileParsers/TDTWriter.cpp
+++ b/Code/GraphMol/FileParsers/TDTWriter.cpp
@@ -9,7 +9,6 @@
 //  of the RDKit source tree.
 //
 #include <fstream>
-#include <iostream>
 #include <iomanip>
 #include <sstream>
 #include <string>

--- a/Code/GraphMol/FileParsers/XYZFileParser.cpp
+++ b/Code/GraphMol/FileParsers/XYZFileParser.cpp
@@ -20,7 +20,6 @@
 #include <RDGeneral/BadFileException.h>
 #include <exception>
 
-#include <iostream>
 #include <fstream>
 #include <sstream>
 #include <string>

--- a/Code/GraphMol/FileParsers/testGeneralFileReader.cpp
+++ b/Code/GraphMol/FileParsers/testGeneralFileReader.cpp
@@ -16,7 +16,6 @@
 #include <boost/iostreams/device/file.hpp>
 #include <boost/iostreams/filtering_stream.hpp>
 #include <fstream>
-#include <iostream>
 #include <map>
 #include <memory>
 #include <string>

--- a/Code/GraphMol/FileParsers/testMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/testMolSupplier.cpp
@@ -11,7 +11,6 @@
 #include <GraphMol/test_fixtures.h>
 #include <GraphMol/RDKitBase.h>
 #include <string>
-#include <iostream>
 #include <fstream>
 #include <map>
 #include <memory>

--- a/Code/GraphMol/FileParsers/testMolWriter.cpp
+++ b/Code/GraphMol/FileParsers/testMolWriter.cpp
@@ -11,7 +11,6 @@
 #include <GraphMol/test_fixtures.h>
 #include <GraphMol/RDKitBase.h>
 #include <string>
-#include <iostream>
 #include <fstream>
 #include <sstream>
 

--- a/Code/GraphMol/FilterCatalog/filtercatalogtest.cpp
+++ b/Code/GraphMol/FilterCatalog/filtercatalogtest.cpp
@@ -35,7 +35,6 @@
 #include <GraphMol/FilterCatalog/FilterCatalog.h>
 #include <GraphMol/SmilesParse/SmilesParse.h>
 #include <fstream>
-#include <iostream>
 #include <map>
 #include <algorithm>
 

--- a/Code/GraphMol/Fingerprints/MHFP.cpp
+++ b/Code/GraphMol/Fingerprints/MHFP.cpp
@@ -10,7 +10,6 @@
 //
 
 #include <algorithm>
-#include <iostream>
 #include <limits>
 #include <numeric>
 #include <stdexcept>

--- a/Code/GraphMol/Fingerprints/Wrap/FingerprintGeneratorWrapper.cpp
+++ b/Code/GraphMol/Fingerprints/Wrap/FingerprintGeneratorWrapper.cpp
@@ -9,7 +9,6 @@
 //
 
 #include <RDBoost/Wrap.h>
-#include <iostream>
 #include <string>
 #include <boost/python.hpp>
 #include <RDBoost/boost_numpy.h>

--- a/Code/GraphMol/ForceFieldHelpers/CrystalFF/TorsionPreferences.cpp
+++ b/Code/GraphMol/ForceFieldHelpers/CrystalFF/TorsionPreferences.cpp
@@ -17,7 +17,6 @@
 #include <RDGeneral/Exceptions.h>
 #include <boost/dynamic_bitset.hpp>
 #include <algorithm>
-#include <iostream>
 #include <sstream>
 #include <RDGeneral/StreamOps.h>
 

--- a/Code/GraphMol/ForceFieldHelpers/CrystalFF/testCrystalFF.cpp
+++ b/Code/GraphMol/ForceFieldHelpers/CrystalFF/testCrystalFF.cpp
@@ -20,7 +20,6 @@
 #include <GraphMol/MolOps.h>
 #include <GraphMol/MolTransforms/MolTransforms.h>
 #include <ForceField/ForceField.h>
-#include <iostream>
 #include <string>
 #include <cmath>
 

--- a/Code/GraphMol/ForceFieldHelpers/MMFF/AtomTyper.h
+++ b/Code/GraphMol/ForceFieldHelpers/MMFF/AtomTyper.h
@@ -15,7 +15,6 @@
 
 #include <vector>
 #include <string>
-#include <iostream>
 #include <ForceField/MMFF/Params.h>
 #include <cstdint>
 
@@ -65,7 +64,10 @@ class RDKIT_FORCEFIELDHELPERS_EXPORT MMFFAtomProperties {
 };
 
 typedef boost::shared_ptr<MMFFAtomProperties> MMFFAtomPropertiesPtr;
-enum { CONSTANT = 1, DISTANCE = 2 };
+enum {
+  CONSTANT = 1,
+  DISTANCE = 2
+};
 enum {
   MMFF_VERBOSITY_NONE = 0,
   MMFF_VERBOSITY_LOW = 1,

--- a/Code/GraphMol/ForceFieldHelpers/MMFF/Builder.cpp
+++ b/Code/GraphMol/ForceFieldHelpers/MMFF/Builder.cpp
@@ -6,7 +6,6 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
-#include <iostream>
 #include <cmath>
 
 #include <RDGeneral/Invariant.h>

--- a/Code/GraphMol/ForceFieldHelpers/MMFF/testMMFFHelpers.cpp
+++ b/Code/GraphMol/ForceFieldHelpers/MMFF/testMMFFHelpers.cpp
@@ -8,7 +8,6 @@
 //
 
 #include <RDGeneral/test.h>
-#include <iostream>
 #include <RDGeneral/Invariant.h>
 #include <RDGeneral/RDLog.h>
 #include <RDGeneral/utils.h>

--- a/Code/GraphMol/ForceFieldHelpers/MMFF/testMultiThread.cpp
+++ b/Code/GraphMol/ForceFieldHelpers/MMFF/testMultiThread.cpp
@@ -9,7 +9,6 @@
 //
 
 #include <RDGeneral/test.h>
-#include <iostream>
 #include <RDGeneral/Invariant.h>
 #include <RDGeneral/RDLog.h>
 #include <RDGeneral/utils.h>

--- a/Code/GraphMol/ForceFieldHelpers/UFF/AtomTyper.cpp
+++ b/Code/GraphMol/ForceFieldHelpers/UFF/AtomTyper.cpp
@@ -7,7 +7,6 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
-#include <iostream>
 #include <GraphMol/RDKitBase.h>
 #include <ForceField/UFF/Params.h>
 #include <ForceField/UFF/Utils.h>

--- a/Code/GraphMol/ForceFieldHelpers/UFF/Builder.cpp
+++ b/Code/GraphMol/ForceFieldHelpers/UFF/Builder.cpp
@@ -6,7 +6,6 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
-#include <iostream>
 #include <cmath>
 
 #include <RDGeneral/Invariant.h>

--- a/Code/GraphMol/ForceFieldHelpers/UFF/testUFFHelpers.cpp
+++ b/Code/GraphMol/ForceFieldHelpers/UFF/testUFFHelpers.cpp
@@ -9,7 +9,6 @@
 //
 
 #include <RDGeneral/test.h>
-#include <iostream>
 #include <RDGeneral/Invariant.h>
 #include <RDGeneral/RDLog.h>
 #include <RDGeneral/utils.h>

--- a/Code/GraphMol/FragCatalog/FragCatalogEntry.cpp
+++ b/Code/GraphMol/FragCatalog/FragCatalogEntry.cpp
@@ -17,7 +17,6 @@
 #include <GraphMol/Subgraphs/SubgraphUtils.h>
 #include <GraphMol/Subgraphs/Subgraphs.h>
 #include <cstdlib>
-#include <iostream>
 #include <fstream>
 #include <cstdint>
 #include <RDGeneral/hash/hash.hpp>

--- a/Code/GraphMol/FragCatalog/FragCatalogUtils.h
+++ b/Code/GraphMol/FragCatalog/FragCatalogUtils.h
@@ -15,7 +15,6 @@
 #include <GraphMol/RDKitBase.h>
 #include <GraphMol/Substruct/SubstructMatch.h>
 #include "FragCatParams.h"
-#include <iostream>
 
 namespace RDKit {
 

--- a/Code/GraphMol/FragCatalog/test1.cpp
+++ b/Code/GraphMol/FragCatalog/test1.cpp
@@ -22,7 +22,6 @@
 #include "FragCatalogUtils.h"
 #include "FragFPGenerator.h"
 #include <cstdlib>
-#include <iostream>
 #include <fstream>
 
 #include <GraphMol/Subgraphs/SubgraphUtils.h>

--- a/Code/GraphMol/MMPA/MMPA_UnitTest.cpp
+++ b/Code/GraphMol/MMPA/MMPA_UnitTest.cpp
@@ -46,7 +46,6 @@
 #include <cstring>
 #include <ctime>
 #include <string>
-#include <iostream>
 #include <RDGeneral/RDLog.h>
 #include <RDGeneral/utils.h>
 #include <GraphMol/Chirality.h>

--- a/Code/GraphMol/MarvinParse/MarvinParser.cpp
+++ b/Code/GraphMol/MarvinParse/MarvinParser.cpp
@@ -12,7 +12,6 @@
 
 #include <string>
 #include <exception>
-#include <iostream>
 #include <fstream>
 #include <vector>
 #include <sstream>

--- a/Code/GraphMol/MarvinParse/MarvinParser.h
+++ b/Code/GraphMol/MarvinParse/MarvinParser.h
@@ -17,7 +17,6 @@
 #include <GraphMol/ChemReactions/Reaction.h>
 
 #include <string>
-#include <iostream>
 
 namespace RDKit {
 namespace v2 {

--- a/Code/GraphMol/MarvinParse/MarvinWriter.cpp
+++ b/Code/GraphMol/MarvinParse/MarvinWriter.cpp
@@ -12,7 +12,6 @@
 
 #include <string>
 #include <exception>
-#include <iostream>
 #include <fstream>
 #include <vector>
 #include <algorithm>

--- a/Code/GraphMol/MolCatalog/MolCatalogEntry.cpp
+++ b/Code/GraphMol/MolCatalog/MolCatalogEntry.cpp
@@ -14,7 +14,6 @@
 #include <RDGeneral/StreamOps.h>
 #include <GraphMol/RDKitBase.h>
 #include <GraphMol/MolPickler.h>
-#include <iostream>
 #include <sstream>
 #include <cstdint>
 

--- a/Code/GraphMol/MolCatalog/MolCatalogParams.h
+++ b/Code/GraphMol/MolCatalog/MolCatalogParams.h
@@ -7,7 +7,6 @@
 
 #include <Catalogs/CatalogParams.h>
 #include <string>
-#include <iostream>
 
 namespace RDKit {
 

--- a/Code/GraphMol/MolCatalog/test1.cpp
+++ b/Code/GraphMol/MolCatalog/test1.cpp
@@ -13,7 +13,6 @@
 #include "MolCatalogParams.h"
 
 #include <cstdlib>
-#include <iostream>
 #include <fstream>
 
 #include <GraphMol/FileParsers/MolSupplier.h>

--- a/Code/GraphMol/MolChemicalFeatures/FeatureParser.h
+++ b/Code/GraphMol/MolChemicalFeatures/FeatureParser.h
@@ -11,7 +11,6 @@
 #ifndef __FEATUREPARSER_H_02122004_1810__
 #define __FEATUREPARSER_H_02122004_1810__
 
-#include <iostream>
 #include <string>
 #include <map>
 #include <utility>

--- a/Code/GraphMol/MolChemicalFeatures/MolChemicalFeatureFactory.h
+++ b/Code/GraphMol/MolChemicalFeatures/MolChemicalFeatureFactory.h
@@ -12,7 +12,6 @@
 #define __CHEMICALFEATUREFACTORY_H_02122004_1545__
 
 #include "MolChemicalFeatureDef.h"
-#include <iostream>
 #include <boost/shared_ptr.hpp>
 
 namespace RDKit {

--- a/Code/GraphMol/MolChemicalFeatures/Wrap/rdMolChemicalFeatures.cpp
+++ b/Code/GraphMol/MolChemicalFeatures/Wrap/rdMolChemicalFeatures.cpp
@@ -13,7 +13,6 @@
 #include <GraphMol/MolChemicalFeatures/MolChemicalFeatureFactory.h>
 #include <fstream>
 #include <sstream>
-#include <iostream>
 #include <GraphMol/MolChemicalFeatures/FeatureParser.h>
 namespace python = boost::python;
 using namespace RDKit;

--- a/Code/GraphMol/MolChemicalFeatures/testFeatures.cpp
+++ b/Code/GraphMol/MolChemicalFeatures/testFeatures.cpp
@@ -10,7 +10,6 @@
 //
 #include <RDGeneral/test.h>
 #include <fstream>
-#include <iostream>
 #include <RDGeneral/Invariant.h>
 #include <RDGeneral/RDLog.h>
 #include <RDGeneral/utils.h>

--- a/Code/GraphMol/MolDraw2D/DrawMol.cpp
+++ b/Code/GraphMol/MolDraw2D/DrawMol.cpp
@@ -11,7 +11,6 @@
 //
 
 #include <algorithm>
-#include <iostream>
 #include <limits>
 
 #include <Geometry/Transform2D.h>
@@ -221,7 +220,7 @@ void DrawMol::extractAll(double scale) {
   if (drawOptions_.addStereoAnnotation) {
     extractCIPCodes(drawOptions_.showAllCIPCodes);
   }
-  extractStereoGroups(); // always show StereoGroups
+  extractStereoGroups();  // always show StereoGroups
   extractBondNotes();
   extractRadicals();
   extractSGroupData();
@@ -469,13 +468,14 @@ void DrawMol::extractCIPCodes(bool showAllCIPCodes) {
   boost::dynamic_bitset<> maskedAtoms(drawMol_->getNumAtoms());
   boost::dynamic_bitset<> maskedBonds(drawMol_->getNumBonds());
 
-  if(!showAllCIPCodes) { // record atoms and bonds whose codes should be hidden
+  if (!showAllCIPCodes) {  // record atoms and bonds whose codes should be
+                           // hidden
     for (const StereoGroup &group : drawMol_->getStereoGroups()) {
       StereoGroupType stereoGroupType;
 
       stereoGroupType = group.getGroupType();
-      if(stereoGroupType == RDKit::StereoGroupType::STEREO_OR || \
-         stereoGroupType == RDKit::StereoGroupType::STEREO_AND ) {
+      if (stereoGroupType == RDKit::StereoGroupType::STEREO_OR ||
+          stereoGroupType == RDKit::StereoGroupType::STEREO_AND) {
         for (const auto atom : group.getAtoms()) {
           maskedAtoms.set(atom->getIdx());
         }
@@ -490,8 +490,8 @@ void DrawMol::extractCIPCodes(bool showAllCIPCodes) {
     std::string cip;
     if (!maskedAtoms[atom->getIdx()] &&
         atom->getPropIfPresent(common_properties::_CIPCode, cip)) {
-        cip = "(" + cip + ")";
-        DrawAnnotation *annot = new DrawAnnotation(
+      cip = "(" + cip + ")";
+      DrawAnnotation *annot = new DrawAnnotation(
           cip, TextAlignType::MIDDLE, "CIP_Code",
           drawOptions_.annotationFontScale, Point2D(0.0, 0.0),
           drawOptions_.atomNoteColour, textDrawer_);
@@ -517,11 +517,11 @@ void DrawMol::extractCIPCodes(bool showAllCIPCodes) {
       if (!cip.empty()) {
         cip = "(" + cip + ")";
         DrawAnnotation *annot = new DrawAnnotation(
-          cip, TextAlignType::MIDDLE, "CIP_Code",
-          drawOptions_.annotationFontScale, Point2D(0.0, 0.0),
-          drawOptions_.bondNoteColour, textDrawer_);
-      calcAnnotationPosition(bond, *annot);
-      annotations_.emplace_back(annot);
+            cip, TextAlignType::MIDDLE, "CIP_Code",
+            drawOptions_.annotationFontScale, Point2D(0.0, 0.0),
+            drawOptions_.bondNoteColour, textDrawer_);
+        calcAnnotationPosition(bond, *annot);
+        annotations_.emplace_back(annot);
       }
     }
   }

--- a/Code/GraphMol/MolDraw2D/DrawTextFT.cpp
+++ b/Code/GraphMol/MolDraw2D/DrawTextFT.cpp
@@ -12,7 +12,6 @@
 //
 
 #include <cstdio>
-#include <iostream>
 
 #include <GraphMol/MolDraw2D/MolDraw2D.h>
 #include <GraphMol/MolDraw2D/DrawTextFT.h>

--- a/Code/GraphMol/MolDraw2D/MolDraw2DJS.h
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DJS.h
@@ -17,7 +17,6 @@
 #ifndef MOLDRAW2DJS_H
 #define MOLDRAW2DJS_H
 
-#include <iostream>
 #include <sstream>
 #include <emscripten.h>
 #include <emscripten/val.h>

--- a/Code/GraphMol/MolDraw2D/MolDraw2DSVG.h
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DSVG.h
@@ -16,7 +16,6 @@
 #ifndef MOLDRAW2DSVG_H
 #define MOLDRAW2DSVG_H
 
-#include <iostream>
 #include <sstream>
 #include <GraphMol/MolDraw2D/MolDraw2D.h>
 

--- a/Code/GraphMol/MolDraw2D/Qt/Demo/QT4SelectItems.cc
+++ b/Code/GraphMol/MolDraw2D/Qt/Demo/QT4SelectItems.cc
@@ -18,8 +18,6 @@
 
 #include "QT4SelectItems.H"
 
-#include <iostream>
-
 using namespace std;
 
 namespace DACLIB {

--- a/Code/GraphMol/MolDraw2D/Qt/Demo/RDKitSVMainWindow.cc
+++ b/Code/GraphMol/MolDraw2D/Qt/Demo/RDKitSVMainWindow.cc
@@ -34,7 +34,6 @@
 #include <boost/lexical_cast.hpp>
 
 #include <fstream>
-#include <iostream>
 #include <list>
 
 #include <GraphMol/FileParsers/MolSupplier.h>
@@ -147,7 +146,9 @@ void RDKitSVMainWindow::parse_args(int argc, char **argv) {
 
   vector<string> mol_files = s.mol_files();
   if (!mol_files.empty()) {
-    BOOST_FOREACH (string mf, mol_files) { read_mols(mf); }
+    BOOST_FOREACH (string mf, mol_files) {
+      read_mols(mf);
+    }
   }
 
   string smarts_file = s.smarts_file();
@@ -357,7 +358,9 @@ void RDKitSVMainWindow::write_mols(RDKitSVPanel &panel,
     return;
   }
 
-  BOOST_FOREACH (RDKit::ROMOL_SPTR mol, mols) { mw->write(*mol); }
+  BOOST_FOREACH (RDKit::ROMOL_SPTR mol, mols) {
+    mw->write(*mol);
+  }
 
   delete mw;
 }

--- a/Code/GraphMol/MolDraw2D/Qt/Demo/RDKitSVSettings.cc
+++ b/Code/GraphMol/MolDraw2D/Qt/Demo/RDKitSVSettings.cc
@@ -12,8 +12,6 @@
 #include <boost/program_options/parsers.hpp>
 #include <boost/program_options/variables_map.hpp>
 
-#include <iostream>
-
 using namespace std;
 namespace po = boost::program_options;
 

--- a/Code/GraphMol/MolDraw2D/Qt/Demo/rdkitsv_main.cc
+++ b/Code/GraphMol/MolDraw2D/Qt/Demo/rdkitsv_main.cc
@@ -12,8 +12,6 @@
 
 #include <RDGeneral/versions.h>
 
-#include <iostream>
-
 #include <QApplication>
 
 using namespace std;

--- a/Code/GraphMol/MolDraw2D/rxn_test1.cpp
+++ b/Code/GraphMol/MolDraw2D/rxn_test1.cpp
@@ -28,7 +28,6 @@
 #include <GraphMol/MolDraw2D/MolDraw2DSVG.h>
 #include <GraphMol/MolDraw2D/MolDraw2DUtils.h>
 
-#include <iostream>
 #include <fstream>
 #include <sstream>
 #include <iterator>
@@ -59,12 +58,12 @@ static const std::map<std::string, std::hash_result_t> SVG_HASHES = {
 };
 #else
 static const std::map<std::string, std::hash_result_t> SVG_HASHES = {
-    {"rxn_test1_1.svg", 1119603847U},    {"rxn_test1_2.svg", 1280072916U},
+    {"rxn_test1_1.svg", 1119603847U},   {"rxn_test1_2.svg", 1280072916U},
     {"rxn_test1_3.svg", 2600700359U},   {"rxn_test1_4.svg", 3286429351U},
     {"rxn_test1_5.svg", 2222269077U},   {"rxn_test1_6.svg", 3393541140U},
-    {"rxn_test1_7.svg", 2511680934U},    {"rxn_test2_1.svg", 408938601U},
+    {"rxn_test1_7.svg", 2511680934U},   {"rxn_test2_1.svg", 408938601U},
     {"rxn_test2_2_1.svg", 2721276293U}, {"rxn_test2_2_2.svg", 2972357489U},
-    {"rxn_test2_2_3.svg", 223414416U}, {"rxn_test2_2_4.svg", 1685655058U},
+    {"rxn_test2_2_3.svg", 223414416U},  {"rxn_test2_2_4.svg", 1685655058U},
     {"rxn_test3_1.svg", 3042468072U},   {"rxn_test4_1.svg", 3101203372U},
     {"rxn_test4_2.svg", 2942016749U},
 };
@@ -81,12 +80,12 @@ static const std::map<std::string, std::hash_result_t> SVG_HASHES = {
 // better because the floats are all output to only 1 decimal place so there
 // is a much smaller chance of different systems producing different files.
 static const std::map<std::string, std::hash_result_t> PNG_HASHES = {
-    {"rxn_test1_1.png", 801892091U},   {"rxn_test1_2.png", 507435337U},
+    {"rxn_test1_1.png", 801892091U},    {"rxn_test1_2.png", 507435337U},
     {"rxn_test1_3.png", 1590809137U},   {"rxn_test1_4.png", 1766700542U},
     {"rxn_test1_5.png", 2552100594U},   {"rxn_test1_6.png", 3791582903U},
-    {"rxn_test1_7.png", 1461397406U},    {"rxn_test2_1.png", 3551633840U},
+    {"rxn_test1_7.png", 1461397406U},   {"rxn_test2_1.png", 3551633840U},
     {"rxn_test2_2_1.png", 1268122583U}, {"rxn_test2_2_2.png", 82821108U},
-    {"rxn_test2_2_3.png", 3828365604U},  {"rxn_test2_2_4.png", 1230108677U},
+    {"rxn_test2_2_3.png", 3828365604U}, {"rxn_test2_2_4.png", 1230108677U},
     {"rxn_test3_1.png", 4189980366U},   {"rxn_test4_1.png", 2745201873U},
     {"rxn_test4_2.png", 3094925886U},
 };

--- a/Code/GraphMol/MolDraw2D/test1.cpp
+++ b/Code/GraphMol/MolDraw2D/test1.cpp
@@ -30,7 +30,6 @@
 #include <algorithm>
 #include <cstdio>
 #include <iosfwd>
-#include <iostream>
 #include <iterator>
 #include <map>
 #include <fstream>

--- a/Code/GraphMol/MolHash/catch_tests.cpp
+++ b/Code/GraphMol/MolHash/catch_tests.cpp
@@ -15,7 +15,6 @@
 #include <GraphMol/SmilesParse/SmilesWrite.h>
 #include "MolHash.h"
 
-#include <iostream>
 #include <fstream>
 
 using namespace RDKit;

--- a/Code/GraphMol/MolInteractionFields/MIFDescriptors.cpp
+++ b/Code/GraphMol/MolInteractionFields/MIFDescriptors.cpp
@@ -21,7 +21,6 @@
 #include <ForceField/UFF/Nonbonded.h>
 #include <ForceField/UFF/Params.h>
 #include <vector>
-#include <iostream>
 #include <fstream>
 
 #ifndef M_PI

--- a/Code/GraphMol/MolInteractionFields/testMIF.cpp
+++ b/Code/GraphMol/MolInteractionFields/testMIF.cpp
@@ -24,7 +24,6 @@
 #include <GraphMol/PartialCharges/GasteigerParams.h>
 #include <vector>
 #include <algorithm>
-#include <iostream>
 #include <fstream>
 
 using namespace RDGeom;

--- a/Code/GraphMol/MolInterchange/MolInterchange.h
+++ b/Code/GraphMol/MolInterchange/MolInterchange.h
@@ -24,7 +24,6 @@ https://github.com/mcs07/CommonChem
 */
 
 #include <string>
-#include <iostream>
 #include <vector>
 
 #include <boost/shared_ptr.hpp>

--- a/Code/GraphMol/MolPickler.cpp
+++ b/Code/GraphMol/MolPickler.cpp
@@ -21,7 +21,6 @@
 #include <DataStructs/DatastructsStreamOps.h>
 #include <Query/QueryObjects.h>
 #include <map>
-#include <iostream>
 #include <cstdint>
 #include <boost/algorithm/string.hpp>
 

--- a/Code/GraphMol/MolPickler.h
+++ b/Code/GraphMol/MolPickler.h
@@ -22,7 +22,6 @@
 #include <Query/QueryObjects.h>
 
 // Std stuff
-#include <iostream>
 #include <string>
 #include <sstream>
 #include <exception>

--- a/Code/GraphMol/MolStandardize/AcidBaseCatalog/AcidBaseCatalogEntry.cpp
+++ b/Code/GraphMol/MolStandardize/AcidBaseCatalog/AcidBaseCatalogEntry.cpp
@@ -13,7 +13,6 @@
 #include <RDGeneral/utils.h>
 #include <GraphMol/RDKitBase.h>
 #include <RDGeneral/StreamOps.h>
-#include <iostream>
 #include <fstream>
 
 namespace RDKit {

--- a/Code/GraphMol/MolStandardize/AcidBaseCatalog/AcidBaseCatalogParams.h
+++ b/Code/GraphMol/MolStandardize/AcidBaseCatalog/AcidBaseCatalogParams.h
@@ -16,7 +16,6 @@
 #include <GraphMol/RDKitBase.h>
 #include <string>
 #include <vector>
-#include <iostream>
 
 namespace RDKit {
 class ROMol;

--- a/Code/GraphMol/MolStandardize/AcidBaseCatalog/AcidBaseCatalogUtils.h
+++ b/Code/GraphMol/MolStandardize/AcidBaseCatalog/AcidBaseCatalogUtils.h
@@ -15,7 +15,6 @@
 #include "AcidBaseCatalogParams.h"
 #include <GraphMol/Substruct/SubstructMatch.h>
 #include <GraphMol/ChemReactions/Reaction.h>
-#include <iostream>
 
 namespace RDKit {
 class ROMol;

--- a/Code/GraphMol/MolStandardize/FragmentCatalog/FragmentCatalogEntry.cpp
+++ b/Code/GraphMol/MolStandardize/FragmentCatalog/FragmentCatalogEntry.cpp
@@ -14,7 +14,6 @@
 #include <GraphMol/RDKitBase.h>
 #include <RDGeneral/StreamOps.h>
 #include <GraphMol/MolPickler.h>
-#include <iostream>
 #include <fstream>
 
 namespace RDKit {

--- a/Code/GraphMol/MolStandardize/FragmentCatalog/FragmentCatalogParams.h
+++ b/Code/GraphMol/MolStandardize/FragmentCatalog/FragmentCatalogParams.h
@@ -16,7 +16,6 @@
 #include <GraphMol/RDKitBase.h>
 #include <string>
 #include <vector>
-#include <iostream>
 
 namespace RDKit {
 class ROMol;

--- a/Code/GraphMol/MolStandardize/FragmentCatalog/FragmentCatalogUtils.h
+++ b/Code/GraphMol/MolStandardize/FragmentCatalog/FragmentCatalogUtils.h
@@ -14,7 +14,6 @@
 #include <GraphMol/RDKitBase.h>
 #include "FragmentCatalogParams.h"
 #include <GraphMol/Substruct/SubstructMatch.h>
-#include <iostream>
 
 namespace RDKit {
 class ROMol;

--- a/Code/GraphMol/MolStandardize/MolStandardize.cpp
+++ b/Code/GraphMol/MolStandardize/MolStandardize.cpp
@@ -13,7 +13,6 @@
 #include "Tautomer.h"
 #include "Fragment.h"
 #include <GraphMol/RDKitBase.h>
-#include <iostream>
 #include <GraphMol/ROMol.h>
 #include <GraphMol/MolOps.h>
 #include <GraphMol/MolStandardize/TransformCatalog/TransformCatalogParams.h>

--- a/Code/GraphMol/MolStandardize/TautomerCatalog/TautomerCatalogEntry.cpp
+++ b/Code/GraphMol/MolStandardize/TautomerCatalog/TautomerCatalogEntry.cpp
@@ -13,7 +13,6 @@
 #include <RDGeneral/utils.h>
 #include <GraphMol/RDKitBase.h>
 #include <RDGeneral/StreamOps.h>
-#include <iostream>
 #include <fstream>
 
 namespace RDKit {

--- a/Code/GraphMol/MolStandardize/TautomerCatalog/TautomerCatalogParams.h
+++ b/Code/GraphMol/MolStandardize/TautomerCatalog/TautomerCatalogParams.h
@@ -15,7 +15,6 @@
 #include <GraphMol/RDKitBase.h>
 #include <string>
 #include <vector>
-#include <iostream>
 
 namespace RDKit {
 class ROMol;

--- a/Code/GraphMol/MolStandardize/TautomerCatalog/TautomerCatalogUtils.h
+++ b/Code/GraphMol/MolStandardize/TautomerCatalog/TautomerCatalogUtils.h
@@ -16,7 +16,6 @@
 #include <GraphMol/Substruct/SubstructMatch.h>
 #include <GraphMol/ChemReactions/Reaction.h>
 #include <GraphMol/Bond.h>
-#include <iostream>
 #include <utility>
 
 namespace RDKit {

--- a/Code/GraphMol/MolStandardize/TransformCatalog/TransformCatalogEntry.cpp
+++ b/Code/GraphMol/MolStandardize/TransformCatalog/TransformCatalogEntry.cpp
@@ -14,7 +14,6 @@
 #include <GraphMol/RDKitBase.h>
 #include <RDGeneral/StreamOps.h>
 #include <GraphMol/ChemReactions/ReactionPickler.h>
-#include <iostream>
 #include <fstream>
 
 namespace RDKit {

--- a/Code/GraphMol/MolStandardize/TransformCatalog/TransformCatalogParams.h
+++ b/Code/GraphMol/MolStandardize/TransformCatalog/TransformCatalogParams.h
@@ -17,7 +17,6 @@
 #include <GraphMol/ChemReactions/Reaction.h>
 #include <string>
 #include <vector>
-#include <iostream>
 
 namespace RDKit {
 class ROMol;

--- a/Code/GraphMol/MolStandardize/TransformCatalog/TransformCatalogUtils.h
+++ b/Code/GraphMol/MolStandardize/TransformCatalog/TransformCatalogUtils.h
@@ -15,7 +15,6 @@
 #include "TransformCatalogParams.h"
 #include <GraphMol/Substruct/SubstructMatch.h>
 #include <GraphMol/ChemReactions/Reaction.h>
-#include <iostream>
 
 namespace RDKit {
 class ROMol;

--- a/Code/GraphMol/MolStandardize/Validate.cpp
+++ b/Code/GraphMol/MolStandardize/Validate.cpp
@@ -17,7 +17,6 @@
 #include <GraphMol/PeriodicTable.h>
 #include <algorithm>
 #include <cmath>
-#include <iostream>
 #include <string>
 #include <utility>
 #include <vector>

--- a/Code/GraphMol/MolStandardize/Validate.h
+++ b/Code/GraphMol/MolStandardize/Validate.h
@@ -21,7 +21,6 @@
 #include <GraphMol/RDKitBase.h>
 #include <GraphMol/ROMol.h>
 #include <GraphMol/Atom.h>
-#include <iostream>
 #include <exception>
 #include <string>
 #include <utility>

--- a/Code/GraphMol/MolStandardize/catch_tests.cpp
+++ b/Code/GraphMol/MolStandardize/catch_tests.cpp
@@ -21,7 +21,6 @@
 #include <GraphMol/MolStandardize/Tautomer.h>
 #include <GraphMol/MolStandardize/Validate.h>
 
-#include <iostream>
 #include <fstream>
 
 using namespace RDKit;

--- a/Code/GraphMol/MolStandardize/test1.cpp
+++ b/Code/GraphMol/MolStandardize/test1.cpp
@@ -20,8 +20,6 @@
 #include <GraphMol/SmilesParse/SmilesWrite.h>
 #include <GraphMol/ROMol.h>
 
-#include <iostream>
-
 using namespace RDKit;
 
 void testCleanup() {

--- a/Code/GraphMol/MolStandardize/test2.cpp
+++ b/Code/GraphMol/MolStandardize/test2.cpp
@@ -20,8 +20,6 @@
 #include <GraphMol/SmilesParse/SmilesWrite.h>
 #include <GraphMol/ROMol.h>
 
-#include <iostream>
-
 using namespace RDKit;
 using namespace MolStandardize;
 

--- a/Code/GraphMol/MolStandardize/testFragment.cpp
+++ b/Code/GraphMol/MolStandardize/testFragment.cpp
@@ -21,7 +21,6 @@
 #include <GraphMol/FileParsers/MolSupplier.h>
 #include <GraphMol/MolStandardize/MolStandardize.h>
 
-#include <iostream>
 #include <fstream>
 
 using namespace RDKit;

--- a/Code/GraphMol/MolStandardize/testNormalize.cpp
+++ b/Code/GraphMol/MolStandardize/testNormalize.cpp
@@ -20,7 +20,6 @@
 #include <GraphMol/FileParsers/MolSupplier.h>
 #include <GraphMol/MolStandardize/MolStandardize.h>
 
-#include <iostream>
 #include <fstream>
 #include <memory>
 

--- a/Code/GraphMol/MolStandardize/testPCS.cpp
+++ b/Code/GraphMol/MolStandardize/testPCS.cpp
@@ -10,7 +10,6 @@
 #include <string>
 #include <GraphMol/RDKitBase.h>
 #include <fstream>
-#include <iostream>
 #include <RDGeneral/BadFileException.h>
 #include <boost/iostreams/filtering_streambuf.hpp>
 #include <boost/iostreams/copy.hpp>

--- a/Code/GraphMol/MolStandardize/testValidate.cpp
+++ b/Code/GraphMol/MolStandardize/testValidate.cpp
@@ -16,8 +16,6 @@
 #include <GraphMol/FileParsers/FileParsers.h>
 #include <GraphMol/Chirality.h>
 
-#include <iostream>
-
 using namespace RDKit;
 using namespace std;
 using namespace MolStandardize;

--- a/Code/GraphMol/MolTransforms/test1.cpp
+++ b/Code/GraphMol/MolTransforms/test1.cpp
@@ -18,7 +18,6 @@
 #include <GraphMol/FileParsers/MolWriters.h>
 #include <Geometry/point.h>
 #include <GraphMol/MolTransforms/MolTransforms.h>
-#include <iostream>
 #include <algorithm>
 
 using namespace RDKit;

--- a/Code/GraphMol/MonomerInfo.cpp
+++ b/Code/GraphMol/MonomerInfo.cpp
@@ -7,7 +7,6 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
-#include <iostream>
 #include "MonomerInfo.h"
 
 using namespace RDKit;

--- a/Code/GraphMol/MonomerInfo.cpp
+++ b/Code/GraphMol/MonomerInfo.cpp
@@ -7,6 +7,7 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
+#include <ostream>
 #include "MonomerInfo.h"
 
 using namespace RDKit;

--- a/Code/GraphMol/PartialCharges/test1.cpp
+++ b/Code/GraphMol/PartialCharges/test1.cpp
@@ -11,7 +11,6 @@
 
 // std bits
 #include <RDGeneral/test.h>
-#include <iostream>
 
 // RD bits
 #include <GraphMol/RDKitBase.h>

--- a/Code/GraphMol/RGroupDecomposition/GaExample.cpp
+++ b/Code/GraphMol/RGroupDecomposition/GaExample.cpp
@@ -9,7 +9,6 @@
 //
 
 #include <RDGeneral/RDLog.h>
-#include <iostream>
 #include <fstream>
 #include <string>
 #include <vector>

--- a/Code/GraphMol/RGroupDecomposition/testRGroupDecomp.cpp
+++ b/Code/GraphMol/RGroupDecomposition/testRGroupDecomp.cpp
@@ -33,7 +33,6 @@
 #include <RDGeneral/utils.h>
 #include <GraphMol/RDKitBase.h>
 #include <string>
-#include <iostream>
 #include <GraphMol/SmilesParse/SmilesParse.h>
 #include <GraphMol/SmilesParse/SmilesWrite.h>
 #include <GraphMol/ChemTransforms/ChemTransforms.h>

--- a/Code/GraphMol/ROMol.cpp
+++ b/Code/GraphMol/ROMol.cpp
@@ -8,8 +8,6 @@
 //  of the RDKit source tree.
 //
 
-#include <iostream>
-
 // our stuff
 #include <RDGeneral/Invariant.h>
 #include <RDGeneral/RDLog.h>

--- a/Code/GraphMol/RascalMCES/PartitionSet.cpp
+++ b/Code/GraphMol/RascalMCES/PartitionSet.cpp
@@ -9,7 +9,6 @@
 //
 
 #include <algorithm>
-#include <iostream>
 #include <limits>
 #include <map>
 #include <memory>

--- a/Code/GraphMol/RascalMCES/RascalMCES.cpp
+++ b/Code/GraphMol/RascalMCES/RascalMCES.cpp
@@ -17,7 +17,6 @@
 
 #include <chrono>
 #include <functional>
-#include <iostream>
 #include <map>
 #include <regex>
 #include <stdexcept>

--- a/Code/GraphMol/RascalMCES/lap_a_la_scipy.cpp
+++ b/Code/GraphMol/RascalMCES/lap_a_la_scipy.cpp
@@ -49,7 +49,6 @@ Author: PM Larsen
 */
 
 #include <algorithm>
-#include <iostream>
 #include <limits>
 #include <numeric>
 #include <vector>

--- a/Code/GraphMol/SLNParse/sln.tab.cpp.cmake
+++ b/Code/GraphMol/SLNParse/sln.tab.cpp.cmake
@@ -105,7 +105,6 @@
 
 #include <cstring>
 #include <cstdio>
-#include <iostream>
 #include <vector>
 #include <boost/algorithm/string.hpp>
 

--- a/Code/GraphMol/SLNParse/sln.yy
+++ b/Code/GraphMol/SLNParse/sln.yy
@@ -37,7 +37,6 @@
 
 #include <cstring>
 #include <cstdio>
-#include <iostream>
 #include <vector>
 #include <boost/algorithm/string.hpp>
 

--- a/Code/GraphMol/SLNParse/test.cpp
+++ b/Code/GraphMol/SLNParse/test.cpp
@@ -33,7 +33,6 @@
 //  Created by Greg Landrum September, 2006
 //
 #include <RDGeneral/test.h>
-#include <iostream>
 #include <GraphMol/RDKitBase.h>
 #include <GraphMol/SLNParse/SLNParse.h>
 #include <GraphMol/SmilesParse/SmilesParse.h>
@@ -1264,7 +1263,6 @@ void test10() {
   BOOST_LOG(rdInfoLog) << "\tdone" << std::endl;
 }
 
-
 void test12() {
   RDKit::RWMol *patt, *mol;
   std::vector<RDKit::MatchVectType> mV;
@@ -1883,9 +1881,9 @@ int main(int argc, char *argv[]) {
   (void)argv;
   RDLog::InitLogs();
 
-// FIX: need a test for handling Hs in the SLN itself. This should be done for
-// both normal and query SLNs and must be done after the SLN parser handles
-// that case (errr, duh)
+  // FIX: need a test for handling Hs in the SLN itself. This should be done for
+  // both normal and query SLNs and must be done after the SLN parser handles
+  // that case (errr, duh)
   test1();
   test2();
   test3();

--- a/Code/GraphMol/ScaffoldNetwork/ScaffoldNetwork.h
+++ b/Code/GraphMol/ScaffoldNetwork/ScaffoldNetwork.h
@@ -16,7 +16,6 @@
 #include <string>
 #include <sstream>
 #include <memory>
-#include <iostream>
 
 #ifdef RDK_USE_BOOST_SERIALIZATION
 #include <RDGeneral/Invariant.h>

--- a/Code/GraphMol/SmilesParse/CXSmilesOps.cpp
+++ b/Code/GraphMol/SmilesParse/CXSmilesOps.cpp
@@ -18,7 +18,6 @@
 #include <GraphMol/Atropisomers.h>
 #include <GraphMol/Chirality.h>
 
-#include <iostream>
 #include <algorithm>
 #include "SmilesWrite.h"
 #include "SmilesParse.h"

--- a/Code/GraphMol/SmilesParse/cxsmiles_test.cpp
+++ b/Code/GraphMol/SmilesParse/cxsmiles_test.cpp
@@ -24,7 +24,6 @@
 #include "SmartsWrite.h"
 #include <RDGeneral/RDLog.h>
 #include <fstream>
-#include <iostream>
 
 constexpr bool GenerateExpectedFiles = false;
 

--- a/Code/GraphMol/SmilesParse/nontetrahedral_tests.cpp
+++ b/Code/GraphMol/SmilesParse/nontetrahedral_tests.cpp
@@ -10,7 +10,6 @@
 
 #include <catch2/catch_all.hpp>
 
-#include <iostream>
 #include <fstream>
 
 #include <GraphMol/RDKitBase.h>

--- a/Code/GraphMol/SmilesParse/smarts.tab.cpp.cmake
+++ b/Code/GraphMol/SmilesParse/smarts.tab.cpp.cmake
@@ -80,7 +80,6 @@
   //   @@ All Rights Reserved  @@
   //
 #include <cstring>
-#include <iostream>
 #include <string>
 #include <string_view>
 #include <utility>

--- a/Code/GraphMol/SmilesParse/smarts.yy
+++ b/Code/GraphMol/SmilesParse/smarts.yy
@@ -6,7 +6,6 @@
   //   @@ All Rights Reserved  @@
   //
 #include <cstring>
-#include <iostream>
 #include <string>
 #include <string_view>
 #include <utility>

--- a/Code/GraphMol/SmilesParse/smatest.cpp
+++ b/Code/GraphMol/SmilesParse/smatest.cpp
@@ -8,7 +8,6 @@
 //  of the RDKit source tree.
 //
 #include <RDGeneral/test.h>
-#include <iostream>
 
 #include <fstream>
 #include "SmilesParse.h"
@@ -59,8 +58,7 @@ void testPass() {
       "[D{1-3}]",  // cactvs range queries
       "[D{-3}]", "[D{1-}]", "[z{1-3}]", "[Z{1-3}]",
       "[2H,13C]",  // github #1719
-      "[+{0-3}]",
-      "[-{0-3}]", "[-{0-3},C]",
+      "[+{0-3}]", "[-{0-3}]", "[-{0-3},C]",
       "[-{0-3},D{1-3}]",       // github #2709
       "C%(1000)CCC%(1000)",    // github #2909
       "C%(1000)CC(C%(1000))",  // github #2909
@@ -474,7 +472,7 @@ void testProblems() {
   // nested recursion (yick!)
   _checkNoMatches("[O]-[!$(*=O)]", "CC(=O)O");
 
-// BOOST_LOG(rdInfoLog) << "-*-*-*-*-*-*-*-*-" << std::endl;
+  // BOOST_LOG(rdInfoLog) << "-*-*-*-*-*-*-*-*-" << std::endl;
   _checkNoMatches("[$([O]-[!$(*=O)])]", "CC(=O)O");
 
   // ISSUE 78
@@ -1167,13 +1165,14 @@ void testSmartsStereochem() {
   _checkMatches("C/C=C/C", "C/C=C/C", 1, 4);
   _checkMatches("C/C=C/C", "C\\C=C\\C", 1, 4);
   _checkMatches("C/C=C/C", "C/C=C\\C", 1, 4);
-  
+
   // directional bonds are set to be a direction \ /
   //  and a query - SingleOrAromatic, make sure that this
   //  is their current representation
   auto m1 = "C/C=C\\C"_smarts;
   TEST_ASSERT(m1->getBondWithIdx(0)->hasQuery());
-  TEST_ASSERT(m1->getBondWithIdx(0)->getQuery()->getDescription() == "SingleOrAromaticBond");
+  TEST_ASSERT(m1->getBondWithIdx(0)->getQuery()->getDescription() ==
+              "SingleOrAromaticBond");
 
   auto m2 = "O=c1/c(=C/c2ccccc2)sc2n1-N-C-N-N=2"_smarts;
   TEST_ASSERT(MolToSmarts(*m2) == "O=c1/c(=C/c2ccccc2)sc2n1-N-C-N-N=2");

--- a/Code/GraphMol/SmilesParse/smiles.tab.cpp.cmake
+++ b/Code/GraphMol/SmilesParse/smiles.tab.cpp.cmake
@@ -82,7 +82,6 @@
   //
 
 #include <cstring>
-#include <iostream>
 #include <limits>
 #include <string>
 #include <string_view>

--- a/Code/GraphMol/SmilesParse/smiles.yy
+++ b/Code/GraphMol/SmilesParse/smiles.yy
@@ -8,7 +8,6 @@
   //
 
 #include <cstring>
-#include <iostream>
 #include <limits>
 #include <string>
 #include <string_view>

--- a/Code/GraphMol/SmilesParse/test.cpp
+++ b/Code/GraphMol/SmilesParse/test.cpp
@@ -8,7 +8,6 @@
 //  of the RDKit source tree.
 //
 #include <RDGeneral/test.h>
-#include <iostream>
 #include <string>
 #include <GraphMol/RDKitBase.h>
 #include "SmilesParse.h"
@@ -129,7 +128,7 @@ void testFail() {
       "[Fe@AL3]",    "C",  //
       "[Fe@TB21]",   "C",  //
       "[Fe@OH31]",   "C",  //
-      "baz",   "C",  //
+      "baz",         "C",  //
       "EOS"};
 
   // turn off the error log temporarily:
@@ -4360,34 +4359,37 @@ void testParserErrorMessage() {
       "c%(100000)ccccc%(100000)",
       "COc(c1)cccc1C#",
       "C)",
-    };
-  for (const auto& smi : smis) {
-      // Test SMILES parsing
-      {
-        std::stringstream ss;
-        rdErrorLog->SetTee(ss);
+  };
+  for (const auto &smi : smis) {
+    // Test SMILES parsing
+    {
+      std::stringstream ss;
+      rdErrorLog->SetTee(ss);
 
-        auto mol = v2::SmilesParse::MolFromSmiles(smi);
-        CHECK_INVARIANT(!mol, smi);
+      auto mol = v2::SmilesParse::MolFromSmiles(smi);
+      CHECK_INVARIANT(!mol, smi);
 
-        rdErrorLog->ClearTee();
-        auto error_msg = ss.str();
-        CHECK_INVARIANT(error_msg.find("check for mistakes around position") != std::string::npos, smi)
-      }
+      rdErrorLog->ClearTee();
+      auto error_msg = ss.str();
+      CHECK_INVARIANT(error_msg.find("check for mistakes around position") !=
+                          std::string::npos,
+                      smi)
+    }
 
-      // Test SMARTS parsing
-      {
-        std::stringstream ss;
-        rdErrorLog->SetTee(ss);
+    // Test SMARTS parsing
+    {
+      std::stringstream ss;
+      rdErrorLog->SetTee(ss);
 
-        auto mol = v2::SmilesParse::MolFromSmarts(smi);
-        CHECK_INVARIANT(!mol, smi);
+      auto mol = v2::SmilesParse::MolFromSmarts(smi);
+      CHECK_INVARIANT(!mol, smi);
 
-        rdErrorLog->ClearTee();
-        auto error_msg = ss.str();
-        CHECK_INVARIANT(error_msg.find("check for mistakes around position") != std::string::npos, smi)
-      }
-
+      rdErrorLog->ClearTee();
+      auto error_msg = ss.str();
+      CHECK_INVARIANT(error_msg.find("check for mistakes around position") !=
+                          std::string::npos,
+                      smi)
+    }
   }
 }
 

--- a/Code/GraphMol/SmilesParse/test2.cpp
+++ b/Code/GraphMol/SmilesParse/test2.cpp
@@ -8,7 +8,6 @@
 //  of the RDKit source tree.
 //
 #include <RDGeneral/test.h>
-#include <iostream>
 #include <string>
 #include <GraphMol/RDKitBase.h>
 #include "SmilesParse.h"

--- a/Code/GraphMol/StereoGroup.h
+++ b/Code/GraphMol/StereoGroup.h
@@ -18,7 +18,6 @@
 #ifndef RD_StereoGroup_092018
 #define RD_StereoGroup_092018
 
-#include <iostream>
 #include <vector>
 
 namespace RDKit {

--- a/Code/GraphMol/StructChecker/StructCheckerOptions.cpp
+++ b/Code/GraphMol/StructChecker/StructCheckerOptions.cpp
@@ -10,7 +10,6 @@
 #include <cctype>
 #include <memory.h>
 #include <cerrno>
-#include <iostream>
 #include <sstream>
 #include <fstream>
 #include <boost/property_tree/json_parser.hpp>

--- a/Code/GraphMol/Subgraphs/SubgraphUtils.cpp
+++ b/Code/GraphMol/Subgraphs/SubgraphUtils.cpp
@@ -14,7 +14,6 @@
 #include <GraphMol/RDKitBase.h>
 #include <GraphMol/QueryAtom.h>
 #include <GraphMol/QueryBond.h>
-#include <iostream>
 #include <algorithm>
 #include <map>
 #include <RDGeneral/hash/hash.hpp>

--- a/Code/GraphMol/Subgraphs/Subgraphs.cpp
+++ b/Code/GraphMol/Subgraphs/Subgraphs.cpp
@@ -14,7 +14,6 @@
 #include <RDGeneral/utils.h>
 #include <RDGeneral/Exceptions.h>
 
-#include <iostream>
 #include <cstring>
 #include <algorithm>
 #include <boost/dynamic_bitset.hpp>

--- a/Code/GraphMol/Subgraphs/catch_tests.cpp
+++ b/Code/GraphMol/Subgraphs/catch_tests.cpp
@@ -14,7 +14,6 @@
 #include <GraphMol/Subgraphs/Subgraphs.h>
 #include <GraphMol/Subgraphs/SubgraphUtils.h>
 
-#include <iostream>
 #include <algorithm>
 
 using namespace RDKit;

--- a/Code/GraphMol/Subgraphs/test1.cpp
+++ b/Code/GraphMol/Subgraphs/test1.cpp
@@ -13,7 +13,6 @@
 #include <GraphMol/Subgraphs/Subgraphs.h>
 #include <GraphMol/SmilesParse/SmilesParse.h>
 
-#include <iostream>
 using namespace std;
 using namespace RDKit;
 

--- a/Code/GraphMol/Subgraphs/test2.cpp
+++ b/Code/GraphMol/Subgraphs/test2.cpp
@@ -15,7 +15,6 @@
 #include <GraphMol/Subgraphs/Subgraphs.h>
 #include <GraphMol/Subgraphs/SubgraphUtils.h>
 
-#include <iostream>
 #include <algorithm>
 
 using namespace std;

--- a/Code/GraphMol/SubstanceGroup.h
+++ b/Code/GraphMol/SubstanceGroup.h
@@ -17,7 +17,6 @@
 #ifndef _RD_SGROUP_H
 #define _RD_SGROUP_H
 
-#include <iostream>
 #include <utility>
 #include <unordered_map>
 

--- a/Code/GraphMol/Substruct/bench.cpp
+++ b/Code/GraphMol/Substruct/bench.cpp
@@ -12,9 +12,6 @@
 #pragma warning(disable : 4788)  // warning: long & complicated stl warning
 #endif
 
-// std bits
-#include <iostream>
-
 // RD bits
 #include <GraphMol/RDKitBase.h>
 #include <GraphMol/RDKitQueries.h>

--- a/Code/GraphMol/Substruct/cmd_match.cpp
+++ b/Code/GraphMol/Substruct/cmd_match.cpp
@@ -8,9 +8,6 @@
 //  of the RDKit source tree.
 //
 
-// std bits
-#include <iostream>
-
 // RD bits
 #include <GraphMol/GraphMol.h>
 #include <GraphMol/Atom.h>

--- a/Code/GraphMol/Substruct/test1.cpp
+++ b/Code/GraphMol/Substruct/test1.cpp
@@ -11,7 +11,6 @@
 
 // std bits
 #include <RDGeneral/test.h>
-#include <iostream>
 
 // RD bits
 #include <GraphMol/RDKitBase.h>

--- a/Code/GraphMol/SubstructLibrary/substructLibraryTest.cpp
+++ b/Code/GraphMol/SubstructLibrary/substructLibraryTest.cpp
@@ -31,7 +31,6 @@
 
 // std bits
 #include <RDGeneral/test.h>
-#include <iostream>
 
 // RD bits
 #include <GraphMol/RDKitBase.h>

--- a/Code/GraphMol/SynthonSpaceSearch/MemoryMappedFileReader.cpp
+++ b/Code/GraphMol/SynthonSpaceSearch/MemoryMappedFileReader.cpp
@@ -11,7 +11,6 @@
 #include <GraphMol/SynthonSpaceSearch/MemoryMappedFileReader.h>
 #include <GraphMol/SynthonSpaceSearch/SynthonSpaceSearch_details.h>
 
-#include <iostream>
 #include <string>
 
 #include <RDGeneral/RDLog.h>
@@ -89,7 +88,7 @@ MemoryMappedFileReader::MemoryMappedFileReader(const std::string &filePath) {
     throw(std::runtime_error("Error reading file " + filePath + "."));
   }
 
-  close(fd); // File descriptor is no longer needed
+  close(fd);  // File descriptor is no longer needed
 #endif
 }
 
@@ -111,7 +110,7 @@ MemoryMappedFileReader::~MemoryMappedFileReader() {
 }
 
 MemoryMappedFileReader &MemoryMappedFileReader::operator=(
-  MemoryMappedFileReader &&other) {
+    MemoryMappedFileReader &&other) {
   if (this != &other) {
 #ifdef _WIN32
     // Windows-specific unmapping
@@ -127,4 +126,4 @@ MemoryMappedFileReader &MemoryMappedFileReader::operator=(
   }
   return *this;
 }
-}; // namespace RDKit::SynthonSpaceSearch::details
+};  // namespace RDKit::SynthonSpaceSearch::details

--- a/Code/GraphMol/SynthonSpaceSearch/SynthonSpace.cpp
+++ b/Code/GraphMol/SynthonSpaceSearch/SynthonSpace.cpp
@@ -10,7 +10,6 @@
 
 #include <algorithm>
 #include <fstream>
-#include <iostream>
 #include <random>
 #include <regex>
 #include <set>

--- a/Code/GraphMol/SynthonSpaceSearch/SynthonSpaceSearch_details.cpp
+++ b/Code/GraphMol/SynthonSpaceSearch/SynthonSpaceSearch_details.cpp
@@ -10,7 +10,6 @@
 
 #include <algorithm>
 #include <fstream>
-#include <iostream>
 #include <list>
 #include <memory>
 #include <regex>

--- a/Code/GraphMol/Wrap/seqs.hpp
+++ b/Code/GraphMol/Wrap/seqs.hpp
@@ -8,7 +8,6 @@
 
 #include <GraphMol/RDKitBase.h>
 #include <RDBoost/python.h>
-#include <iostream>
 #include <utility>
 namespace python = boost::python;
 

--- a/Code/GraphMol/bulktest.cpp
+++ b/Code/GraphMol/bulktest.cpp
@@ -15,7 +15,6 @@
 #include <GraphMol/SmilesParse/SmilesWrite.h>
 #include <RDGeneral/RDLog.h>
 
-#include <iostream>
 #include <cstdlib>
 
 using namespace RDKit;

--- a/Code/GraphMol/cptest.cpp
+++ b/Code/GraphMol/cptest.cpp
@@ -12,7 +12,6 @@
 #include <GraphMol/RDKitQueries.h>
 #include <GraphMol/SmilesParse/SmilesParse.h>
 
-#include <iostream>
 using namespace std;
 using namespace RDKit;
 

--- a/Code/GraphMol/hanoitest.cpp
+++ b/Code/GraphMol/hanoitest.cpp
@@ -18,7 +18,6 @@
 #include <GraphMol/SmilesParse/SmilesWrite.h>
 #include <GraphMol/FileParsers/FileParsers.h>
 
-#include <iostream>
 #include <vector>
 #include <random>
 #include <cstdlib>

--- a/Code/GraphMol/itertest.cpp
+++ b/Code/GraphMol/itertest.cpp
@@ -14,7 +14,6 @@
 #include <GraphMol/SmilesParse/SmilesWrite.h>
 #include <RDGeneral/RDLog.h>
 
-#include <iostream>
 #include <cstdlib>
 #include <vector>
 

--- a/Code/GraphMol/memtest1.cpp
+++ b/Code/GraphMol/memtest1.cpp
@@ -18,7 +18,6 @@
 #include <RDGeneral/RDLog.h>
 #include <RDGeneral/Dict.h>
 
-#include <iostream>
 using namespace std;
 using namespace RDKit;
 

--- a/Code/GraphMol/molopstest.cpp
+++ b/Code/GraphMol/molopstest.cpp
@@ -9,7 +9,6 @@
 //
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #include <algorithm>
-#include <iostream>
 #include <map>
 #include <math.h>
 #include <random>

--- a/Code/GraphMol/new_canon.cpp
+++ b/Code/GraphMol/new_canon.cpp
@@ -15,7 +15,6 @@
 #include <GraphMol/Atropisomers.h>
 #include <cstdint>
 #include <cstring>
-#include <iostream>
 #include <cassert>
 // #define VERBOSE_CANON 1
 

--- a/Code/GraphMol/new_canon.h
+++ b/Code/GraphMol/new_canon.h
@@ -19,7 +19,6 @@
 #include <boost/dynamic_bitset.hpp>
 #include <RDGeneral/BoostEndInclude.h>
 #include <cstring>
-#include <iostream>
 #include <cassert>
 #include <cstring>
 #include <vector>

--- a/Code/GraphMol/querytest.cpp
+++ b/Code/GraphMol/querytest.cpp
@@ -14,7 +14,6 @@
 #include <GraphMol/RDKitQueries.h>
 #include <GraphMol/SmilesParse/SmilesParse.h>
 #include <GraphMol/Substruct/SubstructMatch.h>
-#include <iostream>
 
 using namespace RDKit;
 using namespace std;

--- a/Code/GraphMol/resMolSupplierTest.cpp
+++ b/Code/GraphMol/resMolSupplierTest.cpp
@@ -1,5 +1,4 @@
 #include <RDGeneral/test.h>
-#include <iostream>
 #include <string>
 #include <map>
 #include <GraphMol/RDKitBase.h>

--- a/Code/GraphMol/sanitTest.cpp
+++ b/Code/GraphMol/sanitTest.cpp
@@ -16,7 +16,6 @@
 #include <GraphMol/SmilesParse/SmilesWrite.h>
 
 #include <cstdlib>
-#include <iostream>
 #include <fstream>
 #include <RDGeneral/types.h>
 #include <RDGeneral/Invariant.h>

--- a/Code/GraphMol/test-valgrind.cpp
+++ b/Code/GraphMol/test-valgrind.cpp
@@ -19,7 +19,6 @@
 #include <GraphMol/SmilesParse/SmilesParse.h>
 #include <GraphMol/SmilesParse/SmilesWrite.h>
 #include <sstream>
-#include <iostream>
 
 using namespace std;
 using namespace RDKit;

--- a/Code/GraphMol/test1.cpp
+++ b/Code/GraphMol/test1.cpp
@@ -22,7 +22,6 @@
 #include <GraphMol/SmilesParse/SmilesWrite.h>
 #include <GraphMol/SmilesParse/SmartsWrite.h>
 #include <sstream>
-#include <iostream>
 #include <boost/format.hpp>
 #include <boost/range/iterator_range.hpp>
 

--- a/Code/GraphMol/testChirality.cpp
+++ b/Code/GraphMol/testChirality.cpp
@@ -25,8 +25,6 @@
 #include <GraphMol/FileParsers/MolSupplier.h>
 #include <GraphMol/CIPLabeler/CIPLabeler.h>
 
-#include <iostream>
-
 using namespace RDKit;
 using namespace std;
 

--- a/Code/GraphMol/testMolBundle.cpp
+++ b/Code/GraphMol/testMolBundle.cpp
@@ -8,7 +8,6 @@
 //  of the RDKit source tree.
 //
 #include <RDGeneral/test.h>
-#include <iostream>
 #include <string>
 #include <map>
 #include <GraphMol/RDKitBase.h>

--- a/Code/GraphMol/testPickler.cpp
+++ b/Code/GraphMol/testPickler.cpp
@@ -33,7 +33,6 @@
 
 #include <cstdlib>
 #include <ctime>
-#include <iostream>
 #include <fstream>
 #include <boost/algorithm/string.hpp>
 

--- a/Code/GraphMol/testPicklerGlobalSettings.cpp
+++ b/Code/GraphMol/testPicklerGlobalSettings.cpp
@@ -46,7 +46,6 @@
 
 #include <cstdlib>
 #include <ctime>
-#include <iostream>
 #include <fstream>
 #include <boost/algorithm/string.hpp>
 

--- a/Code/ML/InfoTheory/InfoBitRanker.cpp
+++ b/Code/ML/InfoTheory/InfoBitRanker.cpp
@@ -11,7 +11,6 @@
 #include "InfoBitRanker.h"
 #include "InfoGainFuncs.h"
 #include <RDGeneral/Invariant.h>
-#include <iostream>
 #include <iomanip>
 #include <fstream>
 #include <RDGeneral/FileParseException.h>

--- a/Code/ML/InfoTheory/InfoBitRanker.h
+++ b/Code/ML/InfoTheory/InfoBitRanker.h
@@ -14,7 +14,6 @@
 
 #include <RDGeneral/types.h>
 #include <DataStructs/BitVects.h>
-#include <iostream>
 
 /*! \brief Class used to rank bits based on a specified measure of information
  *

--- a/Code/MinimalLib/cffiwrapper.cpp
+++ b/Code/MinimalLib/cffiwrapper.cpp
@@ -10,7 +10,6 @@
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #include <string>
 #include <cstring>
-#include <iostream>
 #include <regex>
 
 #include <RDGeneral/versions.h>

--- a/Code/MinimalLib/minilib.cpp
+++ b/Code/MinimalLib/minilib.cpp
@@ -9,7 +9,6 @@
 //  of the RDKit source tree.
 //
 #include <string>
-#include <iostream>
 #include "minilib.h"
 #include "common.h"
 

--- a/Code/MinimalLib/testMinilib.cpp
+++ b/Code/MinimalLib/testMinilib.cpp
@@ -10,7 +10,6 @@
 //
 
 #include <emscripten.h>
-#include <iostream>
 #include <string>
 #include <MinimalLib/minilib.h>
 

--- a/Code/Numerics/Matrix.h
+++ b/Code/Numerics/Matrix.h
@@ -13,7 +13,6 @@
 
 #include <RDGeneral/Invariant.h>
 #include "Vector.h"
-#include <iostream>
 #include <iomanip>
 #include <cstring>
 #include <boost/smart_ptr.hpp>

--- a/Code/Numerics/Optimizer/testOptimizer.cpp
+++ b/Code/Numerics/Optimizer/testOptimizer.cpp
@@ -8,7 +8,6 @@
 //  of the RDKit source tree.
 //
 #include <RDGeneral/test.h>
-#include <iostream>
 #include <cmath>
 #include <RDGeneral/Invariant.h>
 #include <catch2/catch_all.hpp>

--- a/Code/Numerics/Vector.h
+++ b/Code/Numerics/Vector.h
@@ -14,7 +14,6 @@
 #include <RDGeneral/Invariant.h>
 #include <RDGeneral/utils.h>
 #include <cmath>
-#include <iostream>
 #include <iomanip>
 #include <cstdlib>
 #include <cstring>

--- a/Code/Numerics/testConrec.cpp
+++ b/Code/Numerics/testConrec.cpp
@@ -10,7 +10,6 @@
 #include <catch2/catch_all.hpp>
 
 #include <RDGeneral/test.h>
-#include <iostream>
 #include <fstream>
 #include "Conrec.h"
 #include <RDGeneral/Invariant.h>

--- a/Code/Numerics/testMatrices.cpp
+++ b/Code/Numerics/testMatrices.cpp
@@ -11,7 +11,6 @@
 #include "Matrix.h"
 #include "SquareMatrix.h"
 #include "SymmMatrix.h"
-#include <iostream>
 #include <RDGeneral/Invariant.h>
 #include <RDGeneral/RDLog.h>
 #include <cmath>

--- a/Code/Query/test.cpp
+++ b/Code/Query/test.cpp
@@ -10,7 +10,6 @@
 
 #include <catch2/catch_all.hpp>
 #include "QueryObjects.h"
-#include <iostream>
 #include <cmath>
 #include <boost/lexical_cast.hpp>
 

--- a/Code/RDBoost/Wrap.cpp
+++ b/Code/RDBoost/Wrap.cpp
@@ -16,7 +16,6 @@
 #include "pyint_api.h"
 #include <RDBoost/PySequenceHolder.h>
 #include <sstream>
-#include <iostream>
 
 // A helper function for dealing with errors. Throw a Python IndexError
 void throw_index_error(int key) {

--- a/Code/RDBoost/Wrap.h
+++ b/Code/RDBoost/Wrap.h
@@ -30,7 +30,6 @@
 
 #include <vector>
 #include <list>
-#include <iostream>
 #include <RDGeneral/Exceptions.h>
 
 namespace python = boost::python;
@@ -58,7 +57,9 @@ RDKIT_RDBOOST_EXPORT void translate_key_error(KeyErrorException const &e);
   \throws AttributeError if the attribute does not exist
   \throws Python error if assignment fails
 */
-RDKIT_RDBOOST_EXPORT void safeSetattr(python::object self, std::string const &name, python::object const &value);
+RDKIT_RDBOOST_EXPORT void safeSetattr(python::object self,
+                                      std::string const &name,
+                                      python::object const &value);
 
 #ifdef INVARIANT_EXCEPTION_METHOD
 RDKIT_RDBOOST_EXPORT void throw_runtime_error(

--- a/Code/RDBoost/Wrap/RDBase.cpp
+++ b/Code/RDBoost/Wrap/RDBase.cpp
@@ -8,7 +8,6 @@
 //  of the RDKit source tree.
 //
 #include <RDBoost/python.h>
-#include <iostream>
 #include <fstream>
 #include <RDBoost/Wrap.h>
 #include <RDBoost/python_streambuf.h>

--- a/Code/RDBoost/python_streambuf.h
+++ b/Code/RDBoost/python_streambuf.h
@@ -28,7 +28,6 @@
 #include <RDGeneral/Exceptions.h>
 
 #include <streambuf>
-#include <iostream>
 
 namespace boost_adaptbx {
 namespace python {

--- a/Code/RDGeneral/Invariant.cpp
+++ b/Code/RDGeneral/Invariant.cpp
@@ -12,7 +12,6 @@
 #include "Invariant.h"
 
 #include <string>
-#include <iostream>
 #include <boost/lexical_cast.hpp>
 #include "versions.h"
 

--- a/Code/RDGeneral/Invariant.h
+++ b/Code/RDGeneral/Invariant.h
@@ -15,7 +15,6 @@
 
 #include <cassert>
 #include <string>
-#include <iostream>
 #include <stdexcept>
 
 #include "BoostStartInclude.h"

--- a/Code/RDGeneral/JSONHelpers.h
+++ b/Code/RDGeneral/JSONHelpers.h
@@ -1,7 +1,6 @@
 #include <RDGeneral/BoostStartInclude.h>
 #include <boost/property_tree/ptree.hpp>
 #include <RDGeneral/BoostEndInclude.h>
-#include <iostream>
 #include <array>
 
 // Convert a JSON object with boolean keys to a bitwise enum flag set.

--- a/Code/RDGeneral/RDAny.h
+++ b/Code/RDGeneral/RDAny.h
@@ -41,7 +41,6 @@
 #include "RDValue.h"
 #include <string>
 #include <vector>
-#include <iostream>
 #include <sstream>
 namespace RDKit {
 

--- a/Code/RDGeneral/RDLog.h
+++ b/Code/RDGeneral/RDLog.h
@@ -17,7 +17,6 @@
 #include <boost/iostreams/tee.hpp>
 #include <boost/iostreams/stream.hpp>
 #include "BoostEndInclude.h"
-#include <iostream>
 #include <fstream>
 #include <vector>
 #include <cstdint>

--- a/Code/RDGeneral/RDValue-doublemagic.h
+++ b/Code/RDGeneral/RDValue-doublemagic.h
@@ -36,7 +36,6 @@
 #include <cassert>
 #include <any>
 #include "Invariant.h"
-#include <iostream>
 #include <iomanip>
 #include <sstream>
 #include <vector>

--- a/Code/RDGeneral/RDValue-taggedunion.h
+++ b/Code/RDGeneral/RDValue-taggedunion.h
@@ -34,7 +34,6 @@
 
 #include <cassert>
 #include "Invariant.h"
-#include <iostream>
 #include <iomanip>
 #include <sstream>
 #include <vector>

--- a/Code/RDGeneral/StreamOps.h
+++ b/Code/RDGeneral/StreamOps.h
@@ -17,7 +17,6 @@
 #include "RDProps.h"
 #include <string>
 #include <sstream>
-#include <iostream>
 #include <unordered_set>
 #include <boost/cstdint.hpp>
 #include <boost/predef.h>

--- a/Code/RDGeneral/catch_logs.cpp
+++ b/Code/RDGeneral/catch_logs.cpp
@@ -8,7 +8,6 @@
 //  of the RDKit source tree.
 //
 #include <string>
-#include <iostream>
 #include <fstream>
 #include <sstream>
 #include <catch2/catch_all.hpp>

--- a/Code/RDGeneral/hanoiSort.h
+++ b/Code/RDGeneral/hanoiSort.h
@@ -14,7 +14,6 @@
 #define HANOISORT_H_
 
 #include <cstring>
-#include <iostream>
 #include <cassert>
 #include <cstdlib>
 

--- a/Code/SimDivPickers/Wrap/LeaderPicker.cpp
+++ b/Code/SimDivPickers/Wrap/LeaderPicker.cpp
@@ -22,7 +22,6 @@
 #include <DataStructs/BitOps.h>
 #include <SimDivPickers/DistPicker.h>
 #include <SimDivPickers/LeaderPicker.h>
-#include <iostream>
 #include <utility>
 
 namespace python = boost::python;

--- a/Code/SimDivPickers/Wrap/MaxMinPicker.cpp
+++ b/Code/SimDivPickers/Wrap/MaxMinPicker.cpp
@@ -23,7 +23,6 @@
 #include <SimDivPickers/DistPicker.h>
 #include <SimDivPickers/MaxMinPicker.h>
 #include <SimDivPickers/HierarchicalClusterPicker.h>
-#include <iostream>
 #include <utility>
 
 namespace python = boost::python;

--- a/Code/SimDivPickers/catch_tests.cpp
+++ b/Code/SimDivPickers/catch_tests.cpp
@@ -15,7 +15,6 @@
 #include <DataStructs/BitOps.h>
 #include <SimDivPickers/LeaderPicker.h>
 
-#include <iostream>
 #include <fstream>
 
 template <typename T>

--- a/Code/SimDivPickers/testPickers.cpp
+++ b/Code/SimDivPickers/testPickers.cpp
@@ -9,7 +9,6 @@
 //
 #include <catch2/catch_all.hpp>
 #include "MaxMinPicker.h"
-#include <iostream>
 #include <RDGeneral/Invariant.h>
 #include <RDGeneral/RDLog.h>
 

--- a/Contrib/ConformerParser/test.cpp
+++ b/Contrib/ConformerParser/test.cpp
@@ -31,7 +31,6 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
 
-#include <iostream>
 #include <fstream>
 #include <memory>
 

--- a/Contrib/PBF/PBFRDKit.h
+++ b/Contrib/PBF/PBFRDKit.h
@@ -46,8 +46,6 @@
 #ifndef _PBFRDKit_h
 #define _PBFRDKit_h
 
-#include <iostream>
-
 #include <GraphMol/RDKitBase.h>
 #include <GraphMol/MolOps.h>
 #include <GraphMol/Conformer.h>
@@ -55,6 +53,6 @@
 
 using namespace RDKit;
 
-double PBFRD(ROMol&, int confId = -1);
+double PBFRD(ROMol &, int confId = -1);
 
 #endif

--- a/External/AvalonTools/test1.cpp
+++ b/External/AvalonTools/test1.cpp
@@ -24,7 +24,6 @@
 #include <GraphMol/FileParsers/FileParsers.h>
 #include <RDGeneral/Invariant.h>
 #include <DataStructs/ExplicitBitVect.h>
-#include <iostream>
 #include <fstream>
 #include <cstdio>
 #include "AvalonTools.h"

--- a/External/ChemDraw/chemdraw.cpp
+++ b/External/ChemDraw/chemdraw.cpp
@@ -31,7 +31,6 @@
 //
 
 #include <string>
-#include <iostream>
 #include <fstream>
 #include <sstream>
 

--- a/External/GA/util/Util.h
+++ b/External/GA/util/Util.h
@@ -15,7 +15,6 @@
 #include <cstdio>
 #include <ctime>
 #include <string>
-#include <iostream>
 #include <iterator>
 #include <fstream>
 #include <sstream>

--- a/External/pubchem_shape/PubChemShape.cpp
+++ b/External/pubchem_shape/PubChemShape.cpp
@@ -1,4 +1,3 @@
-#include <iostream>
 #include <ranges>
 #include <sstream>
 #include <stdexcept>

--- a/External/pubchem_shape/sdf_align.cpp
+++ b/External/pubchem_shape/sdf_align.cpp
@@ -1,4 +1,3 @@
-#include <iostream>
 #include <sstream>
 #include <stdexcept>
 

--- a/External/pubchem_shape/test.cpp
+++ b/External/pubchem_shape/test.cpp
@@ -1,7 +1,6 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 
-#include <iostream>
 #include <sstream>
 #include <stdexcept>
 


### PR DESCRIPTION
In GCC 15.2, the `iostream` include results in adding 1.1 mb to the file being compiled. We should avoid pulling the include into files were we don't need it (especially into headers!).

This PR removes a bunch of these unrequired includes.