### PR TITLE
Minor clean up in SMILES Writing double bond canonicalization

### DIFF
--- a/Code/GraphMol/Canon.cpp
+++ b/Code/GraphMol/Canon.cpp
@@ -184,7 +184,6 @@ void canonicalizeDoubleBond(Bond *dblBond, UINT_VECT &bondVisitOrders,
 
   ROMol &mol = dblBond->getOwningMol();
 
-  ROMol::OBOND_ITER_PAIR atomBonds;
   // -------------------------------------------------------
   // find the lowest visit order bonds from each end and determine
   // if anything is already constraining our choice of directions:
@@ -515,17 +514,14 @@ void canonicalizeDoubleBond(Bond *dblBond, UINT_VECT &bondVisitOrders,
   if (atom3->getDegree() == 3) {
     Bond *otherAtom3Bond = nullptr;
     bool dblBondPresent = false;
-    atomBonds = mol.getAtomBonds(atom3);
-    while (atomBonds.first != atomBonds.second) {
-      Bond *tbond = mol[*atomBonds.first];
+    for (auto tbond : mol.atomBonds(atom3)) {
       if (tbond->getBondType() == Bond::DOUBLE &&
           tbond->getStereo() > Bond::STEREOANY) {
         dblBondPresent = true;
-      } else if ((tbond->getBondType() == Bond::SINGLE) &&
-                 (tbond != firstFromAtom2)) {
+      } else if (tbond->getBondType() == Bond::SINGLE &&
+                 tbond != firstFromAtom2) {
         otherAtom3Bond = tbond;
       }
-      atomBonds.first++;
     }
     if (dblBondPresent && otherAtom3Bond &&
         otherAtom3Bond->getBondDir() == Bond::NONE) {
@@ -679,7 +675,6 @@ void dfsBuildStack(ROMol &mol, int atomIdx, int inBondIdx,
                    std::vector<INT_LIST> &atomTraversalBondOrder,
                    const boost::dynamic_bitset<> *bondsInPlay,
                    const std::vector<std::string> *bondSymbols, bool doRandom) {
-
   Atom *atom = mol.getAtomWithIdx(atomIdx);
   INT_LIST directTravList, cycleEndList;
   boost::dynamic_bitset<> seenFromHere(mol.getNumAtoms());


### PR DESCRIPTION
As I look through SMILES writing code for https://github.com/rdkit/rdkit/pull/8968, I'm noticing some things that can be cleaned up. In this PR I'm suggesting some minor refactors with no functional change:

- Move the `firstVisitOrder` declaration/reset into the `findNeighborBonds` lamba, since it's only used there, and it needs to be reset before each usage.
- Remove one extra bond switch in the `! setFromBond1` branch. This makes the `E/TRANS/Z/CIS` decision more intuitive, and also makes it simillar to the one in the other branch, making it easier to abstract into a separate function in a future refactor.
- Remove the `atomBonds` variable by modernizing the loop where it is uses.
