### PR TITLE
Small bug fix in PR #8968

### DIFF
--- a/Code/GraphMol/Canon.cpp
+++ b/Code/GraphMol/Canon.cpp
@@ -299,12 +299,6 @@ void canonicalizeDoubleBond(Bond *dblBond, const UINT_VECT &bondVisitOrders,
   // and check if both directions on each side are set.
   // We hit this in cases with cycles like CO/C1=C/C=C\C=C/C=N\1.
   if (dir1Set && dir2Set) {
-    // these are guaranteed to exist
-    bondDirCounts[firstFromAtom1->getIdx()] += 1;
-    bondDirCounts[firstFromAtom2->getIdx()] += 1;
-    atomDirCounts[atom1->getIdx()] += 1;
-    atomDirCounts[atom2->getIdx()] += 1;
-
     // To do: check that the existing directions are consistent.
     if (secondFromAtom1) {
       if (!bondDirCounts[firstFromAtom1->getIdx()]) {
@@ -320,6 +314,8 @@ void canonicalizeDoubleBond(Bond *dblBond, const UINT_VECT &bondVisitOrders,
       bondDirCounts[secondFromAtom1->getIdx()] += 1;
       atomDirCounts[atom1->getIdx()] += 1;
     }
+    bondDirCounts[firstFromAtom1->getIdx()] += 1;
+    atomDirCounts[atom1->getIdx()] += 1;
 
     if (secondFromAtom2) {
       if (!bondDirCounts[firstFromAtom2->getIdx()]) {
@@ -335,6 +331,8 @@ void canonicalizeDoubleBond(Bond *dblBond, const UINT_VECT &bondVisitOrders,
       bondDirCounts[secondFromAtom2->getIdx()] += 1;
       atomDirCounts[atom2->getIdx()] += 1;
     }
+    bondDirCounts[firstFromAtom2->getIdx()] += 1;
+    atomDirCounts[atom2->getIdx()] += 1;
 
     return;
   }


### PR DESCRIPTION
This small bug slipped through in the review of #8968:

https://github.com/rdkit/rdkit/blob/8e76c2778436b3fa368dcaf2fae86fd5f6e233d7/Code/GraphMol/Canon.cpp#L301-L314

In Line 303 we increment `bondDirCounts[firstFromAtom1->getIdx()]`, and then we check it in line 310. Obviously, the check will never be triggered (even when it should), due to the increment. There's a similar check for `firstFromAtom2` further down. The fix is just to increment after the checks have taken place.

Luckily, it's infrequent to hit this block (only when directions on both sides have been set already), and even if that's the case, it should only trigger when `bondDirCounts[firstFromAtom1->getIdx()] == 0`.