### PR TITLE
Fix race in MinimalLib test_substruct_library JS test

### DIFF
--- a/Code/MinimalLib/tests/tests.js
+++ b/Code/MinimalLib/tests/tests.js
@@ -396,7 +396,16 @@ function test_substruct_library(done) {
     const numBitOptions = [-1, 0];
     var patternFpArray = [];
     var sslibObjs = [];
-    numBitOptions.forEach((numBits, optIdx) => {
+    // The numBits options must be processed sequentially rather than with a
+    // concurrent forEach: the numBits === 0 pass has no pattern fingerprints of
+    // its own and deliberately reuses the ones generated during the
+    // numBits === -1 pass via the shared patternFpArray. Launching both
+    // readline streams at once made the completion order of their 'close'
+    // events nondeterministic, so the numBits === 0 pass could finish first and
+    // find patternFpArray still empty (assertion "0 == 300"). Chaining the
+    // passes guarantees the numBits === -1 pass completes first.
+    function runOption(optIdx) {
+        var numBits = numBitOptions[optIdx];
         var smiReader = readline.createInterface({
             input: fs.createReadStream(__dirname + '/../../GraphMol/test_data/compounds.smi')
         });
@@ -490,9 +499,12 @@ function test_substruct_library(done) {
                 sslibObjs.forEach((sslib) => {
                     sslib.delete();
                 });
+            } else {
+                runOption(optIdx + 1);
             }
         });
-    });
+    }
+    runOption(0);
 }
 
 function test_substruct_library_merge_hs() {


### PR DESCRIPTION
#### Reference Issue
[build failure](https://dev.azure.com/rdkit-builds/RDKit/_build/results?buildId=9083&view=logs&j=9a40a18a-a8c5-5512-928a-88c86f9718f1&t=5111c976-46c5-5bce-378c-0b0eb983c18e)
[build log](https://github.com/user-attachments/files/29897046/58.txt)

#### What does this implement/fix? Explain your changes.
The two numBits passes (-1 and 0) were launched concurrently via forEach, each with its own readline stream over the same file. The numBits === 0 pass has no pattern fingerprints and reuses those built during the numBits === -1 pass through the shared patternFpArray, so it depends on the -1 pass finishing first. Because the streams' 'close' events fired in nondeterministic order, the 0 pass could complete first and hit an empty patternFpArray, failing with "AssertionError: 0 == 300".

Process the numBits options sequentially so the -1 pass always completes before the 0 pass begins.

#### Any other comments?

