### PR TITLE
Fix link failure on macOS caused by AGL framework injection in Qt

### DIFF
--- a/Code/GraphMol/MolDraw2D/Qt/CMakeLists.txt
+++ b/Code/GraphMol/MolDraw2D/Qt/CMakeLists.txt
@@ -20,9 +20,9 @@ else(RDK_USE_QT6)
   endif()
 endif(RDK_USE_QT6)
 
-# Workaround for Qt 6.5.8 AGL framework issue on modern macOS.
-# AGL (Apple Graphics Layer) was removed from macOS 14+ SDKs, but Qt 6.5.8
-# still injects it into WrapOpenGL::WrapOpenGL, causing link failures.
+# Workaround for an AGL framework issue on modern macOS.
+# AGL (Apple Graphics Layer) was removed from macOS 14+ SDKs, but certain Qt
+# versions still inject it into WrapOpenGL::WrapOpenGL, causing link failures.
 if(APPLE AND TARGET WrapOpenGL::WrapOpenGL)
     get_target_property(_qt_opengl_libs WrapOpenGL::WrapOpenGL INTERFACE_LINK_LIBRARIES)
     if(_qt_opengl_libs)


### PR DESCRIPTION
#### Reference Issue


#### What does this implement/fix? Explain your changes.

Certain Qt versions inject the AGL (Apple Graphics Layer) framework into the `WrapOpenGL::WrapOpenGL` imported target's `INTERFACE_LINK_LIBRARIES`. AGL was removed from macOS 14+ SDKs (Xcode 15/16), causing a link error when building `MolDraw2DQt` on modern macOS:

```
ld: framework not found AGL
```

This adds a small CMake workaround in `Code/GraphMol/MolDraw2D/Qt/CMakeLists.txt` that filters AGL out of `WrapOpenGL::WrapOpenGL`'s link libraries after `find_package(Qt6)` populates them. The guard conditions (`APPLE` and `TARGET WrapOpenGL::WrapOpenGL`) make it a no-op on other platforms and Qt versions that do not create that target, so there is no risk of regression.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)