### PR TITLE
Catch a few more potential zero length vectors.

### DIFF
--- a/Code/GraphMol/MolDraw2D/DrawMol.cpp
+++ b/Code/GraphMol/MolDraw2D/DrawMol.cpp
@@ -792,62 +792,66 @@ void DrawMol::extractBrackets() {
       // bracket is largely horizontal or largely vertical.
       const auto &brkShp = *postShapes_.back();
       Point2D longline = brkShp.points_[1] - brkShp.points_[2];
-      longline.normalize();
-      static const double cos45 = 1.0 / sqrt(2.0);
-      bool horizontal = fabs(longline.x) > cos45;
-      size_t labelBrk = postShapes_.size() - 1;
-      for (int i = 1; i < numBrackets; ++i) {
-        const auto &brkShp = *postShapes_[postShapes_.size() - i - 1];
-        if (horizontal) {
-          if (brkShp.points_[2].y > postShapes_[labelBrk]->points_[2].y) {
-            labelBrk = postShapes_.size() - i - 1;
+      try {
+        longline.normalize();
+        static const double cos45 = 1.0 / sqrt(2.0);
+        bool horizontal = fabs(longline.x) > cos45;
+        size_t labelBrk = postShapes_.size() - 1;
+        for (int i = 1; i < numBrackets; ++i) {
+          const auto &brkShp = *postShapes_[postShapes_.size() - i - 1];
+          if (horizontal) {
+            if (brkShp.points_[2].y > postShapes_[labelBrk]->points_[2].y) {
+              labelBrk = postShapes_.size() - i - 1;
+            }
+          } else {
+            if (brkShp.points_[2].x > postShapes_[labelBrk]->points_[2].x) {
+              labelBrk = postShapes_.size() - i - 1;
+            }
           }
-        } else {
-          if (brkShp.points_[2].x > postShapes_[labelBrk]->points_[2].x) {
-            labelBrk = postShapes_.size() - i - 1;
+        }
+        std::string connect;
+        if (sg.getPropIfPresent("CONNECT", connect)) {
+          // annotations go on the last bracket of an sgroup
+          const auto &brkShp = *postShapes_[labelBrk];
+          // CONNECT goes at the top, but that's now the bottom due to the y
+          // inversion
+          auto botPt = brkShp.points_[2];
+          auto brkPt = brkShp.points_[3];
+          if ((!horizontal && brkShp.points_[1].y < botPt.y) ||
+              (horizontal && brkShp.points_[1].x > botPt.x)) {
+            botPt = brkShp.points_[1];
+            brkPt = brkShp.points_[0];
+              }
+          DrawAnnotation *da = new DrawAnnotation(
+              connect, TextAlignType::MIDDLE, "connect",
+              drawOptions_.annotationFontScale, botPt + (botPt - brkPt),
+              DrawColour(0.0, 0.0, 0.0), textDrawer_);
+          // if we're to the right of the bracket, we need to left justify,
+          // otherwise things seem to work as is
+          if (brkPt.x < botPt.x) {
+            da->align_ = TextAlignType::START;
           }
+          annotations_.emplace_back(da);
         }
-      }
-      std::string connect;
-      if (sg.getPropIfPresent("CONNECT", connect)) {
-        // annotations go on the last bracket of an sgroup
-        const auto &brkShp = *postShapes_[labelBrk];
-        // CONNECT goes at the top, but that's now the bottom due to the y
-        // inversion
-        auto botPt = brkShp.points_[2];
-        auto brkPt = brkShp.points_[3];
-        if ((!horizontal && brkShp.points_[1].y < botPt.y) ||
-            (horizontal && brkShp.points_[1].x > botPt.x)) {
-          botPt = brkShp.points_[1];
-          brkPt = brkShp.points_[0];
-        }
-        DrawAnnotation *da = new DrawAnnotation(
-            connect, TextAlignType::MIDDLE, "connect",
-            drawOptions_.annotationFontScale, botPt + (botPt - brkPt),
-            DrawColour(0.0, 0.0, 0.0), textDrawer_);
-        // if we're to the right of the bracket, we need to left justify,
-        // otherwise things seem to work as is
-        if (brkPt.x < botPt.x) {
-          da->align_ = TextAlignType::START;
-        }
-        annotations_.emplace_back(da);
-      }
 
-      std::string label;
-      if (sg.getPropIfPresent("LABEL", label)) {
-        auto da = drawBottomLabel(label, *postShapes_[labelBrk], drawOptions_,
-                                  textDrawer_, horizontal);
-        annotations_.emplace_back(da);
-      } else if (sg.getPropIfPresent("TYPE", label)) {
-        if (label == "GEN") {
-          // ChemDraw doesn't draw the GEN (type=generic) label.
-          continue;
+        std::string label;
+        if (sg.getPropIfPresent("LABEL", label)) {
+          auto da = drawBottomLabel(label, *postShapes_[labelBrk], drawOptions_,
+                                    textDrawer_, horizontal);
+          annotations_.emplace_back(da);
+        } else if (sg.getPropIfPresent("TYPE", label)) {
+          if (label == "GEN") {
+            // ChemDraw doesn't draw the GEN (type=generic) label.
+            continue;
+          }
+          // draw the lowercase type if there's no label to go there.
+          std::transform(label.begin(), label.end(), label.begin(), ::tolower);
+          auto da = drawBottomLabel(label, *postShapes_[labelBrk], drawOptions_,
+                                    textDrawer_, horizontal);
+          annotations_.emplace_back(da);
         }
-        // draw the lowercase type if there's no label to go there.
-        std::transform(label.begin(), label.end(), label.begin(), ::tolower);
-        auto da = drawBottomLabel(label, *postShapes_[labelBrk], drawOptions_,
-                                  textDrawer_, horizontal);
-        annotations_.emplace_back(da);
+      } catch (std::runtime_error &e) {
+        // the bracket had no length so can be ignored.
       }
     }
   }
@@ -2878,13 +2882,12 @@ double DrawMol::getNoteStartAngle(const Atom *atom) const {
     // If the nbr has the same coords as atom, bond_vec comes out as NaN, NaN
     // (issue 6559), so use a short arbitrary vector instead.
     Point2D bond_vec;
-    if ((at_cds - atCds_[nbr]).lengthSq() < 0.0001) {
-      bond_vec.x = 0.1;
-      bond_vec.y = 0.1;
-    } else {
+    try {
       bond_vec = at_cds.directionVector(atCds_[nbr]);
+    } catch (const std::runtime_error &e) {
+      bond_vec.x = 0.7071;
+      bond_vec.y = 0.7071;
     }
-    bond_vec.normalize();
     bond_vecs.push_back(bond_vec);
   }
 
@@ -3653,15 +3656,15 @@ Point2D DrawMol::doubleBondEnd(unsigned int at1, unsigned int at2,
   v23perp.normalize();
 
   Point2D bis = v21 + v23;
-  if (bis.lengthSq() < 1.0e-6) {
+  try {
+    bis.normalize();
+  } catch (std::exception &e) {
     // if the bonds are colinear, bis comes out as 0, and thus normalizes
     // to NaN which gives a very ugly result (Github #6027).  It's safe
-    // to use v23perp in this case, so long as is on the right side of the
+    // to use v23perp in this case, so long as it is on the right side of the
     // bond, which will be checked on return.
     return (atCds_[at2] - v23perp * offset);
   }
-
-  bis.normalize();
   if (v23perp.dotProduct(bis) < 0.0) {
     v23perp = v23perp * -1.0;
   }

--- a/Code/GraphMol/MolDraw2D/DrawMol.cpp
+++ b/Code/GraphMol/MolDraw2D/DrawMol.cpp
@@ -794,64 +794,65 @@ void DrawMol::extractBrackets() {
       Point2D longline = brkShp.points_[1] - brkShp.points_[2];
       try {
         longline.normalize();
-        static const double cos45 = 1.0 / sqrt(2.0);
-        bool horizontal = fabs(longline.x) > cos45;
-        size_t labelBrk = postShapes_.size() - 1;
-        for (int i = 1; i < numBrackets; ++i) {
-          const auto &brkShp = *postShapes_[postShapes_.size() - i - 1];
-          if (horizontal) {
-            if (brkShp.points_[2].y > postShapes_[labelBrk]->points_[2].y) {
-              labelBrk = postShapes_.size() - i - 1;
-            }
-          } else {
-            if (brkShp.points_[2].x > postShapes_[labelBrk]->points_[2].x) {
-              labelBrk = postShapes_.size() - i - 1;
-            }
-          }
-        }
-        std::string connect;
-        if (sg.getPropIfPresent("CONNECT", connect)) {
-          // annotations go on the last bracket of an sgroup
-          const auto &brkShp = *postShapes_[labelBrk];
-          // CONNECT goes at the top, but that's now the bottom due to the y
-          // inversion
-          auto botPt = brkShp.points_[2];
-          auto brkPt = brkShp.points_[3];
-          if ((!horizontal && brkShp.points_[1].y < botPt.y) ||
-              (horizontal && brkShp.points_[1].x > botPt.x)) {
-            botPt = brkShp.points_[1];
-            brkPt = brkShp.points_[0];
-              }
-          DrawAnnotation *da = new DrawAnnotation(
-              connect, TextAlignType::MIDDLE, "connect",
-              drawOptions_.annotationFontScale, botPt + (botPt - brkPt),
-              DrawColour(0.0, 0.0, 0.0), textDrawer_);
-          // if we're to the right of the bracket, we need to left justify,
-          // otherwise things seem to work as is
-          if (brkPt.x < botPt.x) {
-            da->align_ = TextAlignType::START;
-          }
-          annotations_.emplace_back(da);
-        }
-
-        std::string label;
-        if (sg.getPropIfPresent("LABEL", label)) {
-          auto da = drawBottomLabel(label, *postShapes_[labelBrk], drawOptions_,
-                                    textDrawer_, horizontal);
-          annotations_.emplace_back(da);
-        } else if (sg.getPropIfPresent("TYPE", label)) {
-          if (label == "GEN") {
-            // ChemDraw doesn't draw the GEN (type=generic) label.
-            continue;
-          }
-          // draw the lowercase type if there's no label to go there.
-          std::transform(label.begin(), label.end(), label.begin(), ::tolower);
-          auto da = drawBottomLabel(label, *postShapes_[labelBrk], drawOptions_,
-                                    textDrawer_, horizontal);
-          annotations_.emplace_back(da);
-        }
       } catch (std::runtime_error &e) {
         // the bracket had no length so can be ignored.
+        continue;
+      }
+      static const double cos45 = 1.0 / sqrt(2.0);
+      bool horizontal = fabs(longline.x) > cos45;
+      size_t labelBrk = postShapes_.size() - 1;
+      for (int i = 1; i < numBrackets; ++i) {
+        const auto &brkShp = *postShapes_[postShapes_.size() - i - 1];
+        if (horizontal) {
+          if (brkShp.points_[2].y > postShapes_[labelBrk]->points_[2].y) {
+            labelBrk = postShapes_.size() - i - 1;
+          }
+        } else {
+          if (brkShp.points_[2].x > postShapes_[labelBrk]->points_[2].x) {
+            labelBrk = postShapes_.size() - i - 1;
+          }
+        }
+      }
+      std::string connect;
+      if (sg.getPropIfPresent("CONNECT", connect)) {
+        // annotations go on the last bracket of an sgroup
+        const auto &brkShp = *postShapes_[labelBrk];
+        // CONNECT goes at the top, but that's now the bottom due to the y
+        // inversion
+        auto botPt = brkShp.points_[2];
+        auto brkPt = brkShp.points_[3];
+        if ((!horizontal && brkShp.points_[1].y < botPt.y) ||
+            (horizontal && brkShp.points_[1].x > botPt.x)) {
+          botPt = brkShp.points_[1];
+          brkPt = brkShp.points_[0];
+        }
+        DrawAnnotation *da = new DrawAnnotation(
+            connect, TextAlignType::MIDDLE, "connect",
+            drawOptions_.annotationFontScale, botPt + (botPt - brkPt),
+            DrawColour(0.0, 0.0, 0.0), textDrawer_);
+        // if we're to the right of the bracket, we need to left justify,
+        // otherwise things seem to work as is
+        if (brkPt.x < botPt.x) {
+          da->align_ = TextAlignType::START;
+        }
+        annotations_.emplace_back(da);
+      }
+
+      std::string label;
+      if (sg.getPropIfPresent("LABEL", label)) {
+        auto da = drawBottomLabel(label, *postShapes_[labelBrk], drawOptions_,
+                                  textDrawer_, horizontal);
+        annotations_.emplace_back(da);
+      } else if (sg.getPropIfPresent("TYPE", label)) {
+        if (label == "GEN") {
+          // ChemDraw doesn't draw the GEN (type=generic) label.
+          continue;
+        }
+        // draw the lowercase type if there's no label to go there.
+        std::transform(label.begin(), label.end(), label.begin(), ::tolower);
+        auto da = drawBottomLabel(label, *postShapes_[labelBrk], drawOptions_,
+                                  textDrawer_, horizontal);
+        annotations_.emplace_back(da);
       }
     }
   }

--- a/Code/GraphMol/MolDraw2D/catch_tests.cpp
+++ b/Code/GraphMol/MolDraw2D/catch_tests.cpp
@@ -379,7 +379,8 @@ const std::map<std::string, std::hash_result_t> SVG_HASHES = {
     {"test_Github9280_1.0.svg", 1658116840U},
     {"test_Github9280_2.0.svg", 1805554327U},
     {"test_Github9280_0.3.svg", 893100468U},
-    {"test_Github9280_0.2.svg", 770838895U}};
+    {"test_Github9280_0.2.svg", 770838895U},
+    {"testZeroLengthBrackets.svg", 1120080272U}};
 
 // These PNG hashes aren't completely reliable due to floating point cruft,
 // but they can still reduce the number of drawings that need visual
@@ -2154,6 +2155,48 @@ M  END
       outs << text;
       outs.close();
       check_file_hash("testBrackets-5768.svg");
+    }
+  }
+  SECTION("zero length bracket") {
+    auto m = R"CTAB(
+  ACCLDraw11042015112D
+
+  0  0  0     0  0            999 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 5 4 1 0 0
+M  V30 BEGIN ATOM
+M  V30 1 C 7 -6.7813 0 0
+M  V30 2 C 8.0229 -6.1907 0 0 CFG=3
+M  V30 3 C 8.0229 -5.0092 0 0
+M  V30 4 C 9.046 -6.7814 0 0
+M  V30 5 C 10.0692 -6.1907 0 0
+M  V30 END ATOM
+M  V30 BEGIN BOND
+M  V30 1 1 1 2
+M  V30 2 1 2 3
+M  V30 3 1 2 4
+M  V30 4 1 4 5
+M  V30 END BOND
+M  V30 BEGIN SGROUP
+M  V30 1 SRU 1 ATOMS=(3 3 2 4) XBONDS=(2 1 4) BRKXYZ=(9 7.51 -7.08 0 7.51 -
+M  V30 -5.9 0 0 0 0) BRKXYZ=(9 9.56 -5.9 0 9.56 -5.9 0 0 0 0) -
+M  V30 CONNECT=HT LABEL=n
+M  V30 END SGROUP
+M  V30 END CTAB
+M  END
+)CTAB"_ctab;
+    REQUIRE(m);
+    {
+      // Before, it would throw a zero length exception, so the fact
+      // that it gives a file is test enough.
+      MolDraw2DSVG drawer(350, 300);
+      drawer.drawMolecule(*m);
+      drawer.finishDrawing();
+      auto text = drawer.getDrawingText();
+      std::ofstream outs("testZeroLengthBrackets.svg");
+      outs << text;
+      outs.close();
+      check_file_hash("testZeroLengthBrackets.svg");
     }
   }
 }


### PR DESCRIPTION
#### Reference Issue
No issue, but follows on from #9329

#### What does this implement/fix? Explain your changes.
3 more cases where the code could potentially throw zero length vector errors.
2 of the changes are just tidying the existing detection which involved duplicate length calculations and already have tests.  The other is drawing brackets around polymer units for which a test is added.

#### Any other comments?
I have checked that not of the drawings change compared with master.

