### PR TITLE
Add Getter functions to MMFF property python interface

### DIFF
--- a/Code/ForceField/Wrap/ForceField.cpp
+++ b/Code/ForceField/Wrap/ForceField.cpp
@@ -204,7 +204,8 @@ python::tuple PyForceField::minimizeTrajectory(unsigned int snapshotFreq,
 }
 
 PyObject *PyMMFFMolProperties::getMMFFBondStretchParams(
-    const RDKit::ROMol &mol, const unsigned int idx1, const unsigned int idx2) {
+    const RDKit::ROMol &mol, const unsigned int idx1,
+    const unsigned int idx2) const {
   PyObject *res = nullptr;
   unsigned int bondType;
   ForceFields::MMFF::MMFFBond mmffBondStretchParams;
@@ -218,10 +219,9 @@ PyObject *PyMMFFMolProperties::getMMFFBondStretchParams(
   return res;
 };
 
-PyObject *PyMMFFMolProperties::getMMFFAngleBendParams(const RDKit::ROMol &mol,
-                                                      const unsigned int idx1,
-                                                      const unsigned int idx2,
-                                                      const unsigned int idx3) {
+PyObject *PyMMFFMolProperties::getMMFFAngleBendParams(
+    const RDKit::ROMol &mol, const unsigned int idx1, const unsigned int idx2,
+    const unsigned int idx3) const {
   PyObject *res = nullptr;
   unsigned int angleType;
   ForceFields::MMFF::MMFFAngle mmffAngleBendParams;
@@ -237,7 +237,7 @@ PyObject *PyMMFFMolProperties::getMMFFAngleBendParams(const RDKit::ROMol &mol,
 
 PyObject *PyMMFFMolProperties::getMMFFStretchBendParams(
     const RDKit::ROMol &mol, const unsigned int idx1, const unsigned int idx2,
-    const unsigned int idx3) {
+    const unsigned int idx3) const {
   PyObject *res = nullptr;
   unsigned int stretchBendType;
   ForceFields::MMFF::MMFFStbn mmffStretchBendParams;
@@ -254,11 +254,9 @@ PyObject *PyMMFFMolProperties::getMMFFStretchBendParams(
   return res;
 };
 
-PyObject *PyMMFFMolProperties::getMMFFTorsionParams(const RDKit::ROMol &mol,
-                                                    const unsigned int idx1,
-                                                    const unsigned int idx2,
-                                                    const unsigned int idx3,
-                                                    const unsigned int idx4) {
+PyObject *PyMMFFMolProperties::getMMFFTorsionParams(
+    const RDKit::ROMol &mol, const unsigned int idx1, const unsigned int idx2,
+    const unsigned int idx3, const unsigned int idx4) const {
   PyObject *res = nullptr;
   unsigned int torType;
   ForceFields::MMFF::MMFFTor mmffTorsionParams;
@@ -273,11 +271,9 @@ PyObject *PyMMFFMolProperties::getMMFFTorsionParams(const RDKit::ROMol &mol,
   return res;
 };
 
-PyObject *PyMMFFMolProperties::getMMFFOopBendParams(const RDKit::ROMol &mol,
-                                                    const unsigned int idx1,
-                                                    const unsigned int idx2,
-                                                    const unsigned int idx3,
-                                                    const unsigned int idx4) {
+PyObject *PyMMFFMolProperties::getMMFFOopBendParams(
+    const RDKit::ROMol &mol, const unsigned int idx1, const unsigned int idx2,
+    const unsigned int idx3, const unsigned int idx4) const {
   PyObject *res = nullptr;
   ForceFields::MMFF::MMFFOop mmffOopBendParams;
   if (mmffMolProperties->getMMFFOopBendParams(mol, idx1, idx2, idx3, idx4,
@@ -288,7 +284,7 @@ PyObject *PyMMFFMolProperties::getMMFFOopBendParams(const RDKit::ROMol &mol,
 };
 
 PyObject *PyMMFFMolProperties::getMMFFVdWParams(const unsigned int idx1,
-                                                const unsigned int idx2) {
+                                                const unsigned int idx2) const {
   PyObject *res = nullptr;
   ForceFields::MMFF::MMFFVdWRijstarEps mmffVdWParams;
   if (mmffMolProperties->getMMFFVdWParams(idx1, idx2, mmffVdWParams)) {
@@ -309,7 +305,7 @@ BOOST_PYTHON_MODULE(rdForceField) {
 
   python::class_<PyForceField>("ForceField", "A force field", python::no_init)
       .def("CalcEnergy",
-           (double (PyForceField::*)(const python::object &) const) &
+           (double(PyForceField::*)(const python::object &) const) &
                PyForceField::calcEnergyWithPos,
            ((python::arg("self"), python::arg("pos") = python::object())),
            "Returns the energy (in kcal/mol) of the current arrangement\n"
@@ -483,43 +479,80 @@ BOOST_PYTHON_MODULE(rdForceField) {
            "Sets the DielModel MMFF property (1: constant; 2: "
            "distance-dependent; "
            "defaults to constant)")
+      .def("GetMMFFDielectricModel",
+           &PyMMFFMolProperties::getMMFFDielectricModel, python::arg("self"),
+           "Returns the currently configured MMFF dielectric model "
+           "(1: constant; 2: distance-dependent).")
       .def("SetMMFFDielectricConstant",
            &PyMMFFMolProperties::setMMFFDielectricConstant,
            (python::arg("self"), python::arg("dielConst") = 1.0),
            "Sets the DielConst MMFF property (defaults to 1.0)")
+      .def("GetMMFFDielectricConstant",
+           &PyMMFFMolProperties::getMMFFDielectricConstant, python::arg("self"),
+           "Returns the currently configured MMFF dielectric constant.")
       .def("SetMMFFBondTerm", &PyMMFFMolProperties::setMMFFBondTerm,
            (python::arg("self"), python::arg("state") = true),
            "Sets the bond term to be included in the MMFF equation (defaults "
            "to True)")
+      .def("GetMMFFBondTerm", &PyMMFFMolProperties::getMMFFBondTerm,
+           python::arg("self"),
+           "Returns whether the bond term is included in the MMFF equation.")
       .def("SetMMFFAngleTerm", &PyMMFFMolProperties::setMMFFAngleTerm,
            (python::arg("self"), python::arg("state") = true),
            "Sets the angle term to be included in the MMFF equation (defaults "
            "to True)")
+      .def("GetMMFFAngleTerm", &PyMMFFMolProperties::getMMFFAngleTerm,
+           python::arg("self"),
+           "Returns whether the angle term is included in the MMFF equation.")
       .def("SetMMFFStretchBendTerm",
            &PyMMFFMolProperties::setMMFFStretchBendTerm,
            (python::arg("self"), python::arg("state") = true),
            "Sets the stretch-bend term to be included in the MMFF equation "
            "(defaults to True)")
+      .def("GetMMFFStretchBendTerm",
+           &PyMMFFMolProperties::getMMFFStretchBendTerm, python::arg("self"),
+           "Returns whether the stretch-bend term is included in the MMFF "
+           "equation.")
       .def("SetMMFFOopTerm", &PyMMFFMolProperties::setMMFFOopTerm,
            (python::arg("self"), python::arg("state") = true),
            "Sets the out-of-plane bend term to be included in the MMFF "
            "equation (defaults to True)")
+      .def("GetMMFFOopTerm", &PyMMFFMolProperties::getMMFFOopTerm,
+           python::arg("self"),
+           "Returns whether the out-of-plane bend term is included in the "
+           "MMFF equation.")
       .def("SetMMFFTorsionTerm", &PyMMFFMolProperties::setMMFFTorsionTerm,
            (python::arg("self"), python::arg("state") = true),
            "Sets the torsional term to be included in the MMFF equation "
            "(defaults to True)")
+      .def("GetMMFFTorsionTerm", &PyMMFFMolProperties::getMMFFTorsionTerm,
+           python::arg("self"),
+           "Returns whether the torsional term is included in the MMFF "
+           "equation.")
       .def("SetMMFFVdWTerm", &PyMMFFMolProperties::setMMFFVdWTerm,
            (python::arg("self"), python::arg("state") = true),
            "Sets the Van der Waals term to be included in the MMFF equation "
            "(defaults to True)")
+      .def("GetMMFFVdWTerm", &PyMMFFMolProperties::getMMFFVdWTerm,
+           python::arg("self"),
+           "Returns whether the Van der Waals term is included in the MMFF "
+           "equation.")
       .def("SetMMFFEleTerm", &PyMMFFMolProperties::setMMFFEleTerm,
            (python::arg("self"), python::arg("state") = true),
            "Sets the electrostatic term to be included in the MMFF equation "
            "(defaults to True)")
+      .def("GetMMFFEleTerm", &PyMMFFMolProperties::getMMFFEleTerm,
+           python::arg("self"),
+           "Returns whether the electrostatic term is included in the MMFF "
+           "equation.")
       .def("SetMMFFVariant", &PyMMFFMolProperties::setMMFFVariant,
            (python::arg("self"), python::arg("mmffVariant") = "MMFF94"),
            "Sets the MMFF variant to be used (\"MMFF94\" or \"MMFF94s\"; "
            "defaults to \"MMFF94\")")
+      .def("GetMMFFVariant", &PyMMFFMolProperties::getMMFFVariant,
+           python::arg("self"),
+           "Returns the currently configured MMFF variant "
+           "(\"MMFF94\" or \"MMFF94s\").")
       .def("SetMMFFVerbosity", &PyMMFFMolProperties::setMMFFVerbosity,
            (python::arg("self"), python::arg("verbosity") = 0),
            "Sets the MMFF verbosity (0: none; 1: low; 2: high; defaults to 0)");

--- a/Code/ForceField/Wrap/PyForceField.h
+++ b/Code/ForceField/Wrap/PyForceField.h
@@ -89,66 +89,89 @@ class PyMMFFMolProperties {
       : mmffMolProperties(mp) {}
   ~PyMMFFMolProperties() = default;
 
-  unsigned int getMMFFAtomType(unsigned int idx) {
+  unsigned int getMMFFAtomType(unsigned int idx) const {
     return (unsigned int)(mmffMolProperties->getMMFFAtomType(idx));
   }
-  double getMMFFFormalCharge(unsigned int idx) {
+  double getMMFFFormalCharge(unsigned int idx) const {
     return mmffMolProperties->getMMFFFormalCharge(idx);
   }
-  double getMMFFPartialCharge(unsigned int idx) {
+  double getMMFFPartialCharge(unsigned int idx) const {
     return mmffMolProperties->getMMFFPartialCharge(idx);
   }
   PyObject *getMMFFBondStretchParams(const RDKit::ROMol &mol,
                                      const unsigned int idx1,
-                                     const unsigned int idx2);
+                                     const unsigned int idx2) const;
   PyObject *getMMFFAngleBendParams(const RDKit::ROMol &mol,
                                    const unsigned int idx1,
                                    const unsigned int idx2,
-                                   const unsigned int idx3);
+                                   const unsigned int idx3) const;
   PyObject *getMMFFStretchBendParams(const RDKit::ROMol &mol,
                                      const unsigned int idx1,
                                      const unsigned int idx2,
-                                     const unsigned int idx3);
+                                     const unsigned int idx3) const;
   PyObject *getMMFFTorsionParams(const RDKit::ROMol &mol,
                                  const unsigned int idx1,
                                  const unsigned int idx2,
                                  const unsigned int idx3,
-                                 const unsigned int idx4);
+                                 const unsigned int idx4) const;
   PyObject *getMMFFOopBendParams(const RDKit::ROMol &mol,
                                  const unsigned int idx1,
                                  const unsigned int idx2,
                                  const unsigned int idx3,
-                                 const unsigned int idx4);
-  PyObject *getMMFFVdWParams(const unsigned int idx1, const unsigned int idx2);
+                                 const unsigned int idx4) const;
+  PyObject *getMMFFVdWParams(const unsigned int idx1,
+                             const unsigned int idx2) const;
   void setMMFFDielectricModel(std::uint8_t dielModel) {
     mmffMolProperties->setMMFFDielectricModel(dielModel);
+  }
+  std::uint8_t getMMFFDielectricModel() const {
+    return mmffMolProperties->getMMFFDielectricModel();
   }
   void setMMFFDielectricConstant(double dielConst) {
     mmffMolProperties->setMMFFDielectricConstant(dielConst);
   }
+  double getMMFFDielectricConstant() const {
+    return mmffMolProperties->getMMFFDielectricConstant();
+  }
   void setMMFFBondTerm(bool state) {
     mmffMolProperties->setMMFFBondTerm(state);
   }
+  bool getMMFFBondTerm() const { return mmffMolProperties->getMMFFBondTerm(); }
   void setMMFFAngleTerm(const bool state) {
     mmffMolProperties->setMMFFAngleTerm(state);
+  }
+  bool getMMFFAngleTerm() const {
+    return mmffMolProperties->getMMFFAngleTerm();
   }
   void setMMFFStretchBendTerm(const bool state) {
     mmffMolProperties->setMMFFStretchBendTerm(state);
   }
+  bool getMMFFStretchBendTerm() const {
+    return mmffMolProperties->getMMFFStretchBendTerm();
+  }
   void setMMFFOopTerm(const bool state) {
     mmffMolProperties->setMMFFOopTerm(state);
   }
+  bool getMMFFOopTerm() const { return mmffMolProperties->getMMFFOopTerm(); }
   void setMMFFTorsionTerm(const bool state) {
     mmffMolProperties->setMMFFTorsionTerm(state);
+  }
+  bool getMMFFTorsionTerm() const {
+    return mmffMolProperties->getMMFFTorsionTerm();
   }
   void setMMFFVdWTerm(const bool state) {
     mmffMolProperties->setMMFFVdWTerm(state);
   }
+  bool getMMFFVdWTerm() const { return mmffMolProperties->getMMFFVdWTerm(); }
   void setMMFFEleTerm(const bool state) {
     mmffMolProperties->setMMFFEleTerm(state);
   }
+  bool getMMFFEleTerm() const { return mmffMolProperties->getMMFFEleTerm(); }
   void setMMFFVariant(const std::string &mmffVariant) {
     mmffMolProperties->setMMFFVariant(mmffVariant);
+  }
+  std::string getMMFFVariant() const {
+    return mmffMolProperties->getMMFFVariant();
   }
   void setMMFFVerbosity(unsigned int verbosity) {
     mmffMolProperties->setMMFFVerbosity(verbosity);

--- a/Code/GraphMol/ForceFieldHelpers/MMFF/AtomTyper.cpp
+++ b/Code/GraphMol/ForceFieldHelpers/MMFF/AtomTyper.cpp
@@ -2412,7 +2412,7 @@ MMFFMolProperties::MMFFMolProperties(ROMol &mol, const std::string &mmffVariant,
 unsigned int MMFFMolProperties::getMMFFAngleType(const ROMol &mol,
                                                  const unsigned int idx1,
                                                  const unsigned int idx2,
-                                                 const unsigned int idx3) {
+                                                 const unsigned int idx3) const {
   PRECONDITION(this->isValid(), "missing atom types - invalid force-field");
 
   // ftp://ftp.wiley.com/public/journals/jcc/suppmat/17/553/MMFF-III_AppendixA.html
@@ -2454,7 +2454,7 @@ unsigned int MMFFMolProperties::getMMFFAngleType(const ROMol &mol,
 }
 
 // returns the MMFF bond type of the bond
-unsigned int MMFFMolProperties::getMMFFBondType(const Bond *bond) {
+unsigned int MMFFMolProperties::getMMFFBondType(const Bond *bond) const {
   PRECONDITION(this->isValid(), "missing atom types - invalid force-field");
   PRECONDITION(bond, "invalid bond");
 
@@ -2529,7 +2529,7 @@ const std::pair<unsigned int, unsigned int>
 MMFFMolProperties::getMMFFTorsionType(const ROMol &mol, const unsigned int idx1,
                                       const unsigned int idx2,
                                       const unsigned int idx3,
-                                      const unsigned int idx4) {
+                                      const unsigned int idx4) const {
   PRECONDITION(this->isValid(), "missing atom types - invalid force-field");
 
   const Bond *bondJK = mol.getBondBetweenAtoms(idx2, idx3);
@@ -2575,7 +2575,7 @@ MMFFMolProperties::getMMFFTorsionType(const ROMol &mol, const unsigned int idx1,
 // pointer to a MMFFBond object must be freed by the caller
 const ForceFields::MMFF::MMFFBond *
 MMFFMolProperties::getMMFFBondStretchEmpiricalRuleParams(const ROMol &,
-                                                         const Bond *bond) {
+                                                         const Bond *bond) const {
   PRECONDITION(this->isValid(), "missing atom types - invalid force-field");
 
   const MMFFBond *mmffBndkParams;
@@ -2879,7 +2879,7 @@ const ForceFields::MMFF::MMFFAngle *getMMFFAngleBendEmpiricalRuleParams(
 const ForceFields::MMFF::MMFFTor *
 MMFFMolProperties::getMMFFTorsionEmpiricalRuleParams(const ROMol &mol,
                                                      unsigned int idx2,
-                                                     unsigned int idx3) {
+                                                     unsigned int idx3) const {
   PRECONDITION(this->isValid(), "missing atom types - invalid force-field");
 
   const MMFFPropCollection *mmffProp = DefaultParameters::getMMFFProp();
@@ -3489,7 +3489,7 @@ void MMFFMolProperties::computeMMFFCharges(const ROMol &mol) {
 
 bool MMFFMolProperties::getMMFFBondStretchParams(
     const ROMol &mol, const unsigned int idx1, const unsigned int idx2,
-    unsigned int &bondType, MMFFBond &mmffBondStretchParams) {
+    unsigned int &bondType, MMFFBond &mmffBondStretchParams) const {
   const MMFFBondCollection *mmffBond = DefaultParameters::getMMFFBond();
   bool res = false;
   if (isValid()) {
@@ -3517,12 +3517,10 @@ bool MMFFMolProperties::getMMFFBondStretchParams(
   return res;
 }
 
-bool MMFFMolProperties::getMMFFAngleBendParams(const ROMol &mol,
-                                               const unsigned int idx1,
-                                               const unsigned int idx2,
-                                               const unsigned int idx3,
-                                               unsigned int &angleType,
-                                               MMFFAngle &mmffAngleBendParams) {
+bool MMFFMolProperties::getMMFFAngleBendParams(
+    const ROMol &mol, const unsigned int idx1, const unsigned int idx2,
+    const unsigned int idx3, unsigned int &angleType,
+    MMFFAngle &mmffAngleBendParams) const {
   bool res = false;
   if (isValid() && mol.getBondBetweenAtoms(idx1, idx2) &&
       mol.getBondBetweenAtoms(idx2, idx3)) {
@@ -3569,7 +3567,7 @@ bool MMFFMolProperties::getMMFFStretchBendParams(
     const ROMol &mol, const unsigned int idx1, const unsigned int idx2,
     const unsigned int idx3, unsigned int &stretchBendType,
     MMFFStbn &mmffStretchBendParams, MMFFBond mmffBondStretchParams[2],
-    MMFFAngle &mmffAngleBendParams) {
+    MMFFAngle &mmffAngleBendParams) const {
   bool res = false;
   if (isValid()) {
     const MMFFPropCollection *mmffProp = DefaultParameters::getMMFFProp();
@@ -3629,7 +3627,7 @@ bool MMFFMolProperties::getMMFFStretchBendParams(
 bool MMFFMolProperties::getMMFFTorsionParams(
     const ROMol &mol, const unsigned int idx1, const unsigned int idx2,
     const unsigned int idx3, const unsigned int idx4, unsigned int &torsionType,
-    MMFFTor &mmffTorsionParams) {
+    MMFFTor &mmffTorsionParams) const {
   bool res = false;
   if (isValid() && mol.getBondBetweenAtoms(idx1, idx2) &&
       mol.getBondBetweenAtoms(idx2, idx3) &&
@@ -3669,12 +3667,10 @@ bool MMFFMolProperties::getMMFFTorsionParams(
   return res;
 }
 
-bool MMFFMolProperties::getMMFFOopBendParams(const ROMol &mol,
-                                             const unsigned int idx1,
-                                             const unsigned int idx2,
-                                             const unsigned int idx3,
-                                             const unsigned int idx4,
-                                             MMFFOop &mmffOopBendParams) {
+bool MMFFMolProperties::getMMFFOopBendParams(
+    const ROMol &mol, const unsigned int idx1, const unsigned int idx2,
+    const unsigned int idx3, const unsigned int idx4,
+    MMFFOop &mmffOopBendParams) const {
   bool res = false;
   if (isValid() && mol.getBondBetweenAtoms(idx1, idx2) &&
       mol.getBondBetweenAtoms(idx2, idx3) &&
@@ -3702,7 +3698,7 @@ bool MMFFMolProperties::getMMFFOopBendParams(const ROMol &mol,
 
 bool MMFFMolProperties::getMMFFVdWParams(const unsigned int idx1,
                                          const unsigned int idx2,
-                                         MMFFVdWRijstarEps &mmffVdWParams) {
+                                         MMFFVdWRijstarEps &mmffVdWParams) const {
   bool res = false;
   if (isValid()) {
     const MMFFVdWCollection *mmffVdW = DefaultParameters::getMMFFVdW();

--- a/Code/GraphMol/ForceFieldHelpers/MMFF/AtomTyper.h
+++ b/Code/GraphMol/ForceFieldHelpers/MMFF/AtomTyper.h
@@ -79,56 +79,56 @@ class RDKIT_FORCEFIELDHELPERS_EXPORT MMFFMolProperties {
                     std::uint8_t verbosity = MMFF_VERBOSITY_NONE,
                     std::ostream &oStream = std::cout);
   ~MMFFMolProperties() = default;
-  unsigned int getMMFFBondType(const Bond *bond);
+  unsigned int getMMFFBondType(const Bond *bond) const;
   unsigned int getMMFFAngleType(const ROMol &mol, const unsigned int idx1,
                                 const unsigned int idx2,
-                                const unsigned int idx3);
+                                const unsigned int idx3) const;
   const std::pair<unsigned int, unsigned int> getMMFFTorsionType(
       const ROMol &mol, const unsigned int idx1, const unsigned int idx2,
-      const unsigned int idx3, const unsigned int idx4);
+      const unsigned int idx3, const unsigned int idx4) const;
   void computeMMFFCharges(const ROMol &mol);
   const ForceFields::MMFF::MMFFTor *getMMFFTorsionEmpiricalRuleParams(
-      const ROMol &mol, unsigned int idx2, unsigned int idx3);
+      const ROMol &mol, unsigned int idx2, unsigned int idx3) const;
   const ForceFields::MMFF::MMFFBond *getMMFFBondStretchEmpiricalRuleParams(
-      const ROMol &mol, const Bond *bond);
-  std::uint8_t getMMFFAtomType(const unsigned int idx) {
+      const ROMol &mol, const Bond *bond) const;
+  std::uint8_t getMMFFAtomType(const unsigned int idx) const {
     URANGE_CHECK(idx, this->d_MMFFAtomPropertiesPtrVect.size());
 
     return this->d_MMFFAtomPropertiesPtrVect[idx]->mmffAtomType;
   }
-  double getMMFFFormalCharge(const unsigned int idx) {
+  double getMMFFFormalCharge(const unsigned int idx) const {
     URANGE_CHECK(idx, this->d_MMFFAtomPropertiesPtrVect.size());
 
     return this->d_MMFFAtomPropertiesPtrVect[idx]->mmffFormalCharge;
   }
-  double getMMFFPartialCharge(const unsigned int idx) {
+  double getMMFFPartialCharge(const unsigned int idx) const {
     URANGE_CHECK(idx, this->d_MMFFAtomPropertiesPtrVect.size());
 
     return this->d_MMFFAtomPropertiesPtrVect[idx]->mmffPartialCharge;
   }
   void setMMFFBondTerm(const bool state) { this->d_bondTerm = state; }
-  bool getMMFFBondTerm() { return this->d_bondTerm; }
+  bool getMMFFBondTerm() const { return this->d_bondTerm; }
   void setMMFFAngleTerm(const bool state) { this->d_angleTerm = state; }
-  bool getMMFFAngleTerm() { return this->d_angleTerm; }
+  bool getMMFFAngleTerm() const { return this->d_angleTerm; }
   void setMMFFStretchBendTerm(const bool state) {
     this->d_stretchBendTerm = state;
   }
-  bool getMMFFStretchBendTerm() { return this->d_stretchBendTerm; }
+  bool getMMFFStretchBendTerm() const { return this->d_stretchBendTerm; }
   void setMMFFOopTerm(const bool state) { this->d_oopTerm = state; }
-  bool getMMFFOopTerm() { return this->d_oopTerm; }
+  bool getMMFFOopTerm() const { return this->d_oopTerm; }
   void setMMFFTorsionTerm(const bool state) { this->d_torsionTerm = state; }
-  bool getMMFFTorsionTerm() { return this->d_torsionTerm; }
+  bool getMMFFTorsionTerm() const { return this->d_torsionTerm; }
   void setMMFFVdWTerm(const bool state) { this->d_vdWTerm = state; }
-  bool getMMFFVdWTerm() { return this->d_vdWTerm; }
+  bool getMMFFVdWTerm() const { return this->d_vdWTerm; }
   void setMMFFEleTerm(const bool state) { this->d_eleTerm = state; }
-  bool getMMFFEleTerm() { return this->d_eleTerm; }
+  bool getMMFFEleTerm() const { return this->d_eleTerm; }
   void setMMFFVariant(const std::string &mmffVariant) {
     PRECONDITION((mmffVariant == "MMFF94") || (mmffVariant == "MMFF94s"),
                  "bad MMFF variant");
 
     this->d_mmffs = mmffVariant == "MMFF94s";
   }
-  const std::string getMMFFVariant() {
+  const std::string getMMFFVariant() const {
     return (this->d_mmffs ? "MMFF94s" : "MMFF94");
   }
   void setMMFFDielectricConstant(const double dielConst) {
@@ -136,42 +136,42 @@ class RDKIT_FORCEFIELDHELPERS_EXPORT MMFFMolProperties {
 
     this->d_dielConst = dielConst;
   }
-  double getMMFFDielectricConstant() { return this->d_dielConst; }
+  double getMMFFDielectricConstant() const { return this->d_dielConst; }
   void setMMFFDielectricModel(std::uint8_t dielModel) {
     this->d_dielModel = dielModel;
   }
-  std::uint8_t getMMFFDielectricModel() { return this->d_dielModel; }
+  std::uint8_t getMMFFDielectricModel() const { return this->d_dielModel; }
   void setMMFFVerbosity(std::uint8_t verbosity) {
     this->d_verbosity = verbosity;
   }
-  std::uint8_t getMMFFVerbosity() { return this->d_verbosity; }
+  std::uint8_t getMMFFVerbosity() const { return this->d_verbosity; }
   void setMMFFOStream(std::ostream *oStream) { this->d_oStream = oStream; }
   std::ostream &getMMFFOStream() { return *(this->d_oStream); }
-  bool isValid() { return d_valid; }
+  bool isValid() const { return d_valid; }
   bool getMMFFBondStretchParams(const ROMol &mol, const unsigned int idx1,
                                 const unsigned int idx2, unsigned int &bondType,
-                                MMFFBond &mmffBondStretchParams);
+                                MMFFBond &mmffBondStretchParams) const;
   bool getMMFFAngleBendParams(const ROMol &mol, const unsigned int idx1,
                               const unsigned int idx2, const unsigned int idx3,
                               unsigned int &angleType,
-                              MMFFAngle &mmffAngleBendParams);
+                              MMFFAngle &mmffAngleBendParams) const;
   bool getMMFFStretchBendParams(const ROMol &mol, const unsigned int idx1,
                                 const unsigned int idx2,
                                 const unsigned int idx3,
                                 unsigned int &stretchBendType,
                                 MMFFStbn &mmffStretchBendParams,
                                 MMFFBond mmffBondStretchParams[2],
-                                MMFFAngle &mmffAngleBendParams);
+                                MMFFAngle &mmffAngleBendParams) const;
   bool getMMFFTorsionParams(const ROMol &mol, const unsigned int idx1,
                             const unsigned int idx2, const unsigned int idx3,
                             const unsigned int idx4, unsigned int &torsionType,
-                            MMFFTor &mmffTorsionParams);
+                            MMFFTor &mmffTorsionParams) const;
   bool getMMFFOopBendParams(const ROMol &mol, const unsigned int idx1,
                             const unsigned int idx2, const unsigned int idx3,
                             const unsigned int idx4,
-                            MMFFOop &mmffOopBendParams);
+                            MMFFOop &mmffOopBendParams) const;
   bool getMMFFVdWParams(const unsigned int idx1, const unsigned int idx2,
-                        MMFFVdWRijstarEps &mmffVdWParams);
+                        MMFFVdWRijstarEps &mmffVdWParams) const;
 
  private:
   void setMMFFHeavyAtomType(const RingMembershipSize &rmSize, const Atom *atom);

--- a/Code/GraphMol/ForceFieldHelpers/Wrap/testHelpers.py
+++ b/Code/GraphMol/ForceFieldHelpers/Wrap/testHelpers.py
@@ -416,6 +416,39 @@ M  END"""
       self.assertIsNotNone(ff)
       self.assertTrue(hasattr(ff, "CalcEnergy"))
 
+  def testMMFFMolPropertiesScalarGetters(self):
+    mol = Chem.AddHs(Chem.MolFromSmiles("CCO"))
+    mp = ChemicalForceFields.MMFFGetMoleculeProperties(mol)
+    self.assertIsNotNone(mp)
+
+    mp.SetMMFFVariant("MMFF94s")
+    self.assertEqual(mp.GetMMFFVariant(), "MMFF94s")
+    mp.SetMMFFVariant("MMFF94")
+    self.assertEqual(mp.GetMMFFVariant(), "MMFF94")
+
+    mp.SetMMFFDielectricConstant(2.5)
+    self.assertAlmostEqual(mp.GetMMFFDielectricConstant(), 2.5)
+
+    mp.SetMMFFDielectricModel(2)
+    self.assertEqual(mp.GetMMFFDielectricModel(), 2)
+    mp.SetMMFFDielectricModel(1)
+    self.assertEqual(mp.GetMMFFDielectricModel(), 1)
+
+    term_pairs = [
+        (mp.SetMMFFBondTerm, mp.GetMMFFBondTerm),
+        (mp.SetMMFFAngleTerm, mp.GetMMFFAngleTerm),
+        (mp.SetMMFFStretchBendTerm, mp.GetMMFFStretchBendTerm),
+        (mp.SetMMFFOopTerm, mp.GetMMFFOopTerm),
+        (mp.SetMMFFTorsionTerm, mp.GetMMFFTorsionTerm),
+        (mp.SetMMFFVdWTerm, mp.GetMMFFVdWTerm),
+        (mp.SetMMFFEleTerm, mp.GetMMFFEleTerm),
+    ]
+    for setter, getter in term_pairs:
+      setter(False)
+      self.assertFalse(getter())
+      setter(True)
+      self.assertTrue(getter())
+
 
 if __name__ == "__main__":
   unittest.main()


### PR DESCRIPTION
Fixes #9253 

Adds corresponding get methods to match set methods for python MMFF properties. 

Adds a unit test.

Also adds some const correctness for immutable member functions.

