### PR TITLE
Fix for issue with deprecated boost functions for MacOS build from source

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,12 +16,6 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_C_STANDARD 99)
 set(CMAKE_C_STANDARD_REQUIRED ON)
 
-# fix for _unary_functions error on macos
-if (APPLE)
-  add_compile_definitions(_LIBCPP_ENABLE_CXX17_REMOVED_UNARY_BINARY_FUNCTION)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-enum-constexpr-conversion")
-endif()
-
 set(CMAKE_MODULE_PATH
     ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/Code/cmake/Modules/")
 
@@ -273,7 +267,8 @@ endif()
 if(MINGW)
   target_compile_definitions(rdkit_base INTERFACE "-DBOOST_SYSTEM_NO_DEPRECATED")
 endif(MINGW)
-if (CMAKE_COMPILER_IS_CLANG OR CMAKE_COMPILER_IS_EMCC)
+# fallback on match to "Clang" where CMAKE_C_COMPILER=/usr/bin/cc
+if (CMAKE_COMPILER_IS_CLANG OR CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_COMPILER_IS_EMCC)
   if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 15)
     target_compile_definitions(rdkit_base INTERFACE -DBOOST_SYSTEM_NO_DEPRECATED -DBOOST_NO_CXX98_FUNCTION_BASE -D_HAS_AUTO_PTR_ETC=0)
     target_compile_options(rdkit_base INTERFACE -Wno-deprecated-builtins -Wno-deprecated-non-prototype -Wno-unused-parameter)


### PR DESCRIPTION
#### Reference Issue
#6859 Build failure on MacOS due to deprecated Boost functions


#### What does this implement/fix? Explain your changes.

I found I was having issues with build from source on MacOS 26.0.1 that have cropped up [previously](https://github.com/rdkit/rdkit/discussions/6859) with the deprecated unary and binary boost functions. 

```
In file included from /Users/rachaelpirie/rdkit/Code/GraphMol/Canon.cpp:18:
/Users/rachaelpirie/rdkit/Code/RDGeneral/hash/hash.hpp:402:1: error: no template named 'unary_function' in namespace 'boost::functional::detail'; did you mean '__unary_function'?
  402 | BOOST_HASH_SPECIALIZE(signed char)
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/rachaelpirie/rdkit/Code/RDGeneral/hash/hash.hpp:344:43: note: expanded from macro 'BOOST_HASH_SPECIALIZE'
  344 |       : public boost::functional::detail::unary_function<type,                 \
      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~^
/Users/rachaelpirie/miniconda3/envs/rdkit-source/include/boost/functional.hpp:45:24: note: '__unary_function' declared here
   45 |             using std::unary_function;
      |                        ^
fatal error: too many errors emitted, stopping now [-ferror-limit=]
```

It might just be how my machine is set up, but the line in the current CMakeLists.txt that should mitigate for this doesn't detect clang:

```
string(REGEX MATCH "clang" CMAKE_COMPILER_IS_CLANG "${CMAKE_C_COMPILER}")
```

${CMAKE_C_COMPILER}=/usr/bin/cc so CMAKE_COMPILER_IS_CLANG=false and the options set in lines 273/274 are missed. I think checking CMAKE_COMPILER_IS_CLANG OR CMAKE_CXX_COMPILER_ID MATCHES "Clang" is more robust




