### PR TITLE
Don't silently ignore missing  or extra atoms/bonds in copyMolSubset

### DIFF
--- a/Code/GraphMol/Subset.cpp
+++ b/Code/GraphMol/Subset.cpp
@@ -298,10 +298,7 @@ std::unique_ptr<RDKit::RWMol> copyMolSubset(
     const SubsetOptions &options) {
   const auto natoms = mol.getNumAtoms();
   const auto nbonds = mol.getNumBonds();
-  if ((atoms.size() == natoms && bonds.size() == 0 &&
-       options.method == SubsetMethod::BONDS_BETWEEN_ATOMS) ||
-      (bonds.size() == nbonds && options.method == SubsetMethod::BONDS) ||
-      (atoms.size() == natoms && bonds.size() == nbonds)) {
+  if ((atoms.size() == natoms && bonds.size() == nbonds)) {
     // optimization to copy the entire thing
     return std::make_unique<RDKit::RWMol>(mol);
   }

--- a/Code/GraphMol/catch_molops.cpp
+++ b/Code/GraphMol/catch_molops.cpp
@@ -644,6 +644,13 @@ TEST_CASE("test_manual_atom_bond_subset", "[copyMolSubset]") {
     CHECK(m2->getNumBonds() == 2);
   }
   {
+    std::vector<unsigned int> atoms = {0,1,2};
+    std::vector<unsigned int> bonds = {};
+    auto m2 = copyMolSubset(*m, atoms, bonds);
+    CHECK(m2->getNumAtoms() == 3);
+    CHECK(m2->getNumBonds() == 0);
+  }
+  {
     std::vector<unsigned int> atoms = {0,1,2,3};
     std::vector<unsigned int> bonds = {0,1};
     REQUIRE_THROWS_AS(copyMolSubset(*m, atoms, bonds), IndexErrorException);


### PR DESCRIPTION
Fixes #9084
Fixes #9088