### PR TITLE
Do not add explicit Hs in assignChiralTypesFromMolParity

### DIFF
--- a/Code/GraphMol/Chirality.cpp
+++ b/Code/GraphMol/Chirality.cpp
@@ -2999,10 +2999,10 @@ void findPotentialStereoBonds(ROMol &mol, bool cleanIt) {
               }
             }  // end of check that beg and end atoms have at least 1
                // neighbor:
-          }  // end of 2 and 3 coordinated atoms only
-        }  // end of we want it or CIP code is not set
-      }  // end of double bond
-    }  // end of for loop over all bonds
+          }    // end of 2 and 3 coordinated atoms only
+        }      // end of we want it or CIP code is not set
+      }        // end of double bond
+    }          // end of for loop over all bonds
     mol.setProp(common_properties::_BondsPotentialStereo, 1, true);
   }
 }
@@ -3525,14 +3525,6 @@ void assignChiralTypesFromMolParity(ROMol &mol, bool replaceExistingTags) {
     atom->setChiralTag(chiralTypeVect[parity]);
     if (atom->needsUpdatePropertyCache()) {
       atom->updatePropertyCache(false);
-    }
-    // within the RD representation, if a three-coordinate atom
-    // is chiral and has an implicit H, that H needs to be made explicit:
-    if (atom->getDegree() == 3 && !atom->getNumExplicitHs() &&
-        atom->getNumImplicitHs() == 1) {
-      atom->setNumExplicitHs(1);
-      // recalculated number of implicit Hs:
-      atom->updatePropertyCache();
     }
   }
 }


### PR DESCRIPTION
I'm not sure why we need(ed?) this. It was done a LONG time ago in https://github.com/rdkit/rdkit/pull/2863.

Setting these explicit Hs cause some problems with undoing changes in https://github.com/schrodinger/sketcher, so it would be nice if we could drop this.  I removed it locally, and tried playing a bit, and couldn't find any problems due to doing it.