### PR TITLE
simple substructure search optimization

### DIFF
--- a/Code/GraphMol/Substruct/SubstructMatch.cpp
+++ b/Code/GraphMol/Substruct/SubstructMatch.cpp
@@ -482,7 +482,9 @@ std::vector<MatchVectType> SubstructMatch(
     const ROMol &mol, const ROMol &query,
     const SubstructMatchParameters &params) {
   std::vector<MatchVectType> matches;
-  if (!mol.getNumAtoms() || !query.getNumAtoms()) {
+  const auto &mNumAtoms = mol.getNumAtoms();
+  const auto &qNumAtoms = query.getNumAtoms();
+  if (!mNumAtoms || !qNumAtoms || qNumAtoms > mNumAtoms) {
     return matches;
   }
 

--- a/Code/GraphMol/Substruct/catch_tests.cpp
+++ b/Code/GraphMol/Substruct/catch_tests.cpp
@@ -1105,3 +1105,21 @@ TEST_CASE("extra atom and bond queries") {
     }
   }
 }
+TEST_CASE("quick return when the query has more atoms than the molecule") {
+  SECTION("basics") {
+    SubstructMatchParameters ps;
+    bool touched = false;
+    auto atomQuery = [&touched](const Atom &, const Atom &) -> bool {
+      touched = true;
+      return true;
+    };
+    ps.extraAtomCheck = atomQuery;
+    auto mol = "CC"_smiles;
+    REQUIRE(mol);
+    auto qry = "CCC"_smarts;
+    REQUIRE(qry);
+    auto matches = SubstructMatch(*mol, *qry, ps);
+    CHECK(matches.empty());
+    CHECK(!touched);
+  }
+}


### PR DESCRIPTION
If the query is larger than the molecule, we can automatically fail.

A super simple, no-risk optimization