### PR TITLE
PgSQL: preserve toolchain LDFLAGS on macOS

### DIFF
--- a/Code/PgSQL/rdkit/CMakeLists.txt
+++ b/Code/PgSQL/rdkit/CMakeLists.txt
@@ -94,8 +94,13 @@ if(MSVC)
   endif()
 endif(MSVC)
 if(APPLE)
-  set(CMAKE_EXE_LINKER_FLAGS "-bundle -multiply_defined suppress"
-              "-Wl,-dead_strip_dylibs -bundle_loader ${PG_BINDIR}/postgres")
+  # Append (rather than replace) so any toolchain-provided flags survive --
+  # in particular `-stdlib=libc++ -L${PREFIX}/lib -Wl,-rpath,${PREFIX}/lib`
+  # from conda-forge's clang_osx-64 / clangxx_osx-64 packages. Without these,
+  # the link picks up the wrong libc++ and fails to resolve ABI-tagged symbols
+  # (e.g. `vtable for std::__1::basic_stringstream` with `[abi:ne190107]`)
+  # on libc++ 19+ toolchains.
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -bundle -multiply_defined suppress -Wl,-dead_strip_dylibs -bundle_loader ${PG_BINDIR}/postgres")
   add_executable("${EXTENSION}${EXTENSION_SUFFIX}"
               adapter.cpp bfp_op.c cache.c guc.c low_gist.c mol_op.c
               rdkit_gist.c bfp_gist.c bfp_gin.c bitstring.c rdkit_io.c rxn_op.c sfp_op.c)


### PR DESCRIPTION
#### Reference Issue

No GitHub issue, but the fix unblocks the conda-forge rdkit-postgresql build on osx-64. Downstream tracker: [conda-forge/rdkit-feedstock#209](https://github.com/conda-forge/rdkit-feedstock/issues/209) and [conda-forge/rdkit-feedstock#223](https://github.com/conda-forge/rdkit-feedstock/pull/223).

#### What does this implement/fix? Explain your changes.

[`Code/PgSQL/rdkit/CMakeLists.txt`](https://github.com/rdkit/rdkit/blob/master/Code/PgSQL/rdkit/CMakeLists.txt#L96-L98) does

```cmake
if(APPLE)
  set(CMAKE_EXE_LINKER_FLAGS "-bundle -multiply_defined suppress"
              "-Wl,-dead_strip_dylibs -bundle_loader ${PG_BINDIR}/postgres")
```

which **replaces** `CMAKE_EXE_LINKER_FLAGS` wholesale rather than appending to it. That clobbers any flags the toolchain has already populated into the variable.

In conda-forge's macOS toolchain (clang_osx-64 / clangxx_osx-64), `CMAKE_EXE_LINKER_FLAGS` carries `-stdlib=libc++ -L${PREFIX}/lib -Wl,-rpath,${PREFIX}/lib`. Losing those flags makes the postgres extension link pick up the wrong libc++ and fail to resolve ABI-tagged symbols on libc++ 19+:

```
[ 94%] Linking CXX executable rdkit.dylib
Undefined symbols for architecture x86_64:
  "VTT for std::__1::basic_stringstream<...>"
  "vtable for std::__1::basic_stringbuf<...>"
  "vtable for std::__1::basic_stringstream<...>"
  "vtable for std::__1::basic_istringstream<...>"
ld: symbol(s) not found for architecture x86_64
```

The missing symbols carry the `[abi:ne190107]` ABI tag introduced by libc++ 19+, which only resolves against the conda-forge libc++ — not the system one the link was falling back to. The other rdkit `.dylib`s in the same build are linked via the standard cmake toolchain path and were unaffected.

This PR appends to `CMAKE_EXE_LINKER_FLAGS` instead of replacing, so toolchain-supplied flags survive. Functional behavior is unchanged for builds where the toolchain doesn't pre-populate the variable (i.e. system clang on a vanilla developer machine).

#### Any other comments?

Verified by building rdkit-postgresql on both osx-arm64 (native) and osx-64 (under Rosetta 2) via the conda-forge feedstock with this fix applied as a downstream patch:

```
+ initdb -D test_db
+ pg_ctl -D test_db -l test.log start
server started
+ createdb test
+ psql -c 'CREATE EXTENSION rdkit' test
CREATE EXTENSION
+ pg_ctl -D test_db stop
server stopped
+ exit 0
```

Once this is merged and a release ships, the conda-forge feedstock can drop its [downstream patch](https://github.com/conda-forge/rdkit-feedstock/blob/main/recipe/rdkit-postgresql-osx-linker-flags.patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)