### PR TITLE
Some minor changes to GaussianShape

### DIFF
--- a/Code/GraphMol/GaussianShape/ShapeInput.cpp
+++ b/Code/GraphMol/GaussianShape/ShapeInput.cpp
@@ -126,8 +126,6 @@ ShapeInput::ShapeInput(const ROMol &mol, const int confId,
   PRECONDITION(mol.getNumConformers() > 0,
                "ShapeInput object needs the molecule to have conformers.  " +
                    mol.getProp<std::string>("_Name") + "  " + MolToSmiles(mol));
-  // std::cout << "making shape from " << MolToSmiles(mol) << " with "
-  // << mol.getNumConformers() << " confs" << std::endl;
   std::unique_ptr<RWMol> tmpMol;
   // Subsetting the molecule makes any bespoke atom radii, identified
   // by atom index, incorrect so stash them as atom properties.
@@ -142,7 +140,6 @@ ShapeInput::ShapeInput(const ROMol &mol, const int confId,
     tmpMol.reset(new RWMol(mol));
   }
   d_smiles = MolToSmiles(*tmpMol);
-  // std::cout << "shape smiles : " << d_smiles << std::endl;
   std::vector<unsigned int> atOrder;
   tmpMol->getProp(common_properties::_smilesAtomOutputOrder, atOrder);
   tmpMol.reset(dynamic_cast<RWMol *>(MolOps::renumberAtoms(*tmpMol, atOrder)));
@@ -263,12 +260,14 @@ ShapeInput &ShapeInput::operator=(const ShapeInput &other) {
   return *this;
 }
 
-void ShapeInput::merge(ShapeInput &other) {
-  PRECONDITION(d_smiles == other.d_smiles,
-               "Shapes have different SMILES strings.");
+void ShapeInput::merge(ShapeInput &&other) {
   if (!d_coords.empty() &&
       d_coords.front().size() != other.d_coords.front().size()) {
     BOOST_LOG(rdWarningLog) << "Can't merge shapes as different sizes.\n";
+    return;
+  }
+  if (d_types != other.d_types) {
+    BOOST_LOG(rdWarningLog) << "Can't merge shapes as different types.\n";
     return;
   }
   if (other.d_coords.empty()) {

--- a/Code/GraphMol/GaussianShape/ShapeInput.h
+++ b/Code/GraphMol/GaussianShape/ShapeInput.h
@@ -159,7 +159,9 @@ class RDKIT_GAUSSIANSHAPE_EXPORT ShapeInput {
 
   //! Merge the other ShapeInput, assuming it has the correct number
   //! of atoms etc.  Empties other, unless they can't be merged in which case
-  //! it returns unscathed.
+  //! it returns unscathed.  The can only be done if other has the same
+  // number of coordinates per conformer, and the feature types of the two
+  // match.
   void merge(ShapeInput &&other);
 
   std::string toString() const {

--- a/Code/GraphMol/GaussianShape/ShapeInput.h
+++ b/Code/GraphMol/GaussianShape/ShapeInput.h
@@ -160,7 +160,7 @@ class RDKIT_GAUSSIANSHAPE_EXPORT ShapeInput {
   //! Merge the other ShapeInput, assuming it has the correct number
   //! of atoms etc.  Empties other, unless they can't be merged in which case
   //! it returns unscathed.
-  void merge(ShapeInput &other);
+  void merge(ShapeInput &&other);
 
   std::string toString() const {
 #ifndef RDK_USE_BOOST_SERIALIZATION
@@ -309,8 +309,7 @@ class RDKIT_GAUSSIANSHAPE_EXPORT ShapeInput {
   // alpha is KAPPA / (r * r) where r is the radius
   // of the atom.  This is not used if using all_atoms_carbon mode.
   std::vector<int> d_types;  // The feature types.  The size is the same
-  // as the number of coordinates, padded with 0
-  // for the atoms.
+  // as the number of atoms and features, padded with 0 for the atoms.
   unsigned int d_numAtoms;                     // The number of atoms
   unsigned int d_numFeats;                     // The number of features
   std::vector<double> d_selfOverlapShapeVols;  // Shape volume

--- a/Code/GraphMol/GaussianShape/ShapeInput.h
+++ b/Code/GraphMol/GaussianShape/ShapeInput.h
@@ -159,7 +159,7 @@ class RDKIT_GAUSSIANSHAPE_EXPORT ShapeInput {
 
   //! Merge the other ShapeInput, assuming it has the correct number
   //! of atoms etc.  Empties other, unless they can't be merged in which case
-  //! it returns unscathed.  The can only be done if other has the same
+  //! it returns unscathed.  The merge can only be done if other has the same
   // number of coordinates per conformer, and the feature types of the two
   // match.
   void merge(ShapeInput &&other);


### PR DESCRIPTION
#### Reference Issue
No issue.


#### What does this implement/fix? Explain your changes.
Whilst merging master after PR #9265 into PR #9279, a few things cropped up.
Firstly, in his review of #9279 @d-b-w requested a change to the signature of ShapeInput::merge() function to show that other is altered by the merge.
Also in that function, the PRECONDITION that the SMILES of this and other matched turned out to be too strict.  The SynthonSpace shape searching puts all stereoisomers of a molecule into the same shape, and the PRECONDITION broke that.   The new test on the types of the Gaussians is not very strict, since all atoms have type 0 but better than nothing.  I thought about checking the d_alphas but that would be prone to floating point issues.
There were a couple of commented out debugging writes.

#### Any other comments?

