### PR TITLE
Make DiGraph::getNodes() only visit already seen nodes

### DIFF
--- a/Code/GraphMol/CIPLabeler/Digraph.cpp
+++ b/Code/GraphMol/CIPLabeler/Digraph.cpp
@@ -74,12 +74,15 @@ int Digraph::getNumNodes() const { return d_nodes.size(); }
 
 std::vector<Node *> Digraph::getNodes(Atom *atom) const {
   std::vector<Node *> result;
-  std::vector<Node*> queue = {getCurrentRoot()};
+  std::vector<Node *> queue = {getCurrentRoot()};
 
-  for (size_t i=0; i<queue.size(); ++i) {
+  for (size_t i = 0; i < queue.size(); ++i) {
     auto node = queue[i];
     if (atom == node->getAtom()) {
       result.push_back(node);
+    }
+    if (!node->isExpanded()) {
+      continue;
     }
     for (const auto &e : node->getEdges()) {
       if (!e->isBeg(node)) {

--- a/Code/GraphMol/CIPLabeler/Digraph.h
+++ b/Code/GraphMol/CIPLabeler/Digraph.h
@@ -62,8 +62,8 @@ class Digraph {
   int getNumNodes() const;
 
   /**
-   * Get all nodes which refer to `atom` in order of
-   * distance from the root.
+   * Get all seen nodes which refer to `atom` in order of
+   * distance from the current root.
    */
   std::vector<Node *> getNodes(Atom *atom) const;
 

--- a/Code/GraphMol/CIPLabeler/catch_tests.cpp
+++ b/Code/GraphMol/CIPLabeler/catch_tests.cpp
@@ -192,6 +192,7 @@ TEST_CASE("Digraph", "[accurateCIP]") {
 
   auto new_root_idx = 24u;
   auto new_root_atom = cipmol.getAtom(new_root_idx);
+  expandAll(g);
   auto new_root_nodes = g.getNodes(new_root_atom);
   CHECK(new_root_nodes.size() == 104);
 


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
This makes the bug that Ricardo pointed out in #9171 deterministic - programming errors in auxiliary labelling make it happen every time.

#### Any other comments?

