### PR TITLE
Check OOB causing OSV-2022-1288

### DIFF
--- a/Code/GraphMol/SmilesParse/CXSmilesOps.cpp
+++ b/Code/GraphMol/SmilesParse/CXSmilesOps.cpp
@@ -385,7 +385,7 @@ bool parse_atom_props(Iterator &first, Iterator last, RDKit::RWMol &mol,
       ++first;
     }
   }
-  if (first <= last && *first != '|' && *first != ',') {
+  if ((first > last) || (*first != '|' && *first != ',')) {
     return false;
   }
   if (*first != '|') {


### PR DESCRIPTION
#### Reference Issue
https://issues.oss-fuzz.com/issues/376787368

#### What does this implement/fix? Explain your changes.
The "first" iterator ended up past the "last" iterator, causing memory issues. This checks for that case before accessing "first" to avoid the error.

#### Any other comments?

