### PR TITLE
Build: tag dev-only install rules with COMPONENT dev

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -612,6 +612,7 @@ install(
   FILE ${RDKit_EXPORTED_TARGETS}.cmake
   NAMESPACE RDKit::
   DESTINATION ${RDKit_LibDir}/cmake/rdkit
+  COMPONENT dev
 )
 
 # create and install package configuration and version files
@@ -628,7 +629,8 @@ configure_file (
 install(FILES
     ${RDKit_BINARY_DIR}/rdkit-config.cmake
     ${RDKit_BINARY_DIR}/rdkit-config-version.cmake
-    DESTINATION ${RDKit_LibDir}/cmake/rdkit)
+    DESTINATION ${RDKit_LibDir}/cmake/rdkit
+    COMPONENT dev)
 
 # then manage the targets for the python bindings
 if(RDK_BUILD_PYTHON_WRAPPERS)
@@ -637,6 +639,7 @@ if(RDK_BUILD_PYTHON_WRAPPERS)
     FILE ${RDKitPython_EXPORTED_TARGETS}.cmake
     NAMESPACE RDKit::
     DESTINATION ${RDKit_LibDir}/cmake/rdkitpython
+    COMPONENT dev
   )
 
   write_basic_package_version_file(
@@ -652,7 +655,8 @@ if(RDK_BUILD_PYTHON_WRAPPERS)
   install(FILES
     ${RDKit_BINARY_DIR}/rdkitpython-config.cmake
     ${RDKit_BINARY_DIR}/rdkitpython-config-version.cmake
-    DESTINATION ${RDKit_LibDir}/cmake/rdkitpython)
+    DESTINATION ${RDKit_LibDir}/cmake/rdkitpython
+    COMPONENT dev)
 endif(RDK_BUILD_PYTHON_WRAPPERS)
 
 # Memory testing setup

--- a/Code/RDGeneral/CMakeLists.txt
+++ b/Code/RDGeneral/CMakeLists.txt
@@ -55,7 +55,8 @@ rdkit_headers(Exceptions.h
         DEST RDGeneral)
 
 if (NOT RDK_INSTALL_INTREE)
-    install(DIRECTORY hash DESTINATION ${RDKit_HdrDir}/RDGeneral)
+    install(DIRECTORY hash DESTINATION ${RDKit_HdrDir}/RDGeneral
+            COMPONENT dev)
 endif (NOT RDK_INSTALL_INTREE)
 
 rdkit_catch_test(testDict testDict.cpp LINK_LIBRARIES RDGeneral)


### PR DESCRIPTION
## Summary

Five `install()` calls currently install dev-only artifacts without an explicit `COMPONENT`, so they default to `Unspecified`. That makes it impossible to separate them from runtime artifacts via cmake's per-component install (`cmake -D CMAKE_INSTALL_COMPONENT=dev -P cmake_install.cmake`):

| File | Lines | Artifact |
|---|---|---|
| `Code/RDGeneral/CMakeLists.txt` | 58 | `include/rdkit/RDGeneral/hash/*.hpp` |
| `CMakeLists.txt` | 614 | `lib/cmake/rdkit/rdkit-targets*.cmake` |
| `CMakeLists.txt` | 632 | `lib/cmake/rdkit/rdkit-config*.cmake` |
| `CMakeLists.txt` | 639 | `lib/cmake/rdkitpython/rdkitpython-targets*.cmake` |
| `CMakeLists.txt` | 656 | `lib/cmake/rdkitpython/rdkitpython-config*.cmake` |

This PR adds `COMPONENT dev` to all five. Default (non-component) installs are unchanged, so this is a no-op for anyone who isn't doing component-based installs.

## `dev` is an existing component, not a new one

To be explicit: this PR does **not** introduce a new component. `dev` is already declared in `CPACK_COMPONENTS_ALL` at `CMakeLists.txt:672` (`SET(CPACK_COMPONENTS_ALL runtime base data docs dev python extras)`) and is already in active use:

- `CMakeLists.txt:277` — `install(TARGETS rdkit_base ... COMPONENT dev)`
- `CMakeLists.txt:385` — `install(TARGETS rdkit_py_base ... COMPONENT dev)`
- `Code/cmake/Modules/RDKitUtils.cmake:40,52` — `staticLibComponent dev`
- `Code/GraphMol/MolDraw2D/Qt/CMakeLists.txt:39` — `install(TARGETS QtDependencies ... COMPONENT dev)`
- `rdkit_headers()` (the macro `Code/RDGeneral/CMakeLists.txt:42-55` uses for its sibling `Exceptions.h`, `versions.h`, etc.) already routes through `dev` internally.

The 5 calls this PR touches are the outliers — they install dev-flavored artifacts (headers + cmake package config) but neglect to tag them, so they default to `Unspecified` and end up bundled with the runtime artifacts they shouldn't be co-located with. Tagging them aligns them with the convention already established for every other dev-only install rule in the project.

## Motivation

In [conda-forge/rdkit-feedstock](https://github.com/conda-forge/rdkit-feedstock) we recently split the package into `librdkit` (runtime: `Unspecified base data runtime` components) and `librdkit-dev` (headers + cmake config: `dev` component). With the current upstream tagging:

- The 5 hash headers end up in `librdkit` instead of `librdkit-dev`.
- **All 8 cmake config files** end up in `librdkit` instead of `librdkit-dev`, leaving `librdkit-dev` without any `.cmake` files — so `find_package(RDKit)` against just `librdkit-dev` fails. Downstream consumers currently have to depend on the runtime package to get cmake config, which partially defeats the split.

Verified against `librdkit-2026.03.2-hb1379ee_3`:
- `librdkit` contains: `include/rdkit/RDGeneral/hash/*.hpp` (5 files), `lib/cmake/rdkit/*.cmake` (4 files), `lib/cmake/rdkitpython/*.cmake` (4 files)
- `librdkit-dev` contains: 371 other headers, **0** cmake files

This same problem applies to anyone doing component-based installs (RPM, DEB via CPack, custom packaging), not just conda — it's just that conda-forge's recent split is what surfaced it.

Context: conda-forge/rdkit-feedstock#164 (the downstream issue tracking this cleanup).

## Test plan

Verified against a minimal cmake project mirroring the three install patterns this PR touches:

- [x] Default install (no `CMAKE_INSTALL_COMPONENT` set) places every file in its original location — unchanged behavior.
- [x] `cmake -D CMAKE_INSTALL_COMPONENT=dev -P cmake_install.cmake` installs the hash dir + targets cmake + config cmake (and only those).
- [x] `cmake -D CMAKE_INSTALL_COMPONENT=runtime -P cmake_install.cmake` does not pick them up.
- [x] `cmake -D CMAKE_INSTALL_COMPONENT=Unspecified -P cmake_install.cmake` does not pick them up — they used to under this exact command, which is the bug.
- [ ] Rebuild conda-forge feedstock with this patch and confirm `librdkit-dev` gains the cmake config files and `librdkit` loses them.

## Note

Opening as a draft for visibility/discussion before marking ready — happy to adjust phrasing or split into per-file commits if preferred.

cc @greglandrum

🤖 Generated with [Claude Code](https://claude.com/claude-code)
