### PR TITLE
Further refactoring in SSSR finding

### DIFF
--- a/Code/GraphMol/FindRings.cpp
+++ b/Code/GraphMol/FindRings.cpp
@@ -105,10 +105,10 @@ void trimBonds(unsigned int cand, const ROMol &tMol, std::queue<int> &changed,
  * SUMMARY:
  *  this again is a modified version of the BFS algorithm in Figueras paper to
  *  find the smallest ring with a specified root atom.
- *    JCICS, Vol. 30, No. 5, 1996, 986-991
+ *    JCICS, Vol. 36, No. 5, 1996, 986-991
  *  The following are changes from the original algorithm
  *   - find all smallest rings around a node not just one
- *   - once can provided a list of node IDs that should not be include in the
+ *   - one can provide a list of node IDs that should not be include in the
  *     discovered rings
  *
  * ARGUMENTS:
@@ -523,16 +523,13 @@ void findRingsD3Node(const ROMol &tMol, VECT_INT_VECT &res,
   // We've got a degree three node. The goal of what follows is to find the
   // three rings in which it's involved, push those onto our results, and
   // then remove the node from consideration.  This will create a bunch of
-  // degree
-  // 2 nodes, which we can then chew off the next time around the loop.
+  // degree 2 nodes, which we can then chew off the next time around the loop.
 
   // this part is a bit different from the Figueras algorithm
   // here we try to find all the rings the rings that have a potential for
-  // contributing to
-  // SSSR - i.e. we try to find 3 rings for this node.
+  // contributing to SSSR - i.e. we try to find 3 rings for this node.
   // - each bond (that contributes to the degree 3 ) is allowed to participate
-  // in exactly
-  //    two of these rings.
+  // in exactly two of these rings.
   // - also any rings that are included in already found rings are ignored
 
   // ASSUME: every connection from a degree three node at this point is a


### PR DESCRIPTION
This does some more refactoring in `findSSSR()` code:
- use queues instead of sets to store atoms to be removed from the calculation (no need for sorting; duplicate atoms will be skipped anyway).
- Skip the last 2 atoms in the `findSSSR()` main loop: if these were in a ring, we'd have already noticed.
- Simplify duplicate ring detection in `findRingsD2nodes()`: `nodeInvars` is not required.
- Make smallestRingsBfs a free function: `BFSWorkspace` does not preserve state (the vectors it contains are reassigned on each run of `smallestRingsBfs`), and the instances are recreated several times, so it really doesn't reuse memory either.
- Fix the reference to the Figueras' paper: it's in volume 36, not 30, as the comment said.

I benchmarked these changes by running the C++ several times, and it seems they consistenrly run ~1 s faster than before on my machine. Not much of an improvement but it didn't get worse :)
