### PR TITLE
Fix kekulization failures on complex fused-ring SMILES round-trips

### DIFF
--- a/Code/GraphMol/MolOps.cpp
+++ b/Code/GraphMol/MolOps.cpp
@@ -560,6 +560,25 @@ void cleanupAtropisomers(RWMol &mol, MolOps::Hybridizations &hybs) {
     Atropisomers::cleanupAtropisomerStereoGroups(mol);
   }
 }
+
+namespace {
+// Kekulize as part of sanitization. We normally use canonical=false here
+// because it's faster and sufficient for the vast majority of molecules.
+// The atom-index-order traversal it uses, however, is not guaranteed to
+// find a Kekule structure within the default back-tracking budget even
+// when one exists: for large, densely-fused aromatic ring systems, whether
+// that budget is enough can depend on the (arbitrary) order atoms were
+// numbered in, which in turn can depend on incidental details like which
+// atom a SMILES was rooted at (GitHub #8403). If the fast attempt fails,
+// fall back to the slower, order-independent canonical traversal before
+// concluding that the molecule really can't be kekulized.
+void kekulizeForSanitize(RWMol &mol) {
+  if (!MolOps::KekulizeIfPossible(mol, true, false)) {
+    MolOps::Kekulize(mol, true, true);
+  }
+}
+}  // namespace
+
 void sanitizeMol(RWMol &mol) {
   unsigned int failedOp = 0;
   sanitizeMol(mol, failedOp, SANITIZE_ALL);
@@ -598,7 +617,7 @@ void sanitizeMol(RWMol &mol, unsigned int &operationThatFailed,
   // kekulizations
   operationThatFailed = SANITIZE_KEKULIZE;
   if (sanitizeOps & operationThatFailed) {
-    Kekulize(mol, true, false);
+    kekulizeForSanitize(mol);
   }
 
   // look for radicals:
@@ -692,7 +711,7 @@ std::vector<std::unique_ptr<MolSanitizeException>> detectChemistryProblems(
   operation = SANITIZE_KEKULIZE;
   if (sanitizeOps & operation) {
     try {
-      Kekulize(mol, true, false);
+      kekulizeForSanitize(mol);
     } catch (const MolSanitizeException &e) {
       res.emplace_back(e.copy());
     }

--- a/Code/GraphMol/catch_graphmol.cpp
+++ b/Code/GraphMol/catch_graphmol.cpp
@@ -4933,6 +4933,47 @@ M  END)CTAB"_ctab;
   }
 }
 
+TEST_CASE(
+    "github #8403: rootedAtAtom can produce SMILES that fail to kekulize on "
+    "re-parsing") {
+  // Large, densely-fused all-aromatic ring systems can require more than
+  // the default number of kekulization back-tracks when atoms are visited
+  // in atom-index order. Since rootedAtAtom changes which atom is written
+  // (and therefore re-numbered) first, some roots used to produce SMILES
+  // that MolFromSmiles couldn't kekulize, even though the molecule itself
+  // is unambiguously kekulizable.
+  SECTION("rootedAtAtom, from the issue") {
+    auto smiles =
+        "c1cc2ccc3c4c(ccc(c1)c24)c1c2c4ccc5cccc6ccc(c4c65)c4c5cccc6c7cccc8c9cc"
+        "cc%10c%11cccc%12c3c1c1c(c%11%12)c(c9%10)c(c87)c(c65)c1c42";
+    auto mol = v2::SmilesParse::MolFromSmiles(smiles);
+    REQUIRE(mol);
+    for (auto i = 0u; i < mol->getNumAtoms(); ++i) {
+      SmilesWriteParams params;
+      params.rootedAtAtom = static_cast<int>(i);
+      auto rooted = MolToSmiles(*mol, params);
+      INFO("rootedAtAtom=" << i << " -> " << rooted);
+      auto rootedMol = v2::SmilesParse::MolFromSmiles(rooted);
+      CHECK(rootedMol);
+    }
+  }
+  SECTION("plain canonical round-trip, from discussion #8606") {
+    // Same root cause, but no rootedAtAtom needed: the atom order produced
+    // by canonicalization alone was already enough to blow the default
+    // back-tracking budget for this CAS-RN 133133-06-9 ring system.
+    // https://github.com/rdkit/rdkit/discussions/8606
+    auto smiles =
+        "O=c1c2c3c(c4c(c2c(=O)c2c5c(c6c(c12)c1c2c6cccc2ccc1)c1c2c5cccc2ccc1)c1"
+        "c2c4cccc2ccc1)c1c2c3cccc2ccc1";
+    auto mol = v2::SmilesParse::MolFromSmiles(smiles);
+    REQUIRE(mol);
+    auto canonical = MolToSmiles(*mol);
+    INFO("canonical -> " << canonical);
+    auto roundTripped = v2::SmilesParse::MolFromSmiles(canonical);
+    CHECK(roundTripped);
+  }
+}
+
 TEST_CASE("large smiles benchmark") {
   std::string smiles(1000, 'C');
   auto m = v2::SmilesParse::MolFromSmiles(smiles);


### PR DESCRIPTION
## Description

`Chem.MolFromSmiles` could reject SMILES for molecules that are
unambiguously kekulizable, purely because of the arbitrary order atoms
happened to be numbered in.

`sanitizeMol()` kekulizes with `canonical=false` (atom-index-order
traversal), which is fast and sufficient for the vast majority of
molecules. Its back-tracking search is bounded by the default
`maxBackTracks=100`, though, and for large, densely-fused all-aromatic
ring systems whether that budget is enough can depend on the (arbitrary)
order atoms were numbered in. Since `rootedAtAtom` changes which atom is
written (and therefore renumbered) first on re-parsing, some roots
produced SMILES that `MolFromSmiles` could not kekulize, even though the
molecule itself is unambiguously kekulizable (other roots succeed, as
does the same atom order with a larger back-track budget, as does the
order-independent `canonical=true` traversal added in #9125).

The same failure can also show up on a **plain** canonical round-trip
(`MolToSmiles` -> `MolFromSmiles`, no `rootedAtAtom` involved) when
canonicalization alone produces an atom order that needs more than the
default back-tracking budget - see
https://github.com/rdkit/rdkit/discussions/8606.

### Fix

In `sanitizeMol()` / `detectChemistryProblems()`, retry with the slower,
order-independent `canonical=true` Kekulize traversal only when the fast
`canonical=false` attempt fails, before concluding the molecule can't be
kekulized. `KekulizeIfPossible` fully restores the molecule's aromatic
state on failure, so the retry starts from a clean, fully-aromatic
molecule. This keeps the fast path's performance for the common case and
only pays the extra cost for the rare pathological cases.

## Reproduction

```python
from rdkit import Chem

smiles = "c1cc2ccc3c4c(ccc(c1)c24)c1c2c4ccc5cccc6ccc(c4c65)c4c5cccc6c7cccc8c9cccc%10c%11cccc%12c3c1c1c(c%11%12)c(c9%10)c(c87)c(c65)c1c42"
mol = Chem.MolFromSmiles(smiles)

for i in range(mol.GetNumAtoms()):
    rooted_smiles = Chem.MolToSmiles(mol, rootedAtAtom=i)
    assert Chem.MolFromSmiles(rooted_smiles) is not None  # used to fail for several roots
```

## Testing

Added `TEST_CASE("github #8403: ...")` to
`Code/GraphMol/catch_graphmol.cpp`, covering both the `rootedAtAtom`
case from #8403 and the plain canonical round-trip case from discussion
#8606. Ran the full `graphmolTestsCatch`, `smiTestCatch`, and
`v2smiTestCatch` suites locally - all pass, no regressions.

Fixes #8403