### PR TITLE
Patch GetProp default typing in rdchem stubs

### DIFF
--- a/Scripts/gen_rdkit_stubs/patch/rdkit/Chem/rdchem.pyi.diff
+++ b/Scripts/gen_rdkit_stubs/patch/rdkit/Chem/rdchem.pyi.diff
@@ -1,20 +1,37 @@
 --- a/rdkit/Chem/rdchem.pyi
 +++ b/rdkit/Chem/rdchem.pyi
-@@ -1988,7 +1988,7 @@
-             C++ signature :
-                 RDKit::Atom* GetAtomWithIdx(RDKit::ROMol {lvalue},unsigned int)
+@@ -346,3 +346,3 @@
+     @typing.overload
+-    def GetProp(self, key: str, autoConvert: bool = False, default: typing.Any) -> typing.Any:
++    def GetProp(self, key: str, autoConvert: bool = False, default: typing.Any = ...) -> typing.Any:
+         """
+@@ -1307,3 +1307,3 @@
+     @typing.overload
+-    def GetProp(self, key: str, autoConvert: bool = False, default: typing.Any) -> typing.Any:
++    def GetProp(self, key: str, autoConvert: bool = False, default: typing.Any = ...) -> typing.Any:
+         """
+@@ -1844,3 +1844,3 @@
+     @typing.overload
+-    def GetProp(self, key: str, autoConvert: bool = False, default: typing.Any) -> typing.Any:
++    def GetProp(self, key: str, autoConvert: bool = False, default: typing.Any = ...) -> typing.Any:
+         """
+@@ -2301,3 +2301,3 @@
          """
 -    def GetAtoms(self):
 +    def GetAtoms(self) -> typing.Iterable[Atom]:
          """
-         returns an iterator over the atoms in the molecule
-         """
-@@ -2030,7 +2030,7 @@
-             C++ signature :
-                 RDKit::Bond* GetBondWithIdx(RDKit::ROMol {lvalue},unsigned int)
+@@ -2343,3 +2343,3 @@
          """
 -    def GetBonds(self):
 +    def GetBonds(self) -> typing.Iterable[Bond]:
          """
-         returns an iterator over the bonds in the molecule
+@@ -2521,3 +2521,3 @@
+     @typing.overload
+-    def GetProp(self, key: str, autoConvert: bool = False, default: typing.Any) -> typing.Any:
++    def GetProp(self, key: str, autoConvert: bool = False, default: typing.Any = ...) -> typing.Any:
+         """
+@@ -4644,3 +4644,3 @@
+     @typing.overload
+-    def GetProp(self, key: str, autoConvert: bool = False, default: typing.Any) -> typing.Any:
++    def GetProp(self, key: str, autoConvert: bool = False, default: typing.Any = ...) -> typing.Any:
          """


### PR DESCRIPTION
#### Reference Issue
Fixes #9335

#### What does this implement/fix? Explain your changes.
include `default = ...` in typing patch so that downstream checker doesn't complain about non-default kwarg after default kwarg. Also tighten the chunks to not have to carry as much patch context.