### PR TITLE
Allow abbreviations without XBonds

### DIFF
--- a/Code/GraphMol/Abbreviations/Abbreviations.h
+++ b/Code/GraphMol/Abbreviations/Abbreviations.h
@@ -28,6 +28,8 @@ struct RDKIT_ABBREVIATIONS_EXPORT AbbreviationDefinition {
   std::string smarts;
   std::shared_ptr<ROMol> mol;                  //!< optional
   std::vector<unsigned int> extraAttachAtoms;  //!< optional
+  bool includesXBonds = true;  //! whether or not the abbreviation definition
+                               //! includes bonds to non-abbreviation atoms
   bool operator==(const AbbreviationDefinition &other) const {
     return label == other.label && displayLabel == other.displayLabel &&
            displayLabelW == other.displayLabelW && smarts == other.smarts;

--- a/Code/GraphMol/Abbreviations/Wrap/rdAbbreviations.cpp
+++ b/Code/GraphMol/Abbreviations/Wrap/rdAbbreviations.cpp
@@ -69,7 +69,11 @@ BOOST_PYTHON_MODULE(rdAbbreviations) {
                      "the label in a drawing when the bond comes from the west")
       .def_readwrite(
           "mol", &Abbreviations::AbbreviationDefinition::mol,
-          "the query molecule (should have a dummy as the first atom)");
+          "the query molecule (should have a dummy as the first atom if includesXBonds is true)")
+      .def_readwrite("includesXBonds",
+                     &Abbreviations::AbbreviationDefinition::includesXBonds,
+                     "whether or not the abbreviation definition includes "
+                     "bonds to non-abbreviation atoms");
 
   python::def("GetDefaultAbbreviations",
               &Abbreviations::Utils::getDefaultAbbreviations,


### PR DESCRIPTION
This corresponds to a group that is entirely replaced.
The example from #8902 is:
```
ACID.mol
ChemDraw10242518152D

  0  0  0     0  0            999 V3000
M  V30 BEGIN CTAB
M  V30 COUNTS 4 3 1 0 0
M  V30 BEGIN ATOM
M  V30 1 N 0.000000 -0.206250 0.000000 0  CHG=1
M  V30 2 O 0.714471 -0.618750 0.000000 0  CHG=-1
M  V30 3 O 0.000000 0.618750 0.000000 0
M  V30 4 O -0.714471 -0.618750 0.000000 0
M  V30 END ATOM
M  V30 BEGIN BOND
M  V30 1 1 1 2
M  V30 2 2 1 3
M  V30 3 1 1 4
M  V30 END BOND
M  V30 BEGIN SGROUP
M  V30 1 SUP 1 ATOMS=(4 1 2 3 4) LABEL=HNO3
M  V30 END SGROUP
M  V30 END CTAB
M  END
```
Here the SGroup doesn't contain any XBonds, so the entire group is replaced with the abbreviation.