### PR TITLE
Avoid molecule copy when constructing incremental synthon search results

### DIFF
--- a/Code/GraphMol/SynthonSpaceSearch/SearchResults.h
+++ b/Code/GraphMol/SynthonSpaceSearch/SearchResults.h
@@ -19,8 +19,10 @@ namespace RDKit::SynthonSpaceSearch {
 
 // takes vector of search results; returns true if enough hits have been
 // returned, false if the search should continue.
+// Invoking the callback transfers ownership of the molecules to the
+// callee, which avoids an extra copy of the molecule.
 using SearchResultCallback =
-    std::function<bool(const std::vector<std::unique_ptr<ROMol>> &)>;
+    std::function<bool(std::vector<std::unique_ptr<ROMol>> &)>;
 
 // A class holding a set of results from a search.  Contains the hit
 // molecules and information about how the search progressed, whether

--- a/Code/GraphMol/SynthonSpaceSearch/Wrap/rdSynthonSpaceSearch.cpp
+++ b/Code/GraphMol/SynthonSpaceSearch/Wrap/rdSynthonSpaceSearch.cpp
@@ -101,10 +101,10 @@ SynthonSpaceSearch::SearchResults substructureSearch_helper2(
 struct CallbackAdapter {
   python::object py_callable;
 
-  bool operator()(const std::vector<std::unique_ptr<ROMol>> &results) const {
+  bool operator()(std::vector<std::unique_ptr<ROMol>> &results) const {
     python::list pyres;
     for (auto &mol : results) {
-      pyres.append(boost::make_shared<ROMol>(*mol));
+      pyres.append(boost::shared_ptr<ROMol>(mol.release()));
     }
     return bool(py_callable(pyres));
   }


### PR DESCRIPTION
This PR changes the callback interface for incremental synthon search to take a non-const reference to the list of matched molecules.  In the Python bindings, this permits the molecules to be passed into python without making an extra copy.  In my local testing, using a trivial callback that only counts molecules, the non-copy version was nearly twice as fast as the current copying version (the test input had 3624 synthons and returned 383,398 hits with a search for `C1CNC1`).  

In #8555 which introduced incremental search, the callback was made to take a const reference to the list of molecules.  However, the structure of the code in SynthonSpaceSearcher is such that the list of molecules is always constructed as a temporary object inside a well defined scope, so there is no way for the empty results to be seen.  The original SearchResults object also takes ownership of the provided matched molecules, so the new interface is consistent with that behavior.

I do not see an obvious way to use the same trick for the molecule list held by SearchResults when non-incremental search is performed without significantly changing the interface.