### PR TITLE
Add explicit operator= and copy c'tors to Transform3D and its base classes.

### DIFF
--- a/Code/Geometry/Transform3D.h
+++ b/Code/Geometry/Transform3D.h
@@ -44,6 +44,12 @@ class RDKIT_RDGEOMETRYLIB_EXPORT Transform3D
       d_data[id] = 1.0;
     }
   }
+  Transform3D(const Transform3D &t) = default;
+  Transform3D(Transform3D &&t) = default;
+  ~Transform3D() = default;
+
+  Transform3D &operator=(const Transform3D &t) = default;
+  Transform3D &operator=(Transform3D &&t) = default;
 
   void setToIdentity();
 

--- a/Code/Geometry/catch_tests.cpp
+++ b/Code/Geometry/catch_tests.cpp
@@ -9,6 +9,7 @@
 //
 #include <catch2/catch_all.hpp>
 #include <Geometry/point.h>
+#include <Geometry/Transform3D.h>
 #include <Geometry/UniformGrid3D.h>
 
 TEST_CASE("construct Point2D from Point3D", "[point]") {
@@ -141,5 +142,38 @@ TEST_CASE("compareParams") {
                                RDKit::DiscreteValueVect::TWOBITVALUE, &offset);
     CHECK(!grd.compareParams(grd2));
     CHECK(!grd2.compareParams(grd));
+  }
+}
+
+TEST_CASE("Test copy c'tor and operator=") {
+  RDGeom::Transform3D t1;
+  for (unsigned int i = 0; i < 4; ++i) {
+    for (unsigned int j = 0; j < 4; ++j) {
+      t1.setValUnchecked(i, j, i * j);
+    }
+  }
+
+  RDGeom::Transform3D t2(t1);
+  for (unsigned int i = 0; i < 4; ++i) {
+    for (unsigned int j = 0; j < 4; ++j) {
+      CHECK(t1.getValUnchecked(i, j) == t2.getValUnchecked(i, j));
+    }
+  }
+
+  RDGeom::Transform3D t3;
+  for (unsigned int i = 0; i < 4; ++i) {
+    for (unsigned int j = 0; j < 4; ++j) {
+      if (i == j) {
+        CHECK(t3.getValUnchecked(i, j) == 1.0);
+      } else {
+        CHECK(t3.getValUnchecked(i, j) == 0.0);
+      }
+    }
+  }
+  t3 = t2;
+  for (unsigned int i = 0; i < 4; ++i) {
+    for (unsigned int j = 0; j < 4; ++j) {
+      CHECK(t3.getValUnchecked(i, j) == t2.getValUnchecked(i, j));
+    }
   }
 }

--- a/Code/Numerics/Matrix.h
+++ b/Code/Numerics/Matrix.h
@@ -71,8 +71,16 @@ class Matrix {
            d_dataSize * sizeof(TYPE));
     d_data.reset(data);
   }
-
+  Matrix(Matrix<TYPE> &&other) = default;
   virtual ~Matrix() {}
+
+  Matrix<TYPE> &operator=(const Matrix<TYPE> &other) {
+    if (this == &other) {
+      return *this;
+    }
+    return assign(other);
+  }
+  Matrix<TYPE> &operator=(Matrix<TYPE> &&other) = default;
 
   //! returns the number of rows
   inline unsigned int numRows() const { return d_nRows; }
@@ -159,7 +167,7 @@ class Matrix {
   }
 
   //! Matrix addition.
-  /*! Perform a element by element addition of other Matrix to this Matrix
+  /*! Perform an element by element addition of other Matrix to this Matrix
    */
   virtual Matrix<TYPE> &operator+=(const Matrix<TYPE> &other) {
     PRECONDITION(d_nRows == other.numRows(),
@@ -246,9 +254,6 @@ class Matrix {
   unsigned int d_nCols{0};
   unsigned int d_dataSize{0};
   DATA_SPTR d_data;
-
- private:
-  Matrix<TYPE> &operator=(const Matrix<TYPE> &other);
 };
 
 //! Matrix multiplication
@@ -276,7 +281,7 @@ Matrix<TYPE> &multiply(const Matrix<TYPE> &A, const Matrix<TYPE> &B,
   CHECK_INVARIANT(aRows == cRows, "Size mismatch during multiplication");
   CHECK_INVARIANT(bCols == cCols, "Size mismatch during multiplication");
 
-  // we have the sizes check do do the multiplication
+  // we have the sizes check so do the multiplication
   TYPE *cData = C.getData();
   const TYPE *bData = B.getData();
   const TYPE *aData = A.getData();

--- a/Code/Numerics/SquareMatrix.h
+++ b/Code/Numerics/SquareMatrix.h
@@ -27,9 +27,11 @@ class SquareMatrix : public Matrix<TYPE> {
   SquareMatrix(unsigned int N, typename Matrix<TYPE>::DATA_SPTR data)
       : Matrix<TYPE>(N, N, data) {}
 
-  // inline unsigned int size() const {
-  //  return d_nRows;
-  // }
+  SquareMatrix(const SquareMatrix &B) = default;
+  SquareMatrix(SquareMatrix<TYPE> &&B) = default;
+  SquareMatrix &operator=(const SquareMatrix<TYPE> &B) = default;
+  SquareMatrix &operator=(SquareMatrix<TYPE> &&B) = default;
+  ~SquareMatrix() = default;
 
   SquareMatrix<TYPE> &operator*=(TYPE scale) override {
     Matrix<TYPE>::operator*=(scale);


### PR DESCRIPTION
#### Reference Issue
No issue.


#### What does this implement/fix? Explain your changes.


#### Any other comments?
operator= for Transform3D was explicitly removed. I needed it in the GaussianShape code.
