### PR TITLE
Add ROMol name accessors

### DIFF
--- a/Code/GraphMol/ROMol.cpp
+++ b/Code/GraphMol/ROMol.cpp
@@ -589,6 +589,14 @@ ROMol::ConstBondIterator ROMol::endBonds() const {
   return ConstBondIterator(this, end);
 }
 
+void ROMol::setName(const std::string &name) const {
+  setProp(common_properties::_Name, name);
+}
+
+std::string ROMol::getName() const {
+  return getProp<std::string>(common_properties::_Name);
+}
+
 void ROMol::clearComputedProps(bool includeRings) const {
   // the SSSR information:
   if (includeRings) {

--- a/Code/GraphMol/ROMol.cpp
+++ b/Code/GraphMol/ROMol.cpp
@@ -594,7 +594,9 @@ void ROMol::setName(const std::string &name) const {
 }
 
 std::string ROMol::getName() const {
-  return getProp<std::string>(common_properties::_Name);
+  std::string name;
+  getPropIfPresent(common_properties::_Name, name);
+  return name;
 }
 
 void ROMol::clearComputedProps(bool includeRings) const {

--- a/Code/GraphMol/ROMol.h
+++ b/Code/GraphMol/ROMol.h
@@ -929,7 +929,8 @@ class RDKIT_GRAPHMOL_EXPORT ROMol : public RDProps {
 
   //! sets the molecule name/title; equivalent to setting the \c _Name property
   void setName(const std::string &name) const;
-  //! gets the molecule name/title; equivalent to getting the \c _Name property
+  //! gets the molecule name/title stored in \c _Name, or an empty string if
+  //! absent
   std::string getName() const;
   //! clears all of our \c computed \c properties
   void clearComputedProps(bool includeRings = true) const;

--- a/Code/GraphMol/ROMol.h
+++ b/Code/GraphMol/ROMol.h
@@ -927,6 +927,10 @@ class RDKIT_GRAPHMOL_EXPORT ROMol : public RDProps {
   //! \name Properties
   //! @{
 
+  //! sets the molecule name/title; equivalent to setting the \c _Name property
+  void setName(const std::string &name) const;
+  //! gets the molecule name/title; equivalent to getting the \c _Name property
+  std::string getName() const;
   //! clears all of our \c computed \c properties
   void clearComputedProps(bool includeRings = true) const;
   //! calculates any of our lazy \c properties

--- a/Code/GraphMol/Wrap/Mol.cpp
+++ b/Code/GraphMol/Wrap/Mol.cpp
@@ -753,8 +753,8 @@ struct mol_wrapper {
         .def("GetName", &ROMol::getName, python::args("self"),
              "Returns the molecule name stored as the _Name property.\n\n"
              "  NOTE:\n"
-             "    - If the _Name property has not been set, a KeyError "
-             "exception will be raised.\n")
+             "    - If the _Name property has not been set, an empty string "
+             "will be returned.\n")
         .def(
             "GetProp", GetPyProp<ROMol>,
             (python::arg("self"), python::arg("key"),

--- a/Code/GraphMol/Wrap/Mol.cpp
+++ b/Code/GraphMol/Wrap/Mol.cpp
@@ -745,6 +745,16 @@ struct mol_wrapper {
              "assigned.\n\n"
              "  ARGUMENTS:\n"
              "    - key: the name of the property to check for (a string).\n")
+        .def("SetName", &ROMol::setName,
+             (python::arg("self"), python::arg("name")),
+             "Sets the molecule name; this is stored as the _Name property.\n\n"
+             "  ARGUMENTS:\n"
+             "    - name: the molecule name (a string).\n")
+        .def("GetName", &ROMol::getName, python::args("self"),
+             "Returns the molecule name stored as the _Name property.\n\n"
+             "  NOTE:\n"
+             "    - If the _Name property has not been set, a KeyError "
+             "exception will be raised.\n")
         .def(
             "GetProp", GetPyProp<ROMol>,
             (python::arg("self"), python::arg("key"),

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -4718,8 +4718,7 @@ $$$$
         ob.GetIntProp("foo")
       self.assertEqual(str(e.exception), errors["int overflow"])
 
-    with self.assertRaises(KeyError):
-      m.GetName()
+    self.assertEqual(m.GetName(), "")
 
     m.SetName("ethane")
     self.assertEqual(m.GetName(), "ethane")
@@ -4729,8 +4728,7 @@ $$$$
     self.assertEqual(m.GetName(), "updated name")
 
     m.ClearProp("_Name")
-    with self.assertRaises(KeyError):
-      m.GetName()
+    self.assertEqual(m.GetName(), "")
 
     rwm = Chem.RWMol(m)
     rwm.SetName("editable ethane")

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -4718,6 +4718,25 @@ $$$$
         ob.GetIntProp("foo")
       self.assertEqual(str(e.exception), errors["int overflow"])
 
+    with self.assertRaises(KeyError):
+      m.GetName()
+
+    m.SetName("ethane")
+    self.assertEqual(m.GetName(), "ethane")
+    self.assertEqual(m.GetProp("_Name"), "ethane")
+
+    m.SetProp("_Name", "updated name")
+    self.assertEqual(m.GetName(), "updated name")
+
+    m.ClearProp("_Name")
+    with self.assertRaises(KeyError):
+      m.GetName()
+
+    rwm = Chem.RWMol(m)
+    rwm.SetName("editable ethane")
+    self.assertEqual(rwm.GetName(), "editable ethane")
+    self.assertEqual(rwm.GetProp("_Name"), "editable ethane")
+
   def testInvariantException(self):
     m = Chem.MolFromSmiles("C")
     try:

--- a/Code/GraphMol/catch_graphmol.cpp
+++ b/Code/GraphMol/catch_graphmol.cpp
@@ -4974,6 +4974,26 @@ TEST_CASE("github #9068: properties with empty names") {
   }
 }
 
+TEST_CASE("ROMol setName/getName") {
+  auto m = "CCO"_smiles;
+  REQUIRE(m);
+
+  CHECK_THROWS_AS(m->getName(), KeyErrorException);
+
+  m->setName("ethanol");
+  CHECK(m->hasProp(common_properties::_Name));
+  CHECK(m->getName() == "ethanol");
+  CHECK(m->getProp<std::string>(common_properties::_Name) == "ethanol");
+
+  m->setProp(common_properties::_Name, "updated name");
+  CHECK(m->getName() == "updated name");
+
+  const ROMol &cmol = *m;
+  cmol.setName("const name");
+  CHECK(cmol.getName() == "const name");
+  CHECK(cmol.getProp<std::string>(common_properties::_Name) == "const name");
+}
+
 TEST_CASE("canonical re-kekulization after sanitization preserves stereo",
           "[kekulization]") {
   // Sanitization kekulizes with canonical=false for performance (B1).

--- a/Code/GraphMol/catch_graphmol.cpp
+++ b/Code/GraphMol/catch_graphmol.cpp
@@ -4978,7 +4978,7 @@ TEST_CASE("ROMol setName/getName") {
   auto m = "CCO"_smiles;
   REQUIRE(m);
 
-  CHECK_THROWS_AS(m->getName(), KeyErrorException);
+  CHECK(m->getName().empty());
 
   m->setName("ethanol");
   CHECK(m->hasProp(common_properties::_Name));
@@ -4987,6 +4987,9 @@ TEST_CASE("ROMol setName/getName") {
 
   m->setProp(common_properties::_Name, "updated name");
   CHECK(m->getName() == "updated name");
+
+  m->clearProp(common_properties::_Name);
+  CHECK(m->getName().empty());
 
   const ROMol &cmol = *m;
   cmol.setName("const name");


### PR DESCRIPTION
Added `ROMol::setName()` and `ROMol::getName()` as convenience methods for the molecule title stored in the `_Name` property. The aim is to make the name feel more like a first-class property of the molecule instead of just an internal convention, while keeping backward compatibility.

The new methods are callable from Python as `Mol.SetName()` and `Mol.GetName()`.

#### Notes / questions

I asked Greg many moons ago about this idea and he said something like "sure, send a PR". Here it is, very belatedly! I'm not sure if I should file an issue for it or if going straight to PR is OK.

Question: what do you think about `getName()` returning empty string by default instead of throwing?
