### PR TITLE
Transform::SetRotationFromQuaternion takes const.

### DIFF
--- a/Code/Geometry/Transform3D.cpp
+++ b/Code/Geometry/Transform3D.cpp
@@ -101,7 +101,7 @@ void Transform3D::SetRotation(double angle, const Point3D &axis) {
   this->SetRotation(c, s, axis);
 }
 
-void Transform3D::SetRotationFromQuaternion(double quaternion[4]) {
+void Transform3D::SetRotationFromQuaternion(const double quaternion[4]) {
   double q00 = quaternion[0] * quaternion[0];
   double q11 = quaternion[1] * quaternion[1];
   double q22 = quaternion[2] * quaternion[2];

--- a/Code/Geometry/Transform3D.h
+++ b/Code/Geometry/Transform3D.h
@@ -72,7 +72,7 @@ class RDKIT_RDGEOMETRYLIB_EXPORT Transform3D
   void SetRotation(double cosT, double sinT, const Point3D &axis);
 
   //! Set the rotation matrix from a quaternion
-  void SetRotationFromQuaternion(double quaternion[4]);
+  void SetRotationFromQuaternion(const double quaternion[4]);
 
   //! Reflect the rotation
   void Reflect();


### PR DESCRIPTION
#### Reference Issue
No issue.


#### What does this implement/fix? Explain your changes.
Changes the signature of Transform3D::SetRotationFromQuaternion to take a const double rather than a double.  The function doesn't alter the quaternion, as you'd hope.  This makes it possible, without a dodgy const_cast, to initialise a transformation from a const array of predetermined rotations.

#### Any other comments?

