### PR TITLE
CIP labeller performance: Don't calculate auxiliary descriptors unnecessarily

### DIFF
--- a/Code/GraphMol/CIPLabeler/CIPLabeler.cpp
+++ b/Code/GraphMol/CIPLabeler/CIPLabeler.cpp
@@ -113,6 +113,9 @@ bool labelAux(std::vector<std::unique_ptr<Configuration>> &configs,
     }
     // FIXME: specific to each descriptor
     const auto &foci = config->getFoci();
+    if (!digraph.seenAtom(foci[0])) {
+      continue;
+    }
     for (const auto &node : digraph.getNodes(foci[0])) {
       if (node->isDuplicate()) {
         continue;

--- a/Code/GraphMol/CIPLabeler/CIPLabeler.cpp
+++ b/Code/GraphMol/CIPLabeler/CIPLabeler.cpp
@@ -113,7 +113,10 @@ bool labelAux(std::vector<std::unique_ptr<Configuration>> &configs,
     }
     // FIXME: specific to each descriptor
     const auto &foci = config->getFoci();
-    if (!digraph.seenAtom(foci[0])) {
+
+    // Skip if none of the foci atoms were reached during expansion
+    if (std::none_of(foci.begin(), foci.end(),
+                     [&](auto f) { return digraph.seenAtom(f); })) {
       continue;
     }
     for (const auto &node : digraph.getNodes(foci[0])) {

--- a/Code/GraphMol/CIPLabeler/CIPLabeler.cpp
+++ b/Code/GraphMol/CIPLabeler/CIPLabeler.cpp
@@ -115,7 +115,7 @@ bool labelAux(std::vector<std::unique_ptr<Configuration>> &configs,
     const auto &foci = config->getFoci();
 
     // Skip if none of the foci atoms were reached during expansion
-    if (std::none_of(foci.begin(), foci.end(),
+    if (std::ranges::none_of(foci,
                      [&](auto f) { return digraph.seenAtom(f); })) {
       continue;
     }

--- a/Code/GraphMol/CIPLabeler/Digraph.cpp
+++ b/Code/GraphMol/CIPLabeler/Digraph.cpp
@@ -42,12 +42,8 @@ Node &Digraph::addNode(std::vector<char> &&visit, Atom *atom,
 }
 
 bool Digraph::seenAtom(Atom *atom) const {
-  for (auto &n : d_nodes) {
-    if (n.getAtom() == atom) {
-      return true;
-    }
-  }
-  return false;
+  return std::ranges::any_of(
+      d_nodes, [&](const auto &n) { return n.getAtom() == atom; });
 }
 
 void Digraph::addEdge(Node *beg, Bond *bond, Node *end) {

--- a/Code/GraphMol/CIPLabeler/Digraph.cpp
+++ b/Code/GraphMol/CIPLabeler/Digraph.cpp
@@ -41,6 +41,15 @@ Node &Digraph::addNode(std::vector<char> &&visit, Atom *atom,
   return d_nodes.back();
 }
 
+bool Digraph::seenAtom(Atom *atom) const {
+  for (auto &n : d_nodes) {
+    if (n.getAtom() == atom) {
+      return true;
+    }
+  }
+  return false;
+}
+
 void Digraph::addEdge(Node *beg, Bond *bond, Node *end) {
   d_edges.emplace_back(beg, end, bond);
   auto &e = d_edges.back();
@@ -74,9 +83,9 @@ int Digraph::getNumNodes() const { return d_nodes.size(); }
 
 std::vector<Node *> Digraph::getNodes(Atom *atom) const {
   std::vector<Node *> result;
-  std::vector<Node*> queue = {getCurrentRoot()};
+  std::vector<Node *> queue = {getCurrentRoot()};
 
-  for (size_t i=0; i<queue.size(); ++i) {
+  for (size_t i = 0; i < queue.size(); ++i) {
     auto node = queue[i];
     if (atom == node->getAtom()) {
       result.push_back(node);

--- a/Code/GraphMol/CIPLabeler/Digraph.h
+++ b/Code/GraphMol/CIPLabeler/Digraph.h
@@ -94,6 +94,9 @@ class Digraph {
   Node &addNode(std::vector<char> &&visit, Atom *atom,
                 boost::rational<int> &&frac, int dist, int flags);
 
+  // Has `atom` been seen yet?
+  bool seenAtom(Atom *atom) const;
+
  private:
   const CIPMol &d_mol;
 

--- a/Code/GraphMol/CIPLabeler/catch_tests.cpp
+++ b/Code/GraphMol/CIPLabeler/catch_tests.cpp
@@ -492,6 +492,22 @@ TEST_CASE("para-stereochemistry", "[accurateCIP]") {
                                                    chirality));
     CHECK(chirality == "S");
   }
+  SECTION("auxiliary stereochem beyond initial expansion") {
+    // The label on atom 12 depends on the chirality at
+    // atom 2. The label on atom 9 depends on the label of
+    // atom 12. Atom 2 is not reached in the initial
+    // expansion to score atom 9
+    auto mol = "CC[C@H](C)CCCCC[C@H]1CC[C@@H](C)CC1"_smiles;
+    CIPLabeler::assignCIPLabels(*mol);
+
+    std::string chirality;
+    CHECK(mol->getAtomWithIdx(2)->getProp<std::string>(
+              common_properties::_CIPCode) == "S");
+    CHECK(mol->getAtomWithIdx(9)->getProp<std::string>(
+              common_properties::_CIPCode) == "s");
+    CHECK(mol->getAtomWithIdx(12)->getProp<std::string>(
+              common_properties::_CIPCode) == "S");
+  }
 }
 TEST_CASE("para-stereochemistry2", "[accurateCIP]") {
   SECTION("example 1") {
@@ -631,7 +647,7 @@ TEST_CASE("GitHub Issue #5142", "[bug][accurateCIP]") {
 
 TEST_CASE("Test early termination of CIP calculation", "[accurateCIP]") {
   constexpr const char *molBlock = R"(
-  Mrv2117 11112217353D          
+  Mrv2117 11112217353D
 
  40 50  0  0  0  0            999 V2000
     7.5483   -7.7451   -3.3419 H   0  0  0  0  0  0  0  0  0  0  0  0

--- a/Code/GraphMol/CIPLabeler/catch_tests.cpp
+++ b/Code/GraphMol/CIPLabeler/catch_tests.cpp
@@ -645,6 +645,31 @@ TEST_CASE("GitHub Issue #5142", "[bug][accurateCIP]") {
   CIPLabeler::assignCIPLabels(*mol);
 }
 
+auto view_labels(const ROMol &mol) {
+  std::stringstream msg;
+  std::string label;
+  for (auto a : mol.atoms()) {
+    if (a->getPropIfPresent(common_properties::_CIPCode, label)) {
+      msg << a->getIdx() << label << ' ';
+    }
+  }
+  for (auto b : mol.bonds()) {
+    if (b->getPropIfPresent(common_properties::_CIPCode, label)) {
+      msg << b->getBeginAtomIdx() << '=' << b->getEndAtomIdx() << label << ' ';
+    }
+  }
+  return msg.str();
+}
+
+TEST_CASE("Bad skip side", "[accurateCIP]") {
+  auto m1 = "C1CC[C@H]2C/C(=C3\\C[C@H]4CCCC[C@H]4C3)C[C@H]2C1"_smiles;
+  CIPLabeler::assignCIPLabels(*m1);
+  CHECK("3S 8R 13S 16R 5=6E " == view_labels(*m1));
+  auto m2 = "C1/C(=C2\\C[C@H]3CCCC[C@H]3C2)C[C@H]2CCCC[C@@H]12"_smiles;
+  CIPLabeler::assignCIPLabels(*m2);
+  CHECK("4R 9S 12R 17S 1=2E " == view_labels(*m2));
+}
+
 TEST_CASE("Test early termination of CIP calculation", "[accurateCIP]") {
   constexpr const char *molBlock = R"(
   Mrv2117 11112217353D

--- a/Code/GraphMol/CIPLabeler/configs/AtropisomerBond.cpp
+++ b/Code/GraphMol/CIPLabeler/configs/AtropisomerBond.cpp
@@ -94,6 +94,8 @@ Descriptor AtropisomerBond::label(Node *root1, Digraph &digraph,
   const auto &focus1 = getFoci()[0];
   const auto &focus2 = getFoci()[1];
 
+  const bool is_constitutional = comp.getNumSubRules() == 3;
+
   d_ranked_anchors.clear();
 
   const auto &internal = findInternalEdge(root1->getEdges(), focus1, focus2);
@@ -119,7 +121,7 @@ Descriptor AtropisomerBond::label(Node *root1, Digraph &digraph,
 
   digraph.changeRoot(root1);
   const auto &priority1 = comp.sort(root1, edges1);
-  if (!priority1.isUnique()) {
+  if (!priority1.isUnique() && !is_constitutional) {
     return Descriptor::UNKNOWN;
   }
   // swap
@@ -132,7 +134,7 @@ Descriptor AtropisomerBond::label(Node *root1, Digraph &digraph,
   }
   digraph.changeRoot(root2);
   const auto &priority2 = comp.sort(root2, edges2);
-  if (!priority2.isUnique()) {
+  if (!priority2.isUnique() || !priority1.isUnique()) {
     return Descriptor::UNKNOWN;
   }
   // swap

--- a/Code/GraphMol/CIPLabeler/configs/Sp2Bond.cpp
+++ b/Code/GraphMol/CIPLabeler/configs/Sp2Bond.cpp
@@ -88,6 +88,8 @@ Descriptor Sp2Bond::label(Node *root1, Digraph &digraph, const Rules &comp) {
   const auto &focus1 = getFoci()[0];
   const auto &focus2 = getFoci()[1];
 
+  const bool is_constitutional = comp.getNumSubRules() == 3;
+
   d_ranked_anchors.clear();
 
   const auto &internal = findInternalEdge(root1->getEdges(), focus1, focus2);
@@ -110,7 +112,7 @@ Descriptor Sp2Bond::label(Node *root1, Digraph &digraph, const Rules &comp) {
 
   digraph.changeRoot(root1);
   const auto &priority1 = comp.sort(root1, edges1);
-  if (!priority1.isUnique()) {
+  if (!priority1.isUnique() && !is_constitutional) {
     return Descriptor::UNKNOWN;
   }
   // swap
@@ -123,7 +125,7 @@ Descriptor Sp2Bond::label(Node *root1, Digraph &digraph, const Rules &comp) {
   }
   digraph.changeRoot(root2);
   const auto &priority2 = comp.sort(root2, edges2);
-  if (!priority2.isUnique()) {
+  if (!priority2.isUnique() || !priority1.isUnique()) {
     return Descriptor::UNKNOWN;
   }
   // swap


### PR DESCRIPTION
The first 3 rules (the constitutional rules) are pretty easy to understand. After rule 3, we need to calculate auxiliary stereo descriptors to break ties.

However, we _were actually_ calculating auxiliary stereodescriptors for all centers! We should only need to calculate auxiliary stereocenters for sites that are needed to break ties.

This cost time - it also caused errors if the auxiliary descriptors needed a graph expansion, because bonds in the digraph might be pointed in the wrong direction.

Example case PDB ID 4AXM: 14s -> 0.036s

Before this commit, errored with "Could not calculate parity! Carrier mismatch" after **14s**. After this commit, completes successfully in **0.036s**. Labelled centers all match (for the centers that had labels in the failure case). There are many protein-sized molecules that see similar speedups.

Includes a test that I can imagine breaking with a flawed implementation of this optimization. The reference labels are from before this change.

