### PR TITLE
Speedup testDGeomHelpers

### DIFF
--- a/Code/GraphMol/DistGeomHelpers/CMakeLists.txt
+++ b/Code/GraphMol/DistGeomHelpers/CMakeLists.txt
@@ -9,18 +9,13 @@ rdkit_headers(BoundsMatrixBuilder.h
 
 rdkit_catch_test(testDistGeomHelpers testDgeomHelpers.cpp
            LINK_LIBRARIES
-           DistGeomHelpers MolTransforms FileParsers SmilesParse  )
+           DistGeomHelpers MolTransforms FileParsers SmilesParse SHARD_COUNT 4 )
 
 rdkit_catch_test(distGeomHelpersCatch catch_tests.cpp 
-LINK_LIBRARIES DistGeomHelpers MolTransforms FileParsers SmilesParse )
+LINK_LIBRARIES DistGeomHelpers MolTransforms FileParsers SmilesParse SHARD_COUNT 4 )
 
-rdkit_catch_test(testDgeomHelpersGH3019_0 testGithub3019.cpp
-           LINK_LIBRARIES DistGeomHelpers SmilesParse
-           CLIARGS --shard-count=2 --shard-index=0 )
-
-rdkit_catch_test(testDgeomHelpersGH3019_1 testGithub3019.cpp
-           LINK_LIBRARIES DistGeomHelpers SmilesParse 
-           CLIARGS --shard-count=2 --shard-index=1 )
+rdkit_catch_test(testDgeomHelpersGH3019 testGithub3019.cpp
+           LINK_LIBRARIES DistGeomHelpers SmilesParse SHARD_COUNT 2)
 
 
 if(RDK_BUILD_PYTHON_WRAPPERS)

--- a/Code/GraphMol/DistGeomHelpers/CMakeLists.txt
+++ b/Code/GraphMol/DistGeomHelpers/CMakeLists.txt
@@ -14,6 +14,14 @@ rdkit_catch_test(testDistGeomHelpers testDgeomHelpers.cpp
 rdkit_catch_test(distGeomHelpersCatch catch_tests.cpp 
 LINK_LIBRARIES DistGeomHelpers MolTransforms FileParsers SmilesParse )
 
+rdkit_catch_test(testDgeomHelpersGH3019_0 testGithub3019.cpp
+           LINK_LIBRARIES DistGeomHelpers SmilesParse
+           CLIARGS --shard-count=2 --shard-index=0 )
+
+rdkit_catch_test(testDgeomHelpersGH3019_1 testGithub3019.cpp
+           LINK_LIBRARIES DistGeomHelpers SmilesParse 
+           CLIARGS --shard-count=2 --shard-index=1 )
+
 
 if(RDK_BUILD_PYTHON_WRAPPERS)
 add_subdirectory(Wrap)

--- a/Code/GraphMol/DistGeomHelpers/testDgeomHelpers.cpp
+++ b/Code/GraphMol/DistGeomHelpers/testDgeomHelpers.cpp
@@ -1695,19 +1695,6 @@ TEST_CASE("testDisableFragmentation") {
   CHECK((conf.getAtomPos(1) - conf.getAtomPos(3)).length() > 2.0);
 }
 
-TEST_CASE("testGithub3019") {
-  {  // make sure the mechanics work
-    auto m = v2::SmilesParse::MolFromSmiles(std::string(2000, 'C'));
-    REQUIRE(m);
-    CHECK(m->getNumAtoms() == 2000);
-    const bool legacyETKDG = GENERATE(true, false);
-    DGeomHelpers::EmbedParameters params{
-        .randomSeed = 0xf00d, .useLegacyImplementation = legacyETKDG};
-    int cid = DGeomHelpers::EmbedMolecule(*m, params);
-    CHECK(cid >= 0);
-  }
-}
-
 TEST_CASE("testGithub3667") {
   auto throwError = [](unsigned int) {
     throw ValueErrorException("embedder is abortable");

--- a/Code/GraphMol/DistGeomHelpers/testGithub3019.cpp
+++ b/Code/GraphMol/DistGeomHelpers/testGithub3019.cpp
@@ -1,0 +1,35 @@
+//
+//  Copyright (C) 2026 Niels Maeder and other RDKit contributors
+//
+//   @@ All Rights Reserved @@
+//  This file is part of the RDKit.
+//  The contents are covered by the terms of the BSD license
+//  which is included in the file license.txt, found at the root
+//  of the RDKit source tree.
+//
+#include <catch2/catch_all.hpp>
+#include <string>
+#include <GraphMol/SmilesParse/SmilesParse.h>
+#include "Embedder.h"
+
+namespace {
+void runTest(const bool legacy){
+     auto m = RDKit::v2::SmilesParse::MolFromSmiles(std::string(2000, 'C'));
+    REQUIRE(m);
+    CHECK(m->getNumAtoms() == 2000);
+    RDKit::DGeomHelpers::EmbedParameters params{
+        .randomSeed = 0xf00d, .useLegacyImplementation = legacy};
+    int cid = RDKit::DGeomHelpers::EmbedMolecule(*m, params);
+    CHECK(cid >= 0);
+}
+}  // namespace
+
+const std::string rdbase = getenv("RDBASE");
+
+
+TEST_CASE("testGithub3019Legacy") {
+    runTest(true);
+}
+TEST_CASE("testGithub3019AIO") {
+    runTest(false);
+}

--- a/Code/cmake/Modules/RDKitUtils.cmake
+++ b/Code/cmake/Modules/RDKitUtils.cmake
@@ -231,7 +231,7 @@ endmacro(rdkit_test)
 
 macro(rdkit_catch_test)
   PARSE_ARGUMENTS(RDKTEST
-    "LINK_LIBRARIES;DEPENDS;DEST"
+    "LINK_LIBRARIES;DEPENDS;DEST;CLIARGS"
     ""
     ${ARGN})
   CAR(RDKTEST_NAME ${RDKTEST_DEFAULT_ARGS})
@@ -239,7 +239,7 @@ macro(rdkit_catch_test)
   if(RDK_BUILD_CPP_TESTS)
     add_executable(${RDKTEST_NAME} ${RDKTEST_SOURCES})
     target_link_libraries(${RDKTEST_NAME} PRIVATE rdkitCatch ${RDKTEST_LINK_LIBRARIES} Catch2::Catch2)
-    add_test(${RDKTEST_NAME} ${EXECUTABLE_OUTPUT_PATH}/${RDKTEST_NAME})
+    add_test(${RDKTEST_NAME} ${EXECUTABLE_OUTPUT_PATH}/${RDKTEST_NAME} ${RDKTEST_CLIARGS})
   endif(RDK_BUILD_CPP_TESTS)
 endmacro(rdkit_catch_test)
 

--- a/Code/cmake/Modules/RDKitUtils.cmake
+++ b/Code/cmake/Modules/RDKitUtils.cmake
@@ -1,3 +1,5 @@
+include(CatchShardTests)
+
 include(BoostUtils)
 IF(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 # Mac OS X specific code
@@ -231,7 +233,7 @@ endmacro(rdkit_test)
 
 macro(rdkit_catch_test)
   PARSE_ARGUMENTS(RDKTEST
-    "LINK_LIBRARIES;DEPENDS;DEST;CLIARGS"
+    "LINK_LIBRARIES;DEPENDS;DEST;CLIARGS;SHARD_COUNT"
     ""
     ${ARGN})
   CAR(RDKTEST_NAME ${RDKTEST_DEFAULT_ARGS})
@@ -239,7 +241,11 @@ macro(rdkit_catch_test)
   if(RDK_BUILD_CPP_TESTS)
     add_executable(${RDKTEST_NAME} ${RDKTEST_SOURCES})
     target_link_libraries(${RDKTEST_NAME} PRIVATE rdkitCatch ${RDKTEST_LINK_LIBRARIES} Catch2::Catch2)
-    add_test(${RDKTEST_NAME} ${EXECUTABLE_OUTPUT_PATH}/${RDKTEST_NAME} ${RDKTEST_CLIARGS})
+    if(${RDKTEST_SHARD_COUNT})
+      catch_add_sharded_tests(${RDKTEST_NAME} SHARD_COUNT ${RDKTEST_SHARD_COUNT})
+    else()
+      add_test(${RDKTEST_NAME} ${EXECUTABLE_OUTPUT_PATH}/${RDKTEST_NAME} ${RDKTEST_CLIARGS})
+    endif()
   endif(RDK_BUILD_CPP_TESTS)
 endmacro(rdkit_catch_test)
 


### PR DESCRIPTION
#### Reference Issue
Following the discussion in #9292 

#### What does this implement/fix? Explain your changes.
Extracts one particular test that takes 2x~50 seconds into a seperate test file.
The two tests can be called in parallel using the [catch2 shard utility](https://catch2-temp.readthedocs.io/en/latest/command-line.html#test-sharding).


#### Any other comments?

There is a [macro defined by catch2](https://github.com/catchorg/Catch2/blob/devel/docs/cmake-integration.md) that one could use for that, but I figured the change here is small enough to not use it.
Happy to hear suggestions & comments.