### PR TITLE
Use CXX flags not C flags in ChemDraw cmake config

### DIFF
--- a/External/ChemDraw/CMakeLists.txt
+++ b/External/ChemDraw/CMakeLists.txt
@@ -119,7 +119,6 @@ if(RDK_BUILD_CHEMDRAW_SUPPORT)
   endif()
 
   if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-    string(REPLACE " -Werror" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-comment -Wno-parentheses -Wno-logical-op-parentheses -Wno-pointer-bool-conversion -Wno-unused-value -Wno-unsequenced -Wno-constant-logical-operand")
   endif()
 


### PR DESCRIPTION
Simple fix, this is intended to help with #9094 but I can't duplicate the issues on MacOS 15