### PR TITLE
Bugfix/rgd multicore targetmol crash

### DIFF
--- a/Code/GraphMol/RGroupDecomposition/RGroupDecomp.cpp
+++ b/Code/GraphMol/RGroupDecomposition/RGroupDecomp.cpp
@@ -586,7 +586,8 @@ int RGroupDecomposition::add(const ROMol &inmol) {
           potentialMatches.emplace_back(core_idx, numberMissingUserGroups,
                                         match, extractedCore);
           if (data->params.includeTargetMolInResults) {
-            potentialMatches.back().setTargetMoleculeForHighlights(mol);
+            potentialMatches.back().setTargetMoleculeForHighlights(
+                RWMOL_SPTR(new RWMol(*mol)));
           }
         }
       }

--- a/Code/GraphMol/RGroupDecomposition/Wrap/test_rgroups.py
+++ b/Code/GraphMol/RGroupDecomposition/Wrap/test_rgroups.py
@@ -956,6 +956,37 @@ M  END
     for row in rows:
       checkRow(row)
 
+  def testIncludeTargetMolInResultsWithMultipleCoresInSameMol(self):
+    core = Chem.MolFromSmarts("[*:1]c1c([*:2])cccc1")
+    self.assertIsNotNone(core)
+    mols = [
+      Chem.MolFromSmiles(smi) for smi in [
+        "c1ccc(C)c(N)c1",
+        "c1ccc(F)c(O)c1",
+        "c1ccc(c2ccccc2)c(N)c1",
+      ]
+    ]
+    self.assertTrue(all(mols))
+    ps = RGroupDecompositionParameters()
+    ps.allowMultipleCoresInSameMol = True
+    ps.includeTargetMolInResults = True
+    rgd = RGroupDecomposition(core, ps)
+    for mol in mols:
+      self.assertNotEqual(rgd.Add(mol), -1)
+    self.assertTrue(rgd.Process())
+
+    rows = rgd.GetRGroupsAsRows()
+    self.assertGreater(len(rows), len(mols))
+    for row in rows:
+      self.assertIn("Mol", row)
+      self.assertIn("Core", row)
+
+    cols = rgd.GetRGroupsAsColumns()
+    self.assertIn("Mol", cols)
+    self.assertIn("Core", cols)
+    self.assertEqual(len(cols["Mol"]), len(rows))
+    self.assertEqual(len(cols["Core"]), len(rows))
+
 
 if __name__ == '__main__':
   rdBase.DisableLog("rdApp.debug")

--- a/Code/GraphMol/RGroupDecomposition/catch_rgd.cpp
+++ b/Code/GraphMol/RGroupDecomposition/catch_rgd.cpp
@@ -1209,3 +1209,36 @@ TEST_CASE("Multiple Core Hits") {
 ])JSON"));
   }
 }
+
+TEST_CASE("includeTargetMolInResults with Multiple Core Hits") {
+  std::vector<ROMOL_SPTR> cores{"[*:1]c1c([*:2])cccc1"_smarts};
+  REQUIRE(cores.front());
+  std::vector<ROMOL_SPTR> mols{"c1ccc(C)c(N)c1"_smiles,
+                               "c1ccc(F)c(O)c1"_smiles,
+                               "c1ccc(c2ccccc2)c(N)c1"_smiles};
+  bool areMolsNonNull = std::all_of(mols.begin(), mols.end(),
+                                    [](const auto &mol) { return mol; });
+  REQUIRE(areMolsNonNull);
+
+  RGroupDecompositionParameters ps;
+  ps.allowMultipleCoresInSameMol = true;
+  ps.includeTargetMolInResults = true;
+
+  RGroupRows rows;
+  auto n = RGroupDecompose(cores, mols, rows, nullptr, ps);
+  CHECK(n == mols.size());
+  CHECK(rows.size() > mols.size());
+
+  for (const auto &row : rows) {
+    CHECK(row.find(RGroupData::getMolLabel()) != row.end());
+    CHECK(row.find(RGroupData::getCoreLabel()) != row.end());
+  }
+
+  RGroupColumns cols;
+  n = RGroupDecompose(cores, mols, cols, nullptr, ps);
+  CHECK(n == mols.size());
+  REQUIRE(cols.count(RGroupData::getMolLabel()) == 1);
+  REQUIRE(cols.count(RGroupData::getCoreLabel()) == 1);
+  CHECK(cols[RGroupData::getMolLabel()].size() == rows.size());
+  CHECK(cols[RGroupData::getCoreLabel()].size() == rows.size());
+}


### PR DESCRIPTION
#### Reference Issue

Fixes #9363

#### What does this implement/fix? Explain your changes,

This PR fixes a crash in RGroup decomposition when both of the following options are enabled together:

- `includeTargetMolInResults = true`
- `allowMultipleCoresInSameMol = true`

Root cause:

- The target molecule used for highlight bookkeeping was shared across multiple decomposition matches from the same input molecule.
- That shared mutable state caused invalid/stale atom and bond index remapping during highlight processing and could trigger a `Range Error`.

Code change:

- Updated RGroup decomposition match construction so each match stores its own copy of the target molecule for highlighting instead of sharing one mutable instance.
- This isolates per-match highlight trimming/index remapping and prevents cross-row aliasing side effects.

Tests added:

- C++ regression test in `Code/GraphMol/RGroupDecomposition/catch_rgd.cpp`
- Python wrapper regression test in `Code/GraphMol/RGroupDecomposition/Wrap/test_rgroups.py`
- Both tests cover the combined-options scenario and assert successful decomposition plus consistent `Core` and `Mol` output sizing.

#### Any other comments?

Validation run locally:

- `testRGroupDecomp`
- `testRGroupDecompInternals`
- `rgroupCatchTests`
- `pyRGroupDecomposition`

AI usage acknowledgment:

- I used GitHub Copilot (GPT-5.3-Codex) to assist with implementation drafting and test authoring, then reviewed and validated the final changes and behavior locally before preparing this PR.