### PR TITLE
Use index-order kekulization in MolToInchi to speed it up

### DIFF
--- a/External/INCHI-API/inchi.cpp
+++ b/External/INCHI-API/inchi.cpp
@@ -1753,7 +1753,7 @@ std::string MolToInchi(const ROMol &mol, ExtraInchiReturnValues &rv,
     m->updatePropertyCache(false);
   }
   // kekulize
-  MolOps::Kekulize(*m, false);
+  MolOps::Kekulize(*m, false, false);
 
   // "reverse" cleanup: undo some clean up done by RDKit
   rCleanUp(*m);


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

Speed up InChI generation by using cheaper kekulize codepath.

#### Any other comments?


Profiled locally (on EC2) using GPT 5.4 xhigh -- it also penned the commit message.
On molecules tested, no InChI changes seen -- I think InChI has its own kekulization algo (?)

```
Performance:
- Release_2026_03_1 Python MolToInchi on Regress/Data/mols.1000.sdf.gz improved from 0.40712s to 0.38871s median (-4.52%).
- Release_2026_03_1 rdinchi MolToInchi on the same dataset improved from 0.39755s to 0.37814s median (-4.88%).
- Release_2026_03_1 standalone C++ MolToInchi on /tmp/mols.1000.sdf improved from 7.66775s to 7.03474s wall time (-8.26%), from 20.57B to 19.04B cycles (-7.46%), and from 121.78M to 114.05M cache misses (-6.35%).
```