### PR TITLE
Validate subset atom and bond indices - fixes #9084

### DIFF
--- a/Code/GraphMol/Subset.cpp
+++ b/Code/GraphMol/Subset.cpp
@@ -311,10 +311,26 @@ std::unique_ptr<RDKit::RWMol> copyMolSubset(
   selection_info.bondMapping.clear();
 
   for (auto v : atoms) {
+    if (v >= natoms) {
+      throw ValueErrorException("Invalid atom index");
+    }
     selection_info.selectedAtoms.set(v);
   }
   for (auto v : bonds) {
+    if (v >= nbonds) {
+      throw ValueErrorException("Invalid bond index");
+    }
     selection_info.selectedBonds.set(v);
+  }
+
+  // Validate atoms includes all endpoints in bonds
+  for (auto bondIdx : bonds) {
+    const auto *bnd = mol.getBondWithIdx(bondIdx);
+    const auto a1 = bnd->getBeginAtomIdx();
+    const auto a2 = bnd->getEndAtomIdx();
+    if (!selection_info.selectedAtoms[a1] || !selection_info.selectedAtoms[a2]) {
+      throw ValueErrorException("Subset atoms must include all bond endpoints");
+    }
   }
 
   auto res = copyMolSubset(mol, selection_info, options);

--- a/Code/GraphMol/Wrap/test_subset.py
+++ b/Code/GraphMol/Wrap/test_subset.py
@@ -73,3 +73,24 @@ class TestCase(unittest.TestCase):
     opts.clearComputedProps = True
     sub = Chem.CopyMolSubset(m, N, opts)
     self.assertFalse(sub.HasProp("foo"))
+
+  def test_explicit_atoms_bonds_inconsistent_raises(self):
+    m = Chem.MolFromSmiles("CCC")  # atoms 0-1-2, bonds: 0 (0-1), 1 (1-2)
+    # select atoms 0 and 2, but bond 1 references atom 1 (missing)
+    with self.assertRaises(ValueError):
+      Chem.CopyMolSubset(m, [0, 2], [1])
+
+  def test_explicit_atoms_bonds_consistent_ok(self):
+    m = Chem.MolFromSmiles("CCC")
+    sub = Chem.CopyMolSubset(m, [1, 2], [1])
+    self.assertEqual(Chem.MolToSmiles(sub), "CC")
+
+  def test_explicit_atoms_out_of_range_raises(self):
+    m = Chem.MolFromSmiles("CCC")
+    with self.assertRaises(ValueError):
+      Chem.CopyMolSubset(m, [0, 3], [0])  # atom index 3 is OOR
+
+  def test_explicit_bonds_out_of_range_raises(self):
+    m = Chem.MolFromSmiles("CCC")
+    with self.assertRaises(ValueError):
+      Chem.CopyMolSubset(m, [0, 1], [2])  # bond index 2 is OOR


### PR DESCRIPTION
#### Reference Issue
Fixes #9084

#### What does this implement/fix? Explain your changes.
Prevents an incorrect behavior in `CopyMolSubset(mol, atomIndices, bondIndices, ...)` when `bondIndices` include bonds whose endpoint atoms are not present in `atomIndices`.

Previously, the implementation could produce an incorrect subset by default-inserting missing atom mappings (via `std::map::operator[]`), resulting in bonds being incorrectly connected to atom 0 in the subset.

#### Any other comments?
No changes here to the path-based `CopyMolSubset(mol, path, options)` variant - but noting that it looks like this silently ignores out-of-range atom/bond indices.

@bp-kelley - hopefully this implements your preferred fix for #9084