### PR TITLE
Refactor BreakTies control flow to use explicit termination tracking (#9284)

### DIFF
--- a/Code/GraphMol/catch_canon.cpp
+++ b/Code/GraphMol/catch_canon.cpp
@@ -1767,3 +1767,106 @@ TEST_CASE("Canonicalization issues watch (see GitHub Issue #8775)") {
 
   checkSmilesRoundtrip(smiles, shouldMatch);
 }
+
+TEST_CASE(
+    "Issue 9284: Infinite loop in BreakTies for disconnected/symmetric components",
+    "[canon][bug]") {
+  // Exact CTfile from the bug report - Ammonium iron(III) sulfate dodecahydrate
+  // Two identical SO4 groups + 13 isolated O atoms + isolated N + Fe
+  // caused BreakTies() to loop forever due to oscillating i -= 1
+  constexpr const char *ctab = R"ctab(
+     RDKit          2D
+
+ 24  8  0  0  0  0  0  0  0  0999 V2000
+    0.0000    0.0000    0.0000 N   0  0  0  0  0  0  0  0  0  0  0  0
+    1.0000    0.0000    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0
+    0.0000    1.0000    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0
+    2.0000    0.0000    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0
+    0.0000    2.0000    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0
+    3.0000    0.0000    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0
+    0.0000    3.0000    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0
+    4.0000    0.0000    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0
+    0.0000    4.0000    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0
+    5.0000    0.0000    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0
+    0.0000    5.0000    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0
+    6.0000    0.0000    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0
+    0.0000    6.0000    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0
+    7.0000    0.0000    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0
+    8.2990    0.7500    0.0000 S   0  0  0  0  0  0  0  0  0  0  0  0
+    9.5981    1.5000    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0
+    9.0490   -0.5490    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0
+    7.5490    2.0490    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0
+    0.0000    7.5490    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0
+    1.2990    8.2990    0.0000 S   0  0  0  0  0  0  0  0  0  0  0  0
+    2.5981    9.0490    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0
+    2.0490    7.0000    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0
+    0.5490    9.5981    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0
+   10.5981    0.0000    0.0000 Fe  0  0  0  0  0  0  0  0  0  0  0  0
+ 14 15  6  0
+ 15 16  2  0
+ 15 17  2  0
+ 15 18  6  0
+ 19 20  6  0
+ 20 21  2  0
+ 20 22  2  0
+ 20 23  6  0
+V    1 N
+V    2 O
+V    3 O
+V    4 O
+V    5 O
+V    6 O
+V    7 O
+V    8 O
+V    9 O
+V   10 O
+V   11 O
+V   12 O
+V   13 O
+V   14 O
+V   15 S
+V   16 O
+V   17 O
+V   18 O
+V   19 O
+V   20 S
+V   21 O
+V   22 O
+V   23 O
+M  END
+)ctab";
+
+  SECTION("rankMolAtoms completes and returns correct number of ranks") {
+    auto m = v2::FileParsers::MolFromMolBlock(ctab);
+    REQUIRE(m);
+
+    std::vector<unsigned int> ranks;
+    RDKit::Canon::rankMolAtoms(*m, ranks);
+
+    CHECK(ranks.size() == m->getNumAtoms());
+  }
+
+  SECTION("rankMolAtoms is deterministic across two calls") {
+    auto m = v2::FileParsers::MolFromMolBlock(ctab);
+    REQUIRE(m);
+
+    std::vector<unsigned int> ranks1, ranks2;
+    RDKit::Canon::rankMolAtoms(*m, ranks1);
+    RDKit::Canon::rankMolAtoms(*m, ranks2);
+
+    CHECK(ranks1 == ranks2);
+  }
+
+  SECTION("Two identical molecules produce identical rankings") {
+    auto m1 = v2::FileParsers::MolFromMolBlock(ctab);
+    auto m2 = v2::FileParsers::MolFromMolBlock(ctab);
+    REQUIRE(m1);
+    REQUIRE(m2);
+
+    std::vector<unsigned int> ranks1, ranks2;
+    RDKit::Canon::rankMolAtoms(*m1, ranks1);
+    RDKit::Canon::rankMolAtoms(*m2, ranks2);
+
+    CHECK(ranks1 == ranks2);
+  }
+}

--- a/Code/GraphMol/new_canon.h
+++ b/Code/GraphMol/new_canon.h
@@ -797,15 +797,26 @@ void BreakTies(const ROMol &mol, canon_atom *atoms, CompareFunc compar,
                std::vector<int> &changed,
                std::vector<char> &touchedPartitions) {
   unsigned int nAtoms = mol.getNumAtoms();
+  if (!nAtoms) {
+    return;
+  }
+
+  // Tracking bitset prevents infinite re-verification loops on symmetric pairs
+  boost::dynamic_bitset<> finishedClass(nAtoms);
+
   int partition;
   int offset;
   int index;
   int len;
-  int oldPart = 0;
 
   for (unsigned int i = 0; i < nAtoms; i++) {
     partition = order[i];
-    oldPart = atoms[partition].index;
+    unsigned int symClass = atoms[partition].index;
+
+    if (finishedClass[symClass]) {
+      continue;
+    }
+
     while (count[partition] > 1) {
       len = count[partition];
       offset = atoms[partition].index + len - 1;
@@ -814,33 +825,29 @@ void BreakTies(const ROMol &mol, canon_atom *atoms, CompareFunc compar,
       count[partition] = len - 1;
       count[index] = 1;
 
-      // test for ions, water molecules with no
-      if (atoms[index].degree < 1) {
-        continue;
-      }
-      for (unsigned j = 0; j < atoms[index].degree; ++j) {
-        unsigned int nbor = atoms[index].nbrIds[j];
-        touchedPartitions[atoms[nbor].index] = 1;
-        changed[nbor] = 1;
-      }
-
-      for (unsigned int ii = 0; ii < nAtoms; ++ii) {
-        if (touchedPartitions[ii]) {
-          int npart = order[ii];
-          if ((count[npart] > 1) && (next[npart] == -2)) {
-            next[npart] = activeset;
-            activeset = npart;
-          }
-          touchedPartitions[ii] = 0;
+      if (atoms[index].degree >= 1) {
+        for (unsigned j = 0; j < atoms[index].degree; ++j) {
+          unsigned int nbor = atoms[index].nbrIds[j];
+          touchedPartitions[atoms[nbor].index] = 1;
+          changed[nbor] = 1;
         }
+
+        for (unsigned int ii = 0; ii < nAtoms; ++ii) {
+          if (touchedPartitions[ii]) {
+            int npart = order[ii];
+            if ((count[npart] > 1) && (next[npart] == -2)) {
+              next[npart] = activeset;
+              activeset = npart;
+            }
+            touchedPartitions[ii] = 0;
+          }
+        }
+        RefinePartitions(mol, atoms, compar, mode, order, count, activeset,
+                         next, changed, touchedPartitions);
       }
-      RefinePartitions(mol, atoms, compar, mode, order, count, activeset, next,
-                       changed, touchedPartitions);
+      partition = order[atoms[partition].index];
     }
-    // not sure if this works each time
-    if (atoms[partition].index != oldPart) {
-      i -= 1;
-    }
+    finishedClass[symClass] = 1;
   }
 }  // end of BreakTies()
 


### PR DESCRIPTION
#### Reference Issue
Related to #9284

#### What does this implement/fix?

Fixes an infinite loop in `Canon::BreakTies` triggered by highly symmetric
disconnected structures (e.g. Ammonium iron(III) sulfate dodecahydrate).

**Root cause**

For molecules with identical disconnected fragments and many isolated atoms,
`RefinePartitions` never converged, causing the `i -= 1` backtracking to
fire every iteration and the outer loop to never advance.

**Fix**

Replaced `i -= 1` with a `boost::dynamic_bitset<> finishedClass` that marks
symmetry classes as done once resolved to singletons, guaranteeing the outer
loop terminates in exactly `nAtoms` steps.

#### Any other comments?

Regression test added to `catch_canon.cpp` using the exact CTAB from the
bug report, covering termination, determinism, and cross-instance invariance.


- [x] New unit tests added to `catch_canon.cpp`
