### PR TITLE
use bond labels in the ranking in MolFragmentToSmiles

### DIFF
--- a/Code/GraphMol/SmilesParse/SmilesWrite.cpp
+++ b/Code/GraphMol/SmilesParse/SmilesWrite.cpp
@@ -964,9 +964,12 @@ std::string MolFragmentToSmiles(const ROMol &mol,
   }
   if (params.canonical) {
     bool breakTies = true;
-    Canon::rankFragmentAtoms(tmol, ranks, atomsInPlay, bondsInPlay, atomSymbols,
-                             breakTies, params.doIsomericSmiles,
-                             params.doIsomericSmiles);
+    bool includeChiralPresence = false;
+    bool includeRingStereo = true;
+    Canon::rankFragmentAtoms(
+        tmol, ranks, atomsInPlay, bondsInPlay, atomSymbols, bondSymbols,
+        breakTies, params.doIsomericSmiles, params.doIsomericSmiles,
+        !params.ignoreAtomMapNumbers, includeChiralPresence, includeRingStereo);
     // std::cerr << "RANKS: ";
     // std::copy(ranks.begin(), ranks.end(),
     //           std::ostream_iterator<int>(std::cerr, " "));

--- a/Code/GraphMol/SmilesParse/catch_tests.cpp
+++ b/Code/GraphMol/SmilesParse/catch_tests.cpp
@@ -2824,8 +2824,9 @@ TEST_CASE("Test rootedAtAtom argument", "[smarts]") {
     ps.rootedAtAtom = 20;
 
     // Fixed by #8328. Multiple fragments are supported now.
-    CHECK(MolToSmiles(*mol1, ps) ==
-          "CCOc1c(Cl)c(C(=O)[O-])c(Cl)c(OCC)c1C(=O)[O-].O=C([O-])C#CC#CC(=O)[O-].[Zn][Zn]");
+    CHECK(
+        MolToSmiles(*mol1, ps) ==
+        "CCOc1c(Cl)c(C(=O)[O-])c(Cl)c(OCC)c1C(=O)[O-].O=C([O-])C#CC#CC(=O)[O-].[Zn][Zn]");
   }
 }
 
@@ -3181,47 +3182,49 @@ TEST_CASE("DnaTestError", "DnaTestError") {
   }
 }
 
-TEST_CASE("Github 8328", "MolToSmiles with rootedAtAtom for multiple fragments") {
-    SECTION("basics") {
-        auto mol = "[C:1][C:2].[N:3]([C:4])=[O:5]"_smiles;
-        auto ps = SmilesWriteParams();
-        ps.rootedAtAtom = 0;
-        CHECK(MolToSmiles(*mol, ps) == "[C:1][C:2].[N:3]([C:4])=[O:5]");
-        ps.rootedAtAtom = 1;
-        CHECK(MolToSmiles(*mol, ps) == "[C:2][C:1].[N:3]([C:4])=[O:5]");
-        ps.rootedAtAtom = 2;
-        CHECK(MolToSmiles(*mol, ps) == "[C:1][C:2].[N:3]([C:4])=[O:5]");
-        ps.rootedAtAtom = 3;
-        CHECK(MolToSmiles(*mol, ps) == "[C:1][C:2].[C:4][N:3]=[O:5]");
-        ps.rootedAtAtom = 4;
-        CHECK(MolToSmiles(*mol, ps) == "[C:1][C:2].[O:5]=[N:3][C:4]");
-        ps.rootedAtAtom = 5;
-        CHECK_THROWS_AS(MolToSmiles(*mol, ps), Invar::Invariant);
-    }
-    SECTION("Compare with and without canonicalization") {
-        auto mol = "[Al+3].[Na+2].[O-]S(=O)(=O)[O-].CC(=O)OCC.NC(=O)Cc1ccccc1"_smiles;
-        auto ps = SmilesWriteParams();
+TEST_CASE("Github 8328",
+          "MolToSmiles with rootedAtAtom for multiple fragments") {
+  SECTION("basics") {
+    auto mol = "[C:1][C:2].[N:3]([C:4])=[O:5]"_smiles;
+    auto ps = SmilesWriteParams();
+    ps.rootedAtAtom = 0;
+    CHECK(MolToSmiles(*mol, ps) == "[C:1][C:2].[N:3]([C:4])=[O:5]");
+    ps.rootedAtAtom = 1;
+    CHECK(MolToSmiles(*mol, ps) == "[C:2][C:1].[N:3]([C:4])=[O:5]");
+    ps.rootedAtAtom = 2;
+    CHECK(MolToSmiles(*mol, ps) == "[C:1][C:2].[N:3]([C:4])=[O:5]");
+    ps.rootedAtAtom = 3;
+    CHECK(MolToSmiles(*mol, ps) == "[C:1][C:2].[C:4][N:3]=[O:5]");
+    ps.rootedAtAtom = 4;
+    CHECK(MolToSmiles(*mol, ps) == "[C:1][C:2].[O:5]=[N:3][C:4]");
+    ps.rootedAtAtom = 5;
+    CHECK_THROWS_AS(MolToSmiles(*mol, ps), Invar::Invariant);
+  }
+  SECTION("Compare with and without canonicalization") {
+    auto mol =
+        "[Al+3].[Na+2].[O-]S(=O)(=O)[O-].CC(=O)OCC.NC(=O)Cc1ccccc1"_smiles;
+    auto ps = SmilesWriteParams();
 
-        ps.canonical = true;
-        ps.rootedAtAtom = -1;
-        CHECK(MolToSmiles(*mol, ps) ==
-              "CCOC(C)=O.NC(=O)Cc1ccccc1.O=S(=O)([O-])[O-].[Al+3].[Na+2]");
+    ps.canonical = true;
+    ps.rootedAtAtom = -1;
+    CHECK(MolToSmiles(*mol, ps) ==
+          "CCOC(C)=O.NC(=O)Cc1ccccc1.O=S(=O)([O-])[O-].[Al+3].[Na+2]");
 
-        ps.canonical = true;
-        ps.rootedAtAtom = 10;
-        CHECK(MolToSmiles(*mol, ps) ==
-              "NC(=O)Cc1ccccc1.O(CC)C(C)=O.O=S(=O)([O-])[O-].[Al+3].[Na+2]");
+    ps.canonical = true;
+    ps.rootedAtAtom = 10;
+    CHECK(MolToSmiles(*mol, ps) ==
+          "NC(=O)Cc1ccccc1.O(CC)C(C)=O.O=S(=O)([O-])[O-].[Al+3].[Na+2]");
 
-        ps.canonical = true;
-        ps.rootedAtAtom = 21;
-        CHECK(MolToSmiles(*mol, ps) ==
-              "CCOC(C)=O.O=S(=O)([O-])[O-].[Al+3].[Na+2].c1cccc(CC(N)=O)c1");
+    ps.canonical = true;
+    ps.rootedAtAtom = 21;
+    CHECK(MolToSmiles(*mol, ps) ==
+          "CCOC(C)=O.O=S(=O)([O-])[O-].[Al+3].[Na+2].c1cccc(CC(N)=O)c1");
 
-        ps.canonical = false;
-        ps.rootedAtAtom = 21;
-        CHECK(MolToSmiles(*mol, ps) ==
-              "[Al+3].[Na+2].[O-]S(=O)(=O)[O-].CC(=O)OCC.c1cccc(CC(N)=O)c1");
-    }
+    ps.canonical = false;
+    ps.rootedAtAtom = 21;
+    CHECK(MolToSmiles(*mol, ps) ==
+          "[Al+3].[Na+2].[O-]S(=O)(=O)[O-].CC(=O)OCC.c1cccc(CC(N)=O)c1");
+  }
 }
 
 TEST_CASE("atoms bound to metals should always have Hs specified") {
@@ -3301,5 +3304,23 @@ TEST_CASE(
     auto smi = MolToCXSmiles(*m, ps, cxFlags);
     CHECK(smi ==
           "O=C(N[C@H]1C[C@@H](C(=O)O)[C@@H]2C[C@@H]21)C1CC(=O)N(Cc2ccccn2)C1");
+  }
+}
+
+TEST_CASE("bond labels not being used in fragment canonicalization") {
+  SECTION("as reported") {
+    auto m1 = "CCC"_smiles;
+    REQUIRE(m1);
+    std::vector<std::string> bondLabels = {"A", "B"};
+    std::vector<std::string> bondLabels2 = {"B", "A"};
+    std::vector<int> atoms = {0, 1, 2};
+    std::vector<int> bonds = {0, 1};
+    SmilesWriteParams ps;
+    std::vector<std::string> *atomLabels = nullptr;
+    auto smi1 =
+        MolFragmentToSmiles(*m1, ps, atoms, &bonds, atomLabels, &bondLabels);
+    auto smi2 =
+        MolFragmentToSmiles(*m1, ps, atoms, &bonds, atomLabels, &bondLabels2);
+    CHECK(smi1 == smi2);
   }
 }

--- a/Code/GraphMol/SmilesParse/test.cpp
+++ b/Code/GraphMol/SmilesParse/test.cpp
@@ -3208,7 +3208,7 @@ void testFragmentSmiles() {
     std::string csmiles =
         MolFragmentToSmiles(*m, atomsToUse, nullptr, nullptr, &bondLabels);
     std::cerr << csmiles << std::endl;
-    TEST_ASSERT(csmiles == "CaC(bC)aC" || csmiles == "CbC(ac)ac");
+    TEST_ASSERT(csmiles == "CaC(aC)bC");
     delete m;
   }
   {
@@ -3223,7 +3223,7 @@ void testFragmentSmiles() {
     std::string csmiles =
         MolFragmentToSmiles(*m, atomsToUse, nullptr, nullptr, &bondLabels);
     std::cerr << csmiles << std::endl;
-    TEST_ASSERT(csmiles == "CaC(bC)bC" || csmiles == "CbC(bC)aC");
+    TEST_ASSERT(csmiles == "CbC(aC)bC");
     delete m;
   }
   {


### PR DESCRIPTION
The user-provided bond labels were not being used in the canonical ranking in `MolFragmentToSmiles()`

This one has been there for a while

catch_tests.cpp has some clang-format changes in it too.