### PR TITLE
Fix latent -Wdeprecated-copy in Seed and SubstructTerm

### DIFF
--- a/Code/GraphMol/FMCS/Seed.h
+++ b/Code/GraphMol/FMCS/Seed.h
@@ -95,13 +95,14 @@ class RDKIT_FMCS_EXPORT Seed {
   std::vector<TargetMatch> MatchResult;
 
  public:
-  Seed()
+  Seed() {}
+  // Defined explicitly (rather than defaulted) so that copying goes through
+  // operator=, which sets CopyComplete last as a publication barrier for the
+  // multi-threaded growing path. Without a user-declared copy constructor the
+  // implicit one would be used and is deprecated (-Wdeprecated-copy), since
+  // operator= is user-provided.
+  Seed(const Seed &src) { *this = src; }
 
-  {}
-
-  void setMoleculeFragment(const Seed &src) {
-    MoleculeFragment = src.MoleculeFragment;
-  }
   Seed &operator=(const Seed &src) {
     NewBonds = src.NewBonds;
     GrowingStage = src.GrowingStage;
@@ -119,6 +120,9 @@ class RDKIT_FMCS_EXPORT Seed {
     MatchResult = src.MatchResult;
     CopyComplete = true;  // LAST
     return *this;
+  }
+  void setMoleculeFragment(const Seed &src) {
+    MoleculeFragment = src.MoleculeFragment;
   }
   void createFromParent(const Seed *parent) {
     MoleculeFragment = parent->MoleculeFragment;

--- a/Code/GraphMol/MolStandardize/Tautomer.h
+++ b/Code/GraphMol/MolStandardize/Tautomer.h
@@ -58,6 +58,7 @@ struct RDKIT_MOLSTANDARDIZE_EXPORT SubstructTerm {
                 std::vector<int> reqElements = {},
                 std::string connSmarts = "");
   SubstructTerm(const SubstructTerm &rhs) = default;
+  SubstructTerm &operator=(const SubstructTerm &rhs) = default;
 
   bool operator==(const SubstructTerm &rhs) const {
     return name == rhs.name && smarts == rhs.smarts && score == rhs.score;


### PR DESCRIPTION
## Summary

Fixes two latent `-Wdeprecated-copy` issues where a class declares one copy special-member but relies on the implicitly-defined (and therefore deprecated) other, and is then actually copied at real call sites:

- **`FMCS::Seed`** declares `operator=` but no copy constructor, and is copy-constructed via `std::list<Seed>::push_back` (`SeedSet::push_back`, used in `MaximumCommonSubgraph`). The copy constructor is defined explicitly and **delegates to `operator=`**, preserving the existing semantics where `CopyComplete` is set *last* as a publication barrier for the multi-threaded growing path (so it can't simply be `= default`ed).
- **`MolStandardize::SubstructTerm`** declares a defaulted copy constructor but no copy assignment, and is copied/assigned via `std::vector<SubstructTerm>`. The assignment operator is defaulted to match.

## Why now / why separate

These are carved out of the precompiled-headers work in #9236 (thanks @greglandrum) so that PR can stay purely additive. They stand on their own as small correctness fixes.

Honest scope note: these are **latent** under RDKit's current flags — `-Wno-deprecated` masks `-Wdeprecated-copy` on Clang, so they don't fail CI today — but they're genuine deprecated special-member uses that surface on stricter configurations. The minimal pattern (user-declared `operator=` + implicit copy ctor, then copy-constructed into a container) errors under `-Wdeprecated-copy -Werror`; providing the matching special member clears it.

## Verification

- `FMCS` and `MolStandardize` libraries + the FMCS Catch tests build clean (Apple clang); no behavior change — `Seed` copies still route through `operator=`, `SubstructTerm` assignment is the same member-wise copy.
- Diff is minimal: a documented copy constructor + one defaulted `operator=`; `operator=` itself is byte-identical to before.

Refs #9236.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
