### PR TITLE
Remove hydrogen atoms in scoring process of SA score

### DIFF
--- a/Contrib/SA_Score/sascorer.py
+++ b/Contrib/SA_Score/sascorer.py
@@ -56,6 +56,8 @@ def calculateScore(m):
   if _fscores is None:
     readFragmentScores()
 
+  m = Chem.RemoveHs(m)
+  
   # fragment score
   sfp = mfpgen.GetSparseCountFingerprint(m)
 


### PR DESCRIPTION
If the function calculateScore is imported in Python code, it will behave wrongly if an input molecule has explicit hydrogens. The calculated scores will be incredibly high. This behavior is not observed if using the script from CLI because by default hydrogens are stripped when reading files.

```python
from rdkit import Chem
from rdkit.Chem import RDConfig
import os
import sys
sys.path.append(os.path.join(RDConfig.RDContribDir, 'SA_Score'))
import sascorer

v1 = sascorer.calculateScore(Chem.MolFromSmiles('c1ccccc1'))
v2 = sascorer.calculateScore(Chem.AddHs(Chem.MolFromSmiles('c1ccccc1')))
```

```
v1 = 1.00
v2 = 7.08
```

The fix adds `RemoveHs` inside `calculateScore`