### PR TITLE
Refactor atomVisitOrders and bondVisitOrders in SMILES Writer canonicalization

### DIFF
--- a/Code/GraphMol/Canon.cpp
+++ b/Code/GraphMol/Canon.cpp
@@ -1104,6 +1104,10 @@ void canonicalizeFragment(ROMol &mol, int atomIdx,
       atomVisitOrders[msI.obj.atom->getIdx()] = pos;
     } else if (msI.type == MOL_STACK_BOND) {
       bondVisitOrders[msI.obj.bond->getIdx()] = pos;
+      auto dir = msI.obj.bond->getBondDir();
+      if (dir == Bond::ENDDOWNRIGHT || dir == Bond::ENDUPRIGHT) {
+        msI.obj.bond->setBondDir(Bond::NONE);
+      }
     }
     ++pos;
   }


### PR DESCRIPTION
While debugging some things I did for https://github.com/rdkit/rdkit/pull/8968, I saw something strange: `atomVisitOrders` was twice the size I expected (2x the number of atoms), and while the values made sense, and also correctly correlated with `bondVisitOrders`, didn't exactly match the positions of each atom in `molStack`, which would be more intuitive.

I had a look at the code, and noticed that `atomVisitOrders` and `bondVisitOrders` aren't even used in the construction of `molStack`, so I pulled them out so that now they are calculated right before they are used in bond and atom ring stereochemistry.

Refactoring `atomVisitOrders` and `bondVisitOrders` also allows refactoring `checkBondsInSameBranch()` and turning it into a lambda which avoids iterating `molStack` from the beginning each time it is used, and also allows for bidirectional searching (even if we don't yet need it).
