### PR TITLE
added FABS to test for issue #4364

### DIFF
--- a/Code/GraphMol/ShapeHelpers/testShapeHelpers.cpp
+++ b/Code/GraphMol/ShapeHelpers/testShapeHelpers.cpp
@@ -99,5 +99,5 @@ TEST_CASE("GitHub #4364") {
   CHECK_THAT(dist, Catch::Matchers::WithinAbs(0.31, 0.01));
   double gridSpacing = 1.0;
   auto dist2 = MolShapes::tanimotoDistance(*m, *m2, cid1, cid2, gridSpacing);
-  CHECK(dist2 - dist > 0.001);
+  CHECK(fabs(dist2 - dist) > 0.001);
 }


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! 
-->
#### Reference Issue
When built on an ARM64 architecture, the testShapeHelpers test fails - the difference in the two tanimoto valuses is negative.


#### What does this implement/fix? Explain your changes.
A FABS was added around the difference of the tanimotos.

#### Any other comments?

