### PR TITLE
Use the same libexpat as the current python when building

### DIFF
--- a/.azure-pipelines/vs_build.yml
+++ b/.azure-pipelines/vs_build.yml
@@ -13,7 +13,7 @@ steps:
         libboost-devel=$(boost_version) ^
         numpy matplotlib cairo pillow eigen ^
         numpy=2.4 pandas=3 ^
-        sphinx myst-parser ipython jupyter pytest nbval cmake
+        sphinx myst-parser ipython jupyter pytest nbval cmake expat
     call activate rdkit_build
     conda config --env --add channels conda-forge 
     conda config --env --set channel_priority strict

--- a/.azure-pipelines/vs_build.yml
+++ b/.azure-pipelines/vs_build.yml
@@ -13,7 +13,7 @@ steps:
         libboost-devel=$(boost_version) ^
         numpy matplotlib cairo pillow eigen ^
         numpy=2.4 pandas=3 ^
-        sphinx myst-parser ipython jupyter pytest nbval cmake expat
+        sphinx myst-parser ipython jupyter pytest nbval cmake
     call activate rdkit_build
     conda config --env --add channels conda-forge 
     conda config --env --set channel_priority strict

--- a/.azure-pipelines/vs_build.yml
+++ b/.azure-pipelines/vs_build.yml
@@ -13,7 +13,7 @@ steps:
         libboost-devel=$(boost_version) ^
         numpy matplotlib cairo pillow eigen ^
         numpy=2.4 pandas=3 ^
-        sphinx myst-parser ipython jupyter pytest nbval cmake 
+        sphinx myst-parser ipython jupyter pytest nbval cmake expat
     call activate rdkit_build
     conda config --env --add channels conda-forge 
     conda config --env --set channel_priority strict

--- a/.azure-pipelines/vs_build_dll.yml
+++ b/.azure-pipelines/vs_build_dll.yml
@@ -11,7 +11,7 @@ steps:
         libboost-python-devel=(boost_version) ^
         libboost=$(boost_version) ^
         libboost-devel=$(boost_version) ^
-        numpy matplotlib cairo pillow eigen pandas=2.1
+        numpy matplotlib cairo pillow eigen pandas=2.1 expat
     call activate rdkit_build
     conda config --env --add channels conda-forge
     conda config --env --set channel_priority strict

--- a/.azure-pipelines/vs_build_dll.yml
+++ b/.azure-pipelines/vs_build_dll.yml
@@ -11,7 +11,7 @@ steps:
         libboost-python-devel=(boost_version) ^
         libboost=$(boost_version) ^
         libboost-devel=$(boost_version) ^
-        numpy matplotlib cairo pillow eigen pandas=2.1 expat
+        numpy matplotlib cairo pillow eigen pandas=2.1
     call activate rdkit_build
     conda config --env --add channels conda-forge
     conda config --env --set channel_priority strict

--- a/.azure-pipelines/vs_build_swig.yml
+++ b/.azure-pipelines/vs_build_swig.yml
@@ -15,7 +15,7 @@ steps:
         cmake=3.26 ^
         libboost=$(boost_version) ^
         libboost-devel=$(boost_version) ^
-        cairo eigen swig=4.2 expat
+        cairo eigen swig=4.2 
     call activate rdkit_build
     conda config --env --add channels conda-forge
     conda config --env --set channel_priority strict

--- a/.azure-pipelines/vs_build_swig.yml
+++ b/.azure-pipelines/vs_build_swig.yml
@@ -15,7 +15,7 @@ steps:
         cmake=3.26 ^
         libboost=$(boost_version) ^
         libboost-devel=$(boost_version) ^
-        cairo eigen swig=4.2
+        cairo eigen swig=4.2 expat
     call activate rdkit_build
     conda config --env --add channels conda-forge
     conda config --env --set channel_priority strict

--- a/.azure-pipelines/vs_build_swig.yml
+++ b/.azure-pipelines/vs_build_swig.yml
@@ -15,7 +15,7 @@ steps:
         cmake=3.26 ^
         libboost=$(boost_version) ^
         libboost-devel=$(boost_version) ^
-        cairo eigen swig=4.2 
+        cairo eigen swig=4.2 expat
     call activate rdkit_build
     conda config --env --add channels conda-forge
     conda config --env --set channel_priority strict

--- a/Code/JavaWrappers/csharp_wrapper/CMakeLists.txt
+++ b/Code/JavaWrappers/csharp_wrapper/CMakeLists.txt
@@ -82,8 +82,9 @@ SWIG_ADD_LIBRARY(RDKFuncs TYPE MODULE LANGUAGE CSharp SOURCES GraphMolCSharp.i )
 # as of Oct 2012 using boost 1.51 under at least ubuntu 12.04 we get a
 # link error if they aren't there.
 if(RDK_BUILD_CHEMDRAW_SUPPORT)
+  find_package(EXPAT REQUIRED)
   SWIG_LINK_LIBRARIES(RDKFuncs ${RDKit_Wrapper_Libs}
-      rdkit_base ${RDKit_THREAD_LIBS} ChemDraw expatpp expat)
+      rdkit_base ${RDKit_THREAD_LIBS} ChemDraw expatpp EXPAT::EXPAT)
 else ()
   SWIG_LINK_LIBRARIES(RDKFuncs ${RDKit_Wrapper_Libs}
       rdkit_base ${RDKit_THREAD_LIBS})

--- a/Code/JavaWrappers/csharp_wrapper/CMakeLists.txt
+++ b/Code/JavaWrappers/csharp_wrapper/CMakeLists.txt
@@ -83,7 +83,7 @@ SWIG_ADD_LIBRARY(RDKFuncs TYPE MODULE LANGUAGE CSharp SOURCES GraphMolCSharp.i )
 # link error if they aren't there.
 if(RDK_BUILD_CHEMDRAW_SUPPORT)
   SWIG_LINK_LIBRARIES(RDKFuncs ${RDKit_Wrapper_Libs}
-      rdkit_base ${RDKit_THREAD_LIBS} ChemDraw expat)
+      rdkit_base ${RDKit_THREAD_LIBS} ChemDraw expatpp expat)
 else ()
   SWIG_LINK_LIBRARIES(RDKFuncs ${RDKit_Wrapper_Libs}
       rdkit_base ${RDKit_THREAD_LIBS})

--- a/Code/JavaWrappers/gmwrapper/CMakeLists.txt
+++ b/Code/JavaWrappers/gmwrapper/CMakeLists.txt
@@ -126,7 +126,7 @@ SWIG_ADD_LIBRARY(GraphMolWrap TYPE MODULE LANGUAGE java SOURCES GraphMolJava.i )
 
 if(RDK_BUILD_CHEMDRAW_SUPPORT)
   SWIG_LINK_LIBRARIES(GraphMolWrap ${RDKit_Wrapper_Libs}
-      rdkit_base ${RDKit_THREAD_LIBS} ChemDraw expat)
+      rdkit_base ${RDKit_THREAD_LIBS} ChemDraw expatpp expat)
 else ()
   SWIG_LINK_LIBRARIES(GraphMolWrap ${RDKit_Wrapper_Libs}
       rdkit_base ${RDKit_THREAD_LIBS})

--- a/Code/JavaWrappers/gmwrapper/CMakeLists.txt
+++ b/Code/JavaWrappers/gmwrapper/CMakeLists.txt
@@ -125,8 +125,9 @@ SWIG_ADD_LIBRARY(GraphMolWrap TYPE MODULE LANGUAGE java SOURCES GraphMolJava.i )
 # link error if they aren't there.
 
 if(RDK_BUILD_CHEMDRAW_SUPPORT)
+  find_package(EXPAT REQUIRED)
   SWIG_LINK_LIBRARIES(GraphMolWrap ${RDKit_Wrapper_Libs}
-      rdkit_base ${RDKit_THREAD_LIBS} ChemDraw expatpp expat)
+      rdkit_base ${RDKit_THREAD_LIBS} ChemDraw expatpp EXPAT::EXPAT)
 else ()
   SWIG_LINK_LIBRARIES(GraphMolWrap ${RDKit_Wrapper_Libs}
       rdkit_base ${RDKit_THREAD_LIBS})

--- a/External/ChemDraw/CMakeLists.txt
+++ b/External/ChemDraw/CMakeLists.txt
@@ -10,8 +10,8 @@ include(CMakePrintHelpers)
 # and will need to be fixed in the future
 if(RDK_BUILD_CHEMDRAW_SUPPORT)
   if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/chemdraw/chemdraw/CDXIO.h")
-    set(RELEASE_NO "1.0.12")
-    set(MD5 "8abbd599d798e980b63394a939a08b38")
+    set(RELEASE_NO "1.0.13")
+    set(MD5 "b02e4fb4866d3c1e0882e7894d629d73")
     downloadAndCheckMD5("https://codeload.github.com/Glysade/chemdraw/tar.gz/refs/tags/v${RELEASE_NO}"
       "${CMAKE_CURRENT_SOURCE_DIR}/chemdraw-v${RELEASE_NO}.tar.gz" ${MD5})
 
@@ -26,6 +26,8 @@ if(RDK_BUILD_CHEMDRAW_SUPPORT)
   test_big_endian(WORDS_BIGENDIAN)
 
   include(CheckCXXCompilerFlag)
+  find_package(EXPAT)
+
 
   if (CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
      include(CheckCXXCompilerFlag)
@@ -61,7 +63,7 @@ if(RDK_BUILD_CHEMDRAW_SUPPORT)
   file(GLOB CHEMDRAW_SOURCE "chemdraw/chemdraw/*.cpp")
   rdkit_library(ChemDraw ${CHEMDRAW_SOURCE} SHARED)
   target_compile_definitions(ChemDraw PRIVATE CHEMDRAW_BUILD)
-  target_link_libraries(ChemDraw PRIVATE expat)
+  target_link_libraries(ChemDraw PRIVATE expatpp)
 
   # export all the symbols for ChemDraw on MSVC
   if((MSVC AND RDK_INSTALL_DLLS_MSVC) OR((NOT MSVC) AND WIN32))
@@ -122,7 +124,7 @@ if(RDK_BUILD_CHEMDRAW_SUPPORT)
   endif()
 
   if(TARGET ChemDraw_static)
-    target_link_libraries(ChemDraw_static PUBLIC expat)
+    target_link_libraries(ChemDraw_static PUBLIC expatpp)
   endif()
 
   install(TARGETS ChemDraw DESTINATION ${RDKit_LibDir})
@@ -131,7 +133,7 @@ if(RDK_BUILD_CHEMDRAW_SUPPORT)
   # so it needs to be installed so that it can be linked later on
   # when the libs are used.
   if(RDK_INSTALL_STATIC_LIBS OR NOT BUILD_SHARED_LIBS)
-    install(TARGETS expat EXPORT ${RDKit_EXPORTED_TARGETS} DESTINATION ${RDKit_LibDir} COMPONENT dev)
+    install(TARGETS expatpp EXPORT ${RDKit_EXPORTED_TARGETS} DESTINATION ${RDKit_LibDir} COMPONENT dev)
   endif()
 
   if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" )
@@ -176,6 +178,9 @@ if(RDK_BUILD_CHEMDRAW_SUPPORT)
     target_compile_definitions(RDChemDrawLib PRIVATE RDKIT_RDCHEMDRAWLIB_BUILD)
     target_compile_definitions(RDChemDrawReactionLib PRIVATE RDKIT_RDCHEMDRAWREACTIONLIB_BUILD)
   endif()
+
+  target_link_libraries(RDChemDrawLib PRIVATE EXPAT::EXPAT)
+  target_link_libraries(RDChemDrawReactionLib PRIVATE EXPAT::EXPAT)
 
   install(TARGETS RDChemDrawLib DESTINATION ${RDKit_LibDir})
   install(TARGETS RDChemDrawReactionLib DESTINATION ${RDKit_LibDir})

--- a/External/ChemDraw/CMakeLists.txt
+++ b/External/ChemDraw/CMakeLists.txt
@@ -10,8 +10,8 @@ include(CMakePrintHelpers)
 # and will need to be fixed in the future
 if(RDK_BUILD_CHEMDRAW_SUPPORT)
   if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/chemdraw/chemdraw/CDXIO.h")
-    set(RELEASE_NO "1.0.13")
-    set(MD5 "b02e4fb4866d3c1e0882e7894d629d73")
+    set(RELEASE_NO "1.0.14")
+    set(MD5 "44be1a8e5bd41faaa238a6d584ca258b")
     downloadAndCheckMD5("https://codeload.github.com/Glysade/chemdraw/tar.gz/refs/tags/v${RELEASE_NO}"
       "${CMAKE_CURRENT_SOURCE_DIR}/chemdraw-v${RELEASE_NO}.tar.gz" ${MD5})
 


### PR DESCRIPTION
@greglandrum noticed an issue with a conflict between the version of expat ChemDraw was using to build and the one python uses that could cause segfaults at runtime.

This force ChemDraw to use the system expat, which, at least under conda builds, should be the same one python uses.