### PR TITLE
Minor refactor of the python wrappers

### DIFF
--- a/Code/DataManip/MetricMatrixCalc/Wrap/rdMetricMatrixCalc.cpp
+++ b/Code/DataManip/MetricMatrixCalc/Wrap/rdMetricMatrixCalc.cpp
@@ -168,8 +168,7 @@ PyObject *getEuclideanDistMat(python::object descripMat) {
     // we have probably have a list or a tuple
 
     unsigned int ncols = 0;
-    unsigned int nrows =
-        python::extract<unsigned int>(descripMat.attr("__len__")());
+    unsigned int nrows = boost::python::len(descripMat);
     CHECK_INVARIANT(nrows > 0, "Empty list passed in");
 
     npy_intp dMatLen = nrows * (nrows - 1) / 2;
@@ -204,7 +203,7 @@ PyObject *getEuclideanDistMat(python::object descripMat) {
 PyObject *getTanimotoDistMat(python::object bitVectList) {
   // we will assume here that we have a either a list of ExplicitBitVectors or
   // SparseBitVects
-  int nrows = python::extract<int>(bitVectList.attr("__len__")());
+  unsigned int nrows = boost::python::len(bitVectList);
   CHECK_INVARIANT(nrows > 1, "");
 
   // First check what type of vector we have
@@ -239,7 +238,7 @@ PyObject *getTanimotoDistMat(python::object bitVectList) {
 PyObject *getTanimotoSimMat(python::object bitVectList) {
   // we will assume here that we have a either a list of ExplicitBitVectors or
   // SparseBitVects
-  int nrows = python::extract<int>(bitVectList.attr("__len__")());
+  unsigned int nrows = boost::python::len(bitVectList);
   CHECK_INVARIANT(nrows > 1, "");
 
   // First check what type of vector we have

--- a/Code/DataStructs/Wrap/SparseIntVect.cpp
+++ b/Code/DataStructs/Wrap/SparseIntVect.cpp
@@ -71,7 +71,7 @@ python::list pyToList(SparseIntVect<IndexType> &vect) {
 template <typename T>
 python::list BulkDice(const T &siv1, python::list sivs, bool returnDistance) {
   python::list res;
-  unsigned int nsivs = python::extract<unsigned int>(sivs.attr("__len__")());
+  unsigned int nsivs = python::len(sivs);
   for (unsigned int i = 0; i < nsivs; ++i) {
     double simVal;
     const T *siv2 = python::extract<T *>(sivs[i])();
@@ -84,7 +84,7 @@ template <typename T>
 python::list BulkTanimoto(const T &siv1, python::list sivs,
                           bool returnDistance) {
   python::list res;
-  unsigned int nsivs = python::extract<unsigned int>(sivs.attr("__len__")());
+  unsigned int nsivs = python::len(sivs);
   for (unsigned int i = 0; i < nsivs; ++i) {
     double simVal;
     const T *siv2 = python::extract<T *>(sivs[i])();
@@ -98,7 +98,7 @@ template <typename T>
 python::list BulkTversky(const T &siv1, python::list sivs, double a, double b,
                          bool returnDistance) {
   python::list res;
-  unsigned int nsivs = python::extract<unsigned int>(sivs.attr("__len__")());
+  unsigned int nsivs = python::len(sivs);
   for (unsigned int i = 0; i < nsivs; ++i) {
     double simVal;
     const T *siv2 = python::extract<T *>(sivs[i])();

--- a/Code/DataStructs/Wrap/wrap_BitOps.cpp
+++ b/Code/DataStructs/Wrap/wrap_BitOps.cpp
@@ -44,8 +44,8 @@ template <typename T>
 python::list NeighborWrapper(python::object queries, python::object bvs,
                              double (*metric)(const T &, const T &)) {
   python::list res;
-  unsigned int nbvs = python::extract<unsigned int>(bvs.attr("__len__")());
-  unsigned int nqs = python::extract<unsigned int>(queries.attr("__len__")());
+  unsigned int nbvs = python::len(bvs);
+  unsigned int nqs = python::len(queries);
   for (unsigned int i = 0; i < nqs; ++i) {
     const T *bv1 = python::extract<const T *>(queries[i])();
     double closest = -1;
@@ -68,7 +68,7 @@ python::list BulkWrapper(const T *bv1, python::object bvs,
                          double (*metric)(const T &, const T &),
                          bool returnDistance) {
   python::list res;
-  unsigned int nbvs = python::extract<unsigned int>(bvs.attr("__len__")());
+  unsigned int nbvs = python::len(bvs);
   for (unsigned int i = 0; i < nbvs; ++i) {
     const T *bv2 = python::extract<const T *>(bvs[i])();
     auto sim = metric(*bv1, *bv2);
@@ -85,7 +85,7 @@ python::list BulkWrapper(const T *bv1, python::object bvs, double a, double b,
                          double (*metric)(const T &, const T &, double, double),
                          bool returnDistance) {
   python::list res;
-  unsigned int nbvs = python::extract<unsigned int>(bvs.attr("__len__")());
+  unsigned int nbvs = python::len(bvs);
   for (unsigned int i = 0; i < nbvs; ++i) {
     const T *bv2 = python::extract<T *>(bvs[i])();
     auto sim = metric(*bv1, *bv2, a, b);
@@ -156,12 +156,12 @@ python::list BulkTverskySimilarity(const T *bv1, python::object bvs, double a,
                 (python::args("v1"), python::args("v2")), _help_);             \
     python::def(                                                               \
         #_bulkname_,                                                           \
-        (python::list(*)(const EBV *, python::object, bool))_bulkname_,        \
+        (python::list (*)(const EBV *, python::object, bool))_bulkname_,       \
         (python::args("v1"), python::args("v2"),                               \
          python::args("returnDistance") = 0));                                 \
     python::def(                                                               \
         #_bulkname_,                                                           \
-        (python::list(*)(const EBV *, python::object, bool))_bulkname_,        \
+        (python::list (*)(const EBV *, python::object, bool))_bulkname_,       \
         (python::args("v1"), python::args("v2"),                               \
          python::args("returnDistance") = 0),                                  \
         _help_);                                                               \
@@ -189,21 +189,21 @@ python::list BulkTverskySimilarity(const T *bv1, python::object bvs, double a,
                 _help_);                                                      \
     python::def(                                                              \
         #_bulkname_,                                                          \
-        (python::list(*)(const SBV *, python::object, bool))_bulkname_,       \
+        (python::list (*)(const SBV *, python::object, bool))_bulkname_,      \
         (python::args("bv1"), python::args("bvList"),                         \
          python::args("returnDistance") = 0));                                \
     python::def(                                                              \
         #_bulkname_,                                                          \
-        (python::list(*)(const EBV *, python::object, bool))_bulkname_,       \
+        (python::list (*)(const EBV *, python::object, bool))_bulkname_,      \
         (python::args("bv1"), python::args("bvList"),                         \
          python::args("returnDistance") = 0),                                 \
         _help_);                                                              \
     python::def(#_funcname_ "Neighbors",                                      \
-                (python::list(*)(python::object, python::object))             \
+                (python::list (*)(python::object, python::object))            \
                     _funcname_##Neighbors<ExplicitBitVect>,                   \
                 (python::args("bvqueries"), python::args("bvList")), _help_); \
     python::def(#_funcname_ "Neighbors_sparse",                               \
-                (python::list(*)(python::object, python::object))             \
+                (python::list (*)(python::object, python::object))            \
                     _funcname_##Neighbors<SparseBitVect>,                     \
                 (python::args("bvqueries"), python::args("bvList")), _help_); \
   }
@@ -261,14 +261,14 @@ struct BitOps_wrapper {
                   help.c_str());
       python::def(
           "BulkTverskySimilarity",
-          (python::list(*)(const SBV *, python::object, double, double,
-                           bool))BulkTverskySimilarity,
+          (python::list (*)(const SBV *, python::object, double, double,
+                            bool))BulkTverskySimilarity,
           (python::args("bv1"), python::args("bvList"), python::args("a"),
            python::args("b"), python::args("returnDistance") = 0));
       python::def(
           "BulkTverskySimilarity",
-          (python::list(*)(const EBV *, python::object, double, double,
-                           bool))BulkTverskySimilarity,
+          (python::list (*)(const EBV *, python::object, double, double,
+                            bool))BulkTverskySimilarity,
           (python::args("bv1"), python::args("bvList"), python::args("a"),
            python::args("b"), python::args("returnDistance") = 0),
           help.c_str());
@@ -279,18 +279,18 @@ struct BitOps_wrapper {
             "(B(bv1) - B(bv1^bv2)) / B(bv1)");
 
     python::def("OnBitProjSimilarity",
-                (DoubleVect(*)(const SBV &, const SBV &))OnBitProjSimilarity,
+                (DoubleVect (*)(const SBV &, const SBV &))OnBitProjSimilarity,
                 python::args("bv1", "bv2"));
     python::def(
         "OnBitProjSimilarity",
-        (DoubleVect(*)(const EBV &, const EBV &))OnBitProjSimilarity,
+        (DoubleVect (*)(const EBV &, const EBV &))OnBitProjSimilarity,
         python::args("bv1", "bv2"),
         "Returns a 2-tuple: (B(bv1&bv2) / B(bv1), B(bv1&bv2) / B(bv2))");
     python::def("OffBitProjSimilarity",
-                (DoubleVect(*)(const SBV &, const SBV &))OffBitProjSimilarity,
+                (DoubleVect (*)(const SBV &, const SBV &))OffBitProjSimilarity,
                 python::args("bv1", "bv2"));
     python::def("OffBitProjSimilarity",
-                (DoubleVect(*)(const EBV &, const EBV &))OffBitProjSimilarity,
+                (DoubleVect (*)(const EBV &, const EBV &))OffBitProjSimilarity,
                 python::args("bv1", "bv2"));
 
     python::def("NumBitsInCommon",
@@ -302,18 +302,18 @@ struct BitOps_wrapper {
                 "Returns the total number of bits in common between the two "
                 "bit vectors");
     python::def("OnBitsInCommon",
-                (IntVect(*)(const SBV &, const SBV &))OnBitsInCommon,
+                (IntVect (*)(const SBV &, const SBV &))OnBitsInCommon,
                 python::args("bv1", "bv2"));
     python::def(
-        "OnBitsInCommon", (IntVect(*)(const EBV &, const EBV &))OnBitsInCommon,
+        "OnBitsInCommon", (IntVect (*)(const EBV &, const EBV &))OnBitsInCommon,
         python::args("bv1", "bv2"),
         "Returns the number of on bits in common between the two bit vectors");
     python::def("OffBitsInCommon",
-                (IntVect(*)(const SBV &, const SBV &))OffBitsInCommon,
+                (IntVect (*)(const SBV &, const SBV &))OffBitsInCommon,
                 python::args("bv1", "bv2"));
     python::def(
         "OffBitsInCommon",
-        (IntVect(*)(const EBV &, const EBV &))OffBitsInCommon,
+        (IntVect (*)(const EBV &, const EBV &))OffBitsInCommon,
         python::args("bv1", "bv2"),
         "Returns the number of off bits in common between the two bit vectors");
 
@@ -345,24 +345,24 @@ struct BitOps_wrapper {
         "Returns True if all bits in the first argument match all bits in the \n\
   vector defined by the pickle in the second argument.\n");
 
-    python::def("BitVectToText", (std::string(*)(const SBV &))BitVectToText,
+    python::def("BitVectToText", (std::string (*)(const SBV &))BitVectToText,
                 python::args("bv1"));
     python::def(
-        "BitVectToText", (std::string(*)(const EBV &))BitVectToText,
+        "BitVectToText", (std::string (*)(const EBV &))BitVectToText,
         python::args("bv1"),
         "Returns a string of zeros and ones representing the bit vector.");
     python::def("BitVectToFPSText",
-                (std::string(*)(const SBV &))BitVectToFPSText,
+                (std::string (*)(const SBV &))BitVectToFPSText,
                 python::args("bv1"));
     python::def("BitVectToFPSText",
-                (std::string(*)(const EBV &))BitVectToFPSText,
+                (std::string (*)(const EBV &))BitVectToFPSText,
                 python::args("bv1"),
                 "Returns an FPS string representing the bit vector.");
     python::def("BitVectToBinaryText",
-                (python::object(*)(const SBV &))BVToBinaryText,
+                (python::object (*)(const SBV &))BVToBinaryText,
                 python::args("bv"));
     python::def(
-        "BitVectToBinaryText", (python::object(*)(const EBV &))BVToBinaryText,
+        "BitVectToBinaryText", (python::object (*)(const EBV &))BVToBinaryText,
         python::args("bv"),
         "Returns a binary string (byte array) representing the bit vector.");
   }

--- a/Code/ForceField/Wrap/ForceField.cpp
+++ b/Code/ForceField/Wrap/ForceField.cpp
@@ -127,7 +127,7 @@ double PyForceField::calcEnergyWithPos(const python::object &pos) {
   PRECONDITION(this->field, "no force field");
   if (pos != python::object()) {
     size_t s = this->field->dimension() * this->field->numPoints();
-    size_t numElements = python::extract<size_t>(pos.attr("__len__")());
+    unsigned int numElements = python::len(pos);
     if (s != numElements) {
       throw ValueErrorException(
           "The Python container must have length equal to Dimension() * "
@@ -165,7 +165,7 @@ PyObject *PyForceField::calcGradWithPos(const python::object &pos) {
   std::vector<double> g(s, 0.0);
   PyObject *gradTuple = PyTuple_New(s);
   if (pos != python::object()) {
-    size_t numElements = python::extract<size_t>(pos.attr("__len__")());
+    unsigned int numElements = python::len(pos);
     if (s != numElements) {
       throw ValueErrorException(
           "The Python container must have length equal to Dimension() * "
@@ -309,7 +309,7 @@ BOOST_PYTHON_MODULE(rdForceField) {
 
   python::class_<PyForceField>("ForceField", "A force field", python::no_init)
       .def("CalcEnergy",
-           (double(PyForceField::*)(const python::object &) const) &
+           (double (PyForceField::*)(const python::object &) const) &
                PyForceField::calcEnergyWithPos,
            ((python::arg("self"), python::arg("pos") = python::object())),
            "Returns the energy (in kcal/mol) of the current arrangement\n"

--- a/Code/Geometry/Wrap/Point.cpp
+++ b/Code/Geometry/Wrap/Point.cpp
@@ -37,7 +37,7 @@ struct PointND_pickle_suite : rdkit_pickle_suite {
     return python::tuple(res);
   }
   static void setstate(RDGeom::PointND &pt, python::tuple state) {
-    unsigned int sz = python::extract<unsigned int>(state.attr("__len__")());
+    unsigned int sz = python::len(state);
     for (unsigned int i = 0; i < sz; ++i) {
       pt[i] = python::extract<double>(state[i]);
     }

--- a/Code/GraphMol/ChemReactions/Wrap/Enumerate.cpp
+++ b/Code/GraphMol/ChemReactions/Wrap/Enumerate.cpp
@@ -45,10 +45,10 @@ namespace RDKit {
 template <class T>
 std::vector<RDKit::MOL_SPTR_VECT> ConvertToVect(T bbs) {
   std::vector<RDKit::MOL_SPTR_VECT> vect;
-  size_t num_bbs = python::extract<unsigned int>(bbs.attr("__len__")());
+  unsigned int num_bbs = python::len(bbs);
   vect.resize(num_bbs);
-  for (size_t i = 0; i < num_bbs; ++i) {
-    unsigned int len1 = python::extract<unsigned int>(bbs[i].attr("__len__")());
+  for (unsigned int i = 0; i < num_bbs; ++i) {
+    unsigned int len1 = python::len(bbs[i]);
     RDKit::MOL_SPTR_VECT &reacts = vect[i];
     reacts.reserve(len1);
     for (unsigned int j = 0; j < len1; ++j) {

--- a/Code/GraphMol/ChemReactions/Wrap/rdChemReactions.cpp
+++ b/Code/GraphMol/ChemReactions/Wrap/rdChemReactions.cpp
@@ -106,8 +106,7 @@ PyObject *RunReactants(ChemicalReaction *self, T reactants,
     self->initReactantMatchers();
   }
   MOL_SPTR_VECT reacts;
-  unsigned int len1 =
-      python::extract<unsigned int>(reactants.attr("__len__")());
+  unsigned int len1 = python::len(reactants);
   reacts.resize(len1);
   for (unsigned int i = 0; i < len1; ++i) {
     reacts[i] = python::extract<ROMOL_SPTR>(reactants[i]);
@@ -301,11 +300,11 @@ ChemicalReaction *ReactionFromSmarts(const char *smarts, python::dict replDict,
                                      bool useSmiles) {
   PRECONDITION(smarts, "null SMARTS string");
   std::map<std::string, std::string> replacements;
-  for (unsigned int i = 0;
-       i < python::extract<unsigned int>(replDict.keys().attr("__len__")());
-       ++i) {
-    replacements[python::extract<std::string>(replDict.keys()[i])] =
-        python::extract<std::string>(replDict.values()[i]);
+  const auto items = replDict.items();
+  for (unsigned int i = 0; i < python::len(items); ++i) {
+    const auto item = items[i];
+    replacements[python::extract<std::string>(item[0])] =
+        python::extract<std::string>(item[1]);
   }
   ChemicalReaction *res;
   res = RxnSmartsToChemicalReaction(smarts, &replacements, useSmiles);
@@ -394,12 +393,12 @@ python::object AddRecursiveQueriesToReaction(ChemicalReaction &self,
                                              bool getLabels = false) {
   // transform dictionary into map
   std::map<std::string, ROMOL_SPTR> queries;
-  for (unsigned int i = 0;
-       i < python::extract<unsigned int>(queryDict.keys().attr("__len__")());
-       ++i) {
-    ROMol *m = python::extract<ROMol *>(queryDict.values()[i]);
+  const auto items = queryDict.items();
+  for (unsigned int i = 0; i < python::len(items); ++i) {
+    const auto item = items[i];
+    ROMol *m = python::extract<ROMol *>(item[1]);
     ROMOL_SPTR nm(new ROMol(*m));
-    std::string k = python::extract<std::string>(queryDict.keys()[i]);
+    std::string k = python::extract<std::string>(item[0]);
     queries[k] = nm;
   }
 
@@ -431,16 +430,17 @@ python::object PreprocessReaction(ChemicalReaction &reaction,
                                   std::string propName) {
   // transform dictionary into map
   std::map<std::string, ROMOL_SPTR> queries;
-  unsigned int size =
-      python::extract<unsigned int>(queryDict.keys().attr("__len__")());
+  const auto items = queryDict.items();
+  unsigned int size = python::len(items);
   if (!size) {
     const bool normalized = true;
     queries = GetFlattenedFunctionalGroupHierarchy(normalized);
   } else {
     for (unsigned int i = 0; i < size; ++i) {
-      ROMol *m = python::extract<ROMol *>(queryDict.values()[i]);
+      const auto item = items[i];
+      ROMol *m = python::extract<ROMol *>(item[1]);
       ROMOL_SPTR nm(new ROMol(*m));
-      std::string k = python::extract<std::string>(queryDict.keys()[i]);
+      std::string k = python::extract<std::string>(item[0]);
       queries[k] = nm;
     }
   }
@@ -885,52 +885,54 @@ see the documentation for rdkit.Chem.MolFromSmiles for an explanation\n\
 of the replacements argument.",
       python::return_value_policy<python::manage_new_object>());
   python::def("ReactionToSmarts",
-              (std::string(*)(const RDKit::ChemicalReaction &))
+              (std::string (*)(const RDKit::ChemicalReaction &))
                   RDKit::ChemicalReactionToRxnSmarts,
               (python::arg("reaction")),
               "construct a reaction SMARTS string for a ChemicalReaction");
   python::def("ReactionToSmiles",
-              (std::string(*)(const RDKit::ChemicalReaction &,
-                              bool))RDKit::ChemicalReactionToRxnSmiles,
+              (std::string (*)(const RDKit::ChemicalReaction &,
+                               bool))RDKit::ChemicalReactionToRxnSmiles,
               (python::arg("reaction"), python::arg("canonical") = true),
               "construct a reaction SMILES string for a ChemicalReaction");
   python::def("ReactionToSmarts",
-              (std::string(*)(const RDKit::ChemicalReaction &,
-                              const RDKit::SmilesWriteParams &))
+              (std::string (*)(const RDKit::ChemicalReaction &,
+                               const RDKit::SmilesWriteParams &))
                   RDKit::ChemicalReactionToRxnSmarts,
               (python::arg("reaction"), python::arg("params")),
               "construct a reaction SMARTS string for a ChemicalReaction");
   python::def("ReactionToSmiles",
-              (std::string(*)(const RDKit::ChemicalReaction &,
-                              const RDKit::SmilesWriteParams &))
+              (std::string (*)(const RDKit::ChemicalReaction &,
+                               const RDKit::SmilesWriteParams &))
                   RDKit::ChemicalReactionToRxnSmiles,
               (python::arg("reaction"), python::arg("params")),
               "construct a reaction SMILES string for a ChemicalReaction");
 
   python::def("ReactionToCXSmarts",
-              (std::string(*)(const RDKit::ChemicalReaction &))
+              (std::string (*)(const RDKit::ChemicalReaction &))
                   RDKit::ChemicalReactionToCXRxnSmarts,
               (python::arg("reaction")),
               "construct a reaction SMARTS string for a ChemicalReaction");
   python::def("ReactionToCXSmiles",
-              (std::string(*)(const RDKit::ChemicalReaction &,
-                              bool))RDKit::ChemicalReactionToCXRxnSmiles,
+              (std::string (*)(const RDKit::ChemicalReaction &,
+                               bool))RDKit::ChemicalReactionToCXRxnSmiles,
               (python::arg("reaction"), python::arg("canonical") = true),
               "construct a reaction SMILES string for a ChemicalReaction");
-  python::def("ReactionToCXSmarts",
-              (std::string(*)(const RDKit::ChemicalReaction &,
-                              const RDKit::SmilesWriteParams &,
-                              std::uint32_t))
-                  RDKit::ChemicalReactionToCXRxnSmarts,
-              (python::arg("reaction"), python::arg("params"), python::arg("flags") = RDKit::SmilesWrite::CXSmilesFields::CX_ALL),
-              "construct a reaction CXSMARTS string for a ChemicalReaction");
-  python::def("ReactionToCXSmiles",
-              (std::string(*)(const RDKit::ChemicalReaction &,
-                              const RDKit::SmilesWriteParams &,
-                              std::uint32_t))
-                  RDKit::ChemicalReactionToCXRxnSmiles,
-              (python::arg("reaction"), python::arg("params"), python::arg("flags") = RDKit::SmilesWrite::CXSmilesFields::CX_ALL),
-              "construct a reaction CXSMILES string for a ChemicalReaction");
+  python::def(
+      "ReactionToCXSmarts",
+      (std::string (*)(const RDKit::ChemicalReaction &,
+                       const RDKit::SmilesWriteParams &,
+                       std::uint32_t))RDKit::ChemicalReactionToCXRxnSmarts,
+      (python::arg("reaction"), python::arg("params"),
+       python::arg("flags") = RDKit::SmilesWrite::CXSmilesFields::CX_ALL),
+      "construct a reaction CXSMARTS string for a ChemicalReaction");
+  python::def(
+      "ReactionToCXSmiles",
+      (std::string (*)(const RDKit::ChemicalReaction &,
+                       const RDKit::SmilesWriteParams &,
+                       std::uint32_t))RDKit::ChemicalReactionToCXRxnSmiles,
+      (python::arg("reaction"), python::arg("params"),
+       python::arg("flags") = RDKit::SmilesWrite::CXSmilesFields::CX_ALL),
+      "construct a reaction CXSMILES string for a ChemicalReaction");
 
   python::def(
       "ReactionFromRxnFile", RDKit::RxnFileToChemicalReaction,

--- a/Code/GraphMol/Depictor/Wrap/rdDepictor.cpp
+++ b/Code/GraphMol/Depictor/Wrap/rdDepictor.cpp
@@ -40,8 +40,7 @@ unsigned int Compute2DCoords(RDKit::ROMol &mol, bool canonOrient,
   RDGeom::INT_POINT2D_MAP cMap;
   cMap.clear();
   python::list ks = coordMap.keys();
-  for (unsigned int i = 0;
-       i < python::extract<unsigned int>(ks.attr("__len__")()); i++) {
+  for (unsigned int i = 0; i < python::len(ks); ++i) {
     unsigned int id = python::extract<unsigned int>(ks[i]);
     if (id >= mol.getNumAtoms()) {
       throw_value_error("atom index out of range");

--- a/Code/GraphMol/Descriptors/Wrap/rdMolDescriptors.cpp
+++ b/Code/GraphMol/Descriptors/Wrap/rdMolDescriptors.cpp
@@ -68,9 +68,9 @@ python::list computeCrippenContribs(
     python::list atomTypeLabels = python::list()) {
   std::vector<unsigned int> *tAtomTypes = nullptr;
   std::vector<std::string> *tAtomTypeLabels = nullptr;
-  if (python::extract<unsigned int>(atomTypes.attr("__len__")()) != 0) {
-    if (python::extract<unsigned int>(atomTypes.attr("__len__")()) !=
-        mol.getNumAtoms()) {
+  unsigned int numAtomTypes = python::len(atomTypes);
+  if (numAtomTypes != 0) {
+    if (numAtomTypes != mol.getNumAtoms()) {
       throw_value_error(
           "if atomTypes vector is provided, it must be as long as the number "
           "of atoms");
@@ -78,9 +78,9 @@ python::list computeCrippenContribs(
       tAtomTypes = new std::vector<unsigned int>(mol.getNumAtoms(), 0);
     }
   }
-  if (python::extract<unsigned int>(atomTypeLabels.attr("__len__")()) != 0) {
-    if (python::extract<unsigned int>(atomTypeLabels.attr("__len__")()) !=
-        mol.getNumAtoms()) {
+  unsigned int numAtomTypeLabels = python::len(atomTypeLabels);
+  if (numAtomTypeLabels != 0) {
+    if (numAtomTypeLabels != mol.getNumAtoms()) {
       throw_value_error(
           "if atomTypeLabels vector is provided, it must be as long as the "
           "number of atoms");
@@ -336,8 +336,7 @@ double kappaHelper(double (*fn)(const RDKit::ROMol &, std::vector<double> *),
     // make sure the optional argument actually was a list
     python::list typecheck = python::extract<python::list>(atomContribs);
 
-    if (python::extract<unsigned int>(typecheck.attr("__len__")()) !=
-        mol.getNumAtoms()) {
+    if (python::len(typecheck) != mol.getNumAtoms()) {
       throw_value_error("length of atomContribs list != number of atoms");
     }
 
@@ -367,8 +366,7 @@ MorganFingerprintHelper(const RDKit::ROMol &mol, unsigned int radius, int nBits,
   RDLog::deprecationWarning("please use MorganGenerator");
   std::vector<boost::uint32_t> *invars = nullptr;
   if (invariants) {
-    unsigned int nInvar =
-        python::extract<unsigned int>(invariants.attr("__len__")());
+    unsigned int nInvar = python::len(invariants);
     if (nInvar) {
       if (nInvar != mol.getNumAtoms()) {
         throw_value_error("length of invariant vector != number of atoms");
@@ -384,8 +382,7 @@ MorganFingerprintHelper(const RDKit::ROMol &mol, unsigned int radius, int nBits,
   }
   std::vector<std::uint32_t> *froms = nullptr;
   if (fromAtoms) {
-    unsigned int nFrom =
-        python::extract<unsigned int>(fromAtoms.attr("__len__")());
+    unsigned int nFrom = python::len(fromAtoms);
     if (nFrom) {
       froms = new std::vector<std::uint32_t>();
       for (unsigned int i = 0; i < nFrom; ++i) {
@@ -510,8 +507,7 @@ GetMorganFingerprintBV(const RDKit::ROMol &mol, unsigned int radius,
   RDLog::deprecationWarning("please use MorganGenerator");
   std::vector<boost::uint32_t> *invars = nullptr;
   if (invariants) {
-    unsigned int nInvar =
-        python::extract<unsigned int>(invariants.attr("__len__")());
+    unsigned int nInvar = python::len(invariants);
     if (nInvar) {
       if (nInvar != mol.getNumAtoms()) {
         throw_value_error("length of invariant vector != number of atoms");
@@ -606,8 +602,7 @@ python::list GetUSR(const RDKit::ROMol &mol, int confId) {
 }
 
 python::list GetUSRDistributions(python::object coords, python::object points) {
-  unsigned int numCoords =
-      python::extract<unsigned int>(coords.attr("__len__")());
+  unsigned int numCoords = python::len(coords);
   if (numCoords == 0) {
     throw_value_error("no coordinates");
   }
@@ -644,9 +639,8 @@ python::list GetUSRDistributions(python::object coords, python::object points) {
 
 python::list GetUSRDistributionsFromPoints(python::object coords,
                                            python::object points) {
-  unsigned int numCoords =
-      python::extract<unsigned int>(coords.attr("__len__")());
-  unsigned int numPts = python::extract<unsigned int>(points.attr("__len__")());
+  unsigned int numCoords = python::len(coords);
+  unsigned int numPts = python::len(points);
   if (numCoords == 0) {
     throw_value_error("no coordinates");
   }
@@ -676,15 +670,13 @@ python::list GetUSRDistributionsFromPoints(python::object coords,
 }
 
 python::list GetUSRFromDistributions(python::object distances) {
-  unsigned int numDist =
-      python::extract<unsigned int>(distances.attr("__len__")());
+  unsigned int numDist = python::len(distances);
   if (numDist == 0) {
     throw_value_error("no distances");
   }
   std::vector<std::vector<double>> dist(numDist);
   for (unsigned int i = 0; i < numDist; ++i) {
-    unsigned int numPts =
-        python::extract<unsigned int>(distances[i].attr("__len__")());
+    unsigned int numPts = python::len(distances[i]);
     if (numPts == 0) {
       throw_value_error("distances missing");
     }
@@ -705,15 +697,12 @@ python::list GetUSRFromDistributions(python::object distances) {
 
 double GetUSRScore(python::object descriptor1, python::object descriptor2,
                    python::object weights) {
-  unsigned int numElements =
-      python::extract<unsigned int>(descriptor1.attr("__len__")());
-  if (numElements !=
-      python::extract<unsigned int>(descriptor2.attr("__len__")())) {
+  unsigned int numElements = python::len(descriptor1);
+  if (numElements != python::len(descriptor2)) {
     throw_value_error("descriptors must have the same length");
   }
   unsigned int numWeights = numElements / 12;
-  unsigned int numPyWeights =
-      python::extract<unsigned int>(weights.attr("__len__")());
+  unsigned int numPyWeights = python::len(weights);
   std::vector<double> w(numWeights, 1.0);  // default weights: all to 1.0
   if ((numPyWeights > 0) && (numPyWeights != numWeights)) {
     throw_value_error("number of weights is not correct");
@@ -747,15 +736,13 @@ python::list GetUSRCAT(const RDKit::ROMol &mol, python::object atomSelections,
   if (atomSelections != python::object()) {
     // make sure the optional argument actually was a list
     python::list typecheck = python::extract<python::list>(atomSelections);
-    unsigned int numSel =
-        python::extract<unsigned int>(atomSelections.attr("__len__")());
+    unsigned int numSel = python::len(atomSelections);
     if (numSel == 0) {
       throw_value_error("empty atom selections");
     }
     atomIds.resize(numSel);
     for (unsigned int i = 0; i < numSel; ++i) {
-      unsigned int numPts =
-          python::extract<unsigned int>(atomSelections[i].attr("__len__")());
+      unsigned int numPts = python::len(atomSelections[i]);
       std::vector<unsigned int> tmpIds(numPts);
       for (unsigned int j = 0; j < numPts; ++j) {
         tmpIds[j] = python::extract<unsigned int>(atomSelections[i][j]) - 1;
@@ -777,7 +764,7 @@ python::list CalcSlogPVSA(const RDKit::ROMol &mol, python::object bins,
                           bool force) {
   std::vector<double> *lbins = nullptr;
   if (bins) {
-    unsigned int nBins = python::extract<unsigned int>(bins.attr("__len__")());
+    unsigned int nBins = python::len(bins);
     if (nBins) {
       lbins = new std::vector<double>(nBins, 0.0);
       for (unsigned int i = 0; i < nBins; ++i) {
@@ -798,7 +785,7 @@ python::list CalcSMRVSA(const RDKit::ROMol &mol, python::object bins,
                         bool force) {
   std::vector<double> *lbins = nullptr;
   if (bins) {
-    unsigned int nBins = python::extract<unsigned int>(bins.attr("__len__")());
+    unsigned int nBins = python::len(bins);
     if (nBins) {
       lbins = new std::vector<double>(nBins, 0.0);
       for (unsigned int i = 0; i < nBins; ++i) {
@@ -819,7 +806,7 @@ python::list CalcPEOEVSA(const RDKit::ROMol &mol, python::object bins,
                          bool force) {
   std::vector<double> *lbins = nullptr;
   if (bins) {
-    unsigned int nBins = python::extract<unsigned int>(bins.attr("__len__")());
+    unsigned int nBins = python::len(bins);
     if (nBins) {
       lbins = new std::vector<double>(nBins, 0.0);
       for (unsigned int i = 0; i < nBins; ++i) {
@@ -839,7 +826,7 @@ python::list CalcPEOEVSA(const RDKit::ROMol &mol, python::object bins,
 python::list CalcCustomPropVSA(const RDKit::ROMol &mol,
                                const std::string customPropName,
                                python::object bins, bool force) {
-  unsigned int nBins = python::extract<unsigned int>(bins.attr("__len__")());
+  unsigned int nBins = python::len(bins);
   std::vector<double> lbins = std::vector<double>(nBins, 0.0);
   for (unsigned int i = 0; i < nBins; ++i) {
     lbins[i] = python::extract<double>(bins[i]);
@@ -918,23 +905,22 @@ int registerPropertyHelper(python::object o) {
 }
 
 boost::shared_ptr<RDKit::Descriptors::DoubleCubicLatticeVolume>
-getDoubleCubicLatticeVolume(const RDKit::ROMol &mol,
-                            const python::list &radii,
-                            bool isProtein = false,
-                            bool includeLigand = true,
-                            double probeRadius = 1.4,
-                            int confId = -1) {
+getDoubleCubicLatticeVolume(const RDKit::ROMol &mol, const python::list &radii,
+                            bool isProtein = false, bool includeLigand = true,
+                            double probeRadius = 1.4, int confId = -1) {
   std::vector<double> radiiAsVector;
   radiiAsVector.reserve(mol.getNumAtoms());
   pythonObjectToVect<double>(radii, radiiAsVector);
 
-  return boost::make_shared<RDKit::Descriptors::DoubleCubicLatticeVolume>(mol, std::move(radiiAsVector), isProtein, includeLigand, probeRadius, confId);
+  return boost::make_shared<RDKit::Descriptors::DoubleCubicLatticeVolume>(
+      mol, std::move(radiiAsVector), isProtein, includeLigand, probeRadius,
+      confId);
 }
 
-double getPartialSurfaceAreaHelper(RDKit::Descriptors::DoubleCubicLatticeVolume &self,
-                                   const python::object &atomIdxs) {
-  
-  unsigned int numAtoms = self.mol.getNumAtoms(); 
+double getPartialSurfaceAreaHelper(
+    RDKit::Descriptors::DoubleCubicLatticeVolume &self,
+    const python::object &atomIdxs) {
+  unsigned int numAtoms = self.mol.getNumAtoms();
   auto atoms = pythonObjectToDynBitset(atomIdxs, numAtoms);
 
   if (atoms.empty()) {
@@ -942,30 +928,29 @@ double getPartialSurfaceAreaHelper(RDKit::Descriptors::DoubleCubicLatticeVolume 
   }
 
   return self.getPartialSurfaceArea(atoms);
-  
 }
 
-double getPartialVolumeHelper(RDKit::Descriptors::DoubleCubicLatticeVolume &self,
-                              const python::object &atomIdxs) {
-  
-  
-  unsigned int numAtoms = self.mol.getNumAtoms(); 
+double getPartialVolumeHelper(
+    RDKit::Descriptors::DoubleCubicLatticeVolume &self,
+    const python::object &atomIdxs) {
+  unsigned int numAtoms = self.mol.getNumAtoms();
   auto atoms = pythonObjectToDynBitset(atomIdxs, numAtoms);
   if (atoms.empty()) {
     throw_value_error("No atom indices supplied for Partial Surface Area");
   }
 
   return self.getPartialVolume(atoms);
-  
 }
 
-python::dict getSurfacePointsHelper(RDKit::Descriptors::DoubleCubicLatticeVolume &self) {
-  const std::map<unsigned int, std::vector<RDGeom::Point3D>> &points = self.getSurfacePoints();
+python::dict getSurfacePointsHelper(
+    RDKit::Descriptors::DoubleCubicLatticeVolume &self) {
+  const std::map<unsigned int, std::vector<RDGeom::Point3D>> &points =
+      self.getSurfacePoints();
   python::dict surfacePoints;
-  
+
   for (const auto &it : points) {
     python::list points3D;
-    for (const auto &p : it.second){
+    for (const auto &p : it.second) {
       points3D.append(p);
     }
     surfacePoints[it.first] = points3D;
@@ -1712,7 +1697,7 @@ BOOST_PYTHON_MODULE(rdMolDescriptors) {
               docString.c_str(),
               python::return_value_policy<python::manage_new_object>());
 
-    docString =
+  docString =
       R"DOC(ARGUMENTS:
       "   - mol: molecule or protein under consideration
       "   - radii: radii for atoms of input mol (get using GetPeriodicTable or provide custom list)
@@ -1722,64 +1707,63 @@ BOOST_PYTHON_MODULE(rdMolDescriptors) {
       "   - confId: conformer ID to consider (default=-1)
       ")DOC";
 
-python::class_<RDKit::Descriptors::DoubleCubicLatticeVolume, 
-               boost::shared_ptr<RDKit::Descriptors::DoubleCubicLatticeVolume>>(
-  "DoubleCubicLatticeVolume",
-  "Class for the Double Cubic Lattice Volume method",
-  python::no_init)
-  .def("__init__",
-    python::make_constructor(
-        &getDoubleCubicLatticeVolume,
-        python::default_call_policies(),
-        (python::arg("mol"),
-        python::arg("radii"),
-        python::arg("isProtein") = false,
-        python::arg("includeLigand") = true,
-        python::arg("probeRadius") = 1.4,
-        python::arg("confId") = -1)), 
-        docString.c_str())
-  .def("GetSurfaceArea",
-        &RDKit::Descriptors::DoubleCubicLatticeVolume::getSurfaceArea,
-        (python::args("self")),
-        "Get the Surface Area of the Molecule or Protein")
-  .def("GetAtomSurfaceArea",
-      &RDKit::Descriptors::DoubleCubicLatticeVolume::getAtomSurfaceArea,
-      (python::arg("atom_idx")), "Get the surface area of atom with atom_idx")
-  .def("GetPolarSurfaceArea",
-        &RDKit::Descriptors::DoubleCubicLatticeVolume::getPolarSurfaceArea,
-        (python::arg("includeSandP")=false, python::arg("includeHs")=false), 
-        "Get the Polar Surface Area of the Molecule or Protein")
-  .def("GetPartialSurfaceArea",
-       &getPartialSurfaceAreaHelper,
-       (python::arg("atomIndices")),
-       "Get the Partial Surface Area of the Molecule or Protein for specified subset of atoms")
-  .def("GetSurfacePoints",
-       &getSurfacePointsHelper,
-       "Get the set of points representing the surface")
-  .def("GetVolume",
-        &RDKit::Descriptors::DoubleCubicLatticeVolume::getVolume,
-        "Get the Total Volume of the Molecule or Protein")
-  .def("GetVDWVolume",
-        &RDKit::Descriptors::DoubleCubicLatticeVolume::getVDWVolume,
-        "Get the van der Waals Volume of the Molecule or Protein")
-  .def("GetAtomVolume",
-       &RDKit::Descriptors::DoubleCubicLatticeVolume::getAtomVolume,
-       (python::arg("atomIdx"), python::arg("solventRadius")),
-       "Get the volume atom of atom_idx with volume for specified Probe Radius")
-  .def("GetPolarVolume",
-      &RDKit::Descriptors::DoubleCubicLatticeVolume::getPolarVolume,
-      (python::arg("includeSandP")=false, python::arg("includeHs")=false), 
-      "Get the Polar Volume of the Molecule or Protein")
-  .def("GetPartialVolume",
-      &getPartialVolumeHelper,
-      python::arg("atomIdx"),
-      "Get the Partial Volume of the Molecule or Protein for specified subset of atoms")
-  .def("GetCompactness",
-        &RDKit::Descriptors::DoubleCubicLatticeVolume::getCompactness,
-        "Get the Compactness of the Protein")
-  .def("GetPackingDensity",
-        &RDKit::Descriptors::DoubleCubicLatticeVolume::getPackingDensity,
-        "Get the PackingDensity of the Protein");
+  python::class_<
+      RDKit::Descriptors::DoubleCubicLatticeVolume,
+      boost::shared_ptr<RDKit::Descriptors::DoubleCubicLatticeVolume>>(
+      "DoubleCubicLatticeVolume",
+      "Class for the Double Cubic Lattice Volume method", python::no_init)
+      .def("__init__",
+           python::make_constructor(
+               &getDoubleCubicLatticeVolume, python::default_call_policies(),
+               (python::arg("mol"), python::arg("radii"),
+                python::arg("isProtein") = false,
+                python::arg("includeLigand") = true,
+                python::arg("probeRadius") = 1.4, python::arg("confId") = -1)),
+           docString.c_str())
+      .def("GetSurfaceArea",
+           &RDKit::Descriptors::DoubleCubicLatticeVolume::getSurfaceArea,
+           (python::args("self")),
+           "Get the Surface Area of the Molecule or Protein")
+      .def("GetAtomSurfaceArea",
+           &RDKit::Descriptors::DoubleCubicLatticeVolume::getAtomSurfaceArea,
+           (python::arg("atom_idx")),
+           "Get the surface area of atom with atom_idx")
+      .def("GetPolarSurfaceArea",
+           &RDKit::Descriptors::DoubleCubicLatticeVolume::getPolarSurfaceArea,
+           (python::arg("includeSandP") = false,
+            python::arg("includeHs") = false),
+           "Get the Polar Surface Area of the Molecule or Protein")
+      .def(
+          "GetPartialSurfaceArea", &getPartialSurfaceAreaHelper,
+          (python::arg("atomIndices")),
+          "Get the Partial Surface Area of the Molecule or Protein for specified subset of atoms")
+      .def("GetSurfacePoints", &getSurfacePointsHelper,
+           "Get the set of points representing the surface")
+      .def("GetVolume",
+           &RDKit::Descriptors::DoubleCubicLatticeVolume::getVolume,
+           "Get the Total Volume of the Molecule or Protein")
+      .def("GetVDWVolume",
+           &RDKit::Descriptors::DoubleCubicLatticeVolume::getVDWVolume,
+           "Get the van der Waals Volume of the Molecule or Protein")
+      .def(
+          "GetAtomVolume",
+          &RDKit::Descriptors::DoubleCubicLatticeVolume::getAtomVolume,
+          (python::arg("atomIdx"), python::arg("solventRadius")),
+          "Get the volume atom of atom_idx with volume for specified Probe Radius")
+      .def("GetPolarVolume",
+           &RDKit::Descriptors::DoubleCubicLatticeVolume::getPolarVolume,
+           (python::arg("includeSandP") = false,
+            python::arg("includeHs") = false),
+           "Get the Polar Volume of the Molecule or Protein")
+      .def(
+          "GetPartialVolume", &getPartialVolumeHelper, python::arg("atomIdx"),
+          "Get the Partial Volume of the Molecule or Protein for specified subset of atoms")
+      .def("GetCompactness",
+           &RDKit::Descriptors::DoubleCubicLatticeVolume::getCompactness,
+           "Get the Compactness of the Protein")
+      .def("GetPackingDensity",
+           &RDKit::Descriptors::DoubleCubicLatticeVolume::getPackingDensity,
+           "Get the PackingDensity of the Protein");
 
 #ifdef RDK_BUILD_DESCRIPTORS3D
   python::scope().attr("_CalcCoulombMat_version") =

--- a/Code/GraphMol/DistGeomHelpers/Wrap/rdDistGeom.cpp
+++ b/Code/GraphMol/DistGeomHelpers/Wrap/rdDistGeom.cpp
@@ -36,11 +36,11 @@ struct PyEmbedParameters
     // the EmbedParameters object doesn't own the memory for the coordMap, so we
     // have to take ownership here.
     d_coordMap.reset(new std::map<int, RDGeom::Point3D>());
-    for (unsigned int i = 0;
-         i < python::extract<unsigned int>(cmap.keys().attr("__len__")());
-         ++i) {
-      (*d_coordMap)[python::extract<int>(cmap.keys()[i])] =
-          python::extract<RDGeom::Point3D>(cmap.values()[i]);
+    const auto items = cmap.items();
+    for (unsigned int i = 0; i < python::len(items); ++i) {
+      const auto item = items[i];
+      (*d_coordMap)[python::extract<int>(item[0])] =
+          python::extract<RDGeom::Point3D>(item[1]);
     }
     coordMap = d_coordMap.get();
   }
@@ -58,7 +58,7 @@ struct PyEmbedParameters
         new std::map<std::pair<unsigned int, unsigned int>, double>);
 
     python::list ks = CPCIdict.keys();
-    unsigned int nKeys = python::extract<unsigned int>(ks.attr("__len__")());
+    unsigned int nKeys = python::len(ks);
 
     for (unsigned int i = 0; i < nKeys; ++i) {
       python::tuple id = python::extract<python::tuple>(ks[i]);
@@ -115,7 +115,7 @@ int EmbedMolecule(ROMol &mol, unsigned int maxAttempts, int seed,
                   bool useMacrocycle14config) {
   std::map<int, RDGeom::Point3D> pMap;
   python::list ks = coordMap.keys();
-  unsigned int nKeys = python::extract<unsigned int>(ks.attr("__len__")());
+  unsigned int nKeys = python::len(ks);
   for (unsigned int i = 0; i < nKeys; ++i) {
     unsigned int id = python::extract<unsigned int>(ks[i]);
     pMap[id] = python::extract<RDGeom::Point3D>(coordMap[id]);
@@ -173,7 +173,7 @@ INT_VECT EmbedMultipleConfs(
     bool useMacrocycle14config) {
   std::map<int, RDGeom::Point3D> pMap;
   python::list ks = coordMap.keys();
-  unsigned int nKeys = python::extract<unsigned int>(ks.attr("__len__")());
+  unsigned int nKeys = python::len(ks);
   for (unsigned int i = 0; i < nKeys; ++i) {
     unsigned int id = python::extract<unsigned int>(ks[i]);
     pMap[id] = python::extract<RDGeom::Point3D>(coordMap[id]);

--- a/Code/GraphMol/FMCS/Wrap/rdFMCS.cpp
+++ b/Code/GraphMol/FMCS/Wrap/rdFMCS.cpp
@@ -586,7 +586,7 @@ MCSResult *FindMCSWrapper(python::object mols, bool maximizeBonds,
                           AtomComparator atomComp, BondComparator bondComp,
                           RingComparator ringComp, std::string seedSmarts) {
   std::vector<ROMOL_SPTR> ms;
-  unsigned int nElems = python::extract<unsigned int>(mols.attr("__len__")());
+  unsigned int nElems = python::len(mols);
   ms.resize(nElems);
   for (unsigned int i = 0; i < nElems; ++i) {
     if (!mols[i]) {
@@ -621,7 +621,7 @@ MCSResult *FindMCSWrapper(python::object mols, bool maximizeBonds,
 
 MCSResult *FindMCSWrapper2(python::object mols, PyMCSParameters &pyMcsParams) {
   std::vector<ROMOL_SPTR> ms;
-  unsigned int nElems = python::extract<unsigned int>(mols.attr("__len__")());
+  unsigned int nElems = python::len(mols);
   ms.resize(nElems);
   for (unsigned int i = 0; i < nElems; ++i) {
     if (!mols[i]) {

--- a/Code/GraphMol/FilterCatalog/Wrap/FilterCatalog.cpp
+++ b/Code/GraphMol/FilterCatalog/Wrap/FilterCatalog.cpp
@@ -367,14 +367,13 @@ struct filtercat_wrapper {
 
         .def("IsValid", &SmartsMatcher::isValid, python::args("self"),
              "Returns True if the SmartsMatcher is valid")
-        .def(
-            "SetPattern",
-            (void(SmartsMatcher::*)(const ROMol &)) & SmartsMatcher::setPattern,
-            python::args("self", "pat"),
-            "Set the pattern molecule for the SmartsMatcher")
         .def("SetPattern",
-             (void(SmartsMatcher::*)(const std::string &)) &
-                 SmartsMatcher::setPattern,
+             (void (SmartsMatcher::*)(const ROMol &))&SmartsMatcher::setPattern,
+             python::args("self", "pat"),
+             "Set the pattern molecule for the SmartsMatcher")
+        .def("SetPattern",
+             (void (SmartsMatcher::*)(
+                 const std::string &))&SmartsMatcher::setPattern,
              python::args("self", "pat"),
              "Set the smarts pattern for the Smarts Matcher (warning: "
              "MinimumCount is not reset)")
@@ -455,16 +454,17 @@ struct filtercat_wrapper {
         .def("GetPropList", &FilterCatalogEntry::getPropList,
              python::args("self"))
         .def("SetProp",
-             (void(FilterCatalogEntry::*)(const std::string &, std::string)) &
-                 FilterCatalogEntry::setProp<std::string>,
+             (void (FilterCatalogEntry::*)(
+                 const std::string &,
+                 std::string))&FilterCatalogEntry::setProp<std::string>,
              python::args("self", "key", "val"))
         .def("GetProp",
-             (std::string(FilterCatalogEntry::*)(const std::string &) const) &
+             (std::string (FilterCatalogEntry::*)(const std::string &) const) &
                  FilterCatalogEntry::getProp<std::string>,
              python::args("self", "key"))
         .def("ClearProp",
-             (void(FilterCatalogEntry::*)(const std::string &)) &
-                 FilterCatalogEntry::clearProp,
+             (void (FilterCatalogEntry::*)(
+                 const std::string &))&FilterCatalogEntry::clearProp,
              python::args("self", "key"));
 
     python::def(
@@ -583,8 +583,9 @@ struct filtercat_wrapper {
                 "If a smiles string can't be parsed, a 'Bad smiles' entry is "
                 "returned.");
 
+    auto scope = python::scope();
     std::string nested_name = python::extract<std::string>(
-        python::scope().attr("__name__") + ".FilterMatchOps");
+        scope.attr("__name__") + ".FilterMatchOps");
     python::object nested_module(python::handle<>(
         python::borrowed(PyImport_AddModule(nested_name.c_str()))));
     python::scope().attr("FilterMatchOps") = nested_module;

--- a/Code/GraphMol/Fingerprints/Wrap/FingerprintGeneratorWrapper.cpp
+++ b/Code/GraphMol/Fingerprints/Wrap/FingerprintGeneratorWrapper.cpp
@@ -44,8 +44,7 @@ void convertPyArguments(
     std::unique_ptr<std::vector<std::uint32_t>> &customAtomInvariants,
     std::unique_ptr<std::vector<std::uint32_t>> &customBondInvariants) {
   if (!py_fromAtoms.is_none()) {
-    unsigned int len =
-        python::extract<unsigned int>(py_fromAtoms.attr("__len__")());
+    unsigned int len = python::len(py_fromAtoms);
     if (len) {
       fromAtoms.reset(new std::vector<std::uint32_t>());
       fromAtoms->reserve(len);
@@ -56,8 +55,7 @@ void convertPyArguments(
   }
 
   if (!py_ignoreAtoms.is_none()) {
-    unsigned int len =
-        python::extract<unsigned int>(py_ignoreAtoms.attr("__len__")());
+    unsigned int len = python::len(py_ignoreAtoms);
     if (len) {
       ignoreAtoms.reset(new std::vector<std::uint32_t>());
       ignoreAtoms->reserve(len);
@@ -69,8 +67,7 @@ void convertPyArguments(
   }
 
   if (!py_atomInvs.is_none()) {
-    unsigned int len =
-        python::extract<unsigned int>(py_atomInvs.attr("__len__")());
+    unsigned int len = python::len(py_atomInvs);
     if (len) {
       customAtomInvariants.reset(new std::vector<std::uint32_t>());
       customAtomInvariants->reserve(len);
@@ -82,8 +79,7 @@ void convertPyArguments(
   }
 
   if (!py_bondInvs.is_none()) {
-    unsigned int len =
-        python::extract<unsigned int>(py_bondInvs.attr("__len__")());
+    unsigned int len = python::len(py_bondInvs);
     if (len) {
       customBondInvariants.reset(new std::vector<std::uint32_t>());
       customBondInvariants->reserve(len);
@@ -206,7 +202,7 @@ ExplicitBitVect *getFingerprint(const FingerprintGenerator<OutputType> *fpGen,
 template <typename ReturnType, typename FuncType>
 python::tuple mtgetFingerprints(FuncType func, python::object mols,
                                 int numThreads) {
-  unsigned int nmols = python::extract<unsigned int>(mols.attr("__len__")());
+  unsigned int nmols = python::len(mols);
   std::vector<const ROMol *> tmols;
   for (auto i = 0u; i < nmols; ++i) {
     tmols.push_back(python::extract<const ROMol *>(mols[i])());
@@ -333,10 +329,9 @@ const std::vector<const ROMol *> convertPyArgumentsForBulk(
     const python::list &py_molVect) {
   std::vector<const ROMol *> molVect;
   if (!py_molVect.is_none()) {
-    unsigned int len =
-        python::extract<unsigned int>(py_molVect.attr("__len__")());
+    unsigned int len = python::len(py_molVect);
     if (len) {
-      for (unsigned int i = 0; i < len; i++) {
+      for (unsigned int i = 0; i < len; ++i) {
         molVect.push_back(python::extract<const ROMol *>(py_molVect[i]));
       }
     }
@@ -345,8 +340,7 @@ const std::vector<const ROMol *> convertPyArgumentsForBulk(
 }
 
 python::list getSparseCountFPBulkPy(python::list &py_molVect, FPType fPType) {
-  const std::vector<const ROMol *> molVect =
-      convertPyArgumentsForBulk(py_molVect);
+  const auto molVect = convertPyArgumentsForBulk(py_molVect);
   auto tempResult = getSparseCountFPBulk(molVect, fPType);
   python::list result;
 

--- a/Code/GraphMol/MolChemicalFeatures/Wrap/ChemicalFeatureUtils.cpp
+++ b/Code/GraphMol/MolChemicalFeatures/Wrap/ChemicalFeatureUtils.cpp
@@ -21,8 +21,7 @@ namespace python = boost::python;
 namespace RDKit {
 python::object GetAtomMatch(python::object featMatch, int maxAts = 1024) {
   python::list res;
-  unsigned int nEntries =
-      python::extract<unsigned int>(featMatch.attr("__len__")());
+  unsigned int nEntries = python::len(featMatch);
 
   boost::dynamic_bitset<> indices(maxAts);
   for (unsigned int i = 0; i < nEntries; ++i) {

--- a/Code/GraphMol/MolDraw2D/Wrap/rdMolDraw2D.cpp
+++ b/Code/GraphMol/MolDraw2D/Wrap/rdMolDraw2D.cpp
@@ -39,21 +39,21 @@ void tagAtomHelper(MolDraw2DSVG &self, const ROMol &mol, double radius,
   std::map<std::string, std::string> events;
   if (pyo) {
     python::dict tDict = python::extract<python::dict>(pyo);
-    python::list keys = tDict.keys();
-    python::list vals = tDict.values();
-    for (unsigned int i = 0;
-         i < python::extract<unsigned int>(keys.attr("__len__")()); ++i) {
-      events[python::extract<std::string>(keys[i])] =
-          python::extract<std::string>(vals[i]);
+    const auto items = tDict.items();
+    for (unsigned int i = 0; i < python::len(items); ++i) {
+      const auto item = items[i];
+      events[python::extract<std::string>(item[0])] =
+          python::extract<std::string>(item[1]);
     }
   }
   self.tagAtoms(mol, radius, events);
 }
 void pyDictToColourMap(python::object pyo, ColourPalette &res) {
   python::dict tDict = python::extract<python::dict>(pyo);
-  for (unsigned int i = 0;
-       i < python::extract<unsigned int>(tDict.keys().attr("__len__")()); ++i) {
-    python::tuple tpl = python::extract<python::tuple>(tDict.values()[i]);
+  const auto items = tDict.items();
+  for (unsigned int i = 0; i < python::len(items); ++i) {
+    const auto item = items[i];
+    python::tuple tpl = python::extract<python::tuple>(item[1]);
     float r = python::extract<float>(tpl[0]);
     float g = python::extract<float>(tpl[1]);
     float b = python::extract<float>(tpl[2]);
@@ -62,7 +62,7 @@ void pyDictToColourMap(python::object pyo, ColourPalette &res) {
       a = python::extract<float>(tpl[3]);
     }
     DrawColour clr(r, g, b, a);
-    res[python::extract<int>(tDict.keys()[i])] = clr;
+    res[python::extract<int>(item[0])] = clr;
   }
 }
 ColourPalette *pyDictToColourMap(python::object pyo) {
@@ -75,10 +75,11 @@ ColourPalette *pyDictToColourMap(python::object pyo) {
 }
 void pyDictToDoubleMap(python::object pyo, std::map<int, double> &res) {
   python::dict tDict = python::extract<python::dict>(pyo);
-  for (unsigned int i = 0;
-       i < python::extract<unsigned int>(tDict.keys().attr("__len__")()); ++i) {
-    double r = python::extract<double>(tDict.values()[i]);
-    res[python::extract<int>(tDict.keys()[i])] = r;
+  const auto items = tDict.items();
+  for (unsigned int i = 0; i < python::len(items); ++i) {
+    const auto item = items[i];
+    double r = python::extract<double>(item[1]);
+    res[python::extract<int>(item[0])] = r;
   }
 }
 std::map<int, double> *pyDictToDoubleMap(python::object pyo) {
@@ -91,10 +92,11 @@ std::map<int, double> *pyDictToDoubleMap(python::object pyo) {
 }
 void pyDictToIntMap(python::object pyo, std::map<int, int> &res) {
   python::dict tDict = python::extract<python::dict>(pyo);
-  for (unsigned int i = 0;
-       i < python::extract<unsigned int>(tDict.keys().attr("__len__")()); ++i) {
-    int r = python::extract<int>(tDict.values()[i]);
-    res[python::extract<int>(tDict.keys()[i])] = r;
+  const auto items = tDict.items();
+  for (unsigned int i = 0; i < python::len(items); ++i) {
+    const auto item = items[i];
+    int r = python::extract<int>(item[1]);
+    res[python::extract<int>(item[0])] = r;
   }
 }
 std::map<int, int> *pyDictToIntMap(python::object pyo) {
@@ -133,8 +135,7 @@ DrawColour pyTupleToDrawColour(const python::tuple tpl) {
 void pyListToColourVec(python::object pyo, std::vector<DrawColour> &res) {
   res.clear();
   python::list tList = python::extract<python::list>(pyo);
-  for (unsigned int i = 0;
-       i < python::extract<unsigned int>(tList.attr("__len__")()); ++i) {
+  for (unsigned int i = 0; i < python::len(tList); ++i) {
     python::tuple tpl = python::extract<python::tuple>(tList[i]);
     res.push_back(pyTupleToDrawColour(tpl));
   }
@@ -144,12 +145,13 @@ void pyListToColourVec(python::object pyo, std::vector<DrawColour> &res) {
 void pyDictToMapColourVec(python::object pyo,
                           std::map<int, std::vector<DrawColour>> &res) {
   python::dict tDict = python::extract<python::dict>(pyo);
-  for (unsigned int i = 0;
-       i < python::extract<unsigned int>(tDict.keys().attr("__len__")()); ++i) {
-    python::list pl = python::extract<python::list>(tDict.values()[i]);
+  const auto items = tDict.items();
+  for (unsigned int i = 0; i < python::len(items); ++i) {
+    const auto item = items[i];
+    python::list pl = python::extract<python::list>(item[1]);
     std::vector<DrawColour> v;
     pyListToColourVec(pl, v);
-    res[python::extract<int>(tDict.keys()[i])] = v;
+    res[python::extract<int>(item[0])] = v;
   }
 }
 
@@ -321,8 +323,7 @@ void drawMoleculesHelper2(MolDraw2D &self, python::object pmols,
   unsigned int nThere = mols->size();
   std::unique_ptr<std::vector<std::vector<int>>> highlightAtoms;
   if (highlight_atoms) {
-    if (python::extract<unsigned int>(highlight_atoms.attr("__len__")()) !=
-        nThere) {
+    if (python::len(highlight_atoms) != nThere) {
       throw ValueErrorException(
           "If highlightAtoms is provided it must be the same length as the "
           "molecule list.");
@@ -334,8 +335,7 @@ void drawMoleculesHelper2(MolDraw2D &self, python::object pmols,
   }
   std::unique_ptr<std::vector<std::vector<int>>> highlightBonds;
   if (highlight_bonds) {
-    if (python::extract<unsigned int>(highlight_bonds.attr("__len__")()) !=
-        nThere) {
+    if (python::len(highlight_bonds) != nThere) {
       throw ValueErrorException(
           "If highlightBonds is provided it must be the same length as the "
           "molecule list.");
@@ -348,8 +348,7 @@ void drawMoleculesHelper2(MolDraw2D &self, python::object pmols,
 
   std::unique_ptr<std::vector<ColourPalette>> highlightAtomMap;
   if (highlight_atom_map) {
-    if (python::extract<unsigned int>(highlight_atom_map.attr("__len__")()) !=
-        nThere) {
+    if (python::len(highlight_atom_map) != nThere) {
       throw ValueErrorException(
           "If highlightAtomMap is provided it must be the same length as the "
           "molecule list.");
@@ -361,8 +360,7 @@ void drawMoleculesHelper2(MolDraw2D &self, python::object pmols,
   }
   std::unique_ptr<std::vector<ColourPalette>> highlightBondMap;
   if (highlight_bond_map) {
-    if (python::extract<unsigned int>(highlight_bond_map.attr("__len__")()) !=
-        nThere) {
+    if (python::len(highlight_bond_map) != nThere) {
       throw ValueErrorException(
           "If highlightBondMap is provided it must be the same length as the "
           "molecule list.");
@@ -374,8 +372,7 @@ void drawMoleculesHelper2(MolDraw2D &self, python::object pmols,
   }
   std::unique_ptr<std::vector<std::map<int, double>>> highlightRadii;
   if (highlight_atom_radii) {
-    if (python::extract<unsigned int>(highlight_atom_radii.attr("__len__")()) !=
-        nThere) {
+    if (python::len(highlight_atom_radii) != nThere) {
       throw ValueErrorException(
           "If highlightAtomRadii is provided it must be the same length as the "
           "molecule list.");
@@ -626,8 +623,7 @@ void contourAndDrawGridHelper(RDKit::MolDraw2D &drawer, python::object &data,
 void setColoursHelper(RDKit::MolDraw2DUtils::ContourParams &params,
                       python::object pycolors) {
   std::vector<RDKit::DrawColour> cs;
-  for (size_t i = 0; i < python::extract<size_t>(pycolors.attr("__len__")());
-       ++i) {
+  for (unsigned int i = 0; i < python::len(pycolors); ++i) {
     cs.push_back(
         pyTupleToDrawColour(python::extract<python::tuple>(pycolors[i])));
   }
@@ -1139,28 +1135,29 @@ BOOST_PYTHON_MODULE(rdMolDraw2D) {
       .def("FillPolys", &RDKit::MolDraw2D::fillPolys, python::args("self"),
            "returns whether or not polygons are being filled")
       .def("DrawLine",
-           (void(RDKit::MolDraw2D::*)(const Point2D &, const Point2D &, bool)) &
-               RDKit::MolDraw2D::drawLine,
+           (void (RDKit::MolDraw2D::*)(const Point2D &, const Point2D &,
+                                       bool))&RDKit::MolDraw2D::drawLine,
            (python::arg("self"), python::arg("cds1"), python::arg("cds2"),
             python::arg("rawCoords") = false),
            "draws a line with the current drawing style. The coordinates "
            "are in the molecule frame unless rawCoords is true, "
            "in which case the coordinates are in pixels.")
-      .def("DrawArrow", RDKit::drawArrowHelper,
-           (python::arg("self"), python::arg("cds1"), python::arg("cds2"),
-            python::arg("asPolygon") = false, python::arg("frac") = 0.05,
-            python::arg("angle") = M_PI / 6,
-            python::arg("color") = python::object(),
-            python::arg("rawCoords") = false),
-           "draws an arrow with the current drawing style. The coordinates "
-           "are in the molecule frame unless rawCoords is true, "
-           "in which case the coordinates are in pixels. "
-           "If asPolygon is true the head of the "
-           "arrow will be drawn as a triangle, otherwise two lines are used. "
-           "The fraction of the arrow length to use for the head is given by "
-           "frac. The angle of the arrowhead "
-           "(the angle between the main line and each arrowhead line) is given by angle. "
-           "The color is a tuple of 3 floats (0-1) in red, green, blue (RGB) order.")
+      .def(
+          "DrawArrow", RDKit::drawArrowHelper,
+          (python::arg("self"), python::arg("cds1"), python::arg("cds2"),
+           python::arg("asPolygon") = false, python::arg("frac") = 0.05,
+           python::arg("angle") = M_PI / 6,
+           python::arg("color") = python::object(),
+           python::arg("rawCoords") = false),
+          "draws an arrow with the current drawing style. The coordinates "
+          "are in the molecule frame unless rawCoords is true, "
+          "in which case the coordinates are in pixels. "
+          "If asPolygon is true the head of the "
+          "arrow will be drawn as a triangle, otherwise two lines are used. "
+          "The fraction of the arrow length to use for the head is given by "
+          "frac. The angle of the arrowhead "
+          "(the angle between the main line and each arrowhead line) is given by angle. "
+          "The color is a tuple of 3 floats (0-1) in red, green, blue (RGB) order.")
       .def("DrawTriangle", &RDKit::MolDraw2D::drawTriangle,
            (python::arg("self"), python::arg("cds1"), python::arg("cds2"),
             python::arg("cds3"), python::arg("rawCoords") = false),
@@ -1188,9 +1185,8 @@ BOOST_PYTHON_MODULE(rdMolDraw2D) {
            "are in the molecule frame unless rawCoords is true, "
            "in which case the coordinates are in pixels.")
       .def("DrawArc",
-           (void(RDKit::MolDraw2D::*)(const Point2D &, double, double, double,
-                                      bool)) &
-               RDKit::MolDraw2D::drawArc,
+           (void (RDKit::MolDraw2D::*)(const Point2D &, double, double, double,
+                                       bool))&RDKit::MolDraw2D::drawArc,
            (python::arg("self"), python::arg("center"), python::arg("radius"),
             python::arg("angle1"), python::arg("angle2"),
             python::arg("rawCoords") = false),
@@ -1219,9 +1215,9 @@ BOOST_PYTHON_MODULE(rdMolDraw2D) {
            "are in the molecule frame unless rawCoords is true, "
            "in which case the coordinates are in pixels.")
       .def("DrawString",
-           (void(RDKit::MolDraw2D::*)(const std::string &,
-                                      const RDGeom::Point2D &, bool)) &
-               RDKit::MolDraw2D::drawString,
+           (void (RDKit::MolDraw2D::*)(const std::string &,
+                                       const RDGeom::Point2D &,
+                                       bool))&RDKit::MolDraw2D::drawString,
            (python::arg("self"), python::arg("string"), python::arg("pos"),
             python::arg("rawCoords") = false),
            "add text to the canvas. The coordinates "
@@ -1236,14 +1232,14 @@ BOOST_PYTHON_MODULE(rdMolDraw2D) {
            "are in the molecule frame unless rawCoords is true, "
            "in which case the coordinates are in pixels.")
       .def("GetDrawCoords",
-           (RDGeom::Point2D(RDKit::MolDraw2D::*)(const RDGeom::Point2D &)
+           (RDGeom::Point2D (RDKit::MolDraw2D::*)(const RDGeom::Point2D &)
                 const) &
                RDKit::MolDraw2D::getDrawCoords,
            (python::arg("self"), python::arg("point")),
            "get the coordinates in drawing space for a particular point in "
            "molecule space")
       .def("GetDrawCoords",
-           (RDGeom::Point2D(RDKit::MolDraw2D::*)(int) const) &
+           (RDGeom::Point2D (RDKit::MolDraw2D::*)(int) const) &
                RDKit::MolDraw2D::getDrawCoords,
            (python::arg("self"), python::arg("atomIndex")),
            "get the coordinates in drawing space for a particular atom")
@@ -1273,7 +1269,7 @@ BOOST_PYTHON_MODULE(rdMolDraw2D) {
            python::args("self"),
            "add the last bits of SVG to finish the drawing")
       .def("AddMoleculeMetadata",
-           (void(RDKit::MolDraw2DSVG::*)(const RDKit::ROMol &, int) const) &
+           (void (RDKit::MolDraw2DSVG::*)(const RDKit::ROMol &, int) const) &
                RDKit::MolDraw2DSVG::addMoleculeMetadata,
            ((python::arg("self"), python::arg("mol")),
             python::arg("confId") = -1),
@@ -1471,8 +1467,7 @@ BOOST_PYTHON_MODULE(rdMolDraw2D) {
        python::arg("height") = 300,
        python::arg("highlightAtoms") = python::object(),
        python::arg("kekulize") = true, python::arg("lineWidthMult") = 1,
-       python::arg("includeAtomCircles") = true,
-       python::arg("confId") = -1),
+       python::arg("includeAtomCircles") = true, python::arg("confId") = -1),
       docString.c_str());
   docString = "Returns ACS 1996 mode svg for a molecule";
   python::def("MolToACS1996SVG", &RDKit::molToACS1996SVG,

--- a/Code/GraphMol/MolStandardize/Wrap/rdMolStandardize.cpp
+++ b/Code/GraphMol/MolStandardize/Wrap/rdMolStandardize.cpp
@@ -179,7 +179,7 @@ void mtinPlaceHelper(python::object pymols, int numThreads,
   if (params) {
     ps = python::extract<RDKit::MolStandardize::CleanupParameters *>(params);
   }
-  unsigned int nmols = python::extract<unsigned int>(pymols.attr("__len__")());
+  unsigned int nmols = python::len(pymols);
   std::vector<RDKit::RWMol *> mols(nmols);
   for (auto i = 0u; i < nmols; ++i) {
     auto mol = static_cast<RDKit::RWMol *>(
@@ -199,7 +199,7 @@ void mtinPlaceHelper2(python::object pymols, int numThreads,
   if (params) {
     ps = python::extract<RDKit::MolStandardize::CleanupParameters *>(params);
   }
-  unsigned int nmols = python::extract<unsigned int>(pymols.attr("__len__")());
+  unsigned int nmols = python::len(pymols);
   std::vector<RDKit::RWMol *> mols(nmols);
   for (auto i = 0u; i < nmols; ++i) {
     auto mol = static_cast<RDKit::RWMol *>(

--- a/Code/GraphMol/MolTransforms/Wrap/rdMolTransforms.cpp
+++ b/Code/GraphMol/MolTransforms/Wrap/rdMolTransforms.cpp
@@ -51,7 +51,7 @@ PyObject *computePrincAxesMomentsHelper(
   std::vector<double> weightsVec;
   size_t i;
   if (weights != python::object()) {
-    size_t numElements = python::extract<int>(weights.attr("__len__")());
+    size_t numElements = python::len(weights);
     if (numElements != conf.getNumAtoms()) {
       throw ValueErrorException(
           "The Python container must have length equal to conf.GetNumAtoms()");

--- a/Code/GraphMol/RascalMCES/Wrap/rdRascalMCES.cpp
+++ b/Code/GraphMol/RascalMCES/Wrap/rdRascalMCES.cpp
@@ -99,7 +99,7 @@ python::list findMCESWrapper(const ROMol &mol1, const ROMol &mol2,
 
 std::vector<std::shared_ptr<ROMol>> extractMols(python::object mols) {
   std::vector<std::shared_ptr<ROMol>> cmols;
-  unsigned int nElems = python::extract<unsigned int>(mols.attr("__len__")());
+  unsigned int nElems = python::len(mols);
   cmols.resize(nElems);
   for (unsigned int i = 0; i < nElems; ++i) {
     if (!mols[i]) {

--- a/Code/GraphMol/ShapeHelpers/Wrap/rdShapeHelpers.cpp
+++ b/Code/GraphMol/ShapeHelpers/Wrap/rdShapeHelpers.cpp
@@ -80,22 +80,18 @@ python::tuple getConfBox(const Conformer &conf,
 }
 
 python::tuple getUnionOfTwoBox(python::tuple box1, python::tuple box2) {
-  unsigned int len1 = python::extract<unsigned int>(box1.attr("__len__")());
-  unsigned int len2 = python::extract<unsigned int>(box2.attr("__len__")());
+  unsigned int len1 = python::len(box1);
+  unsigned int len2 = python::len(box2);
   if ((len1 != 2) || (len2 != 2)) {
     throw_value_error(
         "In correct format for one of the box: expecting a tuple of two "
         "Point3D");
   }
-  RDGeom::Point3D lC1 =
-      python::extract<RDGeom::Point3D>(box1.attr("__getitem__")(0));
-  RDGeom::Point3D uC1 =
-      python::extract<RDGeom::Point3D>(box1.attr("__getitem__")(1));
+  RDGeom::Point3D lC1 = python::extract<RDGeom::Point3D>(box1[0]);
+  RDGeom::Point3D uC1 = python::extract<RDGeom::Point3D>(box1[1]);
 
-  RDGeom::Point3D lC2 =
-      python::extract<RDGeom::Point3D>(box2.attr("__getitem__")(0));
-  RDGeom::Point3D uC2 =
-      python::extract<RDGeom::Point3D>(box2.attr("__getitem__")(1));
+  RDGeom::Point3D lC2 = python::extract<RDGeom::Point3D>(box2[0]);
+  RDGeom::Point3D uC2 = python::extract<RDGeom::Point3D>(box2[1]);
 
   RDGeom::Point3D lowerCorner, upperCorner;
   MolShapes::computeUnionBox(lC1, uC1, lC2, uC2, lowerCorner, upperCorner);

--- a/Code/GraphMol/Wrap/Conformer.cpp
+++ b/Code/GraphMol/Wrap/Conformer.cpp
@@ -95,21 +95,24 @@ void SetPos(Conformer *conf, np::ndarray const &array) {
   RDGeom::POINT3D_VECT &pos = conf->getPositions();
   if (array.shape(1) == 2) {
     for (size_t i = 0; i < conf->getNumAtoms(); ++i) {
-      pos[i].x = * reinterpret_cast<const double *>(dataptr + i * stride_atom);
-      pos[i].y = * reinterpret_cast<const double *>(dataptr + i * stride_atom + stride_dim);
+      pos[i].x = *reinterpret_cast<const double *>(dataptr + i * stride_atom);
+      pos[i].y = *reinterpret_cast<const double *>(dataptr + i * stride_atom +
+                                                   stride_dim);
       pos[i].z = 0.0;
     }
   } else {
     for (size_t i = 0; i < conf->getNumAtoms(); ++i) {
-      pos[i].x = * reinterpret_cast<const double *>(dataptr + i * stride_atom);
-      pos[i].y = * reinterpret_cast<const double *>(dataptr + i * stride_atom + stride_dim);
-      pos[i].z = * reinterpret_cast<const double *>(dataptr + i * stride_atom + 2 * stride_dim);
+      pos[i].x = *reinterpret_cast<const double *>(dataptr + i * stride_atom);
+      pos[i].y = *reinterpret_cast<const double *>(dataptr + i * stride_atom +
+                                                   stride_dim);
+      pos[i].z = *reinterpret_cast<const double *>(dataptr + i * stride_atom +
+                                                   2 * stride_dim);
     }
   }
 }
 void SetAtomPos(Conformer *conf, unsigned int aid, python::object loc) {
   // const std::vector<double> &loc) {
-  int dim = python::extract<int>(loc.attr("__len__")());
+  unsigned int dim = python::len(loc);
   CHECK_INVARIANT(dim == 3, "");
   PySequenceHolder<double> pdata(loc);
   RDGeom::Point3D pt(pdata[0], pdata[1], pdata[2]);
@@ -154,8 +157,8 @@ struct conformer_wrapper {
         .def("SetAtomPosition", SetAtomPos, python::args("self", "aid", "loc"),
              "Set the position of the specified atom\n")
         .def("SetAtomPosition",
-             (void(Conformer::*)(unsigned int, const RDGeom::Point3D &)) &
-                 Conformer::setAtomPos,
+             (void (Conformer::*)(
+                 unsigned int, const RDGeom::Point3D &))&Conformer::setAtomPos,
              python::args("self", "atomId", "position"),
              "Set the position of the specified atom\n")
 
@@ -294,7 +297,7 @@ struct conformer_wrapper {
              (python::arg("self"), python::arg("includePrivate") = false,
               python::arg("includeComputed") = false,
               python::arg("autoConvertStrings") = true),
-	     getPropsAsDictDocString.c_str());
+             getPropsAsDictDocString.c_str());
   };
 };
 }  // namespace RDKit

--- a/Code/GraphMol/Wrap/MolOps.cpp
+++ b/Code/GraphMol/Wrap/MolOps.cpp
@@ -56,8 +56,7 @@ python::tuple fragmentOnSomeBondsHelper(const ROMol &mol,
 
   std::vector<std::pair<unsigned int, unsigned int>> *dummyLabels = nullptr;
   if (pyDummyLabels) {
-    unsigned int nVs =
-        python::extract<unsigned int>(pyDummyLabels.attr("__len__")());
+    unsigned int nVs = python::len(pyDummyLabels);
     dummyLabels = new std::vector<std::pair<unsigned int, unsigned int>>(nVs);
     for (unsigned int i = 0; i < nVs; ++i) {
       unsigned int v1 = python::extract<unsigned int>(pyDummyLabels[i][0]);
@@ -67,8 +66,7 @@ python::tuple fragmentOnSomeBondsHelper(const ROMol &mol,
   }
   std::vector<Bond::BondType> *bondTypes = nullptr;
   if (pyBondTypes) {
-    unsigned int nVs =
-        python::extract<unsigned int>(pyBondTypes.attr("__len__")());
+    unsigned int nVs = python::len(pyBondTypes);
     if (nVs != bondIndices->size()) {
       throw_value_error("bondTypes shorter than bondIndices");
     }
@@ -129,8 +127,7 @@ ROMol *fragmentOnBondsHelper(const ROMol &mol, python::object pyBondIndices,
   }
   std::vector<std::pair<unsigned int, unsigned int>> *dummyLabels = nullptr;
   if (pyDummyLabels) {
-    unsigned int nVs =
-        python::extract<unsigned int>(pyDummyLabels.attr("__len__")());
+    unsigned int nVs = python::len(pyDummyLabels);
     dummyLabels = new std::vector<std::pair<unsigned int, unsigned int>>(nVs);
     for (unsigned int i = 0; i < nVs; ++i) {
       unsigned int v1 = python::extract<unsigned int>(pyDummyLabels[i][0]);
@@ -140,8 +137,7 @@ ROMol *fragmentOnBondsHelper(const ROMol &mol, python::object pyBondIndices,
   }
   std::vector<Bond::BondType> *bondTypes = nullptr;
   if (pyBondTypes) {
-    unsigned int nVs =
-        python::extract<unsigned int>(pyBondTypes.attr("__len__")());
+    unsigned int nVs = python::len(pyBondTypes);
     if (nVs != bondIndices->size()) {
       throw_value_error("bondTypes shorter than bondIndices");
     }
@@ -153,8 +149,7 @@ ROMol *fragmentOnBondsHelper(const ROMol &mol, python::object pyBondIndices,
   std::vector<unsigned int> *cutsPerAtom = nullptr;
   if (pyCutsPerAtom) {
     cutsPerAtom = new std::vector<unsigned int>;
-    unsigned int nAts =
-        python::extract<unsigned int>(pyCutsPerAtom.attr("__len__")());
+    unsigned int nAts = python::len(pyCutsPerAtom);
     if (nAts < mol.getNumAtoms()) {
       throw_value_error("cutsPerAtom shorter than the number of atoms");
     }
@@ -176,8 +171,7 @@ ROMol *fragmentOnBondsHelper(const ROMol &mol, python::object pyBondIndices,
 }
 
 ROMol *renumberAtomsHelper(const ROMol &mol, python::object &pyNewOrder) {
-  if (python::extract<unsigned int>(pyNewOrder.attr("__len__")()) <
-      mol.getNumAtoms()) {
+  if (python::len(pyNewOrder) < mol.getNumAtoms()) {
     throw_value_error("atomCounts shorter than the number of atoms");
   }
   auto newOrder = pythonObjectToVect(pyNewOrder, mol.getNumAtoms());
@@ -210,8 +204,7 @@ python::dict splitMolByPDBResidues(const ROMol &mol, python::object pyWhiteList,
                                    bool negateList) {
   std::vector<std::string> *whiteList = nullptr;
   if (pyWhiteList) {
-    unsigned int nVs =
-        python::extract<unsigned int>(pyWhiteList.attr("__len__")());
+    unsigned int nVs = python::len(pyWhiteList);
     whiteList = new std::vector<std::string>(nVs);
     for (unsigned int i = 0; i < nVs; ++i) {
       (*whiteList)[i] = python::extract<std::string>(pyWhiteList[i]);
@@ -234,8 +227,7 @@ python::dict splitMolByPDBChainId(const ROMol &mol, python::object pyWhiteList,
                                   bool negateList) {
   std::vector<std::string> *whiteList = nullptr;
   if (pyWhiteList) {
-    unsigned int nVs =
-        python::extract<unsigned int>(pyWhiteList.attr("__len__")());
+    unsigned int nVs = python::len(pyWhiteList);
     whiteList = new std::vector<std::string>(nVs);
     for (unsigned int i = 0; i < nVs; ++i) {
       (*whiteList)[i] = python::extract<std::string>(pyWhiteList[i]);
@@ -285,12 +277,12 @@ python::dict parseQueryDefFileHelper(python::object &input, bool standardize,
 void addRecursiveQueriesHelper(ROMol &mol, python::dict replDict,
                                std::string propName) {
   std::map<std::string, ROMOL_SPTR> replacements;
-  for (unsigned int i = 0;
-       i < python::extract<unsigned int>(replDict.keys().attr("__len__")());
-       ++i) {
-    ROMol *m = python::extract<ROMol *>(replDict.values()[i]);
+  const auto items = replDict.items();
+  for (unsigned int i = 0; i < python::len(items); ++i) {
+    const auto item = items[i];
+    ROMol *m = python::extract<ROMol *>(item[1]);
     ROMOL_SPTR nm(new ROMol(*m));
-    std::string k = python::extract<std::string>(replDict.keys()[i]);
+    std::string k = python::extract<std::string>(item[0]);
     replacements[k] = nm;
   }
   addRecursiveQueries(mol, replacements, propName);
@@ -628,8 +620,7 @@ ExplicitBitVect *wrapLayeredFingerprint(
   std::unique_ptr<std::vector<unsigned int>> atomCountsV;
   if (atomCounts) {
     atomCountsV.reset(new std::vector<unsigned int>);
-    unsigned int nAts =
-        python::extract<unsigned int>(atomCounts.attr("__len__")());
+    unsigned int nAts = python::len(atomCounts);
     if (nAts < mol.getNumAtoms()) {
       throw_value_error("atomCounts shorter than the number of atoms");
     }
@@ -659,8 +650,7 @@ ExplicitBitVect *wrapPatternFingerprint(const ROMol &mol, unsigned int fpSize,
   std::vector<unsigned int> *atomCountsV = nullptr;
   if (atomCounts) {
     atomCountsV = new std::vector<unsigned int>;
-    unsigned int nAts =
-        python::extract<unsigned int>(atomCounts.attr("__len__")());
+    unsigned int nAts = python::len(atomCounts);
     if (nAts < mol.getNumAtoms()) {
       throw_value_error("atomCounts shorter than the number of atoms");
     }
@@ -859,8 +849,7 @@ ROMol *pathToSubmolHelper(const ROMol &mol, python::object &path, bool useQuery,
                           python::object atomMap) {
   ROMol *result;
   PATH_TYPE pth;
-  for (unsigned int i = 0;
-       i < python::extract<unsigned int>(path.attr("__len__")()); ++i) {
+  for (unsigned int i = 0; i < python::len(path); ++i) {
     pth.push_back(python::extract<unsigned int>(path[i]));
   }
   std::map<int, int> mapping;
@@ -921,13 +910,14 @@ ROMol *replaceCoreHelper(const ROMol &mol, const ROMol &core,
   // convert input to MatchVect
   MatchVectType matchVect;
 
-  unsigned int length = python::extract<unsigned int>(match.attr("__len__")());
-
+  unsigned int length = python::len(match);
   for (unsigned int i = 0; i < length; ++i) {
-    int sz = 1;
-    if (PyObject_HasAttrString(static_cast<python::object>(match[i]).ptr(),
-                               "__len__")) {
-      sz = python::extract<unsigned int>(match[i].attr("__len__")());
+    // This is what boost::python::len() does internally
+    auto pyObj = static_cast<python::object>(match[i]).ptr();
+    unsigned int sz = PyObject_Length(pyObj);
+    if (PyErr_Occurred()) {
+      PyErr_Clear();
+      sz = 1;
     }
 
     int v1, v2;
@@ -973,7 +963,7 @@ void setDoubleBondNeighborDirectionsHelper(ROMol &mol, python::object confObj) {
 void setAtomSymbols(MolzipParams &p, python::object symbols) {
   p.atomSymbols.clear();
   if (symbols) {
-    unsigned int nVs = python::extract<unsigned int>(symbols.attr("__len__")());
+    unsigned int nVs = python::len(symbols);
     for (unsigned int i = 0; i < nVs; ++i) {
       p.atomSymbols.push_back(python::extract<std::string>(symbols[i]));
     }

--- a/Code/GraphMol/Wrap/RingInfo.cpp
+++ b/Code/GraphMol/Wrap/RingInfo.cpp
@@ -64,9 +64,8 @@ python::object bondRingFamilies(const RingInfo *self) {
 #endif
 
 void addRing(RingInfo *self, python::object atomRing, python::object bondRing) {
-  unsigned int nAts = python::extract<unsigned int>(atomRing.attr("__len__")());
-  unsigned int nBnds =
-      python::extract<unsigned int>(bondRing.attr("__len__")());
+  unsigned int nAts = boost::python::len(atomRing);
+  unsigned int nBnds = boost::python::len(bondRing);
   if (nAts != nBnds) {
     throw_value_error("list sizes must match");
   }

--- a/Code/GraphMol/Wrap/SubstanceGroup.cpp
+++ b/Code/GraphMol/Wrap/SubstanceGroup.cpp
@@ -62,7 +62,7 @@ SubstanceGroup *addMolSubstanceGroup(ROMol &mol, const SubstanceGroup &sgroup) {
 }
 
 void addBracketHelper(SubstanceGroup &self, python::object pts) {
-  unsigned int sz = python::extract<unsigned int>(pts.attr("__len__")());
+  unsigned int sz = boost::python::len(pts);
   if (sz != 2 && sz != 3) {
     throw_value_error("pts object have a length of 2 or 3");
   }
@@ -211,37 +211,38 @@ struct sgroup_wrap {
              python::args("self"))
 
         .def("SetProp",
-             (void(RDProps::*)(const std::string &, std::string, bool) const) &
+             (void (RDProps::*)(const std::string &, std::string, bool) const) &
                  SubstanceGroup::setProp<std::string>,
              (python::arg("self"), python::arg("key"), python::arg("val"),
               python::arg("computed") = false),
              "sets the value of a particular property")
         .def("SetDoubleProp",
-             (void(RDProps::*)(const std::string &, double, bool) const) &
+             (void (RDProps::*)(const std::string &, double, bool) const) &
                  SubstanceGroup::setProp<double>,
              (python::arg("self"), python::arg("key"), python::arg("val"),
               python::arg("computed") = false),
              "sets the value of a particular property")
         .def("SetIntProp",
-             (void(RDProps::*)(const std::string &, int, bool) const) &
+             (void (RDProps::*)(const std::string &, int, bool) const) &
                  SubstanceGroup::setProp<int>,
              (python::arg("self"), python::arg("key"), python::arg("val"),
               python::arg("computed") = false),
              "sets the value of a particular property")
-        .def("SetUnsignedProp",
-             (void(RDProps::*)(const std::string &, unsigned int, bool) const) &
-                 SubstanceGroup::setProp<unsigned int>,
-             (python::arg("self"), python::arg("key"), python::arg("val"),
-              python::arg("computed") = false),
-             "sets the value of a particular property")
+        .def(
+            "SetUnsignedProp",
+            (void (RDProps::*)(const std::string &, unsigned int, bool) const) &
+                SubstanceGroup::setProp<unsigned int>,
+            (python::arg("self"), python::arg("key"), python::arg("val"),
+             python::arg("computed") = false),
+            "sets the value of a particular property")
         .def("SetBoolProp",
-             (void(RDProps::*)(const std::string &, bool, bool) const) &
+             (void (RDProps::*)(const std::string &, bool, bool) const) &
                  SubstanceGroup::setProp<bool>,
              (python::arg("self"), python::arg("key"), python::arg("val"),
               python::arg("computed") = false),
              "sets the value of a particular property")
         .def("HasProp",
-             (bool(RDProps::*)(const std::string &) const) &
+             (bool (RDProps::*)(const std::string &) const) &
                  SubstanceGroup::hasProp,
              python::args("self", "key"),
              "returns whether or not a particular property exists")
@@ -259,7 +260,7 @@ struct sgroup_wrap {
             "will be raised.\n",
             boost::python::return_value_policy<return_pyobject_passthrough>())
         .def("GetIntProp",
-             (int(RDProps::*)(const std::string &) const) &
+             (int (RDProps::*)(const std::string &) const) &
                  SubstanceGroup::getProp<int>,
              python::args("self", "key"),
              "returns the value of a particular property")
@@ -269,26 +270,27 @@ struct sgroup_wrap {
              python::args("self", "key"),
              "returns the value of a particular property")
         .def("GetDoubleProp",
-             (double(RDProps::*)(const std::string &) const) &
+             (double (RDProps::*)(const std::string &) const) &
                  SubstanceGroup::getProp<double>,
              python::args("self", "key"),
              "returns the value of a particular property")
         .def("GetBoolProp",
-             (bool(RDProps::*)(const std::string &) const) &
+             (bool (RDProps::*)(const std::string &) const) &
                  SubstanceGroup::getProp<bool>,
              python::args("self", "key"),
              "returns the value of a particular property")
-        .def(
-            "GetUnsignedVectProp",
-            (std::vector<unsigned int>(RDProps::*)(const std::string &) const) &
-                SubstanceGroup::getProp<std::vector<unsigned int>>,
-            python::args("self", "key"),
-            "returns the value of a particular property")
-        .def("GetStringVectProp",
-             (std::vector<std::string>(RDProps::*)(const std::string &) const) &
-                 SubstanceGroup::getProp<std::vector<std::string>>,
+        .def("GetUnsignedVectProp",
+             (std::vector<unsigned int> (RDProps::*)(const std::string &)
+                  const) &
+                 SubstanceGroup::getProp<std::vector<unsigned int>>,
              python::args("self", "key"),
              "returns the value of a particular property")
+        .def(
+            "GetStringVectProp",
+            (std::vector<std::string> (RDProps::*)(const std::string &) const) &
+                SubstanceGroup::getProp<std::vector<std::string>>,
+            python::args("self", "key"),
+            "returns the value of a particular property")
         .def("GetPropNames", &SubstanceGroup::getPropList,
              (python::arg("self"), python::arg("includePrivate") = false,
               python::arg("includeComputed") = false),
@@ -302,7 +304,7 @@ struct sgroup_wrap {
              "SubstanceGroup.\n"
              " n.b. some properties cannot be converted to python types.\n")
         .def("ClearProp",
-             (void(RDProps::*)(const std::string &) const) &
+             (void (RDProps::*)(const std::string &) const) &
                  SubstanceGroup::clearProp,
              python::args("self", "key"),
              "Removes a particular property (does nothing if not set).\n\n");

--- a/Code/GraphMol/Wrap/rdmolfiles.cpp
+++ b/Code/GraphMol/Wrap/rdmolfiles.cpp
@@ -64,11 +64,11 @@ std::string pyObjectToString(python::object input) {
 ROMol *MolFromSmiles(python::object ismiles, bool sanitize,
                      python::dict replDict) {
   std::map<std::string, std::string> replacements;
-  for (unsigned int i = 0;
-       i < python::extract<unsigned int>(replDict.keys().attr("__len__")());
-       ++i) {
-    replacements[python::extract<std::string>(replDict.keys()[i])] =
-        python::extract<std::string>(replDict.values()[i]);
+  const auto items = replDict.items();
+  for (unsigned int i = 0; i < python::len(items); ++i) {
+    const auto item = items[i];
+    replacements[python::extract<std::string>(item[0])] =
+        python::extract<std::string>(item[1]);
   }
   RWMol *newM;
   std::string smiles = pyObjectToString(ismiles);
@@ -83,11 +83,11 @@ ROMol *MolFromSmiles(python::object ismiles, bool sanitize,
 ROMol *MolFromSmarts(python::object ismarts, bool mergeHs,
                      python::dict replDict) {
   std::map<std::string, std::string> replacements;
-  for (unsigned int i = 0;
-       i < python::extract<unsigned int>(replDict.keys().attr("__len__")());
-       ++i) {
-    replacements[python::extract<std::string>(replDict.keys()[i])] =
-        python::extract<std::string>(replDict.values()[i]);
+  const auto items = replDict.items();
+  for (unsigned int i = 0; i < python::len(items); ++i) {
+    const auto item = items[i];
+    replacements[python::extract<std::string>(item[0])] =
+        python::extract<std::string>(item[1]);
   }
   std::string smarts = pyObjectToString(ismarts);
 
@@ -642,11 +642,12 @@ python::object addMetadataToPNGFileHelper(python::dict pymetadata,
   std::string cstr = python::extract<std::string>(fname);
 
   std::vector<std::pair<std::string, std::string>> metadata;
-  for (unsigned int i = 0;
-       i < python::extract<unsigned int>(pymetadata.keys().attr("__len__")());
-       ++i) {
-    std::string key = python::extract<std::string>(pymetadata.keys()[i]);
-    std::string val = python::extract<std::string>(pymetadata.values()[i]);
+
+  const auto items = pymetadata.items();
+  for (unsigned int i = 0; i < python::len(items); ++i) {
+    const auto item = items[i];
+    std::string key = python::extract<std::string>(item[0]);
+    std::string val = python::extract<std::string>(item[1]);
     metadata.push_back(std::make_pair(key, val));
   }
 
@@ -662,11 +663,11 @@ python::object addMetadataToPNGStringHelper(python::dict pymetadata,
   std::string cstr = python::extract<std::string>(png);
 
   std::vector<std::pair<std::string, std::string>> metadata;
-  for (unsigned int i = 0;
-       i < python::extract<unsigned int>(pymetadata.keys().attr("__len__")());
-       ++i) {
-    std::string key = python::extract<std::string>(pymetadata.keys()[i]);
-    std::string val = python::extract<std::string>(pymetadata.values()[i]);
+  const auto items = pymetadata.items();
+  for (unsigned int i = 0; i < python::len(items); ++i) {
+    const auto item = items[i];
+    std::string key = python::extract<std::string>(item[0]);
+    std::string val = python::extract<std::string>(item[1]);
     metadata.push_back(std::make_pair(key, val));
   }
 

--- a/Code/RDBoost/PySequenceHolder.h
+++ b/Code/RDBoost/PySequenceHolder.h
@@ -41,7 +41,7 @@ class PySequenceHolder {
   unsigned int size() const {
     unsigned int res = 0;
     try {
-      res = python::extract<int>(d_seq.attr("__len__")());
+      res = boost::python::len(d_seq);
     } catch (...) {
       throw_value_error("sequence does not support length query");
     }

--- a/Code/SimDivPickers/Wrap/LeaderPicker.cpp
+++ b/Code/SimDivPickers/Wrap/LeaderPicker.cpp
@@ -34,8 +34,7 @@ void LazyLeaderHelper(LeaderPicker *picker, T functor, unsigned int poolSize,
                       python::object firstPicks, RDKit::INT_VECT &res,
                       int nThreads) {
   RDKit::INT_VECT firstPickVect;
-  for (unsigned int i = 0;
-       i < python::extract<unsigned int>(firstPicks.attr("__len__")()); ++i) {
+  for (unsigned int i = 0; i < boost::python::len(firstPicks); ++i) {
     firstPickVect.push_back(python::extract<int>(firstPicks[i]));
   }
   res = picker->lazyPick(functor, poolSize, pickSize, firstPickVect, threshold,

--- a/Code/SimDivPickers/Wrap/MaxMinPicker.cpp
+++ b/Code/SimDivPickers/Wrap/MaxMinPicker.cpp
@@ -47,8 +47,7 @@ RDKit::INT_VECT MaxMinPicks(MaxMinPicker *picker, python::object distMat,
   auto *dMat = (double *)PyArray_DATA(copy);
 
   RDKit::INT_VECT firstPickVect;
-  for (unsigned int i = 0;
-       i < python::extract<unsigned int>(firstPicks.attr("__len__")()); ++i) {
+  for (unsigned int i = 0; i < boost::python::len(firstPicks); ++i) {
     firstPickVect.push_back(python::extract<int>(firstPicks[i]));
   }
   RDKit::INT_VECT res;
@@ -68,8 +67,7 @@ void LazyMaxMinHelper(MaxMinPicker *picker, T functor, unsigned int poolSize,
                       unsigned int pickSize, python::object firstPicks,
                       int seed, RDKit::INT_VECT &res, double &threshold) {
   RDKit::INT_VECT firstPickVect;
-  for (unsigned int i = 0;
-       i < python::extract<unsigned int>(firstPicks.attr("__len__")()); ++i) {
+  for (unsigned int i = 0; i < boost::python::len(firstPicks); ++i) {
     firstPickVect.push_back(python::extract<int>(firstPicks[i]));
   }
   res = picker->lazyPick(functor, poolSize, pickSize, firstPickVect, seed,

--- a/External/CoordGen/Wrap/rdCoordGen.cpp
+++ b/External/CoordGen/Wrap/rdCoordGen.cpp
@@ -25,8 +25,7 @@ namespace {
 void SetCoordMap(CoordGen::CoordGenParams *self, python::dict &coordMap) {
   self->coordMap.clear();
   python::list ks = coordMap.keys();
-  for (unsigned int i = 0;
-       i < python::extract<unsigned int>(ks.attr("__len__")()); i++) {
+  for (unsigned int i = 0; i < boost::python::len(ks); ++i) {
     unsigned int id = python::extract<unsigned int>(ks[i]);
     self->coordMap[id] = python::extract<RDGeom::Point2D>(coordMap[id]);
   }

--- a/External/FreeSASA/Wrap/rdFreeSASA.cpp
+++ b/External/FreeSASA/Wrap/rdFreeSASA.cpp
@@ -71,7 +71,7 @@ double calcSASAHelper(const RDKit::ROMol &mol, python::object radii,
 
   std::vector<double> vradii;
 
-  unsigned int sz = python::extract<unsigned int>(radii.attr("__len__")());
+  unsigned int sz = boost::python::len(radii);
   for (unsigned int i = 0; i < sz; ++i) {
     vradii.push_back(python::extract<double>(radii[i])());
   }


### PR DESCRIPTION
This refactors the Python wrappers to replace two patterns we were using in them:

- Replace `python::extract<unsigned int>(obj.attr("__len__")());`  with the shorter one `python::len(obj)`
, which might be more performant (it works on the Python object with no need to fetch the attribute and extract the value).

- Replace the pattern:
```
  for (unsigned int i = 0; i < sz; ++i) {
    something_with(obj.keys()[i])]);
    something_with(obj.values()[i])]);
  }
``` 
with 
```
  const auto items = obj.items();
  for (unsigned int i = 0; i < python::length(items); ++i) {
    const auto item = items[i];
    something_with(item[0]); // the key
    something_with(item[1]); // the value
  }
``` 
The current pattern seems inefficient because `obj.keys()` and `obj.values()` regenerate the keys and values lists on each iteration.
