### PR TITLE
Typing fix: Reorder arguments to `GetPyPropOrDefault<T>` bindings

### DIFF
--- a/Code/GraphMol/Wrap/Atom.cpp
+++ b/Code/GraphMol/Wrap/Atom.cpp
@@ -348,7 +348,7 @@ struct atom_wrapper {
             "GetProp", GetPyPropOrDefault<Atom>,
             (python::arg("self"), python::arg("key"),
              python::arg("autoConvert") = false,
-             python::arg("default")),
+             python::arg("default") = python::object()),
             "Returns the value of the property.\n\n"
             "  ARGUMENTS:\n"
             "    - key: the name of the property to return (a string).\n\n"

--- a/Code/GraphMol/Wrap/Atom.cpp
+++ b/Code/GraphMol/Wrap/Atom.cpp
@@ -347,13 +347,13 @@ struct atom_wrapper {
         .def(
             "GetProp", GetPyPropOrDefault<Atom>,
             (python::arg("self"), python::arg("key"),
-             python::arg("autoConvert") = false,
-             python::arg("default") = python::object()),
+             python::arg("default"),
+             python::arg("autoConvert") = false),
             "Returns the value of the property.\n\n"
             "  ARGUMENTS:\n"
             "    - key: the name of the property to return (a string).\n\n"
-            "    - autoConvert: if True attempt to convert the property into a python object\n\n"
             "    - default: value to return if the property is not present.\n\n"
+            "    - autoConvert: if True attempt to convert the property into a python object\n\n"
             "  RETURNS: the property value, or default if the property is not present.\n",
             boost::python::return_value_policy<return_pyobject_passthrough>())
 

--- a/Code/GraphMol/Wrap/Bond.cpp
+++ b/Code/GraphMol/Wrap/Bond.cpp
@@ -220,7 +220,7 @@ struct bond_wrapper {
             "GetProp", GetPyPropOrDefault<Bond>,
             (python::arg("self"), python::arg("key"),
              python::arg("autoConvert") = false,
-             python::arg("default")),
+             python::arg("default") = python::object()),
             "Returns the value of the property.\n\n"
             "  ARGUMENTS:\n"
             "    - key: the name of the property to return (a string).\n\n"

--- a/Code/GraphMol/Wrap/Bond.cpp
+++ b/Code/GraphMol/Wrap/Bond.cpp
@@ -219,13 +219,13 @@ struct bond_wrapper {
         .def(
             "GetProp", GetPyPropOrDefault<Bond>,
             (python::arg("self"), python::arg("key"),
-             python::arg("autoConvert") = false,
-             python::arg("default") = python::object()),
+             python::arg("default"),
+             python::arg("autoConvert") = false),
             "Returns the value of the property.\n\n"
             "  ARGUMENTS:\n"
             "    - key: the name of the property to return (a string).\n\n"
-            "    - autoConvert: if True attempt to convert the property into a python object\n\n"
             "    - default: value to return if the property is not present.\n\n"
+            "    - autoConvert: if True attempt to convert the property into a python object\n\n"
             "  RETURNS: the property value, or default if the property is not present.\n",
             boost::python::return_value_policy<return_pyobject_passthrough>())
         .def("SetIntProp", BondSetProp<int>,

--- a/Code/GraphMol/Wrap/Conformer.cpp
+++ b/Code/GraphMol/Wrap/Conformer.cpp
@@ -243,13 +243,13 @@ struct conformer_wrapper {
         .def(
             "GetProp", GetPyPropOrDefault<Conformer>,
             (python::arg("self"), python::arg("key"),
-             python::arg("autoConvert") = false,
-             python::arg("default") = python::object()),
+             python::arg("default"),
+             python::arg("autoConvert") = false),
             "Returns the value of the property.\n\n"
             "  ARGUMENTS:\n"
             "    - key: the name of the property to return (a string).\n\n"
-            "    - autoConvert: if True attempt to convert the property into a python object\n\n"
             "    - default: value to return if the property is not present.\n\n"
+            "    - autoConvert: if True attempt to convert the property into a python object\n\n"
             "  RETURNS: the property value, or default if the property is not present.\n",
             boost::python::return_value_policy<return_pyobject_passthrough>())
         .def("GetDoubleProp", GetProp<Conformer, double>,

--- a/Code/GraphMol/Wrap/Conformer.cpp
+++ b/Code/GraphMol/Wrap/Conformer.cpp
@@ -244,7 +244,7 @@ struct conformer_wrapper {
             "GetProp", GetPyPropOrDefault<Conformer>,
             (python::arg("self"), python::arg("key"),
              python::arg("autoConvert") = false,
-             python::arg("default")),
+             python::arg("default") = python::object()),
             "Returns the value of the property.\n\n"
             "  ARGUMENTS:\n"
             "    - key: the name of the property to return (a string).\n\n"

--- a/Code/GraphMol/Wrap/Mol.cpp
+++ b/Code/GraphMol/Wrap/Mol.cpp
@@ -760,13 +760,13 @@ struct mol_wrapper {
         .def(
             "GetProp", GetPyPropOrDefault<ROMol>,
             (python::arg("self"), python::arg("key"),
-             python::arg("autoConvert") = false,
-             python::arg("default") = python::object()),
+             python::arg("default"),
+             python::arg("autoConvert") = false),
             "Returns the value of the property.\n\n"
             "  ARGUMENTS:\n"
             "    - key: the name of the property to return (a string).\n\n"
-            "    - autoConvert: if True attempt to convert the property into a python object\n\n"
             "    - default: value to return if the property is not present.\n\n"
+            "    - autoConvert: if True attempt to convert the property into a python object\n\n"
             "  RETURNS: the property value, or default if the property is not present.\n",
             boost::python::return_value_policy<return_pyobject_passthrough>())
         .def("GetDoubleProp", GetProp<ROMol, double>,

--- a/Code/GraphMol/Wrap/Mol.cpp
+++ b/Code/GraphMol/Wrap/Mol.cpp
@@ -761,7 +761,7 @@ struct mol_wrapper {
             "GetProp", GetPyPropOrDefault<ROMol>,
             (python::arg("self"), python::arg("key"),
              python::arg("autoConvert") = false,
-             python::arg("default")),
+             python::arg("default") = python::object()),
             "Returns the value of the property.\n\n"
             "  ARGUMENTS:\n"
             "    - key: the name of the property to return (a string).\n\n"

--- a/Code/GraphMol/Wrap/SubstanceGroup.cpp
+++ b/Code/GraphMol/Wrap/SubstanceGroup.cpp
@@ -263,13 +263,13 @@ struct sgroup_wrap {
         .def(
             "GetProp", GetPyPropOrDefault<SubstanceGroup>,
             (python::arg("self"), python::arg("key"),
-             python::arg("autoConvert") = false,
-             python::arg("default") = python::object()),
+             python::arg("default"),
+             python::arg("autoConvert") = false),
             "Returns the value of the property.\n\n"
             "  ARGUMENTS:\n"
             "    - key: the name of the property to return (a string).\n\n"
-            "    - autoConvert: if True attempt to convert the property into a python object\n\n"
             "    - default: value to return if the property is not present.\n\n"
+            "    - autoConvert: if True attempt to convert the property into a python object\n\n"
             "  RETURNS: the property value, or default if the property is not present.\n",
             boost::python::return_value_policy<return_pyobject_passthrough>())
         .def("GetIntProp",

--- a/Code/GraphMol/Wrap/SubstanceGroup.cpp
+++ b/Code/GraphMol/Wrap/SubstanceGroup.cpp
@@ -264,7 +264,7 @@ struct sgroup_wrap {
             "GetProp", GetPyPropOrDefault<SubstanceGroup>,
             (python::arg("self"), python::arg("key"),
              python::arg("autoConvert") = false,
-             python::arg("default")),
+             python::arg("default") = python::object()),
             "Returns the value of the property.\n\n"
             "  ARGUMENTS:\n"
             "    - key: the name of the property to return (a string).\n\n"

--- a/Code/GraphMol/Wrap/props.hpp
+++ b/Code/GraphMol/Wrap/props.hpp
@@ -357,7 +357,7 @@ PyObject *GetPyProp(const RDOb *obj, const std::string &key, bool autoConvert) {
 
 template <class RDOb>
 PyObject *GetPyPropOrDefault(const RDOb *obj, const std::string &key,
-                              bool autoConvert, python::object default_val) {
+                              python::object default_val, bool autoConvert) {
   return GetPyPropImpl(obj, key, autoConvert, &default_val);
 }
 


### PR DESCRIPTION
The generated Python stubs represent invalid Python syntax.

<!--
Thanks for contributing a pull request! 
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->
Fixes #9335 

#### What does this implement/fix? Explain your changes.
~~This PR sets the `GetProp` python "default" argument to python::object(), which _should_ represent `None` and is compatible with `GetPyPropOrDefault`.~~

This PR switches the positions of `default` and `autoconvert` defined in the Python wrappers for `GetPyPropOrDefault<T>` templates. This should preserve still support overloading.