### PR TITLE
Improve synthon substructure search performance ~20%

### DIFF
--- a/Code/GraphMol/SynthonSpaceSearch/SearchResults.h
+++ b/Code/GraphMol/SynthonSpaceSearch/SearchResults.h
@@ -12,6 +12,7 @@
 #define RDKIT_SYNTHONSPACE_SEARCHRESULTS_H
 
 #include <functional>
+#include <boost/unordered/unordered_flat_set.hpp>
 #include <RDGeneral/export.h>
 #include <GraphMol/ROMol.h>
 
@@ -77,7 +78,7 @@ class RDKIT_SYNTHONSPACESEARCH_EXPORT SearchResults {
   std::vector<std::unique_ptr<ROMol>> d_hitMolecules;
   // Only used when merging in another set, so will be
   // filled in then if needed, empty otherwise.
-  std::unordered_set<std::string> d_molNames;
+  boost::unordered_flat_set<std::string> d_molNames;
 
   std::uint64_t d_maxNumResults;
   bool d_timedOut{false};

--- a/Code/GraphMol/SynthonSpaceSearch/SynthonSpaceSearch_details.cpp
+++ b/Code/GraphMol/SynthonSpaceSearch/SynthonSpaceSearch_details.cpp
@@ -17,6 +17,7 @@
 #include <vector>
 
 #include <boost/dynamic_bitset.hpp>
+#include <boost/functional/hash.hpp>
 
 #include <RDGeneral/ControlCHandler.h>
 #include <GraphMol/Chirality.h>
@@ -823,6 +824,17 @@ std::string buildProductName(
   }
   prodName += ";" + hitset->d_reaction->getId();
   return prodName;
+}
+
+std::size_t buildProductHash(
+    const RDKit::SynthonSpaceSearch::SynthonSpaceHitSet *hitset,
+    const std::vector<size_t> &fragNums) {
+  std::size_t seed = 0;
+  for (size_t i = 0; i < fragNums.size(); ++i) {
+    boost::hash_combine(seed, hitset->synthonsToUse[i][fragNums[i]].first);
+  }
+  boost::hash_combine(seed, hitset->d_reaction->getId());
+  return seed;
 }
 
 std::unique_ptr<ROMol> buildProduct(

--- a/Code/GraphMol/SynthonSpaceSearch/SynthonSpaceSearch_details.h
+++ b/Code/GraphMol/SynthonSpaceSearch/SynthonSpaceSearch_details.h
@@ -147,6 +147,11 @@ RDKIT_SYNTHONSPACESEARCH_EXPORT std::string buildProductName(
 RDKIT_SYNTHONSPACESEARCH_EXPORT std::string buildProductName(
     const RDKit::SynthonSpaceSearch::SynthonSpaceHitSet *hitset,
     const std::vector<size_t> &fragNums);
+// Hash of the product identity — same byte sequence as buildProductName but
+// without allocating the concatenated string. Use as a dedup key.
+RDKIT_SYNTHONSPACESEARCH_EXPORT std::size_t buildProductHash(
+    const RDKit::SynthonSpaceSearch::SynthonSpaceHitSet *hitset,
+    const std::vector<size_t> &fragNums);
 // Zip the fragments together to make a molecule.  Assumes the connection
 // points are marking by isotope numbers on dummy atoms.
 RDKIT_SYNTHONSPACESEARCH_EXPORT std::unique_ptr<ROMol> buildProduct(

--- a/Code/GraphMol/SynthonSpaceSearch/SynthonSpaceSearcher.cpp
+++ b/Code/GraphMol/SynthonSpaceSearch/SynthonSpaceSearcher.cpp
@@ -11,6 +11,7 @@
 #include <random>
 #include <thread>
 #include <boost/random/discrete_distribution.hpp>
+#include <boost/unordered/unordered_flat_set.hpp>
 
 #include <GraphMol/Chirality.h>
 #include <GraphMol/MolOps.h>
@@ -380,27 +381,19 @@ void sortHits(std::vector<std::unique_ptr<ROMol>> &hits) {
 void sortAndUniquifyToTry(
     std::vector<std::pair<const SynthonSpaceHitSet *, std::vector<size_t>>>
         &toTry) {
-  std::vector<std::pair<size_t, std::string>> tmp;
-  tmp.reserve(toTry.size());
-  for (size_t i = 0; i < toTry.size(); i++) {
-    tmp.emplace_back(
-        i, details::buildProductName(toTry[i].first, toTry[i].second));
-  }
-  std::sort(tmp.begin(), tmp.end(),
-            [](const auto &lhs, const auto &rhs) -> bool {
-              return lhs.second < rhs.second;
-            });
-  tmp.erase(std::unique(tmp.begin(), tmp.end(),
-                        [](const auto &lhs, const auto &rhs) -> bool {
-                          return lhs.second == rhs.second;
-                        }),
-            tmp.end());
-  std::vector<std::pair<const SynthonSpaceHitSet *, std::vector<size_t>>>
-      newToTry;
-  newToTry.reserve(tmp.size());
-  std::transform(tmp.begin(), tmp.end(), back_inserter(newToTry),
-                 [&](const auto &p) -> auto { return toTry[p.first]; });
-  toTry = newToTry;
+  // Two query fragmentations can map to the same (reaction, synthon-combo)
+  // pair; deduplicate so we don't build the same product twice.
+  boost::unordered_flat_set<std::size_t> seen;
+  seen.reserve(toTry.size());
+  toTry.erase(
+      std::remove_if(toTry.begin(), toTry.end(),
+                     [&seen](const auto &entry) {
+                       return !seen
+                                   .insert(details::buildProductHash(
+                                       entry.first, entry.second))
+                                   .second;
+                     }),
+      toTry.end());
 }
 
 bool haveEnoughHits(const std::vector<std::unique_ptr<ROMol>> &results,


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

Improves synthon substructure search performance by almost 20%, especially for high-hitrate molecules. There are three basic optimizations here:

* Use a map instead of a vector in sortAndUniquifyToTry for lookups
* Use boost::unordered_flat_set instead of std::unordered_set for faster lookups, insertions, and creation
* Key sets on a hash instead of storing millions of strings.

I searched a group of high-hitrate molecules (more than 2million hits), on the 140B-product Freedom space. The overall improvement was something like 20%. Some standouts:

* Benzene:       6.92s → 5.64s  (−19%),
* Ciprofloxacin: 6.82s → 6.09s  (−11%)
* Aspirin:       4.51s → 3.42s  (−24%)

#### Any other comments?

I have a few other small optimizations coming. I think they are independent, so I'll put up separate reviews

Co-authored by claude Sonnet 4.6 with heavy driving by me.