### PR TITLE
Fixes #9381

### DIFF
--- a/Code/GraphMol/CIPLabeler/CIPLabeler.cpp
+++ b/Code/GraphMol/CIPLabeler/CIPLabeler.cpp
@@ -116,7 +116,7 @@ bool labelAux(std::vector<std::unique_ptr<Configuration>> &configs,
 
     // Skip if none of the foci atoms were reached during expansion
     if (std::ranges::none_of(foci,
-                     [&](auto f) { return digraph.seenAtom(f); })) {
+                             [&](auto f) { return digraph.seenAtom(f); })) {
       continue;
     }
     for (const auto &node : digraph.getNodes(foci[0])) {
@@ -231,7 +231,7 @@ void label(std::vector<std::unique_ptr<Configuration>> &configs,
 void assignCIPLabels(ROMol &mol, const boost::dynamic_bitset<> &atoms,
                      const boost::dynamic_bitset<> &bonds,
                      unsigned int maxRecursiveIterations) {
-  ControlCHandler::reset();
+  ControlCHandler hdlr;
 
   // reset the mark, for the case that this fails
   mol.clearProp(common_properties::_CIPComputed);
@@ -242,7 +242,7 @@ void assignCIPLabels(ROMol &mol, const boost::dynamic_bitset<> &atoms,
     label(configs, maxRecursiveIterations);
   } catch (const ControlCCaught &) {
   }
-  if (ControlCHandler::getGotSignal()) {
+  if (hdlr.getGotSignal()) {
     BOOST_LOG(rdWarningLog)
         << "Interrupted, cancelling CIP label calculation" << std::endl;
     return;

--- a/Code/GraphMol/DetermineBonds/DetermineBonds.cpp
+++ b/Code/GraphMol/DetermineBonds/DetermineBonds.cpp
@@ -94,11 +94,10 @@ std::vector<unsigned int> possibleValences(
 }
 
 LazyCartesianProduct<unsigned int> getValenceCombinations(
-    const RDKit::RWMol &mol,
-    size_t iterations = 100) {
+    const RDKit::RWMol &mol, size_t iterations = 100) {
   auto numAtoms = mol.getNumAtoms();
   const std::unordered_map<int, std::vector<unsigned int>> atomicValence = {
-      {1, {1}},  {5, {3, 4}}, {6, {4}},     {7, {3, 4}},     {8, {2, 1, 3}},
+      {1, {1}},  {5, {3, 4}}, {6, {4}},     {7, {3, 4}},        {8, {2, 1, 3}},
       {9, {1}},  {14, {4}},   {15, {5, 3}}, {16, {6, 3, 2, 1}}, {17, {1}},
       {32, {4}}, {35, {1}},   {53, {1}}};
 
@@ -131,7 +130,8 @@ LazyCartesianProduct<unsigned int> getValenceCombinations(
         auto *neighbor = bond->getOtherAtom(atom);
         auto neighIdx = neighbor->getIdx();
         auto neighDegree = neighbor->getDegree();
-        auto maxPos = *std::max_element(curPossible[neighIdx].begin(), curPossible[neighIdx].end());
+        auto maxPos = *std::max_element(curPossible[neighIdx].begin(),
+                                        curPossible[neighIdx].end());
         availBonds += maxPos - neighDegree;
       }
 
@@ -144,9 +144,9 @@ LazyCartesianProduct<unsigned int> getValenceCombinations(
 
       if (newPossible[i].empty()) {
         std::stringstream ss;
-        ss << "Unable to determine valence of atom " << i << " with atomic number "
-           << atom->getAtomicNum() << " and " << atom->getDegree()
-           << " bonds. Check the input molecules bonding.";
+        ss << "Unable to determine valence of atom " << i
+           << " with atomic number " << atom->getAtomicNum() << " and "
+           << atom->getDegree() << " bonds. Check the input molecules bonding.";
         throw ValueErrorException(ss.str());
       }
     }
@@ -156,7 +156,7 @@ LazyCartesianProduct<unsigned int> getValenceCombinations(
     } else {
       curPossible = newPossible;
       std::for_each(newPossible.begin(), newPossible.end(),
-                [](auto& x) { x.clear(); });
+                    [](auto &x) { x.clear(); });
     }
 
     if (--iterations == 0) {
@@ -446,8 +446,7 @@ void determineBondOrders(RWMol &mol, int charge, bool allowChargedFragments,
   bool valencyValid = false;
   bool chargeValid = false;
   bool saturationValid = false;
-
-  ControlCHandler::reset();
+  ControlCHandler hdlr;
 
   while (!valenceCombos.atEnd()) {
     if (--iterations == 0) {

--- a/Code/GraphMol/DistGeomHelpers/Embedder.cpp
+++ b/Code/GraphMol/DistGeomHelpers/Embedder.cpp
@@ -372,7 +372,7 @@ bool _checkKTerms(RDGeom::Point3DPtrVect &positions,
       std::ranges::count_if(eargs.etkdgDetails->angles,
                             [](const auto &angle) { return angle[3]; }) +
       eargs.etkdgDetails->improperAtoms.size();
-  if (totalEnergy > (nCenters * planarityTolerance)){
+  if (totalEnergy > (nCenters * planarityTolerance)) {
     return false;
   }
   for (const auto &contrib : field->contribs()) {
@@ -1353,8 +1353,8 @@ void findChiralSets(const ROMol &mol, DistGeom::VECT_CHIRALSET &chiralCenters,
           }
         }
       }  // if block -chirality check
-    }    // if block - heavy atom check
-  }      // for loop over atoms
+    }  // if block - heavy atom check
+  }  // for loop over atoms
 
   // now do atropisomers
   for (const auto &bond : mol.bonds()) {
@@ -1840,7 +1840,8 @@ void EmbedMultipleConfs(ROMol &mol, INT_VECT &res, unsigned int numConfs,
     }
     int numThreads = getNumThreadsToUse(params.numThreads);
 
-    ControlCHandler::reset();
+    ControlCHandler hdlr;
+    // ControlCHandler::reset();
 
     // do the embedding, using multiple threads if requested
     detail::EmbedArgs eargs = {&confsOk,        fourD,
@@ -1874,7 +1875,7 @@ void EmbedMultipleConfs(ROMol &mol, INT_VECT &res, unsigned int numConfs,
       res.push_back(-1);
       return;
     }
-    if (ControlCHandler::getGotSignal()) {
+    if (hdlr.getGotSignal()) {
       BOOST_LOG(rdWarningLog) << INTERRUPT_MESSAGE << std::endl;
       return;
     }

--- a/Code/GraphMol/DistGeomHelpers/Embedder.cpp
+++ b/Code/GraphMol/DistGeomHelpers/Embedder.cpp
@@ -1841,7 +1841,6 @@ void EmbedMultipleConfs(ROMol &mol, INT_VECT &res, unsigned int numConfs,
     int numThreads = getNumThreadsToUse(params.numThreads);
 
     ControlCHandler hdlr;
-    // ControlCHandler::reset();
 
     // do the embedding, using multiple threads if requested
     detail::EmbedArgs eargs = {&confsOk,        fourD,

--- a/Code/GraphMol/DistGeomHelpers/Wrap/testDistGeom.py
+++ b/Code/GraphMol/DistGeomHelpers/Wrap/testDistGeom.py
@@ -2,9 +2,11 @@ import copy
 import math
 import os
 import signal
+import sys
 import time
 import unittest
 import numpy
+
 
 import rdkit.DistanceGeometry as DG
 from rdkit import Chem, RDConfig, rdBase
@@ -881,11 +883,11 @@ class TestCase(unittest.TestCase):
     # set up our handler
     signal.signal(signal.SIGINT, handler)
     mol = Chem.AddHs(Chem.MolFromSmiles("C[C@H](O)c1ccccc1"))
-    params = AllChem.ETKDGv3()
+    params = AllChem.KDG()
     params.randomSeed = 0xF00D
     # now embed, which changes the handler
     AllChem.EmbedMolecule(mol, params)
-    os.kill(os.getpid(), signal.SIGINT)
+    os.kill(os.getpid(), signal.CTRL_C_EVENT if sys.platform == 'win32' else signal.SIGINT)
     time.sleep(0.2)
     self.assertEqual(seen, [signal.SIGINT])
 

--- a/Code/GraphMol/DistGeomHelpers/Wrap/testDistGeom.py
+++ b/Code/GraphMol/DistGeomHelpers/Wrap/testDistGeom.py
@@ -1,8 +1,9 @@
 import copy
 import math
 import os
+import signal
+import time
 import unittest
-
 import numpy
 
 import rdkit.DistanceGeometry as DG
@@ -869,6 +870,24 @@ class TestCase(unittest.TestCase):
     rdDistGeom.EmbedMolecule(mol, ps)
     fc = ps.GetFailureCounts()
     assert len(fc) == len(legacy_set.union(aio_set))
+
+  def testGithub9381(self):
+    seen = []
+
+    def handler(sig, frame):
+      print("python handler ran")
+      seen.append(sig)
+
+    # set up our handler
+    signal.signal(signal.SIGINT, handler)
+    mol = Chem.AddHs(Chem.MolFromSmiles("C[C@H](O)c1ccccc1"))
+    params = AllChem.ETKDGv3()
+    params.randomSeed = 0xF00D
+    # now embed, which changes the handler
+    AllChem.EmbedMolecule(mol, params)
+    os.kill(os.getpid(), signal.SIGINT)
+    time.sleep(0.2)
+    self.assertEqual(seen, [signal.SIGINT])
 
 
 if __name__ == '__main__':

--- a/Code/GraphMol/DistGeomHelpers/Wrap/testDistGeom.py
+++ b/Code/GraphMol/DistGeomHelpers/Wrap/testDistGeom.py
@@ -7,7 +7,6 @@ import time
 import unittest
 import numpy
 
-
 import rdkit.DistanceGeometry as DG
 from rdkit import Chem, RDConfig, rdBase
 from rdkit.Chem import AllChem, ChemicalForceFields, rdDistGeom, rdMolAlign
@@ -886,15 +885,16 @@ class TestCase(unittest.TestCase):
     params = AllChem.KDG()
     params.randomSeed = 0xF00D
     # now embed, which changes the handler
-    #print('embed')
     AllChem.EmbedMolecule(mol, params)
-    #print('done')
-    # time.sleep(0.5)
-    os.kill(os.getpid(), signal.CTRL_C_EVENT if sys.platform == 'win32' else signal.SIGINT)
-    print('post kill')
     time.sleep(0.5)
-    print('post sleep')
-    self.assertEqual(seen, [signal.SIGINT])
+    os.kill(os.getpid(), signal.CTRL_C_EVENT if sys.platform == 'win32' else signal.SIGINT)
+    time.sleep(0.5)
+    if sys.platform != 'win32':
+      # on the windows CI machines it seems that the signal handling doesn't work
+      # as expected, so we don't do this test.
+      # If things end up really messed up, and the signal handler really is not
+      # installed, the whole test run will fail...
+      self.assertEqual(seen, [signal.SIGINT])
 
 
 if __name__ == '__main__':

--- a/Code/GraphMol/DistGeomHelpers/Wrap/testDistGeom.py
+++ b/Code/GraphMol/DistGeomHelpers/Wrap/testDistGeom.py
@@ -886,15 +886,9 @@ class TestCase(unittest.TestCase):
     params.randomSeed = 0xF00D
     # now embed, which changes the handler
     AllChem.EmbedMolecule(mol, params)
-    time.sleep(0.5)
-    os.kill(os.getpid(), signal.CTRL_C_EVENT if sys.platform == 'win32' else signal.SIGINT)
-    time.sleep(0.5)
-    if sys.platform != 'win32':
-      # on the windows CI machines it seems that the signal handling doesn't work
-      # as expected, so we don't do this test.
-      # If things end up really messed up, and the signal handler really is not
-      # installed, the whole test run will fail...
-      self.assertEqual(seen, [signal.SIGINT])
+    time.sleep(0.2)
+    # make sure our signal handler is once again active:
+    self.assertEqual(signal.getsignal(signal.SIGINT), handler)
 
 
 if __name__ == '__main__':

--- a/Code/GraphMol/DistGeomHelpers/Wrap/testDistGeom.py
+++ b/Code/GraphMol/DistGeomHelpers/Wrap/testDistGeom.py
@@ -886,9 +886,14 @@ class TestCase(unittest.TestCase):
     params = AllChem.KDG()
     params.randomSeed = 0xF00D
     # now embed, which changes the handler
+    #print('embed')
     AllChem.EmbedMolecule(mol, params)
+    #print('done')
+    # time.sleep(0.5)
     os.kill(os.getpid(), signal.CTRL_C_EVENT if sys.platform == 'win32' else signal.SIGINT)
-    time.sleep(0.2)
+    print('post kill')
+    time.sleep(0.5)
+    print('post sleep')
     self.assertEqual(seen, [signal.SIGINT])
 
 

--- a/Code/GraphMol/Substruct/vf2.hpp
+++ b/Code/GraphMol/Substruct/vf2.hpp
@@ -19,7 +19,7 @@
 
 #ifndef __BGL_VF2_SUB_STATE_H__
 #define __BGL_VF2_SUB_STATE_H__
-//#define RDK_VF2_PRUNING
+// #define RDK_VF2_PRUNING
 #define RDK_ADJ_ITER typename Graph::adjacency_iterator
 
 namespace boost {
@@ -641,7 +641,7 @@ bool vf2(const Graph &g1, const Graph &g2, VertexLabeling &vertex_labeling,
   int n = 0;
 
   F.clear();
-  RDKit::ControlCHandler::reset();
+  RDKit::ControlCHandler hdlr;
   if (match(&n, ni1, ni2, s0)) {
     auto sz = num_vertices(g1);
     F.reserve(sz);
@@ -650,7 +650,7 @@ bool vf2(const Graph &g1, const Graph &g2, VertexLabeling &vertex_labeling,
     }
   }
 
-  if (RDKit::ControlCHandler::getGotSignal()) {
+  if (hdlr.getGotSignal()) {
     BOOST_LOG(rdWarningLog)
         << "Substructure search was interrupted, result may not include all matches"
         << std::endl;
@@ -680,11 +680,11 @@ bool vf2_all(const Graph &g1, const Graph &g2, VertexLabeling &vertex_labeling,
 
   F.clear();
 
-  RDKit::ControlCHandler::reset();
+  RDKit::ControlCHandler hdlr;
 
   match(ni1.get(), ni2.get(), s0, F, max_results);
 
-  if (RDKit::ControlCHandler::getGotSignal()) {
+  if (hdlr.getGotSignal()) {
     BOOST_LOG(rdWarningLog)
         << "Substructure search was interrupted, result may not include all matches"
         << std::endl;

--- a/Code/GraphMol/SynthonSpaceSearch/SynthonSpace.cpp
+++ b/Code/GraphMol/SynthonSpaceSearch/SynthonSpace.cpp
@@ -109,7 +109,7 @@ SearchResults SynthonSpace::substructureSearch(
     const ROMol &query, const SubstructMatchParameters &matchParams,
     const SynthonSpaceSearchParams &params) {
   PRECONDITION(query.getNumAtoms() != 0, "Search query must contain atoms.");
-  ControlCHandler::reset();
+  ControlCHandler hdlr;
   SynthonSpaceSubstructureSearcher ssss(query, matchParams, params, *this);
   return ssss.search();
 }
@@ -119,7 +119,7 @@ void SynthonSpace::substructureSearch(
     const SubstructMatchParameters &matchParams,
     const SynthonSpaceSearchParams &params) {
   PRECONDITION(query.getNumAtoms() != 0, "Search query must contain atoms.");
-  ControlCHandler::reset();
+  ControlCHandler hdlr;
   SynthonSpaceSubstructureSearcher ssss(query, matchParams, params, *this);
   ssss.search(cb);
 }
@@ -165,7 +165,7 @@ SearchResults SynthonSpace::substructureSearch(
 SearchResults SynthonSpace::fingerprintSearch(
     const ROMol &query, const FingerprintGenerator<std::uint64_t> &fpGen,
     const SynthonSpaceSearchParams &params) {
-  ControlCHandler::reset();
+  ControlCHandler hdlr;
   PRECONDITION(query.getNumAtoms() != 0, "Search query must contain atoms.");
   SynthonSpaceFingerprintSearcher ssss(query, fpGen, params, *this);
   return ssss.search();
@@ -174,7 +174,7 @@ SearchResults SynthonSpace::fingerprintSearch(
 void SynthonSpace::fingerprintSearch(
     const ROMol &query, const FingerprintGenerator<std::uint64_t> &fpGen,
     const SearchResultCallback &cb, const SynthonSpaceSearchParams &params) {
-  ControlCHandler::reset();
+  ControlCHandler hdlr;
   PRECONDITION(query.getNumAtoms() != 0, "Search query must contain atoms.");
   SynthonSpaceFingerprintSearcher ssss(query, fpGen, params, *this);
   ssss.search(cb);
@@ -318,10 +318,10 @@ void SynthonSpace::readStream(std::istream &is, bool &cancelled) {
   int format = -1;
   std::string nextLine;
   int lineNum = 1;
-  ControlCHandler::reset();
+  ControlCHandler hdlr;
 
   while (!is.eof()) {
-    if (ControlCHandler::getGotSignal()) {
+    if (hdlr.getGotSignal()) {
       cancelled = true;
       return;
     }

--- a/Code/GraphMol/SynthonSpaceSearch/SynthonSpaceSearcher.cpp
+++ b/Code/GraphMol/SynthonSpaceSearch/SynthonSpaceSearcher.cpp
@@ -121,13 +121,14 @@ SearchResults SynthonSpaceSearcher::search() {
   }
   bool timedOut = false;
   std::uint64_t totHits = 0;
+  ControlCHandler hdlr;
   auto allHits = assembleHitSets(endTime, timedOut, totHits);
-  if (!timedOut && !ControlCHandler::getGotSignal() && d_params.buildHits) {
+  if (!timedOut && !hdlr.getGotSignal() && d_params.buildHits) {
     buildHits(allHits, endTime, timedOut, results);
   }
 
   return SearchResults{std::move(results), totHits, timedOut,
-                       ControlCHandler::getGotSignal()};
+                       hdlr.getGotSignal()};
 }
 
 std::unique_ptr<ROMol> SynthonSpaceSearcher::buildAndVerifyHit(
@@ -386,15 +387,14 @@ void sortAndUniquifyToTry(
   // pair; deduplicate so we don't build the same product twice.
   boost::unordered_flat_set<std::size_t> seen;
   seen.reserve(toTry.size());
-  toTry.erase(
-      std::remove_if(toTry.begin(), toTry.end(),
-                     [&seen](const auto &entry) {
-                       return !seen
-                                   .insert(details::buildProductHash(
-                                       entry.first, entry.second))
-                                   .second;
-                     }),
-      toTry.end());
+  toTry.erase(std::remove_if(toTry.begin(), toTry.end(),
+                             [&seen](const auto &entry) {
+                               return !seen
+                                           .insert(details::buildProductHash(
+                                               entry.first, entry.second))
+                                           .second;
+                             }),
+              toTry.end());
 }
 
 }  // namespace
@@ -456,8 +456,9 @@ void SynthonSpaceSearcher::buildAllHits(
                        std::make_move_iterator(partResults.begin()),
                        std::make_move_iterator(partResults.end()));
         partResults.clear();
-        enoughHits = d_params.maxHits != -1 &&
-                     numHitsFound.load() >= d_params.maxHits + d_params.hitStart;
+        enoughHits =
+            d_params.maxHits != -1 &&
+            numHitsFound.load() >= d_params.maxHits + d_params.hitStart;
         timedOut = details::checkTimeOut(endTime);
         toTry.clear();
         if (enoughHits || timedOut || ControlCHandler::getGotSignal()) {

--- a/Code/RDGeneral/ControlCHandler.h
+++ b/Code/RDGeneral/ControlCHandler.h
@@ -14,6 +14,7 @@
 #include <atomic>
 #include <csignal>
 #include <stdexcept>
+#include <iostream>
 
 #include <RDGeneral/export.h>
 
@@ -45,23 +46,29 @@ class ControlCCaught : public std::runtime_error {
 //! released, otherwise a crash is inevitable at some future point.
 class ControlCHandler {
  public:
-  ControlCHandler() { d_prev_handler = std::signal(SIGINT, signalHandler); }
+  ControlCHandler() {
+    std::cerr << "  SETTING UP THE CONTROLC HANDLER " << this << std::endl;
+    d_prev_handler = std::signal(SIGINT, signalHandler);
+  }
   ControlCHandler(const ControlCHandler &) = delete;
   ControlCHandler(ControlCHandler &&) = delete;
   ControlCHandler &operator=(const ControlCHandler &) = delete;
   ControlCHandler &operator=(ControlCHandler &&) = delete;
   ~ControlCHandler() {
+    std::cerr << "  DESTROYING THE CONTROLC HANDLER " << this << std::endl;
     std::signal(SIGINT, d_prev_handler);
     d_gotSignal = false;
   }
   static bool getGotSignal() { return d_gotSignal; }
   static void signalHandler(int signalNumber) {
     if (signalNumber == SIGINT) {
+      std::cerr << "  GOT A SIGINT, SETTING THE FLAG " << std::endl;
       d_gotSignal = true;
       std::signal(SIGINT, d_prev_handler);
     }
   }
   static void reset() {
+    std::cerr << "  RESETTING THE CONTROLC HANDLER " << std::endl;
     d_gotSignal = false;
     std::signal(SIGINT, signalHandler);
   }

--- a/Code/RDGeneral/ControlCHandler.h
+++ b/Code/RDGeneral/ControlCHandler.h
@@ -46,29 +46,23 @@ class ControlCCaught : public std::runtime_error {
 //! released, otherwise a crash is inevitable at some future point.
 class ControlCHandler {
  public:
-  ControlCHandler() {
-    std::cerr << "  SETTING UP THE CONTROLC HANDLER " << this << std::endl;
-    d_prev_handler = std::signal(SIGINT, signalHandler);
-  }
+  ControlCHandler() { d_prev_handler = std::signal(SIGINT, signalHandler); }
   ControlCHandler(const ControlCHandler &) = delete;
   ControlCHandler(ControlCHandler &&) = delete;
   ControlCHandler &operator=(const ControlCHandler &) = delete;
   ControlCHandler &operator=(ControlCHandler &&) = delete;
   ~ControlCHandler() {
-    std::cerr << "  DESTROYING THE CONTROLC HANDLER " << this << std::endl;
     std::signal(SIGINT, d_prev_handler);
     d_gotSignal = false;
   }
   static bool getGotSignal() { return d_gotSignal; }
   static void signalHandler(int signalNumber) {
     if (signalNumber == SIGINT) {
-      std::cerr << "  GOT A SIGINT, SETTING THE FLAG " << std::endl;
       d_gotSignal = true;
       std::signal(SIGINT, d_prev_handler);
     }
   }
   static void reset() {
-    std::cerr << "  RESETTING THE CONTROLC HANDLER " << std::endl;
     d_gotSignal = false;
     std::signal(SIGINT, signalHandler);
   }

--- a/Code/RDGeneral/ControlCHandler.h
+++ b/Code/RDGeneral/ControlCHandler.h
@@ -14,13 +14,12 @@
 #include <atomic>
 #include <csignal>
 #include <stdexcept>
-#include <iostream>
 
 #include <RDGeneral/export.h>
 
 namespace RDKit {
 
-class ControlCCaught : public std::runtime_error {
+class RDKIT_RDGENERAL_EXPORT ControlCCaught : public std::runtime_error {
  public:
   explicit ControlCCaught()
       : std::runtime_error("The process was interrupted with Ctrl+c") {};

--- a/Code/RDGeneral/ControlCHandler.h
+++ b/Code/RDGeneral/ControlCHandler.h
@@ -15,11 +15,9 @@
 #include <csignal>
 #include <stdexcept>
 
-#include <RDGeneral/export.h>
-
 namespace RDKit {
 
-class RDKIT_RDGENERAL_EXPORT ControlCCaught : public std::runtime_error {
+class ControlCCaught : public std::runtime_error {
  public:
   explicit ControlCCaught()
       : std::runtime_error("The process was interrupted with Ctrl+c") {};


### PR DESCRIPTION
When we introduced the `ControlCHandler()` in #8153 we added RAII features, but then we only actually used the handler's static functions. The net result of this is that we never reset the handler to what it was originally.

This remedies that. Hopefully.

It's still unlikely to solve complex multi-threaded use cases, but it will hopefully work most of the time.