### PR TITLE
Fix #8945

### DIFF
--- a/Code/GraphMol/catch_molops.cpp
+++ b/Code/GraphMol/catch_molops.cpp
@@ -425,3 +425,14 @@ TEST_CASE("GitHub #8726: Do not remove hydrides by default") {
   CHECK(h_atom->getAtomicNum() == 1);
   CHECK(h_atom->getFormalCharge() == -1);
 }
+
+TEST_CASE("Github #8945") {
+  SECTION("as reported") {
+    auto m1 = "N#N=O"_smiles;
+    REQUIRE(m1);
+    auto m2 = "O=N#N"_smiles;
+    REQUIRE(m2);
+
+    CHECK(MolToSmiles(*m1) == MolToSmiles(*m2));
+  }
+}


### PR DESCRIPTION
Instead of going through the atoms once and looking at each possible transformation for each atom, this goes through the atoms for each transformation. So all `N=O -> [N+]-[O-]` transformations are done before the `N#N -> [N+]=[N-]` transformations

