### PR TITLE
Fix #9338 by canonicalizing double bond stereo limited to STEREO E/Z/CIS/TRANS

### DIFF
--- a/Code/GraphMol/Canon.cpp
+++ b/Code/GraphMol/Canon.cpp
@@ -29,7 +29,13 @@
 namespace RDKit {
 namespace Canon {
 namespace {
-constexpr Bond::BondDir flipStereoBondDir(Bond::BondDir bondDir) {
+static bool isCanonicalizableStereoDoubleBond(const Bond &bond) {
+  const auto stereo = bond.getStereo();
+  return bond.getBondType() == Bond::DOUBLE && stereo >= Bond::STEREOZ &&
+         stereo <= Bond::STEREOTRANS && bond.getStereoAtoms().size() >= 2;
+}
+
+static constexpr Bond::BondDir flipStereoBondDir(Bond::BondDir bondDir) {
   switch (bondDir) {
     case Bond::ENDUPRIGHT:
       return Bond::ENDDOWNRIGHT;
@@ -724,8 +730,7 @@ void canonicalizeDoubleBonds(ROMol &mol, const UINT_VECT &bondVisitOrders,
                                          const Bond *nbrBnd) -> Bond * {
     auto otherAtom = nbrBnd->getOtherAtom(dblBndAtom);
     for (const auto bond : mol.atomBonds(otherAtom)) {
-      if (bond != nbrBnd && bond->getBondType() == Bond::DOUBLE &&
-          bond->getStereo() > Bond::STEREOANY) {
+      if (bond != nbrBnd && isCanonicalizableStereoDoubleBond(*bond)) {
         return bond;
       }
     }
@@ -765,11 +770,10 @@ void canonicalizeDoubleBonds(ROMol &mol, const UINT_VECT &bondVisitOrders,
       bond->setBondDir(Bond::NONE);
     }
 
-    if (bond->getBondType() != Bond::DOUBLE ||
-        bond->getStereo() <= Bond::STEREOANY ||
-        bond->getStereoAtoms().size() < 2) {
+    if (!isCanonicalizableStereoDoubleBond(*bond)) {
       // not a bond that can have stereo or that needs canonicalization
       bond->setStereo(Bond::STEREONONE);
+      bond->getStereoAtoms().clear();
       continue;
     }
 
@@ -817,6 +821,12 @@ void canonicalizeDoubleBonds(ROMol &mol, const UINT_VECT &bondVisitOrders,
       const auto currentBond = connectedBondsQ.front();
       connectedBondsQ.pop();
       if (seen_bonds[currentBond->getIdx()]) {
+        continue;
+      }
+      if (!isCanonicalizableStereoDoubleBond(*currentBond)) {
+        currentBond->setStereo(Bond::STEREONONE);
+        currentBond->getStereoAtoms().clear();
+        seen_bonds[currentBond->getIdx()] = true;
         continue;
       }
 

--- a/Code/GraphMol/Canon.cpp
+++ b/Code/GraphMol/Canon.cpp
@@ -32,7 +32,7 @@ namespace {
 static bool isCanonicalizableStereoDoubleBond(const Bond &bond) {
   const auto stereo = bond.getStereo();
   return bond.getBondType() == Bond::DOUBLE && stereo >= Bond::STEREOZ &&
-         stereo <= Bond::STEREOTRANS && bond.getStereoAtoms().size() >= 2;
+         stereo <= Bond::STEREOTRANS && bond.getStereoAtoms().size() == 2;
 }
 
 static constexpr Bond::BondDir flipStereoBondDir(Bond::BondDir bondDir) {

--- a/Code/GraphMol/MolStandardize/Tautomer.cpp
+++ b/Code/GraphMol/MolStandardize/Tautomer.cpp
@@ -347,9 +347,8 @@ const RingInfo *getFastRingInfo(ROMol &mol) {
   // SymmSSSR here since that has a performance cost.
   // this might be not precise enough for large rings like 9-or-more macrocycles
   auto ringInfo = mol.getRingInfo();
-  if (!ringInfo || !ringInfo->isFindFastOrBetter()) {
+  if (!ringInfo->isFindFastOrBetter()) {
     MolOps::fastFindRings(mol);
-    ringInfo = mol.getRingInfo();
   }
   return ringInfo;
 }

--- a/Code/GraphMol/MolStandardize/Tautomer.cpp
+++ b/Code/GraphMol/MolStandardize/Tautomer.cpp
@@ -475,8 +475,7 @@ bool TautomerEnumerator::setTautomerStereoAndIsoHs(
           tautBond->getBondType() == Bond::DOUBLE ? getFastRingInfo(taut)
                                                   : nullptr;
       const auto targetStereo = getClearedTautomerBondStereo(ringInfo, *tautBond);
-      modified |= (tautBond->getStereo() != targetStereo ||
-                   !tautBond->getStereoAtoms().empty());
+      modified |= (tautBond->getStereo() != targetStereo);
       tautBond->setStereo(targetStereo);
       tautBond->getStereoAtoms().clear();
       for (auto bi : bondsToClearDirs) {

--- a/Code/GraphMol/MolStandardize/Tautomer.cpp
+++ b/Code/GraphMol/MolStandardize/Tautomer.cpp
@@ -343,6 +343,9 @@ int scoreHeteroHs(const ROMol &mol) {
 
 namespace {
 const RingInfo *getFastRingInfo(ROMol &mol) {
+  // We only need to know whether the bond is in a ring; avoid forcing
+  // SymmSSSR here since that has a performance cost.
+  // this might be not precise enough for large rings like 9-or-more macrocycles
   auto ringInfo = mol.getRingInfo();
   if (!ringInfo || !ringInfo->isFindFastOrBetter()) {
     MolOps::fastFindRings(mol);
@@ -351,7 +354,8 @@ const RingInfo *getFastRingInfo(ROMol &mol) {
   return ringInfo;
 }
 
-bool isTautomerDoubleBondInRing(const RingInfo *ringInfo, const Bond &bond) {
+bool isTautomerBondAtRing(const RingInfo *ringInfo, const Bond &bond) {
+  // either inside a ring or connecting two ring atoms
   const bool bondInRing = ringInfo && ringInfo->numBondRings(bond.getIdx()) != 0;
   const bool beginInRing =
       ringInfo && ringInfo->numAtomRings(bond.getBeginAtomIdx()) != 0;
@@ -363,7 +367,7 @@ bool isTautomerDoubleBondInRing(const RingInfo *ringInfo, const Bond &bond) {
 Bond::BondStereo getClearedTautomerBondStereo(const RingInfo *ringInfo,
                                               const Bond &bond) {
   return (bond.getBondType() == Bond::DOUBLE &&
-          !isTautomerDoubleBondInRing(ringInfo, bond))
+          !isTautomerBondAtRing(ringInfo, bond))
              ? Bond::STEREOANY
              : Bond::STEREONONE;
 }
@@ -463,7 +467,8 @@ bool TautomerEnumerator::setTautomerStereoAndIsoHs(
     if (tautBond->getBondType() != Bond::DOUBLE || d_removeBondStereo ||
         !hasValidSpecifiedDoubleBondStereo(*bond)) {
       // When bond stereo is being removed for bonds involved in tautomerism,
-      // use STEREOANY (for *non-ring* double bonds) instead of STEREONONE.
+      // use STEREOANY (for double bonds not in rings or connecting two ring atoms)
+      // instead of STEREONONE.
       // This prevents downstream tools (notably InChI) from inferring a specific E/Z
       // assignment from 2D coordinates after bond orders have been changed.
       const RingInfo *ringInfo =

--- a/Code/GraphMol/MolStandardize/Tautomer.cpp
+++ b/Code/GraphMol/MolStandardize/Tautomer.cpp
@@ -341,6 +341,40 @@ int scoreHeteroHs(const ROMol &mol) {
 }
 }  // namespace TautomerScoringFunctions
 
+namespace {
+const RingInfo *getFastRingInfo(ROMol &mol) {
+  auto ringInfo = mol.getRingInfo();
+  if (!ringInfo || !ringInfo->isFindFastOrBetter()) {
+    MolOps::fastFindRings(mol);
+    ringInfo = mol.getRingInfo();
+  }
+  return ringInfo;
+}
+
+bool isTautomerDoubleBondInRing(const RingInfo *ringInfo, const Bond &bond) {
+  const bool bondInRing = ringInfo && ringInfo->numBondRings(bond.getIdx()) != 0;
+  const bool beginInRing =
+      ringInfo && ringInfo->numAtomRings(bond.getBeginAtomIdx()) != 0;
+  const bool endInRing =
+      ringInfo && ringInfo->numAtomRings(bond.getEndAtomIdx()) != 0;
+  return bondInRing || (beginInRing && endInRing);
+}
+
+Bond::BondStereo getClearedTautomerBondStereo(const RingInfo *ringInfo,
+                                              const Bond &bond) {
+  return (bond.getBondType() == Bond::DOUBLE &&
+          !isTautomerDoubleBondInRing(ringInfo, bond))
+             ? Bond::STEREOANY
+             : Bond::STEREONONE;
+}
+
+bool hasValidSpecifiedDoubleBondStereo(const Bond &bond) {
+  const auto stereo = bond.getStereo();
+  return bond.getBondType() == Bond::DOUBLE && stereo >= Bond::STEREOZ &&
+         stereo <= Bond::STEREOTRANS && bond.getStereoAtoms().size() == 2;
+}
+}  // namespace
+
 TautomerEnumerator::TautomerEnumerator(const CleanupParameters &params)
     : d_maxTautomers(params.maxTautomers),
       d_maxTransforms(params.maxTransforms),
@@ -426,39 +460,18 @@ bool TautomerEnumerator::setTautomerStereoAndIsoHs(
       }
     }
     auto tautBond = tautBonds[bondIdx];
-    if (tautBond->getBondType() != Bond::DOUBLE || d_removeBondStereo) {
+    if (tautBond->getBondType() != Bond::DOUBLE || d_removeBondStereo ||
+        !hasValidSpecifiedDoubleBondStereo(*bond)) {
       // When bond stereo is being removed for bonds involved in tautomerism,
       // use STEREOANY (for *non-ring* double bonds) instead of STEREONONE.
       // This prevents downstream tools (notably InChI) from inferring a specific E/Z
       // assignment from 2D coordinates after bond orders have been changed.
-      bool isRingBond = false;
-      if (tautBond->getBondType() == Bond::DOUBLE) {
-        auto ringInfo = taut.getRingInfo();
-        // We only need to know whether the bond is in a ring; avoid forcing
-        // SymmSSSR here since that has a performance cost.
-        // this might be not precise enough for large rings like 9-or-more macrocycles
-        if (!ringInfo || !ringInfo->isFindFastOrBetter()) {
-          MolOps::fastFindRings(taut);
-          ringInfo = taut.getRingInfo();
-        }
-        if (ringInfo) {
-          const auto tbidx = tautBond->getIdx();
-          const bool bondInRing = ringInfo->numBondRings(tbidx) != 0;
-          const bool beginInRing =
-              ringInfo->numAtomRings(tautBond->getBeginAtomIdx()) != 0;
-          const bool endInRing =
-              ringInfo->numAtomRings(tautBond->getEndAtomIdx()) != 0;
-          // Only set STEREOANY on clearly non-ring bonds. Using atom-in-ring as
-          // a fallback avoids any edge cases where bond indices or ring data
-          // aren't aligned during enumeration.
-          isRingBond = bondInRing || (beginInRing && endInRing);
-        }
-      }
-      const auto targetStereo = (tautBond->getBondType() == Bond::DOUBLE &&
-                                 !isRingBond)
-                                    ? Bond::STEREOANY
-                                    : Bond::STEREONONE;
-      modified |= (tautBond->getStereo() != targetStereo);
+      const RingInfo *ringInfo =
+          tautBond->getBondType() == Bond::DOUBLE ? getFastRingInfo(taut)
+                                                  : nullptr;
+      const auto targetStereo = getClearedTautomerBondStereo(ringInfo, *tautBond);
+      modified |= (tautBond->getStereo() != targetStereo ||
+                   !tautBond->getStereoAtoms().empty());
       tautBond->setStereo(targetStereo);
       tautBond->getStereoAtoms().clear();
       for (auto bi : bondsToClearDirs) {
@@ -487,12 +500,7 @@ bool TautomerEnumerator::setTautomerStereoAndIsoHs(
     // coordinate-based E/Z inference. If bond stereo removal is enabled,
     // re-apply our contract to the bonds involved in tautomerism.
     if (d_removeBondStereo) {
-      auto ringInfo = taut.getRingInfo();
-      if (!ringInfo || !ringInfo->isFindFastOrBetter()) {
-        // might prefer more expensive calc here to better support 9-or-more macrocycles
-        MolOps::fastFindRings(taut);
-        ringInfo = taut.getRingInfo();
-      }
+      const auto ringInfo = getFastRingInfo(taut);
       for (auto bond : taut.bonds()) {
         const auto bondIdx = bond->getIdx();
         if (!res.d_modifiedBonds.test(bondIdx)) {
@@ -503,15 +511,7 @@ bool TautomerEnumerator::setTautomerStereoAndIsoHs(
           bond->getStereoAtoms().clear();
           continue;
         }
-
-        const bool bondInRing = ringInfo && ringInfo->numBondRings(bondIdx);
-        const bool beginInRing =
-            ringInfo && ringInfo->numAtomRings(bond->getBeginAtomIdx());
-        const bool endInRing =
-            ringInfo && ringInfo->numAtomRings(bond->getEndAtomIdx());
-        const bool isRingBond = bondInRing || (beginInRing && endInRing);
-
-        bond->setStereo(isRingBond ? Bond::STEREONONE : Bond::STEREOANY);
+        bond->setStereo(getClearedTautomerBondStereo(ringInfo, *bond));
         bond->getStereoAtoms().clear();
       }
     }

--- a/Code/GraphMol/MolStandardize/catch_tests.cpp
+++ b/Code/GraphMol/MolStandardize/catch_tests.cpp
@@ -1754,7 +1754,6 @@ TEST_CASE("Custom Scoring Functions") {
                 *mol, terms) == 1000);
   }
 }
-
 TEST_CASE("tautomer canonicalize preserves conformers") {
   // Regression test: quickCopy during tautomer enumeration drops
   // conformers.  canonicalize() must restore them from the original
@@ -1834,3 +1833,51 @@ M  END
   }
 }
 
+TEST_CASE("tautomer canonicalize clears invalid bond stereo after bond-order changes") {
+  std::string molblock = R"CTAB(
+     RDKit          2D
+
+  0  0  0  0  0  0  0  0  0  0999 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 7 6 0 0 0
+M  V30 BEGIN ATOM
+M  V30 1 C 66.546902 -10.607295 0.000000 0
+M  V30 2 C 67.407319 -9.379170 0.000000 0
+M  V30 3 N 68.901071 -9.509378 0.000000 0
+M  V30 4 C 69.532321 -10.864587 0.000000 0
+M  V30 5 O 68.675029 -12.088546 0.000000 0
+M  V30 6 C 71.021905 -10.994795 0.000000 0
+M  V30 7 C 67.180236 -11.966671 0.000000 0
+M  V30 END ATOM
+M  V30 BEGIN BOND
+M  V30 1 2 4 5
+M  V30 2 1 4 6 CFG=1
+M  V30 3 1 3 4
+M  V30 4 2 2 1
+M  V30 5 1 1 7
+M  V30 6 1 3 2
+M  V30 END BOND
+M  V30 END CTAB
+M  END
+)CTAB";
+  std::unique_ptr<RWMol> mol(MolBlockToMol(molblock));
+  REQUIRE(mol);
+
+  MolStandardize::CleanupParameters params;
+  params.tautomerRemoveBondStereo = false;
+  MolStandardize::TautomerEnumerator te(params);
+
+  std::unique_ptr<ROMol> canon;
+  REQUIRE_NOTHROW(canon.reset(te.canonicalize(*mol)));
+  REQUIRE(canon);
+  CHECK(MolToSmiles(*canon) == "CCC=NC(C)=O");
+  for (const auto bond : canon->bonds()) {
+    if (bond->getBondType() != Bond::DOUBLE) {
+      continue;
+    }
+    CHECK(bond->getStereo() < Bond::STEREOATROPCW);
+    if (bond->getStereo() > Bond::STEREOANY) {
+      CHECK(bond->getStereoAtoms().size() == 2);
+    }
+  }
+}


### PR DESCRIPTION
#### Reference Issue
Fixes #9338


#### What does this implement/fix? Explain your changes.
Canonicalization could have copied non-double-bond stereo, like atrop bond stereo, to a bond whose order became double. This happened in our carbonyl-wedge situation. Then you'd have an invalid bond -- double yet atrop. Now we only preserve within the limited allowed bond stereo for a double bond, and clear it otherwise.


#### Any other comments?
Bisected and implemented with GPT 5.4, from MWE identified manually.
cc @ricrogz 
