### PR TITLE
Fix STEREOANY (wavy bond) loss during InChI roundtrip

### DIFF
--- a/Code/GraphMol/SmilesParse/CXSmilesOps.cpp
+++ b/Code/GraphMol/SmilesParse/CXSmilesOps.cpp
@@ -2268,19 +2268,33 @@ std::string get_bond_config_block(
         bond->getStereo() != Bond::BondStereo::STEREOANY) {
       continue;
     }
+    // Skip ring double bonds — they are handled by
+    // get_ringbond_cistrans_block() which emits |ctu:| instead.
+    if (mol.getRingInfo()->isInitialized() &&
+        mol.getRingInfo()->numBondRings(idx)) {
+      continue;
+    }
     // Check if an adjacent single bond already has BondDir::UNKNOWN
-    // (set by the CXSMILES parser). If so, skip — it's already handled
-    // by the main loop above.
+    // (set by the CXSMILES parser) or _MolFileBondCfg (set by the
+    // mol file parser). If so, skip — the wavy bond is already handled
+    // by the main loop above, or by wU/wD markers from mol file wedging.
     bool alreadyHandled = false;
     for (const auto &nbond : mol.atomBonds(bond->getBeginAtom())) {
-      if (nbond->getBondDir() == Bond::BondDir::UNKNOWN) {
+      if (nbond->getBondDir() == Bond::BondDir::UNKNOWN ||
+          nbond->hasProp("_MolFileBondCfg")) {
         alreadyHandled = true;
         break;
       }
     }
+    // Also skip if the double bond itself came from a mol file with crossed
+    // stereo — those are handled by wU/wD markers from mol file wedging.
+    if (!alreadyHandled && bond->hasProp("_MolFileBondStereo")) {
+      alreadyHandled = true;
+    }
     if (!alreadyHandled) {
       for (const auto &nbond : mol.atomBonds(bond->getEndAtom())) {
-        if (nbond->getBondDir() == Bond::BondDir::UNKNOWN) {
+        if (nbond->getBondDir() == Bond::BondDir::UNKNOWN ||
+            nbond->hasProp("_MolFileBondCfg")) {
           alreadyHandled = true;
           break;
         }

--- a/Code/GraphMol/SmilesParse/CXSmilesOps.cpp
+++ b/Code/GraphMol/SmilesParse/CXSmilesOps.cpp
@@ -2286,9 +2286,11 @@ std::string get_bond_config_block(
         break;
       }
     }
-    // Also skip if the double bond itself came from a mol file with crossed
-    // stereo — those are handled by wU/wD markers from mol file wedging.
-    if (!alreadyHandled && bond->hasProp("_MolFileBondStereo")) {
+    // Also skip if the STEREOANY bond has no stereo atoms assigned (e.g.
+    // programmatic SetStereo) or came from a mol file with crossed stereo.
+    if (!alreadyHandled &&
+        (bond->getStereoAtoms().empty() ||
+         bond->hasProp("_MolFileBondStereo"))) {
       alreadyHandled = true;
     }
     if (!alreadyHandled) {

--- a/Code/GraphMol/SmilesParse/CXSmilesOps.cpp
+++ b/Code/GraphMol/SmilesParse/CXSmilesOps.cpp
@@ -2258,6 +2258,58 @@ std::string get_bond_config_block(
           boost::str(boost::format("%d.%d") % begAtomOrder % i));
     }
   }
+  // For double bonds with STEREOANY, emit a wavy marker on an adjacent single
+  // bond so that |w:| is written. This mirrors what the CXSMILES parser does
+  // when reading |w:| (it sets BondDir::UNKNOWN on the single bond neighbor).
+  for (unsigned int i = 0; i < bondOrder.size(); ++i) {
+    auto idx = bondOrder[i];
+    const auto bond = mol.getBondWithIdx(idx);
+    if (bond->getBondType() != Bond::BondType::DOUBLE ||
+        bond->getStereo() != Bond::BondStereo::STEREOANY) {
+      continue;
+    }
+    // Check if an adjacent single bond already has BondDir::UNKNOWN
+    // (set by the CXSMILES parser). If so, skip — it's already handled
+    // by the main loop above.
+    bool alreadyHandled = false;
+    for (const auto &nbond : mol.atomBonds(bond->getBeginAtom())) {
+      if (nbond->getBondDir() == Bond::BondDir::UNKNOWN) {
+        alreadyHandled = true;
+        break;
+      }
+    }
+    if (!alreadyHandled) {
+      for (const auto &nbond : mol.atomBonds(bond->getEndAtom())) {
+        if (nbond->getBondDir() == Bond::BondDir::UNKNOWN) {
+          alreadyHandled = true;
+          break;
+        }
+      }
+    }
+    if (alreadyHandled) {
+      continue;
+    }
+    // Find an adjacent single bond to mark as wavy.
+    for (const auto &nbond : mol.atomBonds(bond->getBeginAtom())) {
+      if (nbond->getIdx() == bond->getIdx() || !canHaveDirection(*nbond)) {
+        continue;
+      }
+      auto nbrBondOrder =
+          std::find(bondOrder.begin(), bondOrder.end(), nbond->getIdx()) -
+          bondOrder.begin();
+      auto begAtomOrder =
+          std::find(atomOrder.begin(), atomOrder.end(),
+                    bond->getBeginAtomIdx()) -
+          atomOrder.begin();
+      if (wParts.find("w") == wParts.end()) {
+        wParts["w"] = std::vector<std::string>();
+      }
+      wParts["w"].push_back(
+          boost::str(boost::format("%d.%d") % begAtomOrder % nbrBondOrder));
+      break;
+    }
+  }
+
   std::string res = "";
 
   for (auto wPart : wParts) {

--- a/External/INCHI-API/inchi.cpp
+++ b/External/INCHI-API/inchi.cpp
@@ -1439,8 +1439,7 @@ RWMol *InchiToMol(const std::string &inchi, ExtraInchiReturnValues &rv,
         Chirality::assignAtomCIPRanks(*m, ranks);
         for (unsigned int i = 0; i < numStereo0D; i++) {
           inchi_Stereo0D *stereo0DPtr = inchiOutput.stereo0D + i;
-          if (stereo0DPtr->parity == INCHI_PARITY_NONE ||
-              stereo0DPtr->parity == INCHI_PARITY_UNDEFINED) {
+          if (stereo0DPtr->parity == INCHI_PARITY_NONE) {
             continue;
           }
           switch (stereo0DPtr->type) {
@@ -1585,6 +1584,10 @@ RWMol *InchiToMol(const std::string &inchi, ExtraInchiReturnValues &rv,
               break;
             }
             case INCHI_StereoType_Tetrahedral: {
+              if (stereo0DPtr->parity == INCHI_PARITY_UNDEFINED ||
+                  stereo0DPtr->parity == INCHI_PARITY_UNKNOWN) {
+                break;
+              }
               unsigned int c =
                   indexToAtomIndexMapping[stereo0DPtr->central_atom];
               Atom *atom = m->getAtomWithIdx(c);
@@ -2034,14 +2037,44 @@ std::string MolToInchi(const ROMol &mol, ExtraInchiReturnValues &rv,
       stereo0D.type = INCHI_StereoType_DoubleBond;
       stereo0DEntries.push_back(stereo0D);
     } else if (bond->getStereo() == Bond::STEREOANY) {
-      // have to treat STEREOANY separately because RDKit will clear out
-      // StereoAtoms information.
-      // Here we just change the coordinates of the two end atoms - to bring
-      // them really close - so that InChI will not try to infer stereobond
-      // info from coordinates.
+      // Collapse coordinates so InChI cannot infer stereo from geometry,
+      // and send a proper stereo0D with UNKNOWN parity so that -SUU
+      // produces the correct unknown annotation. StereoAtoms may be
+      // cleared for STEREOANY, so we find neighbors by iterating bonds.
       inchiAtoms[atomIndex1].x = inchiAtoms[atomIndex2].x;
       inchiAtoms[atomIndex1].y = inchiAtoms[atomIndex2].y;
       inchiAtoms[atomIndex1].z = inchiAtoms[atomIndex2].z;
+      int leftNbr = -1;
+      int rightNbr = -1;
+      for (const auto &nbond : m->atomBonds(m->getAtomWithIdx(atomIndex1))) {
+        auto other = nbond->getOtherAtomIdx(atomIndex1);
+        if (other != static_cast<unsigned int>(atomIndex2)) {
+          leftNbr = other;
+          break;
+        }
+      }
+      for (const auto &nbond : m->atomBonds(m->getAtomWithIdx(atomIndex2))) {
+        auto other = nbond->getOtherAtomIdx(atomIndex2);
+        if (other != static_cast<unsigned int>(atomIndex1)) {
+          rightNbr = other;
+          break;
+        }
+      }
+      if (leftNbr >= 0 && rightNbr >= 0) {
+        inchi_Stereo0D stereo0D;
+        stereo0D.parity = INCHI_PARITY_UNKNOWN;
+        stereo0D.neighbor[0] = leftNbr;
+        stereo0D.neighbor[1] = atomIndex1;
+        stereo0D.neighbor[2] = atomIndex2;
+        stereo0D.neighbor[3] = rightNbr;
+        if (!m->getBondBetweenAtoms(stereo0D.neighbor[0],
+                                    stereo0D.neighbor[1])) {
+          std::swap(stereo0D.neighbor[0], stereo0D.neighbor[3]);
+        }
+        stereo0D.central_atom = NO_ATOM;
+        stereo0D.type = INCHI_StereoType_DoubleBond;
+        stereo0DEntries.push_back(stereo0D);
+      }
     }
 
     // number of bonds

--- a/External/INCHI-API/test.cpp
+++ b/External/INCHI-API/test.cpp
@@ -1031,6 +1031,14 @@ void testStereoAnyRoundtrip() {
       "CC1=C(/C=C/C(C)=C/C=C/C(C)=C/C=O)C(C)(C)CCC1 |w:3.3|",
       "retinal-like C=C");
 
+  // Chiral center adjacent to wavy C=C
+  checkStereoAnyRoundtrip("O=C(O)[C@@H](CC=Cc1ccccc1)N |w:4.4|",
+                           "chiral + wavy C=C");
+
+  // Chiral center adjacent to wavy C=N oxime
+  checkStereoAnyRoundtrip("C[C@H](O)/C(=N/O)c1ccccc1 |w:3.3|",
+                           "chiral + wavy oxime C=N");
+
   BOOST_LOG(rdInfoLog) << "done" << std::endl;
 }
 

--- a/External/INCHI-API/test.cpp
+++ b/External/INCHI-API/test.cpp
@@ -959,46 +959,67 @@ void testGithub8239() {
   BOOST_LOG(rdInfoLog) << "done" << std::endl;
 }
 
+namespace {
+void checkStereoAnyRoundtrip(const char *smiles, const char *desc) {
+  BOOST_LOG(rdInfoLog) << "  " << desc << ": " << smiles << std::endl;
+  auto m = SmilesToMol(smiles);
+  TEST_ASSERT(m);
+
+  // verify STEREOANY is present on input
+  bool foundStereoAny = false;
+  for (const auto bond : m->bonds()) {
+    if (bond->getStereo() == Bond::STEREOANY) {
+      foundStereoAny = true;
+      break;
+    }
+  }
+  TEST_ASSERT(foundStereoAny);
+
+  // convert to InChI with -SUU (include unknown/undefined stereo) and back
+  ExtraInchiReturnValues tmp;
+  auto inchi = MolToInchi(*m, tmp, "-SUU");
+  TEST_ASSERT(!inchi.empty());
+
+  ExtraInchiReturnValues tmp2;
+  std::unique_ptr<ROMol> m2(InchiToMol(inchi, tmp2));
+  TEST_ASSERT(m2);
+
+  // verify STEREOANY survives the roundtrip
+  bool foundStereoAny2 = false;
+  for (const auto bond : m2->bonds()) {
+    if (bond->getStereo() == Bond::STEREOANY) {
+      foundStereoAny2 = true;
+      TEST_ASSERT(bond->getStereoAtoms().size() == 2);
+      break;
+    }
+  }
+  TEST_ASSERT(foundStereoAny2);
+  delete m;
+}
+}  // namespace
+
 void testStereoAnyRoundtrip() {
   BOOST_LOG(rdErrorLog) << "-------------------------------------" << std::endl;
   BOOST_LOG(rdInfoLog)
       << "testing STEREOANY (wavy bond) InChI roundtrip" << std::endl;
 
-  {
-    // wavy bond on the C=N double bond (bond index 8)
-    auto m = "CSC1=NSC(CC=NC2=CC=CC=C2)=C1C#N |w:8.8|"_smiles;
-    TEST_ASSERT(m);
+  // Schiff base with wavy C=N (original bug report molecule)
+  checkStereoAnyRoundtrip("CSC1=NSC(CC=NC2=CC=CC=C2)=C1C#N |w:8.8|",
+                           "Schiff base C=N");
 
-    // verify STEREOANY is present on input
-    bool foundStereoAny = false;
-    for (const auto bond : m->bonds()) {
-      if (bond->getStereo() == Bond::STEREOANY) {
-        foundStereoAny = true;
-        break;
-      }
-    }
-    TEST_ASSERT(foundStereoAny);
+  // Benzaldoxime: wavy C=N (common pharma motif)
+  checkStereoAnyRoundtrip("O/N=C/c1ccccc1 |w:1.1|", "benzaldoxime C=N");
 
-    // convert to InChI with -SUU (include unknown/undefined stereo) and back
-    ExtraInchiReturnValues tmp;
-    auto inchi = MolToInchi(*m, tmp, "-SUU");
-    TEST_ASSERT(!inchi.empty());
+  // Cinnamic acid: wavy C=C in conjugated system
+  checkStereoAnyRoundtrip("OC(=O)/C=C/c1ccccc1 |w:3.3|",
+                           "cinnamic acid C=C");
 
-    ExtraInchiReturnValues tmp2;
-    std::unique_ptr<ROMol> m2(InchiToMol(inchi, tmp2));
-    TEST_ASSERT(m2);
+  // Chalcone: wavy C=C between two aryl groups
+  checkStereoAnyRoundtrip("O=C(/C=C/c1ccccc1)c1ccccc1 |w:2.2|",
+                           "chalcone C=C");
 
-    // verify STEREOANY survives the roundtrip
-    bool foundStereoAny2 = false;
-    for (const auto bond : m2->bonds()) {
-      if (bond->getStereo() == Bond::STEREOANY) {
-        foundStereoAny2 = true;
-        TEST_ASSERT(bond->getStereoAtoms().size() == 2);
-        break;
-      }
-    }
-    TEST_ASSERT(foundStereoAny2);
-  }
+  // Crotonaldehyde: simple wavy C=C
+  checkStereoAnyRoundtrip("C/C=C/C=O |w:1.1|", "crotonaldehyde C=C");
 
   BOOST_LOG(rdInfoLog) << "done" << std::endl;
 }

--- a/External/INCHI-API/test.cpp
+++ b/External/INCHI-API/test.cpp
@@ -959,6 +959,50 @@ void testGithub8239() {
   BOOST_LOG(rdInfoLog) << "done" << std::endl;
 }
 
+void testStereoAnyRoundtrip() {
+  BOOST_LOG(rdErrorLog) << "-------------------------------------" << std::endl;
+  BOOST_LOG(rdInfoLog)
+      << "testing STEREOANY (wavy bond) InChI roundtrip" << std::endl;
+
+  {
+    // wavy bond on the C=N double bond (bond index 8)
+    auto m = "CSC1=NSC(CC=NC2=CC=CC=C2)=C1C#N |w:8.8|"_smiles;
+    TEST_ASSERT(m);
+
+    // verify STEREOANY is present on input
+    bool foundStereoAny = false;
+    for (const auto bond : m->bonds()) {
+      if (bond->getStereo() == Bond::STEREOANY) {
+        foundStereoAny = true;
+        break;
+      }
+    }
+    TEST_ASSERT(foundStereoAny);
+
+    // convert to InChI with -SUU (include unknown/undefined stereo) and back
+    ExtraInchiReturnValues tmp;
+    auto inchi = MolToInchi(*m, tmp, "-SUU");
+    TEST_ASSERT(!inchi.empty());
+
+    ExtraInchiReturnValues tmp2;
+    std::unique_ptr<ROMol> m2(InchiToMol(inchi, tmp2));
+    TEST_ASSERT(m2);
+
+    // verify STEREOANY survives the roundtrip
+    bool foundStereoAny2 = false;
+    for (const auto bond : m2->bonds()) {
+      if (bond->getStereo() == Bond::STEREOANY) {
+        foundStereoAny2 = true;
+        TEST_ASSERT(bond->getStereoAtoms().size() == 2);
+        break;
+      }
+    }
+    TEST_ASSERT(foundStereoAny2);
+  }
+
+  BOOST_LOG(rdInfoLog) << "done" << std::endl;
+}
+
 //-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
 //
 //-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
@@ -985,4 +1029,5 @@ int main() {
   testGithub5311();
   testGithub8123();
   testGithub8239();
+  testStereoAnyRoundtrip();
 }

--- a/External/INCHI-API/test.cpp
+++ b/External/INCHI-API/test.cpp
@@ -1021,6 +1021,16 @@ void testStereoAnyRoundtrip() {
   // Crotonaldehyde: simple wavy C=C
   checkStereoAnyRoundtrip("C/C=C/C=O |w:1.1|", "crotonaldehyde C=C");
 
+  // Tamoxifen-like: wavy C=C in drug-like molecule
+  checkStereoAnyRoundtrip(
+      "CC/C(=C(/c1ccccc1)c1ccc(OCCN(C)C)cc1)c1ccccc1 |w:2.2|",
+      "tamoxifen-like C=C");
+
+  // Retinal-like: wavy C=C in polyene chain
+  checkStereoAnyRoundtrip(
+      "CC1=C(/C=C/C(C)=C/C=C/C(C)=C/C=O)C(C)(C)CCC1 |w:3.3|",
+      "retinal-like C=C");
+
   BOOST_LOG(rdInfoLog) << "done" << std::endl;
 }
 

--- a/rdkit/Chem/UnitTestInchi.py
+++ b/rdkit/Chem/UnitTestInchi.py
@@ -255,9 +255,9 @@ class TestCase(unittest.TestCase):
           same += 1
       fmt = "\n{0}InChI read Summary: {1} identical, {2} variance, {3} reasonable variance{4}"
       print(fmt.format(COLOR_GREEN, same, diff, reasonable, COLOR_RESET))
-      self.assertEqual(same, 688)
+      self.assertEqual(same, 689)
       self.assertEqual(diff, 0)
-      self.assertEqual(reasonable, 493)
+      self.assertEqual(reasonable, 492)
 
   def test2InchiOptions(self):
     m = MolFromSmiles("CC=C(N)C")


### PR DESCRIPTION
## Summary

Wavy bonds (`Bond::STEREOANY` on double bonds) are silently dropped during InChI roundtrip and CXSMILES serialization. This PR fixes the full pipeline so that `CXSMILES(|w:|) → mol → InChI(-SUU) → mol → CXSMILES(|w:|)` preserves wavy bond information.

**Root cause:** Three bugs across two files — all in RDKit's conversion layers, not in the InChI C library.

## What changed

### 1. InChI reverse path (`InchiToMol`) — `External/INCHI-API/inchi.cpp`

The stereo0D processing loop skipped `INCHI_PARITY_UNDEFINED` entries before they could reach the double bond handler, which already had an `else` clause that correctly sets `Bond::STEREOANY`:

```cpp
// Before: UNDEFINED skipped, never reaches STEREOANY handler
if (stereo0DPtr->parity == INCHI_PARITY_NONE ||
    stereo0DPtr->parity == INCHI_PARITY_UNDEFINED) {
  continue;
}
```

**Fix:** Only skip `INCHI_PARITY_NONE`. Add a guard inside the `INCHI_StereoType_Tetrahedral` case to prevent `UNDEFINED`/`UNKNOWN` from incorrectly assigning chirality.

### 2. InChI forward path (`MolToInchi`) — `External/INCHI-API/inchi.cpp`

`STEREOANY` bonds only collapsed coordinates to prevent InChI from inferring stereo from geometry, but never sent an explicit `inchi_Stereo0D` entry. With `-SUU`, InChI needs this entry to produce the correct unknown stereo annotation (`/b..?`).

**Fix:** Keep the coordinate collapse **and** send a `stereo0D` entry with `INCHI_PARITY_UNKNOWN`. Since RDKit clears `getStereoAtoms()` for STEREOANY bonds, neighbors are discovered by iterating atom bonds.

### 3. CXSMILES writer — `Code/GraphMol/SmilesParse/CXSmilesOps.cpp`

`MolToCXSmiles` did not write `|w:|` for double bonds with `Bond::STEREOANY` unless `BondDir::UNKNOWN` was already set on an adjacent single bond. After InChI roundtrip, `STEREOANY` is set on the double bond but no `BondDir` is set on neighbors, so `|w:|` was silently dropped.

**Fix:** In `get_bond_config_block()`, after the main single-bond loop, add a second pass that finds double bonds with `STEREOANY`, locates an adjacent single bond, and emits `|w:|` for it. The new code is careful to skip bonds that are already handled:

- **Ring double bonds** — handled by `get_ringbond_cistrans_block()` as `|ctu:|`
- **Adjacent `BondDir::UNKNOWN`** — already emitted by the main loop
- **Adjacent `_MolFileBondCfg`** — from CXSMILES parser, already handled
- **Empty `getStereoAtoms()`** — programmatically set STEREOANY without neighbor info (e.g. `Bond.SetStereo(STEREOANY)`)
- **`_MolFileBondStereo` on the double bond** — from SDF/MRV parser, handled by `wU`/`wD` markers

This ensures only STEREOANY from InChI roundtrip (which populates stereo atoms but has none of the other markers) gets the new `|w:|` annotation, preserving existing behavior for all other code paths.

### 4. InChI PubChem roundtrip count — `rdkit/Chem/UnitTestInchi.py`

One molecule that previously didn't round-trip identically through InChI now does, thanks to the STEREOANY fix. Updated the expected count from 688→689 identical, 493→492 reasonable variance.

## Before / After

Full pipeline: `CXSMILES → mol → InChI(-SUU) → mol → CXSMILES`

| Molecule | Input | Master (before) | Fix (after) |
|---|---|---|---|
| Schiff base | `CSC1=NSC(CC=NC2=CC=CC=C2)=C1C#N \|w:8.8\|` | `CSc1nsc(CC=Nc2ccccc2)c1C#N` | `CSc1nsc(CC=Nc2ccccc2)c1C#N \|w:7.6\|` |
| Benzaldoxime | `O/N=C/c1ccccc1 \|w:1.1\|` | `ON=Cc1ccccc1` | `ON=Cc1ccccc1 \|w:2.2\|` |
| Cinnamic acid | `OC(=O)/C=C/c1ccccc1 \|w:3.3\|` | `O=C(O)C=Cc1ccccc1` | `O=C(O)C=Cc1ccccc1 \|w:4.4\|` |
| Chalcone | `O=C(/C=C/c1ccccc1)c1ccccc1 \|w:2.2\|` | `O=C(C=Cc1ccccc1)c1ccccc1` | `O=C(C=Cc1ccccc1)c1ccccc1 \|w:3.3\|` |
| Crotonaldehyde | `C/C=C/C=O \|w:1.1\|` | `CC=CC=O` | `CC=CC=O \|w:1.0\|` |
| Tamoxifen-like | `CC/C(=C(/c1ccccc1)...)c1ccccc1 \|w:2.2\|` | `CCC(=C(c1ccccc1)...)c1ccccc1` | `CCC(=C(c1ccccc1)...)c1ccccc1 \|w:2.1\|` |
| Retinal-like | `CC1=C(/C=C/C(C)=C/...)C(C)(C)CCC1 \|w:3.3\|` | `CC1=C(C=C/C(C)=C/...)C(C)(C)CCC1` | `CC1=C(C=C/C(C)=C/...)C(C)(C)CCC1 \|w:4.4\|` |
| Chiral + wavy C=C | `O=C(O)[C@@H](CC=Cc1ccccc1)N \|w:4.4\|` | `N[C@H](CC=Cc1ccccc1)C(=O)O` | `N[C@H](CC=Cc1ccccc1)C(=O)O \|w:3.2\|` |
| Chiral + wavy oxime | `C[C@H](O)/C(=N/O)c1ccccc1 \|w:3.3\|` | `C[C@H](O)C(=NO)c1ccccc1` | `C[C@H](O)C(=NO)c1ccccc1 \|w:3.2\|` |

**Master:** all `|w:|` lost. **Fix:** all `|w:|` preserved.

The `|w:` bond indices differ from the input because atom ordering changes during InChI canonicalization, but the wavy bond annotation is correctly placed on a single bond adjacent to the STEREOANY double bond.

## Why this matters

This is a correctness bug affecting compound canonicalization pipelines that use InChI roundtrips with `-SUU`. Without this fix, wavy bond information (indicating intentionally unspecified double bond stereochemistry) is irreversibly lost, leading to incorrect canonical forms and false-positive duplicate detection.

## Test plan

- [x] `testStereoAnyRoundtrip()` — 9 molecules: Schiff base, benzaldoxime, cinnamic acid, chalcone, crotonaldehyde, tamoxifen-like, retinal-like, chiral+wavy C=C, chiral+wavy oxime
- [x] All existing InChI tests pass (updated PubChem roundtrip count: 688→689 identical)
- [x] All existing CXSmiles tests pass (2524 assertions, 34 test cases)
- [x] All existing SmilesParse tests pass (1863 assertions, 79 test cases)
- [x] Marvin parser tests pass (no unexpected `|w:|` on SDF/MRV molecules)
- [x] Registration hash tests pass (programmatic STEREOANY correctly excluded from `|w:|`)
- [x] CXSMILES roundtrip verified: all 9 molecules produce `|w:|` after `CXSMILES → InChI(-SUU) → CXSMILES`
- [x] All 12 CI checks green