### PR TITLE
Return early in removeSubstanceGroupsReferencing if no sgs are impacted

### DIFF
--- a/Code/GraphMol/SubstanceGroup.cpp
+++ b/Code/GraphMol/SubstanceGroup.cpp
@@ -423,6 +423,10 @@ void removeSubstanceGroupsReferencing(RWMol &mol, unsigned int idx) {
         ++nRemoved;
       }
     }
+    if (!parentsPresent && nRemoved == 0) {
+      // nothing to do, return early to avoid unnecessary moves
+      return;
+    }
 
     // if we're going to be removing anything and there are PARENTS present,
     // we need to build a lookup map between index->position in original array


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

I noticed that removing atoms, even in batch edit mode, was slow for super large molecules. I think this might make it a little faster for structures that happen to have a lot of substance groups.

