### PR TITLE
Converts testSubgraph2 to catch

### DIFF
--- a/Code/GraphMol/Subgraphs/CMakeLists.txt
+++ b/Code/GraphMol/Subgraphs/CMakeLists.txt
@@ -1,13 +1,13 @@
 
 rdkit_library(Subgraphs Subgraphs.cpp SubgraphUtils.cpp
-              LINK_LIBRARIES GraphMol RDGeneral )
+    LINK_LIBRARIES GraphMol RDGeneral)
 target_compile_definitions(Subgraphs PRIVATE RDKIT_SUBGRAPHS_BUILD)
 
 rdkit_headers(Subgraphs.h
-              SubgraphUtils.h DEST GraphMol/Subgraphs)
+    SubgraphUtils.h DEST GraphMol/Subgraphs)
 
 target_include_directories(Subgraphs PUBLIC $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/External/boost-numeric-bindings>)
 
-rdkit_test(testSubgraphs1 test1.cpp LINK_LIBRARIES Subgraphs SmilesParse )
-rdkit_test(testSubgraphs2 test2.cpp LINK_LIBRARIES SmilesParse Subgraphs )
+rdkit_test(testSubgraphs1 test1.cpp LINK_LIBRARIES Subgraphs SmilesParse)
+rdkit_catch_test(testSubgraphs2 testSubgraphs2.cpp LINK_LIBRARIES SmilesParse Subgraphs)
 rdkit_catch_test(subgraphsCatch catch_tests.cpp LINK_LIBRARIES SmilesParse Subgraphs)

--- a/Code/GraphMol/Subgraphs/testSubgraphs2.cpp
+++ b/Code/GraphMol/Subgraphs/testSubgraphs2.cpp
@@ -7,7 +7,8 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
-#include <RDGeneral/test.h>
+#include <catch2/catch_all.hpp>
+
 #include <GraphMol/RDKitBase.h>
 #include <GraphMol/SmilesParse/SmilesParse.h>
 #include <GraphMol/SmilesParse/SmilesWrite.h>
@@ -20,84 +21,78 @@
 using namespace std;
 using namespace RDKit;
 
-std::string canon(std::string smiles) {
+std::string canon(const std::string &smiles) {
   unique_ptr<ROMol> m(SmilesToMol(smiles));
   const bool useStereo = true;
   return MolToSmiles(*m, useStereo);
 }
 
-void test1() {
-  std::cout << "-----------------------\n Test1: pathToSubmol" << std::endl;
-  {
-    std::string smiles = "CC1CC1";
-    RWMol *mol = SmilesToMol(smiles);
-    TEST_ASSERT(mol);
+TEST_CASE("pathToSubmol") {
+  std::string smiles = "CC1CC1";
+  RWMol *mol = SmilesToMol(smiles);
+  REQUIRE(mol);
 
-    PATH_LIST sgs;
-    sgs = findAllSubgraphsOfLengthN(*mol, 3, false, 0);
-    TEST_ASSERT(sgs.size() == 3);
-    for (const auto &tmp : sgs) {
-      TEST_ASSERT(tmp[0] == 0);
-      TEST_ASSERT(tmp.size() == 3);
-      ROMol *frag = Subgraphs::pathToSubmol(*mol, tmp, false);
-      smiles = MolToSmiles(*frag, true, false, 0, false);
-      if (tmp[1] == 1) {
-        if (tmp[2] == 2) {
-          TEST_ASSERT(smiles == "CCCC");
-        } else if (tmp[2] == 3) {
-          TEST_ASSERT(smiles == "CC(C)C");
-        } else {
-          TEST_ASSERT(0);
-        }
-      } else if (tmp[1] == 3) {
-        if (tmp[2] == 2) {
-          TEST_ASSERT(smiles == "CCCC");
-        } else if (tmp[2] == 1) {
-          TEST_ASSERT(smiles == "CC(C)C");
-        } else {
-          TEST_ASSERT(0);
-        }
+  PATH_LIST sgs;
+  sgs = findAllSubgraphsOfLengthN(*mol, 3, false, 0);
+  REQUIRE(sgs.size() == 3);
+  for (const auto &tmp : sgs) {
+    REQUIRE(tmp.size() == 3);
+    CHECK(tmp[0] == 0);
+    ROMol *frag = Subgraphs::pathToSubmol(*mol, tmp, false);
+    smiles = MolToSmiles(*frag, true, false, 0, false);
+    if (tmp[1] == 1) {
+      if (tmp[2] == 2) {
+        CHECK(smiles == "CCCC");
+      } else if (tmp[2] == 3) {
+        CHECK(smiles == "CC(C)C");
       } else {
-        TEST_ASSERT(0);
+        FAIL();
       }
-      delete frag;
+    } else if (tmp[1] == 3) {
+      if (tmp[2] == 2) {
+        CHECK(smiles == "CCCC");
+      } else if (tmp[2] == 1) {
+        CHECK(smiles == "CC(C)C");
+      } else {
+        FAIL();
+      }
+    } else {
+      FAIL();
     }
-    delete mol;
+    delete frag;
   }
-  std::cout << "Finished" << std::endl;
+  delete mol;
 }
 
-void test2() {
-  std::cout << "-----------------------\n Test2: Atom Environments"
-            << std::endl;
+TEST_CASE("Atom Environments") {
   {
     std::string smiles = "CC1CC1";
     RWMol *mol = SmilesToMol(smiles);
-    TEST_ASSERT(mol);
+    REQUIRE(mol);
 
     PATH_TYPE pth = findAtomEnvironmentOfRadiusN(*mol, 1, 0);
-    TEST_ASSERT(pth.size() == 1);
-    TEST_ASSERT(pth[0] == 0);
+    REQUIRE(pth.size() == 1);
+    REQUIRE(pth[0] == 0);
 
     pth = findAtomEnvironmentOfRadiusN(*mol, 2, 0);
-    TEST_ASSERT(pth.size() == 3);
-    TEST_ASSERT(pth[0] == 0);
+    REQUIRE(pth.size() == 3);
+    REQUIRE(pth[0] == 0);
 
     pth = findAtomEnvironmentOfRadiusN(*mol, 3, 0);
-    TEST_ASSERT(pth.size() == 4);
-    TEST_ASSERT(pth[0] == 0);
+    REQUIRE(pth.size() == 4);
+    REQUIRE(pth[0] == 0);
 
     pth = findAtomEnvironmentOfRadiusN(*mol, 4, 0);
-    TEST_ASSERT(pth.size() == 0);
+    REQUIRE(pth.size() == 0);
 
     pth = findAtomEnvironmentOfRadiusN(*mol, 1, 1);
-    TEST_ASSERT(pth.size() == 3);
+    REQUIRE(pth.size() == 3);
 
     pth = findAtomEnvironmentOfRadiusN(*mol, 2, 1);
-    TEST_ASSERT(pth.size() == 4);
+    REQUIRE(pth.size() == 4);
 
     pth = findAtomEnvironmentOfRadiusN(*mol, 3, 1);
-    TEST_ASSERT(pth.size() == 0);
+    REQUIRE(pth.size() == 0);
 
     delete mol;
   }
@@ -105,15 +100,15 @@ void test2() {
   {
     std::string smiles = "CC1CC1";
     RWMol *mol = SmilesToMol(smiles);
-    TEST_ASSERT(mol);
+    REQUIRE(mol);
     ROMol *mH = MolOps::addHs(static_cast<const ROMol &>(*mol));
 
     PATH_TYPE pth = findAtomEnvironmentOfRadiusN(*mH, 1, 0);
-    TEST_ASSERT(pth.size() == 1);
-    TEST_ASSERT(pth[0] == 0);
+    REQUIRE(pth.size() == 1);
+    REQUIRE(pth[0] == 0);
 
     pth = findAtomEnvironmentOfRadiusN(*mH, 1, 0, true);
-    TEST_ASSERT(pth.size() == 4);
+    REQUIRE(pth.size() == 4);
 
     delete mol;
     delete mH;
@@ -122,56 +117,51 @@ void test2() {
   {
     std::string smiles = "O=C(O)CCCC=CC(C1C(O)CC(O)C1(C=CC(O)CCCCC))";
     RWMol *mol = SmilesToMol(smiles);
-    TEST_ASSERT(mol);
+    REQUIRE(mol);
     smiles = MolToSmiles(*mol);
 
     PATH_TYPE pth = findAtomEnvironmentOfRadiusN(*mol, 2, 9);
-    TEST_ASSERT(pth.size() == 8);
+    REQUIRE(pth.size() == 8);
     ROMol *frag = Subgraphs::pathToSubmol(*mol, pth, false);
     smiles = MolToSmiles(*frag, true, false, 0, false);
-    TEST_ASSERT(canon(smiles) == canon("C(C(C(O)C)C(C)C)C"));
+    REQUIRE(canon(smiles) == canon("C(C(C(O)C)C(C)C)C"));
     delete frag;
     delete mol;
   }
-
-  std::cout << "Finished" << std::endl;
 }
 
-void test3() {
-  std::cout << "-----------------------" << std::endl;
-  std::cout << "Test 3: Atom Environments (Extension)" << std::endl;
-
+TEST_CASE("Atom Environments (Extension)") {
   {
     std::string smiles = "C=NC";
     unsigned int rootedAtAtom = 2;
 
     RWMol *mol = SmilesToMol(smiles);
-    TEST_ASSERT(mol);
+    REQUIRE(mol);
     ROMol *mH = MolOps::addHs(static_cast<const ROMol &>(*mol));
 
     PATH_TYPE pth =
         findAtomEnvironmentOfRadiusN(*mH, 2, rootedAtAtom, false, true);
-    TEST_ASSERT(pth.size() == 2);
+    REQUIRE(pth.size() == 2);
     pth = findAtomEnvironmentOfRadiusN(*mH, 2, rootedAtAtom, true, true);
-    TEST_ASSERT(pth.size() == 5);
+    REQUIRE(pth.size() == 5);
 
     pth = findAtomEnvironmentOfRadiusN(*mH, 3, rootedAtAtom, false, true);
-    TEST_ASSERT(pth.size() == 0);
+    REQUIRE(pth.size() == 0);
     pth = findAtomEnvironmentOfRadiusN(*mH, 3, rootedAtAtom, true, true);
-    TEST_ASSERT(pth.size() == 7);
+    REQUIRE(pth.size() == 7);
     pth = findAtomEnvironmentOfRadiusN(*mH, 3, rootedAtAtom, true, false);
-    TEST_ASSERT(pth.size() == 7);
+    REQUIRE(pth.size() == 7);
     pth = findAtomEnvironmentOfRadiusN(*mH, 3, rootedAtAtom, false, false);
-    TEST_ASSERT(pth.size() == 2);
+    REQUIRE(pth.size() == 2);
 
     pth = findAtomEnvironmentOfRadiusN(*mH, 4, rootedAtAtom, false, true);
-    TEST_ASSERT(pth.size() == 0);
+    REQUIRE(pth.size() == 0);
     pth = findAtomEnvironmentOfRadiusN(*mH, 4, rootedAtAtom, true, true);
-    TEST_ASSERT(pth.size() == 0);
+    REQUIRE(pth.size() == 0);
     pth = findAtomEnvironmentOfRadiusN(*mH, 4, rootedAtAtom, true, false);
-    TEST_ASSERT(pth.size() == 7);
+    REQUIRE(pth.size() == 7);
     pth = findAtomEnvironmentOfRadiusN(*mH, 4, rootedAtAtom, false, false);
-    TEST_ASSERT(pth.size() == 2);
+    REQUIRE(pth.size() == 2);
 
     delete mol;
     delete mH;
@@ -183,72 +173,72 @@ void test3() {
     std::unordered_map<unsigned int, unsigned int> cAtomMap;
 
     RWMol *mol = SmilesToMol(smiles);
-    TEST_ASSERT(mol);
+    REQUIRE(mol);
     ROMol *mH = MolOps::addHs(static_cast<const ROMol &>(*mol));
 
     PATH_TYPE pth = findAtomEnvironmentOfRadiusN(*mH, 2, rootedAtAtom, false,
                                                  true, &cAtomMap);
-    TEST_ASSERT(cAtomMap.size() == 3);
-    TEST_ASSERT(cAtomMap[rootedAtAtom] == 0);
-    TEST_ASSERT(cAtomMap[1] == 1);
-    TEST_ASSERT(cAtomMap[0] == 2);
+    REQUIRE(cAtomMap.size() == 3);
+    REQUIRE(cAtomMap[rootedAtAtom] == 0);
+    REQUIRE(cAtomMap[1] == 1);
+    REQUIRE(cAtomMap[0] == 2);
     cAtomMap.clear();
 
     pth = findAtomEnvironmentOfRadiusN(*mH, 2, rootedAtAtom, false, false,
                                        &cAtomMap);
-    TEST_ASSERT(cAtomMap.size() == 3);
-    TEST_ASSERT(cAtomMap[rootedAtAtom] == 0);
-    TEST_ASSERT(cAtomMap[1] == 1);
-    TEST_ASSERT(cAtomMap[0] == 2);
+    REQUIRE(cAtomMap.size() == 3);
+    REQUIRE(cAtomMap[rootedAtAtom] == 0);
+    REQUIRE(cAtomMap[1] == 1);
+    REQUIRE(cAtomMap[0] == 2);
     cAtomMap.clear();
 
     pth = findAtomEnvironmentOfRadiusN(*mH, 2, rootedAtAtom, true, true,
                                        &cAtomMap);
-    TEST_ASSERT(cAtomMap.size() == 4);
-    TEST_ASSERT(cAtomMap[rootedAtAtom] == 0);
-    TEST_ASSERT(cAtomMap[1] == 1);
-    TEST_ASSERT(cAtomMap[5] == 1);
-    TEST_ASSERT(cAtomMap[0] == 2);
+    REQUIRE(cAtomMap.size() == 4);
+    REQUIRE(cAtomMap[rootedAtAtom] == 0);
+    REQUIRE(cAtomMap[1] == 1);
+    REQUIRE(cAtomMap[5] == 1);
+    REQUIRE(cAtomMap[0] == 2);
     cAtomMap.clear();
 
     pth = findAtomEnvironmentOfRadiusN(*mH, 2, rootedAtAtom, true, false,
                                        &cAtomMap);
-    TEST_ASSERT(cAtomMap.size() == 4);
-    TEST_ASSERT(cAtomMap[rootedAtAtom] == 0);
-    TEST_ASSERT(cAtomMap[1] == 1);
-    TEST_ASSERT(cAtomMap[5] == 1);
-    TEST_ASSERT(cAtomMap[0] == 2);
+    REQUIRE(cAtomMap.size() == 4);
+    REQUIRE(cAtomMap[rootedAtAtom] == 0);
+    REQUIRE(cAtomMap[1] == 1);
+    REQUIRE(cAtomMap[5] == 1);
+    REQUIRE(cAtomMap[0] == 2);
     cAtomMap.clear();
 
     pth = findAtomEnvironmentOfRadiusN(*mH, 4, rootedAtAtom, false, true,
                                        &cAtomMap);
-    TEST_ASSERT(pth.size() == 0);
-    TEST_ASSERT(cAtomMap.size() == 0);
+    REQUIRE(pth.size() == 0);
+    REQUIRE(cAtomMap.size() == 0);
 
     pth = findAtomEnvironmentOfRadiusN(*mH, 4, rootedAtAtom, true, true,
                                        &cAtomMap);
-    TEST_ASSERT(pth.size() == 0);
-    TEST_ASSERT(cAtomMap.size() == 0);
+    REQUIRE(pth.size() == 0);
+    REQUIRE(cAtomMap.size() == 0);
 
     pth = findAtomEnvironmentOfRadiusN(*mH, 4, rootedAtAtom, false, false,
                                        &cAtomMap);
-    TEST_ASSERT(pth.size() == 2);
-    TEST_ASSERT(cAtomMap.size() == 3);
-    TEST_ASSERT(cAtomMap[rootedAtAtom] == 0);
-    TEST_ASSERT(cAtomMap[1] == 1);
-    TEST_ASSERT(cAtomMap[0] == 2);
+    REQUIRE(pth.size() == 2);
+    REQUIRE(cAtomMap.size() == 3);
+    REQUIRE(cAtomMap[rootedAtAtom] == 0);
+    REQUIRE(cAtomMap[1] == 1);
+    REQUIRE(cAtomMap[0] == 2);
     cAtomMap.clear();
 
     pth = findAtomEnvironmentOfRadiusN(*mH, 4, rootedAtAtom, true, false,
                                        &cAtomMap);
-    TEST_ASSERT(pth.size() == 5);
-    TEST_ASSERT(cAtomMap.size() == 6);
-    TEST_ASSERT(cAtomMap[rootedAtAtom] == 0);
-    TEST_ASSERT(cAtomMap[1] == 1);
-    TEST_ASSERT(cAtomMap[5] == 1);
-    TEST_ASSERT(cAtomMap[0] == 2);
-    TEST_ASSERT(cAtomMap[3] == 3);
-    TEST_ASSERT(cAtomMap[4] == 3);
+    REQUIRE(pth.size() == 5);
+    REQUIRE(cAtomMap.size() == 6);
+    REQUIRE(cAtomMap[rootedAtAtom] == 0);
+    REQUIRE(cAtomMap[1] == 1);
+    REQUIRE(cAtomMap[5] == 1);
+    REQUIRE(cAtomMap[0] == 2);
+    REQUIRE(cAtomMap[3] == 3);
+    REQUIRE(cAtomMap[4] == 3);
     cAtomMap.clear();
 
     delete mol;
@@ -261,7 +251,7 @@ void test3() {
     std::unordered_map<unsigned int, unsigned int> cAtomMap;
 
     RWMol *mol = SmilesToMol(smiles);
-    TEST_ASSERT(mol);
+    REQUIRE(mol);
 
     // This test worked on ring system to guarantee that the atom ID
     // is marked correctly with the search radius
@@ -270,24 +260,24 @@ void test3() {
     for (size = 2; size < 4; size++) {
       pth = findAtomEnvironmentOfRadiusN(*mol, size, rootedAtAtom, false, true,
                                          &cAtomMap);
-      TEST_ASSERT(cAtomMap.size() == 5);
-      TEST_ASSERT(cAtomMap[rootedAtAtom] == 0);
-      TEST_ASSERT(cAtomMap[0] == 1);
-      TEST_ASSERT(cAtomMap[2] == 1);
-      TEST_ASSERT(cAtomMap[3] == 2);
-      TEST_ASSERT(cAtomMap[4] == 2);
+      REQUIRE(cAtomMap.size() == 5);
+      REQUIRE(cAtomMap[rootedAtAtom] == 0);
+      REQUIRE(cAtomMap[0] == 1);
+      REQUIRE(cAtomMap[2] == 1);
+      REQUIRE(cAtomMap[3] == 2);
+      REQUIRE(cAtomMap[4] == 2);
       cAtomMap.clear();
     }
 
     for (size = 4; size < 6; size++) {
       pth = findAtomEnvironmentOfRadiusN(*mol, size, rootedAtAtom, false, false,
                                          &cAtomMap);
-      TEST_ASSERT(cAtomMap.size() == 5);
-      TEST_ASSERT(cAtomMap[rootedAtAtom] == 0);
-      TEST_ASSERT(cAtomMap[0] == 1);
-      TEST_ASSERT(cAtomMap[2] == 1);
-      TEST_ASSERT(cAtomMap[3] == 2);
-      TEST_ASSERT(cAtomMap[4] == 2);
+      REQUIRE(cAtomMap.size() == 5);
+      REQUIRE(cAtomMap[rootedAtAtom] == 0);
+      REQUIRE(cAtomMap[0] == 1);
+      REQUIRE(cAtomMap[2] == 1);
+      REQUIRE(cAtomMap[3] == 2);
+      REQUIRE(cAtomMap[4] == 2);
       cAtomMap.clear();
     }
     delete mol;
@@ -299,7 +289,7 @@ void test3() {
     std::unordered_map<unsigned int, unsigned int> cAtomMap;
 
     RWMol *mol = SmilesToMol(smiles);
-    TEST_ASSERT(mol);
+    REQUIRE(mol);
 
     PATH_TYPE pth1 = findAtomEnvironmentOfRadiusN(*mol, 2, rootedAtAtom);
     PATH_TYPE pth2 = findAtomEnvironmentOfRadiusN(*mol, 2, rootedAtAtom, false);
@@ -316,76 +306,56 @@ void test3() {
     cAtomMap.clear();
     delete mol;
   }
-  std::cout << "Finished" << std::endl;
 }
 
-void testGithubIssue103() {
-  std::cout << "-----------------------\n Testing github Issue103: "
-               "stereochemistry and pathToSubmol"
-            << std::endl;
+TEST_CASE("Github Issue103: stereochemistry and pathToSubmol") {
   {
     std::string smiles = "O=C(O)C(=O)C[C@@]1(C(=O)O)C=C[C@H](O)C=C1";
     RWMol *mol = SmilesToMol(smiles);
-    TEST_ASSERT(mol);
+    REQUIRE(mol);
 
     PATH_TYPE pth = findAtomEnvironmentOfRadiusN(*mol, 2, 12);
-    TEST_ASSERT(pth.size() == 5);
+    REQUIRE(pth.size() == 5);
     ROMol *frag = Subgraphs::pathToSubmol(*mol, pth, false);
     smiles = MolToSmiles(*frag, true);
-    TEST_ASSERT(canon(smiles) == canon("C=CC(O)C=C"));
+    REQUIRE(canon(smiles) == canon("C=CC(O)C=C"));
     delete frag;
     delete mol;
   }
   {
     std::string smiles = "O=C(O)C(=O)C[C@@]1(C(=O)O)C=C[C@H](O)C=C1";
     RWMol *mol = SmilesToMol(smiles);
-    TEST_ASSERT(mol);
+    REQUIRE(mol);
 
     PATH_TYPE pth = findAtomEnvironmentOfRadiusN(*mol, 2, 12);
-    TEST_ASSERT(pth.size() == 5);
+    REQUIRE(pth.size() == 5);
     ROMol *frag = Subgraphs::pathToSubmol(*mol, pth, false);
     smiles = MolToSmarts(*frag);
-    TEST_ASSERT(smiles == "[#6]=[#6]-[#6@H](-[#8])-[#6]=[#6]");
+    REQUIRE(smiles == "[#6]=[#6]-[#6@H](-[#8])-[#6]=[#6]");
     delete frag;
     delete mol;
   }
   {
     std::string smiles = "O=C(O)C(=O)C[C@@]1(C(=O)O)C=C[C@H](O)C=C1";
     RWMol *mol = SmilesToMol(smiles);
-    TEST_ASSERT(mol);
+    REQUIRE(mol);
 
     PATH_TYPE pth = findAtomEnvironmentOfRadiusN(*mol, 2, 12);
-    TEST_ASSERT(pth.size() == 5);
+    REQUIRE(pth.size() == 5);
     ROMol *frag = Subgraphs::pathToSubmol(*mol, pth, true);
     smiles = MolToSmarts(*frag);
-    TEST_ASSERT(smiles == "[#6]=[#6]-[#6@](-[#8])-[#6]=[#6]");
+    REQUIRE(smiles == "[#6]=[#6]-[#6@](-[#8])-[#6]=[#6]");
     delete frag;
     delete mol;
   }
-
-  std::cout << "Finished" << std::endl;
 }
 
-void testGithubIssue2647() {
-  std::cout << "-----------------------\n Testing github Issue103: "
-               "more stereochemistry and pathToSubmol (path needs to be in "
-               "sorted order)"
-            << std::endl;
+TEST_CASE(
+    "Github Issue103: more stereochemistry and pathToSubmol (path needs to be in sorted order)") {
   std::string smiles = "I[C@](F)(Br)O";
   std::unique_ptr<ROMol> mol(SmilesToMol(smiles));
   std::vector<int> path = {0, 3, 2, 1};
   const bool useQuery = false;
   std::unique_ptr<ROMol> mol2(Subgraphs::pathToSubmol(*mol, path, useQuery));
-  TEST_ASSERT(MolToSmiles(*mol2) == MolToSmiles(*mol));
-  std::cout << "Finished" << std::endl;
-}
-
-// -------------------------------------------------------------------
-int main() {
-  test1();
-  test2();
-  test3();
-  testGithubIssue103();
-  testGithubIssue2647();
-  return 0;
+  REQUIRE(MolToSmiles(*mol2) == MolToSmiles(*mol));
 }


### PR DESCRIPTION
I converted the test file to waf after I noticed the test issue Greg mentioned in https://github.com/rdkit/rdkit/pull/9002, and renamed the source file to make it easier to locate (it's a bit frustrating to have to look at the CMake files to identify what the source file for a test is, especially when the sources are named "test1.cpp", etc).