### PR TITLE
The precondition in Bond::getOtherAtomIdx() is redundant

### DIFF
--- a/Code/GraphMol/Bond.cpp
+++ b/Code/GraphMol/Bond.cpp
@@ -85,7 +85,7 @@ unsigned int Bond::getOtherAtomIdx(const unsigned int thisIdx) const {
   }
   // This "precondition" would check exactly the same that is checked
   // above, but no need to be redundant, so just throw.
-  PRECONDITION(false, "bad index");
+  POSTCONDITION(false, "bad index");
 }
 
 void Bond::setBeginAtomIdx(unsigned int what) {


### PR DESCRIPTION
The precondition tests exactly the same thing as the `if`/ `else if` in the function. So why check twice?
