### PR TITLE
Github9280

### DIFF
--- a/Code/GraphMol/MolDraw2D/DrawText.cpp
+++ b/Code/GraphMol/MolDraw2D/DrawText.cpp
@@ -78,13 +78,11 @@ bool DrawText::setFontScale(double new_scale, bool ignoreLimits) {
   }
   font_scale_ = new_scale;
   double nfs = fontSize();
-  if (max_font_size_ > 0.0 &&
-      nfs * (baseFontSize() / DEFAULT_FONT_SCALE) > max_font_size_) {
+  if (max_font_size_ > 0.0 && nfs > max_font_size_) {
     font_scale_ = max_font_size_ / baseFontSize();
     return false;
   }
-  if (min_font_size_ > 0.0 &&
-      nfs * (baseFontSize() / DEFAULT_FONT_SCALE) < min_font_size_) {
+  if (min_font_size_ > 0.0 && nfs < min_font_size_) {
     font_scale_ = min_font_size_ / baseFontSize();
     return false;
   }

--- a/Code/GraphMol/MolDraw2D/catch_tests.cpp
+++ b/Code/GraphMol/MolDraw2D/catch_tests.cpp
@@ -4868,8 +4868,9 @@ TEST_CASE("legend position Top Left Right and vertical text", "[drawing]") {
       y = std::stod(match[2].str());
       return true;
     }
-    std::regex pathRgx("class='legend' d='M (-?[0-9]+\\.?[0-9]*) "
-                       "(-?[0-9]+\\.?[0-9]*)");
+    std::regex pathRgx(
+        "class='legend' d='M (-?[0-9]+\\.?[0-9]*) "
+        "(-?[0-9]+\\.?[0-9]*)");
     if (std::regex_search(text, match, pathRgx) && match.size() == 3) {
       x = std::stod(match[1].str());
       y = std::stod(match[2].str());
@@ -4888,8 +4889,9 @@ TEST_CASE("legend position Top Left Right and vertical text", "[drawing]") {
     if (!coords.empty()) {
       return coords;
     }
-    std::regex pathRgx("class='legend' d='M (-?[0-9]+\\.?[0-9]*) "
-                       "(-?[0-9]+\\.?[0-9]*)");
+    std::regex pathRgx(
+        "class='legend' d='M (-?[0-9]+\\.?[0-9]*) "
+        "(-?[0-9]+\\.?[0-9]*)");
     for (auto it = std::sregex_iterator(text.begin(), text.end(), pathRgx);
          it != std::sregex_iterator(); ++it) {
       coords.emplace_back(std::stod((*it)[1].str()), std::stod((*it)[2].str()));
@@ -4902,8 +4904,7 @@ TEST_CASE("legend position Top Left Right and vertical text", "[drawing]") {
   double right_x = 0.0, right_y = 0.0;
   SECTION("Top") {
     MolDraw2DSVG drawer(200, 200, -1, -1, NO_FREETYPE);
-    drawer.drawOptions().legendPosition =
-        MolDrawOptions::LegendPosition::Top;
+    drawer.drawOptions().legendPosition = MolDrawOptions::LegendPosition::Top;
     MolDraw2DUtils::prepareAndDrawMolecule(drawer, *m1, legend);
     drawer.finishDrawing();
     auto text = drawer.getDrawingText();
@@ -4917,8 +4918,7 @@ TEST_CASE("legend position Top Left Right and vertical text", "[drawing]") {
   }
   SECTION("Left with vertical text") {
     MolDraw2DSVG drawer(200, 200, -1, -1, NO_FREETYPE);
-    drawer.drawOptions().legendPosition =
-        MolDrawOptions::LegendPosition::Left;
+    drawer.drawOptions().legendPosition = MolDrawOptions::LegendPosition::Left;
     drawer.drawOptions().legendVerticalText = true;
     MolDraw2DUtils::prepareAndDrawMolecule(drawer, *m1, legend);
     drawer.finishDrawing();
@@ -4935,8 +4935,7 @@ TEST_CASE("legend position Top Left Right and vertical text", "[drawing]") {
   }
   SECTION("Left horizontal") {
     MolDraw2DSVG drawer(200, 200, -1, -1, NO_FREETYPE);
-    drawer.drawOptions().legendPosition =
-        MolDrawOptions::LegendPosition::Left;
+    drawer.drawOptions().legendPosition = MolDrawOptions::LegendPosition::Left;
     drawer.drawOptions().legendVerticalText = false;
     MolDraw2DUtils::prepareAndDrawMolecule(drawer, *m1, legend);
     drawer.finishDrawing();
@@ -4950,8 +4949,7 @@ TEST_CASE("legend position Top Left Right and vertical text", "[drawing]") {
   }
   SECTION("Right horizontal") {
     MolDraw2DSVG drawer(200, 200, -1, -1, NO_FREETYPE);
-    drawer.drawOptions().legendPosition =
-        MolDrawOptions::LegendPosition::Right;
+    drawer.drawOptions().legendPosition = MolDrawOptions::LegendPosition::Right;
     drawer.drawOptions().legendVerticalText = false;
     MolDraw2DUtils::prepareAndDrawMolecule(drawer, *m1, legend);
     drawer.finishDrawing();
@@ -4980,8 +4978,7 @@ TEST_CASE("legend position Top Left Right and vertical text", "[drawing]") {
   SECTION("Long vertical side legend fits panel height") {
     const std::string longName(48, 'M');
     MolDraw2DSVG drawer(160, 90, -1, -1, NO_FREETYPE);
-    drawer.drawOptions().legendPosition =
-        MolDrawOptions::LegendPosition::Left;
+    drawer.drawOptions().legendPosition = MolDrawOptions::LegendPosition::Left;
     drawer.drawOptions().legendVerticalText = true;
     drawer.drawOptions().legendFraction = 0.22f;
     MolDraw2DUtils::prepareAndDrawMolecule(drawer, *m1, longName);
@@ -11362,5 +11359,59 @@ M  END
           "testDrawingExtentsIncludeWithHighlights_allButHighlights.svg");
     }
     CHECK(checkCoords(referenceCoords, highlightCoords));
+  }
+}
+
+TEST_CASE("Github 9280 - font scaling bug") {
+  auto mol = "CC(C)Oc1ccc(N2CCc3nccc(C(=O)Nc4ccccn4)c3C2)nc1"_smiles;
+  {
+    MolDraw2DSVG drawer(358, 290, -1, -1, NO_FREETYPE);
+    drawer.drawOptions().baseFontSize = 1.0;
+    drawer.drawMolecule(*mol);
+    drawer.finishDrawing();
+    auto text = drawer.getDrawingText();
+    std::ofstream ofs("test_Github9290_1.0.svg");
+    ofs << text;
+    ofs.close();
+    // With the bug, it snapped to maximum font size, 40 pixels.
+    CHECK(text.find("font-size:40px") == std::string::npos);
+    CHECK(text.find("font-size:24px") != std::string::npos);
+  }
+  {
+    // Check it still maxes out at 40 - font size would be 50 without.
+    MolDraw2DSVG drawer(358, 290, -1, -1, NO_FREETYPE);
+    drawer.drawOptions().baseFontSize = 2.0;
+    drawer.drawMolecule(*mol);
+    drawer.finishDrawing();
+    auto text = drawer.getDrawingText();
+    std::ofstream ofs("test_Github9290_2.0.svg");
+    ofs << text;
+    ofs.close();
+    CHECK(text.find("font-size:40px") != std::string::npos);
+  }
+  {
+    MolDraw2DSVG drawer(358, 290, -1, -1, NO_FREETYPE);
+    drawer.drawOptions().baseFontSize = 0.3;
+    drawer.drawMolecule(*mol);
+    drawer.finishDrawing();
+    auto text = drawer.getDrawingText();
+    std::ofstream ofs("test_Github9290_0.3.svg");
+    ofs << text;
+    ofs.close();
+    // With the bug, it snapped to minimum font size, 6 pixels.
+    CHECK(text.find("font-size:6px") == std::string::npos);
+    CHECK(text.find("font-size:7px") != std::string::npos);
+  }
+  {
+    MolDraw2DSVG drawer(358, 290, -1, -1, NO_FREETYPE);
+    drawer.drawOptions().baseFontSize = 0.2;
+    drawer.drawMolecule(*mol);
+    drawer.finishDrawing();
+    auto text = drawer.getDrawingText();
+    std::ofstream ofs("test_Github9290_0.2.svg");
+    ofs << text;
+    ofs.close();
+    // This should be the minimum font size
+    CHECK(text.find("font-size:6px") != std::string::npos);
   }
 }

--- a/Code/GraphMol/MolDraw2D/catch_tests.cpp
+++ b/Code/GraphMol/MolDraw2D/catch_tests.cpp
@@ -374,7 +374,11 @@ const std::map<std::string, std::hash_result_t> SVG_HASHES = {
     {"testDrawingExtentsIncludeWithHighlights_default.svg", 1595689626U},
     {"testDrawingExtentsInclude_allButHighlights.svg", 1604243819U},
     {"testDrawingExtentsIncludeWithHighlights_allButHighlights.svg",
-     436783789U}};
+     436783789U},
+    {"test_Github9280_1.0.svg", 1658116840U},
+    {"test_Github9280_2.0.svg", 1805554327U},
+    {"test_Github9280_0.3.svg", 893100468U},
+    {"test_Github9280_0.2.svg", 770838895U}};
 
 // These PNG hashes aren't completely reliable due to floating point cruft,
 // but they can still reduce the number of drawings that need visual
@@ -4250,7 +4254,7 @@ TEST_CASE("changing baseFontSize") {
     drawer.drawOptions().baseFontSize = 0.9;
     drawer.drawMolecule(*mol1);
     drawer.finishDrawing();
-    CHECK_THAT(drawer.fontSize(), Catch::Matchers::WithinAbs(5.5, 0.2));
+    CHECK_THAT(drawer.fontSize(), Catch::Matchers::WithinAbs(6.0, 0.2));
     auto text = drawer.getDrawingText();
     std::ofstream outs("testBaseFontSize.1b.svg");
     outs << text;
@@ -11370,12 +11374,13 @@ TEST_CASE("Github 9280 - font scaling bug") {
     drawer.drawMolecule(*mol);
     drawer.finishDrawing();
     auto text = drawer.getDrawingText();
-    std::ofstream ofs("test_Github9290_1.0.svg");
+    std::ofstream ofs("test_Github9280_1.0.svg");
     ofs << text;
     ofs.close();
     // With the bug, it snapped to maximum font size, 40 pixels.
     CHECK(text.find("font-size:40px") == std::string::npos);
     CHECK(text.find("font-size:24px") != std::string::npos);
+    check_file_hash("test_Github9280_1.0.svg");
   }
   {
     // Check it still maxes out at 40 - font size would be 50 without.
@@ -11384,10 +11389,11 @@ TEST_CASE("Github 9280 - font scaling bug") {
     drawer.drawMolecule(*mol);
     drawer.finishDrawing();
     auto text = drawer.getDrawingText();
-    std::ofstream ofs("test_Github9290_2.0.svg");
+    std::ofstream ofs("test_Github9280_2.0.svg");
     ofs << text;
     ofs.close();
     CHECK(text.find("font-size:40px") != std::string::npos);
+    check_file_hash("test_Github9280_2.0.svg");
   }
   {
     MolDraw2DSVG drawer(358, 290, -1, -1, NO_FREETYPE);
@@ -11395,12 +11401,13 @@ TEST_CASE("Github 9280 - font scaling bug") {
     drawer.drawMolecule(*mol);
     drawer.finishDrawing();
     auto text = drawer.getDrawingText();
-    std::ofstream ofs("test_Github9290_0.3.svg");
+    std::ofstream ofs("test_Github9280_0.3.svg");
     ofs << text;
     ofs.close();
     // With the bug, it snapped to minimum font size, 6 pixels.
     CHECK(text.find("font-size:6px") == std::string::npos);
     CHECK(text.find("font-size:7px") != std::string::npos);
+    check_file_hash("test_Github9280_0.3.svg");
   }
   {
     MolDraw2DSVG drawer(358, 290, -1, -1, NO_FREETYPE);
@@ -11408,10 +11415,11 @@ TEST_CASE("Github 9280 - font scaling bug") {
     drawer.drawMolecule(*mol);
     drawer.finishDrawing();
     auto text = drawer.getDrawingText();
-    std::ofstream ofs("test_Github9290_0.2.svg");
+    std::ofstream ofs("test_Github9280_0.2.svg");
     ofs << text;
     ofs.close();
     // This should be the minimum font size
     CHECK(text.find("font-size:6px") != std::string::npos);
+    check_file_hash("test_Github9280_0.2.svg");
   }
 }


### PR DESCRIPTION
#### Reference Issue
Fixes #9280


#### What does this implement/fix? Explain your changes.
Implements the fix as suggested in the issue, and also the min_font_size_ equivalent.

#### Any other comments?
Some extra formatting has happened in catch_tests.cpp.
I've scanned the outputs for the other drawings against the current master branch and nothing else seems to be broken, at least by this PR.
