### PR TITLE
Fix force flag on legacyStereoPerception #9069 

### DIFF
--- a/Code/GraphMol/Chirality.cpp
+++ b/Code/GraphMol/Chirality.cpp
@@ -2283,7 +2283,7 @@ void legacyStereoPerception(ROMol &mol, bool cleanIt,
   // are neither stereocenters nor bonds that we need to consider.
   // The exception to this is when flagPossibleStereoCenters is
   // true; then we always need to do the work
-  bool hasStereoAtoms = false;  // flagPossibleStereoCenters;
+  bool hasStereoAtoms = flagPossibleStereoCenters;
   bool hasPotentialStereoAtoms = false;
   for (auto atom : mol.atoms()) {
     if (cleanIt) {


### PR DESCRIPTION
This is a fix for https://github.com/rdkit/rdkit/issues/9069. My guess is that the removal of the assignStereoChemistry force flag has been used for debug purposes in development, and afterwards forgotten to re-enable. But if I'm wrong, please forget this PR.