### PR TITLE
fix the python docs for CanonicalRankAtomsInFragment

### DIFF
--- a/Code/GraphMol/Wrap/rdmolfiles.cpp
+++ b/Code/GraphMol/Wrap/rdmolfiles.cpp
@@ -1312,8 +1312,8 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
 \n";
   python::def(
       "MolToMolBlock",
-      (std::string (*)(const ROMol &, const MolWriterParams &,
-                       int))RDKit::MolToMolBlock,
+      (std::string(*)(const ROMol &, const MolWriterParams &,
+                      int))RDKit::MolToMolBlock,
       (python::arg("mol"), python::arg("params"), python::arg("confId") = -1),
       docString.c_str());
 
@@ -1335,8 +1335,8 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
     a string\n\
 \n";
   python::def("MolToMolBlock",
-              (std::string (*)(const ROMol &, bool, int, bool,
-                               bool))RDKit::MolToMolBlock,
+              (std::string(*)(const ROMol &, bool, int, bool,
+                              bool))RDKit::MolToMolBlock,
               (python::arg("mol"), python::arg("includeStereo") = true,
                python::arg("confId") = -1, python::arg("kekulize") = true,
                python::arg("forceV3000") = false),
@@ -1356,8 +1356,8 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
 \n ";
   python::def(
       "MolToV3KMolBlock",
-      (std::string (*)(const ROMol &, const MolWriterParams &,
-                       int))RDKit::MolToV3KMolBlock,
+      (std::string(*)(const ROMol &, const MolWriterParams &,
+                      int))RDKit::MolToV3KMolBlock,
       (python::arg("mol"), python::arg("params"), python::arg("confId") = -1),
       docString.c_str());
 
@@ -1379,7 +1379,7 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
 
   python::def(
       "MolToV3KMolBlock",
-      (std::string (*)(const ROMol &, bool, int, bool))RDKit::MolToV3KMolBlock,
+      (std::string(*)(const ROMol &, bool, int, bool))RDKit::MolToV3KMolBlock,
       (python::arg("mol"), python::arg("includeStereo") = true,
        python::arg("confId") = -1, python::arg("kekulize") = true),
       docString.c_str());
@@ -1495,8 +1495,8 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
     a string\n\
 \n";
   python::def("MolToMrvBlock",
-              (std::string (*)(const ROMol &, bool, int, bool,
-                               bool))RDKit::MolToMrvBlock,
+              (std::string(*)(const ROMol &, bool, int, bool,
+                              bool))RDKit::MolToMrvBlock,
               (python::arg("mol"), python::arg("includeStereo") = true,
                python::arg("confId") = -1, python::arg("kekulize") = true,
                python::arg("prettyPrint") = false),
@@ -1516,8 +1516,8 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
 \n";
   python::def(
       "MolToMrvBlock",
-      (std::string (*)(const ROMol &, const MrvWriterParams &,
-                       int))RDKit::MolToMrvBlock,
+      (std::string(*)(const ROMol &, const MrvWriterParams &,
+                      int))RDKit::MolToMrvBlock,
       (python::arg("mol"), python::arg("params"), python::arg("confId") = -1),
       docString.c_str());
 
@@ -1799,8 +1799,8 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
       .def("__setattr__", &safeSetattr);
 
   python::def("MolToSmiles",
-              (std::string (*)(const ROMol &,
-                               const SmilesWriteParams &))RDKit::MolToSmiles,
+              (std::string(*)(const ROMol &,
+                              const SmilesWriteParams &))RDKit::MolToSmiles,
               (python::arg("mol"), python::arg("params")),
               "Returns the canonical SMILES string for a molecule");
 
@@ -1834,8 +1834,8 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
 \n";
   python::def(
       "MolToSmiles",
-      (std::string (*)(const ROMol &, bool, bool, int, bool, bool, bool, bool,
-                       bool))RDKit::MolToSmiles,
+      (std::string(*)(const ROMol &, bool, bool, int, bool, bool, bool, bool,
+                      bool))RDKit::MolToSmiles,
       (python::arg("mol"), python::arg("isomericSmiles") = true,
        python::arg("kekuleSmiles") = false, python::arg("rootedAtAtom") = -1,
        python::arg("canonical") = true, python::arg("allBondsExplicit") = false,
@@ -1957,8 +1957,8 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
 
   python::def(
       "MolToCXSmiles",
-      (std::string (*)(const ROMol &, const SmilesWriteParams &, std::uint32_t,
-                       RestoreBondDirOption))RDKit::MolToCXSmiles,
+      (std::string(*)(const ROMol &, const SmilesWriteParams &, std::uint32_t,
+                      RestoreBondDirOption))RDKit::MolToCXSmiles,
       (python::arg("mol"), python::arg("params"),
        python::arg("flags") = RDKit::SmilesWrite::CXSmilesFields::CX_ALL,
        python::arg("restoreBondDirs") =
@@ -1992,8 +1992,8 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
 \n";
   python::def(
       "MolToCXSmiles",
-      (std::string (*)(const ROMol &, bool, bool, int, bool, bool, bool,
-                       bool))RDKit::MolToCXSmiles,
+      (std::string(*)(const ROMol &, bool, bool, int, bool, bool, bool,
+                      bool))RDKit::MolToCXSmiles,
       (python::arg("mol"), python::arg("isomericSmiles") = true,
        python::arg("kekuleSmiles") = false, python::arg("rootedAtAtom") = -1,
        python::arg("canonical") = true, python::arg("allBondsExplicit") = false,
@@ -2081,7 +2081,7 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
     a string\n\
 \n";
   python::def("MolToSmarts",
-              (std::string (*)(const ROMol &, bool, int))RDKit::MolToSmarts,
+              (std::string(*)(const ROMol &, bool, int))RDKit::MolToSmarts,
               (python::arg("mol"), python::arg("isomericSmiles") = true,
                python::arg("rootedAtAtom") = -1),
               docString.c_str());
@@ -2098,8 +2098,8 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
     a string\n\
 \n";
   python::def("MolToSmarts",
-              (std::string (*)(const ROMol &,
-                               const SmilesWriteParams &))RDKit::MolToSmarts,
+              (std::string(*)(const ROMol &,
+                              const SmilesWriteParams &))RDKit::MolToSmarts,
               (python::arg("mol"), python::arg("params")), docString.c_str());
 
   docString =
@@ -2135,7 +2135,7 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
     a string\n\
 \n";
   python::def("MolToCXSmarts",
-              (std::string (*)(const ROMol &, bool))RDKit::MolToCXSmarts,
+              (std::string(*)(const ROMol &, bool))RDKit::MolToCXSmarts,
               (python::arg("mol"), python::arg("isomericSmiles") = true),
               docString.c_str());
 
@@ -2471,8 +2471,7 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
     - mol: the molecule\n\
     - atomsToUse : a list of atoms to include in the fragment\n\
     - bondsToUse : (optional) a list of bonds to include in the fragment\n\
-      if not provided, all bonds between the atoms provided\n\
-      will be included.\n\
+      if not provided, no bonds will be used\n\
     - atomSymbols : (optional) a list with the symbols to use for the atoms\n\
       in the SMILES. This should have be mol.GetNumAtoms() long.\n\
     - breakTies: (optional) force breaking of ranked ties\n\
@@ -2584,7 +2583,7 @@ BOOST_PYTHON_MODULE(rdmolfiles) {
           "restoreBondDirs", &RDKit::PNGMetadataParams::restoreBondDirs,
           "choose what to do with bond dirs in the CXSMILES string (default=rdkit.Chem.rdmolfiles.RestoreBondDirOption.RestoreBondDirOptionClear)")
       .def("__setattr__", &safeSetattr);
-      
+
   docString =
       R"DOC(Construct a molecule from metadata in a PNG string.
 

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -6268,6 +6268,15 @@ H      0.635000    0.635000    0.635000
           self.assertEqual(order1, order3)
           self.assertEqual(order2, order4)
 
+  def testRankAtomsInFragmentsWithoutBonds(self):
+    mol = Chem.MolFromSmiles('ONCO')
+    order1 = list(Chem.CanonicalRankAtomsInFragment(mol, atomsToUse=range(0, 4), breakTies=False))
+    order2 = list(Chem.CanonicalRankAtoms(mol, breakTies=False))
+    self.assertNotEqual(order1[:4], order2[4:])
+    order3 = list(
+      Chem.CanonicalRankAtomsInFragment(mol, atomsToUse=range(0, 4), bondsToUse=(0, 1, 2),
+                                        breakTies=False))
+
   def testSetBondStereoFromDirections(self):
     m1 = Chem.MolFromMolBlock(
       '''


### PR DESCRIPTION
The docstring explanation of the `bondsToUse` argument was wrong.

some clang-format reformatting of rdmolfiles.cpp also is in here

