### PR TITLE
Update deprecation messages for valence methods

### DIFF
--- a/Code/GraphMol/Wrap/Atom.cpp
+++ b/Code/GraphMol/Wrap/Atom.cpp
@@ -223,11 +223,11 @@ struct atom_wrapper {
         .def(
             "GetExplicitValence", &getExplicitValenceHelper,
             python::args("self"),
-            "DEPRECATED, please use GetValence(Chem.ValenceType,EXPLICIT) instead.\nReturns the explicit valence of the atom.\n")
+            "DEPRECATED, please use GetValence(Chem.ValenceType.EXPLICIT) instead.\nReturns the explicit valence of the atom.\n")
         .def(
             "GetImplicitValence", &getImplicitValenceHelper,
             python::args("self"),
-            "DEPRECATED, please use getValence(Chem.ValenceType,IMPLICIT) instead.\nReturns the number of implicit Hs on the atom.\n")
+            "DEPRECATED, please use getValence(Chem.ValenceType.IMPLICIT) instead.\nReturns the number of implicit Hs on the atom.\n")
         .def("GetValence", &Atom::getValence,
              (python::args("self"), python::args("which")),
              "Returns the valence (explicit or implicit) of the atom.\n")


### PR DESCRIPTION
I found a typo in the Deprecated message in rdkit docs.

Changing:
Chem.ValenceType,EXPLICIT to Chem.ValenceType.EXPLICIT
Chem.ValenceType,IMPLICIT to Chem.ValenceType.IMPLICIT

