### PR TITLE
Propagate using string_view as property names

### DIFF
--- a/Code/GraphMol/ChemReactions/PreprocessRxn.cpp
+++ b/Code/GraphMol/ChemReactions/PreprocessRxn.cpp
@@ -40,7 +40,8 @@
 
 namespace RDKit {
 
-bool preprocessReaction(ChemicalReaction &rxn, const std::string &propName) {
+bool preprocessReaction(ChemicalReaction &rxn,
+                        const std::string_view &propName) {
   const bool normalized = true;
   return preprocessReaction(
       rxn, GetFlattenedFunctionalGroupHierarchy(normalized), propName);
@@ -50,7 +51,7 @@ bool preprocessReaction(
     ChemicalReaction &rxn, unsigned int &numWarnings, unsigned int &numErrors,
     std::vector<std::vector<std::pair<unsigned int, std::string>>>
         &reactantLabels,
-    const std::string &propName) {
+    const std::string_view &propName) {
   const bool normalized = true;
   return preprocessReaction(rxn, numWarnings, numErrors, reactantLabels,
                             GetFlattenedFunctionalGroupHierarchy(normalized),
@@ -59,7 +60,7 @@ bool preprocessReaction(
 
 bool preprocessReaction(ChemicalReaction &rxn,
                         const std::map<std::string, ROMOL_SPTR> &queries,
-                        const std::string &propName) {
+                        const std::string_view &propName) {
   unsigned int numWarnings, numErrors;
   std::vector<std::vector<std::pair<unsigned int, std::string>>> reactantLabels;
 
@@ -72,7 +73,7 @@ bool preprocessReaction(
     std::vector<std::vector<std::pair<unsigned int, std::string>>>
         &reactantLabels,
     const std::map<std::string, ROMOL_SPTR> &queries,
-    const std::string &propName) {
+    const std::string_view &propName) {
   rxn.setImplicitPropertiesFlag(true);
   rxn.initReactantMatchers();
 

--- a/Code/GraphMol/ChemReactions/PreprocessRxn.h
+++ b/Code/GraphMol/ChemReactions/PreprocessRxn.h
@@ -35,30 +35,31 @@
 
 #include "Reaction.h"
 #include <string>
+#include <string_view>
 #include <exception>
 
 namespace RDKit {
 
 RDKIT_CHEMREACTIONS_EXPORT bool preprocessReaction(
     ChemicalReaction &rxn,
-    const std::string &propName = common_properties::molFileValue);
+    const std::string_view &propName = common_properties::molFileValue);
 
 RDKIT_CHEMREACTIONS_EXPORT bool preprocessReaction(
     ChemicalReaction &rxn, unsigned int &numWarnings, unsigned int &numErrors,
     std::vector<std::vector<std::pair<unsigned int, std::string>>>
         &reactantLabels,
-    const std::string &propName = common_properties::molFileValue);
+    const std::string_view &propName = common_properties::molFileValue);
 
 RDKIT_CHEMREACTIONS_EXPORT bool preprocessReaction(
     ChemicalReaction &rxn, const std::map<std::string, ROMOL_SPTR> &queries,
-    const std::string &propName = common_properties::molFileValue);
+    const std::string_view &propName = common_properties::molFileValue);
 
 RDKIT_CHEMREACTIONS_EXPORT bool preprocessReaction(
     ChemicalReaction &rxn, unsigned int &numWarnings, unsigned int &numErrors,
     std::vector<std::vector<std::pair<unsigned int, std::string>>>
         &reactantLabels,
     const std::map<std::string, ROMOL_SPTR> &queries,
-    const std::string &propName = common_properties::molFileValue);
+    const std::string_view &propName = common_properties::molFileValue);
 }  // namespace RDKit
 
 #endif

--- a/Code/GraphMol/ChemReactions/Reaction.cpp
+++ b/Code/GraphMol/ChemReactions/Reaction.cpp
@@ -448,7 +448,7 @@ bool isMoleculeAgentOfReaction(const ChemicalReaction &rxn, const ROMol &mol) {
 
 void addRecursiveQueriesToReaction(
     ChemicalReaction &rxn, const std::map<std::string, ROMOL_SPTR> &queries,
-    const std::string &propName,
+    const std::string_view &propName,
     std::vector<std::vector<std::pair<unsigned int, std::string>>>
         *reactantLabels) {
   if (!rxn.isInitialized()) {

--- a/Code/GraphMol/ChemReactions/Reaction.h
+++ b/Code/GraphMol/ChemReactions/Reaction.h
@@ -39,6 +39,7 @@
 #include <GraphMol/RDKitBase.h>
 #include <RDGeneral/RDProps.h>
 #include <GraphMol/Substruct/SubstructMatch.h>
+#include <string_view>
 #include <vector>
 
 namespace RDKit {
@@ -468,7 +469,7 @@ getReactingAtoms(const ChemicalReaction &rxn, bool mappedAtomsOnly = false);
  */
 RDKIT_CHEMREACTIONS_EXPORT void addRecursiveQueriesToReaction(
     ChemicalReaction &rxn, const std::map<std::string, ROMOL_SPTR> &queries,
-    const std::string &propName,
+    const std::string_view &propName,
     std::vector<std::vector<std::pair<unsigned int, std::string>>>
         *reactantLabels = nullptr);
 

--- a/Code/GraphMol/ChemReactions/SanitizeRxn.cpp
+++ b/Code/GraphMol/ChemReactions/SanitizeRxn.cpp
@@ -40,7 +40,7 @@ namespace RxnOps {
 // molFileRLabel ==> unsigned int
 namespace {
 template <class T>
-T getMaxProp(ChemicalReaction &rxn, const std::string &prop) {
+T getMaxProp(ChemicalReaction &rxn, const std::string_view &prop) {
   T max_atom = (T)0;
   for (auto it = rxn.beginReactantTemplates(); it != rxn.endReactantTemplates();
        ++it) {

--- a/Code/GraphMol/ChemTransforms/ChemTransforms.cpp
+++ b/Code/GraphMol/ChemTransforms/ChemTransforms.cpp
@@ -891,7 +891,7 @@ ROMol *combineMols(const ROMol &mol1, const ROMol &mol2,
 
 void addRecursiveQueries(
     ROMol &mol, const std::map<std::string, ROMOL_SPTR> &queries,
-    const std::string &propName,
+    const std::string_view &propName,
     std::vector<std::pair<unsigned int, std::string>> *reactantLabels) {
   std::string delim = ",";
   boost::char_separator<char> sep(delim.c_str());

--- a/Code/GraphMol/ChemTransforms/ChemTransforms.h
+++ b/Code/GraphMol/ChemTransforms/ChemTransforms.h
@@ -12,6 +12,7 @@
 #define _RD_CHEMTRANSFORMS_H__
 
 #include <boost/smart_ptr.hpp>
+#include <string_view>
 #include <vector>
 
 #include <GraphMol/Substruct/SubstructMatch.h>
@@ -228,7 +229,7 @@ RDKIT_CHEMTRANSFORMS_EXPORT ROMol *combineMols(
 */
 RDKIT_CHEMTRANSFORMS_EXPORT void addRecursiveQueries(
     ROMol &mol, const std::map<std::string, ROMOL_SPTR> &queries,
-    const std::string &propName,
+    const std::string_view &propName,
     std::vector<std::pair<unsigned int, std::string>> *reactantLabels =
         nullptr);
 

--- a/Code/GraphMol/FragCatalog/FragCatalogEntry.h
+++ b/Code/GraphMol/FragCatalog/FragCatalogEntry.h
@@ -21,6 +21,7 @@
 #include <GraphMol/Substruct/SubstructMatch.h>
 #include <map>
 #include <sstream>
+#include <string_view>
 
 namespace RDKit {
 
@@ -67,51 +68,35 @@ class RDKIT_FRAGCATALOG_EXPORT FragCatalogEntry
 
   // FUnctions on the property dictionary
   template <typename T>
-  void setProp(const char *key, T &val) const {
+  void setProp(const std::string_view &key, T &val) const {
+    dp_props->setVal(key, val);
+  }
+
+  void setProp(const std::string_view &key, int val) const {
+    dp_props->setVal(key, val);
+  }
+
+  void setProp(const std::string_view &key, float val) const {
+    dp_props->setVal(key, val);
+  }
+
+  void setProp(const std::string_view &key, std::string &val) const {
     dp_props->setVal(key, val);
   }
 
   template <typename T>
-  void setProp(const std::string &key, T &val) const {
-    setProp(key.c_str(), val);
-  }
-
-  void setProp(const char *key, int val) const { dp_props->setVal(key, val); }
-
-  void setProp(const std::string &key, int val) const {
-    setProp(key.c_str(), val);
-  }
-
-  void setProp(const char *key, float val) const { dp_props->setVal(key, val); }
-
-  void setProp(const std::string &key, float val) const {
-    setProp(key.c_str(), val);
-  }
-
-  void setProp(const std::string &key, std::string &val) const {
-    setProp(key.c_str(), val);
-  }
-
-  template <typename T>
-  void getProp(const char *key, T &res) const {
+  void getProp(const std::string_view &key, T &res) const {
     dp_props->getVal(key, res);
   }
-  template <typename T>
-  void getProp(const std::string &key, T &res) const {
-    getProp(key.c_str(), res);
-  }
 
-  bool hasProp(const char *key) const {
+  bool hasProp(const std::string_view &key) const {
     if (!dp_props) {
       return false;
     }
     return dp_props->hasVal(key);
   }
-  bool hasProp(const std::string &key) const { return hasProp(key.c_str()); }
 
-  void clearProp(const char *key) const { dp_props->clearVal(key); }
-
-  void clearProp(const std::string &key) const { clearProp(key.c_str()); }
+  void clearProp(const std::string_view &key) const { dp_props->clearVal(key); }
 
   void toStream(std::ostream &ss) const override;
   std::string Serialize() const override;

--- a/Code/GraphMol/MolOps.cpp
+++ b/Code/GraphMol/MolOps.cpp
@@ -1001,7 +1001,8 @@ int getFormalCharge(const ROMol &mol) {
   return accum;
 };
 
-unsigned getNumAtomsWithDistinctProperty(const ROMol &mol, std::string prop) {
+unsigned getNumAtomsWithDistinctProperty(const ROMol &mol,
+                                         const std::string_view &prop) {
   unsigned numPropAtoms = 0;
   for (const auto atom : mol.atoms()) {
     if (atom->hasProp(prop)) {

--- a/Code/GraphMol/MolOps.h
+++ b/Code/GraphMol/MolOps.h
@@ -1203,7 +1203,7 @@ RDKIT_GRAPHMOL_EXPORT void assignChiralTypesFromMolParity(
 
 //! returns the number of atoms which have a particular property set
 RDKIT_GRAPHMOL_EXPORT unsigned getNumAtomsWithDistinctProperty(
-    const ROMol &mol, std::string prop);
+    const ROMol &mol, const std::string_view &prop);
 
 //! returns whether or not a molecule needs to have Hs added to it.
 RDKIT_GRAPHMOL_EXPORT bool needsHs(const ROMol &mol);

--- a/Code/GraphMol/MolPickler.cpp
+++ b/Code/GraphMol/MolPickler.cpp
@@ -120,10 +120,10 @@ void MolPickler::_pickleProperties(std::ostream &ss, const RDProps &props,
 
 namespace {
 
-template <typename SAVEAS, typename STOREAS>
-void unpickleExplicitProperties(
-    std::istream &ss, RDProps &props, int version,
-    const std::vector<std::pair<std::string, std::uint16_t>> &explicitProps) {
+template <typename SAVEAS, typename STOREAS, typename EXPLICIT>
+inline void unpickleExplicitProperties(std::istream &ss, RDProps &props,
+                                       int version,
+                                       const EXPLICIT &explicitProps) {
   if (version >= 14000) {
     std::uint8_t bprops;
     streamRead(ss, bprops, version);
@@ -137,10 +137,9 @@ void unpickleExplicitProperties(
   }
 }
 
-template <typename SAVEAS>
-bool pickleExplicitProperties(
-    std::ostream &ss, const RDProps &props,
-    const std::vector<std::pair<std::string, std::uint16_t>> &explicitProps) {
+template <typename SAVEAS, typename EXPLICIT>
+inline bool pickleExplicitProperties(std::ostream &ss, const RDProps &props,
+                                     const EXPLICIT &explicitProps) {
   std::uint8_t bprops = 0;
   std::vector<SAVEAS> ps;
   SAVEAS bv;
@@ -166,24 +165,24 @@ class PropTracker {
   // this is stored as bitflags in a byte, so don't exceed 8 entries or we need
   // to update the pickle format.
   // the properties themselves are stored as std::int8_t
-  const std::vector<std::pair<std::string, std::uint16_t>> explicitBondProps = {
+  std::array<std::pair<std::string, std::uint16_t>, 5> explicitBondProps{{
       {RDKit::common_properties::_MolFileBondType, 0x1},
       {RDKit::common_properties::_MolFileBondStereo, 0x2},
       {RDKit::common_properties::_MolFileBondCfg, 0x4},
       {RDKit::common_properties::_MolFileBondQuery, 0x8},
       {RDKit::common_properties::molStereoCare, 0x10},
-  };
+  }};
   // this is stored as bitflags in a byte, so don't exceed 8 entries or we need
   // to update the pickle format.
   // the properties themselves are stored as std::int16_t
-  const std::vector<std::pair<std::string, std::uint16_t>> explicitAtomProps = {
+  std::array<std::pair<std::string, std::uint16_t>, 4> explicitAtomProps{{
       {common_properties::molStereoCare, 0x1},
       {common_properties::molParity, 0x2},
       {common_properties::molInversionFlag, 0x4},
       {common_properties::_ChiralityPossible, 0x8},
 
-  };
-  const std::vector<std::string> ignoreAtomProps = {
+  }};
+  std::array<std::string, 2> ignoreAtomProps{
       common_properties::molAtomMapNumber,
       common_properties::dummyLabel,
   };

--- a/Code/RDGeneral/RDProps.h
+++ b/Code/RDGeneral/RDProps.h
@@ -48,7 +48,7 @@ class RDProps {
     STR_VECT res, computed;
     if (!includeComputed &&
         getPropIfPresent(RDKit::detail::computedPropName, computed)) {
-      computed.push_back(RDKit::detail::computedPropName);
+      computed.emplace_back(RDKit::detail::computedPropName);
     }
 
     auto pos = tmp.begin();
@@ -57,7 +57,7 @@ class RDProps {
           std::find(computed.begin(), computed.end(), *pos) == computed.end()) {
         res.push_back(*pos);
       }
-      pos++;
+      ++pos;
     }
     return res;
   }


### PR DESCRIPTION
This is a follow up  to https://github.com/rdkit/rdkit/pull/8844, and another required step towards https://github.com/rdkit/rdkit/pull/8765

The changes to the templates in `Code/GraphMol/MolPickler.cpp` and the arrays in `Code/GraphMol/SmilesParse/CXSmilesOps.cpp` are in preparation to make these arrays `constexpr` when the property names they hold get turned into `std::String_view` in the final commit in this series.