### PR TITLE
Fix CXSMILES writer to emit |w:| for STEREOANY double bonds

### DIFF
--- a/Code/GraphMol/SmilesParse/CXSmilesOps.cpp
+++ b/Code/GraphMol/SmilesParse/CXSmilesOps.cpp
@@ -2265,6 +2265,74 @@ std::string get_bond_config_block(
           boost::str(boost::format("%d.%d") % begAtomOrder % i));
     }
   }
+  // For double bonds with STEREOANY, emit a wavy marker on an adjacent single
+  // bond so that |w:| is written. This mirrors what the CXSMILES parser does
+  // when reading |w:| (it sets BondDir::UNKNOWN on the single bond neighbor).
+  for (unsigned int i = 0; i < bondOrder.size(); ++i) {
+    auto idx = bondOrder[i];
+    const auto bond = mol.getBondWithIdx(idx);
+    if (bond->getBondType() != Bond::BondType::DOUBLE ||
+        bond->getStereo() != Bond::BondStereo::STEREOANY) {
+      continue;
+    }
+    // Skip ring double bonds — they are handled by
+    // get_ringbond_cistrans_block() which emits |ctu:| instead.
+    if (mol.getRingInfo()->isInitialized() &&
+        mol.getRingInfo()->numBondRings(idx)) {
+      continue;
+    }
+    // Check if an adjacent single bond already has BondDir::UNKNOWN
+    // (set by the CXSMILES parser) or _MolFileBondCfg (set by the
+    // mol file parser). If so, skip — the wavy bond is already handled
+    // by the main loop above, or by wU/wD markers from mol file wedging.
+    bool alreadyHandled = false;
+    for (const auto &nbond : mol.atomBonds(bond->getBeginAtom())) {
+      if (nbond->getBondDir() == Bond::BondDir::UNKNOWN ||
+          nbond->hasProp(common_properties::_MolFileBondCfg)) {
+        alreadyHandled = true;
+        break;
+      }
+    }
+    // Also skip if the STEREOANY bond has no stereo atoms assigned (e.g.
+    // programmatic SetStereo) or came from a mol file with crossed stereo.
+    if (!alreadyHandled &&
+        (bond->getStereoAtoms().empty() ||
+         bond->hasProp(common_properties::_MolFileBondStereo))) {
+      alreadyHandled = true;
+    }
+    if (!alreadyHandled) {
+      for (const auto &nbond : mol.atomBonds(bond->getEndAtom())) {
+        if (nbond->getBondDir() == Bond::BondDir::UNKNOWN ||
+            nbond->hasProp(common_properties::_MolFileBondCfg)) {
+          alreadyHandled = true;
+          break;
+        }
+      }
+    }
+    if (alreadyHandled) {
+      continue;
+    }
+    // Find an adjacent single bond to mark as wavy.
+    for (const auto &nbond : mol.atomBonds(bond->getBeginAtom())) {
+      if (nbond->getIdx() == bond->getIdx() || !canHaveDirection(*nbond)) {
+        continue;
+      }
+      auto nbrBondOrder =
+          std::find(bondOrder.begin(), bondOrder.end(), nbond->getIdx()) -
+          bondOrder.begin();
+      auto begAtomOrder =
+          std::find(atomOrder.begin(), atomOrder.end(),
+                    bond->getBeginAtomIdx()) -
+          atomOrder.begin();
+      if (wParts.find("w") == wParts.end()) {
+        wParts["w"] = std::vector<std::string>();
+      }
+      wParts["w"].push_back(
+          boost::str(boost::format("%d.%d") % begAtomOrder % nbrBondOrder));
+      break;
+    }
+  }
+
   std::string res = "";
 
   for (auto wPart : wParts) {

--- a/Code/GraphMol/SmilesParse/cxsmiles_test.cpp
+++ b/Code/GraphMol/SmilesParse/cxsmiles_test.cpp
@@ -732,11 +732,12 @@ TEST_CASE("CXSMILES writer emits |w:| for STEREOANY double bonds") {
   }
 
   SECTION("|w:| roundtrip is idempotent and does not duplicate") {
-    // Parsing |w:| sets BondDir::UNKNOWN on the adjacent single bond. The
-    // STEREOANY double bond also gets set, but with no stereo atoms. The
-    // writer must emit |w:| exactly once (from the existing UNKNOWN path),
-    // not also from the new STEREOANY path.
-    auto m = "C/C=C/C |w:1.1|"_smiles;
+    // Parsing |w:0.0| sets BondDir::UNKNOWN on the adjacent single bond
+    // (bond 0) and STEREOANY on the double bond (bond 1). The writer must
+    // emit |w:| exactly once — the existing UNKNOWN path covers it, and
+    // the new STEREOANY path's alreadyHandled guard must suppress a
+    // second emission.
+    auto m = "CC=CC |w:0.0|"_smiles;
     REQUIRE(m);
     auto out = MolToCXSmiles(*m);
     auto firstW = out.find("w:");

--- a/Code/GraphMol/SmilesParse/cxsmiles_test.cpp
+++ b/Code/GraphMol/SmilesParse/cxsmiles_test.cpp
@@ -699,6 +699,101 @@ TEST_CASE("github #6050: stereogroups not combined") {
   }
 }
 
+TEST_CASE("CXSMILES writer emits |w:| for STEREOANY double bonds") {
+  SECTION("acyclic STEREOANY set programmatically produces |w:|") {
+    // The scenario produced by e.g. an InChI roundtrip: STEREOANY is set on
+    // the double bond with stereo atoms, but no adjacent single bond has
+    // BondDir::UNKNOWN. Before the fix the CXSMILES writer dropped this
+    // information silently. The writer should now mark an adjacent single
+    // bond as wavy in the output.
+    auto m = "CC=CC"_smiles;
+    REQUIRE(m);
+    auto bond = m->getBondBetweenAtoms(1, 2);
+    REQUIRE(bond);
+    bond->setStereoAtoms(0, 3);
+    bond->setStereo(Bond::STEREOANY);
+    auto out = MolToCXSmiles(*m);
+    CHECK(out.find("w:") != std::string::npos);
+  }
+
+  SECTION("ring STEREOANY uses |ctu:|, never |w:|") {
+    // STEREOANY on an in-ring double bond is serialized as an unknown
+    // ring-bond cis/trans (|ctu:|). The new code path must not also emit
+    // a wavy marker.
+    auto m = "C1CC=CCCCC1"_smiles;
+    REQUIRE(m);
+    auto bond = m->getBondBetweenAtoms(2, 3);
+    REQUIRE(bond);
+    bond->setStereoAtoms(1, 4);
+    bond->setStereo(Bond::STEREOANY);
+    auto out = MolToCXSmiles(*m);
+    CHECK(out.find("w:") == std::string::npos);
+    CHECK(out.find("ctu:") != std::string::npos);
+  }
+
+  SECTION("|w:| roundtrip is idempotent and does not duplicate") {
+    // Parsing |w:| sets BondDir::UNKNOWN on the adjacent single bond. The
+    // STEREOANY double bond also gets set, but with no stereo atoms. The
+    // writer must emit |w:| exactly once (from the existing UNKNOWN path),
+    // not also from the new STEREOANY path.
+    auto m = "C/C=C/C |w:1.1|"_smiles;
+    REQUIRE(m);
+    auto out = MolToCXSmiles(*m);
+    auto firstW = out.find("w:");
+    REQUIRE(firstW != std::string::npos);
+    CHECK(out.find("w:", firstW + 1) == std::string::npos);
+  }
+
+  SECTION("STEREOANY with empty stereo atoms does not emit |w:|") {
+    // Defensive: STEREOANY without stereo atoms has no anchor to attach a
+    // wavy marker to. The writer must skip silently rather than emit a
+    // garbled marker.
+    auto m = "CC=CC"_smiles;
+    REQUIRE(m);
+    auto bond = m->getBondBetweenAtoms(1, 2);
+    REQUIRE(bond);
+    bond->setStereo(Bond::STEREOANY);
+    auto out = MolToCXSmiles(*m);
+    CHECK(out.find("w:") == std::string::npos);
+  }
+
+  SECTION("STEREOANY with _MolFileBondStereo defers to mol-file wedging") {
+    // _MolFileBondStereo on the double bond marks that wedging info comes
+    // from a mol file (e.g. crossed double bond, cfg=3). The CXSMILES
+    // writer should not emit |w:| in addition — the existing wU/wD path
+    // already covers it.
+    auto m = "CC=CC"_smiles;
+    REQUIRE(m);
+    auto bond = m->getBondBetweenAtoms(1, 2);
+    REQUIRE(bond);
+    bond->setStereoAtoms(0, 3);
+    bond->setStereo(Bond::STEREOANY);
+    bond->setProp(common_properties::_MolFileBondStereo, 3);
+    auto out = MolToCXSmiles(*m);
+    CHECK(out.find("w:") == std::string::npos);
+  }
+
+  SECTION("adjacent _MolFileBondCfg=2 suppresses duplicate |w:|") {
+    // _MolFileBondCfg=2 on an adjacent single bond means a mol-file wavy
+    // marker is already going to be emitted by the wedging path. The new
+    // STEREOANY emission must not duplicate it.
+    auto m = "CC=CC"_smiles;
+    REQUIRE(m);
+    auto db = m->getBondBetweenAtoms(1, 2);
+    REQUIRE(db);
+    db->setStereoAtoms(0, 3);
+    db->setStereo(Bond::STEREOANY);
+    auto adj = m->getBondBetweenAtoms(0, 1);
+    REQUIRE(adj);
+    adj->setProp(common_properties::_MolFileBondCfg, 2u);
+    auto out = MolToCXSmiles(*m);
+    auto firstW = out.find("w:");
+    if (firstW != std::string::npos) {
+      CHECK(out.find("w:", firstW + 1) == std::string::npos);
+    }
+  }
+}
+
 class SmilesTest {
  public:
   std::string fileName;


### PR DESCRIPTION
Split off from #9219 per @greglandrum's review request, with dedicated tests demonstrating each fix.

## Summary

When a `STEREOANY` double bond has its stereo information set (for example, after an InChI roundtrip restores it from an `UNKNOWN`-parity `stereo0D`, but also any programmatic `SetStereo(STEREOANY)` with stereo atoms), the CXSMILES writer previously dropped the marker silently. The CXSMILES parser handles `|w:|` by setting `BondDir::UNKNOWN` on the adjacent single bond, so the writer needs to mirror that — emit a wavy marker on an adjacent single bond.

## Change

The new code path in `get_bond_config_block()` (`Code/GraphMol/SmilesParse/CXSmilesOps.cpp`) runs after the main wedging loop and only fires when nothing else has handled the `STEREOANY` double bond. It carries four guards so it does not duplicate or contradict existing markers:

- **Ring double bonds** are handled by `get_ringbond_cistrans_block()`, which emits `|ctu:|`; skip them here.
- **Adjacent `BondDir::UNKNOWN`**: the main loop already emitted `|w:|` (parser path).
- **Adjacent `_MolFileBondCfg`**: mol-file wedging will produce the wavy via `wU`/`wD`; do not double-emit.
- **Bond carries `_MolFileBondStereo`** (crossed double bond from a mol file) or has no `stereoAtoms` set: defer to existing paths.

## Tests

New `TEST_CASE("CXSMILES writer emits |w:| for STEREOANY double bonds")` in `Code/GraphMol/SmilesParse/cxsmiles_test.cpp` covers each guard:

| sub-test | demonstrates |
|---|---|
| acyclic STEREOANY set programmatically produces `\|w:\|` | core fix |
| ring STEREOANY uses `\|ctu:\|`, never `\|w:\|` | ring-bond skip |
| `\|w:\|` roundtrip is idempotent and does not duplicate | adjacent `BondDir::UNKNOWN` guard |
| STEREOANY with empty stereo atoms does not emit `\|w:\|` | empty-stereo-atoms guard |
| STEREOANY with `_MolFileBondStereo` defers to mol-file wedging | crossed-double-bond guard |
| adjacent `_MolFileBondCfg=2` suppresses duplicate `\|w:\|` | mol-file-cfg guard |

Verified locally — `cxsmilesTest`, `testExtendedStereoParsing`, `fileParsersCatchTest`, `molfileStereoCatchTest`, and the InChI test (`testInchi`) all pass.

## Related

This is the CXSMILES half of the original bundled PR #9219. The InChI half is now #9315.

🤖 Generated with [Claude Code](https://claude.com/claude-code)