### PR TITLE
MolAlign: brace-init BestAlignmentParams in wrapper

### DIFF
--- a/Code/GraphMol/MolAlign/Wrap/rdMolAlign.cpp
+++ b/Code/GraphMol/MolAlign/Wrap/rdMolAlign.cpp
@@ -34,9 +34,9 @@ struct pyBestAlignmentParams : public BestAlignmentParams {
   pyBestAlignmentParams(int maxMatches_, bool symmetrizeTerminalGroups_,
                         bool ignoreHs_, int numThreads_, python::object map_,
                         python::object weights_)
-      : BestAlignmentParams(maxMatches_, symmetrizeTerminalGroups_, ignoreHs_,
+      : BestAlignmentParams{maxMatches_, symmetrizeTerminalGroups_, ignoreHs_,
                             numThreads_, std::vector<MatchVectType>(),
-                            nullptr) {
+                            nullptr} {
     unsigned int nAtms = 0;
     if (map_ != python::object()) {
       map = translateAtomMapSeq(map_);


### PR DESCRIPTION
BestAlignmentParams is an aggregate; paren-init (T(...)) is rejected by Apple Clang (Xcode) and only works on some compilers. Use brace-init (T{...}) for portable initialization.

#### Reference Issue
Fixes #9041

#### What does this implement/fix?
Makes xcode clang builds work

#### Any other comments?
Code was added in #8976. Not sure how the mac CI jobs succeeded there.

