### PR TITLE
Fix typo in _calculateBeta: check nb1 instead of nb2 twice

### DIFF
--- a/rdkit/Chem/TorsionFingerprints.py
+++ b/rdkit/Chem/TorsionFingerprints.py
@@ -392,7 +392,7 @@ def _calculateBeta(mol, distmat, aid1):
   for b in mol.GetBonds():
     nb1 = _getHeavyAtomNeighbors(b.GetBeginAtom())
     nb2 = _getHeavyAtomNeighbors(b.GetEndAtom())
-    if len(nb2) > 1 and len(nb2) > 1:
+    if len(nb1) > 1 and len(nb2) > 1:
       bonds.append(b)
   # get shortest distance
   dmax = 0


### PR DESCRIPTION
#### Reference Issue

N/A — found during code review.

#### What does this implement/fix? Explain your changes.

In `_calculateBeta` (TorsionFingerprints.py, line 395), the guard for filtering
non-terminal bonds checks `len(nb2) > 1` twice instead of `len(nb1) > 1 and len(nb2) > 1`.

This means `nb1` (the begin-atom neighbors) is never checked, so bonds where the
begin-atom is terminal but the end-atom is not are incorrectly included when
computing `dmax` for torsion weights.

The fix changes the first `nb2` to `nb1`.

#### Any other comments?

The existing tests in `UnitTestMol3D.py` should still pass. The bug is hard to trigger
in practice because RDKit's bond iteration order and typical test molecules rarely
have a terminal begin-atom paired with a non-terminal end-atom, but the logic is
clearly wrong as written.

