### PR TITLE
Replace combineMols with RWMol::insertMol in SynthonSpaceSearch

### DIFF
--- a/Code/GraphMol/SynthonSpaceSearch/SynthonSet.cpp
+++ b/Code/GraphMol/SynthonSpaceSearch/SynthonSet.cpp
@@ -228,12 +228,12 @@ std::vector<std::unique_ptr<ROMol>> buildSampleMolecules(
   mzparams.label = MolzipLabel::Isotope;
 
   for (size_t i = 0; i < synthons[longVecNum].size(); ++i) {
-    auto combMol = std::make_unique<ROMol>();
+    auto combMol = std::make_unique<RWMol>();
     for (size_t j = 0; j < synthons.size(); ++j) {
       if (j == longVecNum) {
-        combMol.reset(combineMols(*combMol, *synthons[j][i]));
+        combMol->insertMol(*synthons[j][i]);
       } else {
-        combMol.reset(combineMols(*combMol, *synthons[j].front()));
+        combMol->insertMol(*synthons[j].front());
       }
     }
     try {

--- a/Code/GraphMol/SynthonSpaceSearch/SynthonSpaceSearch_details.cpp
+++ b/Code/GraphMol/SynthonSpaceSearch/SynthonSpaceSearch_details.cpp
@@ -841,13 +841,13 @@ std::unique_ptr<ROMol> buildProduct(
     const std::vector<const ROMol *> &synthons) {
   MolzipParams mzparams;
   mzparams.label = MolzipLabel::Isotope;
-  auto prodMol = std::make_unique<ROMol>(*synthons.front());
+  auto prodMol = std::make_unique<RWMol>(*synthons.front());
   for (size_t i = 1; i < synthons.size(); ++i) {
-    prodMol.reset(combineMols(*prodMol, *synthons[i]));
+    prodMol->insertMol(*synthons[i]);
   }
-  prodMol = molzip(*prodMol, mzparams);
-  MolOps::sanitizeMol(*dynamic_cast<RWMol *>(prodMol.get()));
-  return prodMol;
+  auto zipProdMol = molzip(*prodMol, mzparams);
+  MolOps::sanitizeMol(*dynamic_cast<RWMol *>(zipProdMol.get()));
+  return zipProdMol;
 }
 
 std::map<std::string, std::vector<ROMol *>> mapFragsBySmiles(


### PR DESCRIPTION
#### Reference Issue
No issue.

#### What does this implement/fix? Explain your changes.
As suggested as part of review of #9305, replaces combineMols with RWMol::insertMol, hopefully for a performance gain. 

#### Any other comments?

