### PR TITLE
Update The SSSR Problem `GetSSSR` Documentation

### DIFF
--- a/Docs/Book/GettingStartedInC++.md
+++ b/Docs/Book/GettingStartedInC++.md
@@ -1537,12 +1537,12 @@ will give results that are unappealing.  For example, the SSSR for
 cubane only contains 5 rings, even though there are
 “obviously” 6. This problem can be fixed by implementing a *small*
 (instead of *smallest*) set of smallest rings algorithm that returns
-symmetric results.  This is the approach that we took with the RDKit.
+symmetric results. This is the approach that we took with the RDKit
+in :py:func:`rdkit.Chem.GetSymmSSSR`.
 
-Because it is sometimes useful to be able to count how many SSSR rings
-are present in the molecule, there is a
-`rdkit.Chem.rdmolops.GetSSSR` function, but this only returns the
-SSSR count, not the potentially non-unique set of rings.
+Because it is sometimes useful to know the "true" SSSR rings, there
+is a :py:func:`rdkit.Chem.GetSSSR` function which returns this
+potentially non-unique set of rings.
 
 [^blaney]: Blaney, J. M.; Dixon, J. S. "Distance Geometry
 in Molecular Modeling".  *Reviews in Computational Chemistry*; VCH:

--- a/Docs/Book/GettingStartedInPython.rst
+++ b/Docs/Book/GettingStartedInPython.rst
@@ -3666,12 +3666,12 @@ will give results that are unappealing.  For example, the SSSR for
 cubane only contains 5 rings, even though there are
 “obviously” 6. This problem can be fixed by implementing a *small*
 (instead of *smallest*) set of smallest rings algorithm that returns
-symmetric results.  This is the approach that we took with the RDKit.
+symmetric results. This is the approach that we took with the RDKit
+in :py:func:`rdkit.Chem.GetSymmSSSR`.
 
-Because it is sometimes useful to be able to count how many SSSR rings
-are present in the molecule, there is a
-:py:func:`rdkit.Chem.rdmolops.GetSSSR` function, but this only returns the
-SSSR count, not the potentially non-unique set of rings.
+Because it is sometimes useful to know the "true" SSSR rings, there
+is a :py:func:`rdkit.Chem.GetSSSR` function which returns this
+potentially non-unique set of rings.
 
 
 List of Available Descriptors

--- a/Docs/Book/RDKit_Book.rst
+++ b/Docs/Book/RDKit_Book.rst
@@ -690,9 +690,9 @@ Ring Finding and SSSR
 As others have ranted about with more energy and eloquence than I intend to, the definition of a molecule's smallest set of smallest rings is not unique.
 In some high symmetry molecules, a “true” SSSR will give results that are unappealing.
 For example, the SSSR for cubane only contains 5 rings, even though there are “obviously” 6. This problem can be fixed by implementing a *small* (instead of *smallest*) set of smallest rings algorithm that returns symmetric results.
-This is the approach that we took with the RDKit.
+This is the approach that we took with the RDKit in :py:func:`rdkit.Chem.GetSymmSSSR`.
 
-Because it is sometimes useful to be able to count how many SSSR rings are present in the molecule, there is a GetSSSR function, but this only returns the SSSR count, not the potentially non-unique set of rings.
+Because it is sometimes useful to know the "true" SSSR rings, there is a :py:func:`rdkit.Chem.GetSSSR` function which returns this potentially non-unique set of rings.
 
 For situations where you just care about knowing whether or not atoms/bonds are in rings, the RDKit provides the function
 :py:func:`rdkit.Chem.rdmolops.FastFindRings`. This does a depth-first traversal of the molecule graph and identifies atoms and bonds that


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! 
-->
#### Reference Issue

Related to the already-closed https://github.com/rdkit/rdkit/issues/5395, which requested that `GetSSSR` would return rings (like `GetSymmSSSR`) rather than an int.

The change was made here: https://github.com/rdkit/rdkit/pull/5437
and the docs were partially updated, but some references to the old return type remained elsewhere.

#### What does this implement/fix? Explain your changes.

Updates the outdated docs referring to GetSSSR's return type being an int.

#### Any other comments?

We discovered this apparent typo when working on this unrelated pull request, but I'll mention it here or our own work-tracking purposes: https://github.com/ReactionMechanismGenerator/RMG-Py/pull/2796