### PR TITLE
Option to draw all bonds in symbolColour.

### DIFF
--- a/Code/GraphMol/MolDraw2D/DrawMol.cpp
+++ b/Code/GraphMol/MolDraw2D/DrawMol.cpp
@@ -1116,11 +1116,13 @@ void DrawMol::calculateScale() {
   partitionForLegend();
 
   if (xRange_ > 1e-4 || yRange_ > 1e-4) {
-    double widthForScale = molWidth_ > 0 ? double(molWidth_) : double(drawWidth_);
+    double widthForScale =
+        molWidth_ > 0 ? double(molWidth_) : double(drawWidth_);
     const bool sideLegendHoriz =
         !legend_.empty() &&
         (drawOptions_.legendPosition == MolDrawOptions::LegendPosition::Left ||
-         drawOptions_.legendPosition == MolDrawOptions::LegendPosition::Right) &&
+         drawOptions_.legendPosition ==
+             MolDrawOptions::LegendPosition::Right) &&
         !drawOptions_.legendVerticalText;
     if (sideLegendHoriz && molWidth_ > 0) {
       // Keep a minimum absolute side gap of 8 px so labels do not crowd the
@@ -1132,8 +1134,7 @@ void DrawMol::calculateScale() {
         widthForScale = double(molWidth_) - g;
       }
     }
-    newScale =
-        std::min(widthForScale / xRange_, double(molHeight_) / yRange_);
+    newScale = std::min(widthForScale / xRange_, double(molHeight_) / yRange_);
     double fix_scale = newScale;
     // after all that, use the fixed scale unless it's too big, in which case
     // scale the drawing down to fit.
@@ -1801,24 +1802,23 @@ std::vector<std::string> split_legend_bits(const std::string &legend,
     return legend_bits;
   }
   boost::split(legend_bits, legend, boost::is_any_of("\n"));
-  legend_bits.erase(std::remove_if(legend_bits.begin(), legend_bits.end(),
-                                   [](const std::string &s) {
-                                     return s.empty();
-                                   }),
-                    legend_bits.end());
+  legend_bits.erase(
+      std::remove_if(legend_bits.begin(), legend_bits.end(),
+                     [](const std::string &s) { return s.empty(); }),
+      legend_bits.end());
   return legend_bits;
 }
 
-void place_bottom_legend(const std::vector<std::string> &legend_bits,
-                         double relFontScale, const DrawColour &legendColour,
-                         DrawText &textDrawer, double baseX, double baseY,
-                         double drawWidth, double drawHeight,
-                         std::vector<std::unique_ptr<DrawAnnotation>> &legends) {
+void place_bottom_legend(
+    const std::vector<std::string> &legend_bits, double relFontScale,
+    const DrawColour &legendColour, DrawText &textDrawer, double baseX,
+    double baseY, double drawWidth, double drawHeight,
+    std::vector<std::unique_ptr<DrawAnnotation>> &legends) {
   Point2D loc(baseX + drawWidth / 2.0, baseY + drawHeight);
   for (const auto &bit : legend_bits) {
-    legends.emplace_back(new DrawAnnotation(bit, TextAlignType::MIDDLE, "legend",
-                                            relFontScale, loc, legendColour,
-                                            textDrawer));
+    legends.emplace_back(new DrawAnnotation(bit, TextAlignType::MIDDLE,
+                                            "legend", relFontScale, loc,
+                                            legendColour, textDrawer));
   }
   double xmin, xmax, ymin, ymax;
   double lastAbove = 0.0;
@@ -1847,7 +1847,8 @@ void place_top_legend(const std::vector<std::string> &legend_bits,
   for (size_t i = 0; i < legend_bits.size(); ++i) {
     double height, width;
     DrawAnnotation da(legend_bits[i], TextAlignType::MIDDLE, "legend",
-                      relFontScale, Point2D(0.0, 0.0), legendColour, textDrawer);
+                      relFontScale, Point2D(0.0, 0.0), legendColour,
+                      textDrawer);
     da.getDimensions(width, height);
     total_h += height;
     if (i + 1 < legend_bits.size()) {
@@ -1859,13 +1860,14 @@ void place_top_legend(const std::vector<std::string> &legend_bits,
   for (size_t i = 0; i < legend_bits.size(); ++i) {
     double height, width;
     DrawAnnotation da(legend_bits[i], TextAlignType::MIDDLE, "legend",
-                      relFontScale, Point2D(0.0, 0.0), legendColour, textDrawer);
+                      relFontScale, Point2D(0.0, 0.0), legendColour,
+                      textDrawer);
     da.getDimensions(width, height);
     y += height / 2.0;
     Point2D loc(baseX + drawWidth / 2.0, y);
-    legends.emplace_back(new DrawAnnotation(legend_bits[i], TextAlignType::MIDDLE,
-                                            "legend", relFontScale, loc,
-                                            legendColour, textDrawer));
+    legends.emplace_back(
+        new DrawAnnotation(legend_bits[i], TextAlignType::MIDDLE, "legend",
+                           relFontScale, loc, legendColour, textDrawer));
     y += height / 2.0;
     if (i + 1 < legend_bits.size()) {
       y += gap;
@@ -1876,8 +1878,9 @@ void place_top_legend(const std::vector<std::string> &legend_bits,
 void place_side_legend(const std::vector<std::string> &legend_bits,
                        double relFontScale, const DrawColour &legendColour,
                        DrawText &textDrawer, bool vertText, bool is_left,
-                       double baseX, double baseY, int legendWidth, int molWidth,
-                       double drawWidth, double drawHeight, double marginPadding,
+                       double baseX, double baseY, int legendWidth,
+                       int molWidth, double drawWidth, double drawHeight,
+                       double marginPadding,
                        std::vector<std::unique_ptr<DrawAnnotation>> &legends) {
   if (legend_bits.empty()) {
     return;
@@ -1925,9 +1928,9 @@ void place_side_legend(const std::vector<std::string> &legend_bits,
     for (size_t i = 0; i < legend_bits.size(); ++i) {
       y += max_h / 2.0;
       Point2D loc(stripCentreX, y);
-      legends.emplace_back(new DrawAnnotation(legend_bits[i], TextAlignType::MIDDLE,
-                                              "legend", relFontScale, loc,
-                                              legendColour, textDrawer));
+      legends.emplace_back(
+          new DrawAnnotation(legend_bits[i], TextAlignType::MIDDLE, "legend",
+                             relFontScale, loc, legendColour, textDrawer));
       y += max_h / 2.0;
       if (i + 1 < legend_bits.size()) {
         y += gap;
@@ -1955,9 +1958,9 @@ void place_side_legend(const std::vector<std::string> &legend_bits,
       da.getDimensions(width, height);
       y += height / 2.0;
       Point2D loc(stripCentreX, y);
-      legends.emplace_back(new DrawAnnotation(legend_bits[i], TextAlignType::MIDDLE,
-                                              "legend", relFontScale, loc,
-                                              legendColour, textDrawer));
+      legends.emplace_back(
+          new DrawAnnotation(legend_bits[i], TextAlignType::MIDDLE, "legend",
+                             relFontScale, loc, legendColour, textDrawer));
       y += height / 2.0;
       if (i + 1 < legend_bits.size()) {
         y += gap;
@@ -2007,7 +2010,8 @@ void DrawMol::extractLegend() {
       (drawOptions_.legendPosition == MolDrawOptions::LegendPosition::Left ||
        drawOptions_.legendPosition == MolDrawOptions::LegendPosition::Right) &&
       !vertText;
-  if (total_width > maxWidth && maxWidth > 0 && !flexiCanvasX_ && !sideHorizontal) {
+  if (total_width > maxWidth && maxWidth > 0 && !flexiCanvasX_ &&
+      !sideHorizontal) {
     relFontScale *= maxWidth / total_width;
     calc_legend_dims(legend_bits, relFontScale, drawOptions_.legendColour,
                      textDrawer_, total_width, total_height);
@@ -2064,9 +2068,8 @@ void DrawMol::extractLegend() {
       }
       const double gap = calc_line_gap(textDrawer_, vertText, relFontScale);
       const size_t n = legend_bits.size();
-      const double span =
-          static_cast<double>(n) * max_h +
-          (n > 1 ? static_cast<double>(n - 1) * gap : 0.0);
+      const double span = static_cast<double>(n) * max_h +
+                          (n > 1 ? static_cast<double>(n - 1) * gap : 0.0);
       if (span <= avail || span <= 0.0) {
         break;
       }
@@ -2098,9 +2101,9 @@ void DrawMol::extractLegend() {
       break;
     case MolDrawOptions::LegendPosition::Right:
       place_side_legend(legend_bits, relFontScale, drawOptions_.legendColour,
-                        textDrawer_, vertText, false, baseX, baseY, legendWidth_,
-                        molWidth_, drawWidth_, drawHeight_, marginPadding_,
-                        legends_);
+                        textDrawer_, vertText, false, baseX, baseY,
+                        legendWidth_, molWidth_, drawWidth_, drawHeight_,
+                        marginPadding_, legends_);
       break;
   }
 }
@@ -2385,7 +2388,7 @@ void DrawMol::makeWedgedBond(Bond *bond,
   auto at2 = bond->getEndAtom();
   auto col1 = cols.first;
   auto col2 = cols.second;
-  if (drawOptions_.singleColourWedgeBonds) {
+  if (drawOptions_.singleColourWedgeBonds || drawOptions_.singleColourBonds) {
     col1 = drawOptions_.symbolColour;
     col2 = drawOptions_.symbolColour;
   }
@@ -2570,8 +2573,12 @@ std::pair<DrawColour, DrawColour> DrawMol::getBondColours(Bond *bond) {
     col2 = bondColours_[bond->getIdx()].second;
   } else {
     if (!highlight_bond || drawOptions_.continuousHighlight) {
-      col1 = getColour(bond->getBeginAtomIdx());
-      col2 = getColour(bond->getEndAtomIdx());
+      if (drawOptions_.singleColourBonds) {
+        col1 = col2 = drawOptions_.symbolColour;
+      } else {
+        col1 = getColour(bond->getBeginAtomIdx());
+        col2 = getColour(bond->getEndAtomIdx());
+      }
     } else {
       if (highlightBondMap_.find(bond->getIdx()) != highlightBondMap_.end()) {
         col1 = col2 = highlightBondMap_.find(bond->getIdx())->second;

--- a/Code/GraphMol/MolDraw2D/MolDraw2DHelpers.h
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DHelpers.h
@@ -322,6 +322,9 @@ struct RDKIT_MOLDRAW2D_EXPORT MolDrawOptions {
       false;                        // if true wedged and dashed bonds are drawn
                                     // using symbolColour rather than inheriting
                                     // their colour from the atoms
+  bool singleColourBonds = false;   // if true all bonds are drawn using
+                                    // symbolColour rather than inheriting their
+                                    // colour from the atoms
   bool useMolBlockWedging = false;  // If the molecule came from a MolBlock,
                                     // prefer the wedging information that
                                     // provides.  If false, use RDKit rules.

--- a/Code/GraphMol/MolDraw2D/MolDrawOptionsJSONParsers.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDrawOptionsJSONParsers.cpp
@@ -182,6 +182,7 @@ void updateMolDrawOptionsFromJSON(MolDrawOptions &opts,
   PT_OPT_GET(simplifiedStereoGroupLabel);
   PT_OPT_GET(unspecifiedStereoIsUnknown);
   PT_OPT_GET(singleColourWedgeBonds);
+  PT_OPT_GET(singleColourBonds);
   PT_OPT_GET(useMolBlockWedging);
   PT_OPT_GET(scalingFactor);
   PT_OPT_GET(drawMolsSameScale);
@@ -213,7 +214,8 @@ void updateMolDrawOptionsFromJSON(MolDrawOptions &opts,
   const auto drawingExtentsIncludeIt = pt.find("drawingExtentsInclude");
   if (drawingExtentsIncludeIt != pt.not_found()) {
     bool haveDrawElementFlags = false;
-    auto drawingExtentsInclude = flagsFromJson<DrawElement>(drawingExtentsIncludeIt->second, &haveDrawElementFlags);
+    auto drawingExtentsInclude = flagsFromJson<DrawElement>(
+        drawingExtentsIncludeIt->second, &haveDrawElementFlags);
     if (haveDrawElementFlags) {
       opts.drawingExtentsInclude = drawingExtentsInclude;
     }

--- a/Code/GraphMol/MolDraw2D/Wrap/rdMolDraw2D.cpp
+++ b/Code/GraphMol/MolDraw2D/Wrap/rdMolDraw2D.cpp
@@ -926,11 +926,10 @@ BOOST_PYTHON_MODULE(rdMolDraw2D) {
       .def_readwrite(
           "legendFraction", &RDKit::MolDrawOptions::legendFraction,
           "fraction of the draw panel to be used for the legend if present")
-      .def_readwrite(
-          "legendPosition", &RDKit::MolDrawOptions::legendPosition,
-          "legend position enum. Default=Bottom. "
-          "Values: LegendPosition.Bottom, LegendPosition.Top, "
-          "LegendPosition.Left, LegendPosition.Right.")
+      .def_readwrite("legendPosition", &RDKit::MolDrawOptions::legendPosition,
+                     "legend position enum. Default=Bottom. "
+                     "Values: LegendPosition.Bottom, LegendPosition.Top, "
+                     "LegendPosition.Left, LegendPosition.Right.")
       .def_readwrite(
           "legendVerticalText", &RDKit::MolDrawOptions::legendVerticalText,
           "when legend is Left or Right, draw text vertically (one char per line)")
@@ -1072,6 +1071,11 @@ BOOST_PYTHON_MODULE(rdMolDraw2D) {
           "if true wedged and dashed bonds are drawn using symbolColour "
           "rather than inheriting their colour from the atoms. "
           "Default is false.")
+      .def_readwrite("singleColourBonds",
+                     &RDKit::MolDrawOptions::singleColourBonds,
+                     "if true all bonds are drawn using symbolColour "
+                     "rather than inheriting their colour from the atoms. "
+                     "Default is false.")
       .def_readwrite("useMolBlockWedging",
                      &RDKit::MolDrawOptions::useMolBlockWedging,
                      "If the molecule came from a MolBlock, prefer the wedging"
@@ -1203,8 +1207,8 @@ BOOST_PYTHON_MODULE(rdMolDraw2D) {
       .def("FillPolys", &RDKit::MolDraw2D::fillPolys, python::args("self"),
            "returns whether or not polygons are being filled")
       .def("DrawLine",
-           (void(RDKit::MolDraw2D::*)(const Point2D &, const Point2D &, bool)) &
-               RDKit::MolDraw2D::drawLine,
+           (void (RDKit::MolDraw2D::*)(const Point2D &, const Point2D &,
+                                       bool))&RDKit::MolDraw2D::drawLine,
            (python::arg("self"), python::arg("cds1"), python::arg("cds2"),
             python::arg("rawCoords") = false),
            "draws a line with the current drawing style. The coordinates "
@@ -1253,9 +1257,8 @@ BOOST_PYTHON_MODULE(rdMolDraw2D) {
            "are in the molecule frame unless rawCoords is true, "
            "in which case the coordinates are in pixels.")
       .def("DrawArc",
-           (void(RDKit::MolDraw2D::*)(const Point2D &, double, double, double,
-                                      bool)) &
-               RDKit::MolDraw2D::drawArc,
+           (void (RDKit::MolDraw2D::*)(const Point2D &, double, double, double,
+                                       bool))&RDKit::MolDraw2D::drawArc,
            (python::arg("self"), python::arg("center"), python::arg("radius"),
             python::arg("angle1"), python::arg("angle2"),
             python::arg("rawCoords") = false),
@@ -1284,9 +1287,9 @@ BOOST_PYTHON_MODULE(rdMolDraw2D) {
            "are in the molecule frame unless rawCoords is true, "
            "in which case the coordinates are in pixels.")
       .def("DrawString",
-           (void(RDKit::MolDraw2D::*)(const std::string &,
-                                      const RDGeom::Point2D &, bool)) &
-               RDKit::MolDraw2D::drawString,
+           (void (RDKit::MolDraw2D::*)(const std::string &,
+                                       const RDGeom::Point2D &,
+                                       bool))&RDKit::MolDraw2D::drawString,
            (python::arg("self"), python::arg("string"), python::arg("pos"),
             python::arg("rawCoords") = false),
            "add text to the canvas. The coordinates "
@@ -1301,14 +1304,14 @@ BOOST_PYTHON_MODULE(rdMolDraw2D) {
            "are in the molecule frame unless rawCoords is true, "
            "in which case the coordinates are in pixels.")
       .def("GetDrawCoords",
-           (RDGeom::Point2D(RDKit::MolDraw2D::*)(const RDGeom::Point2D &)
+           (RDGeom::Point2D (RDKit::MolDraw2D::*)(const RDGeom::Point2D &)
                 const) &
                RDKit::MolDraw2D::getDrawCoords,
            (python::arg("self"), python::arg("point")),
            "get the coordinates in drawing space for a particular point in "
            "molecule space")
       .def("GetDrawCoords",
-           (RDGeom::Point2D(RDKit::MolDraw2D::*)(int) const) &
+           (RDGeom::Point2D (RDKit::MolDraw2D::*)(int) const) &
                RDKit::MolDraw2D::getDrawCoords,
            (python::arg("self"), python::arg("atomIndex")),
            "get the coordinates in drawing space for a particular atom")
@@ -1338,7 +1341,7 @@ BOOST_PYTHON_MODULE(rdMolDraw2D) {
            python::args("self"),
            "add the last bits of SVG to finish the drawing")
       .def("AddMoleculeMetadata",
-           (void(RDKit::MolDraw2DSVG::*)(const RDKit::ROMol &, int) const) &
+           (void (RDKit::MolDraw2DSVG::*)(const RDKit::ROMol &, int) const) &
                RDKit::MolDraw2DSVG::addMoleculeMetadata,
            ((python::arg("self"), python::arg("mol")),
             python::arg("confId") = -1),
@@ -1591,10 +1594,9 @@ https://en.wikipedia.org/wiki/Wikipedia:Manual_of_Style/Chemistry/Structure_draw
               (python::arg("mol"), python::arg("confId") = -1),
               "Calculate the mean bond length for the molecule.");
   python::def("SetDarkMode",
-              (void (*)(RDKit::MolDrawOptions &)) & RDKit::setDarkMode,
+              (void (*)(RDKit::MolDrawOptions &))&RDKit::setDarkMode,
               python::args("d2d"), "set dark mode for a MolDrawOptions object");
-  python::def("SetDarkMode",
-              (void (*)(RDKit::MolDraw2D &)) & RDKit::setDarkMode,
+  python::def("SetDarkMode", (void (*)(RDKit::MolDraw2D &))&RDKit::setDarkMode,
               python::args("d2d"), "set dark mode for a MolDraw2D object");
   python::def("SetMonochromeMode", RDKit::setMonochromeMode_helper1,
               (python::arg("options"), python::arg("fgColour"),

--- a/Code/GraphMol/MolDraw2D/Wrap/testMolDraw2D.py
+++ b/Code/GraphMol/MolDraw2D/Wrap/testMolDraw2D.py
@@ -891,6 +891,7 @@ M  END''')
       d2d.drawOptions().addAtomIndices = True
       d2d.drawOptions().addBondIndices = True
       d2d.drawOptions().singleColourWedgeBonds = True  # test symbolColour
+      d2d.drawOptions().singleColourBonds = True # just test it's settable
       setattr(d2d.drawOptions(), attr, val)
       aval = getattr(d2d.drawOptions(), attr)
       for idx in range(4):

--- a/Code/GraphMol/MolDraw2D/catch_tests.cpp
+++ b/Code/GraphMol/MolDraw2D/catch_tests.cpp
@@ -4868,8 +4868,9 @@ TEST_CASE("legend position Top Left Right and vertical text", "[drawing]") {
       y = std::stod(match[2].str());
       return true;
     }
-    std::regex pathRgx("class='legend' d='M (-?[0-9]+\\.?[0-9]*) "
-                       "(-?[0-9]+\\.?[0-9]*)");
+    std::regex pathRgx(
+        "class='legend' d='M (-?[0-9]+\\.?[0-9]*) "
+        "(-?[0-9]+\\.?[0-9]*)");
     if (std::regex_search(text, match, pathRgx) && match.size() == 3) {
       x = std::stod(match[1].str());
       y = std::stod(match[2].str());
@@ -4888,8 +4889,9 @@ TEST_CASE("legend position Top Left Right and vertical text", "[drawing]") {
     if (!coords.empty()) {
       return coords;
     }
-    std::regex pathRgx("class='legend' d='M (-?[0-9]+\\.?[0-9]*) "
-                       "(-?[0-9]+\\.?[0-9]*)");
+    std::regex pathRgx(
+        "class='legend' d='M (-?[0-9]+\\.?[0-9]*) "
+        "(-?[0-9]+\\.?[0-9]*)");
     for (auto it = std::sregex_iterator(text.begin(), text.end(), pathRgx);
          it != std::sregex_iterator(); ++it) {
       coords.emplace_back(std::stod((*it)[1].str()), std::stod((*it)[2].str()));
@@ -4902,8 +4904,7 @@ TEST_CASE("legend position Top Left Right and vertical text", "[drawing]") {
   double right_x = 0.0, right_y = 0.0;
   SECTION("Top") {
     MolDraw2DSVG drawer(200, 200, -1, -1, NO_FREETYPE);
-    drawer.drawOptions().legendPosition =
-        MolDrawOptions::LegendPosition::Top;
+    drawer.drawOptions().legendPosition = MolDrawOptions::LegendPosition::Top;
     MolDraw2DUtils::prepareAndDrawMolecule(drawer, *m1, legend);
     drawer.finishDrawing();
     auto text = drawer.getDrawingText();
@@ -4917,8 +4918,7 @@ TEST_CASE("legend position Top Left Right and vertical text", "[drawing]") {
   }
   SECTION("Left with vertical text") {
     MolDraw2DSVG drawer(200, 200, -1, -1, NO_FREETYPE);
-    drawer.drawOptions().legendPosition =
-        MolDrawOptions::LegendPosition::Left;
+    drawer.drawOptions().legendPosition = MolDrawOptions::LegendPosition::Left;
     drawer.drawOptions().legendVerticalText = true;
     MolDraw2DUtils::prepareAndDrawMolecule(drawer, *m1, legend);
     drawer.finishDrawing();
@@ -4935,8 +4935,7 @@ TEST_CASE("legend position Top Left Right and vertical text", "[drawing]") {
   }
   SECTION("Left horizontal") {
     MolDraw2DSVG drawer(200, 200, -1, -1, NO_FREETYPE);
-    drawer.drawOptions().legendPosition =
-        MolDrawOptions::LegendPosition::Left;
+    drawer.drawOptions().legendPosition = MolDrawOptions::LegendPosition::Left;
     drawer.drawOptions().legendVerticalText = false;
     MolDraw2DUtils::prepareAndDrawMolecule(drawer, *m1, legend);
     drawer.finishDrawing();
@@ -4950,8 +4949,7 @@ TEST_CASE("legend position Top Left Right and vertical text", "[drawing]") {
   }
   SECTION("Right horizontal") {
     MolDraw2DSVG drawer(200, 200, -1, -1, NO_FREETYPE);
-    drawer.drawOptions().legendPosition =
-        MolDrawOptions::LegendPosition::Right;
+    drawer.drawOptions().legendPosition = MolDrawOptions::LegendPosition::Right;
     drawer.drawOptions().legendVerticalText = false;
     MolDraw2DUtils::prepareAndDrawMolecule(drawer, *m1, legend);
     drawer.finishDrawing();
@@ -4980,8 +4978,7 @@ TEST_CASE("legend position Top Left Right and vertical text", "[drawing]") {
   SECTION("Long vertical side legend fits panel height") {
     const std::string longName(48, 'M');
     MolDraw2DSVG drawer(160, 90, -1, -1, NO_FREETYPE);
-    drawer.drawOptions().legendPosition =
-        MolDrawOptions::LegendPosition::Left;
+    drawer.drawOptions().legendPosition = MolDrawOptions::LegendPosition::Left;
     drawer.drawOptions().legendVerticalText = true;
     drawer.drawOptions().legendFraction = 0.22f;
     MolDraw2DUtils::prepareAndDrawMolecule(drawer, *m1, longName);
@@ -11363,4 +11360,33 @@ M  END
     }
     CHECK(checkCoords(referenceCoords, highlightCoords));
   }
+}
+
+TEST_CASE("Uniform bond colour") {
+  auto m1 = "F[C@@H](Cl)Oc1ccc(N2CCc3nccc(C(=O)Nc4ccccn4)c3C2)nc1"_smiles;
+  REQUIRE(m1);
+  MolDraw2DSVG drawer(400, 400, -1, -1, NO_FREETYPE);
+  MolDraw2DUtils::prepareMolForDrawing(*m1);
+  drawer.drawOptions().addBondIndices = true;
+  drawer.drawOptions().singleColourBonds = true;
+  drawer.drawMolecule(*m1);
+  drawer.finishDrawing();
+  std::string text = drawer.getDrawingText();
+  std::ofstream outs("testUniformBondColour_1.svg");
+  outs << text;
+  outs.close();
+  // Bond 2 is C-O so in normal mode would have 2 lines, a black one and a
+  // red one.  Make sure there's only one.
+  const static std::regex bond2("<path class='bond-2 atom-1 atom-3'");
+  std::ptrdiff_t const match_count2(
+      std::distance(std::sregex_iterator(text.begin(), text.end(), bond2),
+                    std::sregex_iterator()));
+  CHECK(match_count2 == 1);
+  // Bond 0 is a wedge to fluorine.  Make sure it is also all black, which
+  // involves 1 triangle not 2.
+  const static std::regex bond0("<path class='bond-0 atom-1 atom-0'");
+  std::ptrdiff_t const match_count0(
+      std::distance(std::sregex_iterator(text.begin(), text.end(), bond2),
+                    std::sregex_iterator()));
+  CHECK(match_count0 == 1);
 }


### PR DESCRIPTION
#### Reference Issue
Addresses feature request #9282


#### What does this implement/fix? Explain your changes.
Adds the option as requested.

#### Any other comments?
There's been some more irritating clang reformatting.  The pertinent changes are in DrawMol.cpp lines 2391 and 2576, rdMolDraw2.cpp line 1074.
