### PR TITLE
CIPLabeler performance: Store vector of bonds

### DIFF
--- a/Code/GraphMol/CIPLabeler/CIPMol.cpp
+++ b/Code/GraphMol/CIPLabeler/CIPMol.cpp
@@ -16,7 +16,12 @@
 namespace RDKit {
 namespace CIPLabeler {
 
-CIPMol::CIPMol(ROMol &mol) : d_mol{mol} {}
+CIPMol::CIPMol(ROMol &mol) : d_mol{mol} {
+    d_bonds.reserve(mol.getNumAtoms() * 2);
+    for (auto b: mol.bonds()) {
+        d_bonds.push_back(b);
+    }
+}
 
 boost::rational<int> CIPMol::getFractionalAtomicNum(Atom *atom) const {
   PRECONDITION(atom, "bad atom")
@@ -36,7 +41,7 @@ CXXAtomIterator<MolGraph, Atom *> CIPMol::atoms() const {
   return d_mol.atoms();
 }
 
-Bond *CIPMol::getBond(int idx) const { return d_mol.getBondWithIdx(idx); };
+Bond *CIPMol::getBond(int idx) const { return d_bonds[idx]; };
 
 CIPMolSpan<Bond *, ROMol::OEDGE_ITER> CIPMol::getBonds(Atom *atom) const {
   PRECONDITION(atom, "bad atom")

--- a/Code/GraphMol/CIPLabeler/CIPMol.cpp
+++ b/Code/GraphMol/CIPLabeler/CIPMol.cpp
@@ -17,10 +17,8 @@ namespace RDKit {
 namespace CIPLabeler {
 
 CIPMol::CIPMol(ROMol &mol) : d_mol{mol} {
-    d_bonds.reserve(mol.getNumAtoms() * 2);
-    for (auto b: mol.bonds()) {
-        d_bonds.push_back(b);
-    }
+  d_bonds.reserve(mol.getNumBonds());
+  std::ranges::copy(mol.bonds(), std::back_inserter(d_bonds));
 }
 
 boost::rational<int> CIPMol::getFractionalAtomicNum(Atom *atom) const {

--- a/Code/GraphMol/CIPLabeler/CIPMol.h
+++ b/Code/GraphMol/CIPLabeler/CIPMol.h
@@ -97,6 +97,7 @@ class CIPMol {
   ROMol &d_mol;
   std::vector<RDKit::Bond::BondType> d_kekulized_bonds;
   std::vector<boost::rational<int>> d_atomnums;
+  std::vector<RDKit::Bond* > d_bonds;
 };
 
 }  // namespace CIPLabeler


### PR DESCRIPTION
CIPLabelling refers to bonds by index over and over again. This causes a measurable hit in performance in findConfigs() because we iterate over a bitset of "allowed" bonds. For very large molecules with many bonds, this can be a rate-limiting step!

This affects many PDB-sized structures.

2J3N goes from 0.7s to 0.25s with this change.

I had another example for which the findBondWithIdx() call was taking 500ms of a 700ms call (after the performance update in #9171 was implemented)

