### PR TITLE
Use adjustQueryProperties logic when dealing with dummy atoms in cxsm…

### DIFF
--- a/Code/GraphMol/SmilesParse/CXSmilesOps.cpp
+++ b/Code/GraphMol/SmilesParse/CXSmilesOps.cpp
@@ -100,7 +100,7 @@ void processCXSmilesLabels(RWMol &mol) {
                       symb.substr(0, symb.size() - 2));
         atom->clearProp(common_properties::atomLabel);
       }
-    } else if (atom->getAtomicNum() == 0 && !atom->hasQuery() &&
+    } else if (atom->getAtomicNum() == 0 && !atom->hasQuery() && !atom->getIsotope() &&
                atom->getSymbol() == "*") {
       addquery(makeAAtomQuery(), "", mol, atom->getIdx());
     }

--- a/Code/GraphMol/SmilesParse/catch_tests.cpp
+++ b/Code/GraphMol/SmilesParse/catch_tests.cpp
@@ -3324,3 +3324,15 @@ TEST_CASE("bond labels not being used in fragment canonicalization") {
     CHECK(smi1 == smi2);
   }
 }
+
+TEST_CASE("github #8906") {
+  SECTION("as reported") {
+    auto m = "[1*][2C] ||"_smiles;
+    REQUIRE(m);
+    CHECK(m->getAtomWithIdx(0)->getIsotope() == 1);
+    CHECK(m->getAtomWithIdx(1)->getIsotope() == 2);
+    auto csmi1 = MolToSmiles(*m);
+    CHECK(csmi1 == "[1*][2C]");
+
+  }
+}


### PR DESCRIPTION
Fixes #8906 and, by extension, #8898