### PR TITLE
Make setDoubleBondNeighborDirections() more consistent

### DIFF
--- a/Code/GraphMol/Chirality.cpp
+++ b/Code/GraphMol/Chirality.cpp
@@ -26,6 +26,7 @@
 #include <algorithm>
 #include <cstdlib>
 #include <optional>
+#include <ranges>
 #include <set>
 #include <sstream>
 #include <utility>
@@ -3649,16 +3650,19 @@ void setDoubleBondNeighborDirections(ROMol &mol, const Conformer *conf) {
     }
     orderedBondsInPlay.push_back(std::make_pair(countHere, dblBond));
   }
-  std::sort(orderedBondsInPlay.begin(), orderedBondsInPlay.end());
+  std::ranges::sort(orderedBondsInPlay, [](const auto &a, const auto &b) {
+    // sort in decreasing order of priority
+    if (a.first != b.first) {
+      return a.first > b.first;
+    }
+    // in case of ties, use the bond index to decide the order
+    return a.second->getIdx() < b.second->getIdx();
+  });
 
   // oof, now loop over the double bonds in that order and
   // update their neighbor directionalities:
-  std::vector<std::pair<unsigned int, Bond *>>::reverse_iterator pairIter;
-  for (pairIter = orderedBondsInPlay.rbegin();
-       pairIter != orderedBondsInPlay.rend(); ++pairIter) {
-    // std::cerr << "RESET?: " << pairIter->second->getIdx() << " "
-    //           << pairIter->second->getStereo() << std::endl;
-    updateDoubleBondNeighbors(mol, pairIter->second, conf, needsDir,
+  for (const auto& pairIter : orderedBondsInPlay) {
+    updateDoubleBondNeighbors(mol, pairIter.second, conf, needsDir,
                               singleBondCounts, singleBondNbrs);
   }
 }


### PR DESCRIPTION
This fixes an issue that makes the double bond directions assigned `setDoubleBondNeighborDirections()` potentially inconsistent for the same inputs.

The issue here is that when sorting `orderedBondsInPlay`, which is a `std::vector<std::pair<unsigned int, Bond *>>`, if the first elements of the pair are the same (which isn't infrequent), we will disambiguate using the address of the `Bond*`, which is arbitrary. This opens the door to different direction assignments for the exact same input molecule based on the pattern of the addresses where the bonds are allocated.

In my case, I hit this when running some checks for https://github.com/rdkit/rdkit/pull/9171: I was going to generate CIP labels from pubchem mols with and without the patch, but accidentally ran the baseline (without the patch) twice, and, to my surprise, I found mismatched labels between two runs that should be identical. Reproducing and debugging the issue was a real pain, but I ended up tracing it back to this issue.

This patch avoids using the addresses for the sorting by using the indexes instead. This doesn't guarantee that the results will always be consistent for the same molecule (e.g. same atoms / bonds but different ordering), as the order in which the bonds are assigned can change what is `ENDUPRIGHT`/`ENDDOWNRIGHT`, and even create conflicts, but the results should now at least should be the same when the inputs are identical (same atoms, same bonds, and in the same order).

I'm not adding a test because I haven't been able to find a reasonably simple way to reproduce the issue.

