### PR TITLE
Allow H removal to be skipped in ShowFeats.py

### DIFF
--- a/rdkit/Chem/Features/ShowFeats.py
+++ b/rdkit/Chem/Features/ShowFeats.py
@@ -264,6 +264,9 @@ parser.add_option('--writeFeats', '--write', default=False, action='store_true',
                   help='print the feature information to the console')
 parser.add_option('--featMapFile', '--mapFile', default='',
                   help='save a feature map definition to the specified file')
+parser.add_option('--removeHs', default=True, action='store_false',
+                  help='remove hydrogens from the molecules')
+
 parser.add_option('--verbose', default=False, action='store_true', help='be verbose')
 
 if __name__ == '__main__':
@@ -329,13 +332,13 @@ if __name__ == '__main__':
 
     if molN != '-':
       try:
-        ms = Chem.SDMolSupplier(molN)
+        ms = Chem.SDMolSupplier(molN, removeHs=options.removeHs)
       except Exception:
         logger.error(f'Problems reading input file: {molN}')
         ms = []
     else:
       ms = Chem.SDMolSupplier()
-      ms.SetData(sys.stdin.read())
+      ms.SetData(sys.stdin.read(), removeHs=options.removeHs)
 
     for m in ms:
       nm = f'Mol_{i}'


### PR DESCRIPTION
I noticed that there was no way to disable H removal when using this script.

This PR fixes that.

There are no tests here since there are no tests for the script itself.