### PR TITLE
switch to specific versions of other actions in the templates action

### DIFF
--- a/.github/workflows/templates_updater.yml
+++ b/.github/workflows/templates_updater.yml
@@ -19,9 +19,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout RDKit
-        uses: actions/checkout@v3
+        uses: actions/checkout@6.0.2
       - name: Checkout molecular_templates
-        uses: actions/checkout@v3
+        uses: actions/checkout@6.0.2
         with:
             repository: ${{ env.tpl_repo }}
             ref: main
@@ -56,7 +56,7 @@ jobs:
             echo "pr_branch=${pr_branch}" >> ${GITHUB_OUTPUT}
       - name: pull-request-action
         if: ${{ steps.push_changes.outputs.header_changed == '1' }}
-        uses: vsoch/pull-request-action@master
+        uses: vsoch/pull-request-action@1.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PULL_REQUEST_FROM_BRANCH: ${{ steps.push_changes.outputs.pr_branch }}


### PR DESCRIPTION
I think we're safer using specific versions of the other actions we use