### PR TITLE
stop ignoring confId in CalcMolDescriptors3D()

### DIFF
--- a/rdkit/Chem/Descriptors3D.py
+++ b/rdkit/Chem/Descriptors3D.py
@@ -210,10 +210,11 @@ if hasattr(rdMolDescriptors, 'CalcPMI1'):
 
     """
 
-
-
 from rdkit.Chem.Descriptors import _isCallable
+
 descList = []
+
+
 def _setupDescriptors(namespace):
   global descList
   descList.clear()
@@ -225,8 +226,9 @@ def _setupDescriptors(namespace):
 
 _setupDescriptors(locals())
 
-def CalcMolDescriptors3D(mol, confId=None):
-    """
+
+def CalcMolDescriptors3D(mol, confId=-1):
+  """
     Compute all 3D descriptors of a molecule
     
     Arguments:
@@ -241,10 +243,10 @@ def CalcMolDescriptors3D(mol, confId=None):
     raises a ValueError 
         If the molecule does not have conformers
     """
-    if mol.GetNumConformers() == 0:
-        raise ValueError('Computing 3D Descriptors requires a structure with at least 1 conformer')
-    else:
-        vals_3D = {}
-        for nm,fn in descList:
-           vals_3D[nm] = fn(mol)
-        return vals_3D
+  if mol.GetNumConformers() == 0:
+    raise ValueError('Computing 3D Descriptors requires a structure with at least 1 conformer')
+  else:
+    vals_3D = {}
+    for nm, fn in descList:
+      vals_3D[nm] = fn(mol, confId=confId)
+    return vals_3D

--- a/rdkit/Chem/UnitTestDescriptors.py
+++ b/rdkit/Chem/UnitTestDescriptors.py
@@ -167,9 +167,9 @@ class TestCase(unittest.TestCase):
       f = getattr(Descriptors, n)
       self.assertEqual(results[i], f(m))
 
-  @unittest.skipIf(
-    not hasattr(rdMolDescriptors, 'BCUT2D') or not hasattr(rdMolDescriptors, 'CalcAUTOCORR2D'),
-    "BCUT or AUTOCORR descriptors not available")
+  @unittest.skipIf(not hasattr(rdMolDescriptors, 'BCUT2D')
+                   or not hasattr(rdMolDescriptors, 'CalcAUTOCORR2D'),
+                   "BCUT or AUTOCORR descriptors not available")
   def testVectorDescriptorsInDescList(self):
     # First try only bcuts should exist
     descriptors = set([n for n, _ in Descriptors.descList])
@@ -212,6 +212,15 @@ class TestCase(unittest.TestCase):
     descs = Descriptors3D.CalcMolDescriptors3D(mol)
     self.assertTrue('InertialShapeFactor' in descs)
     self.assertAlmostEqual(descs['PMI1'], 20.9582649071385, delta=1e-4)
+
+    # test function returns expected outputs
+    AllChem.EmbedMultipleConfs(mol, 10, randomSeed=0xf00d)
+    descs = Descriptors3D.CalcMolDescriptors3D(mol)
+    self.assertTrue('InertialShapeFactor' in descs)
+    self.assertAlmostEqual(descs['PMI1'], 20.9582649071385, delta=1e-4)
+    descs2 = Descriptors3D.CalcMolDescriptors3D(mol, confId=2)
+    for key in descs:
+      self.assertNotEqual(descs2[key], descs[key])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This was a stupid bug in my original implementation