### PR TITLE
Remove unused imports from python tests

### DIFF
--- a/Code/ChemicalFeatures/Wrap/testFeatures.py
+++ b/Code/ChemicalFeatures/Wrap/testFeatures.py
@@ -8,10 +8,9 @@
 import io
 import os
 import pickle
-import sys
 import unittest
 
-from rdkit import Chem, RDConfig
+from rdkit import RDConfig
 from rdkit.Chem import ChemicalFeatures
 from rdkit.Geometry import rdGeometry as geom
 

--- a/Code/DataManip/MetricMatrixCalc/Wrap/testMatricCalc.py
+++ b/Code/DataManip/MetricMatrixCalc/Wrap/testMatricCalc.py
@@ -3,7 +3,7 @@ import unittest
 
 import numpy
 
-from rdkit import DataStructs, RDConfig
+from rdkit import DataStructs
 from rdkit.DataManip.Metric import rdMetricMatrixCalc as rdmmc
 
 

--- a/Code/DataStructs/Wrap/testBV.py
+++ b/Code/DataStructs/Wrap/testBV.py
@@ -4,7 +4,7 @@ import unittest
 
 import numpy
 
-from rdkit import DataStructs, RDConfig
+from rdkit import DataStructs
 
 
 def feq(a, b, tol=1e-4):

--- a/Code/DataStructs/Wrap/testRealValueVect.py
+++ b/Code/DataStructs/Wrap/testRealValueVect.py
@@ -4,7 +4,7 @@
 
 from __future__ import print_function, unicode_literals
 from rdkit import RDConfig
-import os, sys, pickle
+import os, pickle
 import unittest
 from rdkit import DataStructs as ds
 

--- a/Code/DataStructs/Wrap/testSparseIntVect.py
+++ b/Code/DataStructs/Wrap/testSparseIntVect.py
@@ -8,7 +8,6 @@ import io
 import os
 import pickle
 import random
-import sys
 import unittest
 
 from rdkit import DataStructs as ds

--- a/Code/ForceField/Wrap/testConstraints.py
+++ b/Code/ForceField/Wrap/testConstraints.py
@@ -1,10 +1,9 @@
-import os
 import sys
 import unittest
 from multiprocessing import Process, Value
 from time import sleep
 
-from rdkit import Chem, RDConfig
+from rdkit import Chem
 from rdkit.Chem import ChemicalForceFields, rdMolTransforms
 
 

--- a/Code/Geometry/Wrap/testGeometry.py
+++ b/Code/Geometry/Wrap/testGeometry.py
@@ -1,11 +1,9 @@
 import copy
 import math
-import os
 import pickle
-import sys
 import unittest
 
-from rdkit import DataStructs, RDConfig
+from rdkit import DataStructs
 from rdkit.Geometry import rdGeometry as geom
 
 

--- a/Code/GraphMol/ChemReactions/Wrap/testEnumerations.py
+++ b/Code/GraphMol/ChemReactions/Wrap/testEnumerations.py
@@ -32,14 +32,13 @@
 import copy
 import itertools
 import os
-import pickle
 import sys
 import time
 import unittest
 
 import numpy as np
 
-from rdkit import Chem, Geometry, RDConfig, rdBase
+from rdkit import Chem, RDConfig, rdBase
 from rdkit.Chem import AllChem, rdChemReactions
 
 

--- a/Code/GraphMol/ChemReactions/Wrap/testReactionWrapper.py
+++ b/Code/GraphMol/ChemReactions/Wrap/testReactionWrapper.py
@@ -33,11 +33,10 @@ import doctest
 import importlib.util
 import os
 import pickle
-import sys
 import unittest
 import tempfile
 
-from rdkit import Chem, Geometry, RDConfig, rdBase
+from rdkit import Chem, RDConfig
 from rdkit.Chem import AllChem, rdChemReactions
 from rdkit.Chem.SimpleEnum import Enumerator
 

--- a/Code/GraphMol/ChemReactions/Wrap/testSanitize.py
+++ b/Code/GraphMol/ChemReactions/Wrap/testSanitize.py
@@ -29,14 +29,10 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-import itertools
-import os
 import pickle
-import sys
-import time
 import unittest
 
-from rdkit import Chem, Geometry, RDConfig, rdBase
+from rdkit import Chem
 from rdkit.Chem import AllChem, rdChemReactions
 
 test_data = [

--- a/Code/GraphMol/Descriptors/Wrap/testMolDescriptors.py
+++ b/Code/GraphMol/Descriptors/Wrap/testMolDescriptors.py
@@ -3,10 +3,9 @@ from os import environ
 from pathlib import Path
 import re
 
-from rdkit import Chem, DataStructs, RDConfig
+from rdkit import Chem, DataStructs
 from rdkit.Chem import AllChem, Descriptors
 from rdkit.Chem import rdMolDescriptors as rdMD
-from rdkit.Geometry import rdGeometry as rdG
 
 haveBCUT = hasattr(rdMD, 'BCUT2D')
 

--- a/Code/GraphMol/FMCS/Wrap/testFMCS.py
+++ b/Code/GraphMol/FMCS/Wrap/testFMCS.py
@@ -1,4 +1,3 @@
-import sys
 import unittest
 
 from rdkit import Chem

--- a/Code/GraphMol/FilterCatalog/Wrap/rough_test.py
+++ b/Code/GraphMol/FilterCatalog/Wrap/rough_test.py
@@ -39,11 +39,10 @@ import os
 import pickle
 import unittest
 
-from rdkit import RDConfig
 from rdkit.RDLogger import logger
 
 logger = logger()
-from rdkit import Chem, DataStructs, rdBase
+from rdkit import Chem, rdBase
 from rdkit.Chem import FilterCatalog, rdfiltercatalog, rdMolDescriptors
 from rdkit.Chem.FilterCatalog import FilterCatalogParams, FilterMatchOps
 

--- a/Code/GraphMol/FragCatalog/Wrap/rough_test.py
+++ b/Code/GraphMol/FragCatalog/Wrap/rough_test.py
@@ -16,7 +16,7 @@ from rdkit import RDConfig
 from rdkit.RDLogger import logger
 
 logger = logger()
-from rdkit import Chem, DataStructs
+from rdkit import Chem
 from rdkit.Chem import FragmentCatalog
 
 

--- a/Code/GraphMol/GaussianShape/Wrap/test_rdgaussian_shape.py
+++ b/Code/GraphMol/GaussianShape/Wrap/test_rdgaussian_shape.py
@@ -1,8 +1,7 @@
 import unittest
-import numpy as np
 
 from rdkit import Chem
-from rdkit.Chem import rdGaussianShape, rdMolTransforms, rdDistGeom
+from rdkit.Chem import rdGaussianShape
 from rdkit import RDConfig
 from rdkit.Geometry import Point3D
 

--- a/Code/GraphMol/MMPA/Wrap/testMMPA.py
+++ b/Code/GraphMol/MMPA/Wrap/testMMPA.py
@@ -1,6 +1,6 @@
 import unittest
 
-from rdkit import Chem, RDConfig
+from rdkit import Chem
 from rdkit.Chem import rdMMPA
 
 

--- a/Code/GraphMol/MolCatalog/Wrap/rough_test.py
+++ b/Code/GraphMol/MolCatalog/Wrap/rough_test.py
@@ -2,12 +2,10 @@
 #
 #  Copyright (C) 2006  Greg Landrum
 #
-import os
 import pickle
-import sys
 import unittest
 
-from rdkit import Chem, DataStructs, RDConfig
+from rdkit import Chem
 from rdkit.Chem import MolCatalog
 
 

--- a/Code/GraphMol/MolDraw2D/Qt/Wrap/testMolDraw2DQt.py
+++ b/Code/GraphMol/MolDraw2D/Qt/Wrap/testMolDraw2DQt.py
@@ -1,8 +1,8 @@
 import sys
 import unittest
 
-from rdkit import Chem, RDConfig
-from rdkit.Chem import AllChem, Draw, rdDepictor
+from rdkit import Chem
+from rdkit.Chem import Draw
 from rdkit.Chem.Draw import rdMolDraw2DQt
 
 try:

--- a/Code/GraphMol/MolDraw2D/Wrap/testMolDraw2D.py
+++ b/Code/GraphMol/MolDraw2D/Wrap/testMolDraw2D.py
@@ -5,7 +5,7 @@ from os import environ
 
 import numpy as np
 
-from rdkit import Chem, Geometry, RDConfig
+from rdkit import Chem, Geometry
 from rdkit.Chem import AllChem, Draw, rdDepictor
 from rdkit.Chem.Draw import rdMolDraw2D
 

--- a/Code/GraphMol/MolDraw2D/test_dir/test_rdkit_draw.py
+++ b/Code/GraphMol/MolDraw2D/test_dir/test_rdkit_draw.py
@@ -1,9 +1,8 @@
 #!/usr/bin/env python
 
-import os
 import sys
 
-from rdkit import Chem, RDConfig
+from rdkit import Chem
 from rdkit.Chem import AllChem, Draw
 
 suppl = Chem.SDMolSupplier()

--- a/Code/GraphMol/MolEnumerator/Wrap/rough_test.py
+++ b/Code/GraphMol/MolEnumerator/Wrap/rough_test.py
@@ -10,7 +10,7 @@
 
 import unittest
 
-from rdkit import Chem, RDConfig
+from rdkit import Chem
 from rdkit.Chem import rdMolEnumerator
 
 

--- a/Code/GraphMol/MolHash/Wrap/testMolHash.py
+++ b/Code/GraphMol/MolHash/Wrap/testMolHash.py
@@ -1,8 +1,6 @@
-import os
-import sys
 import unittest
 
-from rdkit import Chem, RDConfig
+from rdkit import Chem
 from rdkit.Chem import rdMolHash
 
 

--- a/Code/GraphMol/MolInteractionFields/Wrap/testMIF.py
+++ b/Code/GraphMol/MolInteractionFields/Wrap/testMIF.py
@@ -1,13 +1,10 @@
 from __future__ import print_function
-import os, sys
+import os
 import unittest
 import copy
-from rdkit import DataStructs, RDConfig
+from rdkit import RDConfig
 from rdkit.Geometry import rdGeometry as geom
 from rdkit.Chem import rdMIF, AllChem
-import math
-import numpy as np
-import pickle
 
 
 def feq(v1, v2, tol=1.0e-4):

--- a/Code/GraphMol/MolInterchange/Wrap/testMolInterchange.py
+++ b/Code/GraphMol/MolInterchange/Wrap/testMolInterchange.py
@@ -1,6 +1,6 @@
 import unittest
 
-from rdkit import Chem, RDConfig
+from rdkit import Chem
 from rdkit.Chem import rdMolInterchange
 
 

--- a/Code/GraphMol/MolStandardize/Wrap/testMolStandardize.py
+++ b/Code/GraphMol/MolStandardize/Wrap/testMolStandardize.py
@@ -2,17 +2,15 @@
 # Copyright (C) 2018-2025 Susan H. Leung and other RDKit contributors
 #         All Rights Reserved
 #
-import math
 import os
 import sys
 import unittest
 from datetime import datetime, timedelta
 
-from rdkit import Chem, DataStructs, RDConfig
+from rdkit import Chem, RDConfig
 from rdkit.Chem.MolStandardize import rdMolStandardize
 from rdkit.Chem import inchi, rdCIPLabeler
 from rdkit.Chem.rdchem import Atom
-from rdkit.Geometry import rdGeometry as geom
 
 
 class TestCase(unittest.TestCase):

--- a/Code/GraphMol/MolTransforms/Wrap/testMolTransforms.py
+++ b/Code/GraphMol/MolTransforms/Wrap/testMolTransforms.py
@@ -1,11 +1,10 @@
 import math
 import os
-import sys
 import unittest
 
 import numpy as np
 
-from rdkit import Chem, DataStructs, RDConfig
+from rdkit import Chem, RDConfig
 from rdkit.Chem import rdMolTransforms as rdmt
 from rdkit.Geometry import rdGeometry as geom
 

--- a/Code/GraphMol/ReducedGraphs/Wrap/testReducedGraphs.py
+++ b/Code/GraphMol/ReducedGraphs/Wrap/testReducedGraphs.py
@@ -2,9 +2,8 @@
 #
 import unittest
 
-import numpy
 
-from rdkit import Chem, RDConfig
+from rdkit import Chem
 from rdkit.Chem import rdReducedGraphs as rdRG
 
 

--- a/Code/GraphMol/SLNParse/Wrap/testSLN.py
+++ b/Code/GraphMol/SLNParse/Wrap/testSLN.py
@@ -33,10 +33,9 @@
 # Created by Greg Landrum, September 2006
 #
 import os
-import sys
 import unittest
 
-from rdkit import Chem, Geometry, RDConfig
+from rdkit import Chem, RDConfig
 from rdkit.Chem import rdSLNParse
 
 

--- a/Code/GraphMol/ScaffoldNetwork/Wrap/testPickleScaffoldNetwork.py
+++ b/Code/GraphMol/ScaffoldNetwork/Wrap/testPickleScaffoldNetwork.py
@@ -11,7 +11,7 @@
 import pickle
 import unittest
 
-from rdkit import Chem, RDConfig, rdBase
+from rdkit import Chem, rdBase
 from rdkit.Chem.Scaffolds import rdScaffoldNetwork
 
 rdBase.DisableLog("rdApp.info")

--- a/Code/GraphMol/ScaffoldNetwork/Wrap/testScaffoldNetwork.py
+++ b/Code/GraphMol/ScaffoldNetwork/Wrap/testScaffoldNetwork.py
@@ -8,10 +8,9 @@
 #  of the RDKit source tree.
 #
 
-import pickle
 import unittest
 
-from rdkit import Chem, RDConfig, rdBase
+from rdkit import Chem, rdBase
 from rdkit.Chem.Scaffolds import rdScaffoldNetwork
 
 rdBase.DisableLog("rdApp.info")

--- a/Code/GraphMol/ShapeHelpers/Wrap/testShapeHelpers.py
+++ b/Code/GraphMol/ShapeHelpers/Wrap/testShapeHelpers.py
@@ -1,6 +1,4 @@
-import math
 import os
-import sys
 import unittest
 
 from rdkit import Chem, DataStructs, RDConfig

--- a/Code/GraphMol/SubstructLibrary/Wrap/rough_test.py
+++ b/Code/GraphMol/SubstructLibrary/Wrap/rough_test.py
@@ -37,10 +37,9 @@ it is intended to be shallow but broad.
 import doctest
 import logging
 import os
-import sys
 import unittest
 
-from rdkit import RDConfig, RDLogger, rdBase
+from rdkit import RDLogger, rdBase
 from rdkit.RDLogger import logger
 
 logger = logger()
@@ -49,7 +48,7 @@ import tempfile
 import time
 
 from rdkit import Chem
-from rdkit.Chem import rdSubstructLibrary, rdGeneralizedSubstruct, rdTautomerQuery
+from rdkit.Chem import rdSubstructLibrary, rdGeneralizedSubstruct
 
 
 def load_tests(loader, tests, ignore):

--- a/Code/GraphMol/SynthonSpaceSearch/Wrap/testSynthonSpaceSearch.py
+++ b/Code/GraphMol/SynthonSpaceSearch/Wrap/testSynthonSpaceSearch.py
@@ -37,9 +37,9 @@ import unittest
 
 from pathlib import Path
 
-from rdkit import Chem, rdBase
+from rdkit import Chem
 from rdkit.Chem import (rdSynthonSpaceSearch, rdFingerprintGenerator,
-                        rdRascalMCES, rdGeneralizedSubstruct, rdMolDescriptors)
+                        rdRascalMCES, rdGeneralizedSubstruct)
 
 
 class TestCase(unittest.TestCase):

--- a/Code/GraphMol/Wrap/testConformer.py
+++ b/Code/GraphMol/Wrap/testConformer.py
@@ -3,11 +3,9 @@
 #  Copyright (C) 2004  Rational Discovery LLC
 #         All Rights Reserved
 #
-import os
-import sys
 import unittest
 
-from rdkit import Chem, Geometry, RDConfig
+from rdkit import Chem
 from rdkit.Geometry import Point3D
 
 

--- a/Code/GraphMol/Wrap/testGetPropDefault.py
+++ b/Code/GraphMol/Wrap/testGetPropDefault.py
@@ -1,7 +1,6 @@
 import pytest
 
 from rdkit import Chem
-from rdkit.Chem import AllChem
 
 
 # ---------------------------------------------------------------------------

--- a/Code/GraphMol/Wrap/testMultithreadedMolSupplier.py
+++ b/Code/GraphMol/Wrap/testMultithreadedMolSupplier.py
@@ -1,10 +1,8 @@
-import doctest
 import gzip
 import os
-import sys
 import unittest
 
-from rdkit import Chem, RDConfig, __version__, rdBase
+from rdkit import Chem, RDConfig
 
 
 class TestCase(unittest.TestCase):

--- a/Code/GraphMol/Wrap/testPropertyLists.py
+++ b/Code/GraphMol/Wrap/testPropertyLists.py
@@ -5,7 +5,7 @@
 import unittest
 from io import BytesIO
 
-from rdkit import Chem, RDConfig, rdBase
+from rdkit import Chem
 from rdkit.Chem.rdmolops import _TestSetProps
 
 

--- a/Code/GraphMol/Wrap/testSCSR.py
+++ b/Code/GraphMol/Wrap/testSCSR.py
@@ -10,7 +10,6 @@
 
 #
 import os
-import sys
 import unittest
 
 from rdkit import Chem

--- a/Code/GraphMol/Wrap/testSGroups.py
+++ b/Code/GraphMol/Wrap/testSGroups.py
@@ -8,12 +8,9 @@
 #  of the RDKit source tree.
 #
 
-import os
-import sys
 import unittest
 
 from rdkit import Chem, Geometry
-from rdkit.Chem import RDConfig
 
 
 class TestCase(unittest.TestCase):

--- a/Code/GraphMol/Wrap/testThreads.py
+++ b/Code/GraphMol/Wrap/testThreads.py
@@ -1,5 +1,4 @@
 import multiprocessing
-import sys
 import threading
 
 from rdkit import Chem

--- a/Code/GraphMol/Wrap/testTrajectory.py
+++ b/Code/GraphMol/Wrap/testTrajectory.py
@@ -1,9 +1,8 @@
 import os
-import sys
 import unittest
 
-from rdkit import Chem, RDConfig
-from rdkit.Chem import ChemicalForceFields, rdtrajectory
+from rdkit import Chem
+from rdkit.Chem import ChemicalForceFields
 from rdkit.Chem.rdtrajectory import (ReadAmberTrajectory, ReadGromosTrajectory,
                                      Snapshot, Trajectory)
 

--- a/Code/GraphMol/Wrap/test_cdxml.py
+++ b/Code/GraphMol/Wrap/test_cdxml.py
@@ -8,15 +8,8 @@ it's intended to be shallow, but broad
 
 """
 
-import doctest
-import gc
-import gzip
-import logging
 import os
-import sys
-import tempfile
 import unittest
-from io import StringIO
 
 from rdkit import Chem
 

--- a/Code/GraphMol/Wrap/test_subset.py
+++ b/Code/GraphMol/Wrap/test_subset.py
@@ -2,15 +2,7 @@
 #  Copyright (C) 2025 Hussein Faara, Brian Kelley and other RDKit contributors
 #         All Rights Reserved
 #
-import doctest
-import gc
-import gzip
-import logging
-import os
-import sys
-import tempfile
 import unittest
-from io import StringIO
 
 from rdkit import Chem
 

--- a/rdkit/Chem/Draw/UnitTestDraw.py
+++ b/rdkit/Chem/Draw/UnitTestDraw.py
@@ -10,7 +10,6 @@
 import os
 import pathlib
 import re
-import sys
 import tempfile
 import unittest
 

--- a/rdkit/Chem/Draw/UnitTestSimilarityMaps.py
+++ b/rdkit/Chem/Draw/UnitTestSimilarityMaps.py
@@ -33,7 +33,6 @@
 """ unit testing code for molecule drawing
 """
 
-import sys
 import unittest
 
 from rdkit import Chem

--- a/rdkit/Chem/UnitTestChemv2.py
+++ b/rdkit/Chem/UnitTestChemv2.py
@@ -11,11 +11,10 @@
 """basic unit testing code for the rdkit Boost wrapper
 
 """
-import os
 import pickle
 import unittest
 
-from rdkit import Chem, RDConfig
+from rdkit import Chem
 from rdkit.Chem import AllChem
 
 

--- a/rdkit/Chem/UnitTestCrippen.py
+++ b/rdkit/Chem/UnitTestCrippen.py
@@ -15,7 +15,6 @@
 import io
 import os
 import pickle
-import sys
 import unittest
 
 import numpy

--- a/rdkit/Chem/UnitTestEnumerateHeterocycles.py
+++ b/rdkit/Chem/UnitTestEnumerateHeterocycles.py
@@ -1,5 +1,4 @@
 import csv
-import doctest
 import os
 import unittest
 from random import Random

--- a/rdkit/Chem/UnitTestInchi.py
+++ b/rdkit/Chem/UnitTestInchi.py
@@ -337,7 +337,7 @@ class TestMolFromInchiAndAuxInfo(unittest.TestCase):
 
   def test0RoundTripAtomOrder(self):
     """Verify that round-tripping through InChI+AuxInfo preserves atom ordering."""
-    from rdkit.Chem import MolFromSmiles, MolToSmiles
+    from rdkit.Chem import MolFromSmiles
     smiles_list = ['c1ccccc1O', 'CC(=O)O', 'C(=O)(N)C', 'c1cc(O)ccc1N']
     for smi in smiles_list:
       mol = MolFromSmiles(smi)

--- a/rdkit/Chem/UnitTestOldBugs.py
+++ b/rdkit/Chem/UnitTestOldBugs.py
@@ -15,7 +15,6 @@ relevant... but tests are tests
 
 """
 import os
-import pickle
 import unittest
 
 from rdkit import Chem, RDConfig

--- a/rdkit/Chem/UnitTestSmiles.py
+++ b/rdkit/Chem/UnitTestSmiles.py
@@ -12,8 +12,6 @@
 - canonicalization
 - stereo chemistry parsing consistency
 """
-import os
-import pickle
 import unittest
 
 from rdkit import Chem

--- a/rdkit/Chem/test_data/BuildDescrsTestSet.Crippen.py
+++ b/rdkit/Chem/test_data/BuildDescrsTestSet.Crippen.py
@@ -1,5 +1,4 @@
 import os.path
-import pickle
 
 from rdkit import Chem, RDConfig
 from rdkit.Chem import Descriptors

--- a/rdkit/Chem/test_data/BuildDescrsTestSet.py
+++ b/rdkit/Chem/test_data/BuildDescrsTestSet.py
@@ -1,5 +1,4 @@
 import os.path
-import pickle
 
 from rdkit import Chem, RDConfig
 from rdkit.Chem import Descriptors

--- a/rdkit/DataStructs/UnitTestBitEnsemble.py
+++ b/rdkit/DataStructs/UnitTestBitEnsemble.py
@@ -17,7 +17,7 @@ import unittest
 
 from rdkit import RDConfig
 # This import is important to initialize the BitEnsemble module
-from rdkit.DataStructs import BitEnsembleDb, SparseBitVect
+from rdkit.DataStructs import SparseBitVect
 from rdkit.DataStructs.BitEnsemble import BitEnsemble
 
 

--- a/rdkit/UnitTestLogging.py
+++ b/rdkit/UnitTestLogging.py
@@ -12,7 +12,6 @@ unit testing code for various logging schemes
 """
 
 import collections
-import datetime
 import io
 import logging
 import os
@@ -20,7 +19,6 @@ import re
 import sys
 import tempfile
 import threading
-import time
 import unittest
 
 import rdkit


### PR DESCRIPTION
#### Reference Issue
No issue

#### What does this implement/fix? Explain your changes.
Using ruff to identify and remove unused imports in python test files.

#### Any other comments?
Didn't remove anything in `try: ... except:` statements. 