### PR TITLE
Build: forward-slash Python3_EXECUTABLE when generating rdkit-stubs

### DIFF
--- a/rdkit-stubs/CMakeLists.txt
+++ b/rdkit-stubs/CMakeLists.txt
@@ -14,13 +14,14 @@ set(CONCURRENCY "")
 if (DEFINED ENV{CMAKE_BUILD_PARALLEL_LEVEL})
   set(CONCURRENCY "--concurrency $ENV{CMAKE_BUILD_PARALLEL_LEVEL} ")
 endif()
+string(REGEX REPLACE "\\\\" "/" Python3_EXECUTABLE_FWDSLASH ${Python3_EXECUTABLE})
 string(CONCAT RUN_GEN_RDKIT_STUBS_PY "message("
   "\"-- Building and Installing rdkit-stubs into the following director${DIR_OR_DIRS}: ${STUB_LOCATIONS}\")\n"
   "set (SEPARATOR \"=====================================================================\n\")\n"
   "set (COMMON_FILENAME ${CMAKE_CURRENT_BINARY_DIR_FWDSLASH}/gen_rdkit_stubs)\n"
   "execute_process("
   "COMMAND "
-  "${Python3_EXECUTABLE} -m Scripts.gen_rdkit_stubs ${CONCURRENCY}"
+  "${Python3_EXECUTABLE_FWDSLASH} -m Scripts.gen_rdkit_stubs ${CONCURRENCY}"
   "${CMAKE_SOURCE_DIR_FWDSLASH_QUOTED}${PYTHON_INSTDIR_FWDSLASH_QUOTED}"
   "WORKING_DIRECTORY \"${CMAKE_SOURCE_DIR_FWDSLASH}\" "
   "OUTPUT_FILE \"\${COMMON_FILENAME}.out\" "


### PR DESCRIPTION
#### Reference Issue
<!-- Example: Fixes #1234 -->

#### What does this implement/fix? Explain your changes.
`rdkit-stubs/CMakeLists.txt` assembles a cmake script (`RUN_GEN_RDKIT_STUBS_PY`) that is later executed via `cmake -P`. Every path embedded into that generated script is first converted to forward slashes — `CMAKE_SOURCE_DIR`, `CMAKE_CURRENT_BINARY_DIR`, and `PYTHON_INSTDIR` all go through `string(REGEX REPLACE "\\\\" "/" ...)` — so that the backslashes in native Windows paths are not treated as escape sequences when the generated script is re-parsed.

`Python3_EXECUTABLE` was the one path that was left unconverted, so on Windows the generated `COMMAND` line still contained backslashes and failed to parse. This applies the same forward-slash conversion already used for the neighboring paths.

#### Any other comments?
This has been carried as a patch in [conda-forge/rdkit-feedstock](https://github.com/conda-forge/rdkit-feedstock); upstreaming it so the feedstock can drop the patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)