### PR TITLE
swap zlib download to use github

### DIFF
--- a/Code/MinimalLib/docker/Dockerfile_1_deps
+++ b/Code/MinimalLib/docker/Dockerfile_1_deps
@@ -20,7 +20,7 @@ ARG BOOST_PATCH_VERSION="0"
 ARG BOOST_DOT_VERSION
 ARG BOOST_UNDERSCORE_VERSION
 ARG FREETYPE_VERSION="2.13.3"
-ARG ZLIB_VERSION="1.3.1"
+ARG ZLIB_VERSION="1.3.2"
 ARG http_proxy
 ARG https_proxy
 
@@ -96,7 +96,7 @@ RUN emcmake cmake -DCMAKE_BUILD_TYPE=Release \
 RUN make -j2 && make -j2 install
 
 WORKDIR /src
-RUN wget -q https://zlib.net/zlib-${ZLIB_VERSION}.tar.gz && \
+RUN wget -q https://github.com/madler/zlib/releases/download/v${ZLIB_VERSION}/zlib-${ZLIB_VERSION}.tar.gz && \
   tar xzf zlib-${ZLIB_VERSION}.tar.gz
 WORKDIR /src/zlib-${ZLIB_VERSION}
 RUN mkdir build


### PR DESCRIPTION
zlib.net apparently only keeps the most recent version around, so when they update our CI pipelines break

also bumps the version



