### PR TITLE
Perf: Caches for faster reaction enumeration

### DIFF
--- a/Code/Bench/CMakeLists.txt
+++ b/Code/Bench/CMakeLists.txt
@@ -25,10 +25,11 @@ endif(RDK_BUILD_INCHI_SUPPORT)
 
 if(RDK_BUILD_CPP_TESTS)
   # add a fast version of the benchmarks to the default unit tests
-  # to protect the benchmarks from bit-rot
+  # to protect the benchmarks from bit-rot. [slow] benchmarks are excluded
+  # here and meant to be run on demand (e.g. `bench [slow]`).
   add_test(
     NAME quickbench
-    COMMAND bench --benchmark-samples 1 --benchmark-warmup-time 0
+    COMMAND bench --benchmark-samples 1 --benchmark-warmup-time 0 ~[slow]
   )
   
   # ctest does not automatically build test executables

--- a/Code/Bench/CMakeLists.txt
+++ b/Code/Bench/CMakeLists.txt
@@ -4,6 +4,7 @@ add_executable(bench EXCLUDE_FROM_ALL bench_common.cpp
   meta.cpp
   mol.cpp
   molops.cpp
+  reaction_enumerate.cpp
   pickle.cpp
   smiles.cpp
   stereo.cpp
@@ -13,6 +14,7 @@ target_link_libraries(bench rdkitCatch
   CIPLabeler
   Descriptors
   Fingerprints
+  ChemReactions
   SmilesParse
 )
 

--- a/Code/Bench/reaction_enumerate.cpp
+++ b/Code/Bench/reaction_enumerate.cpp
@@ -1,0 +1,174 @@
+#include <catch2/catch_all.hpp>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <GraphMol/ChemReactions/Reaction.h>
+#include <GraphMol/ChemReactions/ReactionParser.h>
+#include <GraphMol/ChemReactions/ReactionRunner.h>
+#include <GraphMol/RDKitBase.h>
+#include <GraphMol/SmilesParse/SmilesParse.h>
+
+using namespace RDKit;
+
+namespace {
+
+std::vector<ROMOL_SPTR> make_reagent_pool(unsigned int count,
+                                         const std::string &suffix) {
+  std::vector<ROMOL_SPTR> pool;
+  pool.reserve(count);
+  for (unsigned int i = 0; i < count; ++i) {
+    const std::string smiles = std::string(i + 1, 'C') + suffix;
+    auto mol = v2::SmilesParse::MolFromSmiles(smiles);
+    REQUIRE(mol);
+    pool.push_back(ROMOL_SPTR(mol.release()));
+  }
+  return pool;
+}
+
+std::vector<ROMOL_SPTR> make_acid_pool(unsigned int count) {
+  return make_reagent_pool(count, "(=O)O");
+}
+
+std::vector<ROMOL_SPTR> make_amine_pool(unsigned int count) {
+  return make_reagent_pool(count, "N");
+}
+
+constexpr unsigned int BENCH_REPEATS = 8;
+
+std::size_t run_uncached(const ChemicalReaction &rxn,
+                         const std::vector<ROMOL_SPTR> &acids,
+                         const std::vector<ROMOL_SPTR> &amines) {
+  std::size_t total_products = 0;
+  for (unsigned int repeat = 0; repeat < BENCH_REPEATS; ++repeat) {
+    for (const auto &acid : acids) {
+      for (const auto &amine : amines) {
+        MOL_SPTR_VECT reactants{acid, amine};
+        total_products += run_Reactants(rxn, reactants).size();
+      }
+    }
+  }
+  return total_products;
+}
+
+std::size_t run_cached(const ChemicalReaction &rxn,
+                       const std::vector<ROMOL_SPTR> &acids,
+                       const std::vector<ROMOL_SPTR> &amines) {
+  ReactantMatchCache cache;
+  std::size_t total_products = 0;
+  for (unsigned int repeat = 0; repeat < BENCH_REPEATS; ++repeat) {
+    for (const auto &acid : acids) {
+      for (const auto &amine : amines) {
+        MOL_SPTR_VECT reactants{acid, amine};
+        total_products += run_Reactants(rxn, reactants, cache).size();
+      }
+    }
+  }
+  return total_products;
+}
+
+}  // namespace
+
+TEST_CASE("reaction enumeration matching", "[reaction][enumerate]") {
+  std::unique_ptr<ChemicalReaction> rxn(RxnSmartsToChemicalReaction(
+      "[C:1](=[O:2])[O;H1].[N:3]>>[C:1](=[O:2])[N:3]"));
+  REQUIRE(rxn);
+  rxn->initReactantMatchers();
+
+  const auto acids = make_acid_pool(64);
+  const auto amines = make_amine_pool(64);
+
+  const std::size_t uncached_total = run_uncached(*rxn, acids, amines);
+  const std::size_t cached_total = run_cached(*rxn, acids, amines);
+  CHECK(cached_total == uncached_total);
+
+  BENCHMARK("runReactants uncached") {
+    std::size_t total_products = 0;
+    for (unsigned int repeat = 0; repeat < BENCH_REPEATS; ++repeat) {
+      for (const auto &acid : acids) {
+        for (const auto &amine : amines) {
+          MOL_SPTR_VECT reactants{acid, amine};
+          total_products += run_Reactants(*rxn, reactants).size();
+        }
+      }
+    }
+    return total_products;
+  };
+
+  BENCHMARK("runReactants cached") {
+    ReactantMatchCache cache;
+    std::size_t total_products = 0;
+    for (unsigned int repeat = 0; repeat < BENCH_REPEATS; ++repeat) {
+      for (const auto &acid : acids) {
+        for (const auto &amine : amines) {
+          MOL_SPTR_VECT reactants{acid, amine};
+          total_products += run_Reactants(*rxn, reactants, cache).size();
+        }
+      }
+    }
+    return total_products;
+  };
+}
+
+TEST_CASE("reaction enumeration matching (recursive SMARTS)",
+          "[reaction][enumerate]") {
+  // Both reactant templates use recursive SMARTS ($(...)), so the
+  // substructure matching is expensive relative to product assembly. This is
+  // where caching repeated per-reagent matches pays off the most. Smaller
+  // pools are used here because the recursive matching is costly.
+  std::unique_ptr<ChemicalReaction> rxn(RxnSmartsToChemicalReaction(
+      "[N;$(N-[#6]):3]=[C;$(C=S):1].[N;$(N[#6]);!$(N=*);!$([N-]);!$(N#*);"
+      "!$([ND3]);!$([ND4]);!$(N[O,N]);!$(N[C,S]=[S,O,N]):2]>>"
+      "[N:3]-[C:1]-[N+0:2]"));
+  REQUIRE(rxn);
+  rxn->initReactantMatchers();
+
+  constexpr unsigned int POOL = 24;
+  // isothiocyanates of varying chain length match the first template
+  auto isothiocyanates = make_reagent_pool(POOL, "N=C=S");
+  // simple primary amines match the second (restrictive) template
+  std::vector<ROMOL_SPTR> amines;
+  amines.reserve(POOL);
+  for (unsigned int i = 0; i < POOL; ++i) {
+    auto mol = v2::SmilesParse::MolFromSmiles("N" + std::string(i + 1, 'C'));
+    REQUIRE(mol);
+    amines.push_back(ROMOL_SPTR(mol.release()));
+  }
+
+  // correctness: cached and uncached produce the same number of products
+  std::size_t uncached_total = 0;
+  std::size_t cached_total = 0;
+  ReactantMatchCache checkCache;
+  for (const auto &itc : isothiocyanates) {
+    for (const auto &amine : amines) {
+      MOL_SPTR_VECT reactants{itc, amine};
+      uncached_total += run_Reactants(*rxn, reactants).size();
+      cached_total += run_Reactants(*rxn, reactants, checkCache).size();
+    }
+  }
+  CHECK(cached_total == uncached_total);
+
+  BENCHMARK("runReactants uncached (recursive SMARTS)") {
+    std::size_t total_products = 0;
+    for (const auto &itc : isothiocyanates) {
+      for (const auto &amine : amines) {
+        MOL_SPTR_VECT reactants{itc, amine};
+        total_products += run_Reactants(*rxn, reactants).size();
+      }
+    }
+    return total_products;
+  };
+
+  BENCHMARK("runReactants cached (recursive SMARTS)") {
+    ReactantMatchCache cache;
+    std::size_t total_products = 0;
+    for (const auto &itc : isothiocyanates) {
+      for (const auto &amine : amines) {
+        MOL_SPTR_VECT reactants{itc, amine};
+        total_products += run_Reactants(*rxn, reactants, cache).size();
+      }
+    }
+    return total_products;
+  };
+}

--- a/Code/Bench/reaction_enumerate.cpp
+++ b/Code/Bench/reaction_enumerate.cpp
@@ -1,8 +1,10 @@
 #include <catch2/catch_all.hpp>
 
+#include <algorithm>
 #include <set>
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include <GraphMol/ChemReactions/Reaction.h>
@@ -355,5 +357,127 @@ TEST_CASE("reaction enumeration assembly graft cache",
       }
     }
     return benchmark_total_products;
+  };
+}
+
+TEST_CASE("reaction enumeration three-component symmetric monomers",
+          "[reaction][assembly][slow]") {
+  // A three-reactant reaction enumerated over symmetric diamine monomers.
+  // Each monomer is a 2-substituted 1,3-diaminopropane: two equivalent primary
+  // amines (the symmetric core) with an inert alkyl chain grown at the central
+  // carbon, a symmetry-neutral position. Every monomer therefore stays
+  // internally symmetric (so dedup collapses its two equivalent matches) while
+  // remaining distinct from the others, and the growing chain makes product
+  // assembly the dominant cost (so the graft cache pays off). The three modes
+  // compared are: no caching (and no dedup), dedup + match cache, and
+  // dedup + graft cache.
+  std::unique_ptr<ChemicalReaction> rxn(RxnSmartsToChemicalReaction(
+      "[N;H2:1].[N;H2:2].[N;H2:3]>>[N:1]C.[N:2]C.[N:3]C"));
+  REQUIRE(rxn);
+  rxn->initReactantMatchers();
+
+  auto make_symmetric_diamines = [](unsigned int count) {
+    std::vector<ROMOL_SPTR> pool;
+    pool.reserve(count);
+    for (unsigned int i = 0; i < count; ++i) {
+      // H2N-CH2-CH(chain)-CH2-NH2 with a growing inert chain at the center
+      const std::string smiles = "NCC(" + std::string(i + 1, 'C') + ")CN";
+      auto mol = v2::SmilesParse::MolFromSmiles(smiles);
+      REQUIRE(mol);
+      pool.push_back(ROMOL_SPTR(mol.release()));
+    }
+    return pool;
+  };
+
+  constexpr unsigned int POOL = 30;
+  const auto poolA = make_symmetric_diamines(POOL);
+  const auto poolB = make_symmetric_diamines(POOL);
+  const auto poolC = make_symmetric_diamines(POOL);
+
+  enum class Mode { Plain, DedupMatch, DedupGraft };
+
+  auto run_triple = [&](Mode mode, const ROMOL_SPTR &a, const ROMOL_SPTR &b,
+                        const ROMOL_SPTR &c, ReactantMatchCache &matchCache,
+                        ReactionRunnerUtils::ReactantGraftCache &graftCache) {
+    MOL_SPTR_VECT reactants{a, b, c};
+    switch (mode) {
+      case Mode::Plain:
+        return run_Reactants(*rxn, reactants);
+      case Mode::DedupMatch:
+        return run_Reactants(*rxn, reactants, matchCache, true);
+      case Mode::DedupGraft:
+        return run_Reactants(*rxn, reactants, matchCache, graftCache, true);
+    }
+    return std::vector<MOL_SPTR_VECT>{};
+  };
+
+  // correctness: on a small slice all three modes yield the same unique
+  // products; the no-dedup mode just produces extra symmetric duplicates
+  auto collect_unique = [&](Mode mode, unsigned int limit) {
+    std::set<std::string> uniqueProducts;
+    std::size_t setCount = 0;
+    ReactantMatchCache matchCache;
+    ReactionRunnerUtils::ReactantGraftCache graftCache;
+    for (unsigned int i = 0; i < limit; ++i) {
+      for (unsigned int j = 0; j < limit; ++j) {
+        for (unsigned int k = 0; k < limit; ++k) {
+          const auto products = run_triple(mode, poolA[i], poolB[j], poolC[k],
+                                           matchCache, graftCache);
+          setCount += products.size();
+          for (const auto &product_set : products) {
+            std::vector<std::string> parts;
+            parts.reserve(product_set.size());
+            for (const auto &product : product_set) {
+              parts.push_back(MolToSmiles(*product));
+            }
+            std::sort(parts.begin(), parts.end());
+            std::string joined;
+            for (const auto &part : parts) {
+              joined += part;
+              joined.push_back('.');
+            }
+            uniqueProducts.insert(joined);
+          }
+        }
+      }
+    }
+    return std::make_pair(uniqueProducts, setCount);
+  };
+
+  constexpr unsigned int CHECK_LIMIT = 4;
+  const auto plainCheck = collect_unique(Mode::Plain, CHECK_LIMIT);
+  const auto matchCheck = collect_unique(Mode::DedupMatch, CHECK_LIMIT);
+  const auto graftCheck = collect_unique(Mode::DedupGraft, CHECK_LIMIT);
+  CHECK(plainCheck.first == matchCheck.first);
+  CHECK(graftCheck.first == matchCheck.first);
+  // the symmetric core yields duplicate matches, so the no-dedup mode produces
+  // strictly more product sets than the deduped modes for the same unique set
+  CHECK(plainCheck.second > matchCheck.second);
+  CHECK(graftCheck.second == matchCheck.second);
+
+  // lean benchmark loop: full pools, no canonicalization so only assembly and
+  // caching are measured
+  auto bench_run = [&](Mode mode) {
+    ReactantMatchCache matchCache;
+    ReactionRunnerUtils::ReactantGraftCache graftCache;
+    std::size_t total = 0;
+    for (const auto &a : poolA) {
+      for (const auto &b : poolB) {
+        for (const auto &c : poolC) {
+          total += run_triple(mode, a, b, c, matchCache, graftCache).size();
+        }
+      }
+    }
+    return total;
+  };
+
+  BENCHMARK("three-component no caching") { return bench_run(Mode::Plain); };
+
+  BENCHMARK("three-component dedup + match cache") {
+    return bench_run(Mode::DedupMatch);
+  };
+
+  BENCHMARK("three-component dedup + graft cache") {
+    return bench_run(Mode::DedupGraft);
   };
 }

--- a/Code/Bench/reaction_enumerate.cpp
+++ b/Code/Bench/reaction_enumerate.cpp
@@ -1,5 +1,6 @@
 #include <catch2/catch_all.hpp>
 
+#include <set>
 #include <memory>
 #include <string>
 #include <vector>
@@ -9,6 +10,7 @@
 #include <GraphMol/ChemReactions/ReactionRunner.h>
 #include <GraphMol/RDKitBase.h>
 #include <GraphMol/SmilesParse/SmilesParse.h>
+#include <GraphMol/SmilesParse/SmilesWrite.h>
 
 using namespace RDKit;
 
@@ -167,6 +169,84 @@ TEST_CASE("reaction enumeration matching (recursive SMARTS)",
       for (const auto &amine : amines) {
         MOL_SPTR_VECT reactants{itc, amine};
         total_products += run_Reactants(*rxn, reactants, cache).size();
+      }
+    }
+    return total_products;
+  };
+}
+
+TEST_CASE("reaction enumeration matching (symmetric dedup)",
+          "[reaction][enumerate]") {
+  std::unique_ptr<ChemicalReaction> rxn(RxnSmartsToChemicalReaction(
+      "[N;H2:1].[C:2](=[O:3])[O;H1]>>[N:1][C:2]=[O:3]"));
+  REQUIRE(rxn);
+  rxn->initReactantMatchers();
+
+  constexpr unsigned int POOL = 16;
+  std::vector<ROMOL_SPTR> diamines;
+  diamines.reserve(POOL);
+  for (unsigned int i = 0; i < POOL; ++i) {
+    auto mol = v2::SmilesParse::MolFromSmiles("N" + std::string(i + 1, 'C') +
+                                              "N");
+    REQUIRE(mol);
+    diamines.push_back(ROMOL_SPTR(mol.release()));
+  }
+  const auto acids = make_acid_pool(POOL);
+
+  auto collect_unique_product_smiles =
+      [&rxn, &diamines, &acids](bool dedupeSymmetricMatches) {
+        std::set<std::string> product_smiles;
+        ReactantMatchCache cache;
+        for (const auto &diamine : diamines) {
+          for (const auto &acid : acids) {
+            MOL_SPTR_VECT reactants{diamine, acid};
+            const auto products = run_Reactants(*rxn, reactants, cache,
+                                                dedupeSymmetricMatches);
+            for (const auto &product_set : products) {
+              for (const auto &product : product_set) {
+                product_smiles.insert(MolToSmiles(*product));
+              }
+            }
+          }
+        }
+        return product_smiles;
+      };
+
+  std::size_t dedupOff_total = 0;
+  std::size_t dedupOn_total = 0;
+  // the dedup flag is part of the cache key, so false/true entries never
+  // collide even when the same cache is shared between both modes here
+  ReactantMatchCache checkCache;
+  for (const auto &diamine : diamines) {
+    for (const auto &acid : acids) {
+      MOL_SPTR_VECT reactants{diamine, acid};
+      dedupOff_total += run_Reactants(*rxn, reactants, checkCache, false).size();
+      dedupOn_total += run_Reactants(*rxn, reactants, checkCache, true).size();
+    }
+  }
+  CHECK(dedupOn_total < dedupOff_total);
+  CHECK(collect_unique_product_smiles(false) ==
+        collect_unique_product_smiles(true));
+
+  BENCHMARK("runReactants dedupe off") {
+    ReactantMatchCache cache;
+    std::size_t total_products = 0;
+    for (const auto &diamine : diamines) {
+      for (const auto &acid : acids) {
+        MOL_SPTR_VECT reactants{diamine, acid};
+        total_products += run_Reactants(*rxn, reactants, cache, false).size();
+      }
+    }
+    return total_products;
+  };
+
+  BENCHMARK("runReactants dedupe on") {
+    ReactantMatchCache cache;
+    std::size_t total_products = 0;
+    for (const auto &diamine : diamines) {
+      for (const auto &acid : acids) {
+        MOL_SPTR_VECT reactants{diamine, acid};
+        total_products += run_Reactants(*rxn, reactants, cache, true).size();
       }
     }
     return total_products;

--- a/Code/Bench/reaction_enumerate.cpp
+++ b/Code/Bench/reaction_enumerate.cpp
@@ -286,3 +286,74 @@ TEST_CASE("reaction enumeration assembly baseline", "[reaction][assembly]") {
     return benchmark_total_products;
   };
 }
+
+TEST_CASE("reaction enumeration assembly graft cache",
+          "[reaction][assembly]") {
+  // Cheap matching with long side chains makes product assembly the dominant
+  // cost. Reusing the graft cache across the Cartesian product extracts each
+  // reagent's graft once and replays it for every pairing, which is the win
+  // this benchmark measures.
+  std::unique_ptr<ChemicalReaction> rxn(RxnSmartsToChemicalReaction(
+      "[C:1](=[O:2])[O;H1].[N:3]>>[C:1](=[O:2])[N:3]"));
+  REQUIRE(rxn);
+  rxn->initReactantMatchers();
+
+  const auto acids = make_reagent_pool(8, std::string(18, 'C') + "(=O)O");
+  const auto amines = make_reagent_pool(8, std::string(18, 'C') + "N");
+
+  // correctness: the graft-cached path produces exactly the same unique
+  // products (and the same count) as the uncached path
+  auto collect_unique_product_smiles = [&](bool useGraftCache) {
+    std::set<std::string> product_smiles;
+    std::size_t product_set_count = 0;
+    ReactantMatchCache matchCache;
+    ReactionRunnerUtils::ReactantGraftCache graftCache;
+    for (const auto &acid : acids) {
+      for (const auto &amine : amines) {
+        MOL_SPTR_VECT reactants{acid, amine};
+        const auto products =
+            useGraftCache
+                ? run_Reactants(*rxn, reactants, matchCache, graftCache)
+                : run_Reactants(*rxn, reactants);
+        product_set_count += products.size();
+        for (const auto &product_set : products) {
+          for (const auto &product : product_set) {
+            product_smiles.insert(MolToSmiles(*product));
+          }
+        }
+      }
+    }
+    return std::make_pair(product_smiles, product_set_count);
+  };
+
+  const auto uncached = collect_unique_product_smiles(false);
+  const auto grafted = collect_unique_product_smiles(true);
+  CHECK(grafted.first == uncached.first);
+  CHECK(grafted.second == uncached.second);
+  CHECK(grafted.second == acids.size() * amines.size());
+
+  BENCHMARK("assemble products (no graft cache)") {
+    std::size_t benchmark_total_products = 0;
+    for (const auto &acid : acids) {
+      for (const auto &amine : amines) {
+        MOL_SPTR_VECT reactants{acid, amine};
+        benchmark_total_products += run_Reactants(*rxn, reactants).size();
+      }
+    }
+    return benchmark_total_products;
+  };
+
+  BENCHMARK("assemble products (graft cache)") {
+    ReactantMatchCache matchCache;
+    ReactionRunnerUtils::ReactantGraftCache graftCache;
+    std::size_t benchmark_total_products = 0;
+    for (const auto &acid : acids) {
+      for (const auto &amine : amines) {
+        MOL_SPTR_VECT reactants{acid, amine};
+        benchmark_total_products +=
+            run_Reactants(*rxn, reactants, matchCache, graftCache).size();
+      }
+    }
+    return benchmark_total_products;
+  };
+}

--- a/Code/Bench/reaction_enumerate.cpp
+++ b/Code/Bench/reaction_enumerate.cpp
@@ -252,3 +252,37 @@ TEST_CASE("reaction enumeration matching (symmetric dedup)",
     return total_products;
   };
 }
+
+TEST_CASE("reaction enumeration assembly baseline", "[reaction][assembly]") {
+  // Cheap matching with long side chains makes product assembly the dominant
+  // cost, which is the path we want to baseline before graft caching lands.
+  std::unique_ptr<ChemicalReaction> rxn(RxnSmartsToChemicalReaction(
+      "[C:1](=[O:2])[O;H1].[N:3]>>[C:1](=[O:2])[N:3]"));
+  REQUIRE(rxn);
+  rxn->initReactantMatchers();
+
+  const auto acids = make_reagent_pool(8, std::string(18, 'C') + "(=O)O");
+  const auto amines = make_reagent_pool(8, std::string(18, 'C') + "N");
+
+  std::size_t total_products = 0;
+  for (const auto &acid : acids) {
+    for (const auto &amine : amines) {
+      MOL_SPTR_VECT reactants{acid, amine};
+      total_products += run_Reactants(*rxn, reactants).size();
+    }
+  }
+  CHECK(total_products > 0);
+  // each acid+amine pair yields exactly one product set for this amide reaction
+  CHECK(total_products == acids.size() * amines.size());
+
+  BENCHMARK("assemble products (current)") {
+    std::size_t benchmark_total_products = 0;
+    for (const auto &acid : acids) {
+      for (const auto &amine : amines) {
+        MOL_SPTR_VECT reactants{acid, amine};
+        benchmark_total_products += run_Reactants(*rxn, reactants).size();
+      }
+    }
+    return benchmark_total_products;
+  };
+}

--- a/Code/GraphMol/ChemReactions/Enumerate/Enumerate.cpp
+++ b/Code/GraphMol/ChemReactions/Enumerate/Enumerate.cpp
@@ -150,13 +150,17 @@ BBS removeNonmatchingReagents(const ChemicalReaction &rxn, BBS bbs,
           cache && params.reagentMaxMatchCount == INT_MAX &&
           !hasProtectedAtoms(*mol);
       if (canPrimeCache) {
-        const auto cacheKey =
-            std::make_tuple(static_cast<unsigned int>(reactant_idx), mol.get(),
-                  1000u, false);
-        const VectMatchVectType reactantMatches =
+        VectMatchVectType reactantMatches =
             ReactionRunnerUtils::getReactantMatchesToTemplate(
                 *mol.get(), *reactantTemplate.get(), 1000u,
                 rxn.getSubstructParams());
+        if (params.dedupeSymmetricMatches) {
+          reactantMatches = ReactionRunnerUtils::dedupeMatchesBySymmetry(
+              *mol.get(), reactantMatches);
+        }
+        const auto cacheKey = std::make_tuple(
+            static_cast<unsigned int>(reactant_idx), mol.get(), 1000u,
+            params.dedupeSymmetricMatches);
         matches = reactantMatches.size();
         if (matches) {
           cache->emplace(cacheKey, reactantMatches);
@@ -213,6 +217,7 @@ BBS removeNonmatchingReagents(const ChemicalReaction &rxn, BBS bbs,
 EnumerateLibrary::EnumerateLibrary(const ChemicalReaction &rxn, const BBS &bbs,
                                    const EnumerationParams &params)
     : EnumerateLibraryBase(rxn, new CartesianProductStrategy),
+      m_dedupeSymmetricMatches(params.dedupeSymmetricMatches),
       m_matchCache(),
       m_bbs(removeNonmatchingReagents(m_rxn, bbs, params, &m_matchCache)) {
   m_enumerator->initialize(m_rxn, m_bbs);  // getSizesFromBBs(bbs));
@@ -223,6 +228,7 @@ EnumerateLibrary::EnumerateLibrary(const ChemicalReaction &rxn, const BBS &bbs,
                                    const EnumerationStrategyBase &enumerator,
                                    const EnumerationParams &params)
     : EnumerateLibraryBase(rxn),
+      m_dedupeSymmetricMatches(params.dedupeSymmetricMatches),
       m_matchCache(),
       m_bbs(removeNonmatchingReagents(m_rxn, bbs, params, &m_matchCache)) {
   m_enumerator.reset(enumerator.copy());
@@ -231,7 +237,10 @@ EnumerateLibrary::EnumerateLibrary(const ChemicalReaction &rxn, const BBS &bbs,
 }
 
 EnumerateLibrary::EnumerateLibrary(const EnumerateLibrary &rhs)
-    : EnumerateLibraryBase(rhs), m_matchCache(rhs.m_matchCache), m_bbs(rhs.m_bbs) {}
+    : EnumerateLibraryBase(rhs),
+      m_dedupeSymmetricMatches(rhs.m_dedupeSymmetricMatches),
+      m_matchCache(rhs.m_matchCache),
+      m_bbs(rhs.m_bbs) {}
 
 std::vector<MOL_SPTR_VECT> EnumerateLibrary::next() {
   PRECONDITION(static_cast<bool>(*this), "No more enumerations");
@@ -242,7 +251,7 @@ std::vector<MOL_SPTR_VECT> EnumerateLibrary::next() {
     reactants[i] = m_bbs[i][reactantIndices[i]];
   }
 
-  return run_Reactants(m_rxn, reactants, m_matchCache);
+  return run_Reactants(m_rxn, reactants, m_matchCache, m_dedupeSymmetricMatches);
 }
 
 void EnumerateLibrary::toStream(std::ostream &ss) const {

--- a/Code/GraphMol/ChemReactions/Enumerate/Enumerate.cpp
+++ b/Code/GraphMol/ChemReactions/Enumerate/Enumerate.cpp
@@ -219,10 +219,13 @@ EnumerateLibrary::EnumerateLibrary(const ChemicalReaction &rxn, const BBS &bbs,
     : EnumerateLibraryBase(rxn, new CartesianProductStrategy),
       m_dedupeSymmetricMatches(params.dedupeSymmetricMatches),
       m_matchCache(),
-      m_cacheReactantGrafts(params.cacheReactantGrafts),
+      m_cacheMode(params.cacheMode),
       m_graftCache(),
-      m_bbs(removeNonmatchingReagents(m_rxn, bbs, params, &m_matchCache)) {
-  m_enumerator->initialize(m_rxn, m_bbs);  // getSizesFromBBs(bbs));
+      m_bbs(removeNonmatchingReagents(
+          m_rxn, bbs, params,
+          params.cacheMode != ReactantCacheMode::None ? &m_matchCache
+                                                      : nullptr)) {
+  m_enumerator->initialize(m_rxn, m_bbs);  // getSizesFromBBs(bbs))
   m_initialEnumerator.reset(m_enumerator->copy());
 }
 
@@ -232,9 +235,12 @@ EnumerateLibrary::EnumerateLibrary(const ChemicalReaction &rxn, const BBS &bbs,
     : EnumerateLibraryBase(rxn),
       m_dedupeSymmetricMatches(params.dedupeSymmetricMatches),
       m_matchCache(),
-      m_cacheReactantGrafts(params.cacheReactantGrafts),
+      m_cacheMode(params.cacheMode),
       m_graftCache(),
-      m_bbs(removeNonmatchingReagents(m_rxn, bbs, params, &m_matchCache)) {
+      m_bbs(removeNonmatchingReagents(
+          m_rxn, bbs, params,
+          params.cacheMode != ReactantCacheMode::None ? &m_matchCache
+                                                      : nullptr)) {
   m_enumerator.reset(enumerator.copy());
   m_enumerator->initialize(m_rxn, m_bbs);
   m_initialEnumerator.reset(m_enumerator->copy());
@@ -244,7 +250,7 @@ EnumerateLibrary::EnumerateLibrary(const EnumerateLibrary &rhs)
     : EnumerateLibraryBase(rhs),
       m_dedupeSymmetricMatches(rhs.m_dedupeSymmetricMatches),
       m_matchCache(rhs.m_matchCache),
-      m_cacheReactantGrafts(rhs.m_cacheReactantGrafts),
+      m_cacheMode(rhs.m_cacheMode),
       m_graftCache(rhs.m_graftCache),
       m_bbs(rhs.m_bbs) {}
 
@@ -257,11 +263,15 @@ std::vector<MOL_SPTR_VECT> EnumerateLibrary::next() {
     reactants[i] = m_bbs[i][reactantIndices[i]];
   }
 
-  if (m_cacheReactantGrafts) {
+  if (m_cacheMode == ReactantCacheMode::Full) {
     return run_Reactants(m_rxn, reactants, m_matchCache, m_graftCache,
                          m_dedupeSymmetricMatches);
   }
-  return run_Reactants(m_rxn, reactants, m_matchCache, m_dedupeSymmetricMatches);
+  if (m_cacheMode == ReactantCacheMode::MatchOnly) {
+    return run_Reactants(m_rxn, reactants, m_matchCache,
+                         m_dedupeSymmetricMatches);
+  }
+  return run_Reactants(m_rxn, reactants);
 }
 
 void EnumerateLibrary::toStream(std::ostream &ss) const {

--- a/Code/GraphMol/ChemReactions/Enumerate/Enumerate.cpp
+++ b/Code/GraphMol/ChemReactions/Enumerate/Enumerate.cpp
@@ -110,9 +110,24 @@ size_t countMatches(const ROMol &bb, const ROMol &query, int maxMatches) {
                  useQueryQueryMatches, maxMatches + 1);
   return matches.size();
 }
+
+bool hasProtectedAtoms(const ROMol &mol) {
+  for (unsigned int atomIdx = 0; atomIdx < mol.getNumAtoms(); ++atomIdx) {
+    if (mol.getAtomWithIdx(atomIdx)->hasProp(common_properties::_protected)) {
+      return true;
+    }
+  }
+  return false;
+}
 }  // namespace
 BBS removeNonmatchingReagents(const ChemicalReaction &rxn, BBS bbs,
                               const EnumerationParams &params) {
+  return removeNonmatchingReagents(rxn, std::move(bbs), params, nullptr);
+}
+
+BBS removeNonmatchingReagents(const ChemicalReaction &rxn, BBS bbs,
+                              const EnumerationParams &params,
+                              ReactantMatchCache *cache) {
   PRECONDITION(bbs.size() <= rxn.getNumReactantTemplates(),
                "Number of Reagents not compatible with reaction templates");
   BBS result;
@@ -129,8 +144,27 @@ BBS removeNonmatchingReagents(const ChemicalReaction &rxn, BBS bbs,
     for (size_t reagent_idx = 0; reagent_idx < bbs[reactant_idx].size();
          ++reagent_idx) {
       ROMOL_SPTR mol = bbs[reactant_idx][reagent_idx];
-      size_t matches =
-          countMatches(*mol.get(), *reactantTemplate.get(), maxMatches);
+      size_t matches = 0;
+
+      const bool canPrimeCache =
+          cache && params.reagentMaxMatchCount == INT_MAX &&
+          !hasProtectedAtoms(*mol);
+      if (canPrimeCache) {
+        const auto cacheKey =
+            std::make_tuple(static_cast<unsigned int>(reactant_idx), mol.get(),
+                            1000u);
+        const VectMatchVectType reactantMatches =
+            ReactionRunnerUtils::getReactantMatchesToTemplate(
+                *mol.get(), *reactantTemplate.get(), 1000u,
+                rxn.getSubstructParams());
+        matches = reactantMatches.size();
+        if (matches) {
+          cache->emplace(cacheKey, reactantMatches);
+        }
+      } else {
+        matches =
+            countMatches(*mol.get(), *reactantTemplate.get(), maxMatches);
+      }
 
       bool removeReagent = false;
       if (!matches || matches > rdcast<size_t>(params.reagentMaxMatchCount)) {
@@ -179,7 +213,8 @@ BBS removeNonmatchingReagents(const ChemicalReaction &rxn, BBS bbs,
 EnumerateLibrary::EnumerateLibrary(const ChemicalReaction &rxn, const BBS &bbs,
                                    const EnumerationParams &params)
     : EnumerateLibraryBase(rxn, new CartesianProductStrategy),
-      m_bbs(removeNonmatchingReagents(m_rxn, bbs, params)) {
+      m_matchCache(),
+      m_bbs(removeNonmatchingReagents(m_rxn, bbs, params, &m_matchCache)) {
   m_enumerator->initialize(m_rxn, m_bbs);  // getSizesFromBBs(bbs));
   m_initialEnumerator.reset(m_enumerator->copy());
 }
@@ -188,14 +223,15 @@ EnumerateLibrary::EnumerateLibrary(const ChemicalReaction &rxn, const BBS &bbs,
                                    const EnumerationStrategyBase &enumerator,
                                    const EnumerationParams &params)
     : EnumerateLibraryBase(rxn),
-      m_bbs(removeNonmatchingReagents(m_rxn, bbs, params)) {
+      m_matchCache(),
+      m_bbs(removeNonmatchingReagents(m_rxn, bbs, params, &m_matchCache)) {
   m_enumerator.reset(enumerator.copy());
   m_enumerator->initialize(m_rxn, m_bbs);
   m_initialEnumerator.reset(m_enumerator->copy());
 }
 
 EnumerateLibrary::EnumerateLibrary(const EnumerateLibrary &rhs)
-    : EnumerateLibraryBase(rhs), m_bbs(rhs.m_bbs) {}
+    : EnumerateLibraryBase(rhs), m_matchCache(rhs.m_matchCache), m_bbs(rhs.m_bbs) {}
 
 std::vector<MOL_SPTR_VECT> EnumerateLibrary::next() {
   PRECONDITION(static_cast<bool>(*this), "No more enumerations");

--- a/Code/GraphMol/ChemReactions/Enumerate/Enumerate.cpp
+++ b/Code/GraphMol/ChemReactions/Enumerate/Enumerate.cpp
@@ -223,8 +223,10 @@ EnumerateLibrary::EnumerateLibrary(const ChemicalReaction &rxn, const BBS &bbs,
       m_graftCache(),
       m_bbs(removeNonmatchingReagents(
           m_rxn, bbs, params,
-          params.cacheMode != ReactantCacheMode::None ? &m_matchCache
-                                                      : nullptr)) {
+          (params.cacheMode != ReactantCacheMode::None ||
+           params.dedupeSymmetricMatches)
+              ? &m_matchCache
+              : nullptr)) {
   m_enumerator->initialize(m_rxn, m_bbs);  // getSizesFromBBs(bbs))
   m_initialEnumerator.reset(m_enumerator->copy());
 }
@@ -239,8 +241,10 @@ EnumerateLibrary::EnumerateLibrary(const ChemicalReaction &rxn, const BBS &bbs,
       m_graftCache(),
       m_bbs(removeNonmatchingReagents(
           m_rxn, bbs, params,
-          params.cacheMode != ReactantCacheMode::None ? &m_matchCache
-                                                      : nullptr)) {
+          (params.cacheMode != ReactantCacheMode::None ||
+           params.dedupeSymmetricMatches)
+              ? &m_matchCache
+              : nullptr)) {
   m_enumerator.reset(enumerator.copy());
   m_enumerator->initialize(m_rxn, m_bbs);
   m_initialEnumerator.reset(m_enumerator->copy());
@@ -267,7 +271,7 @@ std::vector<MOL_SPTR_VECT> EnumerateLibrary::next() {
     return run_Reactants(m_rxn, reactants, m_matchCache, m_graftCache,
                          m_dedupeSymmetricMatches);
   }
-  if (m_cacheMode == ReactantCacheMode::MatchOnly) {
+  if (m_cacheMode == ReactantCacheMode::MatchOnly || m_dedupeSymmetricMatches) {
     return run_Reactants(m_rxn, reactants, m_matchCache,
                          m_dedupeSymmetricMatches);
   }

--- a/Code/GraphMol/ChemReactions/Enumerate/Enumerate.cpp
+++ b/Code/GraphMol/ChemReactions/Enumerate/Enumerate.cpp
@@ -152,7 +152,7 @@ BBS removeNonmatchingReagents(const ChemicalReaction &rxn, BBS bbs,
       if (canPrimeCache) {
         const auto cacheKey =
             std::make_tuple(static_cast<unsigned int>(reactant_idx), mol.get(),
-                            1000u);
+                  1000u, false);
         const VectMatchVectType reactantMatches =
             ReactionRunnerUtils::getReactantMatchesToTemplate(
                 *mol.get(), *reactantTemplate.get(), 1000u,

--- a/Code/GraphMol/ChemReactions/Enumerate/Enumerate.cpp
+++ b/Code/GraphMol/ChemReactions/Enumerate/Enumerate.cpp
@@ -219,6 +219,8 @@ EnumerateLibrary::EnumerateLibrary(const ChemicalReaction &rxn, const BBS &bbs,
     : EnumerateLibraryBase(rxn, new CartesianProductStrategy),
       m_dedupeSymmetricMatches(params.dedupeSymmetricMatches),
       m_matchCache(),
+      m_cacheReactantGrafts(params.cacheReactantGrafts),
+      m_graftCache(),
       m_bbs(removeNonmatchingReagents(m_rxn, bbs, params, &m_matchCache)) {
   m_enumerator->initialize(m_rxn, m_bbs);  // getSizesFromBBs(bbs));
   m_initialEnumerator.reset(m_enumerator->copy());
@@ -230,6 +232,8 @@ EnumerateLibrary::EnumerateLibrary(const ChemicalReaction &rxn, const BBS &bbs,
     : EnumerateLibraryBase(rxn),
       m_dedupeSymmetricMatches(params.dedupeSymmetricMatches),
       m_matchCache(),
+      m_cacheReactantGrafts(params.cacheReactantGrafts),
+      m_graftCache(),
       m_bbs(removeNonmatchingReagents(m_rxn, bbs, params, &m_matchCache)) {
   m_enumerator.reset(enumerator.copy());
   m_enumerator->initialize(m_rxn, m_bbs);
@@ -240,6 +244,8 @@ EnumerateLibrary::EnumerateLibrary(const EnumerateLibrary &rhs)
     : EnumerateLibraryBase(rhs),
       m_dedupeSymmetricMatches(rhs.m_dedupeSymmetricMatches),
       m_matchCache(rhs.m_matchCache),
+      m_cacheReactantGrafts(rhs.m_cacheReactantGrafts),
+      m_graftCache(rhs.m_graftCache),
       m_bbs(rhs.m_bbs) {}
 
 std::vector<MOL_SPTR_VECT> EnumerateLibrary::next() {
@@ -251,6 +257,10 @@ std::vector<MOL_SPTR_VECT> EnumerateLibrary::next() {
     reactants[i] = m_bbs[i][reactantIndices[i]];
   }
 
+  if (m_cacheReactantGrafts) {
+    return run_Reactants(m_rxn, reactants, m_matchCache, m_graftCache,
+                         m_dedupeSymmetricMatches);
+  }
   return run_Reactants(m_rxn, reactants, m_matchCache, m_dedupeSymmetricMatches);
 }
 

--- a/Code/GraphMol/ChemReactions/Enumerate/Enumerate.cpp
+++ b/Code/GraphMol/ChemReactions/Enumerate/Enumerate.cpp
@@ -206,7 +206,7 @@ std::vector<MOL_SPTR_VECT> EnumerateLibrary::next() {
     reactants[i] = m_bbs[i][reactantIndices[i]];
   }
 
-  return m_rxn.runReactants(reactants);
+  return run_Reactants(m_rxn, reactants, m_matchCache);
 }
 
 void EnumerateLibrary::toStream(std::ostream &ss) const {

--- a/Code/GraphMol/ChemReactions/Enumerate/Enumerate.h
+++ b/Code/GraphMol/ChemReactions/Enumerate/Enumerate.h
@@ -121,12 +121,15 @@ RDKIT_CHEMREACTIONS_EXPORT EnumerationTypes::BBS removeNonmatchingReagents(
 
 class RDKIT_CHEMREACTIONS_EXPORT EnumerateLibrary
     : public EnumerateLibraryBase {
+  bool m_dedupeSymmetricMatches{false};
   ReactantMatchCache m_matchCache;
   EnumerationTypes::BBS m_bbs;
 
  public:
-  EnumerateLibrary() : EnumerateLibraryBase(), m_bbs() {}
-  EnumerateLibrary(const std::string &s) : EnumerateLibraryBase(), m_bbs() {
+  EnumerateLibrary()
+      : EnumerateLibraryBase(), m_dedupeSymmetricMatches(false), m_bbs() {}
+  EnumerateLibrary(const std::string &s)
+      : EnumerateLibraryBase(), m_dedupeSymmetricMatches(false), m_bbs() {
     initFromString(s);
   }
 
@@ -142,6 +145,8 @@ class RDKIT_CHEMREACTIONS_EXPORT EnumerateLibrary
   //! Return the reagents used in the library.  This may be fewer reagents than
   // the input as it is only those compatible with the reaction.
   const EnumerationTypes::BBS &getReagents() const { return m_bbs; }
+
+  bool getDedupeSymmetricMatches() const { return m_dedupeSymmetricMatches; }
 
   size_t getMatchCacheSize() const { return m_matchCache.size(); }
 
@@ -169,9 +174,11 @@ class RDKIT_CHEMREACTIONS_EXPORT EnumerateLibrary
         ar & pickle;
       }
     }
+
+    ar & m_dedupeSymmetricMatches;
   }
   template <class Archive>
-  void load(Archive &ar, const unsigned int /*version*/) {
+  void load(Archive &ar, const unsigned int version) {
     ar &boost::serialization::base_object<EnumerateLibraryBase>(*this);
 
     size_t sz;
@@ -191,6 +198,11 @@ class RDKIT_CHEMREACTIONS_EXPORT EnumerateLibrary
       }
     }
 
+    if (version >= 1) {
+      ar & m_dedupeSymmetricMatches;
+    } else {
+      m_dedupeSymmetricMatches = false;
+    }
     m_matchCache.clear();
   }
 
@@ -201,4 +213,7 @@ class RDKIT_CHEMREACTIONS_EXPORT EnumerateLibrary
 RDKIT_CHEMREACTIONS_EXPORT bool EnumerateLibraryCanSerialize();
 
 }  // namespace RDKit
+#ifdef RDK_USE_BOOST_SERIALIZATION
+BOOST_CLASS_VERSION(RDKit::EnumerateLibrary, 1)
+#endif
 #endif

--- a/Code/GraphMol/ChemReactions/Enumerate/Enumerate.h
+++ b/Code/GraphMol/ChemReactions/Enumerate/Enumerate.h
@@ -76,6 +76,10 @@ RDKIT_CHEMREACTIONS_EXPORT EnumerationTypes::BBS removeNonmatchingReagents(
     const ChemicalReaction &rxn, EnumerationTypes::BBS bbs,
     const EnumerationParams &params = EnumerationParams());
 
+RDKIT_CHEMREACTIONS_EXPORT EnumerationTypes::BBS removeNonmatchingReagents(
+  const ChemicalReaction &rxn, EnumerationTypes::BBS bbs,
+  const EnumerationParams &params, ReactantMatchCache *cache);
+
 //! This is a class for running reactions on sets of reagents.
 /*!
   This class is a fully self contained reaction engine that can be
@@ -111,8 +115,8 @@ RDKIT_CHEMREACTIONS_EXPORT EnumerationTypes::BBS removeNonmatchingReagents(
 
 class RDKIT_CHEMREACTIONS_EXPORT EnumerateLibrary
     : public EnumerateLibraryBase {
-  EnumerationTypes::BBS m_bbs;
   ReactantMatchCache m_matchCache;
+  EnumerationTypes::BBS m_bbs;
 
  public:
   EnumerateLibrary() : EnumerateLibraryBase(), m_bbs() {}
@@ -132,6 +136,8 @@ class RDKIT_CHEMREACTIONS_EXPORT EnumerateLibrary
   //! Return the reagents used in the library.  This may be fewer reagents than
   // the input as it is only those compatible with the reaction.
   const EnumerationTypes::BBS &getReagents() const { return m_bbs; }
+
+  size_t getMatchCacheSize() const { return m_matchCache.size(); }
 
   //! Get the next product set
   std::vector<MOL_SPTR_VECT> next() override;

--- a/Code/GraphMol/ChemReactions/Enumerate/Enumerate.h
+++ b/Code/GraphMol/ChemReactions/Enumerate/Enumerate.h
@@ -33,6 +33,7 @@
 #ifndef RDKIT_ENUMERATE_H
 #define RDKIT_ENUMERATE_H
 #include "EnumerateBase.h"
+#include <GraphMol/ChemReactions/ReactionRunner.h>
 
 /*! \file Enumerate.h
 
@@ -111,6 +112,7 @@ RDKIT_CHEMREACTIONS_EXPORT EnumerationTypes::BBS removeNonmatchingReagents(
 class RDKIT_CHEMREACTIONS_EXPORT EnumerateLibrary
     : public EnumerateLibraryBase {
   EnumerationTypes::BBS m_bbs;
+  ReactantMatchCache m_matchCache;
 
  public:
   EnumerateLibrary() : EnumerateLibraryBase(), m_bbs() {}
@@ -176,6 +178,8 @@ class RDKIT_CHEMREACTIONS_EXPORT EnumerateLibrary
         m_bbs[i][j].reset(mol);
       }
     }
+
+    m_matchCache.clear();
   }
 
   BOOST_SERIALIZATION_SPLIT_MEMBER();

--- a/Code/GraphMol/ChemReactions/Enumerate/Enumerate.h
+++ b/Code/GraphMol/ChemReactions/Enumerate/Enumerate.h
@@ -48,10 +48,10 @@ namespace RDKit {
 
 //! Controls what caching is applied during reaction enumeration.
 /*!
-  - None:      no caching (original baseline behavior)
+  - None:      no caching (original baseline behavior, default)
   - MatchOnly: cache reactant-template substructure matches; each
                reagent/template pair is matched once and replayed
-               (default)
+               across all Cartesian-product combinations
   - Full:      cache matches and per-reagent product grafts; the
                atom/bond subgraph each reagent contributes is extracted
                once and replayed across all Cartesian-product
@@ -75,7 +75,7 @@ enum class ReactantCacheMode {
   atoms, avoiding duplicate products for symmetric reagents.
   Requires cacheMode >= MatchOnly.
 
-  cacheMode [default MatchOnly]
+  cacheMode [default None]
   Controls whether reactant-template matches and/or product grafts are
   cached across enumeration steps. See ReactantCacheMode.
 
@@ -88,7 +88,7 @@ struct RDKIT_CHEMREACTIONS_EXPORT EnumerationParams {
   int reagentMaxMatchCount{INT_MAX};
   bool sanePartialProducts{false};
   bool dedupeSymmetricMatches{false};
-  ReactantCacheMode cacheMode{ReactantCacheMode::MatchOnly};
+  ReactantCacheMode cacheMode{ReactantCacheMode::None};
   EnumerationParams() {}
 
   EnumerationParams(const EnumerationParams &rhs)
@@ -147,7 +147,7 @@ class RDKIT_CHEMREACTIONS_EXPORT EnumerateLibrary
     : public EnumerateLibraryBase {
   bool m_dedupeSymmetricMatches{false};
   ReactantMatchCache m_matchCache;
-  ReactantCacheMode m_cacheMode{ReactantCacheMode::MatchOnly};
+  ReactantCacheMode m_cacheMode{ReactantCacheMode::None};
   ReactionRunnerUtils::ReactantGraftCache m_graftCache;
   EnumerationTypes::BBS m_bbs;
 
@@ -237,7 +237,7 @@ class RDKIT_CHEMREACTIONS_EXPORT EnumerateLibrary
       m_cacheMode = static_cast<ReactantCacheMode>(cacheModeInt);
     } else {
       m_dedupeSymmetricMatches = false;
-      m_cacheMode = ReactantCacheMode::MatchOnly;
+      m_cacheMode = ReactantCacheMode::None;
     }
     m_matchCache.clear();
     m_graftCache.clear();

--- a/Code/GraphMol/ChemReactions/Enumerate/Enumerate.h
+++ b/Code/GraphMol/ChemReactions/Enumerate/Enumerate.h
@@ -53,6 +53,10 @@ namespace RDKit {
    reagentMaxMatchCount [default INT_MAX]
     This specifies how many times the reactant template can match a reagent.
 
+  dedupeSymmetricMatches [default false]
+  Collapse substructure matches that land on symmetry-equivalent reagent
+  atoms, avoiding duplicate products for symmetric reagents.
+
    sanePartialProducts [default false]
     If true, forces all products of the reagent plus the product templates\n\
      pass chemical sanitization.  Note that if the product template itself\n\
@@ -61,11 +65,13 @@ namespace RDKit {
 struct RDKIT_CHEMREACTIONS_EXPORT EnumerationParams {
   int reagentMaxMatchCount{INT_MAX};
   bool sanePartialProducts{false};
+  bool dedupeSymmetricMatches{false};
   EnumerationParams() {}
 
   EnumerationParams(const EnumerationParams &rhs)
       : reagentMaxMatchCount(rhs.reagentMaxMatchCount),
-        sanePartialProducts(rhs.sanePartialProducts) {}
+        sanePartialProducts(rhs.sanePartialProducts),
+        dedupeSymmetricMatches(rhs.dedupeSymmetricMatches) {}
 };
 
 //!  Helper function, remove reagents that are incompatible

--- a/Code/GraphMol/ChemReactions/Enumerate/Enumerate.h
+++ b/Code/GraphMol/ChemReactions/Enumerate/Enumerate.h
@@ -57,6 +57,11 @@ namespace RDKit {
   Collapse substructure matches that land on symmetry-equivalent reagent
   atoms, avoiding duplicate products for symmetric reagents.
 
+  cacheReactantGrafts [default false]
+  Cache and replay the per-reagent "graft" (the atoms/bonds a reagent
+  contributes to a product) across product combinations instead of
+  re-deriving it for every combination. Output is unchanged.
+
    sanePartialProducts [default false]
     If true, forces all products of the reagent plus the product templates\n\
      pass chemical sanitization.  Note that if the product template itself\n\
@@ -66,12 +71,14 @@ struct RDKIT_CHEMREACTIONS_EXPORT EnumerationParams {
   int reagentMaxMatchCount{INT_MAX};
   bool sanePartialProducts{false};
   bool dedupeSymmetricMatches{false};
+  bool cacheReactantGrafts{false};
   EnumerationParams() {}
 
   EnumerationParams(const EnumerationParams &rhs)
       : reagentMaxMatchCount(rhs.reagentMaxMatchCount),
         sanePartialProducts(rhs.sanePartialProducts),
-        dedupeSymmetricMatches(rhs.dedupeSymmetricMatches) {}
+        dedupeSymmetricMatches(rhs.dedupeSymmetricMatches),
+        cacheReactantGrafts(rhs.cacheReactantGrafts) {}
 };
 
 //!  Helper function, remove reagents that are incompatible
@@ -123,6 +130,8 @@ class RDKIT_CHEMREACTIONS_EXPORT EnumerateLibrary
     : public EnumerateLibraryBase {
   bool m_dedupeSymmetricMatches{false};
   ReactantMatchCache m_matchCache;
+  bool m_cacheReactantGrafts{false};
+  ReactionRunnerUtils::ReactantGraftCache m_graftCache;
   EnumerationTypes::BBS m_bbs;
 
  public:
@@ -150,6 +159,10 @@ class RDKIT_CHEMREACTIONS_EXPORT EnumerateLibrary
 
   size_t getMatchCacheSize() const { return m_matchCache.size(); }
 
+  bool getCacheReactantGrafts() const { return m_cacheReactantGrafts; }
+
+  size_t getGraftCacheSize() const { return m_graftCache.size(); }
+
   //! Get the next product set
   std::vector<MOL_SPTR_VECT> next() override;
 
@@ -176,6 +189,7 @@ class RDKIT_CHEMREACTIONS_EXPORT EnumerateLibrary
     }
 
     ar & m_dedupeSymmetricMatches;
+    ar & m_cacheReactantGrafts;
   }
   template <class Archive>
   void load(Archive &ar, const unsigned int version) {
@@ -203,7 +217,13 @@ class RDKIT_CHEMREACTIONS_EXPORT EnumerateLibrary
     } else {
       m_dedupeSymmetricMatches = false;
     }
+    if (version >= 2) {
+      ar & m_cacheReactantGrafts;
+    } else {
+      m_cacheReactantGrafts = false;
+    }
     m_matchCache.clear();
+    m_graftCache.clear();
   }
 
   BOOST_SERIALIZATION_SPLIT_MEMBER();
@@ -214,6 +234,6 @@ RDKIT_CHEMREACTIONS_EXPORT bool EnumerateLibraryCanSerialize();
 
 }  // namespace RDKit
 #ifdef RDK_USE_BOOST_SERIALIZATION
-BOOST_CLASS_VERSION(RDKit::EnumerateLibrary, 1)
+BOOST_CLASS_VERSION(RDKit::EnumerateLibrary, 2)
 #endif
 #endif

--- a/Code/GraphMol/ChemReactions/Enumerate/Enumerate.h
+++ b/Code/GraphMol/ChemReactions/Enumerate/Enumerate.h
@@ -46,6 +46,23 @@ future releases.
 
 namespace RDKit {
 
+//! Controls what caching is applied during reaction enumeration.
+/*!
+  - None:      no caching (original baseline behavior)
+  - MatchOnly: cache reactant-template substructure matches; each
+               reagent/template pair is matched once and replayed
+               (default)
+  - Full:      cache matches and per-reagent product grafts; the
+               atom/bond subgraph each reagent contributes is extracted
+               once and replayed across all Cartesian-product
+               combinations (implies MatchOnly)
+*/
+enum class ReactantCacheMode {
+  None = 0,
+  MatchOnly = 1,
+  Full = 2
+};
+
 //! This is a class for providing enumeration options that control
 ///  how enumerations are performed.
 /*!
@@ -56,11 +73,11 @@ namespace RDKit {
   dedupeSymmetricMatches [default false]
   Collapse substructure matches that land on symmetry-equivalent reagent
   atoms, avoiding duplicate products for symmetric reagents.
+  Requires cacheMode >= MatchOnly.
 
-  cacheReactantGrafts [default false]
-  Cache and replay the per-reagent "graft" (the atoms/bonds a reagent
-  contributes to a product) across product combinations instead of
-  re-deriving it for every combination. Output is unchanged.
+  cacheMode [default MatchOnly]
+  Controls whether reactant-template matches and/or product grafts are
+  cached across enumeration steps. See ReactantCacheMode.
 
    sanePartialProducts [default false]
     If true, forces all products of the reagent plus the product templates\n\
@@ -71,14 +88,14 @@ struct RDKIT_CHEMREACTIONS_EXPORT EnumerationParams {
   int reagentMaxMatchCount{INT_MAX};
   bool sanePartialProducts{false};
   bool dedupeSymmetricMatches{false};
-  bool cacheReactantGrafts{false};
+  ReactantCacheMode cacheMode{ReactantCacheMode::MatchOnly};
   EnumerationParams() {}
 
   EnumerationParams(const EnumerationParams &rhs)
       : reagentMaxMatchCount(rhs.reagentMaxMatchCount),
         sanePartialProducts(rhs.sanePartialProducts),
         dedupeSymmetricMatches(rhs.dedupeSymmetricMatches),
-        cacheReactantGrafts(rhs.cacheReactantGrafts) {}
+        cacheMode(rhs.cacheMode) {}
 };
 
 //!  Helper function, remove reagents that are incompatible
@@ -130,7 +147,7 @@ class RDKIT_CHEMREACTIONS_EXPORT EnumerateLibrary
     : public EnumerateLibraryBase {
   bool m_dedupeSymmetricMatches{false};
   ReactantMatchCache m_matchCache;
-  bool m_cacheReactantGrafts{false};
+  ReactantCacheMode m_cacheMode{ReactantCacheMode::MatchOnly};
   ReactionRunnerUtils::ReactantGraftCache m_graftCache;
   EnumerationTypes::BBS m_bbs;
 
@@ -157,9 +174,9 @@ class RDKIT_CHEMREACTIONS_EXPORT EnumerateLibrary
 
   bool getDedupeSymmetricMatches() const { return m_dedupeSymmetricMatches; }
 
-  size_t getMatchCacheSize() const { return m_matchCache.size(); }
+  ReactantCacheMode getCacheMode() const { return m_cacheMode; }
 
-  bool getCacheReactantGrafts() const { return m_cacheReactantGrafts; }
+  size_t getMatchCacheSize() const { return m_matchCache.size(); }
 
   size_t getGraftCacheSize() const { return m_graftCache.size(); }
 
@@ -189,7 +206,8 @@ class RDKIT_CHEMREACTIONS_EXPORT EnumerateLibrary
     }
 
     ar & m_dedupeSymmetricMatches;
-    ar & m_cacheReactantGrafts;
+    int cacheModeInt = static_cast<int>(m_cacheMode);
+    ar & cacheModeInt;
   }
   template <class Archive>
   void load(Archive &ar, const unsigned int version) {
@@ -214,13 +232,12 @@ class RDKIT_CHEMREACTIONS_EXPORT EnumerateLibrary
 
     if (version >= 1) {
       ar & m_dedupeSymmetricMatches;
+      int cacheModeInt;
+      ar & cacheModeInt;
+      m_cacheMode = static_cast<ReactantCacheMode>(cacheModeInt);
     } else {
       m_dedupeSymmetricMatches = false;
-    }
-    if (version >= 2) {
-      ar & m_cacheReactantGrafts;
-    } else {
-      m_cacheReactantGrafts = false;
+      m_cacheMode = ReactantCacheMode::MatchOnly;
     }
     m_matchCache.clear();
     m_graftCache.clear();
@@ -234,6 +251,6 @@ RDKIT_CHEMREACTIONS_EXPORT bool EnumerateLibraryCanSerialize();
 
 }  // namespace RDKit
 #ifdef RDK_USE_BOOST_SERIALIZATION
-BOOST_CLASS_VERSION(RDKit::EnumerateLibrary, 2)
+BOOST_CLASS_VERSION(RDKit::EnumerateLibrary, 1)
 #endif
 #endif

--- a/Code/GraphMol/ChemReactions/Enumerate/testEnumerate.cpp
+++ b/Code/GraphMol/ChemReactions/Enumerate/testEnumerate.cpp
@@ -38,6 +38,10 @@
 #include <GraphMol/SmilesParse/SmilesParse.h>
 #include <GraphMol/FileParsers/MolSupplier.h>
 
+#include <algorithm>
+#include <set>
+#include <sstream>
+
 #include <GraphMol/ChemReactions/Enumerate/CartesianProduct.h>
 #include <GraphMol/ChemReactions/Enumerate/EvenSamplePairs.h>
 #include <GraphMol/ChemReactions/Enumerate/RandomSample.h>
@@ -162,6 +166,122 @@ const char *smiresults[] = {
     "C=CCNC(=S)NCc1ncc(Cl)cc1Br",   "CC=CCNC(=S)NCc1ncc(Cl)cc1Br",
     "C=CCNC(=S)NCCc1ncc(Cl)cc1Br",  "CC=CCNC(=S)NCCc1ncc(Cl)cc1Br",
     "C=CCNC(=S)NCCCc1ncc(Cl)cc1Br", "CC=CCNC(=S)NCCCc1ncc(Cl)cc1Br"};
+
+namespace {
+ChemicalReaction *makeEnumerationCacheRxn() {
+  return RxnSmartsToChemicalReaction(
+      "[N;$(N-[#6]):3]=[C;$(C=S):1].[N;$(N[#6]);!$(N=*);!$([N-]);!$(N#*);"
+      "!$([ND3]);!$([ND4]);!$(N[O,N]);!$(N[C,S]=[S,O,N]):2]>>[N:3]-[C:1]-[N+0:"
+      "2]");
+}
+
+EnumerationTypes::BBS makeEnumerationCacheBbs() {
+  EnumerationTypes::BBS bbs;
+  bbs.resize(2);
+
+  bbs[0].push_back(boost::shared_ptr<ROMol>(SmilesToMol("C=CCN=C=S")));
+  bbs[0].push_back(boost::shared_ptr<ROMol>(SmilesToMol("CC=CCN=C=S")));
+
+  bbs[1].push_back(boost::shared_ptr<ROMol>(SmilesToMol("NCc1ncc(Cl)cc1Br")));
+  bbs[1].push_back(boost::shared_ptr<ROMol>(SmilesToMol("NCCc1ncc(Cl)cc1Br")));
+  bbs[1].push_back(
+      boost::shared_ptr<ROMol>(SmilesToMol("NCCCc1ncc(Cl)cc1Br")));
+  return bbs;
+}
+
+std::multiset<std::string> collectEnumerationSmiles(EnumerateLibrary &en) {
+  std::multiset<std::string> results;
+  for (; (bool)en;) {
+    std::vector<std::vector<std::string>> smiles = en.nextSmiles();
+    TEST_ASSERT(smiles.size() == 1);
+    TEST_ASSERT(smiles[0].size() == 1);
+    results.insert(smiles[0][0]);
+  }
+  return results;
+}
+
+std::vector<std::string> collectEnumerationSequence(EnumerateLibrary &en) {
+  std::vector<std::string> results;
+  for (; (bool)en;) {
+    std::vector<std::vector<std::string>> smiles = en.nextSmiles();
+    TEST_ASSERT(smiles.size() == 1);
+    TEST_ASSERT(smiles[0].size() == 1);
+    results.push_back(smiles[0][0]);
+  }
+  return results;
+}
+
+std::multiset<std::string> collectDirectProductSmiles(
+    const ChemicalReaction &rxn, const EnumerationTypes::BBS &bbs) {
+  std::multiset<std::string> results;
+  for (size_t i = 0; i < bbs[0].size(); ++i) {
+    for (size_t j = 0; j < bbs[1].size(); ++j) {
+      MOL_SPTR_VECT reactants;
+      reactants.push_back(bbs[0][i]);
+      reactants.push_back(bbs[1][j]);
+      std::vector<MOL_SPTR_VECT> products = rxn.runReactants(reactants);
+      TEST_ASSERT(products.size() == 1);
+      TEST_ASSERT(products[0].size() == 1);
+      results.insert(MolToSmiles(*products[0][0], true));
+    }
+  }
+  return results;
+}
+}  // namespace
+
+void testEnumerationCacheOutputUnchanged() {
+  boost::scoped_ptr<ChemicalReaction> rxn(makeEnumerationCacheRxn());
+  rxn->initReactantMatchers();
+  EnumerationTypes::BBS bbs = makeEnumerationCacheBbs();
+
+  EnumerateLibrary cached(*rxn, bbs);
+  EnumerateLibrary viaLibrary(*rxn, bbs);
+
+  // drive the non-cached baseline from the library's filtered reagents so the
+  // comparison stays valid even if removeNonmatchingReagents drops a reagent
+  const std::multiset<std::string> expected =
+      collectDirectProductSmiles(*rxn, cached.getReagents());
+  const std::multiset<std::string> cachedResults = collectEnumerationSmiles(cached);
+  const std::multiset<std::string> viaLibraryResults =
+      collectEnumerationSmiles(viaLibrary);
+
+  TEST_ASSERT(cachedResults == expected);
+  TEST_ASSERT(viaLibraryResults == expected);
+}
+
+void testEnumerationCacheReuseAcrossReset() {
+  boost::scoped_ptr<ChemicalReaction> rxn(makeEnumerationCacheRxn());
+  rxn->initReactantMatchers();
+  EnumerationTypes::BBS bbs = makeEnumerationCacheBbs();
+
+  EnumerateLibrary en(*rxn, bbs);
+  const std::vector<std::string> firstPass = collectEnumerationSequence(en);
+
+  en.reset();
+
+  const std::vector<std::string> secondPass = collectEnumerationSequence(en);
+  TEST_ASSERT(firstPass == secondPass);
+}
+
+#ifdef RDK_USE_BOOST_SERIALIZATION
+void testEnumerationCacheNotSerialized() {
+  boost::scoped_ptr<ChemicalReaction> rxn(makeEnumerationCacheRxn());
+  rxn->initReactantMatchers();
+  EnumerationTypes::BBS bbs = makeEnumerationCacheBbs();
+
+  EnumerateLibrary en(*rxn, bbs);
+  const std::vector<std::string> baseline = collectEnumerationSequence(en);
+
+  en.reset();
+  std::string serialized = en.Serialize();
+  EnumerateLibrary reloaded(serialized);
+
+  const std::vector<std::string> reloadedSequence = collectEnumerationSequence(reloaded);
+  TEST_ASSERT(reloadedSequence == baseline);
+}
+#else
+void testEnumerationCacheNotSerialized() {}
+#endif
 
 void testEnumerations() {
   EnumerationTypes::BBS bbs;
@@ -381,6 +501,9 @@ void testGithub1657() {}
 int main() {
   RDLog::InitLogs();
 #if 1
+  testEnumerationCacheOutputUnchanged();
+  testEnumerationCacheReuseAcrossReset();
+  testEnumerationCacheNotSerialized();
   testSamplers();
   testEvenSamplers();
   testEnumerations();

--- a/Code/GraphMol/ChemReactions/Enumerate/testEnumerate.cpp
+++ b/Code/GraphMol/ChemReactions/Enumerate/testEnumerate.cpp
@@ -482,7 +482,7 @@ void testGraftCacheOutputUnchanged() {
   EnumerationTypes::BBS bbs = makeEnumerationCacheBbs();
 
   EnumerationParams graftParams;
-  graftParams.cacheReactantGrafts = true;
+  graftParams.cacheMode = ReactantCacheMode::Full;
 
   EnumerateLibrary grafted(*rxn, bbs, graftParams);
   EnumerateLibrary defaultOff(*rxn, bbs);
@@ -496,8 +496,8 @@ void testGraftCacheOutputUnchanged() {
   const std::multiset<std::string> defaultResults =
       collectEnumerationSmiles(defaultOff);
 
-  TEST_ASSERT(grafted.getCacheReactantGrafts());
-  TEST_ASSERT(!defaultOff.getCacheReactantGrafts());
+  TEST_ASSERT(grafted.getCacheMode() == ReactantCacheMode::Full);
+  TEST_ASSERT(defaultOff.getCacheMode() == ReactantCacheMode::MatchOnly);
   TEST_ASSERT(graftedResults == expected);
   TEST_ASSERT(defaultResults == expected);
 }
@@ -508,7 +508,7 @@ void testGraftCachePopulatedAndReused() {
   EnumerationTypes::BBS bbs = makeEnumerationCacheBbs();
 
   EnumerationParams graftParams;
-  graftParams.cacheReactantGrafts = true;
+  graftParams.cacheMode = ReactantCacheMode::Full;
   EnumerateLibrary library(*rxn, bbs, graftParams);
 
   // every reagent matches its template exactly once, so the populated graft
@@ -535,7 +535,7 @@ void testGraftCacheReuseAcrossReset() {
   EnumerationTypes::BBS bbs = makeEnumerationCacheBbs();
 
   EnumerationParams graftParams;
-  graftParams.cacheReactantGrafts = true;
+  graftParams.cacheMode = ReactantCacheMode::Full;
   EnumerateLibrary en(*rxn, bbs, graftParams);
 
   const std::vector<std::string> firstPass = collectEnumerationSequence(en);
@@ -557,7 +557,7 @@ void testGraftCachePreservedOnCopy() {
   EnumerationTypes::BBS bbs = makeEnumerationCacheBbs();
 
   EnumerationParams graftParams;
-  graftParams.cacheReactantGrafts = true;
+  graftParams.cacheMode = ReactantCacheMode::Full;
   EnumerateLibrary en(*rxn, bbs, graftParams);
 
   const std::vector<std::string> baseline = collectEnumerationSequence(en);
@@ -568,7 +568,7 @@ void testGraftCachePreservedOnCopy() {
   // populated graft cache is carried into the copy verbatim
   en.reset();
   EnumerateLibrary copy(en);
-  TEST_ASSERT(copy.getCacheReactantGrafts());
+  TEST_ASSERT(copy.getCacheMode() == ReactantCacheMode::Full);
   TEST_ASSERT(copy.getGraftCacheSize() == populatedGrafts);
 
   const std::vector<std::string> copySequence = collectEnumerationSequence(copy);
@@ -583,7 +583,7 @@ void testGraftCacheNotSerialized() {
   EnumerationTypes::BBS bbs = makeEnumerationCacheBbs();
 
   EnumerationParams graftParams;
-  graftParams.cacheReactantGrafts = true;
+  graftParams.cacheMode = ReactantCacheMode::Full;
   EnumerateLibrary en(*rxn, bbs, graftParams);
   const std::vector<std::string> baseline = collectEnumerationSequence(en);
   TEST_ASSERT(en.getGraftCacheSize() > 0);
@@ -593,7 +593,7 @@ void testGraftCacheNotSerialized() {
   EnumerateLibrary reloaded(serialized);
 
   // the flag survives serialization but the populated cache does not
-  TEST_ASSERT(reloaded.getCacheReactantGrafts());
+  TEST_ASSERT(reloaded.getCacheMode() == ReactantCacheMode::Full);
   TEST_ASSERT(reloaded.getGraftCacheSize() == 0);
 
   const std::vector<std::string> reloadedSequence =

--- a/Code/GraphMol/ChemReactions/Enumerate/testEnumerate.cpp
+++ b/Code/GraphMol/ChemReactions/Enumerate/testEnumerate.cpp
@@ -318,7 +318,9 @@ void testPrefilterPrimesSharedCache() {
   rxn->initReactantMatchers();
   EnumerationTypes::BBS bbs = makeEnumerationCacheBbsWithNonMatches();
 
-  EnumerateLibrary library(*rxn, bbs);
+  EnumerationParams params;
+  params.cacheMode = ReactantCacheMode::MatchOnly;
+  EnumerateLibrary library(*rxn, bbs, params);
   const EnumerationTypes::BBS &filtered = library.getReagents();
   size_t expectedCacheSize = 0;
   for (const auto &pool : filtered) {
@@ -347,6 +349,7 @@ void testPrefilterProtectedAtomFallback() {
   EnumerationTypes::BBS bbs = makeEnumerationCacheBbsWithProtectedAtoms();
 
   EnumerationParams params;
+  params.cacheMode = ReactantCacheMode::MatchOnly;
   EnumerationTypes::BBS baseline = removeNonmatchingReagents(*rxn, bbs, params);
   EnumerateLibrary library(*rxn, bbs, params);
 
@@ -497,7 +500,7 @@ void testGraftCacheOutputUnchanged() {
       collectEnumerationSmiles(defaultOff);
 
   TEST_ASSERT(grafted.getCacheMode() == ReactantCacheMode::Full);
-  TEST_ASSERT(defaultOff.getCacheMode() == ReactantCacheMode::MatchOnly);
+  TEST_ASSERT(defaultOff.getCacheMode() == ReactantCacheMode::None);
   TEST_ASSERT(graftedResults == expected);
   TEST_ASSERT(defaultResults == expected);
 }

--- a/Code/GraphMol/ChemReactions/Enumerate/testEnumerate.cpp
+++ b/Code/GraphMol/ChemReactions/Enumerate/testEnumerate.cpp
@@ -219,9 +219,10 @@ std::multiset<std::string> collectEnumerationSmiles(EnumerateLibrary &en) {
   std::multiset<std::string> results;
   for (; (bool)en;) {
     std::vector<std::vector<std::string>> smiles = en.nextSmiles();
-    TEST_ASSERT(smiles.size() == 1);
-    TEST_ASSERT(smiles[0].size() == 1);
-    results.insert(smiles[0][0]);
+    for (const auto &productSet : smiles) {
+      TEST_ASSERT(productSet.size() == 1);
+      results.insert(productSet[0]);
+    }
   }
   return results;
 }
@@ -230,11 +231,29 @@ std::vector<std::string> collectEnumerationSequence(EnumerateLibrary &en) {
   std::vector<std::string> results;
   for (; (bool)en;) {
     std::vector<std::vector<std::string>> smiles = en.nextSmiles();
-    TEST_ASSERT(smiles.size() == 1);
-    TEST_ASSERT(smiles[0].size() == 1);
-    results.push_back(smiles[0][0]);
+    for (const auto &productSet : smiles) {
+      TEST_ASSERT(productSet.size() == 1);
+      results.push_back(productSet[0]);
+    }
   }
   return results;
+}
+
+std::set<std::string> collectUniqueSmiles(const std::vector<std::string> &seq) {
+  return std::set<std::string>(seq.begin(), seq.end());
+}
+
+ChemicalReaction *makeSymmetricDedupeRxn() {
+  return RxnSmartsToChemicalReaction("[N;H2:1]>>[N:1]C(=O)C");
+}
+
+EnumerationTypes::BBS makeSymmetricDedupBbs() {
+  EnumerationTypes::BBS bbs;
+  bbs.resize(1);
+
+  bbs[0].push_back(boost::shared_ptr<ROMol>(SmilesToMol("NCCN")));
+  bbs[0].push_back(boost::shared_ptr<ROMol>(SmilesToMol("CCN")));
+  return bbs;
 }
 
 std::multiset<std::string> collectDirectProductSmiles(
@@ -369,6 +388,73 @@ void testEnumerationCacheReuseAcrossReset() {
   const std::vector<std::string> secondPass = collectEnumerationSequence(en);
   TEST_ASSERT(firstPass == secondPass);
 }
+
+void testDedupOutputUnchangedWhenDisabled() {
+  boost::scoped_ptr<ChemicalReaction> rxn(makeSymmetricDedupeRxn());
+  rxn->initReactantMatchers();
+  EnumerationTypes::BBS bbs = makeSymmetricDedupBbs();
+
+  EnumerationParams params;
+  params.dedupeSymmetricMatches = false;
+
+  EnumerateLibrary explicitOff(*rxn, bbs, params);
+  EnumerateLibrary defaultOff(*rxn, bbs);
+
+  const std::vector<std::string> explicitOffSequence =
+      collectEnumerationSequence(explicitOff);
+  const std::vector<std::string> defaultOffSequence =
+      collectEnumerationSequence(defaultOff);
+
+  TEST_ASSERT(explicitOffSequence == defaultOffSequence);
+  TEST_ASSERT(collectUniqueSmiles(defaultOffSequence).size() <
+              defaultOffSequence.size());
+}
+
+void testDedupCollapsesSymmetricReagent() {
+  boost::scoped_ptr<ChemicalReaction> rxn(makeSymmetricDedupeRxn());
+  rxn->initReactantMatchers();
+  EnumerationTypes::BBS bbs = makeSymmetricDedupBbs();
+
+  EnumerationParams offParams;
+  offParams.dedupeSymmetricMatches = false;
+  EnumerateLibrary offLibrary(*rxn, bbs, offParams);
+  const std::vector<std::string> offSequence =
+      collectEnumerationSequence(offLibrary);
+
+  EnumerationParams onParams;
+  onParams.dedupeSymmetricMatches = true;
+  EnumerateLibrary onLibrary(*rxn, bbs, onParams);
+  const std::vector<std::string> onSequence =
+      collectEnumerationSequence(onLibrary);
+
+  TEST_ASSERT(offSequence.size() > onSequence.size());
+  TEST_ASSERT(collectUniqueSmiles(offSequence) ==
+              collectUniqueSmiles(onSequence));
+}
+
+#ifdef RDK_USE_BOOST_SERIALIZATION
+void testDedupFlagSerialized() {
+  boost::scoped_ptr<ChemicalReaction> rxn(makeSymmetricDedupeRxn());
+  rxn->initReactantMatchers();
+  EnumerationTypes::BBS bbs = makeSymmetricDedupBbs();
+
+  EnumerationParams params;
+  params.dedupeSymmetricMatches = true;
+  EnumerateLibrary en(*rxn, bbs, params);
+  const std::vector<std::string> baseline = collectEnumerationSequence(en);
+
+  en.reset();
+  std::string serialized = en.Serialize();
+  EnumerateLibrary reloaded(serialized);
+
+  TEST_ASSERT(reloaded.getDedupeSymmetricMatches());
+  const std::vector<std::string> reloadedSequence =
+      collectEnumerationSequence(reloaded);
+  TEST_ASSERT(reloadedSequence == baseline);
+}
+#else
+void testDedupFlagSerialized() {}
+#endif
 
 #ifdef RDK_USE_BOOST_SERIALIZATION
 void testEnumerationCacheNotSerialized() {
@@ -614,6 +700,9 @@ int main() {
   testPrefilterProtectedAtomFallback();
   testEnumerationCacheOutputUnchanged();
   testEnumerationCacheReuseAcrossReset();
+  testDedupOutputUnchangedWhenDisabled();
+  testDedupCollapsesSymmetricReagent();
+  testDedupFlagSerialized();
   testEnumerationCacheNotSerialized();
   testSamplers();
   testEvenSamplers();

--- a/Code/GraphMol/ChemReactions/Enumerate/testEnumerate.cpp
+++ b/Code/GraphMol/ChemReactions/Enumerate/testEnumerate.cpp
@@ -476,6 +476,134 @@ void testEnumerationCacheNotSerialized() {
 void testEnumerationCacheNotSerialized() {}
 #endif
 
+void testGraftCacheOutputUnchanged() {
+  boost::scoped_ptr<ChemicalReaction> rxn(makeEnumerationCacheRxn());
+  rxn->initReactantMatchers();
+  EnumerationTypes::BBS bbs = makeEnumerationCacheBbs();
+
+  EnumerationParams graftParams;
+  graftParams.cacheReactantGrafts = true;
+
+  EnumerateLibrary grafted(*rxn, bbs, graftParams);
+  EnumerateLibrary defaultOff(*rxn, bbs);
+
+  // the non-cached baseline is driven from the library's filtered reagents so
+  // the comparison stays valid even if removeNonmatchingReagents drops one
+  const std::multiset<std::string> expected =
+      collectDirectProductSmiles(*rxn, grafted.getReagents());
+  const std::multiset<std::string> graftedResults =
+      collectEnumerationSmiles(grafted);
+  const std::multiset<std::string> defaultResults =
+      collectEnumerationSmiles(defaultOff);
+
+  TEST_ASSERT(grafted.getCacheReactantGrafts());
+  TEST_ASSERT(!defaultOff.getCacheReactantGrafts());
+  TEST_ASSERT(graftedResults == expected);
+  TEST_ASSERT(defaultResults == expected);
+}
+
+void testGraftCachePopulatedAndReused() {
+  boost::scoped_ptr<ChemicalReaction> rxn(makeEnumerationCacheRxn());
+  rxn->initReactantMatchers();
+  EnumerationTypes::BBS bbs = makeEnumerationCacheBbs();
+
+  EnumerationParams graftParams;
+  graftParams.cacheReactantGrafts = true;
+  EnumerateLibrary library(*rxn, bbs, graftParams);
+
+  // every reagent matches its template exactly once, so the populated graft
+  // cache holds one graft per reagent (= the sum of the filtered pool sizes),
+  // even though the Cartesian product produces many more product sets.
+  size_t expectedGrafts = 0;
+  size_t productCount = 1;
+  for (const auto &pool : library.getReagents()) {
+    expectedGrafts += pool.size();
+    productCount *= pool.size();
+  }
+
+  TEST_ASSERT(library.getGraftCacheSize() == 0);
+  const std::multiset<std::string> products = collectEnumerationSmiles(library);
+
+  TEST_ASSERT(products.size() == productCount);
+  TEST_ASSERT(expectedGrafts < productCount);
+  TEST_ASSERT(library.getGraftCacheSize() == expectedGrafts);
+}
+
+void testGraftCacheReuseAcrossReset() {
+  boost::scoped_ptr<ChemicalReaction> rxn(makeEnumerationCacheRxn());
+  rxn->initReactantMatchers();
+  EnumerationTypes::BBS bbs = makeEnumerationCacheBbs();
+
+  EnumerationParams graftParams;
+  graftParams.cacheReactantGrafts = true;
+  EnumerateLibrary en(*rxn, bbs, graftParams);
+
+  const std::vector<std::string> firstPass = collectEnumerationSequence(en);
+  const size_t graftsAfterFirstPass = en.getGraftCacheSize();
+  TEST_ASSERT(graftsAfterFirstPass > 0);
+
+  en.reset();
+
+  const std::vector<std::string> secondPass = collectEnumerationSequence(en);
+  // the second pass replays the cached grafts; output is identical and no new
+  // grafts are extracted.
+  TEST_ASSERT(firstPass == secondPass);
+  TEST_ASSERT(en.getGraftCacheSize() == graftsAfterFirstPass);
+}
+
+void testGraftCachePreservedOnCopy() {
+  boost::scoped_ptr<ChemicalReaction> rxn(makeEnumerationCacheRxn());
+  rxn->initReactantMatchers();
+  EnumerationTypes::BBS bbs = makeEnumerationCacheBbs();
+
+  EnumerationParams graftParams;
+  graftParams.cacheReactantGrafts = true;
+  EnumerateLibrary en(*rxn, bbs, graftParams);
+
+  const std::vector<std::string> baseline = collectEnumerationSequence(en);
+  const size_t populatedGrafts = en.getGraftCacheSize();
+  TEST_ASSERT(populatedGrafts > 0);
+
+  // reset before copying so the copy's initial enumerator is the start; the
+  // populated graft cache is carried into the copy verbatim
+  en.reset();
+  EnumerateLibrary copy(en);
+  TEST_ASSERT(copy.getCacheReactantGrafts());
+  TEST_ASSERT(copy.getGraftCacheSize() == populatedGrafts);
+
+  const std::vector<std::string> copySequence = collectEnumerationSequence(copy);
+  TEST_ASSERT(copySequence == baseline);
+  TEST_ASSERT(copy.getGraftCacheSize() == populatedGrafts);
+}
+
+#ifdef RDK_USE_BOOST_SERIALIZATION
+void testGraftCacheNotSerialized() {
+  boost::scoped_ptr<ChemicalReaction> rxn(makeEnumerationCacheRxn());
+  rxn->initReactantMatchers();
+  EnumerationTypes::BBS bbs = makeEnumerationCacheBbs();
+
+  EnumerationParams graftParams;
+  graftParams.cacheReactantGrafts = true;
+  EnumerateLibrary en(*rxn, bbs, graftParams);
+  const std::vector<std::string> baseline = collectEnumerationSequence(en);
+  TEST_ASSERT(en.getGraftCacheSize() > 0);
+
+  en.reset();
+  std::string serialized = en.Serialize();
+  EnumerateLibrary reloaded(serialized);
+
+  // the flag survives serialization but the populated cache does not
+  TEST_ASSERT(reloaded.getCacheReactantGrafts());
+  TEST_ASSERT(reloaded.getGraftCacheSize() == 0);
+
+  const std::vector<std::string> reloadedSequence =
+      collectEnumerationSequence(reloaded);
+  TEST_ASSERT(reloadedSequence == baseline);
+}
+#else
+void testGraftCacheNotSerialized() {}
+#endif
+
 void testEnumerations() {
   EnumerationTypes::BBS bbs;
   bbs.resize(2);
@@ -704,6 +832,11 @@ int main() {
   testDedupCollapsesSymmetricReagent();
   testDedupFlagSerialized();
   testEnumerationCacheNotSerialized();
+  testGraftCacheOutputUnchanged();
+  testGraftCachePopulatedAndReused();
+  testGraftCacheReuseAcrossReset();
+  testGraftCachePreservedOnCopy();
+  testGraftCacheNotSerialized();
   testSamplers();
   testEvenSamplers();
   testEnumerations();

--- a/Code/GraphMol/ChemReactions/Enumerate/testEnumerate.cpp
+++ b/Code/GraphMol/ChemReactions/Enumerate/testEnumerate.cpp
@@ -189,6 +189,32 @@ EnumerationTypes::BBS makeEnumerationCacheBbs() {
   return bbs;
 }
 
+EnumerationTypes::BBS makeEnumerationCacheBbsWithNonMatches() {
+  EnumerationTypes::BBS bbs = makeEnumerationCacheBbs();
+  bbs[0].push_back(boost::shared_ptr<ROMol>(SmilesToMol("CC")));
+  bbs[1].push_back(boost::shared_ptr<ROMol>(SmilesToMol("Clc1ccccc1")));
+  return bbs;
+}
+
+EnumerationTypes::BBS makeEnumerationCacheBbsWithProtectedAtoms() {
+  EnumerationTypes::BBS bbs = makeEnumerationCacheBbsWithNonMatches();
+  bbs[0][0]->getAtomWithIdx(0)->setProp(common_properties::_protected, 1);
+  bbs[1][0]->getAtomWithIdx(0)->setProp(common_properties::_protected, 1);
+  return bbs;
+}
+
+std::vector<std::multiset<std::string>> collectReagentSmiles(
+    const EnumerationTypes::BBS &bbs) {
+  std::vector<std::multiset<std::string>> results;
+  results.resize(bbs.size());
+  for (size_t i = 0; i < bbs.size(); ++i) {
+    for (const auto &mol : bbs[i]) {
+      results[i].insert(MolToSmiles(*mol, true));
+    }
+  }
+  return results;
+}
+
 std::multiset<std::string> collectEnumerationSmiles(EnumerateLibrary &en) {
   std::multiset<std::string> results;
   for (; (bool)en;) {
@@ -247,6 +273,87 @@ void testEnumerationCacheOutputUnchanged() {
 
   TEST_ASSERT(cachedResults == expected);
   TEST_ASSERT(viaLibraryResults == expected);
+}
+
+void testPrefilterResultsUnchanged() {
+  boost::scoped_ptr<ChemicalReaction> rxn(makeEnumerationCacheRxn());
+  rxn->initReactantMatchers();
+  EnumerationTypes::BBS bbs = makeEnumerationCacheBbsWithNonMatches();
+
+  EnumerationParams params;
+  EnumerationTypes::BBS baseline = removeNonmatchingReagents(*rxn, bbs, params);
+  EnumerateLibrary library(*rxn, bbs, params);
+
+  TEST_ASSERT(collectReagentSmiles(library.getReagents()) ==
+              collectReagentSmiles(baseline));
+
+  params.reagentMaxMatchCount = 1;
+  baseline = removeNonmatchingReagents(*rxn, bbs, params);
+  EnumerateLibrary cappedLibrary(*rxn, bbs, params);
+  TEST_ASSERT(collectReagentSmiles(cappedLibrary.getReagents()) ==
+              collectReagentSmiles(baseline));
+}
+
+void testPrefilterPrimesSharedCache() {
+  boost::scoped_ptr<ChemicalReaction> rxn(makeEnumerationCacheRxn());
+  rxn->initReactantMatchers();
+  EnumerationTypes::BBS bbs = makeEnumerationCacheBbsWithNonMatches();
+
+  EnumerateLibrary library(*rxn, bbs);
+  const EnumerationTypes::BBS &filtered = library.getReagents();
+  size_t expectedCacheSize = 0;
+  for (const auto &pool : filtered) {
+    expectedCacheSize += pool.size();
+  }
+
+  TEST_ASSERT(library.getMatchCacheSize() == expectedCacheSize);
+}
+
+void testPrefilterFullEnumerationOutputUnchanged() {
+  boost::scoped_ptr<ChemicalReaction> rxn(makeEnumerationCacheRxn());
+  rxn->initReactantMatchers();
+  EnumerationTypes::BBS bbs = makeEnumerationCacheBbsWithNonMatches();
+
+  EnumerateLibrary library(*rxn, bbs);
+  const std::multiset<std::string> expected =
+      collectDirectProductSmiles(*rxn, library.getReagents());
+  const std::multiset<std::string> actual = collectEnumerationSmiles(library);
+
+  TEST_ASSERT(actual == expected);
+}
+
+void testPrefilterProtectedAtomFallback() {
+  boost::scoped_ptr<ChemicalReaction> rxn(makeEnumerationCacheRxn());
+  rxn->initReactantMatchers();
+  EnumerationTypes::BBS bbs = makeEnumerationCacheBbsWithProtectedAtoms();
+
+  EnumerationParams params;
+  EnumerationTypes::BBS baseline = removeNonmatchingReagents(*rxn, bbs, params);
+  EnumerateLibrary library(*rxn, bbs, params);
+
+  // removal behavior must be identical to the 3-arg baseline even when some
+  // reagents carry a _protected atom (those take the countMatches fallback)
+  TEST_ASSERT(collectReagentSmiles(library.getReagents()) ==
+              collectReagentSmiles(baseline));
+
+  // reagents carrying a _protected atom are not primed into the shared cache;
+  // only the protected-free survivors take the fast path
+  size_t nonProtectedSurvivors = 0;
+  for (const auto &pool : library.getReagents()) {
+    for (const auto &mol : pool) {
+      bool hasProtected = false;
+      for (const auto atom : mol->atoms()) {
+        if (atom->hasProp(common_properties::_protected)) {
+          hasProtected = true;
+          break;
+        }
+      }
+      if (!hasProtected) {
+        ++nonProtectedSurvivors;
+      }
+    }
+  }
+  TEST_ASSERT(library.getMatchCacheSize() == nonProtectedSurvivors);
 }
 
 void testEnumerationCacheReuseAcrossReset() {
@@ -501,6 +608,10 @@ void testGithub1657() {}
 int main() {
   RDLog::InitLogs();
 #if 1
+  testPrefilterResultsUnchanged();
+  testPrefilterPrimesSharedCache();
+  testPrefilterFullEnumerationOutputUnchanged();
+  testPrefilterProtectedAtomFallback();
   testEnumerationCacheOutputUnchanged();
   testEnumerationCacheReuseAcrossReset();
   testEnumerationCacheNotSerialized();

--- a/Code/GraphMol/ChemReactions/ReactionRunner.cpp
+++ b/Code/GraphMol/ChemReactions/ReactionRunner.cpp
@@ -37,8 +37,10 @@
 #include <GraphMol/QueryOps.h>
 #include <boost/dynamic_bitset.hpp>
 #include <map>
+#include <set>
 #include <algorithm>
 #include <GraphMol/ChemTransforms/ChemTransforms.h>
+#include <GraphMol/new_canon.h>
 #include <GraphMol/SmilesParse/SmilesWrite.h>
 #include "GraphMol/ChemReactions/ReactionRunner.h"
 #include <RDGeneral/Invariant.h>
@@ -193,6 +195,42 @@ VectMatchVectType getReactantMatchesToTemplate(
       res.push_back(std::move(match));
     }
   }
+  return res;
+}
+
+VectMatchVectType dedupeMatchesBySymmetry(const ROMol &reactant,
+                                          const VectMatchVectType &matches) {
+  if (matches.size() < 2) {
+    return matches;
+  }
+
+  // Matches with the same rank tuple land on symmetry-equivalent reagent
+  // atoms, so they would generate identical products. Keep the first one.
+  std::vector<unsigned int> ranks;
+  Canon::rankMolAtoms(reactant, ranks, false);
+
+  std::set<std::vector<unsigned int>> seenKeys;
+  VectMatchVectType res;
+  res.reserve(matches.size());
+
+  for (const auto &match : matches) {
+    auto orderedMatch = match;
+    std::sort(orderedMatch.begin(), orderedMatch.end(),
+              [](const auto &lhs, const auto &rhs) {
+                return lhs.first < rhs.first;
+              });
+
+    std::vector<unsigned int> key;
+    key.reserve(orderedMatch.size());
+    for (const auto &pair : orderedMatch) {
+      key.push_back(ranks[pair.second]);
+    }
+
+    if (seenKeys.insert(std::move(key)).second) {
+      res.push_back(match);
+    }
+  }
+
   return res;
 }
 

--- a/Code/GraphMol/ChemReactions/ReactionRunner.cpp
+++ b/Code/GraphMol/ChemReactions/ReactionRunner.cpp
@@ -295,11 +295,14 @@ bool getReactantMatches(const MOL_SPTR_VECT &reactants,
 //  or were terminated.
 bool recurseOverReactantCombinations(
     const VectVectMatchVectType &matchesByReactant,
-    VectVectMatchVectType &matchesPerProduct, unsigned int level,
-    VectMatchVectType combination, unsigned int maxProducts) {
+    VectVectMatchVectType &matchesPerProduct,
+    std::vector<std::vector<unsigned int>> &matchIdxPerProduct,
+    unsigned int level, VectMatchVectType combination,
+    std::vector<unsigned int> idxCombination, unsigned int maxProducts) {
   unsigned int nReactants = matchesByReactant.size();
   URANGE_CHECK(level, nReactants);
   PRECONDITION(combination.size() == nReactants, "bad combination size");
+  PRECONDITION(idxCombination.size() == nReactants, "bad index combination size");
 
   if (maxProducts && matchesPerProduct.size() >= maxProducts) {
     return false;
@@ -310,6 +313,9 @@ bool recurseOverReactantCombinations(
        reactIt != matchesByReactant[level].end(); ++reactIt) {
     VectMatchVectType prod = combination;
     prod[level] = *reactIt;
+    std::vector<unsigned int> idxProd = idxCombination;
+    idxProd[level] = static_cast<unsigned int>(
+        reactIt - matchesByReactant[level].begin());
     if (level == nReactants - 1) {
       // this is the bottom of the recursion:
       if (maxProducts && matchesPerProduct.size() >= maxProducts) {
@@ -317,10 +323,12 @@ bool recurseOverReactantCombinations(
         break;
       }
       matchesPerProduct.push_back(prod);
+      matchIdxPerProduct.push_back(idxProd);
 
     } else {
       keepGoing = recurseOverReactantCombinations(
-          matchesByReactant, matchesPerProduct, level + 1, prod, maxProducts);
+          matchesByReactant, matchesPerProduct, matchIdxPerProduct, level + 1,
+          prod, idxProd, maxProducts);
     }
   }
   return keepGoing;
@@ -350,13 +358,18 @@ void updateImplicitAtomProperties(Atom *prodAtom, const Atom *reactAtom) {
 
 void generateReactantCombinations(
     const VectVectMatchVectType &matchesByReactant,
-    VectVectMatchVectType &matchesPerProduct, unsigned int maxProducts) {
+    VectVectMatchVectType &matchesPerProduct,
+    std::vector<std::vector<unsigned int>> &matchIdxPerProduct,
+    unsigned int maxProducts) {
   matchesPerProduct.clear();
+  matchIdxPerProduct.clear();
   VectMatchVectType tmp;
   tmp.clear();
   tmp.resize(matchesByReactant.size());
-  if (!recurseOverReactantCombinations(matchesByReactant, matchesPerProduct, 0,
-                                       tmp, maxProducts)) {
+  std::vector<unsigned int> idxTmp(matchesByReactant.size(), 0);
+  if (!recurseOverReactantCombinations(matchesByReactant, matchesPerProduct,
+                                       matchIdxPerProduct, 0, tmp, idxTmp,
+                                       maxProducts)) {
     BOOST_LOG(rdWarningLog) << "Maximum product count hit " << maxProducts
                             << ", stopping reaction early...\n";
   }
@@ -1763,9 +1776,14 @@ void copyTemplateStereoGroupsToMol(const ROMol &templateMol,
 MOL_SPTR_VECT
 generateOneProductSet(const ChemicalReaction &rxn,
                       const MOL_SPTR_VECT &reactants,
-                      const std::vector<MatchVectType> &reactantsMatch) {
+                      const std::vector<MatchVectType> &reactantsMatch,
+                      ReactantGraftCache *graftCache,
+                      const std::vector<unsigned int> *matchIdxs,
+                      bool dedupeSymmetricMatches) {
   PRECONDITION(reactants.size() == reactantsMatch.size(),
                "vector size mismatch");
+  PRECONDITION(!graftCache || (matchIdxs && matchIdxs->size() == reactants.size()),
+               "graft cache requires one match index per reactant");
 
   // if any of the reactants have a conformer, we'll go ahead and
   // generate conformers for the products:
@@ -1806,11 +1824,35 @@ generateOneProductSet(const ChemicalReaction &rxn,
     unsigned int reactantId = 0;
     for (auto iter = rxn.beginReactantTemplates();
          iter != rxn.endReactantTemplates(); ++iter, reactantId++) {
-      auto graft = extractReactantGraft(rxn, *pTemplIt, *iter,
-                                        reactants.at(reactantId),
-                                        reactantsMatch.at(reactantId),
-                                        reactantId, doConfs);
-      applyReactantGraft(product, conf, graft);
+      if (graftCache) {
+        // reuse (or populate) the graft this reagent/match contributes to this
+        // product template, keyed by reagent pointer identity + match index.
+        // dedupeSymmetricMatches and doConfs are part of the key because they
+        // determine, respectively, which match list the index refers to and
+        // whether the graft carries conformer coordinates.
+        auto key = std::make_tuple(prodId, reactantId,
+                                   reactants.at(reactantId).get(),
+                                   (*matchIdxs)[reactantId],
+                                   dedupeSymmetricMatches, doConfs);
+        auto cacheIt = graftCache->find(key);
+        if (cacheIt == graftCache->end()) {
+          cacheIt =
+              graftCache
+                  ->emplace(key, extractReactantGraft(
+                                     rxn, *pTemplIt, *iter,
+                                     reactants.at(reactantId),
+                                     reactantsMatch.at(reactantId), reactantId,
+                                     doConfs))
+                  .first;
+        }
+        applyReactantGraft(product, conf, cacheIt->second);
+      } else {
+        auto graft = extractReactantGraft(rxn, *pTemplIt, *iter,
+                                          reactants.at(reactantId),
+                                          reactantsMatch.at(reactantId),
+                                          reactantId, doConfs);
+        applyReactantGraft(product, conf, graft);
+      }
     }
 
     if (doConfs) {
@@ -1883,11 +1925,11 @@ void traverseToFindAtomsToRemove(const ROMol &reactant, const ROMol &templ,
 }  // namespace ReactionRunnerUtils
 
 namespace {
-std::vector<MOL_SPTR_VECT> run_ReactantsImpl(const ChemicalReaction &rxn,
-                                             const MOL_SPTR_VECT &reactants,
-                                             unsigned int maxProducts,
-                                             bool dedupeSymmetricMatches,
-                                             ReactantMatchCache *cache) {
+std::vector<MOL_SPTR_VECT> run_ReactantsImpl(
+    const ChemicalReaction &rxn, const MOL_SPTR_VECT &reactants,
+    unsigned int maxProducts, bool dedupeSymmetricMatches,
+    ReactantMatchCache *cache,
+    ReactionRunnerUtils::ReactantGraftCache *graftCache) {
   if (!rxn.isInitialized()) {
     throw ChemicalReactionException(
         "initMatchers() must be called before runReactants()");
@@ -1922,14 +1964,18 @@ std::vector<MOL_SPTR_VECT> run_ReactantsImpl(const ChemicalReaction &rxn,
   // we now have matches for each reactant, so we can start creating products:
   // start by doing the combinatorics on the matches:
   VectVectMatchVectType reactantMatchesPerProduct;
+  std::vector<std::vector<unsigned int>> matchIdxPerProduct;
   ReactionRunnerUtils::generateReactantCombinations(
-      matchesByReactant, reactantMatchesPerProduct, maxProducts);
+      matchesByReactant, reactantMatchesPerProduct, matchIdxPerProduct,
+      maxProducts);
   productMols.resize(reactantMatchesPerProduct.size());
 
   for (unsigned int productId = 0; productId != productMols.size();
        ++productId) {
     MOL_SPTR_VECT lProds = ReactionRunnerUtils::generateOneProductSet(
-        rxn, reactants, reactantMatchesPerProduct[productId]);
+        rxn, reactants, reactantMatchesPerProduct[productId], graftCache,
+        graftCache ? &matchIdxPerProduct[productId] : nullptr,
+        dedupeSymmetricMatches);
     productMols[productId] = lProds;
   }
 
@@ -1940,7 +1986,8 @@ std::vector<MOL_SPTR_VECT> run_ReactantsImpl(const ChemicalReaction &rxn,
 std::vector<MOL_SPTR_VECT> run_Reactants(const ChemicalReaction &rxn,
                                          const MOL_SPTR_VECT &reactants,
                                          unsigned int maxProducts) {
-  return run_ReactantsImpl(rxn, reactants, maxProducts, false, nullptr);
+  return run_ReactantsImpl(rxn, reactants, maxProducts, false, nullptr,
+                           nullptr);
 }
 
 std::vector<MOL_SPTR_VECT> run_Reactants(const ChemicalReaction &rxn,
@@ -1948,8 +1995,17 @@ std::vector<MOL_SPTR_VECT> run_Reactants(const ChemicalReaction &rxn,
                                          ReactantMatchCache &cache,
                                          bool dedupeSymmetricMatches,
                                          unsigned int maxProducts) {
-  return run_ReactantsImpl(rxn, reactants, maxProducts,
-                           dedupeSymmetricMatches, &cache);
+  return run_ReactantsImpl(rxn, reactants, maxProducts, dedupeSymmetricMatches,
+                           &cache, nullptr);
+}
+
+std::vector<MOL_SPTR_VECT> run_Reactants(
+    const ChemicalReaction &rxn, const MOL_SPTR_VECT &reactants,
+    ReactantMatchCache &matchCache,
+    ReactionRunnerUtils::ReactantGraftCache &graftCache,
+    bool dedupeSymmetricMatches, unsigned int maxProducts) {
+  return run_ReactantsImpl(rxn, reactants, maxProducts, dedupeSymmetricMatches,
+                           &matchCache, &graftCache);
 }
 
 namespace {

--- a/Code/GraphMol/ChemReactions/ReactionRunner.cpp
+++ b/Code/GraphMol/ChemReactions/ReactionRunner.cpp
@@ -48,7 +48,6 @@
 #include <GraphMol/QueryBond.h>
 
 namespace RDKit {
-typedef std::vector<MatchVectType> VectMatchVectType;
 typedef std::vector<VectMatchVectType> VectVectMatchVectType;
 
 namespace {
@@ -201,7 +200,8 @@ bool getReactantMatches(const MOL_SPTR_VECT &reactants,
                         const ChemicalReaction &rxn,
                         VectVectMatchVectType &matchesByReactant,
                         unsigned int maxMatches,
-                        unsigned int matchSingleReactant = MatchAll) {
+                        unsigned int matchSingleReactant = MatchAll,
+                        ReactantMatchCache *cache = nullptr) {
   PRECONDITION(reactants.size() == rxn.getNumReactantTemplates(),
                "reactant size mismatch");
 
@@ -213,9 +213,23 @@ bool getReactantMatches(const MOL_SPTR_VECT &reactants,
   for (auto iter = rxn.beginReactantTemplates();
        iter != rxn.endReactantTemplates(); ++iter, i++) {
     if (matchSingleReactant == MatchAll || matchSingleReactant == i) {
-      auto matches =
-          getReactantMatchesToTemplate(*reactants[i].get(), *iter->get(),
-                                       maxMatches, rxn.getSubstructParams());
+      const auto cacheKey = std::make_tuple(i, reactants[i].get(), maxMatches);
+      VectMatchVectType matches;
+      if (cache) {
+        auto cacheIt = cache->find(cacheKey);
+        if (cacheIt != cache->end()) {
+          matches = cacheIt->second;
+        } else {
+          matches = getReactantMatchesToTemplate(*reactants[i].get(),
+                                                 *iter->get(), maxMatches,
+                                                 rxn.getSubstructParams());
+          cache->emplace(cacheKey, matches);
+        }
+      } else {
+        matches = getReactantMatchesToTemplate(*reactants[i].get(), *iter->get(),
+                                               maxMatches,
+                                               rxn.getSubstructParams());
+      }
       if (matches.empty()) {
         // no point continuing if we don't match one of the reactants:
         res = false;
@@ -1600,9 +1614,11 @@ void traverseToFindAtomsToRemove(const ROMol &reactant, const ROMol &templ,
 
 }  // namespace ReactionRunnerUtils
 
-std::vector<MOL_SPTR_VECT> run_Reactants(const ChemicalReaction &rxn,
-                                         const MOL_SPTR_VECT &reactants,
-                                         unsigned int maxProducts) {
+namespace {
+std::vector<MOL_SPTR_VECT> run_ReactantsImpl(const ChemicalReaction &rxn,
+                                             const MOL_SPTR_VECT &reactants,
+                                             unsigned int maxProducts,
+                                             ReactantMatchCache *cache) {
   if (!rxn.isInitialized()) {
     throw ChemicalReactionException(
         "initMatchers() must be called before runReactants()");
@@ -1628,7 +1644,7 @@ std::vector<MOL_SPTR_VECT> run_Reactants(const ChemicalReaction &rxn,
   // find the matches for each reactant:
   VectVectMatchVectType matchesByReactant;
   if (!ReactionRunnerUtils::getReactantMatches(
-          reactants, rxn, matchesByReactant, maxProducts)) {
+      reactants, rxn, matchesByReactant, maxProducts, UINT_MAX, cache)) {
     // some reactants didn't find a match, return an empty product list:
     return productMols;
   }
@@ -1649,6 +1665,20 @@ std::vector<MOL_SPTR_VECT> run_Reactants(const ChemicalReaction &rxn,
 
   return productMols;
 }  // end of ChemicalReaction::runReactants()
+}  // namespace
+
+std::vector<MOL_SPTR_VECT> run_Reactants(const ChemicalReaction &rxn,
+                                         const MOL_SPTR_VECT &reactants,
+                                         unsigned int maxProducts) {
+  return run_ReactantsImpl(rxn, reactants, maxProducts, nullptr);
+}
+
+std::vector<MOL_SPTR_VECT> run_Reactants(const ChemicalReaction &rxn,
+                                         const MOL_SPTR_VECT &reactants,
+                                         ReactantMatchCache &cache,
+                                         unsigned int maxProducts) {
+  return run_ReactantsImpl(rxn, reactants, maxProducts, &cache);
+}
 
 namespace {
 bool updateAtomsModifiedByReaction(

--- a/Code/GraphMol/ChemReactions/ReactionRunner.cpp
+++ b/Code/GraphMol/ChemReactions/ReactionRunner.cpp
@@ -1493,6 +1493,15 @@ ReactantGraft extractReactantGraft(const ChemicalReaction &rxn,
     graft.iso->addConformer(conf, true);
   }
 
+  // NOTE: we deliberately do NOT call graft.iso->updatePropertyCache() here.
+  // The only mutable state the graft needs to carry into every product is each
+  // atom's intrinsic input data (atomic number, charge, isotope, explicit H
+  // count, noImplicit flag, etc.), all of which is established by
+  // addReactantAtomsAndBonds above. The computed valence cache is recomputed
+  // per product by the updatePropertyCache() at the end of
+  // generateOneProductSet (which runs unconditionally), so finalizing the iso
+  // here would just be thrown away.
+
   std::set<unsigned int> reactantMapNums;
   for (const auto atom : reactantTemplate->atoms()) {
     const auto mapNum = atom->getAtomMapNum();
@@ -1560,6 +1569,21 @@ void applyReactantGraft(RWMOL_SPTR product, Conformer *productConf,
     if (isoBond->getStereoAtoms().size() == 2) {
       stereoBondsToRemap.emplace_back(bondIdx, isoBond);
     }
+  }
+
+  // RWMol::replaceBond (github #7128) decrements an atom's explicit H count
+  // whenever the replacement bond has a higher order than the bond it
+  // supersedes. Here the product-template anchor bonds are typically lower
+  // order (e.g. an unspecified/single query bond) than the fully resolved iso
+  // bonds (e.g. aromatic), so the anchor-bond replacements above can spuriously
+  // strip explicit Hs (for example the H on an aromatic [nH]). The direct
+  // assembly path sets bond properties in place and never triggers this, so we
+  // restore the anchor atoms' explicit-H state from the iso source of truth.
+  for (unsigned int atomIdx : graft.anchorAtomIdxs) {
+    const auto *isoAtom = graft.iso->getAtomWithIdx(atomIdx);
+    auto *prodAtom = product->getAtomWithIdx(atomIdx);
+    prodAtom->setNumExplicitHs(isoAtom->getNumExplicitHs());
+    prodAtom->setNoImplicit(isoAtom->getNoImplicit());
   }
 
   for (unsigned int bondIdx = graft.templateBondCount;
@@ -1847,11 +1871,13 @@ generateOneProductSet(const ChemicalReaction &rxn,
         }
         applyReactantGraft(product, conf, cacheIt->second);
       } else {
-        auto graft = extractReactantGraft(rxn, *pTemplIt, *iter,
-                                          reactants.at(reactantId),
-                                          reactantsMatch.at(reactantId),
-                                          reactantId, doConfs);
-        applyReactantGraft(product, conf, graft);
+        // No graft cache: assemble the product directly. This is the original
+        // (upstream) code path and is byte-for-byte faithful to it; the
+        // extract/apply graft machinery only pays off when a graft cache lets
+        // us replay an extracted graft across the reactant Cartesian product.
+        addReactantAtomsAndBonds(rxn, product, reactants.at(reactantId),
+                                 reactantsMatch.at(reactantId), *iter, conf,
+                                 reactantId);
       }
     }
 

--- a/Code/GraphMol/ChemReactions/ReactionRunner.cpp
+++ b/Code/GraphMol/ChemReactions/ReactionRunner.cpp
@@ -239,7 +239,8 @@ bool getReactantMatches(const MOL_SPTR_VECT &reactants,
                         VectVectMatchVectType &matchesByReactant,
                         unsigned int maxMatches,
                         unsigned int matchSingleReactant = MatchAll,
-                        ReactantMatchCache *cache = nullptr) {
+                        ReactantMatchCache *cache = nullptr,
+                        bool dedupeSymmetricMatches = false) {
   PRECONDITION(reactants.size() == rxn.getNumReactantTemplates(),
                "reactant size mismatch");
 
@@ -251,7 +252,9 @@ bool getReactantMatches(const MOL_SPTR_VECT &reactants,
   for (auto iter = rxn.beginReactantTemplates();
        iter != rxn.endReactantTemplates(); ++iter, i++) {
     if (matchSingleReactant == MatchAll || matchSingleReactant == i) {
-      const auto cacheKey = std::make_tuple(i, reactants[i].get(), maxMatches);
+      const auto cacheKey =
+          std::make_tuple(i, reactants[i].get(), maxMatches,
+                          dedupeSymmetricMatches);
       VectMatchVectType matches;
       if (cache) {
         auto cacheIt = cache->find(cacheKey);
@@ -261,12 +264,20 @@ bool getReactantMatches(const MOL_SPTR_VECT &reactants,
           matches = getReactantMatchesToTemplate(*reactants[i].get(),
                                                  *iter->get(), maxMatches,
                                                  rxn.getSubstructParams());
+          if (dedupeSymmetricMatches) {
+            matches = ReactionRunnerUtils::dedupeMatchesBySymmetry(
+                *reactants[i].get(), matches);
+          }
           cache->emplace(cacheKey, matches);
         }
       } else {
         matches = getReactantMatchesToTemplate(*reactants[i].get(), *iter->get(),
                                                maxMatches,
                                                rxn.getSubstructParams());
+        if (dedupeSymmetricMatches) {
+          matches = ReactionRunnerUtils::dedupeMatchesBySymmetry(
+              *reactants[i].get(), matches);
+        }
       }
       if (matches.empty()) {
         // no point continuing if we don't match one of the reactants:
@@ -1656,6 +1667,7 @@ namespace {
 std::vector<MOL_SPTR_VECT> run_ReactantsImpl(const ChemicalReaction &rxn,
                                              const MOL_SPTR_VECT &reactants,
                                              unsigned int maxProducts,
+                                             bool dedupeSymmetricMatches,
                                              ReactantMatchCache *cache) {
   if (!rxn.isInitialized()) {
     throw ChemicalReactionException(
@@ -1682,7 +1694,8 @@ std::vector<MOL_SPTR_VECT> run_ReactantsImpl(const ChemicalReaction &rxn,
   // find the matches for each reactant:
   VectVectMatchVectType matchesByReactant;
   if (!ReactionRunnerUtils::getReactantMatches(
-      reactants, rxn, matchesByReactant, maxProducts, UINT_MAX, cache)) {
+      reactants, rxn, matchesByReactant, maxProducts, UINT_MAX, cache,
+      dedupeSymmetricMatches)) {
     // some reactants didn't find a match, return an empty product list:
     return productMols;
   }
@@ -1708,14 +1721,16 @@ std::vector<MOL_SPTR_VECT> run_ReactantsImpl(const ChemicalReaction &rxn,
 std::vector<MOL_SPTR_VECT> run_Reactants(const ChemicalReaction &rxn,
                                          const MOL_SPTR_VECT &reactants,
                                          unsigned int maxProducts) {
-  return run_ReactantsImpl(rxn, reactants, maxProducts, nullptr);
+  return run_ReactantsImpl(rxn, reactants, maxProducts, false, nullptr);
 }
 
 std::vector<MOL_SPTR_VECT> run_Reactants(const ChemicalReaction &rxn,
                                          const MOL_SPTR_VECT &reactants,
                                          ReactantMatchCache &cache,
+                                         bool dedupeSymmetricMatches,
                                          unsigned int maxProducts) {
-  return run_ReactantsImpl(rxn, reactants, maxProducts, &cache);
+  return run_ReactantsImpl(rxn, reactants, maxProducts,
+                           dedupeSymmetricMatches, &cache);
 }
 
 namespace {

--- a/Code/GraphMol/ChemReactions/ReactionRunner.cpp
+++ b/Code/GraphMol/ChemReactions/ReactionRunner.cpp
@@ -1386,6 +1386,223 @@ void addReactantAtomsAndBonds(const ChemicalReaction &rxn, RWMOL_SPTR product,
                               const ROMOL_SPTR reactantSptr,
                               const MatchVectType &match,
                               const ROMOL_SPTR reactantTemplate,
+                              Conformer *productConf, unsigned int reactantId);
+
+Atom *cloneAtomForProduct(const Atom &srcAtom) {
+  if (!srcAtom.hasQuery()) {
+    return new Atom(srcAtom);
+  }
+  return new QueryAtom(dynamic_cast<const QueryAtom &>(srcAtom));
+}
+
+Bond *cloneBondForProduct(const Bond &srcBond) {
+  if (!srcBond.hasQuery()) {
+    return new Bond(srcBond);
+  }
+  return new QueryBond(dynamic_cast<const QueryBond &>(srcBond));
+}
+
+// Remap a copied bond's stereo-atom references (held in iso atom indices) to
+// the corresponding product atom indices. The bond already carries its stereo
+// and stereo-atom values from the copy constructor, so we only translate the
+// indices here, preserving their order (begin/end orientation is unchanged).
+void remapBondStereoAtoms(const Bond &isoBond, Bond *prodBond,
+                          const std::vector<int> &isoToProd) {
+  PRECONDITION(prodBond, "no bond");
+  const auto &stereoAtoms = isoBond.getStereoAtoms();
+  if (stereoAtoms.size() != 2) {
+    return;
+  }
+  CHECK_INVARIANT(isoToProd[stereoAtoms[0]] >= 0, "missing stereo atom map");
+  CHECK_INVARIANT(isoToProd[stereoAtoms[1]] >= 0, "missing stereo atom map");
+  prodBond->setStereoAtoms(rdcast<unsigned int>(isoToProd[stereoAtoms[0]]),
+                           rdcast<unsigned int>(isoToProd[stereoAtoms[1]]));
+}
+
+void copyStereoGroupsFromGraft(const ROMol &iso, RWMOL_SPTR product,
+                               const std::vector<int> &isoToProd) {
+  std::vector<StereoGroup> newStereoGroups;
+  for (const auto &sg : iso.getStereoGroups()) {
+    std::vector<Atom *> atoms;
+    std::vector<Bond *> bonds;
+    for (const auto &isoAtom : sg.getAtoms()) {
+      const auto mappedIdx = isoToProd[isoAtom->getIdx()];
+      if (mappedIdx < 0) {
+        continue;
+      }
+
+      auto productAtom = product->getAtomWithIdx(rdcast<unsigned int>(mappedIdx));
+      if (productAtom->getChiralTag() == Atom::CHI_UNSPECIFIED) {
+        continue;
+      }
+      int flagVal = 0;
+      productAtom->getPropIfPresent(common_properties::molInversionFlag,
+                                    flagVal);
+      if (flagVal == 4) {
+        continue;
+      }
+      atoms.push_back(productAtom);
+    }
+    if (!atoms.empty()) {
+      newStereoGroups.emplace_back(sg.getGroupType(), std::move(atoms),
+                                   std::move(bonds), sg.getReadId());
+    }
+  }
+
+  if (!newStereoGroups.empty()) {
+    auto &existing_sg = product->getStereoGroups();
+    newStereoGroups.insert(newStereoGroups.end(), existing_sg.begin(),
+                           existing_sg.end());
+    product->setStereoGroups(std::move(newStereoGroups));
+  }
+}
+
+ReactantGraft extractReactantGraft(const ChemicalReaction &rxn,
+                                   const ROMOL_SPTR &productTemplate,
+                                   const ROMOL_SPTR &reactantTemplate,
+                                   const ROMOL_SPTR &reactant,
+                                   const MatchVectType &match,
+                                   unsigned int reactantId, bool doConfs) {
+  ReactantGraft graft;
+  graft.iso = convertTemplateToMol(productTemplate);
+  graft.templateAtomCount = graft.iso->getNumAtoms();
+  graft.templateBondCount = graft.iso->getNumBonds();
+
+  Conformer *conf = nullptr;
+  if (doConfs) {
+    conf = new Conformer(graft.iso->getNumAtoms());
+    conf->set3D(false);
+  }
+
+  addReactantAtomsAndBonds(rxn, graft.iso, reactant, match, reactantTemplate,
+                           conf, reactantId);
+  if (doConfs) {
+    graft.iso->addConformer(conf, true);
+  }
+
+  std::set<unsigned int> reactantMapNums;
+  for (const auto atom : reactantTemplate->atoms()) {
+    const auto mapNum = atom->getAtomMapNum();
+    if (mapNum) {
+      reactantMapNums.insert(mapNum);
+    }
+  }
+
+  for (unsigned int atomIdx = 0; atomIdx < graft.templateAtomCount;
+       ++atomIdx) {
+    unsigned int mapNum = 0;
+    if (graft.iso->getAtomWithIdx(atomIdx)->getPropIfPresent(
+            common_properties::reactionMapNum, mapNum) &&
+        reactantMapNums.find(mapNum) != reactantMapNums.end()) {
+      graft.anchorAtomIdxs.push_back(atomIdx);
+    }
+  }
+
+  std::set<unsigned int> anchorAtoms(graft.anchorAtomIdxs.begin(),
+                                      graft.anchorAtomIdxs.end());
+  for (unsigned int bondIdx = 0; bondIdx < graft.templateBondCount; ++bondIdx) {
+    const auto bond = graft.iso->getBondWithIdx(bondIdx);
+    if (anchorAtoms.find(bond->getBeginAtomIdx()) != anchorAtoms.end() &&
+        anchorAtoms.find(bond->getEndAtomIdx()) != anchorAtoms.end()) {
+      graft.anchorBondIdxs.push_back(bondIdx);
+    }
+  }
+
+  return graft;
+}
+
+void applyReactantGraft(RWMOL_SPTR product, Conformer *productConf,
+                        const ReactantGraft &graft) {
+  PRECONDITION(product, "no product");
+
+  std::vector<int> isoToProd(graft.iso->getNumAtoms(), -1);
+  for (unsigned int atomIdx = 0; atomIdx < graft.templateAtomCount;
+       ++atomIdx) {
+    isoToProd[atomIdx] = rdcast<int>(atomIdx);
+  }
+
+  for (unsigned int atomIdx : graft.anchorAtomIdxs) {
+    auto *newAtom = cloneAtomForProduct(*graft.iso->getAtomWithIdx(atomIdx));
+    product->replaceAtom(atomIdx, newAtom, false, false);
+  }
+
+  for (unsigned int atomIdx = graft.templateAtomCount;
+       atomIdx < graft.iso->getNumAtoms(); ++atomIdx) {
+    auto *newAtom = cloneAtomForProduct(*graft.iso->getAtomWithIdx(atomIdx));
+    const auto prodIdx = product->addAtom(newAtom, false, true);
+    isoToProd[atomIdx] = rdcast<int>(prodIdx);
+  }
+
+  // Bond stereo atoms reference neighboring atoms; we can only retarget them
+  // once every bond exists in the product, so we record the (product bond,
+  // iso bond) pairs here and remap them in a final pass below.
+  std::vector<std::pair<unsigned int, const Bond *>> stereoBondsToRemap;
+
+  for (unsigned int bondIdx : graft.anchorBondIdxs) {
+    const auto *isoBond = graft.iso->getBondWithIdx(bondIdx);
+    auto *newBond = cloneBondForProduct(*isoBond);
+    // keepSGroups=true matches the original setReactantBondPropertiesToProduct
+    // path so any SGroup bond membership in the product template is preserved.
+    product->replaceBond(bondIdx, newBond, false, true);
+    if (isoBond->getStereoAtoms().size() == 2) {
+      stereoBondsToRemap.emplace_back(bondIdx, isoBond);
+    }
+  }
+
+  for (unsigned int bondIdx = graft.templateBondCount;
+       bondIdx < graft.iso->getNumBonds(); ++bondIdx) {
+    const auto *isoBond = graft.iso->getBondWithIdx(bondIdx);
+    const auto begIdx =
+        rdcast<unsigned int>(isoToProd[isoBond->getBeginAtomIdx()]);
+    const auto endIdx =
+        rdcast<unsigned int>(isoToProd[isoBond->getEndAtomIdx()]);
+    // Copy the bond verbatim (type, direction, stereo, stereo atoms, aromatic
+    // flag, and properties all come across via the copy constructor) and then
+    // retarget it onto the product atom indices.
+    auto *newBond = cloneBondForProduct(*isoBond);
+    newBond->setBeginAtomIdx(begIdx);
+    newBond->setEndAtomIdx(endIdx);
+    bool takeOwnership = true;
+    product->addBond(newBond, takeOwnership);
+    if (isoBond->getStereoAtoms().size() == 2) {
+      stereoBondsToRemap.emplace_back(product->getNumBonds() - 1, isoBond);
+    }
+  }
+
+  // now that all bonds are present, retarget the stereo-atom references
+  for (const auto &[prodBondIdx, isoBond] : stereoBondsToRemap) {
+    remapBondStereoAtoms(*isoBond, product->getBondWithIdx(prodBondIdx),
+                         isoToProd);
+  }
+
+  if (productConf && graft.iso->getNumConformers()) {
+    const auto &isoConf = graft.iso->getConformer();
+    if (isoConf.is3D()) {
+      productConf->set3D(true);
+    }
+    productConf->resize(product->getNumAtoms());
+    std::set<unsigned int> anchorAtoms(graft.anchorAtomIdxs.begin(),
+                                       graft.anchorAtomIdxs.end());
+    for (unsigned int atomIdx = 0; atomIdx < graft.iso->getNumAtoms();
+         ++atomIdx) {
+      if (atomIdx < graft.templateAtomCount &&
+          anchorAtoms.find(atomIdx) == anchorAtoms.end()) {
+        continue;
+      }
+      const auto prodIdx = isoToProd[atomIdx];
+      CHECK_INVARIANT(prodIdx >= 0, "missing atom map in graft application");
+      productConf->setAtomPos(rdcast<unsigned int>(prodIdx),
+                              isoConf.getAtomPos(atomIdx));
+    }
+  }
+
+  copyStereoGroupsFromGraft(*graft.iso, product, isoToProd);
+}
+
+void addReactantAtomsAndBonds(const ChemicalReaction &rxn, RWMOL_SPTR product,
+                              const ROMOL_SPTR reactantSptr,
+                              const MatchVectType &match,
+                              const ROMOL_SPTR reactantTemplate,
                               Conformer *productConf, unsigned int reactantId) {
   // start by looping over all matches and marking the reactant atoms that
   // have already been "added" by virtue of being in the product. We'll also
@@ -1589,9 +1806,11 @@ generateOneProductSet(const ChemicalReaction &rxn,
     unsigned int reactantId = 0;
     for (auto iter = rxn.beginReactantTemplates();
          iter != rxn.endReactantTemplates(); ++iter, reactantId++) {
-      addReactantAtomsAndBonds(rxn, product, reactants.at(reactantId),
-                               reactantsMatch.at(reactantId), *iter, conf,
-                               reactantId);
+      auto graft = extractReactantGraft(rxn, *pTemplIt, *iter,
+                                        reactants.at(reactantId),
+                                        reactantsMatch.at(reactantId),
+                                        reactantId, doConfs);
+      applyReactantGraft(product, conf, graft);
     }
 
     if (doConfs) {

--- a/Code/GraphMol/ChemReactions/ReactionRunner.h
+++ b/Code/GraphMol/ChemReactions/ReactionRunner.h
@@ -135,6 +135,9 @@ RDKIT_CHEMREACTIONS_EXPORT VectMatchVectType getReactantMatchesToTemplate(
   const ROMol &reactant, const ROMol &templ, unsigned int maxMatches,
   const SubstructMatchParameters &ssparams);
 
+RDKIT_CHEMREACTIONS_EXPORT VectMatchVectType dedupeMatchesBySymmetry(
+    const ROMol &reactant, const VectMatchVectType &matches);
+
 RDKIT_CHEMREACTIONS_EXPORT MOL_SPTR_VECT generateOneProductSet(
     const ChemicalReaction &rxn, const MOL_SPTR_VECT &reactants,
     const std::vector<MatchVectType> &reactantsMatch);

--- a/Code/GraphMol/ChemReactions/ReactionRunner.h
+++ b/Code/GraphMol/ChemReactions/ReactionRunner.h
@@ -36,10 +36,26 @@
 #ifndef RD_REACTION_RUNNER_H
 #define RD_REACTION_RUNNER_H
 
+#include <map>
+#include <tuple>
+
 #include <GraphMol/ChemReactions/Reaction.h>
 #include <GraphMol/ROMol.h>
+#include <GraphMol/Substruct/SubstructMatch.h>
 
 namespace RDKit {
+using VectMatchVectType = std::vector<MatchVectType>;
+//! Caches reactant-template substructure matches across run_Reactants() calls.
+/*!
+  Keyed on (reactant template index, reagent pointer identity, effective
+  maxMatches). The ROMol objects whose raw pointers are used as keys must
+  outlive this cache and must not be structurally modified between calls,
+  otherwise stale match data may be returned. Not thread-safe.
+*/
+using ReactantMatchCache =
+    std::map<std::tuple<unsigned int, const ROMol *, unsigned int>,
+             VectMatchVectType>;
+
 //! Runs the reaction on a set of reactants
 /*!
   \param rxn:       the template reaction we are interested
@@ -60,6 +76,17 @@ namespace RDKit {
 RDKIT_CHEMREACTIONS_EXPORT std::vector<MOL_SPTR_VECT> run_Reactants(
     const ChemicalReaction &rxn, const MOL_SPTR_VECT &reactants,
     unsigned int maxProducts = 1000);
+
+//! Runs the reaction on a set of reactants using a reactant match cache
+/*!
+  This overload reuses previously computed reactant-template matches for
+  repeated reagent/template combinations. The cache key is the reactant
+  template index, the reagent pointer identity, and the effective
+  maxMatches/maxProducts value.
+*/
+RDKIT_CHEMREACTIONS_EXPORT std::vector<MOL_SPTR_VECT> run_Reactants(
+    const ChemicalReaction &rxn, const MOL_SPTR_VECT &reactants,
+    ReactantMatchCache &cache, unsigned int maxProducts = 1000);
 
 //! Runs a single reactant against a single reactant template
 /*!

--- a/Code/GraphMol/ChemReactions/ReactionRunner.h
+++ b/Code/GraphMol/ChemReactions/ReactionRunner.h
@@ -48,12 +48,13 @@ using VectMatchVectType = std::vector<MatchVectType>;
 //! Caches reactant-template substructure matches across run_Reactants() calls.
 /*!
   Keyed on (reactant template index, reagent pointer identity, effective
-  maxMatches). The ROMol objects whose raw pointers are used as keys must
-  outlive this cache and must not be structurally modified between calls,
-  otherwise stale match data may be returned. Not thread-safe.
+  maxMatches, dedupeSymmetricMatches). The ROMol objects whose raw pointers
+  are used as keys must outlive this cache and must not be structurally
+  modified between calls, otherwise stale match data may be returned.
+  Not thread-safe.
 */
 using ReactantMatchCache =
-    std::map<std::tuple<unsigned int, const ROMol *, unsigned int>,
+    std::map<std::tuple<unsigned int, const ROMol *, unsigned int, bool>,
              VectMatchVectType>;
 
 //! Runs the reaction on a set of reactants
@@ -77,16 +78,17 @@ RDKIT_CHEMREACTIONS_EXPORT std::vector<MOL_SPTR_VECT> run_Reactants(
     const ChemicalReaction &rxn, const MOL_SPTR_VECT &reactants,
     unsigned int maxProducts = 1000);
 
-//! Runs the reaction on a set of reactants using a reactant match cache
+//! Runs a reaction on a set of reactants using a reactant match cache
 /*!
   This overload reuses previously computed reactant-template matches for
   repeated reagent/template combinations. The cache key is the reactant
-  template index, the reagent pointer identity, and the effective
-  maxMatches/maxProducts value.
+  template index, the reagent pointer identity, the effective
+  maxMatches/maxProducts value, and whether symmetry deduplication is on.
 */
 RDKIT_CHEMREACTIONS_EXPORT std::vector<MOL_SPTR_VECT> run_Reactants(
     const ChemicalReaction &rxn, const MOL_SPTR_VECT &reactants,
-    ReactantMatchCache &cache, unsigned int maxProducts = 1000);
+    ReactantMatchCache &cache, bool dedupeSymmetricMatches = false,
+    unsigned int maxProducts = 1000);
 
 //! Runs a single reactant against a single reactant template
 /*!

--- a/Code/GraphMol/ChemReactions/ReactionRunner.h
+++ b/Code/GraphMol/ChemReactions/ReactionRunner.h
@@ -131,6 +131,10 @@ RDKIT_CHEMREACTIONS_EXPORT ROMol *reduceProductToSideChains(
     const ROMOL_SPTR &product, bool addDummyAtoms = true);
 
 namespace ReactionRunnerUtils {
+RDKIT_CHEMREACTIONS_EXPORT VectMatchVectType getReactantMatchesToTemplate(
+  const ROMol &reactant, const ROMol &templ, unsigned int maxMatches,
+  const SubstructMatchParameters &ssparams);
+
 RDKIT_CHEMREACTIONS_EXPORT MOL_SPTR_VECT generateOneProductSet(
     const ChemicalReaction &rxn, const MOL_SPTR_VECT &reactants,
     const std::vector<MatchVectType> &reactantsMatch);

--- a/Code/GraphMol/ChemReactions/ReactionRunner.h
+++ b/Code/GraphMol/ChemReactions/ReactionRunner.h
@@ -133,6 +133,14 @@ RDKIT_CHEMREACTIONS_EXPORT ROMol *reduceProductToSideChains(
     const ROMOL_SPTR &product, bool addDummyAtoms = true);
 
 namespace ReactionRunnerUtils {
+struct ReactantGraft {
+  RWMOL_SPTR iso;
+  unsigned int templateAtomCount;
+  unsigned int templateBondCount;
+  std::vector<unsigned int> anchorAtomIdxs;
+  std::vector<unsigned int> anchorBondIdxs;
+};
+
 RDKIT_CHEMREACTIONS_EXPORT VectMatchVectType getReactantMatchesToTemplate(
   const ROMol &reactant, const ROMol &templ, unsigned int maxMatches,
   const SubstructMatchParameters &ssparams);
@@ -146,6 +154,15 @@ RDKIT_CHEMREACTIONS_EXPORT MOL_SPTR_VECT generateOneProductSet(
 
 RDKIT_CHEMREACTIONS_EXPORT RWMOL_SPTR
 convertTemplateToMol(const ROMOL_SPTR prodTemplateSptr);
+
+RDKIT_CHEMREACTIONS_EXPORT ReactantGraft extractReactantGraft(
+  const ChemicalReaction &rxn, const ROMOL_SPTR &productTemplate,
+  const ROMOL_SPTR &reactantTemplate, const ROMOL_SPTR &reactant,
+  const MatchVectType &match, unsigned int reactantId, bool doConfs);
+
+RDKIT_CHEMREACTIONS_EXPORT void applyReactantGraft(RWMOL_SPTR product,
+                           Conformer *productConf,
+                           const ReactantGraft &graft);
 }  // namespace ReactionRunnerUtils
 
 }  // namespace RDKit

--- a/Code/GraphMol/ChemReactions/ReactionRunner.h
+++ b/Code/GraphMol/ChemReactions/ReactionRunner.h
@@ -141,6 +141,25 @@ struct ReactantGraft {
   std::vector<unsigned int> anchorBondIdxs;
 };
 
+//! Caches reusable reactant grafts across product-assembly calls.
+/*!
+  Keyed on (product template index, reactant template index, reagent pointer
+  identity, match index within that reactant's match list, dedupeSymmetricMatches
+  flag, doConfs flag). A graft captures the atoms/bonds a reagent contributes to
+  a product and can be replayed onto any number of products. The two trailing
+  flags are part of the key because the match list a match index refers to
+  depends on dedupeSymmetricMatches, and whether a graft carries conformer
+  coordinates depends on doConfs; including them keeps a single cache correct
+  even when reused across calls with differing settings. The ROMol objects whose
+  raw pointers are used as keys must outlive this cache and must not be
+  structurally modified between calls, otherwise stale graft data may be
+  replayed. Not thread-safe.
+*/
+using ReactantGraftCache = std::map<
+    std::tuple<unsigned int, unsigned int, const ROMol *, unsigned int, bool,
+               bool>,
+    ReactantGraft>;
+
 RDKIT_CHEMREACTIONS_EXPORT VectMatchVectType getReactantMatchesToTemplate(
   const ROMol &reactant, const ROMol &templ, unsigned int maxMatches,
   const SubstructMatchParameters &ssparams);
@@ -148,9 +167,21 @@ RDKIT_CHEMREACTIONS_EXPORT VectMatchVectType getReactantMatchesToTemplate(
 RDKIT_CHEMREACTIONS_EXPORT VectMatchVectType dedupeMatchesBySymmetry(
     const ROMol &reactant, const VectMatchVectType &matches);
 
+//! Assembles one product set for a single reactant/match combination
+/*!
+  When \c graftCache is non-null, each reactant's contribution is looked up in
+  (or extracted into) the cache using the per-reactant \c matchIdxs and replayed
+  instead of being re-derived. \c matchIdxs must then have one entry per
+  reactant, and \c dedupeSymmetricMatches must reflect how that reactant's match
+  list was built (it participates in the cache key). With \c graftCache null the
+  assembly is recomputed from scratch.
+*/
 RDKIT_CHEMREACTIONS_EXPORT MOL_SPTR_VECT generateOneProductSet(
     const ChemicalReaction &rxn, const MOL_SPTR_VECT &reactants,
-    const std::vector<MatchVectType> &reactantsMatch);
+    const std::vector<MatchVectType> &reactantsMatch,
+    ReactantGraftCache *graftCache = nullptr,
+    const std::vector<unsigned int> *matchIdxs = nullptr,
+    bool dedupeSymmetricMatches = false);
 
 RDKIT_CHEMREACTIONS_EXPORT RWMOL_SPTR
 convertTemplateToMol(const ROMOL_SPTR prodTemplateSptr);
@@ -164,6 +195,23 @@ RDKIT_CHEMREACTIONS_EXPORT void applyReactantGraft(RWMOL_SPTR product,
                            Conformer *productConf,
                            const ReactantGraft &graft);
 }  // namespace ReactionRunnerUtils
+
+//! Runs a reaction reusing both reactant matches and reactant grafts
+/*!
+  In addition to the reactant-match cache, this overload caches the per-reagent
+  "graft" (the atoms and bonds a reagent contributes to each product) keyed by
+  (product template index, reactant template index, reagent pointer identity,
+  match index) and replays it across Cartesian-product combinations rather than
+  re-deriving it for every combination. Output is identical to the uncached
+  path, including stereochemistry, conformers and query atoms. Both caches must
+  outlive the call and the reagents must not be structurally modified between
+  calls. Not thread-safe.
+*/
+RDKIT_CHEMREACTIONS_EXPORT std::vector<MOL_SPTR_VECT> run_Reactants(
+    const ChemicalReaction &rxn, const MOL_SPTR_VECT &reactants,
+    ReactantMatchCache &matchCache,
+    ReactionRunnerUtils::ReactantGraftCache &graftCache,
+    bool dedupeSymmetricMatches = false, unsigned int maxProducts = 1000);
 
 }  // namespace RDKit
 

--- a/Code/GraphMol/ChemReactions/Wrap/Enumerate.cpp
+++ b/Code/GraphMol/ChemReactions/Wrap/Enumerate.cpp
@@ -209,7 +209,7 @@ Options:\n\
      reagent atoms, avoiding duplicate products for symmetric reagents.\n\
      Requires cacheMode >= MatchOnly.\n\
 \n\
-  cacheMode [default MatchOnly]\n\
+  cacheMode [default None]\n\
     Controls whether reactant-template matches and/or product grafts are\n\
      cached across enumeration steps.\n\
     ReactantCacheMode.None:      no caching (baseline behavior).\n\

--- a/Code/GraphMol/ChemReactions/Wrap/Enumerate.cpp
+++ b/Code/GraphMol/ChemReactions/Wrap/Enumerate.cpp
@@ -207,12 +207,22 @@ Options:\n\
   dedupeSymmetricMatches [default false]\n\
     If true, collapses substructure matches that land on symmetry-equivalent\n\
      reagent atoms, avoiding duplicate products for symmetric reagents.\n\
+     Requires cacheMode >= MatchOnly.\n\
 \n\
-  cacheReactantGrafts [default false]\n\
-    If true, caches and replays the per-reagent graft (the atoms and bonds a\n\
-     reagent contributes to a product) across product combinations instead of\n\
-     re-deriving it for every combination.  The output is unchanged.\n\
+  cacheMode [default MatchOnly]\n\
+    Controls whether reactant-template matches and/or product grafts are\n\
+     cached across enumeration steps.\n\
+    ReactantCacheMode.None:      no caching (baseline behavior).\n\
+    ReactantCacheMode.MatchOnly: cache reactant-template substructure matches.\n\
+    ReactantCacheMode.Full:      cache matches and per-reagent product grafts\n\
+                                 (~22x faster on large libraries, implies MatchOnly).\n\
 ";
+
+    python::enum_<RDKit::ReactantCacheMode>("ReactantCacheMode")
+        .value("NoCache", RDKit::ReactantCacheMode::None)
+        .value("MatchOnly", RDKit::ReactantCacheMode::MatchOnly)
+        .value("Full", RDKit::ReactantCacheMode::Full)
+        .export_values();
 
     python::class_<RDKit::EnumerationParams,
                    boost::shared_ptr<RDKit::EnumerationParams>,
@@ -225,8 +235,7 @@ Options:\n\
                        &RDKit::EnumerationParams::sanePartialProducts)
         .def_readwrite("dedupeSymmetricMatches",
                        &RDKit::EnumerationParams::dedupeSymmetricMatches)
-        .def_readwrite("cacheReactantGrafts",
-                       &RDKit::EnumerationParams::cacheReactantGrafts);
+        .def_readwrite("cacheMode", &RDKit::EnumerationParams::cacheMode);
 
     docString =
         "EnumerateLibrary\n\
@@ -328,15 +337,14 @@ for result in itertools.islice(libary2, 1000):\n\
              python::args("self"),
              "Return whether symmetry-equivalent substructure matches are"
              " collapsed for this library.")
+        .def("GetCacheMode", &RDKit::EnumerateLibrary::getCacheMode,
+             python::args("self"),
+             "Return the ReactantCacheMode controlling match and graft"
+             " caching for this library.")
         .def("GetMatchCacheSize", &RDKit::EnumerateLibrary::getMatchCacheSize,
              python::args("self"),
              "Return the number of entries currently held in the reactant"
              " match cache.")
-        .def("GetCacheReactantGrafts",
-             &RDKit::EnumerateLibrary::getCacheReactantGrafts,
-             python::args("self"),
-             "Return whether per-reagent grafts are cached and replayed across"
-             " product combinations for this library.")
         .def("GetGraftCacheSize", &RDKit::EnumerateLibrary::getGraftCacheSize,
              python::args("self"),
              "Return the number of entries currently held in the reactant"

--- a/Code/GraphMol/ChemReactions/Wrap/Enumerate.cpp
+++ b/Code/GraphMol/ChemReactions/Wrap/Enumerate.cpp
@@ -203,6 +203,15 @@ Options:\n\
     If true, forces all products of the reagent plus the product templates\n\
      pass chemical sanitization.  Note that if the product template itself\n\
      does not pass sanitization, then none of the products will.\n\
+\n\
+  dedupeSymmetricMatches [default false]\n\
+    If true, collapses substructure matches that land on symmetry-equivalent\n\
+     reagent atoms, avoiding duplicate products for symmetric reagents.\n\
+\n\
+  cacheReactantGrafts [default false]\n\
+    If true, caches and replays the per-reagent graft (the atoms and bonds a\n\
+     reagent contributes to a product) across product combinations instead of\n\
+     re-deriving it for every combination.  The output is unchanged.\n\
 ";
 
     python::class_<RDKit::EnumerationParams,
@@ -213,7 +222,11 @@ Options:\n\
         .def_readwrite("reagentMaxMatchCount",
                        &RDKit::EnumerationParams::reagentMaxMatchCount)
         .def_readwrite("sanePartialProducts",
-                       &RDKit::EnumerationParams::sanePartialProducts);
+                       &RDKit::EnumerationParams::sanePartialProducts)
+        .def_readwrite("dedupeSymmetricMatches",
+                       &RDKit::EnumerationParams::dedupeSymmetricMatches)
+        .def_readwrite("cacheReactantGrafts",
+                       &RDKit::EnumerationParams::cacheReactantGrafts);
 
     docString =
         "EnumerateLibrary\n\
@@ -309,7 +322,25 @@ for result in itertools.islice(libary2, 1000):\n\
             " be smaller than the input reagent sets.",
             python::return_internal_reference<
                 1, python::with_custodian_and_ward_postcall<0, 1>>(),
-            python::args("self"));
+            python::args("self"))
+        .def("GetDedupeSymmetricMatches",
+             &RDKit::EnumerateLibrary::getDedupeSymmetricMatches,
+             python::args("self"),
+             "Return whether symmetry-equivalent substructure matches are"
+             " collapsed for this library.")
+        .def("GetMatchCacheSize", &RDKit::EnumerateLibrary::getMatchCacheSize,
+             python::args("self"),
+             "Return the number of entries currently held in the reactant"
+             " match cache.")
+        .def("GetCacheReactantGrafts",
+             &RDKit::EnumerateLibrary::getCacheReactantGrafts,
+             python::args("self"),
+             "Return whether per-reagent grafts are cached and replayed across"
+             " product combinations for this library.")
+        .def("GetGraftCacheSize", &RDKit::EnumerateLibrary::getGraftCacheSize,
+             python::args("self"),
+             "Return the number of entries currently held in the reactant"
+             " graft cache.");
 
     // iterator_wrappers<EnumerateLibrary>().wrap("EnumerateLibraryIterator");
 

--- a/Code/GraphMol/ChemReactions/Wrap/testEnumerations.py
+++ b/Code/GraphMol/ChemReactions/Wrap/testEnumerations.py
@@ -313,6 +313,50 @@ class TestCase(unittest.TestCase):
       i += 1
     self.assertEqual(i, 6)
 
+  def testEnumerationParamsCaching(self):
+    log("testEnumerationParamsCaching")
+    # symmetric diamine reagents so dedupeSymmetricMatches has an effect
+    rxn = rdChemReactions.ReactionFromSmarts(
+      "[N;H2:1].[C:2](=[O:3])[O;H1]>>[N:1][C:2]=[O:3]")
+    reagents = [[Chem.MolFromSmiles('NCCN'),
+                 Chem.MolFromSmiles('NCCCN')],
+                [Chem.MolFromSmiles('CC(=O)O'),
+                 Chem.MolFromSmiles('CCC(=O)O')]]
+
+    # defaults: both flags off
+    params = rdChemReactions.EnumerationParams()
+    self.assertFalse(params.dedupeSymmetricMatches)
+    self.assertFalse(params.cacheReactantGrafts)
+
+    baseline = rdChemReactions.EnumerateLibrary(rxn, reagents)
+    self.assertFalse(baseline.GetDedupeSymmetricMatches())
+    self.assertFalse(baseline.GetCacheReactantGrafts())
+    baseSmiles = sorted(Chem.MolToSmiles(mols[0])
+                        for prods in baseline for mols in prods)
+
+    # enable both flags through the params object
+    params = rdChemReactions.EnumerationParams()
+    params.dedupeSymmetricMatches = True
+    params.cacheReactantGrafts = True
+    self.assertTrue(params.dedupeSymmetricMatches)
+    self.assertTrue(params.cacheReactantGrafts)
+
+    cached = rdChemReactions.EnumerateLibrary(rxn, reagents, params)
+    self.assertTrue(cached.GetDedupeSymmetricMatches())
+    self.assertTrue(cached.GetCacheReactantGrafts())
+    self.assertEqual(cached.GetGraftCacheSize(), 0)
+
+    cachedSmiles = sorted(Chem.MolToSmiles(mols[0])
+                          for prods in cached for mols in prods)
+
+    # dedup collapses the symmetric diamine duplicates, so the cached run
+    # yields the same unique products with fewer total entries
+    self.assertEqual(set(cachedSmiles), set(baseSmiles))
+    self.assertTrue(len(cachedSmiles) < len(baseSmiles))
+    # the graft cache and match cache populated during enumeration
+    self.assertTrue(cached.GetGraftCacheSize() > 0)
+    self.assertTrue(cached.GetMatchCacheSize() > 0)
+
   def testRandomEnumerateLibrary(self):
     log("testRandomEnumerateLibrary")
     smirks_thiourea = "[N;$(N-[#6]):3]=[C;$(C=S):1].[N;$(N[#6]);!$(N=*);!$([N-]);!$(N#*);!$([ND3]);!$([ND4]);!$(N[O,N]);!$(N[C,S]=[S,O,N]):2]>>[N:3]-[C:1]-[N+0:2]"

--- a/Code/GraphMol/ChemReactions/Wrap/testEnumerations.py
+++ b/Code/GraphMol/ChemReactions/Wrap/testEnumerations.py
@@ -326,11 +326,11 @@ class TestCase(unittest.TestCase):
     # defaults: both flags off
     params = rdChemReactions.EnumerationParams()
     self.assertFalse(params.dedupeSymmetricMatches)
-    self.assertEqual(params.cacheMode, rdChemReactions.ReactantCacheMode.MatchOnly)
+    self.assertEqual(params.cacheMode, rdChemReactions.ReactantCacheMode.NoCache)
 
     baseline = rdChemReactions.EnumerateLibrary(rxn, reagents)
     self.assertFalse(baseline.GetDedupeSymmetricMatches())
-    self.assertEqual(baseline.GetCacheMode(), rdChemReactions.ReactantCacheMode.MatchOnly)
+    self.assertEqual(baseline.GetCacheMode(), rdChemReactions.ReactantCacheMode.NoCache)
     baseSmiles = sorted(Chem.MolToSmiles(mols[0])
                         for prods in baseline for mols in prods)
 

--- a/Code/GraphMol/ChemReactions/Wrap/testEnumerations.py
+++ b/Code/GraphMol/ChemReactions/Wrap/testEnumerations.py
@@ -326,24 +326,24 @@ class TestCase(unittest.TestCase):
     # defaults: both flags off
     params = rdChemReactions.EnumerationParams()
     self.assertFalse(params.dedupeSymmetricMatches)
-    self.assertFalse(params.cacheReactantGrafts)
+    self.assertEqual(params.cacheMode, rdChemReactions.ReactantCacheMode.MatchOnly)
 
     baseline = rdChemReactions.EnumerateLibrary(rxn, reagents)
     self.assertFalse(baseline.GetDedupeSymmetricMatches())
-    self.assertFalse(baseline.GetCacheReactantGrafts())
+    self.assertEqual(baseline.GetCacheMode(), rdChemReactions.ReactantCacheMode.MatchOnly)
     baseSmiles = sorted(Chem.MolToSmiles(mols[0])
                         for prods in baseline for mols in prods)
 
-    # enable both flags through the params object
+    # enable dedup and full caching through the params object
     params = rdChemReactions.EnumerationParams()
     params.dedupeSymmetricMatches = True
-    params.cacheReactantGrafts = True
+    params.cacheMode = rdChemReactions.ReactantCacheMode.Full
     self.assertTrue(params.dedupeSymmetricMatches)
-    self.assertTrue(params.cacheReactantGrafts)
+    self.assertEqual(params.cacheMode, rdChemReactions.ReactantCacheMode.Full)
 
     cached = rdChemReactions.EnumerateLibrary(rxn, reagents, params)
     self.assertTrue(cached.GetDedupeSymmetricMatches())
-    self.assertTrue(cached.GetCacheReactantGrafts())
+    self.assertEqual(cached.GetCacheMode(), rdChemReactions.ReactantCacheMode.Full)
     self.assertEqual(cached.GetGraftCacheSize(), 0)
 
     cachedSmiles = sorted(Chem.MolToSmiles(mols[0])

--- a/Code/GraphMol/ChemReactions/catch_tests.cpp
+++ b/Code/GraphMol/ChemReactions/catch_tests.cpp
@@ -9,6 +9,9 @@
 ///
 #include <catch2/catch_all.hpp>
 
+#include <set>
+#include <tuple>
+
 #include <GraphMol/RDKitBase.h>
 #include <GraphMol/QueryOps.h>
 #include <GraphMol/QueryAtom.h>
@@ -65,6 +68,17 @@ static void clearAtomMappingProps(ROMol &mol) {
   for (auto &&a : mol.atoms()) {
     a->clear();
   }
+}
+
+static std::set<std::string> collectCanonicalSmiles(
+    const std::vector<MOL_SPTR_VECT> &products) {
+  std::set<std::string> res;
+  for (const auto &productSet : products) {
+    for (const auto &product : productSet) {
+      res.insert(MolToSmiles(*product));
+    }
+  }
+  return res;
 }
 
 TEST_CASE("Github #2366 Enhanced Stereo", "[Reaction][StereoGroup][bug]") {
@@ -174,6 +188,57 @@ TEST_CASE("Github #2427 cannot set maxProducts>1000 in runReactants",
       CHECK(prods.size() == 2000);
       CHECK(prods[0].size() == 1);
     }
+  }
+}
+
+TEST_CASE("reactant match cache", "[Reaction][enumerate][cache]") {
+  SECTION("cached run_Reactants matches uncached") {
+    std::unique_ptr<ChemicalReaction> rxn(RxnSmartsToChemicalReaction(
+        "[C:1](=[O:2])[OH].[N:3]>>[C:1](=[O:2])[N:3]"));
+    REQUIRE(rxn);
+
+    MOL_SPTR_VECT reactants = {ROMOL_SPTR(SmilesToMol("CC(=O)O")),
+                               ROMOL_SPTR(SmilesToMol("CN"))};
+    REQUIRE(reactants[0]);
+    REQUIRE(reactants[1]);
+
+    rxn->initReactantMatchers();
+    auto uncached = run_Reactants(*rxn, reactants);
+    ReactantMatchCache cache;
+    auto cached = run_Reactants(*rxn, reactants, cache);
+
+    CHECK(collectCanonicalSmiles(uncached) == collectCanonicalSmiles(cached));
+    CHECK(cache.size() == 2);
+  }
+
+  SECTION("cache populated and reused across combinations") {
+    std::unique_ptr<ChemicalReaction> rxn(RxnSmartsToChemicalReaction(
+        "[C:1](=[O:2])[OH].[N:3]>>[C:1](=[O:2])[N:3]"));
+    REQUIRE(rxn);
+    rxn->initReactantMatchers();
+
+    auto fixedReactant = ROMOL_SPTR(SmilesToMol("CC(=O)O"));
+    REQUIRE(fixedReactant);
+
+    const std::vector<ROMOL_SPTR> variableReactants = {
+      ROMOL_SPTR(SmilesToMol("CN")), ROMOL_SPTR(SmilesToMol("CCN")),
+      ROMOL_SPTR(SmilesToMol("CCCN"))};
+    for (const auto &reactant1 : variableReactants) {
+      REQUIRE(reactant1);
+    }
+
+    ReactantMatchCache cache;
+    MOL_SPTR_VECT reactants = {fixedReactant, variableReactants.front()};
+    for (const auto &reactant1 : variableReactants) {
+      reactants[1] = reactant1;
+      auto products = run_Reactants(*rxn, reactants, cache);
+      REQUIRE(!products.empty());
+      REQUIRE(!products[0].empty());
+    }
+
+    const auto fixedKey = std::make_tuple(0u, fixedReactant.get(), 1000u);
+    CHECK(cache.find(fixedKey) != cache.end());
+    CHECK(cache.size() == 4);
   }
 }
 

--- a/Code/GraphMol/ChemReactions/catch_tests.cpp
+++ b/Code/GraphMol/ChemReactions/catch_tests.cpp
@@ -242,6 +242,54 @@ TEST_CASE("reactant match cache", "[Reaction][enumerate][cache]") {
   }
 }
 
+TEST_CASE("dedupeMatchesBySymmetry", "[reaction][dedupe]") {
+  SECTION("collapses symmetric matches") {
+    auto reagent = ROMOL_SPTR(SmilesToMol("NCCN"));
+    auto templ = ROMOL_SPTR(SmartsToMol("[N:1]"));
+    REQUIRE(reagent);
+    REQUIRE(templ);
+
+    auto raw = ReactionRunnerUtils::getReactantMatchesToTemplate(
+        *reagent, *templ, 1000, SubstructMatchParameters());
+    REQUIRE(raw.size() >= 2);
+
+    auto deduped = ReactionRunnerUtils::dedupeMatchesBySymmetry(*reagent, raw);
+    CHECK(deduped.size() < raw.size());
+    CHECK(deduped.size() == 1);
+  }
+
+  SECTION("keeps distinct asymmetric matches") {
+    auto reagent = ROMOL_SPTR(SmilesToMol("NCCO"));
+    auto templ = ROMOL_SPTR(SmartsToMol("[N,O:1]"));
+    REQUIRE(reagent);
+    REQUIRE(templ);
+
+    auto raw = ReactionRunnerUtils::getReactantMatchesToTemplate(
+        *reagent, *templ, 1000, SubstructMatchParameters());
+    REQUIRE(raw.size() >= 2);
+
+    auto deduped = ReactionRunnerUtils::dedupeMatchesBySymmetry(*reagent, raw);
+    CHECK(deduped.size() == raw.size());
+    CHECK(deduped.size() == 2);
+  }
+
+  SECTION("passes through fewer than two matches") {
+    auto reagent = ROMOL_SPTR(SmilesToMol("CC"));
+    REQUIRE(reagent);
+
+    VectMatchVectType emptyMatches;
+    auto emptyDeduped = ReactionRunnerUtils::dedupeMatchesBySymmetry(
+        *reagent, emptyMatches);
+    CHECK(emptyDeduped.empty());
+
+    VectMatchVectType singleMatch = {MatchVectType{{0, 0}}};
+    auto singleDeduped = ReactionRunnerUtils::dedupeMatchesBySymmetry(
+        *reagent, singleMatch);
+    REQUIRE(singleDeduped.size() == 1);
+    CHECK(singleDeduped[0] == singleMatch[0]);
+  }
+}
+
 TEST_CASE("negative charge queries. Part of testing changes for github #2604",
           "[Reaction]") {
   SECTION("no redundancy") {

--- a/Code/GraphMol/ChemReactions/catch_tests.cpp
+++ b/Code/GraphMol/ChemReactions/catch_tests.cpp
@@ -102,6 +102,18 @@ static bool hasAnyChiralAtom(const ROMol &mol) {
   return false;
 }
 
+static std::set<unsigned int> collectReactionMapNums(const ROMol &mol,
+                                                    const std::vector<unsigned int> &atomIdxs) {
+  std::set<unsigned int> res;
+  for (auto atomIdx : atomIdxs) {
+    unsigned int mapNum = 0;
+    REQUIRE(mol.getAtomWithIdx(atomIdx)->getPropIfPresent(
+        common_properties::reactionMapNum, mapNum));
+    res.insert(mapNum);
+  }
+  return res;
+}
+
 TEST_CASE("product assembly golden", "[reaction][assembly][golden]") {
   SECTION("assemblyGolden_amide") {
     std::unique_ptr<ChemicalReaction> rxn(RxnSmartsToChemicalReaction(
@@ -266,8 +278,203 @@ TEST_CASE("product assembly golden", "[reaction][assembly][golden]") {
     REQUIRE(products[0].size() == 1);
     CHECK(products[0][0]->getNumConformers() == 1);
     CHECK(collectCanonicalSmiles(products) == std::set<std::string>{"CCOC"});
+    const auto &productConf = products[0][0]->getConformer();
+    CHECK(productConf.is3D());
+    // the mapped oxygen keeps its reactant coordinates in the product
+    const Atom *oxygen = nullptr;
+    for (const auto atom : products[0][0]->atoms()) {
+      if (atom->getAtomicNum() == 8) {
+        oxygen = atom;
+        break;
+      }
+    }
+    REQUIRE(oxygen);
+    const auto oxygenPos = productConf.getAtomPos(oxygen->getIdx());
+    CHECK(oxygenPos.x == Catch::Approx(2.7));
+    CHECK(oxygenPos.y == Catch::Approx(0.0));
+    CHECK(oxygenPos.z == Catch::Approx(0.0));
+  }
+
+  SECTION("assemblyGolden_queryBondAnchor") {
+    // the product template carries a query bond (~) between two anchor atoms,
+    // exercising the QueryBond clone+replace path in applyReactantGraft
+    std::unique_ptr<ChemicalReaction> rxn(
+        RxnSmartsToChemicalReaction("[C:1][N:2]>>[C:1]~[N:2]"));
+    REQUIRE(rxn);
+    rxn->initReactantMatchers();
+
+    auto reactant = ROMOL_SPTR(SmilesToMol("CCN"));
+    REQUIRE(reactant);
+
+    MOL_SPTR_VECT reactants = {reactant};
+    const auto products = rxn->runReactants(reactants);
+    REQUIRE(products.size() == 1);
+    REQUIRE(products[0].size() == 1);
+    CHECK(collectCanonicalSmiles(products) == std::set<std::string>{"CCN"});
   }
 }
+
+  TEST_CASE("graft replay equals direct", "[reaction][assembly][graft]") {
+    SECTION("graftReplayEqualsDirect_battery") {
+    struct CaseData {
+      const char *smarts;
+      std::vector<const char *> reactants;
+      std::set<std::string> expected;
+    };
+
+    const std::vector<CaseData> cases = {
+      {"[C:1](=[O:2])[O;H1].[N:3]>>[C:1](=[O:2])[N:3]",
+       {"CC(=O)O", "CCN"}, {"CCNC(C)=O"}},
+      {"[C:1]=[C:2].[C:3]=[C:4][C:5]=[C:6]>>[C:1]1[C:2][C:3][C:4]=[C:5][C:6]1",
+       {"ClC=C", "BrC=CC=C"}, {"ClC1CC=CC(Br)C1", "ClC1CCC=CC1Br"}},
+      {"[C@:1](F)(Cl)[Br:2]>>[C@:1](F)(Cl)[I:2]",
+       {"C[C@](F)(Cl)Br"}, {"C[C@@](F)(Cl)I"}},
+      {"[O:1]>>[O:1]C", {"C/C=C/CO"}, {"C/C=C/COC"}},
+      {"[C@:1]>>[C@:1]", {"F[C@H](Cl)Br |o1:1|"}, {"F[C@H](Cl)Br"}},
+      {"[C:1][O:2][C:3]>>[C:1][O:2].[C:3]", {"CCOCCC"}, {"CCC", "CCO", "CC", "CCCO"}},
+      {"[#6:1]-[O:2]>>[#6:1]-[O:2]C", {"CCO"}, {"CCOC"}},
+    };
+
+    for (const auto &testCase : cases) {
+      std::unique_ptr<ChemicalReaction> rxn(RxnSmartsToChemicalReaction(testCase.smarts));
+      REQUIRE(rxn);
+      rxn->initReactantMatchers();
+
+      MOL_SPTR_VECT reactants;
+      for (const auto *smi : testCase.reactants) {
+      reactants.push_back(ROMOL_SPTR(SmilesToMol(smi)));
+      REQUIRE(reactants.back());
+      }
+
+      const auto direct = rxn->runReactants(reactants);
+      CHECK(collectCanonicalIsomericSmiles(direct) == testCase.expected);
+    }
+    }
+  }
+
+  TEST_CASE("extractReactantGraft_amideAnchors", "[reaction][assembly][graft]") {
+    std::unique_ptr<ChemicalReaction> rxn(RxnSmartsToChemicalReaction(
+      "[C:1](=[O:2])[O;H1].[N:3]>>[C:1](=[O:2])[N:3]"));
+    REQUIRE(rxn);
+    rxn->initReactantMatchers();
+
+    auto productTemplate = *rxn->beginProductTemplates();
+    auto acid = ROMOL_SPTR(SmilesToMol("CC(=O)O"));
+    auto amine = ROMOL_SPTR(SmilesToMol("CCN"));
+    REQUIRE(productTemplate);
+    REQUIRE(acid);
+    REQUIRE(amine);
+
+    const auto acidTemplate = *rxn->beginReactantTemplates();
+    const auto amineTemplate = *std::next(rxn->beginReactantTemplates());
+    auto acidMatches = ReactionRunnerUtils::getReactantMatchesToTemplate(
+      *acid, *acidTemplate, 1000, SubstructMatchParameters());
+    auto amineMatches = ReactionRunnerUtils::getReactantMatchesToTemplate(
+      *amine, *amineTemplate, 1000, SubstructMatchParameters());
+    REQUIRE(!acidMatches.empty());
+    REQUIRE(!amineMatches.empty());
+
+    auto acidGraft = ReactionRunnerUtils::extractReactantGraft(
+        *rxn, productTemplate, acidTemplate, acid,
+      acidMatches.front(), 0, false);
+    auto amineGraft = ReactionRunnerUtils::extractReactantGraft(
+        *rxn, productTemplate, amineTemplate, amine,
+      amineMatches.front(), 1, false);
+
+    CHECK(acidGraft.templateAtomCount == 3);
+    CHECK(acidGraft.iso->getNumAtoms() == 4);
+    CHECK(acidGraft.iso->getNumAtoms() - acidGraft.templateAtomCount == 1);
+    CHECK(collectReactionMapNums(*acidGraft.iso, acidGraft.anchorAtomIdxs) ==
+      std::set<unsigned int>{1, 2});
+    CHECK(acidGraft.iso->getAtomWithIdx(3)->getAtomicNum() == 6);
+
+      CHECK(amineGraft.templateAtomCount == 3);
+      CHECK(amineGraft.iso->getNumAtoms() == 5);
+      CHECK(amineGraft.iso->getNumAtoms() - amineGraft.templateAtomCount == 2);
+    CHECK(collectReactionMapNums(*amineGraft.iso, amineGraft.anchorAtomIdxs) ==
+      std::set<unsigned int>{3});
+      CHECK(amineGraft.iso->getAtomWithIdx(3)->getAtomicNum() == 6);
+      CHECK(amineGraft.iso->getAtomWithIdx(4)->getAtomicNum() == 6);
+  }
+
+  TEST_CASE("extractReactantGraft_ringClosureSurvivingAtoms",
+        "[reaction][assembly][graft]") {
+    std::unique_ptr<ChemicalReaction> rxn(RxnSmartsToChemicalReaction(
+      "[C:1]=[C:2].[C:3]=[C:4][C:5]=[C:6]>>[C:1]1[C:2][C:3][C:4]=[C:5][C:6]1"));
+    REQUIRE(rxn);
+    rxn->initReactantMatchers();
+
+    auto productTemplate = *rxn->beginProductTemplates();
+    auto first = ROMOL_SPTR(SmilesToMol("ClC=C"));
+    auto second = ROMOL_SPTR(SmilesToMol("BrC=CC=C"));
+    REQUIRE(productTemplate);
+    REQUIRE(first);
+    REQUIRE(second);
+
+    const auto firstTemplate = *rxn->beginReactantTemplates();
+    const auto secondTemplate = *std::next(rxn->beginReactantTemplates());
+    auto firstMatches = ReactionRunnerUtils::getReactantMatchesToTemplate(
+          *first, *firstTemplate, 1000, SubstructMatchParameters());
+    auto secondMatches = ReactionRunnerUtils::getReactantMatchesToTemplate(
+          *second, *secondTemplate, 1000, SubstructMatchParameters());
+    REQUIRE(!firstMatches.empty());
+    REQUIRE(!secondMatches.empty());
+
+    auto firstGraft = ReactionRunnerUtils::extractReactantGraft(
+        *rxn, productTemplate, firstTemplate, first,
+      firstMatches.front(), 0, false);
+    auto secondGraft = ReactionRunnerUtils::extractReactantGraft(
+        *rxn, productTemplate, secondTemplate, second,
+      secondMatches.front(), 1, false);
+
+    CHECK(firstGraft.iso->getNumAtoms() - firstGraft.templateAtomCount == 1);
+    CHECK(secondGraft.iso->getNumAtoms() - secondGraft.templateAtomCount == 1);
+    CHECK(firstGraft.iso->getAtomWithIdx(firstGraft.templateAtomCount)
+        ->getAtomicNum() == 17);
+    CHECK(secondGraft.iso->getAtomWithIdx(secondGraft.templateAtomCount)
+        ->getAtomicNum() == 35);
+  }
+
+  TEST_CASE("applyReactantGraft_indexOffsetCorrect",
+        "[reaction][assembly][graft]") {
+    std::unique_ptr<ChemicalReaction> rxn(RxnSmartsToChemicalReaction(
+      "[C:1](=[O:2])[O;H1].[N:3]>>[C:1](=[O:2])[N:3]"));
+    REQUIRE(rxn);
+    rxn->initReactantMatchers();
+
+    auto productTemplate = *rxn->beginProductTemplates();
+    auto acid = ROMOL_SPTR(SmilesToMol("CC(=O)O"));
+    auto amine = ROMOL_SPTR(SmilesToMol("CCN"));
+    REQUIRE(productTemplate);
+    REQUIRE(acid);
+    REQUIRE(amine);
+
+    const auto acidTemplate = *rxn->beginReactantTemplates();
+    const auto amineTemplate = *std::next(rxn->beginReactantTemplates());
+    auto acidMatches = ReactionRunnerUtils::getReactantMatchesToTemplate(
+        *acid, *acidTemplate, 1000, SubstructMatchParameters());
+    auto amineMatches = ReactionRunnerUtils::getReactantMatchesToTemplate(
+        *amine, *amineTemplate, 1000, SubstructMatchParameters());
+    REQUIRE(!acidMatches.empty());
+    REQUIRE(!amineMatches.empty());
+
+    auto product = ReactionRunnerUtils::convertTemplateToMol(productTemplate);
+    auto acidGraft = ReactionRunnerUtils::extractReactantGraft(
+        *rxn, productTemplate, acidTemplate, acid,
+      acidMatches.front(), 0, false);
+    ReactionRunnerUtils::applyReactantGraft(product, nullptr, acidGraft);
+    CHECK(product->getNumAtoms() == 4);
+
+    auto amineGraft = ReactionRunnerUtils::extractReactantGraft(
+        *rxn, productTemplate, amineTemplate, amine,
+      amineMatches.front(), 1, false);
+    ReactionRunnerUtils::applyReactantGraft(product, nullptr, amineGraft);
+
+    CHECK(product->getNumAtoms() == 6);
+    CHECK(product->getBondBetweenAtoms(2, 4));
+    CHECK(product->getBondBetweenAtoms(4, 5));
+    CHECK(MolToSmiles(*product, true) == "CCNC(C)=O");
+  }
 
 TEST_CASE("Github #2366 Enhanced Stereo", "[Reaction][StereoGroup][bug]") {
   SECTION("Reaction Preserves Stereo") {

--- a/Code/GraphMol/ChemReactions/catch_tests.cpp
+++ b/Code/GraphMol/ChemReactions/catch_tests.cpp
@@ -476,6 +476,205 @@ TEST_CASE("product assembly golden", "[reaction][assembly][golden]") {
     CHECK(MolToSmiles(*product, true) == "CCNC(C)=O");
   }
 
+TEST_CASE("graft cache products match uncached",
+          "[reaction][assembly][graft][cache]") {
+  SECTION("graftCacheProductsMatchUncached_battery") {
+    struct CaseData {
+      const char *smarts;
+      std::vector<const char *> reactants;
+      std::set<std::string> expected;
+    };
+    const std::vector<CaseData> cases = {
+        {"[C:1](=[O:2])[O;H1].[N:3]>>[C:1](=[O:2])[N:3]",
+         {"CC(=O)O", "CCN"},
+         {"CCNC(C)=O"}},
+        {"[C:1]=[C:2].[C:3]=[C:4][C:5]=[C:6]>>[C:1]1[C:2][C:3][C:4]=[C:5][C:6]"
+         "1",
+         {"ClC=C", "BrC=CC=C"},
+         {"ClC1CC=CC(Br)C1", "ClC1CCC=CC1Br"}},
+        {"[C@:1](F)(Cl)[Br:2]>>[C@:1](F)(Cl)[I:2]",
+         {"C[C@](F)(Cl)Br"},
+         {"C[C@@](F)(Cl)I"}},
+        {"[O:1]>>[O:1]C", {"C/C=C/CO"}, {"C/C=C/COC"}},
+        {"[C:1][O:2][C:3]>>[C:1][O:2].[C:3]",
+         {"CCOCCC"},
+         {"CCC", "CCO", "CC", "CCCO"}},
+    };
+    for (const auto &testCase : cases) {
+      std::unique_ptr<ChemicalReaction> rxn(
+          RxnSmartsToChemicalReaction(testCase.smarts));
+      REQUIRE(rxn);
+      rxn->initReactantMatchers();
+      MOL_SPTR_VECT reactants;
+      for (const auto *smi : testCase.reactants) {
+        reactants.push_back(ROMOL_SPTR(SmilesToMol(smi)));
+        REQUIRE(reactants.back());
+      }
+      const auto uncached = rxn->runReactants(reactants);
+      ReactantMatchCache matchCache;
+      ReactionRunnerUtils::ReactantGraftCache graftCache;
+      const auto cached =
+          run_Reactants(*rxn, reactants, matchCache, graftCache);
+      CHECK(collectCanonicalIsomericSmiles(cached) == testCase.expected);
+      CHECK(collectCanonicalIsomericSmiles(cached) ==
+            collectCanonicalIsomericSmiles(uncached));
+    }
+  }
+}
+
+TEST_CASE("graft cache reused across combinations",
+          "[reaction][assembly][graft][cache]") {
+  // A single acid match combined with two amine matches => two products, but
+  // the acid graft is extracted once and replayed for both products.
+  std::unique_ptr<ChemicalReaction> rxn(RxnSmartsToChemicalReaction(
+      "[C:1](=[O:2])[O;H1].[N:3]>>[C:1](=[O:2])[N:3]"));
+  REQUIRE(rxn);
+  rxn->initReactantMatchers();
+
+  MOL_SPTR_VECT reactants = {ROMOL_SPTR(SmilesToMol("CC(=O)O")),
+                             ROMOL_SPTR(SmilesToMol("NCCN"))};
+  REQUIRE(reactants[0]);
+  REQUIRE(reactants[1]);
+
+  ReactantMatchCache matchCache;
+  ReactionRunnerUtils::ReactantGraftCache graftCache;
+  const auto products = run_Reactants(*rxn, reactants, matchCache, graftCache);
+
+  // Two reactive nitrogens => two products.
+  CHECK(products.size() == 2);
+  // Grafts: one acid graft (reused) + one amine graft per match (2) = 3.
+  CHECK(graftCache.size() == 3);
+}
+
+TEST_CASE("graft cache key separates reagents and reuses identity",
+          "[reaction][assembly][graft][cache]") {
+  std::unique_ptr<ChemicalReaction> rxn(RxnSmartsToChemicalReaction(
+      "[C:1](=[O:2])[O;H1].[N:3]>>[C:1](=[O:2])[N:3]"));
+  REQUIRE(rxn);
+  rxn->initReactantMatchers();
+
+  auto amine = ROMOL_SPTR(SmilesToMol("CCN"));
+  auto acidA = ROMOL_SPTR(SmilesToMol("CC(=O)O"));
+  auto acidB = ROMOL_SPTR(SmilesToMol("CCC(=O)O"));
+  REQUIRE(amine);
+  REQUIRE(acidA);
+  REQUIRE(acidB);
+
+  ReactantMatchCache matchCache;
+  ReactionRunnerUtils::ReactantGraftCache graftCache;
+
+  MOL_SPTR_VECT firstReactants = {acidA, amine};
+  run_Reactants(*rxn, firstReactants, matchCache, graftCache);
+  // One acid graft + one amine graft.
+  CHECK(graftCache.size() == 2);
+
+  MOL_SPTR_VECT secondReactants = {acidB, amine};
+  run_Reactants(*rxn, secondReactants, matchCache, graftCache);
+  // acidB is a different reagent pointer => new graft; the amine graft is
+  // reused via pointer identity, so only one entry is added.
+  CHECK(graftCache.size() == 3);
+}
+
+TEST_CASE("graft cache empty side chain",
+          "[reaction][assembly][graft][cache]") {
+  // The reactant template covers the whole molecule, so the graft carries no
+  // surviving side-chain atoms.
+  std::unique_ptr<ChemicalReaction> rxn(
+      RxnSmartsToChemicalReaction("[C:1][O:2]>>[C:1]=[O:2]"));
+  REQUIRE(rxn);
+  rxn->initReactantMatchers();
+
+  MOL_SPTR_VECT reactants = {ROMOL_SPTR(SmilesToMol("CO"))};
+  REQUIRE(reactants[0]);
+
+  const auto uncached = rxn->runReactants(reactants);
+  ReactantMatchCache matchCache;
+  ReactionRunnerUtils::ReactantGraftCache graftCache;
+  const auto cached = run_Reactants(*rxn, reactants, matchCache, graftCache);
+
+  CHECK(!cached.empty());
+  CHECK(collectCanonicalIsomericSmiles(cached) ==
+        collectCanonicalIsomericSmiles(uncached));
+  // Single reagent, single match => one graft.
+  CHECK(graftCache.size() == 1);
+}
+
+TEST_CASE("graft cache honors dedupeSymmetricMatches",
+          "[reaction][assembly][graft][cache]") {
+  // A symmetric diamine yields two equivalent nitrogen matches; with
+  // deduplication on, the cached path must collapse them exactly like the
+  // match-cache-only path (the flag participates in the graft cache key).
+  std::unique_ptr<ChemicalReaction> rxn(RxnSmartsToChemicalReaction(
+      "[C:1](=[O:2])[O;H1].[N:3]>>[C:1](=[O:2])[N:3]"));
+  REQUIRE(rxn);
+  rxn->initReactantMatchers();
+
+  MOL_SPTR_VECT reactants = {ROMOL_SPTR(SmilesToMol("CC(=O)O")),
+                             ROMOL_SPTR(SmilesToMol("NCCN"))};
+  REQUIRE(reactants[0]);
+  REQUIRE(reactants[1]);
+
+  ReactantMatchCache matchOnlyCache;
+  const auto matchOnly =
+      run_Reactants(*rxn, reactants, matchOnlyCache, /*dedupe=*/true);
+
+  ReactantMatchCache matchCache;
+  ReactionRunnerUtils::ReactantGraftCache graftCache;
+  const auto withGraft = run_Reactants(*rxn, reactants, matchCache, graftCache,
+                                       /*dedupe=*/true);
+
+  // deduplication collapses the two symmetric nitrogens to a single product
+  CHECK(matchOnly.size() == 1);
+  CHECK(withGraft.size() == 1);
+  CHECK(collectCanonicalIsomericSmiles(withGraft) ==
+        collectCanonicalIsomericSmiles(matchOnly));
+}
+
+TEST_CASE("graft cache preserves conformers",
+          "[reaction][assembly][graft][cache]") {
+  std::unique_ptr<ChemicalReaction> rxn(
+      RxnSmartsToChemicalReaction("[O:1]>>[O:1]C"));
+  REQUIRE(rxn);
+  rxn->initReactantMatchers();
+
+  auto reactant = ROMOL_SPTR(SmilesToMol("CCO"));
+  REQUIRE(reactant);
+  auto *conf = new Conformer(reactant->getNumAtoms());
+  conf->set3D(true);
+  conf->setAtomPos(0, RDGeom::Point3D(0.0, 0.0, 0.0));
+  conf->setAtomPos(1, RDGeom::Point3D(1.5, 0.0, 0.0));
+  conf->setAtomPos(2, RDGeom::Point3D(2.7, 0.0, 0.0));
+  reactant->addConformer(conf, true);
+
+  MOL_SPTR_VECT reactants = {reactant};
+
+  const auto uncached = rxn->runReactants(reactants);
+  ReactantMatchCache matchCache;
+  ReactionRunnerUtils::ReactantGraftCache graftCache;
+  const auto cached = run_Reactants(*rxn, reactants, matchCache, graftCache);
+
+  REQUIRE(cached.size() == 1);
+  REQUIRE(cached[0].size() == 1);
+  CHECK(collectCanonicalIsomericSmiles(cached) ==
+        collectCanonicalIsomericSmiles(uncached));
+  // the cached graft must still carry the mapped oxygen's 3D coordinates
+  REQUIRE(cached[0][0]->getNumConformers() == 1);
+  const auto &cachedConf = cached[0][0]->getConformer();
+  CHECK(cachedConf.is3D());
+  const Atom *oxygen = nullptr;
+  for (const auto atom : cached[0][0]->atoms()) {
+    if (atom->getAtomicNum() == 8) {
+      oxygen = atom;
+      break;
+    }
+  }
+  REQUIRE(oxygen);
+  const auto pos = cachedConf.getAtomPos(oxygen->getIdx());
+  CHECK(pos.x == Catch::Approx(2.7));
+  CHECK(pos.y == Catch::Approx(0.0));
+  CHECK(pos.z == Catch::Approx(0.0));
+}
+
 TEST_CASE("Github #2366 Enhanced Stereo", "[Reaction][StereoGroup][bug]") {
   SECTION("Reaction Preserves Stereo") {
     ROMOL_SPTR mol("F[C@H](Cl)Br |o1:1|"_smiles);

--- a/Code/GraphMol/ChemReactions/catch_tests.cpp
+++ b/Code/GraphMol/ChemReactions/catch_tests.cpp
@@ -16,6 +16,7 @@
 #include <GraphMol/QueryOps.h>
 #include <GraphMol/QueryAtom.h>
 #include <GraphMol/MonomerInfo.h>
+#include <Geometry/point.h>
 #include <GraphMol/FileParsers/FileParsers.h>
 #include <GraphMol/FileParsers/MolSupplier.h>
 #include <GraphMol/SmilesParse/SmilesParse.h>
@@ -79,6 +80,193 @@ static std::set<std::string> collectCanonicalSmiles(
     }
   }
   return res;
+}
+
+static std::set<std::string> collectCanonicalIsomericSmiles(
+    const std::vector<MOL_SPTR_VECT> &products) {
+  std::set<std::string> res;
+  for (const auto &productSet : products) {
+    for (const auto &product : productSet) {
+      res.insert(MolToSmiles(*product, true));
+    }
+  }
+  return res;
+}
+
+static bool hasAnyChiralAtom(const ROMol &mol) {
+  for (const auto atom : mol.atoms()) {
+    if (atom->getChiralTag() != Atom::CHI_UNSPECIFIED) {
+      return true;
+    }
+  }
+  return false;
+}
+
+TEST_CASE("product assembly golden", "[reaction][assembly][golden]") {
+  SECTION("assemblyGolden_amide") {
+    std::unique_ptr<ChemicalReaction> rxn(RxnSmartsToChemicalReaction(
+        "[C:1](=[O:2])[O;H1].[N:3]>>[C:1](=[O:2])[N:3]"));
+    REQUIRE(rxn);
+    rxn->initReactantMatchers();
+
+    MOL_SPTR_VECT reactants = {ROMOL_SPTR(SmilesToMol("CC(=O)O")),
+                               ROMOL_SPTR(SmilesToMol("CCN"))};
+    REQUIRE(reactants[0]);
+    REQUIRE(reactants[1]);
+
+    const auto products = rxn->runReactants(reactants);
+    REQUIRE(products.size() == 1);
+    REQUIRE(products[0].size() == 1);
+    CHECK(collectCanonicalIsomericSmiles(products) ==
+          std::set<std::string>{"CCNC(C)=O"});
+  }
+
+  SECTION("assemblyGolden_ringClosure") {
+    std::unique_ptr<ChemicalReaction> rxn(RxnSmartsToChemicalReaction(
+        "[C:1]=[C:2].[C:3]=[C:4][C:5]=[C:6]>>[C:1]1[C:2][C:3][C:4]=[C:5][C:6]1"));
+    REQUIRE(rxn);
+    rxn->initReactantMatchers();
+
+    MOL_SPTR_VECT reactants = {ROMOL_SPTR(SmilesToMol("ClC=C")),
+                               ROMOL_SPTR(SmilesToMol("BrC=CC=C"))};
+    REQUIRE(reactants[0]);
+    REQUIRE(reactants[1]);
+
+    const auto products = rxn->runReactants(reactants);
+    REQUIRE(!products.empty());
+    CHECK(collectCanonicalSmiles(products) ==
+          std::set<std::string>{"ClC1CC=CC(Br)C1", "ClC1CCC=CC1Br"});
+  }
+
+  SECTION("assemblyGolden_chirality") {
+    std::unique_ptr<ChemicalReaction> rxn(RxnSmartsToChemicalReaction(
+        "[C@:1](F)(Cl)[Br:2]>>[C@:1](F)(Cl)[I:2]"));
+    REQUIRE(rxn);
+    rxn->initReactantMatchers();
+
+    auto reactant = ROMOL_SPTR(SmilesToMol("C[C@](F)(Cl)Br"));
+    REQUIRE(reactant);
+
+    MOL_SPTR_VECT reactants = {reactant};
+    const auto products = rxn->runReactants(reactants);
+    REQUIRE(products.size() == 1);
+    REQUIRE(products[0].size() == 1);
+    const auto &product = products[0][0];
+    CHECK(collectCanonicalIsomericSmiles(products) ==
+        std::set<std::string>{"C[C@@](F)(Cl)I"});
+    CHECK(hasAnyChiralAtom(*product));
+  }
+
+  SECTION("assemblyGolden_doubleBondStereo") {
+    std::unique_ptr<ChemicalReaction> rxn(
+      RxnSmartsToChemicalReaction("[O:1]>>[O:1]C"));
+    REQUIRE(rxn);
+    rxn->initReactantMatchers();
+
+    auto reactant = ROMOL_SPTR(SmilesToMol("C/C=C/CO"));
+    REQUIRE(reactant);
+
+    MOL_SPTR_VECT reactants = {reactant};
+    const auto products = rxn->runReactants(reactants);
+    REQUIRE(products.size() == 1);
+    REQUIRE(products[0].size() == 1);
+    const auto &product = products[0][0];
+    const auto smiles = MolToSmiles(*product, true);
+    CHECK(smiles == "C/C=C/COC");
+    const bool hasDirectionalBond =
+      smiles.find('/') != std::string::npos ||
+      smiles.find('\\') != std::string::npos;
+    CHECK(hasDirectionalBond);
+  }
+
+  SECTION("assemblyGolden_enhancedStereoGroup") {
+    std::unique_ptr<ChemicalReaction> rxn(
+        RxnSmartsToChemicalReaction("[C@:1]>>[C@:1]"));
+    REQUIRE(rxn);
+    rxn->initReactantMatchers();
+
+    auto reactant = ROMOL_SPTR(SmilesToMol("F[C@H](Cl)Br |o1:1|"));
+    REQUIRE(reactant);
+
+    MOL_SPTR_VECT reactants = {reactant};
+    const auto products = rxn->runReactants(reactants);
+    REQUIRE(products.size() == 1);
+    REQUIRE(products[0].size() == 1);
+    const auto &product = products[0][0];
+
+    clearAtomMappingProps(*product);
+    CHECK(MolToCXSmiles(*product) == "F[C@H](Cl)Br |o1:1|");
+    CHECK(product->getStereoGroups().size() == 1);
+    CHECK(hasAnyChiralAtom(*product));
+  }
+
+  SECTION("assemblyGolden_multiProduct") {
+    std::unique_ptr<ChemicalReaction> rxn(RxnSmartsToChemicalReaction(
+        "[C:1][O:2][C:3]>>[C:1][O:2].[C:3]"));
+    REQUIRE(rxn);
+    rxn->initReactantMatchers();
+
+    auto reactant = ROMOL_SPTR(SmilesToMol("CCOCCC"));
+    REQUIRE(reactant);
+
+    MOL_SPTR_VECT reactants = {reactant};
+    const auto products = rxn->runReactants(reactants);
+        REQUIRE(products.size() == 2);
+        REQUIRE(products[0].size() == 2);
+        REQUIRE(products[1].size() == 2);
+    const auto productSet0 =
+      collectCanonicalSmiles(std::vector<MOL_SPTR_VECT>{products[0]});
+    const auto productSet1 =
+      collectCanonicalSmiles(std::vector<MOL_SPTR_VECT>{products[1]});
+    const std::set<std::string> expected0{"CCC", "CCO"};
+    const std::set<std::string> expected1{"CC", "CCCO"};
+    // order-agnostic: which match comes first is not a guaranteed invariant
+    const bool matchesCurrentBehavior =
+      (productSet0 == expected0 && productSet1 == expected1) ||
+      (productSet0 == expected1 && productSet1 == expected0);
+    CHECK(matchesCurrentBehavior);
+  }
+
+  SECTION("assemblyGolden_queryAtomReagent") {
+    std::unique_ptr<ChemicalReaction> rxn(RxnSmartsToChemicalReaction(
+        "[#6:1]-[O:2]>>[#6:1]-[O:2]C"));
+    REQUIRE(rxn);
+    rxn->initReactantMatchers();
+
+    auto reactant = ROMOL_SPTR(SmilesToMol("CCO"));
+    REQUIRE(reactant);
+
+    MOL_SPTR_VECT reactants = {reactant};
+    const auto products = rxn->runReactants(reactants);
+    REQUIRE(products.size() == 1);
+    REQUIRE(products[0].size() == 1);
+    CHECK(collectCanonicalSmiles(products) == std::set<std::string>{"CCOC"});
+  }
+
+  SECTION("assemblyGolden_withConformer") {
+    std::unique_ptr<ChemicalReaction> rxn(
+        RxnSmartsToChemicalReaction("[O:1]>>[O:1]C"));
+    REQUIRE(rxn);
+    rxn->initReactantMatchers();
+
+    auto reactant = ROMOL_SPTR(SmilesToMol("CCO"));
+    REQUIRE(reactant);
+
+    auto *conf = new Conformer(reactant->getNumAtoms());
+    conf->set3D(true);
+    conf->setAtomPos(0, RDGeom::Point3D(0.0, 0.0, 0.0));
+    conf->setAtomPos(1, RDGeom::Point3D(1.5, 0.0, 0.0));
+    conf->setAtomPos(2, RDGeom::Point3D(2.7, 0.0, 0.0));
+    reactant->addConformer(conf, true);
+    REQUIRE(reactant->getNumConformers() == 1);
+
+    MOL_SPTR_VECT reactants = {reactant};
+    const auto products = rxn->runReactants(reactants);
+    REQUIRE(products.size() == 1);
+    REQUIRE(products[0].size() == 1);
+    CHECK(products[0][0]->getNumConformers() == 1);
+    CHECK(collectCanonicalSmiles(products) == std::set<std::string>{"CCOC"});
+  }
 }
 
 TEST_CASE("Github #2366 Enhanced Stereo", "[Reaction][StereoGroup][bug]") {

--- a/Code/GraphMol/ChemReactions/catch_tests.cpp
+++ b/Code/GraphMol/ChemReactions/catch_tests.cpp
@@ -236,7 +236,8 @@ TEST_CASE("reactant match cache", "[Reaction][enumerate][cache]") {
       REQUIRE(!products[0].empty());
     }
 
-    const auto fixedKey = std::make_tuple(0u, fixedReactant.get(), 1000u);
+    const auto fixedKey =
+      std::make_tuple(0u, fixedReactant.get(), 1000u, false);
     CHECK(cache.find(fixedKey) != cache.end());
     CHECK(cache.size() == 4);
   }
@@ -287,6 +288,59 @@ TEST_CASE("dedupeMatchesBySymmetry", "[reaction][dedupe]") {
         *reagent, singleMatch);
     REQUIRE(singleDeduped.size() == 1);
     CHECK(singleDeduped[0] == singleMatch[0]);
+  }
+}
+
+TEST_CASE("run_Reactants symmetric dedup", "[reaction][dedupe]") {
+  std::unique_ptr<ChemicalReaction> rxn(
+      RxnSmartsToChemicalReaction("[N;H2:1]>>[N:1]C"));
+  REQUIRE(rxn);
+  rxn->initReactantMatchers();
+
+  MOL_SPTR_VECT reactants = {ROMOL_SPTR(SmilesToMol("NCCN"))};
+  REQUIRE(reactants[0]);
+
+  SECTION("dedupe drops duplicate symmetric products") {
+    auto noDedup = run_Reactants(*rxn, reactants);
+    ReactantMatchCache cache;
+    auto deduped = run_Reactants(*rxn, reactants, cache, true);
+
+    REQUIRE(noDedup.size() > deduped.size());
+
+    // the cached dedupe=false path must be count-equivalent to the uncached run
+    ReactantMatchCache noDedupCache;
+    auto noDedupCached = run_Reactants(*rxn, reactants, noDedupCache, false);
+    CHECK(noDedupCached.size() == noDedup.size());
+  }
+
+  SECTION("dedupe preserves unique product set") {
+    auto noDedup = run_Reactants(*rxn, reactants);
+    ReactantMatchCache cache;
+    auto deduped = run_Reactants(*rxn, reactants, cache, true);
+
+    CHECK(collectCanonicalSmiles(noDedup) == collectCanonicalSmiles(deduped));
+  }
+
+  SECTION("dedupe cache key separates modes") {
+    ReactantMatchCache cache;
+    auto noDedup = run_Reactants(*rxn, reactants, cache, false);
+    auto deduped = run_Reactants(*rxn, reactants, cache, true);
+
+    REQUIRE(noDedup.size() > deduped.size());
+
+    unsigned int falseCount = 0;
+    unsigned int trueCount = 0;
+    for (const auto &entry : cache) {
+      if (std::get<3>(entry.first)) {
+        ++trueCount;
+      } else {
+        ++falseCount;
+      }
+    }
+
+    CHECK(falseCount == 1);
+    CHECK(trueCount == 1);
+    CHECK(cache.size() == 2);
   }
 }
 


### PR DESCRIPTION
## Enumeration performance improvements: match caching, graft caching, and symmetric deduplication

This PR adds three opt-in performance features to the RDKit reaction library enumeration engine. All changes are backward-compatible — default behavior is unchanged — and the new options are controlled via `EnumerationParams`.

## Summary
- Reactant match cache (cacheMode = ReactantCacheMode::MatchOnly)
New in this PR. Previously, every Cartesian-product combination re-matched each reagent against its reaction template from scratch (EnumerateLibrary::next() called rxn.runReactants(reactants) with no caching). With this option, each (reagent, template) pair is matched once and the result is replayed across all combinations. The m_matchCache is owned by EnumerateLibrary but only consulted when caching is enabled.

- Graft/fragment cache (cacheMode = ReactantCacheMode::Full)
The reagent subgraph contributed to each product is extracted once per (reagent, match) pair and replayed for every downstream combination, eliminating redundant bond-by-bond assembly. Implies MatchOnly. ~2x speedup in isolation on assembly-dominated reactions.

- Symmetric match deduplication (dedupeSymmetricMatches = true)
Substructure matches that map onto symmetry-equivalent atom sets are collapsed before the Cartesian product, removing duplicate products for symmetric reagents and halving the work for fully symmetric inputs. Requires cacheMode >= MatchOnly.

### Defaults / compatibility
cacheMode defaults to ReactantCacheMode::None and dedupeSymmetricMatches defaults to false, so default behavior is byte-for-byte identical to the previous baseline.
All three features are opt-in via EnumerationParams and exposed in the Python wrapper.

### Benchmarks
On a realistic three-component library with complex SMARTS, combining all three features yields ~22x end-to-end speedup (24.0 s → 1.09 s).

### API

The two previous boolean flags (`cacheReactantGrafts`, and the always-on match cache) are replaced by a single `ReactantCacheMode` enum that makes the hierarchy explicit:

```
ReactantCacheMode.NoCache    — no caching (default for backwards-compat)
ReactantCacheMode.MatchOnly  — cache reactant-template matches
ReactantCacheMode.Full       — cache matches + per-reagent product grafts
```

`EnumerationParams.cacheMode` and `EnumerationParams.dedupeSymmetricMatches` (default `false`) are the two knobs. Both are serialized in a single new `EnumerateLibrary` serialization version (v0 → v1); old pickles at version 0 deserialize cleanly with defaults applied. I am not 1000% sure if the rank-based deduplication covers all cases for global symmetry also, but in simple cases like symmetric functional groups that are sketched weirdly for various reasons like an (NH of an NH2 group) it works wonders.

<details>
<summary>New accessors and types</summary>

- `EnumerateLibrary.GetCacheMode()` — returns current `ReactantCacheMode`
- `EnumerateLibrary.GetMatchCacheSize()` / `GetGraftCacheSize()` — cache introspection
- `ReactionRunnerUtils::ReactantMatchCache`, `ReactantGraftCache`, `dedupeMatchesBySymmetry`
- `run_Reactants` overloads wiring match cache only, or both caches + dedup flag
- Benchmark target `reaction_enumerate` in Bench

Graft caches are cleared on deserialization and preserved on copy. Match caches are always live.
</details>

<details>
<summary>Benchmark results (macOS M1, three-component library)</summary>

| Mode | Time | Speedup |
|---|---|---|
| No caching | 24.0 s | 1x |
| Dedup + MatchOnly | 2.6 s | ~9x |
| Dedup + Full | 1.09 s | **~22x** |

Correctness assertions (identical unique product sets) pass in all cases.
</details>

<details>
<summary>Test coverage</summary>

- Catch2 unit tests: cached vs. uncached output equality, cache key correctness, graft reuse across combinations, dedup on symmetric/asymmetric inputs, serialization round-trips, `ReactantCacheMode` enum values
- Python tests: defaults, flag propagation, cache sizes after enumeration, dedup collapses symmetric reagents, `GetCacheMode()` accessor
- Full CTest suite (testReaction, testReactionFingerprints, testEnumeration, rxnTestCatch) passing
</details>

<details>
<summary>Commits</summary>

- **feat: cache reactant template matches in run_Reactants**
- **feat: use reactant match cache in EnumerateLibrary**
- **erf: share reactant match cache with enumeration prefilter**
- **test: add reaction enumeration matching benchmark**
- **feat: add symmetric-match dedup helper for enumeration**
- **feat: apply symmetric-match dedup in cached run_Reactants**
- **feat: expose symmetric-match dedup on EnumerateLibrary**
- **test: add symmetric-match dedup enumeration benchmark**
- **test: add product-assembly golden oracle and baseline bench**
- **refactor: split product assembly into extract/apply graft**
- **feat: add opt-in reactant graft cache to run_Reactants**
- **feat: cache reactant grafts across EnumerateLibrary runs**
- **test: benchmark reactant graft cache on vs off**
- **test: add three-component symmetric-monomer benchmark**
- **feat: expose graft cache and symmetric dedup in Python**
- **api: collapse cacheModes into one param**

</details>

#### Reference Issue
https://github.com/rdkit/rdkit/discussions/7563

