### PR TITLE
Make substructure search Ctrl+c interruptible

### DIFF
--- a/Code/GraphMol/Substruct/catch_tests.cpp
+++ b/Code/GraphMol/Substruct/catch_tests.cpp
@@ -15,6 +15,12 @@
 #include <tuple>
 #include <utility>
 
+#ifdef RDK_TEST_MULTITHREADED
+#include <csignal>
+#include <thread>
+#include <chrono>
+#endif
+
 #include <GraphMol/RDKitBase.h>
 #include <GraphMol/SmilesParse/SmilesParse.h>
 #include <GraphMol/SmilesParse/SmilesWrite.h>
@@ -1123,3 +1129,118 @@ TEST_CASE("quick return when the query has more atoms than the molecule") {
     CHECK(!touched);
   }
 }
+
+#ifdef RDK_TEST_MULTITHREADED
+TEST_CASE("Test early termination of Substructure Matching") {
+  constexpr const char *molBlock = R"(
+     RDKit          3D
+
+  0  0  0  0  0  0  0  0  0  0999 V3000
+M  V30 BEGIN CTAB
+M  V30 COUNTS 38 37 0 0 1
+M  V30 BEGIN ATOM
+M  V30 1 O -8.024222 -0.715013 -1.425119 0
+M  V30 2 C -8.103944 2.094831 3.935276 0
+M  V30 3 C -7.855502 5.047772 3.862929 0
+M  V30 4 N -8.022501 3.875095 3.016789 0
+M  V30 5 C -8.285463 4.220999 1.630734 0
+M  V30 6 H -7.696213 4.758063 4.910916 0
+M  V30 7 H -6.986720 5.654843 3.558860 0
+M  V30 8 H -8.741671 5.704396 3.841010 0
+M  V30 9 H -8.409979 3.312855 1.033695 0
+M  V30 10 H -9.200918 4.829527 1.523497 0
+M  V30 11 H -7.459384 4.805200 1.191633 0
+M  V30 12 C -5.244756 2.507112 5.180590 0
+M  V30 13 N -6.403091 1.673744 4.911170 0
+M  V30 14 C -6.258602 0.324076 5.437228 0
+M  V30 15 H -5.397909 3.515043 4.781177 0
+M  V30 16 H -5.048413 2.598612 6.262184 0
+M  V30 17 H -4.329306 2.101112 4.718062 0
+M  V30 18 H -7.142759 -0.286087 5.203700 0
+M  V30 19 H -5.386809 -0.196867 5.007543 0
+M  V30 20 H -6.140076 0.318047 6.533595 0
+M  V30 21 C -7.533190 -0.221904 2.013029 0
+M  V30 22 N -8.527885 0.696166 2.548649 0
+M  V30 23 C -9.877789 0.334620 2.146322 0
+M  V30 24 H -6.526208 0.060613 2.341771 0
+M  V30 25 H -7.709596 -1.262759 2.337075 0
+M  V30 26 H -7.533190 -0.221904 0.910653 0
+M  V30 27 H -10.608744 1.041371 2.555060 0
+M  V30 28 H -9.988912 0.338721 1.049135 0
+M  V30 29 H -10.161435 -0.671969 2.499294 0
+M  V30 30 C -9.660315 1.664325 6.607604 0
+M  V30 31 N -9.643847 2.175405 5.247830 0
+M  V30 32 C -10.887882 2.843906 4.901017 0
+M  V30 33 H -8.719010 1.155320 6.842548 0
+M  V30 34 H -9.794663 2.468761 7.351980 0
+M  V30 35 H -10.479173 0.941165 6.764630 0
+M  V30 36 H -10.839119 3.258557 3.886413 0
+M  V30 37 H -11.750360 2.156219 4.937816 0
+M  V30 38 H -11.111989 3.682293 5.583119 0
+M  V30 END ATOM
+M  V30 BEGIN BOND
+M  V30 1 1 4 2
+M  V30 2 1 4 3
+M  V30 3 1 5 4
+M  V30 4 1 6 3
+M  V30 5 1 7 3
+M  V30 6 1 8 3
+M  V30 7 1 9 5
+M  V30 8 1 10 5
+M  V30 9 1 11 5
+M  V30 10 1 13 2
+M  V30 11 1 13 12
+M  V30 12 1 14 13
+M  V30 13 1 15 12
+M  V30 14 1 16 12
+M  V30 15 1 17 12
+M  V30 16 1 18 14
+M  V30 17 1 19 14
+M  V30 18 1 20 14
+M  V30 19 1 22 2
+M  V30 20 1 22 21
+M  V30 21 1 23 22
+M  V30 22 1 24 21
+M  V30 23 1 25 21
+M  V30 24 9 1 26
+M  V30 25 1 26 21
+M  V30 26 1 27 23
+M  V30 27 1 28 23
+M  V30 28 1 29 23
+M  V30 29 1 31 2
+M  V30 30 1 31 30
+M  V30 31 1 32 31
+M  V30 32 1 33 30
+M  V30 33 1 34 30
+M  V30 34 1 35 30
+M  V30 35 1 36 32
+M  V30 36 1 37 32
+M  V30 37 1 38 32
+M  V30 END BOND
+M  V30 END CTAB
+M  END
+)";
+
+  v2::FileParsers::MolFileParserParams params{.sanitize = false};
+  auto mol = v2::FileParsers::MolFromMolBlock(molBlock, params);
+  REQUIRE(mol);
+
+  using namespace std::chrono_literals;
+
+  // create one thread for SubstructMatch...
+  std::thread cgThread([&mol]() {
+    // this search takes ~8 seconds on my desktop, so it should
+    // be long enough to allow the interrupt thread to do its thing
+    SubstructMatch(*mol, *mol);
+  });
+  // ... then another one to raise SIGINT
+  std::thread interruptThread([]() {
+    // sleep for a bit to allow for a few iterations, then
+    // trigger the interrupt signal
+    std::this_thread::sleep_for(100ms);
+    std::raise(SIGINT);
+  });
+  cgThread.join();
+  interruptThread.join();
+}
+#endif

--- a/Code/GraphMol/Substruct/vf2.hpp
+++ b/Code/GraphMol/Substruct/vf2.hpp
@@ -10,6 +10,8 @@
  *  http://amalfi.dis.unina.it/graph/db/vflib-2.0/doc/vflib.html
  *
  */
+#include <RDGeneral/ControlCHandler.h>
+
 #include <boost/graph/adjacency_list.hpp>
 #include <vector>
 #include <algorithm>
@@ -136,7 +138,7 @@ node_id *SortNodesByFrequency(const Graph *g) {
   }
   std::sort(vect.begin(), vect.end(), nodeInfoComp2);
 
-  node_id *nodes = new node_id[vect.size()];
+  auto nodes = new node_id[vect.size()];
   for (unsigned int i = 0; i < vect.size(); ++i) {
     nodes[i] = vect[i].id;
   }
@@ -569,7 +571,7 @@ class VF2SubState {
     }
 
     Pair<Graph> pair;
-    while (NextPair(pair)) {
+    while (NextPair(pair) && !RDKit::ControlCHandler::getGotSignal()) {
       if (IsFeasiblePair(pair.n1, pair.n2)) {
         AddPair(pair.n1, pair.n2);
         if (MatchAll(c1, c2, res, lim)) {  // recurse
@@ -634,11 +636,12 @@ bool vf2(const Graph &g1, const Graph &g2, VertexLabeling &vertex_labeling,
          BackInsertionSequence &F) {
   detail::VF2SubState<const Graph, VertexLabeling, EdgeLabeling, MatchChecking>
       s0(&g1, &g2, vertex_labeling, edge_labeling, match_checking, false);
-  detail::node_id *ni1 = new detail::node_id[num_vertices(g1)];
-  detail::node_id *ni2 = new detail::node_id[num_vertices(g2)];
+  auto *ni1 = new detail::node_id[num_vertices(g1)];
+  auto *ni2 = new detail::node_id[num_vertices(g2)];
   int n = 0;
 
   F.clear();
+  RDKit::ControlCHandler::reset();
   if (match(&n, ni1, ni2, s0)) {
     auto sz = num_vertices(g1);
     F.reserve(sz);
@@ -646,6 +649,13 @@ bool vf2(const Graph &g1, const Graph &g2, VertexLabeling &vertex_labeling,
       F.emplace_back(ni1[i], ni2[i]);
     }
   }
+
+  if (RDKit::ControlCHandler::getGotSignal()) {
+    BOOST_LOG(rdWarningLog)
+        << "Substructure search was interrupted, result may not include all matches"
+        << std::endl;
+  }
+
   delete[] ni1;
   delete[] ni2;
 
@@ -669,9 +679,16 @@ bool vf2_all(const Graph &g1, const Graph &g2, VertexLabeling &vertex_labeling,
   std::unique_ptr<detail::node_id[]> ni2(new detail::node_id[num_vertices(g2)]);
 
   F.clear();
-  F.resize(0);
+
+  RDKit::ControlCHandler::reset();
 
   match(ni1.get(), ni2.get(), s0, F, max_results);
+
+  if (RDKit::ControlCHandler::getGotSignal()) {
+    BOOST_LOG(rdWarningLog)
+        << "Substructure search was interrupted, result may not include all matches"
+        << std::endl;
+  }
 
   return !F.empty();
 };


### PR DESCRIPTION
Substructure searching is another of those calculations that can run for a long, long time if the query being searched for has the right size and symmetry conditions. And it currently doesn't respond to attempts to interrupt it via Ctrl+c .

This patch allows it to be interrupted in the same way we do with other potentially long running calculations like CIP labeling or embedding.
