### PR TITLE
Tautomer insensitive hash v2, E/Z and stereocenter-preservation

### DIFF
--- a/Code/GraphMol/MolHash/catch_tests.cpp
+++ b/Code/GraphMol/MolHash/catch_tests.cpp
@@ -471,15 +471,29 @@ TEST_CASE("tautomer v2") {
                  "C1C=CC=C2C=C(O)NC=12",
              }},
             // ---------------------------
-            // some areas for potential improvement
+            // E/Z isomers with heteroaromatic rings
             // ---------------------------
-            // these two are tautomers, but the current algorithm does not catch
-            // them
-            // problematic because pyridine is recognized as tautomeric
-            {{"c1ccccc1/C=C/c1ncccc1", "c1ccccc1/C=C\\c1ncccc1",
-              "c1ccccc1C=Cc1ncccc1"},
-             {}},
-        };
+            // Stilbene with pyridyl: E and Z are NOT tautomers and should have
+            // different hashes. Previously the algorithm incorrectly treated
+            // aromatic heteroatoms like pyridine N as tautomeric candidates,
+            // causing stereo to be stripped.
+            {{"c1ccccc1/C=C/c1ncccc1"}, // in ChEMBL (CHEMBL1877619)
+             {"c1ccccc1/C=C\\c1ncccc1", "c1ccccc1C=Cc1ncccc1"}},
+            // 5-benzylidenerhodanine: E/Z isomers are NOT tautomers and should
+            // have different hashes. The exocyclic C=C to phenyl should
+            // preserve stereochemistry.
+            {{"O=C1NC(=S)S/C1=C/c2ccccc2"}, // in ChEMBL (CHEMBL4796170)
+             {"O=C1NC(=S)S/C1=C\\c2ccccc2", "O=C1NC(=S)SC1=Cc2ccccc2"}},
+            // ---------------------------
+            // stereocenters near amide bonds should not be destroyed
+            // by extension through flagged bonds
+            // ---------------------------
+            // proline-like stereocenter between two amide C=O groups
+            {{"NC(=O)[C@H]1CCCN1C=O"},
+            {"NC(=O)[C@@H]1CCCN1C=O"}}, // in SureChEMBL (8959051)
+            // stereocenters near amide bonds on pyrrolidine ring
+            {{"CC(=O)N[C@H]1CCNC1"}, {"CC(=O)N[C@@H]1CCNC1", "CC(=O)NC1CCNC1"}}, // in SureChEMBL (39850)
+            };
     for (const auto &[same, diff] : data) {
       std::unique_ptr<RWMol> m{SmilesToMol(same[0])};
       REQUIRE(m);

--- a/Code/GraphMol/MolHash/catch_tests.cpp
+++ b/Code/GraphMol/MolHash/catch_tests.cpp
@@ -484,6 +484,11 @@ TEST_CASE("tautomer v2") {
             // preserve stereochemistry.
             {{"O=C1NC(=S)S/C1=C/c2ccccc2"}, // in ChEMBL (CHEMBL4796170)
              {"O=C1NC(=S)S/C1=C\\c2ccccc2", "O=C1NC(=S)SC1=Cc2ccccc2"}},
+            // E/Z hydrazones with exocyclic C=N to a ring: E and Z isomers
+            // are NOT tautomers and should have different hashes.
+            {{"c1ccccc1N/N=C2\\CCCCC2C"}, // in SureChEMBL (11696321)
+             {"c1ccccc1N/N=C2/CCCCC2C",
+              "c1ccccc1NN=C2CCCCC2C"}},
             // ---------------------------
             // stereocenters near amide bonds should not be destroyed
             // by extension through flagged bonds
@@ -493,6 +498,13 @@ TEST_CASE("tautomer v2") {
             {"NC(=O)[C@@H]1CCCN1C=O"}}, // in SureChEMBL (8959051)
             // stereocenters near amide bonds on pyrrolidine ring
             {{"CC(=O)N[C@H]1CCNC1"}, {"CC(=O)N[C@@H]1CCNC1", "CC(=O)NC1CCNC1"}}, // in SureChEMBL (39850)
+            // stereocenter adjacent to pyrimidine/pyrazole: enantiomers should differ
+            // (stereocenter connected via single non-conjugated N-C bond)
+            {{"C[C@H](c1ccccc1)Nc2ncc(c(n2)Nc3cc([nH]n3)C4CC4)Cl"}, // in SureChEMBL (4072338)
+             {"C[C@@H](c1ccccc1)Nc2ncc(c(n2)Nc3cc([nH]n3)C4CC4)Cl"}},
+            // diastereomers on indole ring: aromatic C should not pull in stereocenters
+            {{"C[C@@H]1Cc2c3ccccc3[nH]c2[C@@H](N1CC(F)(F)F)c4cc(ccc4Cl)OCCNCCCF"},
+             {"C[C@@H]1Cc2c3ccccc3[nH]c2[C@H](N1CC(F)(F)F)c4cc(ccc4Cl)OCCNCCCF"}}, // in ChEMBL CHEMBL5972799
             };
     for (const auto &[same, diff] : data) {
       std::unique_ptr<RWMol> m{SmilesToMol(same[0])};

--- a/Code/GraphMol/MolHash/hashfunctions.cpp
+++ b/Code/GraphMol/MolHash/hashfunctions.cpp
@@ -619,6 +619,9 @@ bool checkForOverreach(
 std::string TautomerHashv2(RWMol *mol, bool proto, bool useCXSmiles,
                            unsigned cxFlagsToSkip = 0) {
   PRECONDITION(mol, "bad molecule");
+  if (!mol->getRingInfo()->isFindFastOrBetter()) {
+    MolOps::fastFindRings(*mol);
+  }
   std::string result;
   unsigned int hcount = 0;
   int charge = 0;
@@ -921,10 +924,12 @@ std::string TautomerHashv2(RWMol *mol, bool proto, bool useCXSmiles,
         bool endInRing = queryIsAtomInRing(bptr->getEndAtom());
         isExocyclicWithStereo = (beginInRing != endInRing);
       }
-      bptr->setIsAromatic(false);
       if (!isExocyclicWithStereo) {
         bptr->setBondType(Bond::AROMATIC);
+        bptr->setIsAromatic(true);  // Must be consistent with bond type
         bptr->setStereo(Bond::BondStereo::STEREONONE);
+      } else {
+        bptr->setIsAromatic(false);
       }
       atomsToModify.set(bptr->getBeginAtomIdx());
       atomsToModify.set(bptr->getEndAtomIdx());
@@ -1307,7 +1312,7 @@ std::string RegioisomerHash(RWMol *mol, bool useCXSmiles,
   // we need a copy of the molecule so that we can loop over the bonds of
   // something while modifying something else
   RDKit::ROMol molcpy(*mol);
-  if (molcpy.getRingInfo()->isFindFastOrBetter()) {
+  if (!molcpy.getRingInfo()->isFindFastOrBetter()) {
     MolOps::fastFindRings(molcpy);
   }
   for (int i = molcpy.getNumBonds() - 1; i >= 0; --i) {

--- a/Code/GraphMol/MolHash/hashfunctions.cpp
+++ b/Code/GraphMol/MolHash/hashfunctions.cpp
@@ -508,7 +508,8 @@ bool hasStartBond(const Atom *aptr, const boost::dynamic_bitset<> &startBonds) {
 // Aromatic atoms shouldn't pull in substituent stereocenters.
 bool shouldSkipChiralNeighbor(const Atom *sourceAtom, const Atom *targetAtom,
                                const Bond *connectingBond) {
-  if (targetAtom->getChiralTag() == Atom::CHI_UNSPECIFIED) {
+  if (targetAtom->getHybridization() != Atom::SP3 ||
+      targetAtom->getTotalNumHs() != 1) {
     return false;
   }
   if (isUnsaturatedBond(connectingBond) || connectingBond->getIsConjugated()) {
@@ -878,10 +879,17 @@ std::string TautomerHashv2(RWMol *mol, bool proto, bool useCXSmiles,
         if (!oatom->getTotalNumHs()) {
           continue;
         }
-        // don't extend to reach a stereocenter — doing so would incorrectly
-        // pull the stereocenter into the tautomeric system and destroy its
-        // chirality
-        if (oatom->getChiralTag() != Atom::CHI_UNSPECIFIED) {
+        // don't extend to reach a potential stereocenter — doing so would
+        // incorrectly pull the stereocenter into the tautomeric system and
+        // destroy its chirality. Use structural criteria (SP3 + 1H) for
+        // chain atoms so behavior is consistent regardless of annotation.
+        // For ring atoms, only skip if chirality is actually annotated,
+        // since ring SP3+1H atoms often genuinely participate in ring
+        // tautomerism (e.g. purine NH, glutarimide).
+        if (oatom->getHybridization() == Atom::SP3 &&
+            oatom->getTotalNumHs() == 1 &&
+            (!queryIsAtomInRing(oatom) ||
+             oatom->getChiralTag() != Atom::CHI_UNSPECIFIED)) {
           continue;
         }
         unsigned int numModifiedNeighbors = 0;

--- a/Code/GraphMol/MolHash/hashfunctions.cpp
+++ b/Code/GraphMol/MolHash/hashfunctions.cpp
@@ -559,35 +559,6 @@ bool skipNeighborBond(const Atom *atom, const Atom *otherAtom,
            !hasStartBond(atom, startBonds)));
 }
 
-// Check if we're extending from an aromatic system to an exocyclic C=C bond
-// where the aromatic system doesn't have any atoms with mobile H that could
-// participate in tautomerism with the exocyclic bond. This prevents cases
-// like stilbene-pyridyl (c1ccccc1/C=C/c1ncccc1) from incorrectly losing E/Z
-// stereo on the exocyclic C=C.
-// Only blocks when:
-// 1. The neighbor bond is a C=C double bond (not aromatic, not single)
-// 2. The current atom is aromatic carbon without H
-// 3. Both atoms of the C=C bond are carbon (pure hydrocarbon C=C)
-bool checkForAromaticOverreach(const Atom *atom, const Atom *otherAtom,
-                               const Bond *nbrBond) {
-  // Only check non-aromatic double bonds
-  if (nbrBond->getIsAromatic() ||
-      nbrBond->getBondType() != Bond::BondType::DOUBLE) {
-    return false;
-  }
-  // Current atom must be aromatic carbon without H
-  if (!atom->getIsAromatic() || atom->getAtomicNum() != 6 ||
-      atom->getTotalNumHs() > 0) {
-    return false;
-  }
-  // The other atom must also be carbon (blocking C=C but not C=N etc)
-  if (otherAtom->getAtomicNum() != 6) {
-    return false;
-  }
-  // Block extension: aromatic C (no H) → exocyclic C=C
-  return true;
-}
-
 // counts the number of neighboring atoms that have conjugated bonds.
 unsigned int getNumConjugatedNeighbors(
     const Atom *atom, const boost::dynamic_bitset<> &startBonds) {
@@ -701,9 +672,22 @@ std::string TautomerHashv2(RWMol *mol, bool proto, bool useCXSmiles,
                               numConjugatedNeighbors)) {
           continue;
         }
-        // Check if we're extending from aromatic C without H to exocyclic C=C
-        if (checkForAromaticOverreach(atm, oatom, nbrBond)) {
-          continue;
+        // Don't extend to a stereocenter via single non-conjugated bonds,
+        // unless the source atom has a non-aromatic unsaturated bond
+        // (indicating the stereocenter could become sp2 in a tautomer).
+        // Aromatic atoms shouldn't pull in substituent stereocenters.
+        if (oatom->getChiralTag() != Atom::CHI_UNSPECIFIED &&
+            !isUnsaturatedBond(nbrBond) && !nbrBond->getIsConjugated()) {
+          bool hasNonAromaticUnsatBond = false;
+          for (const auto &srcBnd : mol->atomBonds(atm)) {
+            if (!srcBnd->getIsAromatic() && isUnsaturatedBond(srcBnd)) {
+              hasNonAromaticUnsatBond = true;
+              break;
+            }
+          }
+          if (!hasNonAromaticUnsatBond) {
+            continue;
+          }
         }
 
         // if the bond is not eligible, then we can skip this neighbor
@@ -786,9 +770,20 @@ std::string TautomerHashv2(RWMol *mol, bool proto, bool useCXSmiles,
                                 numConjugatedNeighbors)) {
             continue;
           }
-          // Check if we're extending from aromatic C without H to exocyclic C=C
-          if (checkForAromaticOverreach(atm, oatom, nbrBnd)) {
-            continue;
+          // Don't extend to a stereocenter via single non-conjugated bonds,
+          // unless the source has a non-aromatic unsaturated bond.
+          if (oatom->getChiralTag() != Atom::CHI_UNSPECIFIED &&
+              !isUnsaturatedBond(nbrBnd) && !nbrBnd->getIsConjugated()) {
+            bool hasNonAromaticUnsatBond = false;
+            for (const auto &srcBnd : mol->atomBonds(atm)) {
+              if (!srcBnd->getIsAromatic() && isUnsaturatedBond(srcBnd)) {
+                hasNonAromaticUnsatBond = true;
+                break;
+              }
+            }
+            if (!hasNonAromaticUnsatBond) {
+              continue;
+            }
           }
           if ((skipNeighborBond(atm, oatom, nbrBnd, startBonds, atomFlags,
                                 bondFlags) &&
@@ -885,11 +880,10 @@ std::string TautomerHashv2(RWMol *mol, bool proto, bool useCXSmiles,
         if (!oatom->getTotalNumHs()) {
           continue;
         }
-        // don't extend through a flagged bond (e.g. amide, carboxyl) to reach
-        // a stereocenter — doing so would incorrectly pull the stereocenter
-        // into the tautomeric system and destroy its chirality
-        if (bondFlags[nbrBond->getIdx()] &&
-            oatom->getChiralTag() != Atom::CHI_UNSPECIFIED) {
+        // don't extend to reach a stereocenter — doing so would incorrectly
+        // pull the stereocenter into the tautomeric system and destroy its
+        // chirality
+        if (oatom->getChiralTag() != Atom::CHI_UNSPECIFIED) {
           continue;
         }
         unsigned int numModifiedNeighbors = 0;
@@ -922,9 +916,21 @@ std::string TautomerHashv2(RWMol *mol, bool proto, bool useCXSmiles,
       if (!bondsToModify[bptr->getIdx()]) {
         continue;
       }
+      // Preserve E/Z stereo on exocyclic double bonds (one atom in ring, one not)
+      // to avoid merging distinct geometric isomers (e.g., E/Z hydrazones).
+      // For these bonds, keep them as DOUBLE bonds (not AROMATIC) so that
+      // E/Z stereo is preserved in the SMILES output.
+      bool isExocyclicWithStereo = false;
+      if (bptr->getStereo() != Bond::BondStereo::STEREONONE) {
+        bool beginInRing = queryIsAtomInRing(bptr->getBeginAtom());
+        bool endInRing = queryIsAtomInRing(bptr->getEndAtom());
+        isExocyclicWithStereo = (beginInRing != endInRing);
+      }
       bptr->setIsAromatic(false);
-      bptr->setBondType(Bond::AROMATIC);
-      bptr->setStereo(Bond::BondStereo::STEREONONE);
+      if (!isExocyclicWithStereo) {
+        bptr->setBondType(Bond::AROMATIC);
+        bptr->setStereo(Bond::BondStereo::STEREONONE);
+      }
       atomsToModify.set(bptr->getBeginAtomIdx());
       atomsToModify.set(bptr->getEndAtomIdx());
     }

--- a/Code/GraphMol/MolHash/hashfunctions.cpp
+++ b/Code/GraphMol/MolHash/hashfunctions.cpp
@@ -502,6 +502,27 @@ bool hasStartBond(const Atom *aptr, const boost::dynamic_bitset<> &startBonds) {
   return false;
 }
 
+// Don't extend to a stereocenter via single non-conjugated bonds,
+// unless the source atom has a non-aromatic unsaturated bond
+// (indicating the stereocenter could become sp2 in a tautomer).
+// Aromatic atoms shouldn't pull in substituent stereocenters.
+bool shouldSkipChiralNeighbor(const Atom *sourceAtom, const Atom *targetAtom,
+                               const Bond *connectingBond) {
+  if (targetAtom->getChiralTag() == Atom::CHI_UNSPECIFIED) {
+    return false;
+  }
+  if (isUnsaturatedBond(connectingBond) || connectingBond->getIsConjugated()) {
+    return false;
+  }
+  // Check if source has a non-aromatic unsaturated bond
+  for (const auto &srcBnd : sourceAtom->getOwningMol().atomBonds(sourceAtom)) {
+    if (!srcBnd->getIsAromatic() && isUnsaturatedBond(srcBnd)) {
+      return false;  // Source could participate in tautomerism
+    }
+  }
+  return true;  // Skip this chiral neighbor
+}
+
 // skip the neighbor bond if otherAtom isn't a candidate and doesn't have a
 // start bond OR if the bond is neither unsaturated nor conjugated and atom
 // doesn't have a start bond
@@ -514,10 +535,10 @@ bool skipNeighborBond(const Atom *atom, const Atom *otherAtom,
     return true;
   }
 
-  // Special case: prevent extending between aromatic rings without H-bearing
-  // heteroatoms and exocyclic C=C systems. This handles cases like
-  // stilbene-pyridyl (c1ccccc1/C=C/c1ncccc1) where the pyridine N has no H but
-  // the algorithm would otherwise extend to the exocyclic C=C.
+  // Special case: prevent extending from an aromatic carbon (with no H)
+  // to an exocyclic C=C system. This handles cases like stilbene-pyridyl
+  // (c1ccccc1/C=C/c1ncccc1) where the aromatic C has no mobile H but the
+  // algorithm would otherwise extend to the exocyclic C=C and destroy E/Z.
   // Check BOTH directions: either the aromatic atom extending to vinyl,
   // or the vinyl atom being connected from aromatic.
   if (!nbrBond->getIsAromatic()) {
@@ -672,22 +693,8 @@ std::string TautomerHashv2(RWMol *mol, bool proto, bool useCXSmiles,
                               numConjugatedNeighbors)) {
           continue;
         }
-        // Don't extend to a stereocenter via single non-conjugated bonds,
-        // unless the source atom has a non-aromatic unsaturated bond
-        // (indicating the stereocenter could become sp2 in a tautomer).
-        // Aromatic atoms shouldn't pull in substituent stereocenters.
-        if (oatom->getChiralTag() != Atom::CHI_UNSPECIFIED &&
-            !isUnsaturatedBond(nbrBond) && !nbrBond->getIsConjugated()) {
-          bool hasNonAromaticUnsatBond = false;
-          for (const auto &srcBnd : mol->atomBonds(atm)) {
-            if (!srcBnd->getIsAromatic() && isUnsaturatedBond(srcBnd)) {
-              hasNonAromaticUnsatBond = true;
-              break;
-            }
-          }
-          if (!hasNonAromaticUnsatBond) {
-            continue;
-          }
+        if (shouldSkipChiralNeighbor(atm, oatom, nbrBond)) {
+          continue;
         }
 
         // if the bond is not eligible, then we can skip this neighbor
@@ -770,20 +777,8 @@ std::string TautomerHashv2(RWMol *mol, bool proto, bool useCXSmiles,
                                 numConjugatedNeighbors)) {
             continue;
           }
-          // Don't extend to a stereocenter via single non-conjugated bonds,
-          // unless the source has a non-aromatic unsaturated bond.
-          if (oatom->getChiralTag() != Atom::CHI_UNSPECIFIED &&
-              !isUnsaturatedBond(nbrBnd) && !nbrBnd->getIsConjugated()) {
-            bool hasNonAromaticUnsatBond = false;
-            for (const auto &srcBnd : mol->atomBonds(atm)) {
-              if (!srcBnd->getIsAromatic() && isUnsaturatedBond(srcBnd)) {
-                hasNonAromaticUnsatBond = true;
-                break;
-              }
-            }
-            if (!hasNonAromaticUnsatBond) {
-              continue;
-            }
+          if (shouldSkipChiralNeighbor(atm, oatom, nbrBnd)) {
+            continue;
           }
           if ((skipNeighborBond(atm, oatom, nbrBnd, startBonds, atomFlags,
                                 bondFlags) &&


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! 
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.

This PR improves the TautomerHashv2 algorithm by making it more conservative about what it considers part of a tautomeric system.

The changes prevent extending the tautomeric system to stereocenters via single non-conjugated bonds, avoiding incorrect destruction of chirality information. They also preserve E/Z stereo on exocyclic double bonds, keeping geometric isomer information (e.g., E/Z hydrazones) by maintaining exocyclic double bonds as DOUBLE rather than converting them to AROMATIC. Finally, the algorithm no longer reaches from aromatic rings (with no H-bearing heteroatoms) into exocyclic C=C systems like stilbene-pyridyl cases.

On our ~5M internal dataset, TautomerHashv1 was outperforming v2, producing half the number of incorrect compound collapses despite v2 being designed to be more precise. These changes address specific cases where v2 was being overly aggressive, resulting in v2 now performing better than v1 on our internal data.


Addreses known limitation:
https://github.com/rdkit/rdkit/blob/master/Code/GraphMol/MolHash/catch_tests.cpp#L473-L481

#### Any other comments?
This PR is AI assisted (with Claude Opus 4.5).


