### PR TITLE
Support ChemDraw abnormal valence import

### DIFF
--- a/External/ChemDraw/chemdraw.cpp
+++ b/External/ChemDraw/chemdraw.cpp
@@ -102,6 +102,10 @@ void visit_children(
       }
 
       if (mol->hasProp(NEEDS_FUSE)) {
+        CDXMLSanitizationHint sanitizationHint;
+        const auto hasSanitizationHint =
+            mol->getPropIfPresent<CDXMLSanitizationHint>(
+                CDXML_SANITIZATION_HINTS, sanitizationHint);
         mol->clearProp(NEEDS_FUSE);
         std::unique_ptr<ROMol> fused;
         try {
@@ -113,6 +117,10 @@ void visit_children(
           // perhaps have an option to extract all fragments?
           // mols.push_back(std::move(mol));
           continue;
+        }
+        if (hasSanitizationHint) {
+          fused->setProp<CDXMLSanitizationHint>(CDXML_SANITIZATION_HINTS,
+                                                sanitizationHint);
         }
         fused->setProp<int>(CDX_FRAG_ID, static_cast<int>(frag_id));
         pagedata.mols.emplace_back(dynamic_cast<RWMol *>(fused.release()));
@@ -183,9 +191,14 @@ void visit_children(
             // rings in bond stereo detection, and another in
             // sanitization's SSSR symmetrization).
             unsigned int failedOp = 0;
-            MolOps::sanitizeMol(*res, failedOp,
-                                MolOps::SANITIZE_CLEANUP |
-                                    MolOps::SANITIZE_FINDRADICALS);
+            unsigned int sanitizeOps = MolOps::SANITIZE_CLEANUP;
+            CDXMLSanitizationHint sanitizationHint;
+            if (res->getPropIfPresent<CDXMLSanitizationHint>(
+                    CDXML_SANITIZATION_HINTS, sanitizationHint) &&
+                sanitizationHint == CDXMLSanitizationHint::radical) {
+              sanitizeOps |= MolOps::SANITIZE_FINDRADICALS;
+            }
+            MolOps::sanitizeMol(*res, failedOp, sanitizeOps);
             MolOps::detectBondStereochemistry(*res);
             MolOps::removeHs(*res);
           } else {

--- a/External/ChemDraw/chemdraw.cpp
+++ b/External/ChemDraw/chemdraw.cpp
@@ -183,7 +183,9 @@ void visit_children(
             // rings in bond stereo detection, and another in
             // sanitization's SSSR symmetrization).
             unsigned int failedOp = 0;
-            MolOps::sanitizeMol(*res, failedOp, MolOps::SANITIZE_CLEANUP);
+            MolOps::sanitizeMol(*res, failedOp,
+                                MolOps::SANITIZE_CLEANUP |
+                                    MolOps::SANITIZE_FINDRADICALS);
             MolOps::detectBondStereochemistry(*res);
             MolOps::removeHs(*res);
           } else {

--- a/External/ChemDraw/fragment.h
+++ b/External/ChemDraw/fragment.h
@@ -66,6 +66,7 @@ struct PageData {
 
   void clearCDXProps() {
     for (auto &mol : mols) {
+      mol->clearProp(CDXML_SANITIZATION_HINTS);
       for (auto atom : mol->atoms()) {
         atom->clearProp(CDX_ATOM_ID);
         atom->clearProp(CDX_BOND_ORDERING);

--- a/External/ChemDraw/node.cpp
+++ b/External/ChemDraw/node.cpp
@@ -189,6 +189,8 @@ bool parseNode(
   rd_atom->setNoImplicit(explicitHs);
   if (node.m_abnormalValence) {
     rd_atom->setNoImplicit(true);
+    mol.setProp<CDXMLSanitizationHint>(CDXML_SANITIZATION_HINTS,
+                                       CDXMLSanitizationHint::radical);
   }
 
   rd_atom->setIsotope(isotope);

--- a/External/ChemDraw/node.cpp
+++ b/External/ChemDraw/node.cpp
@@ -187,6 +187,9 @@ bool parseNode(
   rd_atom->setFormalCharge(charge);
   rd_atom->setNumExplicitHs(num_hydrogens);
   rd_atom->setNoImplicit(explicitHs);
+  if (node.m_abnormalValence) {
+    rd_atom->setNoImplicit(true);
+  }
 
   rd_atom->setIsotope(isotope);
   if (rgroup_num >= 0) {

--- a/External/ChemDraw/test.cpp
+++ b/External/ChemDraw/test.cpp
@@ -1413,6 +1413,35 @@ TEST_CASE("Geometry") {
   }
 }
 
+TEST_CASE("Abnormal valence") {
+  std::string path =
+      std::string(getenv("RDBASE")) + "/External/ChemDraw/test_data/";
+  SECTION("Cyclopentane radicals") {
+    auto fname = path + "abnormal-valence-cyclopentane.cdxml";
+    auto mols = MolsFromChemDrawFile(fname);
+    REQUIRE(mols.size() == 1);
+    auto &mol = *mols[0];
+
+    unsigned int radicalAtoms = 0;
+    for (const auto atom : mol.atoms()) {
+      if (atom->getNumRadicalElectrons() == 2) {
+        ++radicalAtoms;
+        CHECK(atom->getNoImplicit());
+      }
+    }
+    CHECK(radicalAtoms == 5);
+
+    const auto v3k = MolToV3KMolBlock(mol);
+    size_t val2Count = 0;
+    size_t pos = 0;
+    while ((pos = v3k.find(" VAL=2", pos)) != std::string::npos) {
+      ++val2Count;
+      pos += 6;
+    }
+    CHECK(val2Count == 5);
+  }
+}
+
 TEST_CASE("Test Reading Wrong File Format") {
   std::string path =
       std::string(getenv("RDBASE")) + "/Code/GraphMol/test_data/CDXML/";

--- a/External/ChemDraw/test_data/abnormal-valence-cyclopentane.cdxml
+++ b/External/ChemDraw/test_data/abnormal-valence-cyclopentane.cdxml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE CDXML SYSTEM "https://static.chemistry.revvitycloud.com/cdxml/CDXML.dtd" >
+<CDXML>
+<page><fragment><n id="1" AbnormalValence="yes"/><n id="2" AbnormalValence="yes"/><n id="3" AbnormalValence="yes"/><n id="4" AbnormalValence="yes"/><n id="5" AbnormalValence="yes"/><b B="1" E="2"/><b B="2" E="3"/><b B="3" E="4"/><b B="4" E="5"/><b B="5" E="1"/></fragment></page>
+</CDXML>

--- a/External/ChemDraw/utils.h
+++ b/External/ChemDraw/utils.h
@@ -59,6 +59,9 @@ const std::string CDX_BOND_ID("_CDX_BOND_ID");
 const std::string CDX_BOND_ORDERING("CDX_BOND_ORDERING");
 const std::string CDX_CIP("CDX_CIP");
 const std::string CDX_IMPLICIT_HYDROGEN_STEREO("CDX_ATOM_STEREO");
+const std::string CDXML_SANITIZATION_HINTS("CDXML_SANITIZATION_HINTS");
+
+enum class CDXMLSanitizationHint { radical };
 
 // Convert a ChemDrawNode to a string
 std::string NodeType(CDXNodeType nodetype);


### PR DESCRIPTION
#### Reference Issue
Fixes #9347 

#### What does this implement/fix?
Respect `m_abnormalValence` when reading CDXML atom nodes.


#### Any other comments?
GPT 5.4 assisted code implementation and CDXML minimization.
