### PR TITLE
Prevent CIP labels of bonds from being calculated twice.

### DIFF
--- a/Code/GraphMol/CIPLabeler/CIPLabeler.cpp
+++ b/Code/GraphMol/CIPLabeler/CIPLabeler.cpp
@@ -178,7 +178,7 @@ void label(std::vector<std::unique_ptr<Configuration>> &configs,
   // resolved.
   for (auto &conf : configs) {
     // Make sure this stereo center has no label
-    conf->getFocus()->clearProp(common_properties::_CIPCode);
+    conf->resetPrimaryLabel();
 
     remainingCallCount = constitutionalRuleTimeout;
     try {
@@ -200,7 +200,7 @@ void label(std::vector<std::unique_ptr<Configuration>> &configs,
 
   // try again on everything that hasn't been resolved yet
   for (const auto &conf : configs) {
-    if (conf->getFocus()->hasProp(common_properties::_CIPCode)) {
+    if (conf->hasPrimaryLabel()) {
       // already resolved!
       continue;
     }

--- a/Code/GraphMol/CIPLabeler/configs/AtropisomerBond.cpp
+++ b/Code/GraphMol/CIPLabeler/configs/AtropisomerBond.cpp
@@ -10,6 +10,7 @@
 //
 #include <GraphMol/Chirality.h>
 #include <GraphMol/Atropisomers.h>
+#include <RDGeneral/types.h>
 
 #include "AtropisomerBond.h"
 #include "../Sort.h"
@@ -47,9 +48,6 @@ void AtropisomerBond::setPrimaryLabel(Descriptor desc) {
     case Descriptor::P:
     case Descriptor::m:
     case Descriptor::p: {
-      auto carriers = getCarriers();
-      // dp_bond->setStereoAtoms(carriers[0]->getIdx(), carriers[1]->getIdx());
-      // dp_bond->setStereo(d_cfg);
       dp_bond->setProp(common_properties::_CIPCode, to_string(desc));
       return;
     }
@@ -69,6 +67,14 @@ void AtropisomerBond::setPrimaryLabel(Descriptor desc) {
     default:
       throw std::runtime_error("Received an invalid Bond Descriptor");
   }
+}
+
+bool AtropisomerBond::hasPrimaryLabel() const {
+  return dp_bond->hasProp(common_properties::_CIPCode);
+}
+
+void AtropisomerBond::resetPrimaryLabel() const {
+  dp_bond->clearProp(common_properties::_CIPCode);
 }
 
 Descriptor AtropisomerBond::label(const Rules &comp) {

--- a/Code/GraphMol/CIPLabeler/configs/AtropisomerBond.h
+++ b/Code/GraphMol/CIPLabeler/configs/AtropisomerBond.h
@@ -24,6 +24,10 @@ class AtropisomerBond : public Configuration {
 
   void setPrimaryLabel(Descriptor desc) override;
 
+  bool hasPrimaryLabel() const override;
+
+  void resetPrimaryLabel() const override;
+
   Descriptor label(const Rules &comp) override;
 
   Descriptor label(Node *root1, Digraph &digraph, const Rules &comp) override;
@@ -34,8 +38,7 @@ class AtropisomerBond : public Configuration {
   // bond->getStereo() can return both E/Z or CIS/TRANS,
   // so we cache CIS/TRANS we found.
   Bond::BondStereo d_cfg;
-
-};  // namespace CIPLabeler
+};
 
 }  // namespace CIPLabeler
 }  // namespace RDKit

--- a/Code/GraphMol/CIPLabeler/configs/Configuration.h
+++ b/Code/GraphMol/CIPLabeler/configs/Configuration.h
@@ -180,6 +180,10 @@ class Configuration {
 
   virtual void setPrimaryLabel(Descriptor desc) = 0;
 
+  virtual bool hasPrimaryLabel() const = 0;
+
+  virtual void resetPrimaryLabel() const = 0;
+
  protected:
   Edge *findInternalEdge(const std::vector<Edge *> &edges, Atom *f1, Atom *f2);
 

--- a/Code/GraphMol/CIPLabeler/configs/Sp2Bond.cpp
+++ b/Code/GraphMol/CIPLabeler/configs/Sp2Bond.cpp
@@ -9,6 +9,7 @@
 //  of the RDKit source tree.
 //
 #include <GraphMol/Chirality.h>
+#include <RDGeneral/types.h>
 
 #include "Sp2Bond.h"
 #include "../Sort.h"
@@ -61,6 +62,14 @@ void Sp2Bond::setPrimaryLabel(Descriptor desc) {
     default:
       throw std::runtime_error("Received an invalid Bond Descriptor");
   }
+}
+
+bool Sp2Bond::hasPrimaryLabel() const {
+  return dp_bond->hasProp(common_properties::_CIPCode);
+}
+
+void Sp2Bond::resetPrimaryLabel() const {
+  dp_bond->clearProp(common_properties::_CIPCode);
 }
 
 Descriptor Sp2Bond::label(const Rules &comp) {

--- a/Code/GraphMol/CIPLabeler/configs/Sp2Bond.h
+++ b/Code/GraphMol/CIPLabeler/configs/Sp2Bond.h
@@ -24,6 +24,10 @@ class Sp2Bond : public Configuration {
 
   void setPrimaryLabel(Descriptor desc) override;
 
+  bool hasPrimaryLabel() const override;
+
+  void resetPrimaryLabel() const override;
+
   Descriptor label(const Rules &comp) override;
 
   Descriptor label(Node *root1, Digraph &digraph, const Rules &comp) override;
@@ -34,8 +38,7 @@ class Sp2Bond : public Configuration {
   // bond->getStereo() can return both E/Z or CIS/TRANS,
   // so we cache CIS/TRANS we found.
   Bond::BondStereo d_cfg;
-
-};  // namespace CIPLabeler
+};
 
 }  // namespace CIPLabeler
 }  // namespace RDKit

--- a/Code/GraphMol/CIPLabeler/configs/Tetrahedral.cpp
+++ b/Code/GraphMol/CIPLabeler/configs/Tetrahedral.cpp
@@ -8,6 +8,7 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
+#include <RDGeneral/types.h>
 
 #include "Tetrahedral.h"
 #include "../rules/Rules.h"
@@ -66,6 +67,14 @@ void Tetrahedral::setPrimaryLabel(Descriptor desc) {
     default:
       throw std::runtime_error("Received an invalid Atom Descriptor");
   }
+}
+
+bool Tetrahedral::hasPrimaryLabel() const {
+  return getFocus()->hasProp(common_properties::_CIPCode);
+}
+
+void Tetrahedral::resetPrimaryLabel() const {
+  getFocus()->clearProp(common_properties::_CIPCode);
 }
 
 Descriptor Tetrahedral::label(const Rules &comp) {

--- a/Code/GraphMol/CIPLabeler/configs/Tetrahedral.h
+++ b/Code/GraphMol/CIPLabeler/configs/Tetrahedral.h
@@ -23,6 +23,10 @@ class Tetrahedral : public Configuration {
 
   void setPrimaryLabel(Descriptor desc) override;
 
+  bool hasPrimaryLabel() const override;
+
+  void resetPrimaryLabel() const override;
+
   Descriptor label(const Rules &comp) override;
 
   Descriptor label(Node *node, Digraph &digraph, const Rules &comp) override;


### PR DESCRIPTION
I just noticed a couple of bugs in #8582 (or rather, the same bug twice):

In the second run of the CIP calculation, we check stereo centers to see if they have already been labeled:
https://github.com/rdkit/rdkit/blob/4b92c2fa8c41410191cceae6f469b4b9fb980d2b/Code/GraphMol/CIPLabeler/CIPLabeler.cpp#L203-L206

But this check is wrong. It will not check stereo bonds or atropisomer bonds, since `conf->getFocus()` is always an atom. Fortunately, the bonds that were labeled twice are the ones that resolve quickly...

Also, while working on this, I noticed that the call were we reset CIP codes before the calculation also incurred on the same error: we only deleted stereo labels on atoms.