### PR TITLE
Build: tag rdkitpython install rules with COMPONENT python

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -639,7 +639,7 @@ if(RDK_BUILD_PYTHON_WRAPPERS)
     FILE ${RDKitPython_EXPORTED_TARGETS}.cmake
     NAMESPACE RDKit::
     DESTINATION ${RDKit_LibDir}/cmake/rdkitpython
-    COMPONENT dev
+    COMPONENT python
   )
 
   write_basic_package_version_file(
@@ -656,7 +656,7 @@ if(RDK_BUILD_PYTHON_WRAPPERS)
     ${RDKit_BINARY_DIR}/rdkitpython-config.cmake
     ${RDKit_BINARY_DIR}/rdkitpython-config-version.cmake
     DESTINATION ${RDKit_LibDir}/cmake/rdkitpython
-    COMPONENT dev)
+    COMPONENT python)
 endif(RDK_BUILD_PYTHON_WRAPPERS)
 
 # Memory testing setup


### PR DESCRIPTION
## Summary

Refines the two `install()` calls for the python-bindings cmake config from `COMPONENT dev` to `COMPONENT python`. These calls were tagged `COMPONENT dev` in #9287; this PR refines them to `COMPONENT python` since they are python-version-coupled (see below) rather than python-agnostic dev artifacts.

- `install(EXPORT ${RDKitPython_EXPORTED_TARGETS} … DESTINATION lib/cmake/rdkitpython)` (line 637)
- `install(FILES rdkitpython-config*.cmake … DESTINATION lib/cmake/rdkitpython)` (line 655)

## Motivation

`rdkitpython-config.cmake` is generated from `rdkitpython-config.cmake.in` via `configure_file(@ONLY)` and bakes in the python version found by `find_package(Python3)` during build configure. The result, as installed, contains literal python version values:

```cmake
find_dependency(Python3 3.12 COMPONENTS Interpreter Development.Module NumPy)
find_dependency(Boost 1.90.0 COMPONENTS python312 numpy312)
```

`rdkitpython-targets.cmake` similarly embeds `python3.12/include` and `python3.12/site-packages/numpy/_core/include` in its `INTERFACE_INCLUDE_DIRECTORIES`.

In conda-forge, all four `rdkitpython-*.cmake` files currently end up in `librdkit` (python-agnostic, one per platform). Different platforms ship different python versions baked in — verified against current conda-forge releases of `librdkit-2026.03.2`:

| Platform | rdkitpython-config.cmake says |
|---|---|
| osx-arm64 | `Python3 3.12` / `python312` |
| win-64 | `Python3 3.11` / `python311` |
| linux-64 | `Python3 3.11` / `python311` |

A user on osx-arm64 running python 3.11 who calls `find_package(RDKitPython REQUIRED)` will hit `find_dependency(Boost … python312 numpy312)` and fail, because `libboost_python312.*` is not installed (conda-forge ships separate boost packages per python version).

With `COMPONENT python`, packagers can install these files together with the python wrapper binaries (which are themselves python-version-specific), keeping the cmake config and the binaries it references co-located.

## Relationship to conda-forge/rdkit-feedstock#170

[conda-forge/rdkit-feedstock#170](https://github.com/conda-forge/rdkit-feedstock/issues/170) was opened about the same class of bug in `rdkit-targets.cmake` (the C++ targets file) and was correctly resolved upstream by splitting out the python-coupled targets into `rdkitpython-targets.cmake`. The split was a great improvement, but it relocated the problem rather than eliminating it: the split file still ships in a python-agnostic package because nothing tags it differently. This PR completes that fix.

## Test plan

- [ ] Verify a default install (no `CMAKE_INSTALL_COMPONENT` set) is unchanged.
- [ ] Verify `cmake -D CMAKE_INSTALL_COMPONENT=python -P cmake_install.cmake` now installs `rdkitpython-config*.cmake` and `rdkitpython-targets*.cmake`.
- [ ] Verify those files are no longer installed under `CMAKE_INSTALL_COMPONENT=dev`.

cc @greglandrum

🤖 Generated with [Claude Code](https://claude.com/claude-code)
