### PR TITLE
Catch zero-length vector in getAtomSymbolAndOrientation.

### DIFF
--- a/Code/GraphMol/MolDraw2D/DrawMol.cpp
+++ b/Code/GraphMol/MolDraw2D/DrawMol.cpp
@@ -4082,10 +4082,14 @@ bool isLinearAtom(const Atom &atom, const std::vector<Point2D> &atCds) {
     ROMol const &mol = atom.getOwningMol();
     int i = 0;
     for (auto nbr : make_iterator_range(mol.getAtomNeighbors(&atom))) {
-      Point2D bond_vec = at1_cds.directionVector(atCds[nbr]);
-      bond_vec.normalize();
-      bond_vecs[i] = bond_vec;
-      bts[i] = mol.getBondBetweenAtoms(atom.getIdx(), nbr)->getBondType();
+      try {
+        Point2D bond_vec = at1_cds.directionVector(atCds[nbr]);
+        bond_vecs[i] = bond_vec;
+        bts[i] = mol.getBondBetweenAtoms(atom.getIdx(), nbr)->getBondType();
+      } catch (std::runtime_error &e) {
+        // A zero-length vector throws and can be ignored.
+        continue;
+      }
       ++i;
     }
     return (bts[0] == bts[1] && bond_vecs[0].dotProduct(bond_vecs[1]) < -0.95);

--- a/Code/GraphMol/MolDraw2D/catch_tests.cpp
+++ b/Code/GraphMol/MolDraw2D/catch_tests.cpp
@@ -379,7 +379,8 @@ const std::map<std::string, std::hash_result_t> SVG_HASHES = {
     {"test_Github9280_1.0.svg", 1658116840U},
     {"test_Github9280_2.0.svg", 1805554327U},
     {"test_Github9280_0.3.svg", 893100468U},
-    {"test_Github9280_0.2.svg", 770838895U}};
+    {"test_Github9280_0.2.svg", 770838895U},
+    {"testGithub9329_1.svg", 2464826369U}};
 
 // These PNG hashes aren't completely reliable due to floating point cruft,
 // but they can still reduce the number of drawings that need visual
@@ -11482,4 +11483,20 @@ TEST_CASE("Uniform bond colour") {
       std::distance(std::sregex_iterator(text.begin(), text.end(), bond2),
                     std::sregex_iterator()));
   CHECK(match_count0 == 1);
+}
+
+TEST_CASE("Github 9329 - zero length vector") {
+  auto m1 = "CCO |(0.0, 0.0,;0.0,0.0,;1.0,0.0,;)|"_smiles;
+  REQUIRE(m1);
+  MolDraw2DSVG drawer(400, 400);
+  MolDraw2DUtils::prepareMolForDrawing(*m1);
+  drawer.drawMolecule(*m1);
+  drawer.finishDrawing();
+  std::string text = drawer.getDrawingText();
+  std::ofstream outs("testGithub9329_1.svg");
+  outs << text;
+  outs.close();
+  // It used to throw an exception, so the test is just that we got something.
+  CHECK(!text.empty());
+  check_file_hash("testGithub9329_1.svg");
 }


### PR DESCRIPTION
#### Reference Issue
Fixes #9329


#### What does this implement/fix? Explain your changes.
Catches the exception thrown by directionVector when trying to work out the orientation of atom labels.

#### Any other comments?
I believe that the try has no overhead, so this should be faster than testing the length before calling thus giving 2 length tests. Unwinding the exception will be slow, but that should be rare.  Indeed, this code hasn't been changed since 2022 and it's the first time someone has noticed the problem :-). 
