### PR TITLE
Cleanup/modernize typedefs

### DIFF
--- a/Code/Catalogs/Catalog.h
+++ b/Code/Catalogs/Catalog.h
@@ -39,8 +39,8 @@ const int endianId = 0xDEADBEEF;
 template <class entryType, class paramType>
 class Catalog {
  public:
-  typedef entryType entryType_t;
-  typedef paramType paramType_t;
+  using entryType_t = entryType;
+  using paramType_t = paramType;
 
   //------------------------------------
   Catalog() : dp_cParams(nullptr) {}
@@ -139,24 +139,18 @@ class HierarchCatalog : public Catalog<entryType, paramType> {
   //! used by the BGL to set up the node properties in our graph
   struct vertex_entry_t {
     enum { num = 1003 };
-    typedef boost::vertex_property_tag kind;
+    using kind = boost::vertex_property_tag;
   };
-  typedef boost::property<vertex_entry_t, entryType *> EntryProperty;
+  using EntryProperty = boost::property<vertex_entry_t, entryType *>;
 
   //! the type of the graph itself:
-  typedef boost::adjacency_list<
-      boost::vecS,
-      boost::vecS,  // FIX: should be using setS for edges so that parallel
-                    // edges are never added (page 225 BGL book)
-      // but that seems result in compile errors
-      boost::bidirectionalS, EntryProperty>
-      CatalogGraph;
+  using CatalogGraph = boost::adjacency_list<boost::vecS, boost::vecS, boost::bidirectionalS, EntryProperty>;
 
-  typedef boost::graph_traits<CatalogGraph> CAT_GRAPH_TRAITS;
-  typedef typename CAT_GRAPH_TRAITS::vertex_iterator VER_ITER;
-  typedef std::pair<VER_ITER, VER_ITER> ENT_ITER_PAIR;
-  typedef typename CAT_GRAPH_TRAITS::adjacency_iterator DOWN_ENT_ITER;
-  typedef std::pair<DOWN_ENT_ITER, DOWN_ENT_ITER> DOWN_ENT_ITER_PAIR;
+  using CAT_GRAPH_TRAITS = boost::graph_traits<CatalogGraph>;
+  using VER_ITER = typename CAT_GRAPH_TRAITS::vertex_iterator;
+  using ENT_ITER_PAIR = std::pair<VER_ITER, VER_ITER>;
+  using DOWN_ENT_ITER = typename CAT_GRAPH_TRAITS::adjacency_iterator;
+  using DOWN_ENT_ITER_PAIR = std::pair<DOWN_ENT_ITER, DOWN_ENT_ITER>;
 
   //------------------------------------
   HierarchCatalog() {};

--- a/Code/DataStructs/BitVect.h
+++ b/Code/DataStructs/BitVect.h
@@ -14,10 +14,10 @@
 #include <vector>
 #include <string>
 
-typedef std::vector<int> IntVect;
-typedef IntVect::iterator IntVectIter;
-typedef std::vector<double> DoubleVect;
-typedef DoubleVect::iterator DoubleVectIter;
+using IntVect = std::vector<int>;
+using IntVectIter = IntVect::iterator;
+using DoubleVect = std::vector<double>;
+using DoubleVectIter = DoubleVect::iterator;
 const int ci_BITVECT_VERSION = 0x0020;  //!< version number to use in pickles
 
 //! Abstract base class for storing BitVectors

--- a/Code/DataStructs/BitVects.h
+++ b/Code/DataStructs/BitVects.h
@@ -19,7 +19,7 @@
 #include "BitVect.h"
 #include "ExplicitBitVect.h"
 #include "SparseBitVect.h"
-typedef SparseBitVect SBV;
-typedef ExplicitBitVect EBV;
+using SBV = SparseBitVect;
+using EBV = ExplicitBitVect;
 
 #endif

--- a/Code/DataStructs/DiscreteValueVect.h
+++ b/Code/DataStructs/DiscreteValueVect.h
@@ -23,16 +23,16 @@ const unsigned int BITS_PER_INT = 32;
 //! a class for efficiently storing vectors of discrete values
 class RDKIT_DATASTRUCTS_EXPORT DiscreteValueVect {
  public:
-  typedef boost::shared_array<std::uint32_t> DATA_SPTR;
+  using DATA_SPTR = boost::shared_array<std::uint32_t>;
 
   //! used to define the possible range of the values
-  typedef enum {
+  enum DiscreteValueType {
     ONEBITVALUE = 0,
     TWOBITVALUE,
     FOURBITVALUE,
     EIGHTBITVALUE,
     SIXTEENBITVALUE,
-  } DiscreteValueType;
+  };
 
   //! initialize with a particular type and size
   DiscreteValueVect(DiscreteValueType valType, unsigned int length)

--- a/Code/DataStructs/MultiFPBReader.h
+++ b/Code/DataStructs/MultiFPBReader.h
@@ -52,7 +52,7 @@ namespace RDKit {
 */
 class RDKIT_DATASTRUCTS_EXPORT MultiFPBReader {
  public:
-  typedef std::tuple<double, unsigned int, unsigned int> ResultTuple;
+  using ResultTuple = std::tuple<double, unsigned int, unsigned int>;
   MultiFPBReader() {}
 
   /*!

--- a/Code/DataStructs/RealValueVect.cpp
+++ b/Code/DataStructs/RealValueVect.cpp
@@ -13,6 +13,9 @@
 #include <RDGeneral/StreamOps.h>
 #include "DatastructsException.h"
 
+#include <cmath>
+#include <numeric>
+
 constexpr double VAL_TOL = 0.01;
 
 namespace RDKit {

--- a/Code/DataStructs/SparseBitVect.h
+++ b/Code/DataStructs/SparseBitVect.h
@@ -19,9 +19,9 @@ using std::set;
 #include <algorithm>
 #include <limits>
 
-typedef set<int> IntSet;
-typedef IntSet::iterator IntSetIter;
-typedef IntSet::const_iterator IntSetConstIter;
+using IntSet = set<int>;
+using IntSetIter = IntSet::iterator;
+using IntSetConstIter = IntSet::const_iterator;
 
 //! a class for bit vectors that are sparsely occupied.
 /*!

--- a/Code/DataStructs/SparseIntVect.h
+++ b/Code/DataStructs/SparseIntVect.h
@@ -27,7 +27,7 @@ namespace RDKit {
 template <typename IndexType>
 class SparseIntVect {
  public:
-  typedef std::map<IndexType, int> StorageType;
+  using StorageType = std::map<IndexType, int>;
 
   SparseIntVect() : d_length(0) {}
 

--- a/Code/Demos/RDKit/Basement/TemplEnum/TemplEnum.h
+++ b/Code/Demos/RDKit/Basement/TemplEnum/TemplEnum.h
@@ -25,7 +25,7 @@ class EnumException : public std::exception {
 void orientSidechain(RWMol *mol, RWMol *sidechain, int molAttachIdx,
                      int sidechainAttachIdx);
 
-typedef std::vector<RWMOL_SPTR_VECT> VECT_RWMOL_SPTR_VECT;
+using VECT_RWMOL_SPTR_VECT = std::vector<RWMOL_SPTR_VECT>;
 void markAttachmentPoints(RWMOL_SPTR *mol, char frontMarker = 'X');
 void markAttachmentPoints(RWMol *mol, char frontMarker = 'X');
 void prepareSidechains(RWMOL_SPTR_VECT *sidechains, char frontMarker = 'Y');

--- a/Code/Demos/boost/EBV_err/classC.h
+++ b/Code/Demos/boost/EBV_err/classC.h
@@ -1,4 +1,3 @@
-#include <map>
 #include <iostream>
 #include <string>
 #include <vector>
@@ -15,8 +14,8 @@
                                  // 'const float'
 #endif
 
-typedef std::pair<std::string, int> STR_INT;
-typedef std::vector<STR_INT> PAIR_VECT;
+using STR_INT = std::pair<std::string, int>;
+using PAIR_VECT = std::vector<STR_INT>;
 
 class classC {
  public:

--- a/Code/Demos/boost/cross_mod_err/classC.h
+++ b/Code/Demos/boost/cross_mod_err/classC.h
@@ -1,4 +1,3 @@
-#include <map>
 #include <iostream>
 #include <string>
 #include <vector>
@@ -15,8 +14,8 @@
                                  // 'const float'
 #endif
 
-typedef std::pair<std::string, int> STR_INT;
-typedef std::vector<STR_INT> PAIR_VECT;
+using STR_INT = std::pair<std::string, int>;
+using PAIR_VECT = std::vector<STR_INT>;
 
 class classC {
  public:

--- a/Code/Demos/boost/smartPtrsAndIters/module.cpp
+++ b/Code/Demos/boost/smartPtrsAndIters/module.cpp
@@ -20,9 +20,9 @@ class DemoKlass {
  private:
   int val_;
 };
-typedef boost::shared_ptr<DemoKlass> DemoKlassSPtr;
-typedef std::vector<DemoKlass *> DemoKlassPtrVect;
-typedef std::vector<DemoKlassSPtr> DemoKlassSPtrVect;
+using DemoKlassSPtr = boost::shared_ptr<DemoKlass>;
+using DemoKlassPtrVect = std::vector<DemoKlass *>;
+using DemoKlassSPtrVect = std::vector<DemoKlassSPtr>;
 
 DemoKlass *buildPtr(int v) { return new DemoKlass(v); }
 DemoKlassSPtr buildSPtr(int v) { return DemoKlassSPtr(new DemoKlass(v)); }
@@ -45,8 +45,8 @@ DemoKlassSPtrVect buildSPtrVector(unsigned int sz) {
 
 class DemoContainer {
  public:
-  typedef DemoKlassSPtrVect::iterator iterator;
-  typedef DemoKlassSPtrVect::const_iterator const_iterator;
+  using iterator = DemoKlassSPtrVect::iterator;
+  using const_iterator = DemoKlassSPtrVect::const_iterator;
   explicit DemoContainer(unsigned int sz) { vect_ = buildSPtrVector(sz); }
   iterator begin() { return vect_.begin(); }
   iterator end() { return vect_.end(); }

--- a/Code/DistGeom/BoundsMatrix.h
+++ b/Code/DistGeom/BoundsMatrix.h
@@ -13,7 +13,6 @@
 
 #include <RDGeneral/Invariant.h>
 #include <boost/smart_ptr.hpp>
-#include <iomanip>
 #include <Numerics/SquareMatrix.h>
 
 namespace DistGeom {
@@ -26,7 +25,7 @@ namespace DistGeom {
 class RDKIT_DISTGEOMETRY_EXPORT BoundsMatrix
     : public RDNumeric::SquareMatrix<double> {
  public:
-  typedef boost::shared_array<double> DATA_SPTR;
+  using DATA_SPTR = boost::shared_array<double>;
 
   explicit BoundsMatrix(unsigned int N)
       : RDNumeric::SquareMatrix<double>(N, 0.0) {}
@@ -104,7 +103,7 @@ class RDKIT_DISTGEOMETRY_EXPORT BoundsMatrix
   }
 };
 
-typedef boost::shared_ptr<BoundsMatrix> BoundsMatPtr;
+using BoundsMatPtr = boost::shared_ptr<BoundsMatrix>;
 }  // namespace DistGeom
 
 #endif

--- a/Code/DistGeom/ChiralSet.h
+++ b/Code/DistGeom/ChiralSet.h
@@ -59,8 +59,8 @@ class RDKIT_DISTGEOMETRY_EXPORT ChiralSet {
   inline double getLowerVolumeBound() const { return d_volumeLowerBound; }
 };
 
-typedef boost::shared_ptr<ChiralSet> ChiralSetPtr;
-typedef std::vector<ChiralSetPtr> VECT_CHIRALSET;
+using ChiralSetPtr = boost::shared_ptr<ChiralSet>;
+using VECT_CHIRALSET = std::vector<ChiralSetPtr>;
 }  // namespace DistGeom
 
 #endif

--- a/Code/Features/testFeatures.cpp
+++ b/Code/Features/testFeatures.cpp
@@ -18,12 +18,12 @@ using namespace RDKit;
 using namespace RDGeom;
 using namespace RDFeatures;
 
-typedef enum {
+enum TypeMarker {
   fooType,
   barType,
   bazType,
   grnType,
-} TypeMarker;
+};
 
 TEST_CASE("Basics for ExplicitFeatures") {
   ExplicitFeature<TypeMarker> f1;
@@ -97,7 +97,7 @@ TEST_CASE("Basics for ImplicitFeatures") {
 }
 
 TEST_CASE("ExplicitFeatures 2D, string type.") {
-  typedef ExplicitFeature<std::string, std::string, Point2D> LocalFeature;
+  using LocalFeature = ExplicitFeature<std::string, std::string, Point2D>;
   LocalFeature f1;
   f1.setType("foo");
   REQUIRE(f1.getType() == "foo");

--- a/Code/ForceField/ForceField.h
+++ b/Code/ForceField/ForceField.h
@@ -40,9 +40,9 @@ computeDihedral(const RDGeom::Point3D *p1, const RDGeom::Point3D *p2,
 
 namespace ForceFields {
 class ForceFieldContrib;
-typedef std::vector<int> INT_VECT;
-typedef boost::shared_ptr<const ForceFieldContrib> ContribPtr;
-typedef std::vector<ContribPtr> ContribPtrVect;
+using INT_VECT = std::vector<int>;
+using ContribPtr = boost::shared_ptr<const ForceFieldContrib>;
+using ContribPtrVect = std::vector<ContribPtr>;
 
 //-------------------------------------------------------
 //! A class to store forcefields and handle minimization

--- a/Code/ForceField/MMFF/Nonbonded.h
+++ b/Code/ForceField/MMFF/Nonbonded.h
@@ -34,7 +34,7 @@ class RDKIT_FORCEFIELD_EXPORT NonbondedContrib : public ForceFieldContrib {
   }
 
  private:
-  enum ContribType {
+  enum ContribType : unsigned int {
     VDW = 1 << 0,           //!< van der Waals contribution
     ELECTROSTATIC = 1 << 1  //!< electrostatic contribution
   };

--- a/Code/ForceField/MMFF/Nonbonded.h
+++ b/Code/ForceField/MMFF/Nonbonded.h
@@ -34,7 +34,7 @@ class RDKIT_FORCEFIELD_EXPORT NonbondedContrib : public ForceFieldContrib {
   }
 
  private:
-  enum ContribType : unsigned int {
+  enum ContribType {
     VDW = 1 << 0,           //!< van der Waals contribution
     ELECTROSTATIC = 1 << 1  //!< electrostatic contribution
   };

--- a/Code/ForceField/MMFF/Params.cpp
+++ b/Code/ForceField/MMFF/Params.cpp
@@ -21,7 +21,7 @@
 #include <boost/tokenizer.hpp>
 #include <Geometry/point.h>
 
-typedef boost::tokenizer<boost::char_separator<char>> tokenizer;
+using tokenizer = boost::tokenizer<boost::char_separator<char>>;
 
 namespace ForceFields {
 namespace MMFF {

--- a/Code/ForceField/MMFF/Params.h
+++ b/Code/ForceField/MMFF/Params.h
@@ -12,7 +12,6 @@
 #ifndef RD_MMFFPARAMS_H
 #define RD_MMFFPARAMS_H
 
-#include <memory>
 #include <RDGeneral/Invariant.h>
 #include <cmath>
 #include <string>

--- a/Code/ForceField/UFF/Params.cpp
+++ b/Code/ForceField/UFF/Params.cpp
@@ -19,7 +19,7 @@
 #include <boost/tokenizer.hpp>
 #include <Geometry/point.h>
 
-typedef boost::tokenizer<boost::char_separator<char>> tokenizer;
+using tokenizer = boost::tokenizer<boost::char_separator<char>>;
 
 #include <RDGeneral/BoostStartInclude.h>
 #include <boost/flyweight.hpp>
@@ -32,10 +32,9 @@ namespace UFF {
 
 extern const std::string defaultParamData;
 
-typedef boost::flyweight<
-    boost::flyweights::key_value<std::string, ParamCollection>,
-    boost::flyweights::no_tracking>
-    param_flyweight;
+using param_flyweight =
+    boost::flyweight<boost::flyweights::key_value<std::string, ParamCollection>,
+                     boost::flyweights::no_tracking>;
 
 const ParamCollection *ParamCollection::getParams(
     const std::string &paramData) {

--- a/Code/Geometry/Transform.h
+++ b/Code/Geometry/Transform.h
@@ -13,7 +13,11 @@
 
 namespace RDGeom {
 
-typedef enum { X_Axis, Y_Axis, Z_Axis } AxisType;
-}
+enum AxisType {
+  X_Axis,
+  Y_Axis,
+  Z_Axis
+};
+}  // namespace RDGeom
 
 #endif

--- a/Code/Geometry/point.h
+++ b/Code/Geometry/point.h
@@ -428,7 +428,7 @@ class RDKIT_RDGEOMETRYLIB_EXPORT Point2D : public Point {
 
 class RDKIT_RDGEOMETRYLIB_EXPORT PointND : public Point {
  public:
-  typedef boost::shared_ptr<RDNumeric::Vector<double>> VECT_SH_PTR;
+  using VECT_SH_PTR = boost::shared_ptr<RDNumeric::Vector<double>>;
 
   PointND(unsigned int dim) {
     RDNumeric::Vector<double> *nvec = new RDNumeric::Vector<double>(dim, 0.0);
@@ -534,28 +534,28 @@ class RDKIT_RDGEOMETRYLIB_EXPORT PointND : public Point {
 #endif
 #endif
 
-typedef std::vector<RDGeom::Point *> PointPtrVect;
-typedef PointPtrVect::iterator PointPtrVect_I;
-typedef PointPtrVect::const_iterator PointPtrVect_CI;
+using PointPtrVect = std::vector<RDGeom::Point *>;
+using PointPtrVect_I = PointPtrVect::iterator;
+using PointPtrVect_CI = PointPtrVect::const_iterator;
 
-typedef std::vector<RDGeom::Point3D *> Point3DPtrVect;
-typedef std::vector<RDGeom::Point2D *> Point2DPtrVect;
-typedef Point3DPtrVect::iterator Point3DPtrVect_I;
-typedef Point3DPtrVect::const_iterator Point3DPtrVect_CI;
-typedef Point2DPtrVect::iterator Point2DPtrVect_I;
-typedef Point2DPtrVect::const_iterator Point2DPtrVect_CI;
+using Point3DPtrVect = std::vector<RDGeom::Point3D *>;
+using Point2DPtrVect = std::vector<RDGeom::Point2D *>;
+using Point3DPtrVect_I = Point3DPtrVect::iterator;
+using Point3DPtrVect_CI = Point3DPtrVect::const_iterator;
+using Point2DPtrVect_I = Point2DPtrVect::iterator;
+using Point2DPtrVect_CI = Point2DPtrVect::const_iterator;
 
-typedef std::vector<const RDGeom::Point3D *> Point3DConstPtrVect;
-typedef Point3DConstPtrVect::iterator Point3DConstPtrVect_I;
-typedef Point3DConstPtrVect::const_iterator Point3DConstPtrVect_CI;
+using Point3DConstPtrVect = std::vector<const RDGeom::Point3D *>;
+using Point3DConstPtrVect_I = Point3DConstPtrVect::iterator;
+using Point3DConstPtrVect_CI = Point3DConstPtrVect::const_iterator;
 
-typedef std::vector<Point3D> POINT3D_VECT;
-typedef std::vector<Point3D>::iterator POINT3D_VECT_I;
-typedef std::vector<Point3D>::const_iterator POINT3D_VECT_CI;
+using POINT3D_VECT = std::vector<Point3D>;
+using POINT3D_VECT_I = std::vector<Point3D>::iterator;
+using POINT3D_VECT_CI = std::vector<Point3D>::const_iterator;
 
-typedef std::map<int, Point2D> INT_POINT2D_MAP;
-typedef INT_POINT2D_MAP::iterator INT_POINT2D_MAP_I;
-typedef INT_POINT2D_MAP::const_iterator INT_POINT2D_MAP_CI;
+using INT_POINT2D_MAP = std::map<int, Point2D>;
+using INT_POINT2D_MAP_I = INT_POINT2D_MAP::iterator;
+using INT_POINT2D_MAP_CI = INT_POINT2D_MAP::const_iterator;
 
 RDKIT_RDGEOMETRYLIB_EXPORT std::ostream &operator<<(std::ostream &target,
                                                     const RDGeom::Point &pt);

--- a/Code/GraphMol/AdjustQuery.cpp
+++ b/Code/GraphMol/AdjustQuery.cpp
@@ -35,7 +35,7 @@ bool isMapped(const Atom *atom) {
 namespace MolOps {
 
 namespace {
-typedef boost::tokenizer<boost::char_separator<char>> tokenizer;
+using tokenizer = boost::tokenizer<boost::char_separator<char>>;
 
 unsigned int parseWhichString(const std::string &txt) {
   unsigned int res = MolOps::ADJUST_IGNORENONE;

--- a/Code/GraphMol/Aromaticity.cpp
+++ b/Code/GraphMol/Aromaticity.cpp
@@ -114,17 +114,17 @@ void makeRingNeighborMap(const VECT_INT_VECT &brings,
 namespace {
 using namespace RDKit;
 
-typedef enum {
+enum ElectronDonorType {
   VacantElectronDonorType,
   OneElectronDonorType,
   TwoElectronDonorType,
   OneOrTwoElectronDonorType,
   AnyElectronDonorType,
   NoElectronDonorType
-} ElectronDonorType;  // used in setting aromaticity
-typedef std::vector<ElectronDonorType> VECT_EDON_TYPE;
-typedef VECT_EDON_TYPE::iterator VECT_EDON_TYPE_I;
-typedef VECT_EDON_TYPE::const_iterator VECT_EDON_TYPE_CI;
+};  // used in setting aromaticity
+using VECT_EDON_TYPE = std::vector<ElectronDonorType>;
+using VECT_EDON_TYPE_I = VECT_EDON_TYPE::iterator;
+using VECT_EDON_TYPE_CI = VECT_EDON_TYPE::const_iterator;
 
 /******************************************************************************
  * SUMMARY:

--- a/Code/GraphMol/Atom.h
+++ b/Code/GraphMol/Atom.h
@@ -86,10 +86,10 @@ class RDKIT_GRAPHMOL_EXPORT Atom : public RDProps {
       std::numeric_limits<unsigned int>::max();
 
   // FIX: grn...
-  typedef Queries::Query<int, Atom const *, true> QUERYATOM_QUERY;
+  using QUERYATOM_QUERY = Queries::Query<int, const Atom *, true>;
 
   //! store hybridization
-  typedef enum {
+  enum HybridizationType {
     UNSPECIFIED = 0,  //!< hybridization that hasn't been specified
     S,
     SP,
@@ -99,10 +99,10 @@ class RDKIT_GRAPHMOL_EXPORT Atom : public RDProps {
     SP3D,
     SP3D2,
     OTHER  //!< unrecognized hybridization
-  } HybridizationType;
+  };
 
   //! store type of chirality
-  typedef enum {
+  enum ChiralType {
     CHI_UNSPECIFIED = 0,  //!< chirality that hasn't been specified
     CHI_TETRAHEDRAL_CW,   //!< tetrahedral: clockwise rotation (SMILES \@\@)
     CHI_TETRAHEDRAL_CCW,  //!< tetrahedral: counter-clockwise rotation (SMILES
@@ -113,7 +113,7 @@ class RDKIT_GRAPHMOL_EXPORT Atom : public RDProps {
     CHI_SQUAREPLANAR,     //!< square planar, use permutation flag
     CHI_TRIGONALBIPYRAMIDAL,  //!< trigonal bipyramidal, use permutation flag
     CHI_OCTAHEDRAL            //!< octahedral, use permutation flag
-  } ChiralType;
+  };
 
   enum class ValenceType : std::uint8_t {
     IMPLICIT = 0,

--- a/Code/GraphMol/AtomIterators.h
+++ b/Code/GraphMol/AtomIterators.h
@@ -30,7 +30,7 @@ class QueryAtom;
 template <class Atom_, class Mol_>
 class RDKIT_GRAPHMOL_EXPORT AtomIterator_ {
  public:
-  typedef AtomIterator_<Atom_, Mol_> ThisType;
+  using ThisType = AtomIterator_<Atom_, Mol_>;
   AtomIterator_() : _mol(nullptr) {}
   AtomIterator_(Mol_ *mol);
   AtomIterator_(Mol_ *mol, int pos);
@@ -73,7 +73,7 @@ class RDKIT_GRAPHMOL_EXPORT AtomIterator_ {
 template <class Atom_, class Mol_>
 class RDKIT_GRAPHMOL_EXPORT HeteroatomIterator_ {
  public:
-  typedef HeteroatomIterator_<Atom_, Mol_> ThisType;
+  using ThisType = HeteroatomIterator_<Atom_, Mol_>;
   HeteroatomIterator_() : _mol(nullptr) {}
   HeteroatomIterator_(Mol_ *mol);
   HeteroatomIterator_(Mol_ *mol, int pos);
@@ -110,7 +110,7 @@ class RDKIT_GRAPHMOL_EXPORT HeteroatomIterator_ {
 template <class Atom_, class Mol_>
 class RDKIT_GRAPHMOL_EXPORT AromaticAtomIterator_ {
  public:
-  typedef AromaticAtomIterator_<Atom_, Mol_> ThisType;
+  using ThisType = AromaticAtomIterator_<Atom_, Mol_>;
   AromaticAtomIterator_() : _mol(nullptr) {}
   AromaticAtomIterator_(Mol_ *mol);
   AromaticAtomIterator_(Mol_ *mol, int pos);
@@ -143,7 +143,7 @@ class RDKIT_GRAPHMOL_EXPORT AromaticAtomIterator_ {
 template <class Atom_, class Mol_>
 class RDKIT_GRAPHMOL_EXPORT QueryAtomIterator_ {
  public:
-  typedef QueryAtomIterator_<Atom_, Mol_> ThisType;
+  using ThisType = QueryAtomIterator_<Atom_, Mol_>;
   QueryAtomIterator_() : _mol(nullptr) {}
   QueryAtomIterator_(Mol_ *mol, QueryAtom const *what);
   QueryAtomIterator_(Mol_ *mol, int pos);
@@ -177,7 +177,7 @@ class RDKIT_GRAPHMOL_EXPORT QueryAtomIterator_ {
 template <class Atom_, class Mol_>
 class RDKIT_GRAPHMOL_EXPORT MatchingAtomIterator_ {
  public:
-  typedef MatchingAtomIterator_<Atom_, Mol_> ThisType;
+  using ThisType = MatchingAtomIterator_<Atom_, Mol_>;
   MatchingAtomIterator_() : _mol(nullptr), _qF(nullptr) {}
   MatchingAtomIterator_(Mol_ *mol, bool (*fn)(Atom_ *));
   MatchingAtomIterator_(Mol_ *mol, int pos);

--- a/Code/GraphMol/Bond.h
+++ b/Code/GraphMol/Bond.h
@@ -49,10 +49,10 @@ class RDKIT_GRAPHMOL_EXPORT Bond : public RDProps {
 
  public:
   // FIX: grn...
-  typedef Queries::Query<int, Bond const *, true> QUERYBOND_QUERY;
+  using QUERYBOND_QUERY = Queries::Query<int, const Bond *, true>;
 
   //! the type of Bond
-  typedef enum {
+  enum BondType {
     UNSPECIFIED = 0,
     SINGLE,
     DOUBLE,
@@ -76,10 +76,10 @@ class RDKIT_GRAPHMOL_EXPORT Bond : public RDProps {
     OTHER,
     ZERO  //!< Zero-order bond (from
     // http://pubs.acs.org/doi/abs/10.1021/ci200488k)
-  } BondType;
+  };
 
   //! the bond's direction (for chirality)
-  typedef enum {
+  enum BondDir {
     NONE = 0,    //!< no special style
     BEGINWEDGE,  //!< wedged: narrow at begin
     BEGINDASH,   //!< dashed: narrow at begin
@@ -88,10 +88,10 @@ class RDKIT_GRAPHMOL_EXPORT Bond : public RDProps {
     ENDUPRIGHT,    //!<  ditto
     EITHERDOUBLE,  //!< a "crossed" double bond
     UNKNOWN,       //!< intentionally unspecified stereochemistry
-  } BondDir;
+  };
 
   //! the nature of the bond's stereochem (for cis/trans)
-  typedef enum {     // stereochemistry of double bonds
+  enum BondStereo {     // stereochemistry of double bonds
     STEREONONE = 0,  // no special style
     STEREOANY,       // intentionally unspecified
     // -- Put any true specifications about this point so
@@ -102,7 +102,7 @@ class RDKIT_GRAPHMOL_EXPORT Bond : public RDProps {
     STEREOTRANS,     // trans double bond
     STEREOATROPCW,   //  atropisomer clockwise rotation
     STEREOATROPCCW,  //  atropisomer counter clockwise rotation
-  } BondStereo;
+  };
 
   Bond();
   //! construct with a particular BondType

--- a/Code/GraphMol/Canon.h
+++ b/Code/GraphMol/Canon.h
@@ -10,6 +10,8 @@
 #include <RDGeneral/export.h>
 #ifndef RD_CANON_H
 #define RD_CANON_H
+#include <vector>
+#include <boost/dynamic_bitset.hpp>
 
 namespace RDKit {
 class ROMol;
@@ -22,26 +24,26 @@ constexpr int MAX_CYCLES = 1024;  //!< used in the canonical traversal code
 constexpr int MAX_BONDTYPE = 32;  //!< used in the canonical traversal code
 
 //! used in traversals of the molecule
-typedef enum {
+enum AtomColors {
   WHITE_NODE = 0,  //!< not visited
   GREY_NODE,       //!< visited, but not finished
   BLACK_NODE,      //!< visited and finished
-} AtomColors;
+};
 
 //! used to indicate types of entries in the molecular stack:
-typedef enum {
+enum MolStackTypes {
   MOL_STACK_ATOM = 0,      //!< an Atom
   MOL_STACK_BOND,          //!< a Bond
   MOL_STACK_RING,          //!< a ring closure
   MOL_STACK_BRANCH_OPEN,   //!< beginning of a branch
   MOL_STACK_BRANCH_CLOSE,  //!< end of a branch
-} MolStackTypes;
+};
 
 //! used to store components in the molecular stack
-typedef union {
+union MolStackUnion {
   Atom *atom;
   Bond *bond;
-} MolStackUnion;
+};
 
 //! these are the actual elements in the molecular stack
 class RDKIT_GRAPHMOL_EXPORT MolStackElem {
@@ -87,10 +89,10 @@ class RDKIT_GRAPHMOL_EXPORT MolStackElem {
   int number =
       -1;  //!< stores our number (relevant for bonds and ring closures)
 };
-typedef std::vector<MolStackElem> MolStack;
+using MolStack = std::vector<MolStackElem>;
 
 //! used to represent possible branches from an atom
-typedef std::tuple<int, int, Bond *> PossibleType;
+using PossibleType = std::tuple<int, int, Bond *>;
 
 //! constructs the canonical traversal order for a molecular fragment
 /*!

--- a/Code/GraphMol/ChemReactions/Enumerate/EnumerateTypes.h
+++ b/Code/GraphMol/ChemReactions/Enumerate/EnumerateTypes.h
@@ -39,7 +39,7 @@ namespace RDKit {
 namespace EnumerationTypes {
 //! BBS - Helper typedef for holding building blocks for reactions
 //!   holds vectors of reagents for each reactant in a Reaction
-typedef std::vector<MOL_SPTR_VECT> BBS;
+using BBS = std::vector<MOL_SPTR_VECT>;
 
 //! RGROUPS Helper typedef for indexing into the BBS vector
 //!  - The indices into the BBS molecule list to create a product
@@ -53,7 +53,7 @@ typedef std::vector<MOL_SPTR_VECT> BBS;
 //!   building_blocks.push_back( BBS[0][groups[0] );
 //!   building_blocks.push_back( BBS[1][groups[1] );
 //!    rxn.runReactants( building_blocks );
-typedef std::vector<boost::uint64_t> RGROUPS;
+using RGROUPS = std::vector<boost::uint64_t>;
 }  // namespace EnumerationTypes
 }  // namespace RDKit
 #endif

--- a/Code/GraphMol/ChemReactions/ReactionPickler.h
+++ b/Code/GraphMol/ChemReactions/ReactionPickler.h
@@ -47,7 +47,7 @@ class RDKIT_CHEMREACTIONS_EXPORT ReactionPickler {
   //! the pickle format is tagged using these tags:
   //! NOTE: if you add to this list, be sure to put new entries AT THE BOTTOM,
   //! otherwise you will break old pickles.
-  typedef enum {
+  enum Tags {
     VERSION = 10000,
     BEGINREACTANTS,
     ENDREACTANTS,
@@ -60,7 +60,7 @@ class RDKIT_CHEMREACTIONS_EXPORT ReactionPickler {
     ENDPROPS,
     BEGINSSSPARAMS,
     ENDSSSPARAMS
-  } Tags;
+  };
 
   //! pickles a reaction and sends the results to stream \c ss
   static void pickleReaction(const ChemicalReaction *rxn, std::ostream &ss,

--- a/Code/GraphMol/ChemReactions/ReactionRunner.cpp
+++ b/Code/GraphMol/ChemReactions/ReactionRunner.cpp
@@ -48,8 +48,8 @@
 #include <GraphMol/QueryBond.h>
 
 namespace RDKit {
-typedef std::vector<MatchVectType> VectMatchVectType;
-typedef std::vector<VectMatchVectType> VectVectMatchVectType;
+using VectMatchVectType = std::vector<MatchVectType>;
+using VectVectMatchVectType = std::vector<VectMatchVectType>;
 
 namespace {
 const std::string WAS_DUMMY =

--- a/Code/GraphMol/ChemReactions/SanitizeRxn.h
+++ b/Code/GraphMol/ChemReactions/SanitizeRxn.h
@@ -112,7 +112,7 @@ inline const MolOps::AdjustQueryParameters MatchOnlyAtRgroupsAdjustParams() {
   return params;
 }
 
-enum SanitizeRxnFlags : unsigned int {
+enum SanitizeRxnFlags {
   SANITIZE_NONE = 0x0,
   SANITIZE_RGROUP_NAMES = 0x1,
   SANITIZE_ATOM_MAPS = 0x2,

--- a/Code/GraphMol/ChemReactions/SanitizeRxn.h
+++ b/Code/GraphMol/ChemReactions/SanitizeRxn.h
@@ -112,7 +112,7 @@ inline const MolOps::AdjustQueryParameters MatchOnlyAtRgroupsAdjustParams() {
   return params;
 }
 
-typedef enum {
+enum SanitizeRxnFlags : unsigned int {
   SANITIZE_NONE = 0x0,
   SANITIZE_RGROUP_NAMES = 0x1,
   SANITIZE_ATOM_MAPS = 0x2,
@@ -120,7 +120,7 @@ typedef enum {
   SANITIZE_MERGEHS = 0x8,
   SANITIZE_ADJUST_PRODUCTS = 0x10,
   SANITIZE_ALL = 0xFFFFFFFF
-} SanitizeRxnFlags;
+};
 
 //! \brief carries out a collection of tasks for cleaning up a reaction and
 /// ensuring

--- a/Code/GraphMol/ChemReactions/Wrap/rdChemReactions.cpp
+++ b/Code/GraphMol/ChemReactions/Wrap/rdChemReactions.cpp
@@ -475,7 +475,7 @@ python::object PreprocessReaction(ChemicalReaction &reaction,
                             python::tuple(reactantLabels));
 }
 
-typedef boost::uint64_t sanitize_ops;
+using sanitize_ops = boost::uint64_t;
 
 RxnOps::SanitizeRxnFlags sanitizeReaction(
     ChemicalReaction &rxn, sanitize_ops sanitizeOps,

--- a/Code/GraphMol/ChemTransforms/ChemTransforms.h
+++ b/Code/GraphMol/ChemTransforms/ChemTransforms.h
@@ -20,7 +20,7 @@
 
 namespace RDKit {
 class ROMol;
-typedef boost::shared_ptr<ROMol> ROMOL_SPTR;
+using ROMOL_SPTR = boost::shared_ptr<ROMol>;
 
 //! \brief Returns a copy of an ROMol with the atoms and bonds that
 //!      match a pattern removed.

--- a/Code/GraphMol/Chirality.cpp
+++ b/Code/GraphMol/Chirality.cpp
@@ -949,13 +949,13 @@ void setStereoForBond(ROMol &mol, Bond *bond, Bond::BondStereo stereo,
 }
 }  // namespace detail
 
-typedef std::pair<int, int> INT_PAIR;
-typedef std::vector<INT_PAIR> INT_PAIR_VECT;
-typedef std::vector<INT_PAIR>::iterator INT_PAIR_VECT_I;
-typedef std::vector<INT_PAIR>::const_iterator INT_PAIR_VECT_CI;
+using INT_PAIR = std::pair<int, int>;
+using INT_PAIR_VECT = std::vector<INT_PAIR>;
+using INT_PAIR_VECT_I = std::vector<INT_PAIR>::iterator;
+using INT_PAIR_VECT_CI = std::vector<INT_PAIR>::const_iterator;
 
-typedef INT_VECT CIP_ENTRY;
-typedef std::vector<CIP_ENTRY> CIP_ENTRY_VECT;
+using CIP_ENTRY = INT_VECT;
+using CIP_ENTRY_VECT = std::vector<CIP_ENTRY>;
 
 template <typename T>
 void debugVect(const std::vector<T> arg) {

--- a/Code/GraphMol/Conformer.h
+++ b/Code/GraphMol/Conformer.h
@@ -157,7 +157,7 @@ class RDKIT_GRAPHMOL_EXPORT Conformer : public RDProps {
   RDGeom::POINT3D_VECT d_positions;  // positions of the atoms
 };
 
-typedef boost::shared_ptr<Conformer> CONFORMER_SPTR;
+using CONFORMER_SPTR = boost::shared_ptr<Conformer>;
 
 //! Returns true if any of the z coords are non zero, false otherwise
 /*!

--- a/Code/GraphMol/Depictor/DepictUtils.h
+++ b/Code/GraphMol/Depictor/DepictUtils.h
@@ -32,20 +32,20 @@ RDKIT_DEPICTOR_EXPORT extern unsigned int MAX_COLL_ITERS;
 RDKIT_DEPICTOR_EXPORT extern double HETEROATOM_COLL_SCALE;
 RDKIT_DEPICTOR_EXPORT extern unsigned int NUM_BONDS_FLIPS;
 
-typedef std::vector<const RDGeom::Point2D *> VECT_C_POINT;
+using VECT_C_POINT = std::vector<const RDGeom::Point2D *>;
 
-typedef std::pair<int, int> PAIR_I_I;
-typedef std::vector<PAIR_I_I> VECT_PII;
+using PAIR_I_I = std::pair<int, int>;
+using VECT_PII = std::vector<PAIR_I_I>;
 struct RDKIT_DEPICTOR_EXPORT gtIIPair {
   bool operator()(const PAIR_I_I &pd1, const PAIR_I_I &pd2) const {
     return pd1.first > pd2.first;
   }
 };
 
-typedef std::priority_queue<PAIR_I_I, VECT_PII, gtIIPair> PR_QUEUE;
+using PR_QUEUE = std::priority_queue<PAIR_I_I, VECT_PII, gtIIPair>;
 
-typedef std::pair<double, PAIR_I_I> PAIR_D_I_I;
-typedef std::list<PAIR_D_I_I> LIST_PAIR_DII;
+using PAIR_D_I_I = std::pair<double, PAIR_I_I>;
+using LIST_PAIR_DII = std::list<PAIR_D_I_I>;
 
 //! Some utility functions used in generating 2D coordinates
 
@@ -173,11 +173,11 @@ RDKIT_DEPICTOR_EXPORT RDKit::INT_VECT findNextRingToEmbed(
     const RDKit::INT_VECT &doneRings, const RDKit::VECT_INT_VECT &fusedRings,
     int &nextId);
 
-typedef std::pair<int, int> INT_PAIR;
-typedef std::vector<INT_PAIR> INT_PAIR_VECT;
-typedef INT_PAIR_VECT::const_iterator INT_PAIR_VECT_CI;
+using INT_PAIR = std::pair<int, int>;
+using INT_PAIR_VECT = std::vector<INT_PAIR>;
+using INT_PAIR_VECT_CI = INT_PAIR_VECT::const_iterator;
 
-typedef std::pair<double, INT_PAIR> DOUBLE_INT_PAIR;
+using DOUBLE_INT_PAIR = std::pair<double, INT_PAIR>;
 
 //! Sort a list of atoms by their  CIP rank
 /*!

--- a/Code/GraphMol/Depictor/EmbeddedFrag.h
+++ b/Code/GraphMol/Depictor/EmbeddedFrag.h
@@ -24,16 +24,16 @@ class Bond;
 }  // namespace RDKit
 
 namespace RDDepict {
-typedef boost::shared_array<double> DOUBLE_SMART_PTR;
+using DOUBLE_SMART_PTR = boost::shared_array<double>;
 
 //! Class that contains the data for an atoms that has already been embedded
 class RDKIT_DEPICTOR_EXPORT EmbeddedAtom {
  public:
-  typedef enum {
+  enum EAtomType {
     UNSPECIFIED = 0,
     CISTRANS,
     RING
-  } EAtomType;
+  };
 
   EmbeddedAtom() { neighs.clear(); }
 
@@ -134,9 +134,9 @@ class RDKIT_DEPICTOR_EXPORT EmbeddedAtom {
   bool df_fixed{false};
 };
 
-typedef std::map<unsigned int, EmbeddedAtom> INT_EATOM_MAP;
-typedef INT_EATOM_MAP::iterator INT_EATOM_MAP_I;
-typedef INT_EATOM_MAP::const_iterator INT_EATOM_MAP_CI;
+using INT_EATOM_MAP = std::map<unsigned int, EmbeddedAtom>;
+using INT_EATOM_MAP_I = INT_EATOM_MAP::iterator;
+using INT_EATOM_MAP_CI = INT_EATOM_MAP::const_iterator;
 
 //! Class containing a fragment of a molecule that has already been embedded
 /*

--- a/Code/GraphMol/Depictor/RDDepictor.h
+++ b/Code/GraphMol/Depictor/RDDepictor.h
@@ -26,7 +26,7 @@ namespace RDDepict {
 RDKIT_DEPICTOR_EXPORT extern bool
     preferCoordGen;  // Ignored if coordgen support isn't active
 
-typedef boost::shared_array<double> DOUBLE_SMART_PTR;
+using DOUBLE_SMART_PTR = boost::shared_array<double>;
 
 class RDKIT_DEPICTOR_EXPORT DepictException : public std::exception {
  public:

--- a/Code/GraphMol/Depictor/testDepictor.cpp
+++ b/Code/GraphMol/Depictor/testDepictor.cpp
@@ -32,7 +32,7 @@
 #include <cmath>
 
 #include <boost/tokenizer.hpp>
-typedef boost::tokenizer<boost::char_separator<char>> tokenizer;
+using tokenizer = boost::tokenizer<boost::char_separator<char>>;
 
 using namespace RDKit;
 

--- a/Code/GraphMol/Descriptors/Crippen.cpp
+++ b/Code/GraphMol/Descriptors/Crippen.cpp
@@ -19,7 +19,7 @@
 #include <boost/lexical_cast.hpp>
 #include <boost/dynamic_bitset.hpp>
 #include <boost/tokenizer.hpp>
-typedef boost::tokenizer<boost::char_separator<char>> tokenizer;
+using tokenizer = boost::tokenizer<boost::char_separator<char>>;
 
 #include <RDGeneral/BoostStartInclude.h>
 #include <boost/flyweight.hpp>
@@ -131,10 +131,9 @@ double calcMR(const ROMol &mol) {
   return mr;
 }
 
-typedef boost::flyweight<
+using param_flyweight = boost::flyweight<
     boost::flyweights::key_value<std::string, CrippenParamCollection>,
-    boost::flyweights::no_tracking>
-    param_flyweight;
+    boost::flyweights::no_tracking>;
 
 const CrippenParamCollection *CrippenParamCollection::getParams(
     const std::string &paramData) {

--- a/Code/GraphMol/Descriptors/Crippen.h
+++ b/Code/GraphMol/Descriptors/Crippen.h
@@ -120,7 +120,7 @@ RDKIT_DESCRIPTORS_EXPORT double calcMR(const ROMol &mol);
 */
 class RDKIT_DESCRIPTORS_EXPORT CrippenParamCollection {
  public:
-  typedef std::vector<CrippenParams> ParamsVect;
+  using ParamsVect = std::vector<CrippenParams>;
   static const CrippenParamCollection *getParams(
       const std::string &paramData = "");
   ParamsVect::const_iterator begin() const { return d_params.begin(); }

--- a/Code/GraphMol/Descriptors/Lipinski.cpp
+++ b/Code/GraphMol/Descriptors/Lipinski.cpp
@@ -53,16 +53,16 @@ class ss_matcher {
   ~ss_matcher() { delete m_matcher; };
 
  private:
-  ss_matcher() : m_pattern("") {};
+  ss_matcher() : m_pattern(""){};
   std::string m_pattern;
   bool m_needCopies{false};
   const RDKit::ROMol *m_matcher{nullptr};
 };
 }  // namespace
 
-typedef boost::flyweight<boost::flyweights::key_value<std::string, ss_matcher>,
-                         boost::flyweights::no_tracking>
-    pattern_flyweight;
+using pattern_flyweight =
+    boost::flyweight<boost::flyweights::key_value<std::string, ss_matcher>,
+                     boost::flyweights::no_tracking>;
 #define SMARTSCOUNTFUNC(nm, pattern, vers)         \
   const std::string nm##Version = vers;            \
   unsigned int calc##nm(const RDKit::ROMol &mol) { \

--- a/Code/GraphMol/Descriptors/Property.h
+++ b/Code/GraphMol/Descriptors/Property.h
@@ -92,24 +92,24 @@ class RDKIT_DESCRIPTORS_EXPORT Properties {
   static std::vector<boost::shared_ptr<PropertyFunctor>> registry;
 };
 
-typedef Queries::Query<bool, const ROMol &, true> PROP_BOOL_QUERY;
-typedef Queries::AndQuery<int, const ROMol &, true> PROP_AND_QUERY;
-typedef Queries::OrQuery<int, const ROMol &, true> PROP_OR_QUERY;
-typedef Queries::XOrQuery<int, const ROMol &, true> PROP_XOR_QUERY;
+using PROP_BOOL_QUERY = Queries::Query<bool, const ROMol &, true>;
+using PROP_AND_QUERY = Queries::AndQuery<int, const ROMol &, true>;
+using PROP_OR_QUERY = Queries::OrQuery<int, const ROMol &, true>;
+using PROP_XOR_QUERY = Queries::XOrQuery<int, const ROMol &, true>;
 
-typedef Queries::EqualityQuery<double, const ROMol &, true> PROP_EQUALS_QUERY;
+using PROP_EQUALS_QUERY = Queries::EqualityQuery<double, const ROMol &, true>;
 
-typedef Queries::GreaterQuery<double, const ROMol &, true> PROP_GREATER_QUERY;
+using PROP_GREATER_QUERY = Queries::GreaterQuery<double, const ROMol &, true>;
 
-typedef Queries::GreaterEqualQuery<double, const ROMol &, true>
-    PROP_GREATEREQUAL_QUERY;
+using PROP_GREATEREQUAL_QUERY =
+    Queries::GreaterEqualQuery<double, const ROMol &, true>;
 
-typedef Queries::LessQuery<double, const ROMol &, true> PROP_LESS_QUERY;
+using PROP_LESS_QUERY = Queries::LessQuery<double, const ROMol &, true>;
 
-typedef Queries::LessEqualQuery<double, const ROMol &, true>
-    PROP_LESSEQUAL_QUERY;
+using PROP_LESSEQUAL_QUERY =
+    Queries::LessEqualQuery<double, const ROMol &, true>;
 
-typedef Queries::RangeQuery<double, const ROMol &, true> PROP_RANGE_QUERY;
+using PROP_RANGE_QUERY = Queries::RangeQuery<double, const ROMol &, true>;
 
 template <class T>
 T *makePropertyQuery(const std::string &name, double what) {

--- a/Code/GraphMol/Descriptors/USRDescriptor.cpp
+++ b/Code/GraphMol/Descriptors/USRDescriptor.cpp
@@ -122,9 +122,8 @@ void calcMoments(const std::vector<double> &dist,
       } else {
         moments[2] = -1. * pow(-1. * moments[2], 1. / 3.);
       }
-
-      moments[2] =
-          std::cbrt(moments[2] / (moments[1] * moments[1] * moments[1]));
+#else
+      moments[2] = cbrt(moments[2] / (moments[1] * moments[1] * moments[1]));
 #endif
     }
   }

--- a/Code/GraphMol/Descriptors/USRDescriptor.cpp
+++ b/Code/GraphMol/Descriptors/USRDescriptor.cpp
@@ -122,8 +122,9 @@ void calcMoments(const std::vector<double> &dist,
       } else {
         moments[2] = -1. * pow(-1. * moments[2], 1. / 3.);
       }
-#else
-      moments[2] = cbrt(moments[2] / (moments[1] * moments[1] * moments[1]));
+
+      moments[2] =
+          std::cbrt(moments[2] / (moments[1] * moments[1] * moments[1]));
 #endif
     }
   }
@@ -133,7 +134,7 @@ void calcMoments(const std::vector<double> &dist,
 
 class ss_matcher {
  public:
-  ss_matcher() {};
+  ss_matcher(){};
   ss_matcher(const std::string &pattern) {
     RDKit::RWMol *p = RDKit::SmartsToMol(pattern);
     TEST_ASSERT(p);
@@ -155,9 +156,9 @@ $([N&v3;H1,H2]-[!$(*=[O,N,P,S])]),$([N;v3;H0]),$([n,o,s;+0]),F]",  // acceptor
     "[N!H0v3,N!H0+v4,OH+0,SH+0,nH+0]"                              // donor
 };
 std::vector<std::string> featureSmarts(smartsPatterns, smartsPatterns + 4);
-typedef boost::flyweight<boost::flyweights::key_value<std::string, ss_matcher>,
-                         boost::flyweights::no_tracking>
-    pattern_flyweight;
+using pattern_flyweight =
+    boost::flyweight<boost::flyweights::key_value<std::string, ss_matcher>,
+                     boost::flyweights::no_tracking>;
 
 void getAtomIdsForFeatures(const ROMol &mol,
                            std::vector<std::vector<unsigned int>> &atomIds) {

--- a/Code/GraphMol/DetermineBonds/DetermineBonds.cpp
+++ b/Code/GraphMol/DetermineBonds/DetermineBonds.cpp
@@ -28,8 +28,8 @@
 #include <GraphMol/FileParsers/ProximityBonds.h>
 #include <RDGeneral/ControlCHandler.h>
 
-typedef boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS>
-    Graph;
+using Graph =
+    boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS>;
 using boost::multiprecision::uint1024_t;
 
 namespace {
@@ -94,11 +94,10 @@ std::vector<unsigned int> possibleValences(
 }
 
 LazyCartesianProduct<unsigned int> getValenceCombinations(
-    const RDKit::RWMol &mol,
-    size_t iterations = 100) {
+    const RDKit::RWMol &mol, size_t iterations = 100) {
   auto numAtoms = mol.getNumAtoms();
   const std::unordered_map<int, std::vector<unsigned int>> atomicValence = {
-      {1, {1}},  {5, {3, 4}}, {6, {4}},     {7, {3, 4}},     {8, {2, 1, 3}},
+      {1, {1}},  {5, {3, 4}}, {6, {4}},     {7, {3, 4}},        {8, {2, 1, 3}},
       {9, {1}},  {14, {4}},   {15, {5, 3}}, {16, {6, 3, 2, 1}}, {17, {1}},
       {32, {4}}, {35, {1}},   {53, {1}}};
 
@@ -131,7 +130,8 @@ LazyCartesianProduct<unsigned int> getValenceCombinations(
         auto *neighbor = bond->getOtherAtom(atom);
         auto neighIdx = neighbor->getIdx();
         auto neighDegree = neighbor->getDegree();
-        auto maxPos = *std::max_element(curPossible[neighIdx].begin(), curPossible[neighIdx].end());
+        auto maxPos = *std::max_element(curPossible[neighIdx].begin(),
+                                        curPossible[neighIdx].end());
         availBonds += maxPos - neighDegree;
       }
 
@@ -144,9 +144,9 @@ LazyCartesianProduct<unsigned int> getValenceCombinations(
 
       if (newPossible[i].empty()) {
         std::stringstream ss;
-        ss << "Unable to determine valence of atom " << i << " with atomic number "
-           << atom->getAtomicNum() << " and " << atom->getDegree()
-           << " bonds. Check the input molecules bonding.";
+        ss << "Unable to determine valence of atom " << i
+           << " with atomic number " << atom->getAtomicNum() << " and "
+           << atom->getDegree() << " bonds. Check the input molecules bonding.";
         throw ValueErrorException(ss.str());
       }
     }
@@ -156,7 +156,7 @@ LazyCartesianProduct<unsigned int> getValenceCombinations(
     } else {
       curPossible = newPossible;
       std::for_each(newPossible.begin(), newPossible.end(),
-                [](auto& x) { x.clear(); });
+                    [](auto &x) { x.clear(); });
     }
 
     if (--iterations == 0) {

--- a/Code/GraphMol/DistGeomHelpers/BoundsMatrixBuilder.cpp
+++ b/Code/GraphMol/DistGeomHelpers/BoundsMatrixBuilder.cpp
@@ -40,14 +40,14 @@ static const double minMacrocycleRingSize = 9;
 namespace RDKit {
 namespace DGeomHelpers {
 // forward declarations:
-typedef boost::shared_ptr<RDNumeric::IntSymmMatrix> SymmIntMatPtr;
-typedef boost::shared_ptr<RDNumeric::DoubleSymmMatrix> SymmDoubleMatPtr;
+using SymmIntMatPtr = boost::shared_ptr<RDNumeric::IntSymmMatrix>;
+using SymmDoubleMatPtr = boost::shared_ptr<RDNumeric::DoubleSymmMatrix>;
 
-typedef boost::dynamic_bitset<> BIT_SET;
+using BIT_SET = boost::dynamic_bitset<>;
 
 //! Bunch of functions to set distance bound based on topology
 
-typedef std::vector<long int> LINT_VECT;
+using LINT_VECT = std::vector<long>;
 
 enum class TorsionType {
   CIS = 0,
@@ -84,15 +84,15 @@ struct Optional14Info {
   std::size_t ringSize = 0;
 };
 
-typedef enum {
+enum DistType {
   DIST12,
   DIST13,
   DIST14
-} DistType;
+};
 
-typedef std::vector<Path14Configuration> PATH14_VECT;
-typedef PATH14_VECT::iterator PATH14_VECT_I;
-typedef PATH14_VECT::const_iterator PATH14_VECT_CI;
+using PATH14_VECT = std::vector<Path14Configuration>;
+using PATH14_VECT_I = PATH14_VECT::iterator;
+using PATH14_VECT_CI = PATH14_VECT::const_iterator;
 
 class ComputedData {
  public:
@@ -869,14 +869,9 @@ bool _checkAmideEster14(const Bond *bnd1, const Bond *bnd3, const Atom *,
   //           << " " << a4Num << " " << bnd1->getBondType() << " " << a2Num
   //           << " "
   //           << atm2->getTotalNumHs(true) << std::endl;
-  if (a3Num == 6 && bnd3->getBondType() == Bond::DOUBLE &&
+  return (a3Num == 6 && bnd3->getBondType() == Bond::DOUBLE &&
       (a4Num == 8 || a4Num == 7) && bnd1->getBondType() == Bond::SINGLE &&
-      (a2Num == 8 || (a2Num == 7 && atm2->getTotalNumHs(true) == 1))) {
-    // std::cerr << " yes!" << std::endl;
-    return true;
-  }
-  // std::cerr << " no!" << std::endl;
-  return false;
+      (a2Num == 8 || (a2Num == 7 && atm2->getTotalNumHs(true) == 1)));
 }
 
 // checking for amide/ester when all three bonds are

--- a/Code/GraphMol/FMCS/Composition2N.h
+++ b/Code/GraphMol/FMCS/Composition2N.h
@@ -11,7 +11,7 @@
 #pragma once
 namespace RDKit {
 namespace FMCS {
-typedef unsigned long long BitSet;
+using BitSet = unsigned long long;
 class Composition2N {  // generator of 2^N-1 possible bit combinations
   BitSet Bits, InverseBits;
   BitSet MaxValue, ValueMask;  // need for inverse bitset must be 2^N-1

--- a/Code/GraphMol/FMCS/DuplicatedSeedCache.h
+++ b/Code/GraphMol/FMCS/DuplicatedSeedCache.h
@@ -11,14 +11,14 @@
 #pragma once
 #include <map>
 #include <vector>
-#include <stdexcept>
 #include <algorithm>
+#include <cstring>
 
 namespace RDKit {
 namespace FMCS {
 class DuplicatedSeedCache {
  public:
-  typedef bool TValue;
+  using TValue = bool;
   class TKey {
     std::vector<unsigned int> AtomIdx;  // sorted
     std::vector<unsigned int> BondIdx;  // sorted

--- a/Code/GraphMol/FMCS/FMCS.h
+++ b/Code/GraphMol/FMCS/FMCS.h
@@ -11,7 +11,6 @@
 #pragma once
 #include <vector>
 #include <string>
-#include <stdexcept>
 #include "../RDKitBase.h"
 #include "Graph.h"
 
@@ -19,24 +18,24 @@ namespace RDKit {
 
 struct MCSParameters;
 
-typedef enum {
+enum AtomComparator {
   AtomCompareAny,
   AtomCompareElements,
   AtomCompareIsotopes,
   AtomCompareAnyHeavyAtom
-} AtomComparator;
+};
 
-typedef enum {
+enum BondComparator {
   BondCompareAny,
   BondCompareOrder,
   BondCompareOrderExact
-} BondComparator;
+};
 
-typedef enum {
+enum RingComparator {
   IgnoreRingFusion,
   PermissiveRingFusion,
   StrictRingFusion
-} RingComparator;
+};
 
 struct RDKIT_FMCS_EXPORT MCSAtomCompareParameters {
   bool MatchValences = false;
@@ -56,21 +55,21 @@ struct RDKIT_FMCS_EXPORT MCSBondCompareParameters {
   bool MatchStereo = false;
 };
 
-typedef bool (*MCSAtomCompareFunction)(const MCSAtomCompareParameters &,
-                                       const ROMol &, unsigned int,
-                                       const ROMol &, unsigned int, void *);
-typedef bool (*MCSBondCompareFunction)(const MCSBondCompareParameters &,
-                                       const ROMol &, unsigned int,
-                                       const ROMol &, unsigned int, void *);
-typedef bool (*MCSAcceptanceFunction)(const ROMol &, const ROMol &,
-                                      const std::vector<std::pair<int, int>> &,
-                                      const std::vector<std::pair<int, int>> &,
-                                      const MCSParameters *);
-typedef bool (*MCSFinalMatchCheckFunction)(const std::uint32_t[],
-                                           const std::uint32_t[], const ROMol &,
-                                           const FMCS::Graph &, const ROMol &,
-                                           const FMCS::Graph &,
-                                           const MCSParameters *);
+using MCSAtomCompareFunction = bool (*)(const MCSAtomCompareParameters &,
+                                        const ROMol &, unsigned int,
+                                        const ROMol &, unsigned int, void *);
+using MCSBondCompareFunction = bool (*)(const MCSBondCompareParameters &,
+                                        const ROMol &, unsigned int,
+                                        const ROMol &, unsigned int, void *);
+using MCSAcceptanceFunction = bool (*)(const ROMol &, const ROMol &,
+                                       const std::vector<std::pair<int, int>> &,
+                                       const std::vector<std::pair<int, int>> &,
+                                       const MCSParameters *);
+using MCSFinalMatchCheckFunction = bool (*)(const std::uint32_t *,
+                                            const std::uint32_t *,
+                                            const ROMol &, const FMCS::Graph &,
+                                            const ROMol &, const FMCS::Graph &,
+                                            const MCSParameters *);
 
 // Some predefined functors:
 RDKIT_FMCS_EXPORT bool checkAtomRingMatch(const MCSAtomCompareParameters &p,
@@ -137,9 +136,8 @@ struct RDKIT_FMCS_EXPORT MCSProgressData {
   MCSProgressData() {}
 };
 
-typedef bool (*MCSProgressCallback)(const MCSProgressData &stat,
-                                    const MCSParameters &params,
-                                    void *userData);
+using MCSProgressCallback = bool (*)(const MCSProgressData &,
+                                     const MCSParameters &, void *);
 RDKIT_FMCS_EXPORT bool MCSProgressCallbackTimeout(const MCSProgressData &stat,
                                                   const MCSParameters &params,
                                                   void *userData);

--- a/Code/GraphMol/FMCS/Graph.h
+++ b/Code/GraphMol/FMCS/Graph.h
@@ -17,16 +17,14 @@
 
 namespace RDKit {
 namespace FMCS {
-typedef unsigned int AtomIdx_t;
-typedef unsigned int BondIdx_t;
-typedef boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS,
-                              AtomIdx_t, BondIdx_t>
-    Graph_t;
+using AtomIdx_t = unsigned int;
+using BondIdx_t = unsigned int;
+using Graph_t = boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS, AtomIdx_t, BondIdx_t>;
 
 class RDKIT_FMCS_EXPORT Graph : public Graph_t {
  public:
-  typedef edge_iterator EDGE_ITER;
-  typedef std::pair<EDGE_ITER, EDGE_ITER> BOND_ITER_PAIR;
+  using EDGE_ITER = edge_iterator;
+  using BOND_ITER_PAIR = std::pair<EDGE_ITER, EDGE_ITER>;
 
   void addAtom(unsigned int atom) {
     Graph::vertex_descriptor which = boost::add_vertex(*this);

--- a/Code/GraphMol/FMCS/MatchTable.h
+++ b/Code/GraphMol/FMCS/MatchTable.h
@@ -10,7 +10,6 @@
 #include <RDGeneral/export.h>
 #pragma once
 #include <vector>
-#include <stdexcept>
 
 namespace RDKit {
 namespace FMCS {
@@ -45,6 +44,6 @@ class RDKIT_FMCS_EXPORT
   inline T at(size_t row, size_t col) const { return Data[row * XSize + col]; }
 };
 
-typedef TArray2D<bool> MatchTable;  // row is index in QueryMolecule
+using MatchTable = TArray2D<bool>;  // row is index in QueryMolecule
 }  // namespace FMCS
 }  // namespace RDKit

--- a/Code/GraphMol/FMCS/SubstructMatchCustom.h
+++ b/Code/GraphMol/FMCS/SubstructMatchCustom.h
@@ -17,9 +17,7 @@
 
 namespace RDKit {
 namespace FMCS {
-typedef std::vector<
-    std::pair<FMCS::Graph::vertex_descriptor, FMCS::Graph::vertex_descriptor>>
-    match_V_t;
+using match_V_t = std::vector<std::pair<FMCS::Graph::vertex_descriptor, FMCS::Graph::vertex_descriptor>>;
 const unsigned int NotSet = std::numeric_limits<unsigned int>::max();
 
 RDKIT_FMCS_EXPORT bool SubstructMatchCustomTable(

--- a/Code/GraphMol/FileParsers/FileParsers.h
+++ b/Code/GraphMol/FileParsers/FileParsers.h
@@ -16,8 +16,6 @@
 #include <GraphMol/FileParsers/FileWriters.h>
 #include "CDXMLParser.h"
 #include <string>
-#include <string_view>
-#include <vector>
 #include <exception>
 
 #include <boost/shared_ptr.hpp>
@@ -260,9 +258,9 @@ namespace FileParsers {
 //  MOL2 handling
 //-----
 
-typedef enum {
+enum Mol2Type {
   CORINA = 0  //!< supports output from Corina and some dbtranslate output
-} Mol2Type;
+};
 
 struct Mol2ParserParams {
   bool sanitize = true; /**< sanitize the molecule after building it */

--- a/Code/GraphMol/FileParsers/Mol2FileParser.cpp
+++ b/Code/GraphMol/FileParsers/Mol2FileParser.cpp
@@ -78,7 +78,7 @@ void readFormalChargesFromAttr(std::istream *inStream, RWMol *res) {
   PRECONDITION(inStream, "inStream not valid");
   PRECONDITION(!inStream->eof(), "inStream is at eof");
   PRECONDITION(res, "RWMol not valid");
-  typedef boost::tokenizer<boost::char_separator<char>> tokenizer;
+  using tokenizer = boost::tokenizer<boost::char_separator<char>>;
   boost::char_separator<char> sep(" \t\n");
   bool readNextAtomAttribs = true;
   unsigned int atomIdx = 0, noAtomAttr = 0;
@@ -524,7 +524,7 @@ bool cleanUpMol2Substructures(RWMol *res) {
 }
 
 Atom *ParseMol2FileAtomLine(const std::string atomLine, RDGeom::Point3D &pos) {
-  typedef boost::tokenizer<boost::char_separator<char>> tokenizer;
+  using tokenizer = boost::tokenizer<boost::char_separator<char>>;
   boost::char_separator<char> sep(" \t\n");
   std::string tAN, tAT;
   tokenizer tokens(atomLine, sep);
@@ -645,7 +645,7 @@ Bond *ParseMol2FileBondLine(const std::string bondLine,
                             const INT_VECT &idxCorresp) {
   unsigned int idx1, idx2;
 
-  typedef boost::tokenizer<boost::char_separator<char>> tokenizer;
+  using tokenizer = boost::tokenizer<boost::char_separator<char>>;
   boost::char_separator<char> sep(" \t\n");
 
   tokenizer tokens(bondLine, sep);
@@ -818,7 +818,7 @@ namespace FileParsers {
 std::unique_ptr<RWMol> MolFromMol2DataStream(std::istream &inStream,
                                              const Mol2ParserParams &params) {
   std::string tempStr, lineBeg;
-  typedef boost::tokenizer<boost::char_separator<char>> tokenizer;
+  using tokenizer = boost::tokenizer<boost::char_separator<char>>;
   boost::char_separator<char> sep(" \t\n");
   Utils::LocaleSwitcher ls;
 

--- a/Code/GraphMol/FileParsers/MolSGroupParsing.h
+++ b/Code/GraphMol/FileParsers/MolSGroupParsing.h
@@ -17,8 +17,8 @@
 namespace RDKit {
 
 namespace SGroupParsing {
-typedef std::map<int, SubstanceGroup> IDX_TO_SGROUP_MAP;
-typedef std::map<int, STR_VECT> IDX_TO_STR_VECT_MAP;
+using IDX_TO_SGROUP_MAP = std::map<int, SubstanceGroup>;
+using IDX_TO_STR_VECT_MAP = std::map<int, STR_VECT>;
 
 /* ------------------ V2000 Utils  ------------------ */
 

--- a/Code/GraphMol/FileParsers/MolSGroupWriting.h
+++ b/Code/GraphMol/FileParsers/MolSGroupWriting.h
@@ -18,7 +18,7 @@
 
 namespace RDKit {
 namespace SGroupWriting {
-typedef std::unordered_map<int, SubstanceGroup> IDX_TO_SGROUP_MAP;
+using IDX_TO_SGROUP_MAP = std::unordered_map<int, SubstanceGroup>;
 
 /* ------------------ Inlined Formatters ------------------ */
 

--- a/Code/GraphMol/FileParsers/MultithreadedMolSupplier.h
+++ b/Code/GraphMol/FileParsers/MultithreadedMolSupplier.h
@@ -26,7 +26,7 @@
 #include "FileParsers.h"
 #include "MolSupplier.h"
 
-typedef boost::tokenizer<boost::char_separator<char>> tokenizer;
+using tokenizer = boost::tokenizer<boost::char_separator<char>>;
 
 namespace RDKit {
 namespace v2 {

--- a/Code/GraphMol/FileParsers/SmilesMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/SmilesMolSupplier.cpp
@@ -14,9 +14,8 @@
 #include "MolSupplier.h"
 #include "FileParsers.h"
 #include <boost/tokenizer.hpp>
-typedef boost::tokenizer<boost::char_separator<char>> tokenizer;
+using tokenizer = boost::tokenizer<boost::char_separator<char>>;
 
-#include <fstream>
 #include <sstream>
 #include <string>
 #include <cstdlib>

--- a/Code/GraphMol/FileParsers/TDTMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/TDTMolSupplier.cpp
@@ -21,13 +21,12 @@
 #include <GraphMol/SmilesParse/SmilesParse.h>
 #include <RDGeneral/LocaleSwitcher.h>
 
-#include <fstream>
 #include <sstream>
 #include <string>
 
 namespace RDKit {
 namespace TDTParseUtils {
-typedef boost::tokenizer<boost::escaped_list_separator<char>> CommaTokenizer;
+using CommaTokenizer = boost::tokenizer<boost::escaped_list_separator<char>>;
 
 /*
  * if inStream is valid, we'll allow the numbers to be broken across multiple

--- a/Code/GraphMol/FilterCatalog/FilterCatalog.h
+++ b/Code/GraphMol/FilterCatalog/FilterCatalog.h
@@ -118,15 +118,15 @@ class RDKIT_FILTERCATALOG_EXPORT FilterCatalogParams
 #endif
 };
 
-typedef RDCatalog::Catalog<FilterCatalogEntry, FilterCatalogParams> FCatalog;
+using FCatalog = RDCatalog::Catalog<FilterCatalogEntry, FilterCatalogParams>;
 class RDKIT_FILTERCATALOG_EXPORT FilterCatalog : public FCatalog {
  public:
   // syntactic sugar for getMatch(es) return values.
-  typedef boost::shared_ptr<FilterCatalogEntry> SENTRY;
+  using SENTRY = boost::shared_ptr<FilterCatalogEntry>;
 
   // If boost::python can support shared_ptr of const objects
   //  we can enable support for this feature
-  typedef boost::shared_ptr<const entryType_t> CONST_SENTRY;
+  using CONST_SENTRY = boost::shared_ptr<const entryType_t>;
 
   FilterCatalog() : FCatalog(), d_entries() {}
 

--- a/Code/GraphMol/FilterCatalog/FilterCatalogEntry.h
+++ b/Code/GraphMol/FilterCatalog/FilterCatalogEntry.h
@@ -52,7 +52,7 @@
 #include "FilterMatchers.h"
 
 namespace RDKit {
-typedef std::map<std::string, std::string> STRING_PROPS;
+using STRING_PROPS = std::map<std::string, std::string>;
 
 class RDKIT_FILTERCATALOG_EXPORT FilterCatalogEntry
     : public RDCatalog::CatalogEntry {

--- a/Code/GraphMol/Fingerprints/FingerprintGenerator.cpp
+++ b/Code/GraphMol/Fingerprints/FingerprintGenerator.cpp
@@ -375,12 +375,12 @@ FingerprintGenerator<OutputType>::getFingerprintHelper(
   // result in an RNG that's much too computationally intensive
   // to seed.
   // These are the parameters that have been used for the RDKit fingerprint.
-  typedef boost::random::mersenne_twister<std::uint32_t, 32, 4, 2, 31,
-                                          0x9908b0df, 11, 7, 0x9d2c5680, 15,
-                                          0xefc60000, 18, 3346425566U>
-      rng_type;
-  typedef boost::uniform_int<> distrib_type;
-  typedef boost::variate_generator<rng_type &, distrib_type> source_type;
+  using rng_type =
+      boost::random::mersenne_twister<std::uint32_t, 32, 4, 2, 31, 0x9908b0df,
+                                      11, 7, 0x9d2c5680, 15, 0xefc60000, 18,
+                                      3346425566U>;
+  using distrib_type = boost::uniform_int<>;
+  using source_type = boost::variate_generator<rng_type &, distrib_type>;
   std::unique_ptr<rng_type> generator;
   //
   // if we generate arbitrarily sized ints then mod them down to the

--- a/Code/GraphMol/Fingerprints/FingerprintUtil.cpp
+++ b/Code/GraphMol/Fingerprints/FingerprintUtil.cpp
@@ -192,22 +192,22 @@ $([N;H0&+0]([C;!$(C(=O))])([C;!$(C(=O))])[C;!$(C(=O))])]",  // Basic
 
 const RDKit::ROMol *ss_matcher::getMatcher() const { return m_matcher.get(); }
 
-ss_matcher::ss_matcher() {};
+ss_matcher::ss_matcher(){};
 ss_matcher::ss_matcher(const std::string &pattern) {
   RDKit::RWMol *p = RDKit::SmartsToMol(pattern);
   TEST_ASSERT(p);
   m_matcher.reset(p);
 };
 
-typedef boost::flyweight<boost::flyweights::key_value<std::string, ss_matcher>,
-                         boost::flyweights::no_tracking>
-    pattern_flyweight;
+using pattern_flyweight =
+    boost::flyweight<boost::flyweights::key_value<std::string, ss_matcher>,
+                     boost::flyweights::no_tracking>;
 
 std::vector<std::string> defaultFeatureSmarts(smartsPatterns,
                                               smartsPatterns + 6);
-typedef boost::flyweight<boost::flyweights::key_value<std::string, ss_matcher>,
-                         boost::flyweights::no_tracking>
-    pattern_flyweight;
+using pattern_flyweight =
+    boost::flyweight<boost::flyweights::key_value<std::string, ss_matcher>,
+                     boost::flyweights::no_tracking>;
 void getFeatureInvariants(const ROMol &mol, std::vector<uint32_t> &invars,
                           const std::vector<const ROMol *> *patterns) {
   unsigned int nAtoms = mol.getNumAtoms();

--- a/Code/GraphMol/Fingerprints/FingerprintUtil.h
+++ b/Code/GraphMol/Fingerprints/FingerprintUtil.h
@@ -96,7 +96,7 @@ class RDKIT_FINGERPRINTS_EXPORT ss_matcher {
   RDKit::ROMOL_SPTR m_matcher;
 };
 
-typedef std::tuple<boost::dynamic_bitset<>, uint32_t, unsigned int> AccumTuple;
+using AccumTuple = std::tuple<boost::dynamic_bitset<>, uint32_t, unsigned int>;
 
 RDKIT_FINGERPRINTS_EXPORT extern std::vector<std::string> defaultFeatureSmarts;
 

--- a/Code/GraphMol/Fingerprints/MorganFingerprints.h
+++ b/Code/GraphMol/Fingerprints/MorganFingerprints.h
@@ -53,9 +53,9 @@
 namespace RDKit {
 class ROMol;
 namespace MorganFingerprints {
-typedef std::map<std::uint32_t,
-                 std::vector<std::pair<std::uint32_t, std::uint32_t>>>
-    BitInfoMap;
+using BitInfoMap =
+    std::map<std::uint32_t,
+             std::vector<std::pair<std::uint32_t, std::uint32_t>>>;
 
 const std::string morganFingerprintVersion = "1.0.0";
 

--- a/Code/GraphMol/Fingerprints/PatternFingerprints.cpp
+++ b/Code/GraphMol/Fingerprints/PatternFingerprints.cpp
@@ -24,7 +24,6 @@
 #include <cstdint>
 #include <RDGeneral/hash/hash.hpp>
 #include <RDGeneral/types.h>
-#include <algorithm>
 #include <boost/dynamic_bitset.hpp>
 
 #include <RDGeneral/BoostStartInclude.h>
@@ -38,7 +37,7 @@
 namespace {
 class ss_matcher {
  public:
-  ss_matcher() {};
+  ss_matcher(){};
   ss_matcher(const std::string &pattern) {
     RDKit::RWMol *p = RDKit::SmartsToMol(pattern);
     TEST_ASSERT(p);
@@ -75,9 +74,9 @@ const char *pqs[] = {
     "[*]~[R](@[R])@[R](@[R])~[*]", "[*]~[R](@[R])@[R]@[R](@[R])~[*]",
     "[*]",  // single atom fragment
     ""};
-typedef boost::flyweight<boost::flyweights::key_value<std::string, ss_matcher>,
-                         boost::flyweights::no_tracking>
-    pattern_flyweight;
+using pattern_flyweight =
+    boost::flyweight<boost::flyweights::key_value<std::string, ss_matcher>,
+                     boost::flyweights::no_tracking>;
 
 namespace detail {
 void getAtomNumbers(const Atom *a, std::vector<int> &atomNums) {

--- a/Code/GraphMol/Fingerprints/Wrap/MHFPWrapper.cpp
+++ b/Code/GraphMol/Fingerprints/Wrap/MHFPWrapper.cpp
@@ -19,8 +19,8 @@ using RDKit::MHFPFingerprints::MHFPEncoder;
 namespace RDKit {
 namespace MHFPWrapper {
 
-typedef std::vector<std::vector<uint32_t>> VectMinHashVect;
-typedef std::vector<ExplicitBitVect> VectExplicitBitVect;
+using VectMinHashVect = std::vector<std::vector<uint32_t>>;
+using VectExplicitBitVect = std::vector<ExplicitBitVect>;
 
 template <typename T>
 std::vector<T> ListToVector(const python::object &obj) {

--- a/Code/GraphMol/ForceFieldHelpers/CrystalFF/TorsionPreferences.cpp
+++ b/Code/GraphMol/ForceFieldHelpers/CrystalFF/TorsionPreferences.cpp
@@ -22,7 +22,7 @@
 
 #include <boost/lexical_cast.hpp>
 #include <boost/tokenizer.hpp>
-typedef boost::tokenizer<boost::char_separator<char>> tokenizer;
+using tokenizer = boost::tokenizer<boost::char_separator<char>>;
 #include <boost/flyweight.hpp>
 #include <boost/flyweight/key_value.hpp>
 #include <boost/flyweight/no_tracking.hpp>
@@ -52,7 +52,7 @@ constexpr unsigned int MIN_MACROCYCLE_SIZE = 9;
 // class to store the experimental torsion angles
 class ExpTorsionAngleCollection {
  public:
-  typedef std::vector<ExpTorsionAngle> ParamsVect;
+  using ParamsVect = std::vector<ExpTorsionAngle>;
   static const ExpTorsionAngleCollection *getParams(
       unsigned int version, bool useSmallRingTorsions,
       bool useMacrocycleTorsions, const std::string &paramData = "");
@@ -64,10 +64,9 @@ class ExpTorsionAngleCollection {
   ParamsVect d_params;  //!< the parameters
 };
 
-typedef boost::flyweight<
+using param_flyweight = boost::flyweight<
     boost::flyweights::key_value<std::string, ExpTorsionAngleCollection>,
-    boost::flyweights::no_tracking>
-    param_flyweight;
+    boost::flyweights::no_tracking>;
 
 const ExpTorsionAngleCollection *ExpTorsionAngleCollection::getParams(
     unsigned int version, bool useSmallRingTorsions, bool useMacrocycleTorsions,

--- a/Code/GraphMol/ForceFieldHelpers/MMFF/AtomTyper.cpp
+++ b/Code/GraphMol/ForceFieldHelpers/MMFF/AtomTyper.cpp
@@ -119,8 +119,8 @@ class RingMembership {
 };
 
 class RingMembershipSize {
-  typedef std::map<unsigned int, RingMembership> RingMembershipMap;
-  typedef std::map<unsigned int, RingMembershipMap> RingSizeMembershipMap;
+  using RingMembershipMap = std::map<unsigned int, RingMembership>;
+  using RingSizeMembershipMap = std::map<unsigned int, RingMembershipMap>;
 
  public:
   static const std::uint32_t IS_AROMATIC_BIT;

--- a/Code/GraphMol/ForceFieldHelpers/MMFF/AtomTyper.h
+++ b/Code/GraphMol/ForceFieldHelpers/MMFF/AtomTyper.h
@@ -12,12 +12,13 @@
 #include <RDGeneral/export.h>
 #ifndef _RD_MMFFATOMTYPER_H__
 #define _RD_MMFFATOMTYPER_H__
-
+#include <RDGeneral/types.h>
 #include <vector>
 #include <string>
 #include <ForceField/MMFF/Params.h>
 #include <cstdint>
-
+#include <iostream>
+#include <boost/shared_ptr.hpp>
 namespace RDKit {
 class ROMol;
 class RWMol;
@@ -63,7 +64,7 @@ class RDKIT_FORCEFIELDHELPERS_EXPORT MMFFAtomProperties {
   double mmffPartialCharge{0.0};
 };
 
-typedef boost::shared_ptr<MMFFAtomProperties> MMFFAtomPropertiesPtr;
+using MMFFAtomPropertiesPtr = boost::shared_ptr<MMFFAtomProperties>;
 enum {
   CONSTANT = 1,
   DISTANCE = 2

--- a/Code/GraphMol/ForceFieldHelpers/UFF/AtomTyper.h
+++ b/Code/GraphMol/ForceFieldHelpers/UFF/AtomTyper.h
@@ -25,7 +25,7 @@ class ROMol;
 class Atom;
 
 namespace UFF {
-typedef std::vector<const ForceFields::UFF::AtomicParams *> AtomicParamVect;
+using AtomicParamVect = std::vector<const ForceFields::UFF::AtomicParams *>;
 
 RDKIT_FORCEFIELDHELPERS_EXPORT std::pair<AtomicParamVect, bool> getAtomTypes(
     const ROMol &mol, const std::string &paramData = "");

--- a/Code/GraphMol/ForceFieldHelpers/UFF/Builder.h
+++ b/Code/GraphMol/ForceFieldHelpers/UFF/Builder.h
@@ -30,7 +30,7 @@ class AtomicParams;
 namespace RDKit {
 class ROMol;
 namespace UFF {
-typedef std::vector<const ForceFields::UFF::AtomicParams *> AtomicParamVect;
+using AtomicParamVect = std::vector<const ForceFields::UFF::AtomicParams *>;
 
 //! Builds and returns a UFF force field for a molecule
 /*!

--- a/Code/GraphMol/FragCatalog/FragCatGenerator.h
+++ b/Code/GraphMol/FragCatalog/FragCatGenerator.h
@@ -19,8 +19,7 @@
 namespace RDKit {
 class ROMol;
 
-typedef RDCatalog::HierarchCatalog<FragCatalogEntry, FragCatParams, int>
-    FragCatalog;
+using FragCatalog = RDCatalog::HierarchCatalog<FragCatalogEntry, FragCatParams, int>;
 
 class RDKIT_FRAGCATALOG_EXPORT FragCatGenerator {
  public:

--- a/Code/GraphMol/FragCatalog/FragCatParams.h
+++ b/Code/GraphMol/FragCatalog/FragCatParams.h
@@ -18,7 +18,7 @@
 
 namespace RDKit {
 class ROMol;
-typedef std::vector<boost::shared_ptr<ROMol>> MOL_SPTR_VECT;
+using MOL_SPTR_VECT = std::vector<boost::shared_ptr<ROMol>>;
 
 //! container for user parameters used to create a fragment catalog
 class RDKIT_FRAGCATALOG_EXPORT FragCatParams : public RDCatalog::CatalogParams {

--- a/Code/GraphMol/FragCatalog/FragCatalogUtils.cpp
+++ b/Code/GraphMol/FragCatalog/FragCatalogUtils.cpp
@@ -18,7 +18,7 @@
 #include <string>
 #include <GraphMol/SmilesParse/SmilesParse.h>
 #include <boost/tokenizer.hpp>
-typedef boost::tokenizer<boost::char_separator<char>> tokenizer;
+using tokenizer = boost::tokenizer<boost::char_separator<char>>;
 #include <boost/algorithm/string.hpp>
 
 namespace RDKit {

--- a/Code/GraphMol/FragCatalog/FragFPGenerator.h
+++ b/Code/GraphMol/FragCatalog/FragFPGenerator.h
@@ -19,9 +19,9 @@
 class ExplicitBitVect;
 namespace RDKit {
 class ROMol;
-typedef RDCatalog::HierarchCatalog<FragCatalogEntry, FragCatParams, int>
-    FragCatalog;
-typedef std::vector<std::pair<int, int>> MatchVectType;
+using FragCatalog =
+    RDCatalog::HierarchCatalog<FragCatalogEntry, FragCatParams, int>;
+using MatchVectType = std::vector<std::pair<int, int>>;
 
 class RDKIT_FRAGCATALOG_EXPORT FragFPGenerator {
  public:

--- a/Code/GraphMol/MMPA/MMPA.cpp
+++ b/Code/GraphMol/MMPA/MMPA.cpp
@@ -25,8 +25,8 @@
 namespace RDKit {
 namespace MMPA {
 
-typedef std::vector<std::pair<unsigned, unsigned>>
-    BondVector_t;  // pair of BeginAtomIdx, EndAtomIdx
+using BondVector_t = std::vector<
+    std::pair<unsigned int, unsigned int>>;  // pair of BeginAtomIdx, EndAtomIdx
 
 namespace detail {
 unsigned long long computeMorganCodeHash(const ROMol &mol) {
@@ -397,8 +397,7 @@ static inline void appendBonds(BondVector_t &bonds,
 }
 
 static inline void processCuts(
-    size_t i, size_t minCuts, size_t maxCuts,
-    BondVector_t &bonds_selected,
+    size_t i, size_t minCuts, size_t maxCuts, BondVector_t &bonds_selected,
     const std::vector<BondVector_t> &matching_bonds, const ROMol &mol,
     std::vector<std::pair<ROMOL_SPTR, ROMOL_SPTR>> &res) {
   if (maxCuts < minCuts) {

--- a/Code/GraphMol/MolAlign/AlignMolecules.h
+++ b/Code/GraphMol/MolAlign/AlignMolecules.h
@@ -16,7 +16,7 @@
 #include <vector>
 
 namespace RDKit {
-typedef std::vector<std::pair<int, int>> MatchVectType;
+using MatchVectType = std::vector<std::pair<int, int>>;
 
 class Conformer;
 class ROMol;

--- a/Code/GraphMol/MolAlign/O3AAlignMolecules.cpp
+++ b/Code/GraphMol/MolAlign/O3AAlignMolecules.cpp
@@ -1648,7 +1648,7 @@ void randomTransform(ROMol &mol, const int cid, const int seed) {
 
 #ifdef RDK_BUILD_THREADSAFE_SSS
 namespace detail {
-typedef struct {
+struct O3AHelperArgs_ {
   O3A::AtomTypeScheme atomTypes;
   int refCid;
   bool reflect;
@@ -1656,7 +1656,7 @@ typedef struct {
   unsigned int options;
   MatchVectType const *constraintMap;
   RDNumeric::DoubleVector const *constraintWeights;
-} O3AHelperArgs_;
+};
 void O3AHelper_(ROMol *prbMol, const ROMol *refMol, void *prbProp,
                 void *refProp, std::vector<boost::shared_ptr<O3A>> *res,
                 unsigned int threadIdx, int numThreads,

--- a/Code/GraphMol/MolAlign/O3AAlignMolecules.h
+++ b/Code/GraphMol/MolAlign/O3AAlignMolecules.h
@@ -238,13 +238,13 @@ class RDKIT_MOLALIGN_EXPORT SDM {
   unsigned int size() { return d_SDMPtrVect.size(); }
 
  private:
-  typedef struct SDMElement {
+  struct SDMElement {
     unsigned int idx[2];
     int score;
     int cost;
     double sqDist;
     O3AConstraint *o3aConstraint;
-  } SDMElement;
+  };
   const Conformer *d_prbConf;
   const Conformer *d_refConf;
   O3AConstraintVect *d_o3aConstraintVect;
@@ -274,7 +274,7 @@ class RDKIT_MOLALIGN_EXPORT SDM {
 class RDKIT_MOLALIGN_EXPORT O3A {
  public:
   //! pre-defined atom typing schemes
-  typedef enum { MMFF94 = 0, CRIPPEN } AtomTypeScheme;
+  enum AtomTypeScheme { MMFF94 = 0, CRIPPEN };
   O3A(ROMol &prbMol, const ROMol &refMol, void *prbProp, void *refProp,
       AtomTypeScheme atomTypes = MMFF94, const int prbCid = -1,
       const int refCid = -1, const bool reflect = false,

--- a/Code/GraphMol/MolCatalog/MolCatalog.h
+++ b/Code/GraphMol/MolCatalog/MolCatalog.h
@@ -13,8 +13,8 @@
 namespace RDKit {
 
 //! a hierarchical catalog for holding molecules
-typedef RDCatalog::HierarchCatalog<MolCatalogEntry, MolCatalogParams, int>
-    MolCatalog;
+using MolCatalog =
+    RDCatalog::HierarchCatalog<MolCatalogEntry, MolCatalogParams, int>;
 }  // namespace RDKit
 
 #endif

--- a/Code/GraphMol/MolChemicalFeatures/FeatureParser.cpp
+++ b/Code/GraphMol/MolChemicalFeatures/FeatureParser.cpp
@@ -18,7 +18,7 @@
 #include <boost/algorithm/string.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/tokenizer.hpp>
-typedef boost::tokenizer<boost::char_separator<char>> tokenizer;
+using tokenizer = boost::tokenizer<boost::char_separator<char>>;
 
 #include <fstream>
 #include <sstream>
@@ -26,7 +26,7 @@ typedef boost::tokenizer<boost::char_separator<char>> tokenizer;
 
 namespace RDKit {
 namespace Local {
-typedef boost::tokenizer<boost::escaped_list_separator<char>> CommaTokenizer;
+using CommaTokenizer = boost::tokenizer<boost::escaped_list_separator<char>>;
 
 void getNextLine(std::istream &inStream, std::string &line,
                  unsigned int &lineNo) {

--- a/Code/GraphMol/MolChemicalFeatures/MolChemicalFeature.h
+++ b/Code/GraphMol/MolChemicalFeatures/MolChemicalFeature.h
@@ -28,8 +28,8 @@ class RDKIT_MOLCHEMICALFEATURES_EXPORT MolChemicalFeature
   friend class MolChemicalFeatureFactory;
 
  public:
-  typedef std::vector<const Atom *> AtomPtrContainer;
-  typedef AtomPtrContainer::const_iterator AtomPtrContainer_CI;
+  using AtomPtrContainer = std::vector<const Atom *>;
+  using AtomPtrContainer_CI = AtomPtrContainer::const_iterator;
 
   //! Constructor
   MolChemicalFeature(const ROMol *mol, const MolChemicalFeatureFactory *factory,
@@ -83,7 +83,7 @@ class RDKIT_MOLCHEMICALFEATURES_EXPORT MolChemicalFeature
   AtomPtrContainer::const_iterator endAtoms() const { return d_atoms.end(); }
 
  private:
-  typedef std::map<int, RDGeom::Point3D> PointCacheType;
+  using PointCacheType = std::map<int, RDGeom::Point3D>;
 
   const ROMol *dp_mol;
   const MolChemicalFeatureFactory *dp_factory;

--- a/Code/GraphMol/MolChemicalFeatures/MolChemicalFeatureDef.h
+++ b/Code/GraphMol/MolChemicalFeatures/MolChemicalFeatureDef.h
@@ -24,7 +24,7 @@ class MolChemicalFeatureDef;
 
 class RDKIT_MOLCHEMICALFEATURES_EXPORT MolChemicalFeatureDef {
  public:
-  typedef std::list<boost::shared_ptr<MolChemicalFeatureDef>> CollectionType;
+  using CollectionType = std::list<boost::shared_ptr<MolChemicalFeatureDef>>;
 
   MolChemicalFeatureDef() : d_family(""), d_type(""), d_smarts("") {}
   MolChemicalFeatureDef(const std::string &smarts, std::string family,

--- a/Code/GraphMol/MolChemicalFeatures/MolChemicalFeatureFactory.cpp
+++ b/Code/GraphMol/MolChemicalFeatures/MolChemicalFeatureFactory.cpp
@@ -32,7 +32,7 @@ FeatSPtrList MolChemicalFeatureFactory::getFeaturesForMol(
 #endif
   FeatSPtrList res;
   int idx = 1;
-  typedef std::vector<std::pair<std::string, std::set<int>>> MatchSetCollection;
+  using MatchSetCollection = std::vector<std::pair<std::string, std::set<int>>>;
   MatchSetCollection matchSets;
   for (auto featDefIt = beginFeatureDefs(); featDefIt != endFeatureDefs();
        featDefIt++) {

--- a/Code/GraphMol/MolChemicalFeatures/MolChemicalFeatureFactory.h
+++ b/Code/GraphMol/MolChemicalFeatures/MolChemicalFeatureFactory.h
@@ -16,9 +16,9 @@
 
 namespace RDKit {
 class MolChemicalFeature;
-typedef boost::shared_ptr<MolChemicalFeature> FeatSPtr;
-typedef std::list<FeatSPtr> FeatSPtrList;
-typedef FeatSPtrList::iterator FeatSPtrList_I;
+using FeatSPtr = boost::shared_ptr<MolChemicalFeature>;
+using FeatSPtrList = std::list<FeatSPtr>;
+using FeatSPtrList_I = FeatSPtrList::iterator;
 
 //! The class for finding chemical features in molecules
 class RDKIT_MOLCHEMICALFEATURES_EXPORT MolChemicalFeatureFactory {

--- a/Code/GraphMol/MolDraw2D/MolDraw2DHelpers.h
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DHelpers.h
@@ -65,8 +65,8 @@ struct DrawColour {
   DrawColour operator*(double v) const { return {r * v, g * v, b * v, a * v}; }
 };
 
-typedef std::map<int, DrawColour> ColourPalette;
-typedef std::vector<double> DashPattern;
+using ColourPalette = std::map<int, DrawColour>;
+using DashPattern = std::vector<double>;
 
 // This is used to convert the line width into something that SVG and
 // Cairo use.  It was picked by eye, and was formerly hidden in

--- a/Code/GraphMol/MolEnumerator/LinkNode.cpp
+++ b/Code/GraphMol/MolEnumerator/LinkNode.cpp
@@ -18,9 +18,8 @@
 #include <boost/lexical_cast.hpp>
 #include <boost/tokenizer.hpp>
 #include <boost/format.hpp>
-#include <algorithm>
 
-typedef boost::tokenizer<boost::char_separator<char>> tokenizer;
+using tokenizer = boost::tokenizer<boost::char_separator<char>>;
 
 namespace RDKit {
 namespace MolEnumerator {

--- a/Code/GraphMol/MolEnumerator/LinkNode.h
+++ b/Code/GraphMol/MolEnumerator/LinkNode.h
@@ -11,13 +11,15 @@
 #define RD_MOLENUMERATOR_LINKNODE_H
 
 #include <RDGeneral/Invariant.h>
-
-#include <map>
+#include <RDGeneral/Exceptions.h>
+#include <GraphMol/Atom.h>
+#include <GraphMol/ROMol.h>
 #include <boost/lexical_cast.hpp>
 #include <boost/tokenizer.hpp>
 #include <algorithm>
+#include <map>
 
-typedef boost::tokenizer<boost::char_separator<char>> tokenizer;
+using tokenizer = boost::tokenizer<boost::char_separator<char>>;
 
 namespace RDKit {
 namespace MolEnumerator {

--- a/Code/GraphMol/MolEnumerator/RepeatUnit.cpp
+++ b/Code/GraphMol/MolEnumerator/RepeatUnit.cpp
@@ -20,7 +20,7 @@
 #include <algorithm>
 #include <charconv>
 
-typedef boost::tokenizer<boost::char_separator<char>> tokenizer;
+using tokenizer = boost::tokenizer<boost::char_separator<char>>;
 
 namespace RDKit {
 namespace MolEnumerator {

--- a/Code/GraphMol/MolOps.h
+++ b/Code/GraphMol/MolOps.h
@@ -30,9 +30,9 @@ class RWMol;
 class Atom;
 class Bond;
 class Conformer;
-typedef std::vector<double> INVAR_VECT;
-typedef INVAR_VECT::iterator INVAR_VECT_I;
-typedef INVAR_VECT::const_iterator INVAR_VECT_CI;
+using INVAR_VECT = std::vector<double>;
+using INVAR_VECT_I = INVAR_VECT::iterator;
+using INVAR_VECT_CI = INVAR_VECT::const_iterator;
 
 //! \brief Groups a variety of molecular query and transformation operations.
 namespace MolOps {
@@ -395,7 +395,7 @@ RDKIT_GRAPHMOL_EXPORT void mergeQueryHs(RWMol &mol,
 */
 RDKIT_GRAPHMOL_EXPORT std::pair<bool, bool> hasQueryHs(const ROMol &mol);
 
-typedef enum {
+enum AdjustQueryWhichFlags {
   ADJUST_IGNORENONE = 0x0,
   ADJUST_IGNORECHAINS = 0x1,
   ADJUST_IGNORERINGS = 0x4,
@@ -403,7 +403,7 @@ typedef enum {
   ADJUST_IGNORENONDUMMIES = 0x8,
   ADJUST_IGNOREMAPPED = 0x10,
   ADJUST_IGNOREALL = 0xFFFFFFF
-} AdjustQueryWhichFlags;
+};
 
 //! Parameters controlling the behavior of MolOps::adjustQueryProperties
 /*!
@@ -613,14 +613,14 @@ does not consider the outer envelope of fused rings)
 - \c AROMATICIT_MMFF94 the aromaticity model used by the MMFF94 force field
 - \c AROMATICITY_CUSTOM uses a caller-provided function
 */
-typedef enum {
+enum AromaticityModel {
   AROMATICITY_DEFAULT = 0x0,  ///< future proofing
   AROMATICITY_RDKIT = 0x1,
   AROMATICITY_SIMPLE = 0x2,
   AROMATICITY_MDL = 0x4,
   AROMATICITY_MMFF94 = 0x8,
   AROMATICITY_CUSTOM = 0xFFFFFFF  ///< use a function
-} AromaticityModel;
+};
 
 //! sets the aromaticity model for a molecule to MMFF94
 RDKIT_GRAPHMOL_EXPORT void setMMFFAromaticity(RWMol &mol);

--- a/Code/GraphMol/MolOps.h
+++ b/Code/GraphMol/MolOps.h
@@ -395,7 +395,7 @@ RDKIT_GRAPHMOL_EXPORT void mergeQueryHs(RWMol &mol,
 */
 RDKIT_GRAPHMOL_EXPORT std::pair<bool, bool> hasQueryHs(const ROMol &mol);
 
-enum AdjustQueryWhichFlags : unsigned int {
+enum AdjustQueryWhichFlags {
   ADJUST_IGNORENONE = 0x0,
   ADJUST_IGNORECHAINS = 0x1,
   ADJUST_IGNORERINGS = 0x4,
@@ -613,7 +613,7 @@ does not consider the outer envelope of fused rings)
 - \c AROMATICIT_MMFF94 the aromaticity model used by the MMFF94 force field
 - \c AROMATICITY_CUSTOM uses a caller-provided function
 */
-enum AromaticityModel : unsigned int {
+enum AromaticityModel {
   AROMATICITY_DEFAULT = 0x0,  ///< future proofing
   AROMATICITY_RDKIT = 0x1,
   AROMATICITY_SIMPLE = 0x2,

--- a/Code/GraphMol/MolOps.h
+++ b/Code/GraphMol/MolOps.h
@@ -395,7 +395,7 @@ RDKIT_GRAPHMOL_EXPORT void mergeQueryHs(RWMol &mol,
 */
 RDKIT_GRAPHMOL_EXPORT std::pair<bool, bool> hasQueryHs(const ROMol &mol);
 
-enum AdjustQueryWhichFlags {
+enum AdjustQueryWhichFlags : unsigned int {
   ADJUST_IGNORENONE = 0x0,
   ADJUST_IGNORECHAINS = 0x1,
   ADJUST_IGNORERINGS = 0x4,
@@ -613,7 +613,7 @@ does not consider the outer envelope of fused rings)
 - \c AROMATICIT_MMFF94 the aromaticity model used by the MMFF94 force field
 - \c AROMATICITY_CUSTOM uses a caller-provided function
 */
-enum AromaticityModel {
+enum AromaticityModel : unsigned int {
   AROMATICITY_DEFAULT = 0x0,  ///< future proofing
   AROMATICITY_RDKIT = 0x1,
   AROMATICITY_SIMPLE = 0x2,

--- a/Code/GraphMol/MolPickler.h
+++ b/Code/GraphMol/MolPickler.h
@@ -23,7 +23,6 @@
 
 // Std stuff
 #include <string>
-#include <sstream>
 #include <exception>
 #ifdef WIN32
 #include <ios>
@@ -75,7 +74,7 @@ class RDKIT_GRAPHMOL_EXPORT MolPickler {
   //! NOTE: if you add to this list, be sure to put new entries AT THE BOTTOM,
   /// otherwise
   //! you will break old pickles.
-  typedef enum {
+  enum Tags {
     VERSION = 0,
     BEGINATOM,
     ATOM_INDEX,
@@ -156,7 +155,7 @@ class RDKIT_GRAPHMOL_EXPORT MolPickler {
     END_ATOM_MONOMER_INFO,
     // add new entries above here
     INVALID_TAG = 255
-  } Tags;
+  };
 
   static unsigned int getDefaultPickleProperties();
   static void setDefaultPickleProperties(unsigned int);

--- a/Code/GraphMol/MolStandardize/AcidBaseCatalog/AcidBaseCatalogUtils.cpp
+++ b/Code/GraphMol/MolStandardize/AcidBaseCatalog/AcidBaseCatalogUtils.cpp
@@ -12,7 +12,7 @@
 #include <GraphMol/SmilesParse/SmilesParse.h>
 #include <boost/algorithm/string.hpp>
 #include <boost/tokenizer.hpp>
-typedef boost::tokenizer<boost::char_separator<char>> tokenizer;
+using tokenizer = boost::tokenizer<boost::char_separator<char>>;
 #include <fstream>
 #include <string>
 

--- a/Code/GraphMol/MolStandardize/Charge.cpp
+++ b/Code/GraphMol/MolStandardize/Charge.cpp
@@ -30,17 +30,15 @@ std::vector<ChargeCorrection> CHARGE_CORRECTIONS = {
     ChargeCorrection("[Mg,Ca]", "[Mg,Ca;X0+0]", 2),
     ChargeCorrection("[Cl]", "[Cl;X0+0]", -1)};
 
-typedef boost::flyweight<
+using param_filename_flyweight = boost::flyweight<
     boost::flyweights::key_value<std::string, AcidBaseCatalogParams>,
-    boost::flyweights::no_tracking>
-    param_filename_flyweight;
+    boost::flyweights::no_tracking>;
 
-typedef boost::flyweight<
+using param_data_flyweight = boost::flyweight<
     boost::flyweights::key_value<
         std::vector<std::tuple<std::string, std::string, std::string>>,
         AcidBaseCatalogParams>,
-    boost::flyweights::no_tracking>
-    param_data_flyweight;
+    boost::flyweights::no_tracking>;
 
 // constructor
 Reionizer::Reionizer() {
@@ -248,10 +246,10 @@ void Reionizer::reionizeInPlace(RWMol &mol) {
   }  // while loop
 }
 
-std::pair<unsigned int, std::vector<unsigned int>> *
-Reionizer::strongestProtonated(
-    const ROMol &mol,
-    const std::vector<std::pair<ROMOL_SPTR, ROMOL_SPTR>> &abpairs) {
+std::pair<unsigned int, std::vector<unsigned int>>
+    *Reionizer::strongestProtonated(
+        const ROMol &mol,
+        const std::vector<std::pair<ROMOL_SPTR, ROMOL_SPTR>> &abpairs) {
   // position is the position in the acid list.
   unsigned int position = 0;
   for (const auto &abpair : abpairs) {
@@ -306,7 +304,7 @@ Uncharger::Uncharger()
           // hali(a)te, perhalate
           "$([O-][Cl,Br,I;+,+2,+3][O-]),"
           // tetrazole
-          "$([n-]1nnnc1),$([n-]1ncnn1)]")) {};
+          "$([n-]1nnnc1),$([n-]1ncnn1)]")){};
 
 namespace {
 void removeCharge(Atom *atom, int charge, int hDelta) {

--- a/Code/GraphMol/MolStandardize/Charge.h
+++ b/Code/GraphMol/MolStandardize/Charge.h
@@ -31,9 +31,8 @@ namespace MolStandardize {
 RDKIT_MOLSTANDARDIZE_EXPORT extern const CleanupParameters
     defaultCleanupParameters;
 
-typedef RDCatalog::HierarchCatalog<AcidBaseCatalogEntry, AcidBaseCatalogParams,
-                                   int>
-    AcidBaseCatalog;
+using AcidBaseCatalog = RDCatalog::HierarchCatalog<AcidBaseCatalogEntry,
+                                                   AcidBaseCatalogParams, int>;
 
 struct RDKIT_MOLSTANDARDIZE_EXPORT ChargeCorrection {
   std::string Name;

--- a/Code/GraphMol/MolStandardize/Fragment.cpp
+++ b/Code/GraphMol/MolStandardize/Fragment.cpp
@@ -11,7 +11,7 @@
 #include <GraphMol/MolStandardize/FragmentCatalog/FragmentCatalogUtils.h>
 #include <boost/tokenizer.hpp>
 #include <utility>
-typedef boost::tokenizer<boost::char_separator<char>> tokenizer;
+using tokenizer = boost::tokenizer<boost::char_separator<char>>;
 #include <GraphMol/ChemTransforms/ChemTransforms.h>
 #include <GraphMol/SmilesParse/SmilesWrite.h>
 #include <GraphMol/Substruct/SubstructMatch.h>

--- a/Code/GraphMol/MolStandardize/Fragment.h
+++ b/Code/GraphMol/MolStandardize/Fragment.h
@@ -24,9 +24,8 @@ namespace MolStandardize {
 RDKIT_MOLSTANDARDIZE_EXPORT extern const CleanupParameters
     defaultCleanupParameters;
 
-typedef RDCatalog::HierarchCatalog<FragmentCatalogEntry, FragmentCatalogParams,
-                                   int>
-    FragmentCatalog;
+using FragmentCatalog = RDCatalog::HierarchCatalog<FragmentCatalogEntry,
+                                                   FragmentCatalogParams, int>;
 
 class RDKIT_MOLSTANDARDIZE_EXPORT FragmentRemover {
  public:

--- a/Code/GraphMol/MolStandardize/FragmentCatalog/FragmentCatalogUtils.cpp
+++ b/Code/GraphMol/MolStandardize/FragmentCatalog/FragmentCatalogUtils.cpp
@@ -13,7 +13,7 @@
 #include <GraphMol/SmilesParse/SmilesParse.h>
 #include <boost/algorithm/string.hpp>
 #include <boost/tokenizer.hpp>
-typedef boost::tokenizer<boost::char_separator<char>> tokenizer;
+using tokenizer = boost::tokenizer<boost::char_separator<char>>;
 #include <fstream>
 #include <string>
 

--- a/Code/GraphMol/MolStandardize/Normalize.cpp
+++ b/Code/GraphMol/MolStandardize/Normalize.cpp
@@ -30,16 +30,15 @@ class ROMol;
 
 namespace MolStandardize {
 
-typedef boost::flyweight<
+using param_filename_flyweight = boost::flyweight<
     boost::flyweights::key_value<std::string, TransformCatalogParams>,
-    boost::flyweights::no_tracking>
-    param_filename_flyweight;
+    boost::flyweights::no_tracking>;
 
-typedef boost::flyweight<boost::flyweights::key_value<
-                             std::vector<std::pair<std::string, std::string>>,
-                             TransformCatalogParams>,
-                         boost::flyweights::no_tracking>
-    param_data_flyweight;
+using param_data_flyweight =
+    boost::flyweight<boost::flyweights::key_value<
+                         std::vector<std::pair<std::string, std::string>>,
+                         TransformCatalogParams>,
+                     boost::flyweights::no_tracking>;
 
 // unsigned int MAX_RESTARTS = 200;
 

--- a/Code/GraphMol/MolStandardize/Normalize.h
+++ b/Code/GraphMol/MolStandardize/Normalize.h
@@ -29,10 +29,10 @@ namespace MolStandardize {
 RDKIT_MOLSTANDARDIZE_EXPORT extern const CleanupParameters
     defaultCleanupParameters;
 
-typedef RDCatalog::HierarchCatalog<TransformCatalogEntry,
-                                   TransformCatalogParams, int>
-    TransformCatalog;
-typedef std::pair<std::string, ROMOL_SPTR> SmilesMolPair;
+using TransformCatalog =
+    RDCatalog::HierarchCatalog<TransformCatalogEntry, TransformCatalogParams,
+                               int>;
+using SmilesMolPair = std::pair<std::string, ROMOL_SPTR>;
 
 //! The Normalizer class for applying Normalization transforms.
 /*!

--- a/Code/GraphMol/MolStandardize/Tautomer.h
+++ b/Code/GraphMol/MolStandardize/Tautomer.h
@@ -28,9 +28,8 @@ class RWMol;
 
 namespace MolStandardize {
 
-typedef RDCatalog::HierarchCatalog<TautomerCatalogEntry, TautomerCatalogParams,
-                                   int>
-    TautomerCatalog;
+using TautomerCatalog = RDCatalog::HierarchCatalog<TautomerCatalogEntry,
+                                                   TautomerCatalogParams, int>;
 
 namespace TautomerScoringFunctions {
 const std::string tautomerScoringVersion = "1.0.0";
@@ -55,8 +54,7 @@ struct RDKIT_MOLSTANDARDIZE_EXPORT SubstructTerm {
   RWMol connectivityMatcher;
 
   SubstructTerm(std::string aname, std::string asmarts, int ascore,
-                std::vector<int> reqElements = {},
-                std::string connSmarts = "");
+                std::vector<int> reqElements = {}, std::string connSmarts = "");
   SubstructTerm(const SubstructTerm &rhs) = default;
   SubstructTerm &operator=(const SubstructTerm &rhs) = default;
 
@@ -95,8 +93,8 @@ RDKIT_MOLSTANDARDIZE_EXPORT int scoreSubstructs(
 ///      doesn't match (since tautomerization doesn't create/destroy bonds)
 /// Returns indices into the terms vector for relevant terms.
 RDKIT_MOLSTANDARDIZE_EXPORT std::vector<size_t> getRelevantSubstructTermIndices(
-    const ROMol &mol,
-    const std::vector<SubstructTerm> &terms = getDefaultTautomerScoreSubstructs());
+    const ROMol &mol, const std::vector<SubstructTerm> &terms =
+                          getDefaultTautomerScoreSubstructs());
 
 //! Score substructures using only the terms at the specified indices.
 /// Uses specialized matchers for simple patterns (C=O, N=O, P=O, methyl, etc.)
@@ -181,8 +179,8 @@ class Tautomer {
   bool d_done;
 };
 
-typedef std::map<std::string, Tautomer> SmilesTautomerMap;
-typedef std::pair<std::string, Tautomer> SmilesTautomerPair;
+using SmilesTautomerMap = std::map<std::string, Tautomer>;
+using SmilesTautomerPair = std::pair<std::string, Tautomer>;
 
 //! Contains results of tautomer enumeration
 class RDKIT_MOLSTANDARDIZE_EXPORT TautomerEnumeratorResult {
@@ -191,11 +189,11 @@ class RDKIT_MOLSTANDARDIZE_EXPORT TautomerEnumeratorResult {
  public:
   class const_iterator {
    public:
-    typedef ROMOL_SPTR value_type;
-    typedef std::ptrdiff_t difference_type;
-    typedef const ROMol *pointer;
-    typedef const ROMOL_SPTR &reference;
-    typedef std::bidirectional_iterator_tag iterator_category;
+    using value_type = ROMOL_SPTR;
+    using difference_type = std::ptrdiff_t;
+    using pointer = const ROMol *;
+    using reference = const ROMOL_SPTR &;
+    using iterator_category = std::bidirectional_iterator_tag;
 
     explicit const_iterator(const SmilesTautomerMap::const_iterator &it)
         : d_it(it) {}

--- a/Code/GraphMol/MolStandardize/TautomerCatalog/TautomerCatalogUtils.cpp
+++ b/Code/GraphMol/MolStandardize/TautomerCatalog/TautomerCatalogUtils.cpp
@@ -14,7 +14,7 @@
 #include <GraphMol/SmilesParse/SmilesWrite.h>
 #include <boost/algorithm/string.hpp>
 #include <boost/tokenizer.hpp>
-typedef boost::tokenizer<boost::char_separator<char>> tokenizer;
+using tokenizer = boost::tokenizer<boost::char_separator<char>>;
 #include <fstream>
 #include <string>
 

--- a/Code/GraphMol/MolStandardize/TransformCatalog/TransformCatalogUtils.cpp
+++ b/Code/GraphMol/MolStandardize/TransformCatalog/TransformCatalogUtils.cpp
@@ -14,7 +14,7 @@
 #include <GraphMol/ChemReactions/ReactionParser.h>
 #include <boost/algorithm/string.hpp>
 #include <boost/tokenizer.hpp>
-typedef boost::tokenizer<boost::char_separator<char>> tokenizer;
+using tokenizer = boost::tokenizer<boost::char_separator<char>>;
 #include <fstream>
 #include <string>
 

--- a/Code/GraphMol/MolStandardize/Wrap/Tautomer.cpp
+++ b/Code/GraphMol/MolStandardize/Wrap/Tautomer.cpp
@@ -14,7 +14,6 @@
 #include <GraphMol/RDKitBase.h>
 #include <GraphMol/MolStandardize/MolStandardize.h>
 #include <GraphMol/MolStandardize/Tautomer.h>
-#include <sstream>
 
 namespace python = boost::python;
 using namespace RDKit;
@@ -109,7 +108,7 @@ class PyTautomerEnumeratorCallback
   python::object d_pyCallbackObject;
 };
 
-typedef boost::shared_ptr<MolStandardize::Tautomer> TAUT_SPTR;
+using TAUT_SPTR = boost::shared_ptr<MolStandardize::Tautomer>;
 
 ROMol *getTautomerHelper(const TAUT_SPTR &self) {
   return new ROMol(*self->tautomer);

--- a/Code/GraphMol/MonomerInfo.h
+++ b/Code/GraphMol/MonomerInfo.h
@@ -25,7 +25,7 @@ namespace RDKit {
 //! The abstract base class for atom-level monomer info
 class RDKIT_GRAPHMOL_EXPORT AtomMonomerInfo {
  public:
-  typedef enum { UNKNOWN = 0, PDBRESIDUE, OTHER } AtomMonomerType;
+  enum AtomMonomerType { UNKNOWN = 0, PDBRESIDUE, OTHER };
 
   virtual ~AtomMonomerInfo() {}
 

--- a/Code/GraphMol/PartialCharges/GasteigerParams.cpp
+++ b/Code/GraphMol/PartialCharges/GasteigerParams.cpp
@@ -12,7 +12,7 @@
 #include <boost/flyweight/key_value.hpp>
 #include <boost/flyweight/no_tracking.hpp>
 #include <boost/tokenizer.hpp>
-typedef boost::tokenizer<boost::char_separator<char>> tokenizer;
+using tokenizer = boost::tokenizer<boost::char_separator<char>>;
 #include <RDGeneral/BoostEndInclude.h>
 #include "GasteigerParams.h"
 
@@ -66,10 +66,9 @@ Al      sp3     5.375   4.953   0.867 \n \
 Al      sp2     5.795   5.020   0.695 \n \
 ";
 
-typedef boost::flyweight<
-    boost::flyweights::key_value<std::string, GasteigerParams>,
-    boost::flyweights::no_tracking>
-    gparam_flyweight;
+using gparam_flyweight =
+    boost::flyweight<boost::flyweights::key_value<std::string, GasteigerParams>,
+                     boost::flyweights::no_tracking>;
 
 GasteigerParams::GasteigerParams(std::string paramData) {
   boost::char_separator<char> eolSep("\n");

--- a/Code/GraphMol/PeriodicTable.cpp
+++ b/Code/GraphMol/PeriodicTable.cpp
@@ -11,7 +11,7 @@
 #include <string>
 #include <atomic>
 #include <boost/tokenizer.hpp>
-typedef boost::tokenizer<boost::char_separator<char>> tokenizer;
+using tokenizer = boost::tokenizer<boost::char_separator<char>>;
 #include <sstream>
 #include <locale>
 

--- a/Code/GraphMol/QueryAtom.h
+++ b/Code/GraphMol/QueryAtom.h
@@ -27,7 +27,7 @@ namespace RDKit {
  */
 class RDKIT_GRAPHMOL_EXPORT QueryAtom : public Atom {
  public:
-  typedef Queries::Query<int, Atom const *, true> QUERYATOM_QUERY;
+  using QUERYATOM_QUERY = Queries::Query<int, Atom const *, true>;
 
   QueryAtom() : Atom() {}
   explicit QueryAtom(int num) : Atom(num), dp_query(makeAtomNumQuery(num)) {}

--- a/Code/GraphMol/QueryBond.h
+++ b/Code/GraphMol/QueryBond.h
@@ -27,7 +27,7 @@ namespace RDKit {
 
 class RDKIT_GRAPHMOL_EXPORT QueryBond : public Bond {
  public:
-  typedef Queries::Query<int, Bond const *, true> QUERYBOND_QUERY;
+  using QUERYBOND_QUERY = Queries::Query<int, const Bond *, true>;
 
   QueryBond() : Bond() {}
   //! initialize with a particular bond order

--- a/Code/GraphMol/QueryOps.h
+++ b/Code/GraphMol/QueryOps.h
@@ -33,43 +33,41 @@
 #endif
 
 namespace RDKit {
-typedef Queries::Query<bool, Atom const *, true> ATOM_BOOL_QUERY;
-typedef Queries::Query<bool, Bond const *, true> BOND_BOOL_QUERY;
+using ATOM_BOOL_QUERY = Queries::Query<bool, const Atom *, true>;
+using BOND_BOOL_QUERY = Queries::Query<bool, const Bond *, true>;
 
-typedef Queries::AndQuery<int, Atom const *, true> ATOM_AND_QUERY;
-typedef Queries::AndQuery<int, Bond const *, true> BOND_AND_QUERY;
+using ATOM_AND_QUERY = Queries::AndQuery<int, const Atom *, true>;
+using BOND_AND_QUERY = Queries::AndQuery<int, const Bond *, true>;
 
-typedef Queries::OrQuery<int, Atom const *, true> ATOM_OR_QUERY;
-typedef Queries::OrQuery<int, Bond const *, true> BOND_OR_QUERY;
+using ATOM_OR_QUERY = Queries::OrQuery<int, const Atom *, true>;
+using BOND_OR_QUERY = Queries::OrQuery<int, const Bond *, true>;
 
-typedef Queries::XOrQuery<int, Atom const *, true> ATOM_XOR_QUERY;
-typedef Queries::XOrQuery<int, Bond const *, true> BOND_XOR_QUERY;
+using ATOM_XOR_QUERY = Queries::XOrQuery<int, const Atom *, true>;
+using BOND_XOR_QUERY = Queries::XOrQuery<int, const Bond *, true>;
 
-typedef Queries::EqualityQuery<int, Atom const *, true> ATOM_EQUALS_QUERY;
-typedef Queries::EqualityQuery<int, Bond const *, true> BOND_EQUALS_QUERY;
+using ATOM_EQUALS_QUERY = Queries::EqualityQuery<int, const Atom *, true>;
+using BOND_EQUALS_QUERY = Queries::EqualityQuery<int, const Bond *, true>;
 
-typedef Queries::GreaterQuery<int, Atom const *, true> ATOM_GREATER_QUERY;
-typedef Queries::GreaterQuery<int, Bond const *, true> BOND_GREATER_QUERY;
+using ATOM_GREATER_QUERY = Queries::GreaterQuery<int, const Atom *, true>;
+using BOND_GREATER_QUERY = Queries::GreaterQuery<int, const Bond *, true>;
 
-typedef Queries::GreaterEqualQuery<int, Atom const *, true>
-    ATOM_GREATEREQUAL_QUERY;
-typedef Queries::GreaterEqualQuery<int, Bond const *, true>
-    BOND_GREATEREQUAL_QUERY;
+using ATOM_GREATEREQUAL_QUERY = Queries::GreaterEqualQuery<int, const Atom *, true>;
+using BOND_GREATEREQUAL_QUERY = Queries::GreaterEqualQuery<int, const Bond *, true>;
 
-typedef Queries::LessQuery<int, Atom const *, true> ATOM_LESS_QUERY;
-typedef Queries::LessQuery<int, Bond const *, true> BOND_LESS_QUERY;
+using ATOM_LESS_QUERY = Queries::LessQuery<int, const Atom *, true>;
+using BOND_LESS_QUERY = Queries::LessQuery<int, const Bond *, true>;
 
-typedef Queries::LessEqualQuery<int, Atom const *, true> ATOM_LESSEQUAL_QUERY;
-typedef Queries::LessEqualQuery<int, Bond const *, true> BOND_LESSEQUAL_QUERY;
+using ATOM_LESSEQUAL_QUERY = Queries::LessEqualQuery<int, const Atom *, true>;
+using BOND_LESSEQUAL_QUERY = Queries::LessEqualQuery<int, const Bond *, true>;
 
-typedef Queries::RangeQuery<int, Atom const *, true> ATOM_RANGE_QUERY;
-typedef Queries::RangeQuery<int, Bond const *, true> BOND_RANGE_QUERY;
+using ATOM_RANGE_QUERY = Queries::RangeQuery<int, const Atom *, true>;
+using BOND_RANGE_QUERY = Queries::RangeQuery<int, const Bond *, true>;
 
-typedef Queries::SetQuery<int, Atom const *, true> ATOM_SET_QUERY;
-typedef Queries::SetQuery<int, Bond const *, true> BOND_SET_QUERY;
+using ATOM_SET_QUERY = Queries::SetQuery<int, const Atom *, true>;
+using BOND_SET_QUERY = Queries::SetQuery<int, const Bond *, true>;
 
-typedef Queries::Query<int, Bond const *, true> BOND_NULL_QUERY;
-typedef Queries::Query<int, Atom const *, true> ATOM_NULL_QUERY;
+using BOND_NULL_QUERY = Queries::Query<int, const Bond *, true>;
+using ATOM_NULL_QUERY = Queries::Query<int, const Atom *, true>;
 
 // -------------------------------------------------
 // common atom queries
@@ -747,7 +745,7 @@ static inline int queryAtomRingMembership(Atom const *at) {
 // the definition of Match, then complains about an override
 // that differs only by const/volatile (c4301), then generates
 // incorrect code if we don't do this... so let's do it.
-typedef Atom const *ConstAtomPtr;
+using ConstAtomPtr = const Atom *;
 
 class RDKIT_GRAPHMOL_EXPORT AtomRingQuery
     : public Queries::EqualityQuery<int, ConstAtomPtr, true> {
@@ -857,7 +855,7 @@ bool nullQueryFun(T) {
   return true;
 }
 
-typedef Bond const *ConstBondPtr;
+using ConstBondPtr = const Bond *;
 
 // ! Query whether an atom has a property
 template <class TargetPtr>
@@ -894,8 +892,8 @@ class HasPropQuery : public Queries::EqualityQuery<int, TargetPtr, true> {
   const std::string &getPropName() const { return propname; }
 };
 
-typedef Queries::EqualityQuery<int, Atom const *, true> ATOM_PROP_QUERY;
-typedef Queries::EqualityQuery<int, Bond const *, true> BOND_PROP_QUERY;
+using ATOM_PROP_QUERY = Queries::EqualityQuery<int, const Atom *, true>;
+using BOND_PROP_QUERY = Queries::EqualityQuery<int, const Bond *, true>;
 
 //! returns a Query for matching atoms that have a particular property
 template <class Target>

--- a/Code/GraphMol/RGroupDecomposition/RGroupDecomp.h
+++ b/Code/GraphMol/RGroupDecomposition/RGroupDecomp.h
@@ -28,11 +28,11 @@ struct RDKIT_RGROUPDECOMPOSITION_EXPORT RGroupDecompositionProcessResult {
 
 struct RGroupMatch;
 
-typedef std::map<std::string, ROMOL_SPTR> RGroupRow;
-typedef std::vector<ROMOL_SPTR> RGroupColumn;
+using RGroupRow = std::map<std::string, ROMOL_SPTR>;
+using RGroupColumn = std::vector<ROMOL_SPTR>;
 
-typedef std::vector<RGroupRow> RGroupRows;
-typedef std::map<std::string, RGroupColumn> RGroupColumns;
+using RGroupRows = std::vector<RGroupRow>;
+using RGroupColumns = std::map<std::string, RGroupColumn>;
 
 class UsedLabelMap {
  public:

--- a/Code/GraphMol/RGroupDecomposition/RGroupGa.h
+++ b/Code/GraphMol/RGroupDecomposition/RGroupGa.h
@@ -13,7 +13,6 @@
 
 #include <vector>
 #include <memory>
-#include <map>
 #include <chrono>
 
 #include "../../../External/GA/ga/StringChromosome.h"
@@ -33,14 +32,14 @@ class RGroupDecompositionChromosome;
 class RGroupGa;
 struct RGroupDecompData;
 
-typedef LinkedPopLinearSel<RGroupDecompositionChromosome, RGroupGa>
-    RGroupGaPopulation;
+using RGroupGaPopulation =
+    LinkedPopLinearSel<RGroupDecompositionChromosome, RGroupGa>;
 
-typedef enum {
+enum OperationName {
   RgroupMutate = 0x01,
   Crossover = 0x02,
   Create = 0x04,
-} OperationName;
+};
 
 class RGroupDecompositionChromosome : public IntegerStringChromosome {
  public:

--- a/Code/GraphMol/RGroupDecomposition/RGroupMatch.h
+++ b/Code/GraphMol/RGroupDecomposition/RGroupMatch.h
@@ -12,8 +12,8 @@
 #include "RGroupData.h"
 
 namespace RDKit {
-typedef boost::shared_ptr<RGroupData> RData;
-typedef std::map<int, RData> R_DECOMP;
+using RData = boost::shared_ptr<RGroupData>;
+using R_DECOMP = std::map<int, RData>;
 
 //! RGroupMatch is the decomposition for a single molecule
 struct RGroupMatch {

--- a/Code/GraphMol/RGroupDecomposition/testRGroupDecomp.cpp
+++ b/Code/GraphMol/RGroupDecomposition/testRGroupDecomp.cpp
@@ -46,12 +46,12 @@
 #include <RDGeneral/Exceptions.h>
 #include <boost/tokenizer.hpp>
 #include <regex>
-
-typedef boost::tokenizer<boost::char_separator<char>> tokenizer;
+#include <cmath>
+using tokenizer = boost::tokenizer<boost::char_separator<char>>;
 
 using namespace RDKit;
 
-typedef std::vector<std::unique_ptr<ROMol>> UMOLS;
+using UMOLS = std::vector<std::unique_ptr<ROMol>>;
 #define UPTR(m) std::unique_ptr<ROMol>(m)
 
 void CHECK_RGROUP(RGroupRows::const_iterator &it, const std::string &expected,

--- a/Code/GraphMol/ROMol.h
+++ b/Code/GraphMol/ROMol.h
@@ -359,22 +359,20 @@ class RDKIT_GRAPHMOL_EXPORT ROMol : public RDProps {
   using ATOM_BOOKMARK_MAP = std::map<int, ATOM_PTR_LIST>;
   using BOND_BOOKMARK_MAP = std::map<int, BOND_PTR_LIST>;
 
-  using AtomIterator = class AtomIterator_<Atom, ROMol>;
-  using ConstAtomIterator = class AtomIterator_<const Atom, const ROMol>;
-  using BondIterator = class BondIterator_;
-  using ConstBondIterator = class ConstBondIterator_;
-  using AromaticAtomIterator = class AromaticAtomIterator_<Atom, ROMol>;
+  using AtomIterator = AtomIterator_<Atom, ROMol>;
+  using ConstAtomIterator = AtomIterator_<const Atom, const ROMol>;
+  using BondIterator = BondIterator_;
+  using ConstBondIterator = ConstBondIterator_;
+  using AromaticAtomIterator = AromaticAtomIterator_<Atom, ROMol>;
   using ConstAromaticAtomIterator =
-      class AromaticAtomIterator_<const Atom, const ROMol>;
-  using HeteroatomIterator = class HeteroatomIterator_<Atom, ROMol>;
-  using ConstHeteroatomIterator =
-      class HeteroatomIterator_<const Atom, const ROMol>;
-  using QueryAtomIterator = class QueryAtomIterator_<Atom, ROMol>;
-  using ConstQueryAtomIterator =
-      class QueryAtomIterator_<const Atom, const ROMol>;
-  using MatchingAtomIterator = class MatchingAtomIterator_<Atom, ROMol>;
+      AromaticAtomIterator_<const Atom, const ROMol>;
+  using HeteroatomIterator = HeteroatomIterator_<Atom, ROMol>;
+  using ConstHeteroatomIterator = HeteroatomIterator_<const Atom, const ROMol>;
+  using QueryAtomIterator = QueryAtomIterator_<Atom, ROMol>;
+  using ConstQueryAtomIterator = QueryAtomIterator_<const Atom, const ROMol>;
+  using MatchingAtomIterator = MatchingAtomIterator_<Atom, ROMol>;
   using ConstMatchingAtomIterator =
-      class MatchingAtomIterator_<const Atom, const ROMol>;
+      MatchingAtomIterator_<const Atom, const ROMol>;
 
   using ConformerIterator = CONF_SPTR_LIST_I;
   using ConstConformerIterator = CONF_SPTR_LIST_CI;

--- a/Code/GraphMol/ROMol.h
+++ b/Code/GraphMol/ROMol.h
@@ -24,7 +24,6 @@
 #include <utility>
 #include <map>
 #include <ranges>
-#include <limits>
 
 // boost stuff
 #include <RDGeneral/BoostStartInclude.h>
@@ -52,9 +51,8 @@ class SubstanceGroup;
 class Atom;
 class Bond;
 //! This is the BGL type used to store the topology:
-typedef boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS,
-                              Atom *, Bond *>
-    MolGraph;
+using MolGraph = boost::adjacency_list<boost::vecS, boost::vecS,
+                                       boost::undirectedS, Atom *, Bond *>;
 class MolPickler;
 class RWMol;
 class QueryAtom;
@@ -139,7 +137,7 @@ struct CXXAtomIterator {
       }
     }
 
-    CXXAtomIter() {};
+    CXXAtomIter(){};
 
     CXXAtomIter(Graph *graph, Iterator pos) : graph(graph), pos(pos) {
       if (CheckedAtoms) {
@@ -220,7 +218,7 @@ struct CXXAtomIterator {
     std::tie(vstart, vend) = boost::vertices(*graph);
   }
   CXXAtomIterator(Graph *graph, Iterator start, Iterator end)
-      : graph(graph), vstart(start), vend(end) {};
+      : graph(graph), vstart(start), vend(end){};
   CXXAtomIter begin() { return {graph, vstart}; }
   CXXAtomIter end() { return {graph, vend}; }
   size_t size() const { return vend - vstart; }
@@ -250,7 +248,7 @@ struct CXXBondIterator {
     Iterator pos;
     size_t osize{0};
 
-    CXXBondIter() {};
+    CXXBondIter(){};
 
     CXXBondIter(Graph *graph, Iterator pos) : graph(graph), pos(pos) {
       if (Checked) {
@@ -299,7 +297,7 @@ struct CXXBondIterator {
     vend = vs.second;
   }
   CXXBondIterator(Graph *graph, Iterator start, Iterator end)
-      : graph(graph), vstart(start), vend(end) {};
+      : graph(graph), vstart(start), vend(end){};
   CXXBondIter begin() { return {graph, vstart}; }
   CXXBondIter end() { return {graph, vend}; }
   size_t size() const {
@@ -325,61 +323,61 @@ class RDKIT_GRAPHMOL_EXPORT ROMol : public RDProps {
 
   //! \name typedefs
   //! @{
-  typedef MolGraph::vertex_descriptor vertex_descriptor;
-  typedef MolGraph::edge_descriptor edge_descriptor;
+  using vertex_descriptor = MolGraph::vertex_descriptor;
+  using edge_descriptor = MolGraph::edge_descriptor;
 
-  typedef MolGraph::edge_iterator EDGE_ITER;
-  typedef MolGraph::out_edge_iterator OEDGE_ITER;
-  typedef MolGraph::vertex_iterator VERTEX_ITER;
-  typedef MolGraph::adjacency_iterator ADJ_ITER;
-  typedef std::pair<EDGE_ITER, EDGE_ITER> BOND_ITER_PAIR;
-  typedef std::pair<OEDGE_ITER, OEDGE_ITER> OBOND_ITER_PAIR;
-  typedef std::pair<VERTEX_ITER, VERTEX_ITER> ATOM_ITER_PAIR;
-  typedef std::pair<ADJ_ITER, ADJ_ITER> ADJ_ITER_PAIR;
+  using EDGE_ITER = MolGraph::edge_iterator;
+  using OEDGE_ITER = MolGraph::out_edge_iterator;
+  using VERTEX_ITER = MolGraph::vertex_iterator;
+  using ADJ_ITER = MolGraph::adjacency_iterator;
+  using BOND_ITER_PAIR = std::pair<EDGE_ITER, EDGE_ITER>;
+  using OBOND_ITER_PAIR = std::pair<OEDGE_ITER, OEDGE_ITER>;
+  using ATOM_ITER_PAIR = std::pair<VERTEX_ITER, VERTEX_ITER>;
+  using ADJ_ITER_PAIR = std::pair<ADJ_ITER, ADJ_ITER>;
 
-  typedef std::vector<Atom *> ATOM_PTR_VECT;
-  typedef ATOM_PTR_VECT::iterator ATOM_PTR_VECT_I;
-  typedef ATOM_PTR_VECT::const_iterator ATOM_PTR_VECT_CI;
-  typedef std::vector<Bond *> BOND_PTR_VECT;
-  typedef BOND_PTR_VECT::iterator BOND_PTR_VECT_I;
-  typedef BOND_PTR_VECT::const_iterator BOND_PTR_VECT_CI;
+  using ATOM_PTR_VECT = std::vector<Atom *>;
+  using ATOM_PTR_VECT_I = ATOM_PTR_VECT::iterator;
+  using ATOM_PTR_VECT_CI = ATOM_PTR_VECT::const_iterator;
+  using BOND_PTR_VECT = std::vector<Bond *>;
+  using BOND_PTR_VECT_I = BOND_PTR_VECT::iterator;
+  using BOND_PTR_VECT_CI = BOND_PTR_VECT::const_iterator;
 
-  typedef std::list<Atom *> ATOM_PTR_LIST;
-  typedef ATOM_PTR_LIST::iterator ATOM_PTR_LIST_I;
-  typedef ATOM_PTR_LIST::const_iterator ATOM_PTR_LIST_CI;
-  typedef std::list<Bond *> BOND_PTR_LIST;
-  typedef BOND_PTR_LIST::iterator BOND_PTR_LIST_I;
-  typedef BOND_PTR_LIST::const_iterator BOND_PTR_LIST_CI;
+  using ATOM_PTR_LIST = std::list<Atom *>;
+  using ATOM_PTR_LIST_I = ATOM_PTR_LIST::iterator;
+  using ATOM_PTR_LIST_CI = ATOM_PTR_LIST::const_iterator;
+  using BOND_PTR_LIST = std::list<Bond *>;
+  using BOND_PTR_LIST_I = BOND_PTR_LIST::iterator;
+  using BOND_PTR_LIST_CI = BOND_PTR_LIST::const_iterator;
 
   // list of conformations
-  typedef std::list<CONFORMER_SPTR> CONF_SPTR_LIST;
-  typedef CONF_SPTR_LIST::iterator CONF_SPTR_LIST_I;
-  typedef CONF_SPTR_LIST::const_iterator CONF_SPTR_LIST_CI;
-  typedef std::pair<CONF_SPTR_LIST_I, CONF_SPTR_LIST_I> CONFS_I_PAIR;
+  using CONF_SPTR_LIST = std::list<CONFORMER_SPTR>;
+  using CONF_SPTR_LIST_I = CONF_SPTR_LIST::iterator;
+  using CONF_SPTR_LIST_CI = CONF_SPTR_LIST::const_iterator;
+  using CONFS_I_PAIR = std::pair<CONF_SPTR_LIST_I, CONF_SPTR_LIST_I>;
 
   // ROFIX: these will need to be readonly somehow?
-  typedef std::map<int, ATOM_PTR_LIST> ATOM_BOOKMARK_MAP;
-  typedef std::map<int, BOND_PTR_LIST> BOND_BOOKMARK_MAP;
+  using ATOM_BOOKMARK_MAP = std::map<int, ATOM_PTR_LIST>;
+  using BOND_BOOKMARK_MAP = std::map<int, BOND_PTR_LIST>;
 
-  typedef class AtomIterator_<Atom, ROMol> AtomIterator;
-  typedef class AtomIterator_<const Atom, const ROMol> ConstAtomIterator;
-  typedef class BondIterator_ BondIterator;
-  typedef class ConstBondIterator_ ConstBondIterator;
-  typedef class AromaticAtomIterator_<Atom, ROMol> AromaticAtomIterator;
-  typedef class AromaticAtomIterator_<const Atom, const ROMol>
-      ConstAromaticAtomIterator;
-  typedef class HeteroatomIterator_<Atom, ROMol> HeteroatomIterator;
-  typedef class HeteroatomIterator_<const Atom, const ROMol>
-      ConstHeteroatomIterator;
-  typedef class QueryAtomIterator_<Atom, ROMol> QueryAtomIterator;
-  typedef class QueryAtomIterator_<const Atom, const ROMol>
-      ConstQueryAtomIterator;
-  typedef class MatchingAtomIterator_<Atom, ROMol> MatchingAtomIterator;
-  typedef class MatchingAtomIterator_<const Atom, const ROMol>
-      ConstMatchingAtomIterator;
+  using AtomIterator = class AtomIterator_<Atom, ROMol>;
+  using ConstAtomIterator = class AtomIterator_<const Atom, const ROMol>;
+  using BondIterator = class BondIterator_;
+  using ConstBondIterator = class ConstBondIterator_;
+  using AromaticAtomIterator = class AromaticAtomIterator_<Atom, ROMol>;
+  using ConstAromaticAtomIterator =
+      class AromaticAtomIterator_<const Atom, const ROMol>;
+  using HeteroatomIterator = class HeteroatomIterator_<Atom, ROMol>;
+  using ConstHeteroatomIterator =
+      class HeteroatomIterator_<const Atom, const ROMol>;
+  using QueryAtomIterator = class QueryAtomIterator_<Atom, ROMol>;
+  using ConstQueryAtomIterator =
+      class QueryAtomIterator_<const Atom, const ROMol>;
+  using MatchingAtomIterator = class MatchingAtomIterator_<Atom, ROMol>;
+  using ConstMatchingAtomIterator =
+      class MatchingAtomIterator_<const Atom, const ROMol>;
 
-  typedef CONF_SPTR_LIST_I ConformerIterator;
-  typedef CONF_SPTR_LIST_CI ConstConformerIterator;
+  using ConformerIterator = CONF_SPTR_LIST_I;
+  using ConstConformerIterator = CONF_SPTR_LIST_CI;
 
   //! @}
   //! \endcond
@@ -997,8 +995,8 @@ class RDKIT_GRAPHMOL_EXPORT ROMol : public RDProps {
 
   friend RDKIT_GRAPHMOL_EXPORT std::vector<SubstanceGroup> &getSubstanceGroups(
       ROMol &);
-  friend RDKIT_GRAPHMOL_EXPORT const std::vector<SubstanceGroup> &
-  getSubstanceGroups(const ROMol &);
+  friend RDKIT_GRAPHMOL_EXPORT const std::vector<SubstanceGroup>
+      &getSubstanceGroups(const ROMol &);
   void clearSubstanceGroups() { d_sgroups.clear(); }
 
  protected:
@@ -1046,12 +1044,12 @@ class RDKIT_GRAPHMOL_EXPORT ROMol : public RDProps {
   void initFromOther(const ROMol &other, bool quickCopy, int confId);
 };
 
-typedef std::vector<ROMol> MOL_VECT;
-typedef boost::shared_ptr<ROMol> ROMOL_SPTR;
-typedef std::vector<ROMol *> MOL_PTR_VECT;
-typedef std::vector<ROMOL_SPTR> MOL_SPTR_VECT;
+using MOL_VECT = std::vector<ROMol>;
+using ROMOL_SPTR = boost::shared_ptr<ROMol>;
+using MOL_PTR_VECT = std::vector<ROMol *>;
+using MOL_SPTR_VECT = std::vector<ROMOL_SPTR>;
 
-typedef MOL_PTR_VECT::const_iterator MOL_PTR_VECT_CI;
-typedef MOL_PTR_VECT::iterator MOL_PTR_VECT_I;
+using MOL_PTR_VECT_CI = MOL_PTR_VECT::const_iterator;
+using MOL_PTR_VECT_I = MOL_PTR_VECT::iterator;
 };  // namespace RDKit
 #endif

--- a/Code/GraphMol/RWMol.h
+++ b/Code/GraphMol/RWMol.h
@@ -219,8 +219,8 @@ class RDKIT_GRAPHMOL_EXPORT RWMol : public ROMol {
   void batchRemoveAtoms();
 };
 
-typedef boost::shared_ptr<RWMol> RWMOL_SPTR;
-typedef std::vector<RWMOL_SPTR> RWMOL_SPTR_VECT;
+using RWMOL_SPTR = boost::shared_ptr<RWMol>;
+using RWMOL_SPTR_VECT = std::vector<RWMOL_SPTR>;
 
 };  // namespace RDKit
 

--- a/Code/GraphMol/ReducedGraphs/ReducedGraphs.cpp
+++ b/Code/GraphMol/ReducedGraphs/ReducedGraphs.cpp
@@ -31,7 +31,7 @@ namespace {
 // FIX: this is duplicated here and in the MorganFingerprints code
 class ss_matcher {
  public:
-  ss_matcher() {};
+  ss_matcher(){};
   ss_matcher(const std::string &pattern) {
     RDKit::RWMol *p = RDKit::SmartsToMol(pattern);
     TEST_ASSERT(p);
@@ -72,9 +72,9 @@ $([N;H0&+0]([C;!$(C(=O))])([C;!$(C(=O))])[C;!$(C(=O))])]",  // Positive
 };
 std::vector<std::string> defaultFeatureSmarts(smartsPatterns,
                                               smartsPatterns + nFeatures);
-typedef boost::flyweight<boost::flyweights::key_value<std::string, ss_matcher>,
-                         boost::flyweights::no_tracking>
-    pattern_flyweight;
+using pattern_flyweight =
+    boost::flyweight<boost::flyweights::key_value<std::string, ss_matcher>,
+                     boost::flyweights::no_tracking>;
 
 void getErGAtomTypes(const ROMol &mol,
                      std::vector<boost::dynamic_bitset<>> &types,

--- a/Code/GraphMol/Resonance.cpp
+++ b/Code/GraphMol/Resonance.cpp
@@ -177,7 +177,7 @@ class CEVect2Store {
 
 class AtomElectrons {
  public:
-  enum AtomElectronsFlags : std::uint64_t{
+  enum AtomElectronsFlags : unsigned int{
     LAST_BOND = (1 << 0),
     DEFINITIVE = (1 << 1),
     STACKED = (1 << 2),
@@ -233,7 +233,7 @@ class AtomElectrons {
 
 class BondElectrons {
  public:
-  enum BondElectronsFlags : std::uint64_t{
+  enum BondElectronsFlags : unsigned int{
     DEFINITIVE = (1 << 0)
   };
   BondElectrons(ConjElectrons *parent, const Bond *b);

--- a/Code/GraphMol/Resonance.cpp
+++ b/Code/GraphMol/Resonance.cpp
@@ -81,12 +81,12 @@ struct CEStats {
 
 class ConjElectrons {
  public:
-  enum ConjElectronsFlags {
+  enum ConjElectronsFlags : unsigned int {
     HAVE_CATION_RIGHT_OF_N = (1 << 0),
     HAVE_CATION = (1 << 1),
     HAVE_ANION = (1 << 2)
   };
-  enum FPFlags {
+  enum FPFlags : unsigned int {
     FP_BONDS = (1 << 0),
     FP_ATOMS = (1 << 1)
   };
@@ -177,7 +177,7 @@ class CEVect2Store {
 
 class AtomElectrons {
  public:
-  enum AtomElectronsFlags {
+  enum AtomElectronsFlags : std::uint64_t{
     LAST_BOND = (1 << 0),
     DEFINITIVE = (1 << 1),
     STACKED = (1 << 2),
@@ -233,7 +233,7 @@ class AtomElectrons {
 
 class BondElectrons {
  public:
-  enum BondElectronsFlags {
+  enum BondElectronsFlags : std::uint64_t{
     DEFINITIVE = (1 << 0)
   };
   BondElectrons(ConjElectrons *parent, const Bond *b);

--- a/Code/GraphMol/Resonance.cpp
+++ b/Code/GraphMol/Resonance.cpp
@@ -13,6 +13,7 @@
 #include <GraphMol/Resonance.h>
 #include <RDGeneral/hash/hash.hpp>
 #include <RDGeneral/RDThreads.h>
+#include <stack>
 #ifdef RDK_BUILD_THREADSAFE_SSS
 #include <thread>
 #include <future>
@@ -22,8 +23,8 @@
 namespace RDKit {
 // class definitions that do not need being exposed in Resonance.h
 
-typedef std::set<std::size_t> CESet;
-typedef std::unordered_map<std::size_t, unsigned int> CEDegCount;
+using CESet = std::set<std::size_t>;
+using CEDegCount = std::unordered_map<std::size_t, unsigned int>;
 
 class CEVect2 {
  public:
@@ -80,15 +81,15 @@ struct CEStats {
 
 class ConjElectrons {
  public:
-  typedef enum {
+  enum ConjElectronsFlags {
     HAVE_CATION_RIGHT_OF_N = (1 << 0),
     HAVE_CATION = (1 << 1),
     HAVE_ANION = (1 << 2)
-  } ConjElectronsFlags;
-  typedef enum {
+  };
+  enum FPFlags {
     FP_BONDS = (1 << 0),
     FP_ATOMS = (1 << 1)
-  } FPFlags;
+  };
   ConjElectrons(ResonanceMolSupplier *parent, unsigned int groupIdx);
   ConjElectrons(const ConjElectrons &ce);
   ~ConjElectrons();
@@ -176,15 +177,15 @@ class CEVect2Store {
 
 class AtomElectrons {
  public:
-  typedef enum {
+  enum AtomElectronsFlags {
     LAST_BOND = (1 << 0),
     DEFINITIVE = (1 << 1),
     STACKED = (1 << 2),
     HAS_MULTIPLE_BOND = (1 << 3),
-  } AtomElectronsFlags;
-  typedef enum {
+  };
+  enum AllowedBondFlag {
     NEED_CHARGE_BIT = 1
-  } AllowedBondFlag;
+  };
   AtomElectrons(ConjElectrons *parent, const Atom *a);
   AtomElectrons(ConjElectrons *parent, const AtomElectrons &ae);
   ~AtomElectrons() = default;
@@ -232,9 +233,9 @@ class AtomElectrons {
 
 class BondElectrons {
  public:
-  typedef enum {
+  enum BondElectronsFlags {
     DEFINITIVE = (1 << 0)
-  } BondElectronsFlags;
+  };
   BondElectrons(ConjElectrons *parent, const Bond *b);
   BondElectrons(ConjElectrons *parent, const BondElectrons &be);
   ~BondElectrons() = default;

--- a/Code/GraphMol/Resonance.cpp
+++ b/Code/GraphMol/Resonance.cpp
@@ -81,12 +81,12 @@ struct CEStats {
 
 class ConjElectrons {
  public:
-  enum ConjElectronsFlags : unsigned int {
+  enum ConjElectronsFlags {
     HAVE_CATION_RIGHT_OF_N = (1 << 0),
     HAVE_CATION = (1 << 1),
     HAVE_ANION = (1 << 2)
   };
-  enum FPFlags : unsigned int {
+  enum FPFlags {
     FP_BONDS = (1 << 0),
     FP_ATOMS = (1 << 1)
   };
@@ -177,7 +177,7 @@ class CEVect2Store {
 
 class AtomElectrons {
  public:
-  enum AtomElectronsFlags : unsigned int{
+  enum AtomElectronsFlags {
     LAST_BOND = (1 << 0),
     DEFINITIVE = (1 << 1),
     STACKED = (1 << 2),
@@ -233,7 +233,7 @@ class AtomElectrons {
 
 class BondElectrons {
  public:
-  enum BondElectronsFlags : unsigned int{
+  enum BondElectronsFlags {
     DEFINITIVE = (1 << 0)
   };
   BondElectrons(ConjElectrons *parent, const Bond *b);

--- a/Code/GraphMol/Resonance.h
+++ b/Code/GraphMol/Resonance.h
@@ -86,7 +86,7 @@ class RDKIT_GRAPHMOL_EXPORT ResonanceMolSupplierCallback {
 
 class RDKIT_GRAPHMOL_EXPORT ResonanceMolSupplier {
  public:
-  enum ResonanceFlags : unsigned int {
+  enum ResonanceFlags {
     /*! include resonance structures whose octets are less complete
      *  than the most octet-complete structure */
     ALLOW_INCOMPLETE_OCTETS = (1 << 0),

--- a/Code/GraphMol/Resonance.h
+++ b/Code/GraphMol/Resonance.h
@@ -12,9 +12,10 @@
 #define _RESONANCE_H__
 
 #include <vector>
-#include <stack>
 #include <map>
 #include <unordered_map>
+#include <cstdint>
+#include <memory>
 
 namespace RDKit {
 class ROMol;
@@ -24,12 +25,12 @@ class BondElectrons;
 class AtomElectrons;
 class ConjElectrons;
 class CEVect2;
-typedef std::map<unsigned int, BondElectrons *> ConjBondMap;
-typedef std::map<unsigned int, AtomElectrons *> ConjAtomMap;
-typedef std::vector<ConjElectrons *> CEVect;
-typedef std::vector<CEVect2 *> CEVect3;
-typedef std::vector<std::uint8_t> ConjFP;
-typedef std::unordered_map<std::size_t, ConjElectrons *> CEMap;
+using ConjBondMap = std::map<unsigned int, BondElectrons *>;
+using ConjAtomMap = std::map<unsigned int, AtomElectrons *>;
+using CEVect = std::vector<ConjElectrons *>;
+using CEVect3 = std::vector<CEVect2 *>;
+using ConjFP = std::vector<std::uint8_t>;
+using CEMap = std::unordered_map<std::size_t, ConjElectrons *>;
 
 /*!
  * Create a derived class from this abstract base class
@@ -85,7 +86,7 @@ class RDKIT_GRAPHMOL_EXPORT ResonanceMolSupplierCallback {
 
 class RDKIT_GRAPHMOL_EXPORT ResonanceMolSupplier {
  public:
-  typedef enum {
+  enum ResonanceFlags {
     /*! include resonance structures whose octets are less complete
      *  than the most octet-complete structure */
     ALLOW_INCOMPLETE_OCTETS = (1 << 0),
@@ -109,7 +110,7 @@ class RDKIT_GRAPHMOL_EXPORT ResonanceMolSupplier {
      *  UNCONSTRAINED_ANIONS implies ALLOW_CHARGE_SEPARATION.
      */
     UNCONSTRAINED_ANIONS = (1 << 4)
-  } ResonanceFlags;
+  };
   /*!
    *   \param mol        - the starter molecule
    *   \param flags      - flags which influence criteria to generate
@@ -197,10 +198,10 @@ class RDKIT_GRAPHMOL_EXPORT ResonanceMolSupplier {
   ROMol *operator[](unsigned int idx);
 
  private:
-  typedef struct CEPerm {
+  struct CEPerm {
     unsigned int idx;
     std::vector<unsigned int> v;
-  } CEPerm;
+  };
   unsigned int d_nConjGrp;
   unsigned int d_length;
   unsigned int d_flags;

--- a/Code/GraphMol/Resonance.h
+++ b/Code/GraphMol/Resonance.h
@@ -86,7 +86,7 @@ class RDKIT_GRAPHMOL_EXPORT ResonanceMolSupplierCallback {
 
 class RDKIT_GRAPHMOL_EXPORT ResonanceMolSupplier {
  public:
-  enum ResonanceFlags {
+  enum ResonanceFlags : unsigned int {
     /*! include resonance structures whose octets are less complete
      *  than the most octet-complete structure */
     ALLOW_INCOMPLETE_OCTETS = (1 << 0),

--- a/Code/GraphMol/RingInfo.h
+++ b/Code/GraphMol/RingInfo.h
@@ -11,7 +11,6 @@
 #ifndef RD_RINGINFO_H
 #define RD_RINGINFO_H
 
-#include <map>
 #include <vector>
 #include <RDGeneral/BoostStartInclude.h>
 #include <boost/dynamic_bitset.hpp>
@@ -24,21 +23,21 @@ namespace RDKit {
 /*!
 
  */
-typedef enum {
+enum FIND_RING_TYPE {
   FIND_RING_TYPE_FAST,
   FIND_RING_TYPE_SSSR,
   FIND_RING_TYPE_SYMM_SSSR,
   FIND_RING_TYPE_OTHER_OR_UNKNOWN
-} FIND_RING_TYPE;
+};
 
 class RDKIT_GRAPHMOL_EXPORT RingInfo {
   friend class MolPickler;
 
  public:
-  typedef std::vector<int> MemberType;
-  typedef std::vector<MemberType> DataType;
-  typedef std::vector<int> INT_VECT;
-  typedef std::vector<INT_VECT> VECT_INT_VECT;
+  using MemberType = std::vector<int>;
+  using DataType = std::vector<MemberType>;
+  using INT_VECT = std::vector<int>;
+  using VECT_INT_VECT = std::vector<INT_VECT>;
 
   RingInfo() {}
   RingInfo(const RingInfo &other) = default;

--- a/Code/GraphMol/Rings.h
+++ b/Code/GraphMol/Rings.h
@@ -24,9 +24,9 @@ class ROMol;
 };
 
 namespace RingUtils {
-typedef std::vector<int> INT_VECT;
-typedef std::vector<std::vector<int>> VECT_INT_VECT;
-typedef std::map<int, std::vector<int>> INT_INT_VECT_MAP;
+using INT_VECT = std::vector<int>;
+using VECT_INT_VECT = std::vector<std::vector<int>>;
+using INT_INT_VECT_MAP = std::map<int, std::vector<int>>;
 
 //! Pick a set of rings that are fused together and contain a specified ring
 /*!

--- a/Code/GraphMol/SLNParse/SLNAttribs.h
+++ b/Code/GraphMol/SLNParse/SLNAttribs.h
@@ -42,14 +42,16 @@
 namespace RDKit {
 class Atom;
 class Bond;
+class RWMol;
+class ROMol;
 
 namespace SLNParse {
-typedef enum {
+enum AttribCombineOp {
   AttribLowPriAnd = 0,
   AttribOr,
   AttribAnd,
   AttribNot
-} AttribCombineOp;
+};
 
 class RDKIT_SLNPARSE_EXPORT AttribType {
  public:
@@ -61,8 +63,8 @@ class RDKIT_SLNPARSE_EXPORT AttribType {
   void *structQuery{nullptr};
 };
 
-typedef std::vector<std::pair<AttribCombineOp, boost::shared_ptr<AttribType>>>
-    AttribListType;
+using AttribListType =
+    std::vector<std::pair<AttribCombineOp, boost::shared_ptr<AttribType>>>;
 
 //! parses the attributes provided for an atom and sets
 /// the appropriate RD properties/queries.

--- a/Code/GraphMol/SmilesParse/SmilesParse.cpp
+++ b/Code/GraphMol/SmilesParse/SmilesParse.cpp
@@ -181,7 +181,7 @@ int smiles_parse(const std::string &inp, std::vector<RDKit::RWMol *> &molVect) {
   return smiles_parse_helper(inp, molVect, atom, bond, start_tok);
 }
 
-typedef enum { BASE = 0, BRANCH, RECURSE } SmaState;
+enum SmaState { BASE = 0, BRANCH, RECURSE };
 
 std::string labelRecursivePatterns(const std::string &sma) {
 #ifndef NO_AUTOMATIC_SMARTS_RELABELLING

--- a/Code/GraphMol/SmilesParse/SmilesParseOps.cpp
+++ b/Code/GraphMol/SmilesParse/SmilesParseOps.cpp
@@ -198,8 +198,8 @@ void AddFragToMol(RWMol *mol, RWMol *frag, Bond::BondType bondOrder,
   frag->clearAllBondBookmarks();
 };
 
-typedef std::pair<size_t, int> SIZET_PAIR;
-typedef std::pair<int, int> INT_PAIR;
+using SIZET_PAIR = std::pair<size_t, int>;
+using INT_PAIR = std::pair<int, int>;
 template <typename T>
 bool operator<(const std::pair<T, T> &p1, const std::pair<T, T> &p2) {
   return p1.first < p2.first;

--- a/Code/GraphMol/SmilesParse/SmilesWrite.cpp
+++ b/Code/GraphMol/SmilesParse/SmilesWrite.cpp
@@ -698,9 +698,8 @@ std::string MolToSmiles(const ROMol &mol, const SmilesWriteParams &params,
   if (params.canonical) {
     // Sort the vfragsmi, but also sort the atom and bond order vectors into
     // the same order
-    typedef std::tuple<std::string, std::vector<unsigned int>,
-                       std::vector<unsigned int>>
-        tplType;
+    using tplType = std::tuple<std::string, std::vector<unsigned int>,
+                               std::vector<unsigned int>>;
     std::vector<tplType> tmp(vfragsmi.size());
     for (unsigned int ti = 0; ti < vfragsmi.size(); ++ti) {
       tmp[ti] = std::make_tuple(vfragsmi[ti], allAtomOrdering[ti],

--- a/Code/GraphMol/SmilesParse/SmilesWrite.h
+++ b/Code/GraphMol/SmilesParse/SmilesWrite.h
@@ -13,9 +13,7 @@
 
 #include <string>
 #include <vector>
-#include <memory>
 #include <cstdint>
-#include <limits>
 #include <RDGeneral/BetterEnums.h>
 
 #include <boost/shared_ptr.hpp>
@@ -25,7 +23,7 @@ class Atom;
 class Bond;
 class ROMol;
 
-typedef std::vector<boost::shared_ptr<ROMol>> MOL_SPTR_VECT;
+using MOL_SPTR_VECT = std::vector<boost::shared_ptr<ROMol>>;
 
 struct RDKIT_SMILESPARSE_EXPORT SmilesWriteParams {
   bool doIsomericSmiles =

--- a/Code/GraphMol/SmilesParse/smatest.cpp
+++ b/Code/GraphMol/SmilesParse/smatest.cpp
@@ -9,7 +9,6 @@
 //
 #include <RDGeneral/test.h>
 
-#include <fstream>
 #include "SmilesParse.h"
 #include "SmilesWrite.h"
 #include "SmartsWrite.h"
@@ -20,7 +19,7 @@
 // #include <boost/log/functions.hpp>
 using namespace RDKit;
 using namespace std;
-typedef ROMol Mol;
+using Mol = ROMol;
 
 #define LOCAL_TEST_ALL 1
 #if LOCAL_TEST_ALL

--- a/Code/GraphMol/StructChecker/StructChecker.h
+++ b/Code/GraphMol/StructChecker/StructChecker.h
@@ -244,7 +244,7 @@ or
 */
 class RDKIT_STRUCTCHECKER_EXPORT StructChecker {
  public:
-  typedef enum StructureFlags {
+  enum StructureFlags {
     NO_CHANGE = 0,
     BAD_MOLECULE = 0x0001,
     ALIAS_CONVERSION_FAILED = 0x0002,
@@ -270,7 +270,7 @@ class RDKIT_STRUCTCHECKER_EXPORT StructChecker {
     TRANSFORMED_SET = (TRANSFORMED | FRAGMENTS_FOUND | EITHER_WARNING |
                        DUBIOUS_STEREO_REMOVED | STEREO_TRANSFORMED |
                        TEMPLATE_TRANSFORMED | TAUTOMER_TRANSFORMED | RECHARGED),
-  } StructureFlags;
+  };
   // attributes:
  private:
   StructCheckerOptions Options;

--- a/Code/GraphMol/StructChecker/Utilites.cpp
+++ b/Code/GraphMol/StructChecker/Utilites.cpp
@@ -62,7 +62,7 @@ bool getMolAtomPoints(const ROMol &mol, std::vector<RDGeom::Point3D> &atomPoint,
   return non_zero_z;
 }
 
-typedef std::tuple<std::string, int, int, int> NbrData;
+using NbrData = std::tuple<std::string, int, int, int>;
 
 bool lessTuple(const NbrData &left, const NbrData &right) {
   if (std::get<0>(left) < std::get<0>(right)) {

--- a/Code/GraphMol/Subgraphs/SubgraphUtils.h
+++ b/Code/GraphMol/Subgraphs/SubgraphUtils.h
@@ -23,7 +23,7 @@ class ROMol;
 
 namespace Subgraphs {
 //! used to return path discriminators (three unsigned ints):
-typedef std::tuple<std::uint32_t, std::uint32_t, std::uint32_t> DiscrimTuple;
+using DiscrimTuple = std::tuple<std::uint32_t, std::uint32_t, std::uint32_t>;
 
 RDKIT_SUBGRAPHS_EXPORT DiscrimTuple calcPathDiscriminators(
     const ROMol &mol, const PATH_TYPE &path, bool useBO = true,

--- a/Code/GraphMol/Subgraphs/Subgraphs.h
+++ b/Code/GraphMol/Subgraphs/Subgraphs.h
@@ -39,13 +39,13 @@ class ROMol;
 // NOTE: before replacing the defn of PATH_TYPE: be aware that
 // we do occasionally use reverse iterators on these things, so
 // replacing with a slist would probably be a bad idea.
-typedef std::vector<int> PATH_TYPE;
-typedef std::list<PATH_TYPE> PATH_LIST;
-typedef PATH_LIST::const_iterator PATH_LIST_CI;
+using PATH_TYPE = std::vector<int>;
+using PATH_LIST = std::list<PATH_TYPE>;
+using PATH_LIST_CI = PATH_LIST::const_iterator;
 
-typedef std::map<int, PATH_LIST> INT_PATH_LIST_MAP;
-typedef INT_PATH_LIST_MAP::const_iterator INT_PATH_LIST_MAP_CI;
-typedef INT_PATH_LIST_MAP::iterator INT_PATH_LIST_MAP_I;
+using INT_PATH_LIST_MAP = std::map<int, PATH_LIST>;
+using INT_PATH_LIST_MAP_CI = INT_PATH_LIST_MAP::const_iterator;
+using INT_PATH_LIST_MAP_I = INT_PATH_LIST_MAP::iterator;
 
 // --- --- --- --- --- --- --- --- --- --- --- --- ---
 //

--- a/Code/GraphMol/SubstanceGroup.h
+++ b/Code/GraphMol/SubstanceGroup.h
@@ -18,7 +18,6 @@
 #define _RD_SGROUP_H
 
 #include <utility>
-#include <unordered_map>
 
 #include <Geometry/point.h>
 #include <RDGeneral/types.h>
@@ -59,7 +58,7 @@ class RDKIT_GRAPHMOL_EXPORT SubstanceGroup : public RDProps {
     CBOND,  // Internal/Contained bond
   };
 
-  typedef std::array<RDGeom::Point3D, 3> Bracket;
+  using Bracket = std::array<RDGeom::Point3D, 3>;
 
   //! Data structure for SAP lines (see V3000 spec)
   //! lvIdx may not be set; this signaled with value -1

--- a/Code/GraphMol/Substruct/SubstructMatch.cpp
+++ b/Code/GraphMol/Substruct/SubstructMatch.cpp
@@ -113,13 +113,13 @@ bool enhancedStereoIsOK(
 
 }  // namespace
 
-typedef std::map<unsigned int, QueryAtom::QUERYATOM_QUERY *> SUBQUERY_MAP;
+using SUBQUERY_MAP = std::map<unsigned int, QueryAtom::QUERYATOM_QUERY *>;
 
-typedef struct {
+struct ResSubstructMatchHelperArgs_ {
   ResonanceMolSupplier &resMolSupplier;
   const ROMol &query;
   const SubstructMatchParameters &params;
-} ResSubstructMatchHelperArgs_;
+};
 
 void MatchSubqueries(const ROMol &mol, QueryAtom::QUERYATOM_QUERY *q,
                      const SubstructMatchParameters &params,
@@ -170,9 +170,8 @@ void ResSubstructMatchHelper_(const ResSubstructMatchHelperArgs_ &args,
                               std::set<MatchVectType> *matches, unsigned int bi,
                               unsigned int ei);
 
-typedef std::vector<
-    std::pair<MolGraph::vertex_descriptor, MolGraph::vertex_descriptor>>
-    ssPairType;
+using ssPairType = std::vector<
+    std::pair<MolGraph::vertex_descriptor, MolGraph::vertex_descriptor>>;
 
 }  // namespace detail
 
@@ -387,7 +386,7 @@ class AtomLabelFunctor {
  public:
   AtomLabelFunctor(const ROMol &query, const ROMol &mol,
                    const SubstructMatchParameters &ps)
-      : d_query(query), d_mol(mol), d_params(ps) {};
+      : d_query(query), d_mol(mol), d_params(ps){};
 
   bool operator()(unsigned int i, unsigned int j) const {
     bool res = false;
@@ -416,7 +415,7 @@ class BondLabelFunctor {
  public:
   BondLabelFunctor(const ROMol &query, const ROMol &mol,
                    const SubstructMatchParameters &ps)
-      : d_query(query), d_mol(mol), d_params(ps) {};
+      : d_query(query), d_mol(mol), d_params(ps){};
   bool operator()(MolGraph::edge_descriptor i,
                   MolGraph::edge_descriptor j) const {
     if (d_params.useChirality) {

--- a/Code/GraphMol/Substruct/SubstructMatch.h
+++ b/Code/GraphMol/Substruct/SubstructMatch.h
@@ -37,7 +37,7 @@ class MolBundle;
 
 //! \brief used to return matches from substructure searching,
 //!   The format is (queryAtomIdx, molAtomIdx)
-typedef std::vector<std::pair<int, int>> MatchVectType;
+using MatchVectType = std::vector<std::pair<int, int>>;
 
 struct RDKIT_SUBSTRUCTMATCH_EXPORT SubstructMatchParameters {
   bool useChirality = false;  //!< Use chirality in determining whether or not

--- a/Code/GraphMol/Substruct/SubstructUtils.cpp
+++ b/Code/GraphMol/Substruct/SubstructUtils.cpp
@@ -29,7 +29,7 @@ namespace detail {
 // is added to each score based on match indices.
 class ScoreMatchesByDegreeOfCoreSubstitution {
  public:
-  typedef std::pair<unsigned int, double> IdxScorePair;
+  using IdxScorePair = std::pair<unsigned int, double>;
   ScoreMatchesByDegreeOfCoreSubstitution(
       const RDKit::ROMol &mol, const RDKit::ROMol &query,
       const std::vector<RDKit::MatchVectType> &matches)

--- a/Code/GraphMol/Substruct/catch_tests.cpp
+++ b/Code/GraphMol/Substruct/catch_tests.cpp
@@ -30,7 +30,7 @@
 #include <GraphMol/MolPickler.h>
 
 using namespace RDKit;
-typedef std::tuple<std::string, std::string, size_t> matchCase;
+using matchCase = std::tuple<std::string, std::string, size_t>;
 
 class _IsSubstructOf : public Catch::Matchers::MatcherBase<const ROMol &> {
   ROMol const *m_mol;

--- a/Code/GraphMol/Substruct/vf2.hpp
+++ b/Code/GraphMol/Substruct/vf2.hpp
@@ -24,7 +24,7 @@
 
 namespace boost {
 namespace detail {
-typedef std::uint32_t node_id;
+using node_id = std::uint32_t;
 const node_id NULL_NODE = 0xFFFFFFFF;
 struct NodeInfo {
   node_id id;

--- a/Code/GraphMol/Trajectory/Snapshot.h
+++ b/Code/GraphMol/Trajectory/Snapshot.h
@@ -18,7 +18,7 @@
 namespace RDKit {
 class Snapshot;
 class Trajectory;
-typedef std::vector<Snapshot> SnapshotVect;
+using SnapshotVect = std::vector<Snapshot>;
 }  // namespace RDKit
 
 namespace RDKit {

--- a/Code/GraphMol/Wrap/seqs.hpp
+++ b/Code/GraphMol/Wrap/seqs.hpp
@@ -121,11 +121,10 @@ class ReadOnlySeq {
   }
 };
 
-typedef ReadOnlySeq<ROMol::QueryAtomIterator, Atom *, AtomCountFunctor>
-    QueryAtomIterSeq;
+using QueryAtomIterSeq =
+    ReadOnlySeq<ROMol::QueryAtomIterator, Atom *, AtomCountFunctor>;
 
-typedef ReadOnlySeq<ROMol::ConformerIterator, CONFORMER_SPTR &,
-                    ConformerCountFunctor>
-    ConformerIterSeq;
+using ConformerIterSeq = ReadOnlySeq<ROMol::ConformerIterator, CONFORMER_SPTR &,
+                                     ConformerCountFunctor>;
 }  // namespace RDKit
 #endif

--- a/Code/GraphMol/atomic_data.cpp
+++ b/Code/GraphMol/atomic_data.cpp
@@ -14,7 +14,7 @@
 #include <sstream>
 #include <locale>
 
-typedef boost::tokenizer<boost::char_separator<char>> tokenizer;
+using tokenizer = boost::tokenizer<boost::char_separator<char>>;
 
 namespace RDKit {
 

--- a/Code/GraphMol/details.h
+++ b/Code/GraphMol/details.h
@@ -11,5 +11,5 @@
 #include <cstdint>
 
 namespace RDKit {
-typedef std::uint32_t atomindex_t;
+using atomindex_t = std::uint32_t;
 }

--- a/Code/GraphMol/hanoitest.cpp
+++ b/Code/GraphMol/hanoitest.cpp
@@ -99,12 +99,9 @@ void hs1(const std::vector<std::vector<int>> &vects) {
 void test1() {
   BOOST_LOG(rdInfoLog) << "Testing the hanoi sort" << std::endl;
 
-  typedef boost::random::mersenne_twister<std::uint32_t, 32, 4, 2, 31,
-                                          0x9908b0df, 11, 7, 0x9d2c5680, 15,
-                                          0xefc60000, 18, 3346425566U>
-      rng_type;
-  typedef boost::uniform_int<> distrib_type;
-  typedef boost::variate_generator<rng_type &, distrib_type> source_type;
+  using rng_type = boost::random::mersenne_twister<std::uint32_t, 32, 4, 2, 31, 2567483615U, 11, 7, 2636928640U, 15, 4022730752U, 18, 3346425566U>;
+  using distrib_type = boost::uniform_int<>;
+  using source_type = boost::variate_generator<rng_type &, distrib_type>;
   rng_type generator(42u);
 
   const unsigned int nVects = 500000;

--- a/Code/GraphMol/itertest.cpp
+++ b/Code/GraphMol/itertest.cpp
@@ -19,7 +19,7 @@
 using namespace RDKit;
 using namespace std;
 
-using Mol = class ROMol;
+using Mol = ROMol;
 
 void test1() {
   string smi = "CCOC";

--- a/Code/GraphMol/itertest.cpp
+++ b/Code/GraphMol/itertest.cpp
@@ -15,12 +15,11 @@
 #include <RDGeneral/RDLog.h>
 
 #include <cstdlib>
-#include <vector>
 
 using namespace RDKit;
 using namespace std;
 
-typedef class ROMol Mol;
+using Mol = class ROMol;
 
 void test1() {
   string smi = "CCOC";

--- a/Code/GraphMol/molopstest.cpp
+++ b/Code/GraphMol/molopstest.cpp
@@ -39,7 +39,7 @@
 using namespace RDKit;
 using namespace std;
 RWMol _t;
-typedef class ROMol Mol;
+using Mol = class ROMol;
 
 TEST_CASE("test1") {
   string smi;

--- a/Code/GraphMol/molopstest.cpp
+++ b/Code/GraphMol/molopstest.cpp
@@ -39,7 +39,7 @@
 using namespace RDKit;
 using namespace std;
 RWMol _t;
-using Mol = class ROMol;
+using Mol = ROMol;
 
 TEST_CASE("test1") {
   string smi;

--- a/Code/GraphMol/querytest.cpp
+++ b/Code/GraphMol/querytest.cpp
@@ -17,7 +17,7 @@
 
 using namespace RDKit;
 using namespace std;
-typedef class RWMol Mol;
+using Mol = class RWMol;
 
 void test1() {
   BOOST_LOG(rdErrorLog) << "---------------------- Test1" << std::endl;

--- a/Code/GraphMol/querytest.cpp
+++ b/Code/GraphMol/querytest.cpp
@@ -17,7 +17,7 @@
 
 using namespace RDKit;
 using namespace std;
-using Mol = class RWMol;
+using Mol = RWMol;
 
 void test1() {
   BOOST_LOG(rdErrorLog) << "---------------------- Test1" << std::endl;

--- a/Code/ML/Cluster/Murtagh/Clustering.cpp
+++ b/Code/ML/Cluster/Murtagh/Clustering.cpp
@@ -9,13 +9,12 @@
 #define PY_ARRAY_UNIQUE_SYMBOL Py_Array_API_Clustering
 
 #include <RDBoost/Wrap.h>
-#include <cstdint>
 
 namespace python = boost::python;
 
 #include <RDBoost/import_array.h>
 
-typedef double real;
+using real = double;
 
 extern "C" void distdriver_(boost::int64_t *n, boost::int64_t *len, real *dists,
                             boost::int64_t *toggle, boost::int64_t *ia,

--- a/Code/ML/InfoTheory/InfoBitRanker.cpp
+++ b/Code/ML/InfoTheory/InfoBitRanker.cpp
@@ -18,8 +18,8 @@
 #include <queue>
 
 namespace RDInfoTheory {
-typedef std::pair<double, int> PAIR_D_I;
-typedef std::vector<PAIR_D_I> VECT_PDI;
+using PAIR_D_I = std::pair<double, int>;
+using VECT_PDI = std::vector<PAIR_D_I>;
 
 struct gtDIPair {
   bool operator()(const PAIR_D_I &pd1, const PAIR_D_I &pd2) const {
@@ -27,7 +27,7 @@ struct gtDIPair {
   }
 };
 
-typedef std::priority_queue<PAIR_D_I, VECT_PDI, gtDIPair> PR_QUEUE;
+using PR_QUEUE = std::priority_queue<PAIR_D_I, VECT_PDI, gtDIPair>;
 
 void InfoBitRanker::setBiasList(RDKit::INT_VECT &classList) {
   URANGE_CHECK(classList.size(), d_classes);

--- a/Code/ML/InfoTheory/InfoBitRanker.h
+++ b/Code/ML/InfoTheory/InfoBitRanker.h
@@ -79,20 +79,20 @@
  * 1 0.000 1 1
  */
 namespace RDInfoTheory {
-typedef std::vector<RDKit::USHORT> USHORT_VECT;
-typedef std::vector<USHORT_VECT> VECT_USHORT_VECT;
+using USHORT_VECT = std::vector<RDKit::USHORT>;
+using VECT_USHORT_VECT = std::vector<USHORT_VECT>;
 
 class RDKIT_INFOTHEORY_EXPORT InfoBitRanker {
  public:
   /*! \brief the type of measure for information
    *
    */
-  typedef enum {
+  enum InfoType {
     ENTROPY = 1,
     BIASENTROPY = 2,
     CHISQUARE = 3,
     BIASCHISQUARE = 4
-  } InfoType;
+  };
 
   /*! \brief Constructor
    *

--- a/Code/Numerics/Matrix.h
+++ b/Code/Numerics/Matrix.h
@@ -27,7 +27,7 @@ namespace RDNumeric {
 template <class TYPE>
 class Matrix {
  public:
-  typedef boost::shared_array<TYPE> DATA_SPTR;
+  using DATA_SPTR = boost::shared_array<TYPE>;
 
   //! Initialize with a size.
   Matrix(unsigned int nRows, unsigned int nCols)
@@ -340,7 +340,7 @@ Vector<TYPE> &multiply(const Matrix<TYPE> &A, const Vector<TYPE> &x,
   return y;
 };
 
-typedef Matrix<double> DoubleMatrix;
+using DoubleMatrix = Matrix<double>;
 };  // namespace RDNumeric
 
 //! ostream operator for Matrix's

--- a/Code/Numerics/SquareMatrix.h
+++ b/Code/Numerics/SquareMatrix.h
@@ -85,7 +85,7 @@ class SquareMatrix : public Matrix<TYPE> {
     return (*this);
   }
 };
-typedef SquareMatrix<double> DoubleSquareMatrix;
+using DoubleSquareMatrix = SquareMatrix<double>;
 }  // namespace RDNumeric
 
 #endif

--- a/Code/Numerics/SymmMatrix.h
+++ b/Code/Numerics/SymmMatrix.h
@@ -29,7 +29,7 @@ namespace RDNumeric {
 template <class TYPE>
 class SymmMatrix {
  public:
-  typedef boost::shared_array<TYPE> DATA_SPTR;
+  using DATA_SPTR = boost::shared_array<TYPE>;
 
   explicit SymmMatrix(unsigned int N) : d_size(N), d_dataSize(N * (N + 1) / 2) {
     TYPE *data = new TYPE[d_dataSize];
@@ -336,9 +336,9 @@ Vector<TYPE> &multiply(const SymmMatrix<TYPE> &A, const Vector<TYPE> &x,
   return y;
 }
 
-typedef SymmMatrix<double> DoubleSymmMatrix;
-typedef SymmMatrix<int> IntSymmMatrix;
-typedef SymmMatrix<unsigned int> UintSymmMatrix;
+using DoubleSymmMatrix = SymmMatrix<double>;
+using IntSymmMatrix = SymmMatrix<int>;
+using UintSymmMatrix = SymmMatrix<unsigned int>;
 }  // namespace RDNumeric
 
 //! ostream operator for Matrix's

--- a/Code/Numerics/Vector.h
+++ b/Code/Numerics/Vector.h
@@ -29,7 +29,7 @@ namespace RDNumeric {
 template <class TYPE>
 class Vector {
  public:
-  typedef std::shared_ptr<TYPE[]> DATA_SPTR;
+  using DATA_SPTR = std::shared_ptr<TYPE[]>;
 
   //! Initialize with only a size.
   constexpr explicit Vector(unsigned int N) {
@@ -293,7 +293,7 @@ class Vector {
   Vector<TYPE> &operator=(const Vector<TYPE> &other);
 };
 
-typedef Vector<double> DoubleVector;
+using DoubleVector = Vector<double>;
 
 //! returns the algebraic tanimoto similarity [defn' from JCIM 46:587-96 (2006)]
 template <typename T>

--- a/Code/Query/AndQuery.h
+++ b/Code/Query/AndQuery.h
@@ -21,7 +21,7 @@ template <class MatchFuncArgType, class DataFuncArgType = MatchFuncArgType,
 class RDKIT_QUERY_EXPORT AndQuery
     : public Query<MatchFuncArgType, DataFuncArgType, needsConversion> {
  public:
-  typedef Query<MatchFuncArgType, DataFuncArgType, needsConversion> BASE;
+  using BASE = Query<MatchFuncArgType, DataFuncArgType, needsConversion>;
   AndQuery() { this->df_negate = false; }
 
   bool Match(const DataFuncArgType what) const override {

--- a/Code/Query/OrQuery.h
+++ b/Code/Query/OrQuery.h
@@ -20,7 +20,7 @@ template <class MatchFuncArgType, class DataFuncArgType = MatchFuncArgType,
 class RDKIT_QUERY_EXPORT OrQuery
     : public Query<MatchFuncArgType, DataFuncArgType, needsConversion> {
  public:
-  typedef Query<MatchFuncArgType, DataFuncArgType, needsConversion> BASE;
+  using BASE = Query<MatchFuncArgType, DataFuncArgType, needsConversion>;
   OrQuery() { this->df_negate = false; }
 
   bool Match(const DataFuncArgType what) const override {

--- a/Code/Query/QueryObjects.h
+++ b/Code/Query/QueryObjects.h
@@ -33,6 +33,10 @@
 #include "XOrQuery.h"
 
 namespace Queries {
-typedef enum { COMPOSITE_AND, COMPOSITE_OR, COMPOSITE_XOR } CompositeQueryType;
-}
+enum CompositeQueryType {
+  COMPOSITE_AND,
+  COMPOSITE_OR,
+  COMPOSITE_XOR
+};
+}  // namespace Queries
 #endif

--- a/Code/Query/SetQuery.h
+++ b/Code/Query/SetQuery.h
@@ -25,7 +25,7 @@ template <class MatchFuncArgType, class DataFuncArgType = MatchFuncArgType,
 class RDKIT_QUERY_EXPORT SetQuery
     : public Query<MatchFuncArgType, DataFuncArgType, needsConversion> {
  public:
-  typedef std::set<MatchFuncArgType> CONTAINER_TYPE;
+  using CONTAINER_TYPE = std::set<MatchFuncArgType>;
 
   SetQuery() : Query<MatchFuncArgType, DataFuncArgType, needsConversion>() {}
 

--- a/Code/Query/XOrQuery.h
+++ b/Code/Query/XOrQuery.h
@@ -21,7 +21,7 @@ template <class MatchFuncArgType, class DataFuncArgType = MatchFuncArgType,
 class RDKIT_QUERY_EXPORT XOrQuery
     : public Query<MatchFuncArgType, DataFuncArgType, needsConversion> {
  public:
-  typedef Query<MatchFuncArgType, DataFuncArgType, needsConversion> BASE;
+  using BASE = Query<MatchFuncArgType, DataFuncArgType, needsConversion>;
   XOrQuery() { this->df_negate = false; }
 
   bool Match(const DataFuncArgType what) const override {

--- a/Code/RDBoost/Wrap.h
+++ b/Code/RDBoost/Wrap.h
@@ -24,12 +24,10 @@
 #include <memory>
 
 #include <boost/python/suite/indexing/vector_indexing_suite.hpp>
-#include <cstdint>
 #include "list_indexing_suite.hpp"
 #include <RDGeneral/BoostEndInclude.h>
 
 #include <list>
-#include <string_view>
 #include <vector>
 #include <RDGeneral/Exceptions.h>
 
@@ -307,11 +305,10 @@ struct iterable_converter {
 
     // Obtain a handle to the memory block that the converter has allocated
     // for the C++ type.
-    typedef python::converter::rvalue_from_python_storage<Container>
-        storage_type;
+    using storage_type = python::converter::rvalue_from_python_storage<Container>;
     void *storage = reinterpret_cast<storage_type *>(data)->storage.bytes;
 
-    typedef python::stl_input_iterator<typename Container::value_type> iterator;
+    using iterator = python::stl_input_iterator<typename Container::value_type>;
 
     // Allocate the C++ type into the converter's memory block, and assign
     // its handle to the converter's convertible variable.  The C++

--- a/Code/RDBoost/Wrap/RDBase.cpp
+++ b/Code/RDBoost/Wrap/RDBase.cpp
@@ -8,7 +8,6 @@
 //  of the RDKit source tree.
 //
 #include <RDBoost/python.h>
-#include <fstream>
 #include <RDBoost/Wrap.h>
 #include <RDBoost/python_streambuf.h>
 #include <RDGeneral/versions.h>
@@ -229,7 +228,7 @@ struct PyCaptureErrorLog : boost::noncopyable {
 
 namespace {
 struct python_streambuf_wrapper {
-  typedef boost_adaptbx::python::streambuf wt;
+  using wt = boost_adaptbx::python::streambuf;
 
   static void wrap() {
     using namespace boost::python;
@@ -241,7 +240,7 @@ struct python_streambuf_wrapper {
 };
 
 struct python_ostream_wrapper {
-  typedef boost_adaptbx::python::ostream wt;
+  using wt = boost_adaptbx::python::ostream;
 
   static void wrap() {
     using namespace boost::python;

--- a/Code/RDBoost/boost_numpy.h
+++ b/Code/RDBoost/boost_numpy.h
@@ -3,8 +3,8 @@
 #include <RDGeneral/export.h>
 #if BOOST_VERSION < 106500
 #include <boost/python/numeric.hpp>
-typedef boost::python::numeric::array NumpyArrayType;
+using NumpyArrayType = boost::python::numeric::array;
 #else
 #include <boost/python/numpy.hpp>
-typedef boost::python::numpy::ndarray NumpyArrayType;
+using NumpyArrayType = boost::python::numpy::ndarray;
 #endif

--- a/Code/RDBoost/list_indexing_suite.hpp
+++ b/Code/RDBoost/list_indexing_suite.hpp
@@ -53,11 +53,11 @@ template <class Container, bool NoProxy = false,
 class list_indexing_suite
     : public indexing_suite<Container, DerivedPolicies, NoProxy> {
  public:
-  typedef typename Container::value_type data_type;
-  typedef typename Container::value_type key_type;
-  typedef typename Container::size_type index_type;
-  typedef typename Container::size_type size_type;
-  typedef typename Container::iterator iterator_type;
+  using data_type = typename Container::value_type;
+  using key_type = typename Container::value_type;
+  using index_type = typename Container::size_type;
+  using size_type = typename Container::size_type;
+  using iterator_type = typename Container::iterator;
 
   static typename mpl::if_<is_class<data_type>, data_type&, data_type>::type
   get_item(Container& container, index_type i) {

--- a/Code/RDBoost/python_streambuf.h
+++ b/Code/RDBoost/python_streambuf.h
@@ -109,18 +109,18 @@ namespace bp = boost::python;
 */
 class streambuf : public std::basic_streambuf<char> {
  private:
-  typedef std::basic_streambuf<char> base_t;
+  using base_t = std::basic_streambuf<char>;
 
  public:
   /* The syntax
       using base_t::char_type;
      would be nicer but Visual Studio C++ 8 chokes on it
   */
-  typedef base_t::char_type char_type;
-  typedef base_t::int_type int_type;
-  typedef base_t::pos_type pos_type;
-  typedef base_t::off_type off_type;
-  typedef base_t::traits_type traits_type;
+  using char_type = base_t::char_type;
+  using int_type = base_t::int_type;
+  using pos_type = base_t::pos_type;
+  using off_type = base_t::off_type;
+  using traits_type = base_t::traits_type;
 
   // work around Visual C++ 7.1 problem
   inline static int traits_type_eof() { return traits_type::eof(); }

--- a/Code/RDGeneral/Dict.h
+++ b/Code/RDGeneral/Dict.h
@@ -26,7 +26,7 @@
 #include <RDGeneral/BoostEndInclude.h>
 
 namespace RDKit {
-typedef std::vector<std::string> STR_VECT;
+using STR_VECT = std::vector<std::string>;
 
 //! \brief The \c Dict class can be used to store objects of arbitrary
 //!        type keyed by \c strings.
@@ -49,7 +49,7 @@ class RDKIT_RDGENERAL_EXPORT Dict {
     void cleanup() { RDValue::cleanup_rdvalue(val); }
   };
 
-  typedef std::vector<Pair> DataType;
+  using DataType = std::vector<Pair>;
 
   Dict() {}
 

--- a/Code/RDGeneral/RDLog.h
+++ b/Code/RDGeneral/RDLog.h
@@ -25,8 +25,8 @@
 namespace boost {
 namespace logging {
 
-typedef boost::iostreams::tee_device<std::ostream, std::ostream> RDTee;
-typedef boost::iostreams::stream<RDTee> RDTeeStream;
+using RDTee = boost::iostreams::tee_device<std::ostream, std::ostream>;
+using RDTeeStream = boost::iostreams::stream<RDTee>;
 
 class RDKIT_RDGENERAL_EXPORT rdLogger {
  public:

--- a/Code/RDGeneral/RDValue-taggedunion.h
+++ b/Code/RDGeneral/RDValue-taggedunion.h
@@ -34,8 +34,6 @@
 
 #include <cassert>
 #include "Invariant.h"
-#include <iomanip>
-#include <sstream>
 #include <vector>
 #include <cstdint>
 #include <RDGeneral/BoostStartInclude.h>
@@ -356,7 +354,7 @@ inline void copy_rdvalue(RDValue &dest, const RDValue &src) {
 // avoid register pressure and spilling on 32 bit systems
 typedef const RDValue &RDValue_cast_t;
 #else
-typedef RDValue RDValue_cast_t;
+using RDValue_cast_t = RDValue;
 #endif
 
 /////////////////////////////////////////////////////////////////////////////////////

--- a/Code/RDGeneral/RDValue.h
+++ b/Code/RDGeneral/RDValue.h
@@ -29,6 +29,7 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
 #include <RDGeneral/export.h>
+#include <string>
 #ifndef RDKIT_RDVALUE_H
 #define RDKIT_RDVALUE_H
 
@@ -39,6 +40,7 @@
 #include "RDValue-taggedunion.h"
 #endif
 
+#include <iomanip>
 #include <boost/algorithm/string.hpp>
 
 namespace RDKit {
@@ -195,7 +197,7 @@ inline bool rdvalue_tostring(RDValue_cast_t val, std::string &res) {
       res = rdvalue_cast<std::string>(val);
       break;
     case RDTypeTag::IntTag:
-      res = boost::lexical_cast<std::string>(rdvalue_cast<int>(val));
+      res = std::to_string(rdvalue_cast<int>(val));
       break;
     case RDTypeTag::DoubleTag: {
       Utils::LocaleSwitcher ls;  // for lexical cast...
@@ -203,7 +205,7 @@ inline bool rdvalue_tostring(RDValue_cast_t val, std::string &res) {
       break;
     }
     case RDTypeTag::UnsignedIntTag:
-      res = boost::lexical_cast<std::string>(rdvalue_cast<unsigned int>(val));
+      res = std::to_string(rdvalue_cast<unsigned int>(val));
       break;
 #ifdef RDVALUE_HASBOOL
     case RDTypeTag::BoolTag:
@@ -241,16 +243,16 @@ inline bool rdvalue_tostring(RDValue_cast_t val, std::string &res) {
       } catch (const std::bad_any_cast &) {
         auto &rdtype = rdvalue_cast<std::any &>(val).type();
         if (rdtype == typeid(long)) {
-          res = boost::lexical_cast<std::string>(
+          res = std::to_string(
               std::any_cast<long>(rdvalue_cast<std::any &>(val)));
         } else if (rdtype == typeid(int64_t)) {
-          res = boost::lexical_cast<std::string>(
+          res = std::to_string(
               std::any_cast<int64_t>(rdvalue_cast<std::any &>(val)));
         } else if (rdtype == typeid(uint64_t)) {
-          res = boost::lexical_cast<std::string>(
+          res = std::to_string(
               std::any_cast<uint64_t>(rdvalue_cast<std::any &>(val)));
         } else if (rdtype == typeid(unsigned long)) {
-          res = boost::lexical_cast<std::string>(
+          res = std::to_string(
               std::any_cast<unsigned long>(rdvalue_cast<std::any &>(val)));
         } else {
           throw;

--- a/Code/RDGeneral/StreamOps.h
+++ b/Code/RDGeneral/StreamOps.h
@@ -383,8 +383,8 @@ class CustomPropHandler {
   virtual CustomPropHandler *clone() const = 0;
 };
 
-typedef std::vector<std::shared_ptr<const CustomPropHandler>>
-    CustomPropHandlerVec;
+using CustomPropHandlerVec =
+    std::vector<std::shared_ptr<const CustomPropHandler>>;
 
 inline bool isSerializable(const Dict::Pair &pair,
                            const CustomPropHandlerVec &handlers = {}) {

--- a/Code/RDGeneral/hash/hash_fwd.hpp
+++ b/Code/RDGeneral/hash/hash_fwd.hpp
@@ -16,11 +16,10 @@
 
 #include <cstdint>
 namespace std {
-typedef std::uint32_t hash_result_t;
+using hash_result_t = std::uint32_t;
 }
 
 #include <boost/config.hpp>
-#include <cstddef>
 #include <boost/detail/workaround.hpp>
 
 namespace gboost {

--- a/Code/RDGeneral/testDict.cpp
+++ b/Code/RDGeneral/testDict.cpp
@@ -321,7 +321,7 @@ TEST_CASE("testRDValue") {
 
   {
     // check shared ptrs -- std::any deletes these :)
-    typedef boost::shared_ptr<std::vector<int>> vptr;
+    using vptr = boost::shared_ptr<std::vector<int>>;
     vptr p(new std::vector<int>());
     p->push_back(100);
     RDAny v(p);
@@ -330,7 +330,7 @@ TEST_CASE("testRDValue") {
     REQUIRE((*rdany_cast<vptr>(vv))[0] == 100);
     REQUIRE((*rdany_cast<vptr>((const RDAny &)vv))[0] == 100);
 
-    typedef boost::shared_ptr<std::map<int, int>> mptr;
+    using mptr = boost::shared_ptr<std::map<int, int>>;
     mptr m(new std::map<int, int>());
     (*m)[0] = 1;
     RDAny mv(m);

--- a/Code/RDGeneral/testRDValue.cpp
+++ b/Code/RDGeneral/testRDValue.cpp
@@ -122,7 +122,7 @@ TEST_CASE("testStringVect") {
 
 TEST_CASE("testMapsAndLists") {
   {
-    typedef std::map<std::string, int> listtype;
+    using listtype = std::map<std::string, int>;
     listtype m;
     m["foo"] = 1;
     m["bar"] = 2;

--- a/Code/RDGeneral/types.h
+++ b/Code/RDGeneral/types.h
@@ -33,13 +33,10 @@
 #include <set>
 #include <string>
 #include <string_view>
-#include <algorithm>
-#include <numeric>
 #include <list>
 #include <limits>
 
 #include <cstring>
-#include <any>
 #include <RDGeneral/BoostStartInclude.h>
 #include <boost/lexical_cast.hpp>
 #include <RDGeneral/BoostEndInclude.h>
@@ -202,7 +199,7 @@ inline constexpr std::string_view _displayLabelW = "_displayLabelW";
 
 }  // namespace common_properties
 #ifndef WIN32
-typedef long long int LONGINT;
+using LONGINT = long long;
 #else
 typedef __int64 LONGINT;
 #endif
@@ -217,62 +214,62 @@ inline constexpr double MAX_DOUBLE = std::numeric_limits<double>::max();
 inline constexpr double EPS_DOUBLE = std::numeric_limits<double>::epsilon();
 inline constexpr int MAX_INT = std::numeric_limits<int>::max();
 
-typedef unsigned int UINT;
-typedef unsigned short USHORT;
-typedef unsigned char UCHAR;
+using UINT = unsigned int;
+using USHORT = unsigned short;
+using UCHAR = unsigned char;
 
-typedef std::vector<int> INT_VECT;
-typedef INT_VECT::iterator INT_VECT_I;
-typedef INT_VECT::const_iterator INT_VECT_CI;
-typedef INT_VECT::reverse_iterator INT_VECT_RI;
-typedef INT_VECT::const_reverse_iterator INT_VECT_CRI;
+using INT_VECT = std::vector<int>;
+using INT_VECT_I = INT_VECT::iterator;
+using INT_VECT_CI = INT_VECT::const_iterator;
+using INT_VECT_RI = INT_VECT::reverse_iterator;
+using INT_VECT_CRI = INT_VECT::const_reverse_iterator;
 
-typedef std::list<int> INT_LIST;
-typedef INT_LIST::iterator INT_LIST_I;
-typedef INT_LIST::const_iterator INT_LIST_CI;
+using INT_LIST = std::list<int>;
+using INT_LIST_I = INT_LIST::iterator;
+using INT_LIST_CI = INT_LIST::const_iterator;
 
-typedef std::list<INT_VECT> LIST_INT_VECT;
-typedef LIST_INT_VECT::iterator LIST_INT_VECT_I;
-typedef LIST_INT_VECT::const_iterator LIST_INT_VECT_CI;
+using LIST_INT_VECT = std::list<INT_VECT>;
+using LIST_INT_VECT_I = LIST_INT_VECT::iterator;
+using LIST_INT_VECT_CI = LIST_INT_VECT::const_iterator;
 
-typedef std::vector<INT_VECT> VECT_INT_VECT;
-typedef VECT_INT_VECT::iterator VECT_INT_VECT_I;
-typedef VECT_INT_VECT::const_iterator VECT_INT_VECT_CI;
+using VECT_INT_VECT = std::vector<INT_VECT>;
+using VECT_INT_VECT_I = VECT_INT_VECT::iterator;
+using VECT_INT_VECT_CI = VECT_INT_VECT::const_iterator;
 
-typedef std::vector<UINT>::const_iterator UINT_VECT_CI;
-typedef std::vector<UINT> UINT_VECT;
+using UINT_VECT_CI = std::vector<UINT>::const_iterator;
+using UINT_VECT = std::vector<UINT>;
 
-typedef std::vector<std::string>::const_iterator STR_VECT_CI;
-typedef std::vector<std::string>::iterator STR_VECT_I;
-typedef std::vector<std::string> STR_VECT;
+using STR_VECT_CI = std::vector<std::string>::const_iterator;
+using STR_VECT_I = std::vector<std::string>::iterator;
+using STR_VECT = std::vector<std::string>;
 
-typedef std::vector<double> DOUBLE_VECT;
-typedef DOUBLE_VECT::iterator DOUBLE_VECT_I;
-typedef DOUBLE_VECT::const_iterator DOUBLE_VECT_CI;
-typedef std::vector<DOUBLE_VECT> VECT_DOUBLE_VECT;
-typedef VECT_DOUBLE_VECT::iterator VECT_DOUBLE_VECT_I;
-typedef VECT_DOUBLE_VECT::const_iterator VECT_DOUBLE_VECT_CI;
+using DOUBLE_VECT = std::vector<double>;
+using DOUBLE_VECT_I = DOUBLE_VECT::iterator;
+using DOUBLE_VECT_CI = DOUBLE_VECT::const_iterator;
+using VECT_DOUBLE_VECT = std::vector<DOUBLE_VECT>;
+using VECT_DOUBLE_VECT_I = VECT_DOUBLE_VECT::iterator;
+using VECT_DOUBLE_VECT_CI = VECT_DOUBLE_VECT::const_iterator;
 
-typedef std::map<std::string, UINT> STR_UINT_MAP;
-typedef std::map<std::string, UINT>::const_iterator STR_UINT_MAP_CI;
+using STR_UINT_MAP = std::map<std::string, UINT>;
+using STR_UINT_MAP_CI = std::map<std::string, UINT>::const_iterator;
 
-typedef std::map<int, INT_VECT> INT_INT_VECT_MAP;
-typedef INT_INT_VECT_MAP::const_iterator INT_INT_VECT_MAP_CI;
+using INT_INT_VECT_MAP = std::map<int, INT_VECT>;
+using INT_INT_VECT_MAP_CI = INT_INT_VECT_MAP::const_iterator;
 
-typedef std::map<int, int> INT_MAP_INT;
-typedef INT_MAP_INT::iterator INT_MAP_INT_I;
-typedef INT_MAP_INT::const_iterator INT_MAP_INT_CI;
+using INT_MAP_INT = std::map<int, int>;
+using INT_MAP_INT_I = INT_MAP_INT::iterator;
+using INT_MAP_INT_CI = INT_MAP_INT::const_iterator;
 
-typedef std::deque<int> INT_DEQUE;
-typedef INT_DEQUE::iterator INT_DEQUE_I;
-typedef INT_DEQUE::const_iterator INT_DEQUE_CI;
+using INT_DEQUE = std::deque<int>;
+using INT_DEQUE_I = INT_DEQUE::iterator;
+using INT_DEQUE_CI = INT_DEQUE::const_iterator;
 
-typedef std::map<int, INT_DEQUE> INT_INT_DEQ_MAP;
-typedef INT_INT_DEQ_MAP::const_iterator INT_INT_DEQ_MAP_CI;
+using INT_INT_DEQ_MAP = std::map<int, INT_DEQUE>;
+using INT_INT_DEQ_MAP_CI = INT_INT_DEQ_MAP::const_iterator;
 
-typedef std::set<int> INT_SET;
-typedef INT_SET::iterator INT_SET_I;
-typedef INT_SET::const_iterator INT_SET_CI;
+using INT_SET = std::set<int>;
+using INT_SET_I = INT_SET::iterator;
+using INT_SET_CI = INT_SET::const_iterator;
 
 //! functor to compare two doubles with a tolerance
 struct RDKIT_RDGENERAL_EXPORT ltDouble {
@@ -291,7 +288,7 @@ struct RDKIT_RDGENERAL_EXPORT ltDouble {
 };
 
 //! std::map from double to integer.
-typedef std::map<double, int, ltDouble> DOUBLE_INT_MAP;
+using DOUBLE_INT_MAP = std::map<double, int, ltDouble>;
 
 //! functor for returning the larger of two values
 template <typename T>

--- a/Code/RDGeneral/utils.h
+++ b/Code/RDGeneral/utils.h
@@ -33,11 +33,11 @@ RDKIT_RDGENERAL_EXPORT double computeIntVectPrimesProduct(const INT_VECT &ring);
 //! floating point comparison with a tolerance
 RDKIT_RDGENERAL_EXPORT bool feq(double v1, double v2, double tol = 1e-4);
 
-typedef boost::minstd_rand rng_type;
-typedef boost::uniform_int<> uniform_int;
-typedef boost::uniform_real<> uniform_double;
-typedef boost::variate_generator<rng_type &, uniform_int> int_source_type;
-typedef boost::variate_generator<rng_type &, uniform_double> double_source_type;
+using rng_type = boost::minstd_rand;
+using uniform_int = boost::uniform_int<>;
+using uniform_double = boost::uniform_real<>;
+using int_source_type = boost::variate_generator<rng_type &, uniform_int>;
+using double_source_type = boost::variate_generator<rng_type &, uniform_double>;
 
 //! Optionally seed and return a reference to the global (Boost) random
 /// generator

--- a/Code/SimDivPickers/HierarchicalClusterPicker.cpp
+++ b/Code/SimDivPickers/HierarchicalClusterPicker.cpp
@@ -11,7 +11,7 @@
 #include <RDGeneral/Invariant.h>
 #include <RDGeneral/types.h>
 
-typedef double real;
+using real = double;
 extern "C" void distdriver_(long int *n, long int *len, real *dists,
                             long int *toggle, long int *ia, long int *ib,
                             real *crit);

--- a/Code/SimDivPickers/HierarchicalClusterPicker.h
+++ b/Code/SimDivPickers/HierarchicalClusterPicker.h
@@ -26,7 +26,7 @@ class RDKIT_SIMDIVPICKERS_EXPORT HierarchicalClusterPicker : public DistPicker {
  public:
   /*! \brief The type of hierarchical clustering algorithm to use
    */
-  typedef enum {
+  enum ClusterMethod {
     WARD = 1,
     SLINK = 2,
     CLINK = 3,
@@ -34,7 +34,7 @@ class RDKIT_SIMDIVPICKERS_EXPORT HierarchicalClusterPicker : public DistPicker {
     MCQUITTY = 5,
     GOWER = 6,
     CENTROID = 7
-  } ClusterMethod;
+  };
 
   /*! \brief Constructor - takes a ClusterMethod as an argument
    *

--- a/Code/SimDivPickers/LeaderPicker.h
+++ b/Code/SimDivPickers/LeaderPicker.h
@@ -136,17 +136,17 @@ void *LeaderPickerWork(void *arg);
 
 template <typename T>
 struct LeaderPickerState {
-  typedef struct {
+  struct LeaderPickerBlock {
     int *ptr;
     unsigned int capacity;
     unsigned int len;
     unsigned int next[2];
-  } LeaderPickerBlock;
-  typedef struct {
+  };
+  struct LeaderPickerThread {
     LeaderPickerState<T> *stat;
     pthread_t tid;
     unsigned int id;
-  } LeaderPickerThread;
+  };
 
   std::vector<LeaderPickerThread> threads;
   std::vector<LeaderPickerBlock> blocks;

--- a/Code/SimDivPickers/MaxMinPicker.h
+++ b/Code/SimDivPickers/MaxMinPicker.h
@@ -166,9 +166,9 @@ RDKit::INT_VECT MaxMinPicker::lazyPick(T &func, unsigned int poolSize,
   // pick the first entry
   if (firstPicks.empty()) {
     // get a seeded random number generator:
-    typedef boost::mt19937 rng_type;
-    typedef boost::uniform_int<> distrib_type;
-    typedef boost::variate_generator<rng_type &, distrib_type> source_type;
+    using rng_type = boost::mt19937;
+    using distrib_type = boost::uniform_int<>;
+    using source_type = boost::variate_generator<rng_type &, distrib_type>;
     rng_type generator;
     distrib_type dist(0, poolSize - 1);
     if (seed >= 0) {

--- a/Code/SimDivPickers/Wrap/PickerHelpers.h
+++ b/Code/SimDivPickers/Wrap/PickerHelpers.h
@@ -12,11 +12,12 @@
 
 #include <vector>
 #include <DataStructs/BitOps.h>
-
+#include <boost/python/extract.hpp>
+#include <RDBoost/Wrap.h>
 // NOTE: TANIMOTO and DICE provably return the same results for the diversity
 // picking this is still here just in case we ever later want to support other
 //    methods.
-typedef enum { TANIMOTO = 1, DICE } DistanceMethod;
+enum DistanceMethod { TANIMOTO = 1, DICE };
 
 template <typename BV>
 class pyBVFunctor {


### PR DESCRIPTION
Running clang-tidy modernize-use-using.

Removed a few unused includes.

Replaced a few `boost::lexical_cast` with `std::to_string` where possible without changing the result.