### PR TITLE
Homogenize maxAttempts / maxIterations documentation

### DIFF
--- a/Code/GraphMol/DistGeomHelpers/Wrap/rdDistGeom.cpp
+++ b/Code/GraphMol/DistGeomHelpers/Wrap/rdDistGeom.cpp
@@ -331,7 +331,7 @@ BOOST_PYTHON_MODULE(rdDistGeom) {
  \n\
  ARGUMENTS:\n\n\
     - mol : the molecule of interest\n\
-    - maxAttempts : the maximum number of attempts to try embedding \n\
+    - maxAttempts : maximum number of embedding attempts to use for a single conformation \n\
     - randomSeed : provide a seed for the random number generator \n\
                    so that the same coordinates can be obtained \n\
                    for a molecule on multiple runs. If -1, the \n\
@@ -394,7 +394,7 @@ BOOST_PYTHON_MODULE(rdDistGeom) {
  ARGUMENTS:\n\n\
   - mol : the molecule of interest\n\
   - numConfs : the number of conformers to generate \n\
-  - maxAttempts : the maximum number of attempts to try embedding \n\
+  - maxAttempts : maximum number of embedding attempts to use for a single conformation \n\
   - randomSeed : provide a seed for the random number generator \n\
                  so that the same coordinates can be obtained \n\
                  for a molecule on multiple runs. If -1, the \n\


### PR DESCRIPTION
Related to #8807.

Copying the docstring of `maxIterations` in `EmbedParameters` to `maxAttempts` in `EmbedMolecule` and `EmbedMultipleConfs` since both of them accomplish exactly the same, but are unfortunately named different.
