### PR TITLE
Some more cleaning up in SMILES Writing

### DIFF
--- a/Code/GraphMol/Canon.cpp
+++ b/Code/GraphMol/Canon.cpp
@@ -321,7 +321,7 @@ void canonicalizeDoubleBond(Bond *dblBond, UINT_VECT &bondVisitOrders,
       firstFromAtom1->setBondDir(atom1Dir);
 
       bondDirCounts[firstFromAtom1->getIdx()] += 1;
-      atomDirCounts[atom1->getIdx()] += 1;
+      atomDirCounts[atom1->getIdx()] += 2;
       atom1ControllingBond = secondFromAtom1;
     }
   } else {
@@ -356,7 +356,7 @@ void canonicalizeDoubleBond(Bond *dblBond, UINT_VECT &bondVisitOrders,
       firstFromAtom2->setBondDir(atom2Dir);
 
       bondDirCounts[firstFromAtom2->getIdx()] += 1;
-      atomDirCounts[atom2->getIdx()] += 1;
+      atomDirCounts[atom2->getIdx()] += 2;
       atom2ControllingBond = secondFromAtom2;
     }
     // CHECK_INVARIANT(0,"ring stereochemistry not handled");


### PR DESCRIPTION
This is based on https://github.com/rdkit/rdkit/pull/8971 : it abstracts some of the common code that's used in both `setFromBond1 == true` and `setFromBond1 == false` into a separate `get_direction()` lambda.

~It also updates a couple of places were we do `atomDirCounts[atom->getIdx()] += 2;` despite were only setting 1 new bond direction. I checked that each `someBond->setBondDir(someDir);` in `canonicalizeDoubleBond()` has it's own related `atomDirCounts` increment, so it doesn't really make sense to increment it by two in these instances...~

