### PR TITLE
Trim heavy includes from public headers (Eigen/Dense, boost/format)

### DIFF
--- a/Code/GraphMol/MolEnumerator/LinkNode.h
+++ b/Code/GraphMol/MolEnumerator/LinkNode.h
@@ -12,7 +12,6 @@
 #include <map>
 #include <boost/lexical_cast.hpp>
 #include <boost/tokenizer.hpp>
-#include <boost/format.hpp>
 #include <algorithm>
 
 typedef boost::tokenizer<boost::char_separator<char>> tokenizer;

--- a/Code/GraphMol/MolTransforms/MolTransforms.cpp
+++ b/Code/GraphMol/MolTransforms/MolTransforms.cpp
@@ -18,6 +18,13 @@
 #include <boost/dynamic_bitset.hpp>
 #include <RDGeneral/Exceptions.h>
 
+#ifdef RDK_HAS_EIGEN3
+// Eigen module headers (LU/QR/SVD/...) must be included at global scope, not
+// inside a namespace. MolTransforms.h only needs the Matrix3d/Vector3d typedefs
+// (from Eigen/Core), so the full Eigen/Dense include lives here in the impl.
+#include <Eigen/Dense>
+#endif
+
 #ifndef RDK_HAS_EIGEN3
 constexpr double EIGEN_TOLERANCE = 5.0e-2;
 #endif
@@ -149,7 +156,6 @@ void computeInertiaTerms(const Conformer &conf, const RDGeom::Point3D &center,
 }  // namespace
 
 #ifdef RDK_HAS_EIGEN3
-#include <Eigen/Dense>
 
 namespace {
 bool getEigenValEigenVectHelper(Eigen::Matrix3d &eigVecs,

--- a/Code/GraphMol/MolTransforms/MolTransforms.h
+++ b/Code/GraphMol/MolTransforms/MolTransforms.h
@@ -15,7 +15,10 @@
 #include <Numerics/SymmMatrix.h>
 
 #ifdef RDK_HAS_EIGEN3
-#include <Eigen/Dense>
+// only the Matrix3d/Vector3d typedefs are needed in the declarations below;
+// Eigen/Core provides them and is far lighter than Eigen/Dense. The
+// implementation (MolTransforms.cpp) pulls in Eigen/Dense for the solver.
+#include <Eigen/Core>
 #endif
 
 namespace RDKit {

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -12,6 +12,9 @@ GitHub)
 - Since #9208, atom rings are "normalized" so that the first atom in the ring
 definition is the one with the lowest index, and the second one is the neighbor
 to the first which also has the lowest index.
+- `MolTransforms.h` now includes `<Eigen/Core>` instead of `<Eigen/Dense>`. C++
+code that included `MolTransforms.h` and relied on it to transitively pull in the
+Eigen dense modules (LU/QR/SVD/etc.) must now include `<Eigen/Dense>` directly.
 
 ## Code removed in this release:
 - The version of hanoiSort() that takes raw pointers has been removed. Please use


### PR DESCRIPTION
## Summary

A small, low-risk "header diet" pass: move heavy includes out of public headers and into implementations where only the implementation needs them. This complements the precompiled-headers work in #9236 by reducing the actual parse cost for **all** compilers — including GCC/Linux (where the PCH is disabled because it regresses) and any incremental build or downstream consumer that doesn't use the PCH.

### 1. `MolTransforms.h`: `<Eigen/Core>` instead of `<Eigen/Dense>`
The public declarations in `MolTransforms.h` only reference the `Eigen::Matrix3d` / `Eigen::Vector3d` typedefs, which live in `<Eigen/Core>`. `<Eigen/Dense>` additionally pulls in LU / QR / SVD / Eigenvalues / Geometry, none of which the header needs.

- **~16,000 fewer preprocessed lines per consumer** when Eigen support is enabled (`Eigen/Dense` = 170,080 lines vs `Eigen/Core` = 154,017, measured with `clang -E`). The header is included by ~31 translation units.
- The implementation (`MolTransforms.cpp`) still uses Dense for the eigensolver, so it now includes `<Eigen/Dense>` directly.

### Latent bug fixed along the way
Trimming the header exposed a real bug: `MolTransforms.cpp` included `<Eigen/Dense>` **inside `namespace MolTransforms`**. Including an Eigen *module* header inside a namespace is illegal (the module's internal names resolve against the wrong namespace) — it only compiled before because `MolTransforms.h` happened to pre-include Dense at global scope, so the in-namespace include hit an already-set include guard and did nothing. With the header on `Eigen/Core`, the in-namespace include tried to pull the Dense modules in for the first time and failed. The fix moves the `<Eigen/Dense>` include to global scope in the `.cpp`, which is where Eigen module headers must live.

### 2. `LinkNode.h`: drop unused `<boost/format.hpp>`
The header includes `<boost/format.hpp>` but uses no `boost::format` symbol. Dead include, removed.

## Scope note (deliberately conservative)
The other five headers that include `<boost/format.hpp>` (`FileParserUtils.h`, `MolSGroupWriting.h`, `PNGParser.h`, `ReactionParser.h`, `MolDraw2DDetails.h`) genuinely use `boost::format` in inline/template bodies, so their includes can't simply be dropped — that would require moving functions into `.cpp` files, a larger and riskier change left for a follow-up. This PR sticks to the changes that are unambiguously safe.

## Verification
- Full local build (`cmake` + `ninja`, Python wrappers + Eigen enabled): **clean, zero errors** — all ~31 `MolTransforms.h` consumers and the `LinkNode.h` consumers recompile without relying on the removed transitive includes.
- Per-consumer parse-cost reduction measured directly via `clang -E | wc -l`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
