### PR TITLE
Allow labeled atoms to have working queries

### DIFF
--- a/Code/GraphMol/RGroupDecomposition/RGroupCore.cpp
+++ b/Code/GraphMol/RGroupDecomposition/RGroupCore.cpp
@@ -2,7 +2,7 @@
 //  Copyright (c) 2017-2021, Novartis Institutes for BioMedical Research Inc.
 //  and other RDKit contributors
 //
-//   @@ All Rights Reserved @@
+//   @@ Alnl Rights Reserved @@
 //  This file is part of the RDKit.
 //  The contents are covered by the terms of the BSD license
 //  which is included in the file license.txt, found at the root
@@ -418,6 +418,22 @@ void RCore::buildMatchingMol() {
     // then keep one attachment
     if (atom->getAtomicNum() == 0 && atom->getDegree() == 1 &&
         isDummyRGroupAttachment(*atom)) {
+      // if we are a query in disguise, don't strip
+      if(atom->hasQuery()) {
+        auto q = atom->getQuery()->getDescription();
+	// If we are anything but AtomNull or AtomAtomicNum we are not
+	//  fully a dummy atom
+	if(q != "AtomNull" && q != "AtomAtomicNum") {
+	  unsigned int type=0xFFFFFFFF;
+	  //  If we are were set as an RLABEL of type Isotope we probably
+	  //   have a query of named "AtomIsotope"
+	  //   we DO strip these unless they are have an additional query
+	  if(!atom->getPropIfPresent(RLABEL_TYPE, type) || type != RGroupLabels::IsotopeLabels || q != "AtomIsotope") {
+	    continue;
+	  }
+	}
+      }
+      
       // remove terminal user R groups and map the index of the core neighbor
       // atom to the index of the removed terminal R group
       const int neighborIdx = *matchingMol->getAtomNeighbors(atom).first;

--- a/Code/GraphMol/RGroupDecomposition/testRGroupDecomp.cpp
+++ b/Code/GraphMol/RGroupDecomposition/testRGroupDecomp.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2017, Novartis Institutes for BioMedical Research Inc.
+//  Copyright (c) 2017, Novartis Institutes for BioMedical Research Inc.):
 //  All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -4147,13 +4147,42 @@ void testRgroupDecompZipping() {
   }
 }
 
+void testSmartsOnDummyAtoms() {
+  BOOST_LOG(rdInfoLog)
+      << "********************************************************\n";
+  BOOST_LOG(rdInfoLog)
+      << "Test we can reconstruct rgroup decomps that break rings" << std::endl;
+
+  const auto core = "[$([1C]):1]C[$([2C]):2]"_smarts;
+    
+  const auto mol1 = "N[1C]C[2C]"_smiles;
+  const auto mol2 = "N[2C]C[1C]"_smiles;
+
+  const std::vector<std::string> expected = {
+    "Core:C([*:1])[*:2] R1:N[1C][*:1] R2:[2C][*:2]",
+    "Core:C([*:1])[*:2] R1:[1C][*:1] R2:N[2C][*:2]"
+  };
+
+  RGroupDecomposition decomp(*core);
+  auto add11 = decomp.add(*mol1);
+  TEST_ASSERT(add11 == 0);
+  add11 = decomp.add(*mol2);
+  TEST_ASSERT(add11 == 1)
+  decomp.process();
+  RGroupRows rows = decomp.getRGroupsAsRows();
+  int i = 0;
+  for (RGroupRows::const_iterator it = rows.begin(); it != rows.end();
+       ++it, ++i) {
+    CHECK_RGROUP(it, expected[i]);
+  }
+}
+
 int main() {
   RDLog::InitLogs();
   boost::logging::disable_logs("rdApp.debug");
   BOOST_LOG(rdInfoLog)
       << "********************************************************\n";
   BOOST_LOG(rdInfoLog) << "Testing R-Group Decomposition \n";
-
   testSymmetryMatching(FingerprintVariance);
   testSymmetryMatching();
   testRGroupOnlyMatching();
@@ -4211,6 +4240,7 @@ int main() {
   testStereoBondBug();
   testNotEnumeratedCore();
   testRgroupDecompZipping();
+  testSmartsOnDummyAtoms();
   BOOST_LOG(rdInfoLog)
       << "********************************************************\n";
   return 0;


### PR DESCRIPTION
@greglandrum noticed an issue with labeled queries:

```
In [17]: scaff = Chem.MolFromSmarts('[a:1]CC[AR:2]')

In [18]: ms = [Chem.MolFromSmiles(smi) for smi in ('c1ccccc1CCC1CCCCC1','FC1CCCCC1CCc1ccncc1')]

In [19]: rdRGroupDecomposition.RGroupDecompose(scaff,ms,asSmiles=True)
Out[19]: 
([{'Core': 'C(C[*:2])[*:1]',
   'R1': 'c1ccc(CCC(CCC[*:2])[*:1])cc1',
   'R2': 'c1ccc(CCC(CCC[*:2])[*:1])cc1'},
  {'Core': 'C(C[*:2])[*:1]', 'R1': 'c1cc([*:1])ccn1', 'R2': 'FC1CCCCC1[*:2]'}],
 [])
```

This happens because the buildMolMatch code strips out dummy atoms and doesn't properly check for atom queries.

The fix is a bit annoying since we have atom labels which can be isotopes which are converted to queries and need to be removed.  This fix takes care of most of the corner cases but leaves dummy atoms that have non-dummy queries on them.

An easier test case is the following which doesn't properly match the isotopes in the output

```
>>> scaffold = Chem.MolFromSmarts("[$([1C]):1]C[$([2C]):2]")
>>> rgd.RGroupDecompose(scaffold, [Chem.MolFromSmiles(s) for s in ["N[1C]C[2C]", "N[2C]C[1C]"]], asSmiles=True)
([{'Core': 'C([*:1])[*:2]', 'R1': '[2C][*:1]', 'R2': 'N[1C][*:2]'},
  {'Core': 'C([*:1])[*:2]', 'R1': '[1C][*:1]', 'R2': 'N[2C][*:2]'}],
 [])
```






