### PR TITLE
Accept non-kekulisable molecules in drawMols3D.

### DIFF
--- a/rdkit/Chem/Draw/IPythonConsole.py
+++ b/rdkit/Chem/Draw/IPythonConsole.py
@@ -73,7 +73,15 @@ None'''
   else:
     # py3Dmol does not currently support v3k mol files, so
     # we can only provide those with "smaller" molecules
-    mb = Chem.MolToMolBlock(mol, confId=confId)
+    try:
+      mb = Chem.MolToMolBlock(mol, confId=confId)
+    except Chem.AtomKekulizeException:
+      # The bonding is likely to be wrong, but it would be good
+      # to see something.
+      p = Chem.rdmolfiles.MolWriterParams()
+      p.kekulize = False
+      mb = Chem.MolToMolBlock(mol, confId=confId, params=p)
+
     view.addModel(mb, 'sdf')
   if drawAs is None:
     drawAs = drawing_type_3d
@@ -545,3 +553,4 @@ def UninstallIPythonRenderer():
 
 
 InstallIPythonRenderer()
+


### PR DESCRIPTION
#### Reference Issue
No issue.

#### What does this implement/fix? Explain your changes.
I've recently found myself wanting to draw non-kekulisable bits of 3D molecules.  drawMols3D throws an AtomKekulizeException and fails.  This catches the exception and parses the molecule without.

#### Any other comments?

