### PR TITLE
Extended fix for #9101

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -153,6 +153,7 @@ __pycache__/
 
 /Testing/
 
+
 # JS distribution or temp files
 Code/MinimalLib/dist
 MAIN_RDKIT_README*

--- a/.gitignore
+++ b/.gitignore
@@ -153,7 +153,6 @@ __pycache__/
 
 /Testing/
 
-
 # JS distribution or temp files
 Code/MinimalLib/dist
 MAIN_RDKIT_README*

--- a/.gitignore
+++ b/.gitignore
@@ -133,6 +133,8 @@ __pycache__/
 
 /Data/eht_parms.dat
 
+/External/pubchem_shape/test_data/bulk.pubchem_out.sdf
+
 /Projects/DbCLI/testData/bzr/
 
 /rdkit/sping/tests/testallps.ps

--- a/Code/GraphMol/FileParsers/SDMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/SDMolSupplier.cpp
@@ -358,11 +358,8 @@ void SDMolSupplier::buildIndexTo(unsigned int targetIdx) {
               posHold = posHold + std::streamoff(1);
               needEOL = false;
             }
-            this->checkForEnd();
-          } else {
-            this->peekCheckForEnd(nlPos, bufEnd,
-                                  posHold);  // the optimized peek version
           }
+          this->peekCheckForEnd(nlPos, bufEnd, posHold);  // the optimized peek version
           if (!this->df_end) {
             d_molpos.push_back(posHold);
             ++d_last;

--- a/Code/GraphMol/FileParsers/SDMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/SDMolSupplier.cpp
@@ -359,7 +359,8 @@ void SDMolSupplier::buildIndexTo(unsigned int targetIdx) {
               needEOL = false;
             }
           }
-          this->peekCheckForEnd(nlPos, bufEnd, posHold);  // the optimized peek version
+          this->peekCheckForEnd(nlPos, bufEnd,
+                                posHold);  // the optimized peek version
           if (!this->df_end) {
             d_molpos.push_back(posHold);
             ++d_last;

--- a/Code/GraphMol/FileParsers/testMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/testMolSupplier.cpp
@@ -2753,7 +2753,8 @@ TEST_CASE("chunk boundary stream drift with 3+ molecules") {
       "M  END\n"
       "$$$$\n";
 
-  // first separator must hit exactly at the 65536 byte boundary (the others could too but no need)
+  // first separator must hit exactly at the 65536 byte boundary (the others
+  // could too but no need)
   size_t paddingSize = 65536 - m1.size() - 5;
   std::string padding(paddingSize, 'x');
   std::string data = m1 + padding + m1tail + m2 + m3;

--- a/Code/GraphMol/FileParsers/testMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/testMolSupplier.cpp
@@ -2725,33 +2725,33 @@ TEST_CASE("github9101 - $$$$ at buffer end") {
 // (although the second created drift it only took effect on the next molecule
 // which would be the third). this creates the edge case but with three
 TEST_CASE("chunk boundary stream drift with 3+ molecules") {
-  std::string m1 =
-      "mol1\n"
-      "     RDKit          3D\n"
-      "\n"
-      "  1  0  0  0  0  0  0  0  0  0999 V2000\n"
-      "    0.0000    0.0000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n"
-      "M  END\n"
-      "> <comment>\n";
-  std::string m1tail =
-      "\n"
-      "$$$$\n";
-  std::string m2 =
-      "mol2\n"
-      "     RDKit          3D\n"
-      "\n"
-      "  1  0  0  0  0  0  0  0  0  0999 V2000\n"
-      "    0.0000    0.0000    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0\n"
-      "M  END\n"
-      "$$$$\n";
-  std::string m3 =
-      "mol3\n"
-      "     RDKit          3D\n"
-      "\n"
-      "  1  0  0  0  0  0  0  0  0  0999 V2000\n"
-      "    0.0000    0.0000    0.0000 N   0  0  0  0  0  0  0  0  0  0  0  0\n"
-      "M  END\n"
-      "$$$$\n";
+  std::string m1 = R"CTAB(mol1
+     RDKit          3D
+
+  1  0  0  0  0  0  0  0  0  0999 V2000
+    0.0000    0.0000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+M  END
+> <comment>
+)CTAB";
+  std::string m1tail = R"CTAB(
+$$$$
+)CTAB";
+  std::string m2 = R"CTAB(mol2
+     RDKit          3D
+
+  1  0  0  0  0  0  0  0  0  0999 V2000
+    0.0000    0.0000    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0
+M  END
+$$$$
+)CTAB";
+  std::string m3 = R"CTAB(mol3
+     RDKit          3D
+
+  1  0  0  0  0  0  0  0  0  0999 V2000
+    0.0000    0.0000    0.0000 N   0  0  0  0  0  0  0  0  0  0  0  0
+M  END
+$$$$
+)CTAB";
 
   // first separator must hit exactly at the 65536 byte boundary (the others
   // could too but no need)

--- a/Code/GraphMol/FileParsers/testMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/testMolSupplier.cpp
@@ -2719,3 +2719,67 @@ TEST_CASE("github9101 - $$$$ at buffer end") {
   REQUIRE(mol);
   delete mol;
 }
+
+// extends the "github9101 - $$$$ at buffer end" test case
+// just two molecules werent enough to reliably trigger the issue
+// (although the second created drift it only took effect on the next molecule
+// which would be the third). this creates the edge case but with three
+TEST_CASE("chunk boundary stream drift with 3+ molecules") {
+  std::string m1 =
+      "mol1\n"
+      "     RDKit          3D\n"
+      "\n"
+      "  1  0  0  0  0  0  0  0  0  0999 V2000\n"
+      "    0.0000    0.0000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n"
+      "M  END\n"
+      "> <comment>\n";
+  std::string m1tail =
+      "\n"
+      "$$$$\n";
+  std::string m2 =
+      "mol2\n"
+      "     RDKit          3D\n"
+      "\n"
+      "  1  0  0  0  0  0  0  0  0  0999 V2000\n"
+      "    0.0000    0.0000    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0\n"
+      "M  END\n"
+      "$$$$\n";
+  std::string m3 =
+      "mol3\n"
+      "     RDKit          3D\n"
+      "\n"
+      "  1  0  0  0  0  0  0  0  0  0999 V2000\n"
+      "    0.0000    0.0000    0.0000 N   0  0  0  0  0  0  0  0  0  0  0  0\n"
+      "M  END\n"
+      "$$$$\n";
+
+  // first separator must hit exactly at the 65536 byte boundary (the others could too but no need)
+  size_t paddingSize = 65536 - m1.size() - 5;
+  std::string padding(paddingSize, 'x');
+  std::string data = m1 + padding + m1tail + m2 + m3;
+
+  size_t firstDollar = data.find("$$$$");
+  REQUIRE(firstDollar != std::string::npos);
+  REQUIRE(firstDollar + 4 == 65536);
+
+  SDMolSupplier supplier;
+  supplier.setData(data);
+
+  // trigger indexing (that mangles the positions if the issue is present)
+  CHECK(supplier.length() == 3);
+
+  auto *mol = supplier[0];
+  REQUIRE(mol);
+  CHECK(mol->getProp<std::string>("_Name") == "mol1");
+  delete mol;
+
+  mol = supplier[1];
+  REQUIRE(mol);
+  CHECK(mol->getProp<std::string>("_Name") == "mol2");
+  delete mol;
+
+  mol = supplier[2];
+  REQUIRE(mol);
+  CHECK(mol->getProp<std::string>("_Name") == "mol3");
+  delete mol;
+}

--- a/Projects/DbCLI/UnitTestDbCLI.py
+++ b/Projects/DbCLI/UnitTestDbCLI.py
@@ -8,6 +8,7 @@ import os
 import subprocess
 import sys
 import unittest
+import gc
 
 from rdkit import RDConfig
 from rdkit.Dbase.DbConnection import DbConnect
@@ -363,6 +364,7 @@ class TestCase(unittest.TestCase):
     os.unlink('testData/bzr/search.out')
 
   def test4CreateOptions(self):
+    gc.collect()
     for fn in ('Compounds.sqlt', 'AtomPairs.sqlt', 'Descriptors.sqlt', 'Fingerprints.sqlt'):
       if os.path.exists(f'testData/bzr/{fn}'):
         try:

--- a/Projects/DbCLI/UnitTestDbCLI.py
+++ b/Projects/DbCLI/UnitTestDbCLI.py
@@ -8,7 +8,6 @@ import os
 import subprocess
 import sys
 import unittest
-import gc
 
 from rdkit import RDConfig
 from rdkit.Dbase.DbConnection import DbConnect
@@ -364,7 +363,6 @@ class TestCase(unittest.TestCase):
     os.unlink('testData/bzr/search.out')
 
   def test4CreateOptions(self):
-    gc.collect()
     for fn in ('Compounds.sqlt', 'AtomPairs.sqlt', 'Descriptors.sqlt', 'Fingerprints.sqlt'):
       if os.path.exists(f'testData/bzr/{fn}'):
         try:

--- a/rdkit/Chem/UnitTestFeatFinderCLI.py
+++ b/rdkit/Chem/UnitTestFeatFinderCLI.py
@@ -17,7 +17,8 @@ class TestCase(unittest.TestCase):
     parser = FeatFinderCLI.initParser()
     cmd = '-n 10 {0} {1}'.format(featureFile, smilesFile)
     with outputRedirect() as (out, err):
-      args = parser.parse_args(cmd.split())
+      args_list = ['-n', '10', featureFile, smilesFile]
+      args = parser.parse_args(args_list)
       FeatFinderCLI.processArgs(args, parser)
     out = out.getvalue()
     err = err.getvalue()
@@ -29,7 +30,8 @@ class TestCase(unittest.TestCase):
 
     cmd = '-n 2 -r {0} {1}'.format(featureFile, smilesFile)
     with outputRedirect() as (out, err):
-      args = parser.parse_args(cmd.split())
+      args_list = ['-n', '2', '-r', featureFile, smilesFile]
+      args = parser.parse_args(args_list)
       FeatFinderCLI.processArgs(args, parser)
     out = out.getvalue()
     err = err.getvalue()
@@ -46,13 +48,15 @@ class TestCase(unittest.TestCase):
     parser = FeatFinderCLI.initParser()
     cmd = '-n 10 {0} {1}'.format(smilesFile, smilesFile)
     with self.assertRaises(SystemExit), outputRedirect() as (_, err):
-      args = parser.parse_args(cmd.split())
+      args_list = ['-n', '10', smilesFile, smilesFile]
+      args = parser.parse_args(args_list)
       FeatFinderCLI.processArgs(args, parser)
     self.assertIn('error', err.getvalue())
 
     cmd = '-n 10 {0} {1}'.format(featureFile, 'incorrectFilename')
     with self.assertRaises(SystemExit), outputRedirect() as (_, err):
-      args = parser.parse_args(cmd.split())
+      args_list = ['-n', '10', featureFile, 'incorrectFilename']
+      args = parser.parse_args(args_list)
       FeatFinderCLI.processArgs(args, parser)
     self.assertIn('error', err.getvalue())
 


### PR DESCRIPTION
#### Reference Issue
Fixes #9101 (extends what was already done)
Original fixing was done in PR #9162 
Original source of the bug was PR #9010 

#### What does this implement/fix? Explain your changes.
After version 2025.9.5, buffered reading was introduced for better performance with SDMolSupplier. This did not account for a boundary condition where a delimiter was present at the very end of the buffer. PR #9162 fixed this (somewhat) and introduced testing. However, while the test passed, similar problems still persisted on some real files I was using. The problem was that the fix was using the older `checkForEnd`, which changes the pointer position, instead of `peekCheckForEnd` (introduced in PR #9010 ) that restores the pointer position and avoids drift. The test case was not catching this because it only contained 2 molecules (drift would only be observed after that).

I changed the supplier to always use the peek version of the function, and added an extended test case with three molecules, that catches this issue.

#### Any other comments?
I did not remove the old test (although it may be redundant now, it really is just one more test).

Some other QoL changes:
- Some tests were failing on Windows, due to the "spaces in paths" issue. It is a common issue on Windows since the username folder itself usually contains a space, and i figured it wouldn't hurt to update that, it may help other people building there.
- Due to garbage collection delays (also probably only visible on Windows), a test was failing. I forced garbage collection on that one, it is just a test, doesn't hurt performance, and makes it more deterministic.
- gitignored a test file that was being generated

Ran the changes through clang too.