### PR TITLE
Ignore whitespace when patching RapidJSON

### DIFF
--- a/Code/GraphMol/MolInterchange/CMakeLists.txt
+++ b/Code/GraphMol/MolInterchange/CMakeLists.txt
@@ -10,7 +10,7 @@ if(NOT EXISTS "${RDKit_ExternalDir}/rapidjson/rapidjson-1.1.0")
     # (based on the change which has already been applied to the RapidJSON master branch, see
     # https://github.com/Tencent/rapidjson/blob/24b5e7a8b27f42fa16b96fc70aade9106cf7102f/include/rapidjson/document.h#L414
     # and https://patch-diff.githubusercontent.com/raw/Tencent/rapidjson/pull/1698.diff
-    execute_process(COMMAND git --git-dir= apply
+    execute_process(COMMAND git --git-dir= apply --ignore-whitespace
       ${RDKit_ExternalDir}/rapidjson/patch-rapidjson-1.1.0.diff
       WORKING_DIRECTORY ${RDKit_ExternalDir}/rapidjson)
 else()


### PR DESCRIPTION
This is not strictly necessary, but it seems this patch can fail on Windows under certain circumstances, e.g. the workers that run the CI in https://github.com/schrodinger/sketcher/pull/138