### PR TITLE
Add utility functions and constants for dummy atoms, attachment points, and R-groups

### DIFF
--- a/Code/GraphMol/CMakeLists.txt
+++ b/Code/GraphMol/CMakeLists.txt
@@ -9,6 +9,7 @@ rdkit_library(GraphMol
         new_canon.cpp SubstanceGroup.cpp FindStereo.cpp MonomerInfo.cpp
         NontetrahedralStereo.cpp Atropisomers.cpp
         WedgeBonds.cpp MolProps.cpp Subset.cpp
+        DummyAtom.cpp
         SHARED
         LINK_LIBRARIES RDGeometryLib RDGeneral)
 target_compile_definitions(GraphMol PRIVATE RDKIT_GRAPHMOL_BUILD)
@@ -29,6 +30,7 @@ rdkit_headers(Atom.h
         Chirality.h
         Conformer.h
         details.h
+        DummyAtom.h
         GraphMol.h
         MolOps.h
         MolPickler.h
@@ -204,4 +206,7 @@ rdkit_catch_test(tableTestsCatch catch_periodictable.cpp
 
 rdkit_catch_test(molopsTestsCatch catch_molops.cpp
         LINK_LIBRARIES FileParsers SmilesParse GraphMol)
+
+rdkit_catch_test(dummyAtomTestsCatch catch_dummyatom.cpp
+        LINK_LIBRARIES GraphMol)
 

--- a/Code/GraphMol/DummyAtom.cpp
+++ b/Code/GraphMol/DummyAtom.cpp
@@ -1,0 +1,65 @@
+//
+// Copyright (C) 2025 Greg Landrum and other RDKit contributors
+//
+//   @@ All Rights Reserved @@
+//  This file is part of the RDKit.
+//  The contents are covered by the terms of the BSD license
+//  which is included in the file license.txt, found at the root
+//  of the RDKit source tree.
+//
+#include "DummyAtom.h"
+
+#include <stdexcept>
+#include <string>
+
+#include <GraphMol/QueryAtom.h>
+#include <GraphMol/QueryOps.h>
+#include <RDGeneral/types.h>
+
+namespace RDKit {
+
+std::unique_ptr<Atom> createDummyAtom() {
+  auto atom = std::make_unique<QueryAtom>();
+  atom->setAtomicNum(dummyAtomicNum);
+  // This prevents the atom from being shown in SMARTS as [#0]
+  atom->setQuery(makeAtomNullQuery());
+  // This prevents the atom from having a VAL in MDL MOL file output
+  atom->setNoImplicit(false);
+  return atom;
+}
+
+bool isAttachmentPointDummy(const Atom &atom) {
+  std::string label;
+  return atom.getAtomicNum() == dummyAtomicNum && atom.getDegree() == 1 &&
+         atom.getPropIfPresent(common_properties::atomLabel, label) &&
+         label.find(attachmentPointLabelPrefix) == 0;
+}
+
+std::unique_ptr<Atom> makeNewRGroup(unsigned int rGroupNum) {
+  if (rGroupNum == 0) {
+    throw std::invalid_argument("R-groups cannot have an index of 0.");
+  }
+  auto atom = createDummyAtom();
+  // Set atomLabel as _RX and dummyLabel as RX
+  auto rLabel = std::string(rGroupLabelPrefix) + std::to_string(rGroupNum);
+  auto dLabel = rLabel.substr(1);
+  atom->setProp(common_properties::atomLabel, rLabel);
+  atom->setProp(common_properties::dummyLabel, dLabel);
+  atom->setProp(common_properties::_MolFileRLabel, rGroupNum);
+  atom->setIsotope(rGroupNum);
+  return atom;
+}
+
+std::optional<unsigned int> getRGroupNumber(const Atom *atom) {
+  unsigned int rGroupNum = 0;
+  if (!(atom->getAtomicNum() == dummyAtomicNum &&
+        atom->getPropIfPresent(common_properties::_MolFileRLabel, rGroupNum))) {
+    return std::nullopt;
+  }
+  if (rGroupNum == 0) {
+    throw std::invalid_argument("R-groups cannot have an index of 0.");
+  }
+  return rGroupNum;
+}
+
+}  // namespace RDKit

--- a/Code/GraphMol/DummyAtom.h
+++ b/Code/GraphMol/DummyAtom.h
@@ -1,0 +1,62 @@
+//
+// Copyright (C) 2025 Greg Landrum and other RDKit contributors
+//
+//   @@ All Rights Reserved @@
+//  This file is part of the RDKit.
+//  The contents are covered by the terms of the BSD license
+//  which is included in the file license.txt, found at the root
+//  of the RDKit source tree.
+//
+#include <RDGeneral/export.h>
+#ifndef RD_DUMMY_ATOM_H
+#define RD_DUMMY_ATOM_H
+
+#include <memory>
+#include <optional>
+#include <string_view>
+#include <GraphMol/Atom.h>
+
+namespace RDKit {
+
+//! The atomic number used for dummy atoms (wildcards, R-groups, attachment
+//! points).
+constexpr int dummyAtomicNum = 0;
+
+//! The atomLabel property prefix used to identify attachment point dummy atoms.
+inline constexpr std::string_view attachmentPointLabelPrefix = "_AP";
+
+//! The atomLabel property prefix used for R-group dummy atoms.
+inline constexpr std::string_view rGroupLabelPrefix = "_R";
+
+//! Creates a dummy atom properly configured for SMARTS and MDL MOL file output.
+//!
+//! The atom has atomic number 0, a null query (so it appears as * rather than
+//! [#0] in SMARTS output), and no implicit valence (so no VAL line is written
+//! in MDL MOL files).
+[[nodiscard]] RDKIT_GRAPHMOL_EXPORT std::unique_ptr<Atom> createDummyAtom();
+
+//! Returns whether the atom is an attachment point dummy.
+//!
+//! An attachment point dummy has atomic number 0, exactly one neighbor, and an
+//! atomLabel property whose value starts with "_AP".
+RDKIT_GRAPHMOL_EXPORT bool isAttachmentPointDummy(const Atom &atom);
+
+//! Returns the R-group number of the atom, or an empty optional if the atom is
+//! not an R-group atom.
+//!
+//! \throws std::invalid_argument if the atom's R-group number is 0.
+[[nodiscard]] RDKIT_GRAPHMOL_EXPORT std::optional<unsigned int> getRGroupNumber(
+    const Atom *atom);
+
+//! Creates a new R-group atom with the specified R-group number.
+//!
+//! The atom has atomic number 0 and its atomLabel, dummyLabel, _MolFileRLabel,
+//! and isotope properties set appropriately for the given R-group number.
+//!
+//! \throws std::invalid_argument if rGroupNum is 0.
+[[nodiscard]] RDKIT_GRAPHMOL_EXPORT std::unique_ptr<Atom> makeNewRGroup(
+    unsigned int rGroupNum);
+
+}  // namespace RDKit
+
+#endif

--- a/Code/GraphMol/catch_dummyatom.cpp
+++ b/Code/GraphMol/catch_dummyatom.cpp
@@ -1,0 +1,161 @@
+//
+// Copyright (C) 2025 Greg Landrum and other RDKit contributors
+//
+//   @@ All Rights Reserved @@
+//  This file is part of the RDKit.
+//  The contents are covered by the terms of the BSD license
+//  which is included in the file license.txt, found at the root
+//  of the RDKit source tree.
+//
+#include <catch2/catch_all.hpp>
+
+#include <GraphMol/RDKitBase.h>
+#include <GraphMol/QueryAtom.h>
+#include <GraphMol/DummyAtom.h>
+#include <RDGeneral/types.h>
+
+using namespace RDKit;
+
+TEST_CASE("createDummyAtom") {
+  auto atom = createDummyAtom();
+  REQUIRE(atom != nullptr);
+
+  SECTION("atomic number is 0") { CHECK(atom->getAtomicNum() == 0); }
+
+  SECTION("has a null query") { CHECK(atom->hasQuery()); }
+
+  SECTION("no implicit H suppression") { CHECK(!atom->getNoImplicit()); }
+}
+
+TEST_CASE("isAttachmentPointDummy") {
+  SECTION("returns false for a carbon atom") {
+    Atom carbon(6);
+    CHECK(!isAttachmentPointDummy(carbon));
+  }
+
+  SECTION("returns false for a dummy atom without atomLabel") {
+    RWMol mol;
+    mol.addAtom(new Atom(6), false, true);
+    auto *dummy = new Atom(0);
+    mol.addAtom(dummy, false, true);
+    mol.addBond(0, 1, Bond::SINGLE);
+    CHECK(!isAttachmentPointDummy(*mol.getAtomWithIdx(1)));
+  }
+
+  SECTION("returns false for a dummy atom with wrong label prefix") {
+    RWMol mol;
+    mol.addAtom(new Atom(6), false, true);
+    auto *dummy = new Atom(0);
+    mol.addAtom(dummy, false, true);
+    mol.addBond(0, 1, Bond::SINGLE);
+    mol.getAtomWithIdx(1)->setProp(common_properties::atomLabel,
+                                   std::string("_R1"));
+    CHECK(!isAttachmentPointDummy(*mol.getAtomWithIdx(1)));
+  }
+
+  SECTION("returns false when degree is not 1") {
+    RWMol mol;
+    mol.addAtom(new Atom(6), false, true);
+    mol.addAtom(new Atom(6), false, true);
+    auto *dummy = new Atom(0);
+    mol.addAtom(dummy, false, true);
+    mol.addBond(0, 2, Bond::SINGLE);
+    mol.addBond(1, 2, Bond::SINGLE);
+    mol.getAtomWithIdx(2)->setProp(common_properties::atomLabel,
+                                   std::string("_AP1"));
+    CHECK(!isAttachmentPointDummy(*mol.getAtomWithIdx(2)));
+  }
+
+  SECTION("returns true for a degree-1 dummy with _AP label") {
+    RWMol mol;
+    mol.addAtom(new Atom(6), false, true);
+    auto *dummy = new Atom(0);
+    mol.addAtom(dummy, false, true);
+    mol.addBond(0, 1, Bond::SINGLE);
+    mol.getAtomWithIdx(1)->setProp(common_properties::atomLabel,
+                                   std::string("_AP1"));
+    CHECK(isAttachmentPointDummy(*mol.getAtomWithIdx(1)));
+  }
+
+  SECTION("matches any _AP prefix, not just _AP1") {
+    RWMol mol;
+    mol.addAtom(new Atom(6), false, true);
+    auto *dummy = new Atom(0);
+    mol.addAtom(dummy, false, true);
+    mol.addBond(0, 1, Bond::SINGLE);
+    mol.getAtomWithIdx(1)->setProp(common_properties::atomLabel,
+                                   std::string("_AP99"));
+    CHECK(isAttachmentPointDummy(*mol.getAtomWithIdx(1)));
+  }
+}
+
+TEST_CASE("makeNewRGroup") {
+  SECTION("throws for rGroupNum == 0") {
+    CHECK_THROWS_AS(makeNewRGroup(0), std::invalid_argument);
+  }
+
+  SECTION("creates atom with correct properties for R1") {
+    auto atom = makeNewRGroup(1);
+    REQUIRE(atom != nullptr);
+    CHECK(atom->getAtomicNum() == 0);
+    CHECK(atom->getIsotope() == 1);
+
+    std::string label;
+    REQUIRE(atom->getPropIfPresent(common_properties::atomLabel, label));
+    CHECK(label == "_R1");
+
+    std::string dLabel;
+    REQUIRE(atom->getPropIfPresent(common_properties::dummyLabel, dLabel));
+    CHECK(dLabel == "R1");
+
+    unsigned int rLabel = 0;
+    REQUIRE(atom->getPropIfPresent(common_properties::_MolFileRLabel, rLabel));
+    CHECK(rLabel == 1u);
+  }
+
+  SECTION("creates atom with correct properties for R10") {
+    auto atom = makeNewRGroup(10);
+    REQUIRE(atom != nullptr);
+    CHECK(atom->getIsotope() == 10);
+
+    std::string label;
+    REQUIRE(atom->getPropIfPresent(common_properties::atomLabel, label));
+    CHECK(label == "_R10");
+
+    std::string dLabel;
+    REQUIRE(atom->getPropIfPresent(common_properties::dummyLabel, dLabel));
+    CHECK(dLabel == "R10");
+
+    unsigned int rLabel = 0;
+    REQUIRE(atom->getPropIfPresent(common_properties::_MolFileRLabel, rLabel));
+    CHECK(rLabel == 10u);
+  }
+}
+
+TEST_CASE("getRGroupNumber") {
+  SECTION("returns nullopt for a non-dummy atom") {
+    Atom carbon(6);
+    CHECK(!getRGroupNumber(&carbon).has_value());
+  }
+
+  SECTION("returns nullopt for a dummy atom without _MolFileRLabel") {
+    Atom dummy(0);
+    CHECK(!getRGroupNumber(&dummy).has_value());
+  }
+
+  SECTION("returns correct number for an R-group atom") {
+    auto atom = makeNewRGroup(5);
+    auto result = getRGroupNumber(atom.get());
+    REQUIRE(result.has_value());
+    CHECK(*result == 5u);
+  }
+
+  SECTION("round-trips through makeNewRGroup for various indices") {
+    for (unsigned int n : {1u, 2u, 10u, 20u, 99u}) {
+      auto atom = makeNewRGroup(n);
+      auto result = getRGroupNumber(atom.get());
+      REQUIRE(result.has_value());
+      CHECK(*result == n);
+    }
+  }
+}


### PR DESCRIPTION
#### Reference Issue
<!-- Example: Fixes #1234 -->

#### What does this implement/fix? Explain your changes.

Adds `DummyAtom.h` and `DummyAtom.cpp` to `Code/GraphMol` with utility functions and constants for working with dummy atoms (atomic number 0) in their three common roles: generic wildcards, attachment points, and R-groups.

Three constants are defined: `dummyAtomicNum` (0), `attachmentPointLabelPrefix` (`"_AP"`), and `rGroupLabelPrefix` (`"_R"`). Four functions are provided: `createDummyAtom()` returns a `QueryAtom` configured with a null query (so it appears as `*` rather than `[#0]` in SMARTS output) and `noImplicit` false (so no `VAL` line is written in MDL MOL files); `isAttachmentPointDummy()` returns true for a degree-1 dummy atom whose `atomLabel` starts with `"_AP"`; `makeNewRGroup()` creates a dummy atom with `atomLabel`, `dummyLabel`, `_MolFileRLabel`, and isotope all set for the given R-group number; and `getRGroupNumber()` returns `std::optional<unsigned int>` from `_MolFileRLabel`, or `nullopt` if the atom is not an R-group.

Tests in `catch_dummyatom.cpp` cover all four functions with normal cases, edge cases, and round-trip behavior.

#### Any other comments?