### PR TITLE
Fix flaky DiversityPickerTests.test3.

### DIFF
--- a/Code/JavaWrappers/gmwrapper/src-test/org/RDKit/DiversityPickerTests.java
+++ b/Code/JavaWrappers/gmwrapper/src-test/org/RDKit/DiversityPickerTests.java
@@ -151,16 +151,30 @@ public class DiversityPickerTests extends GraphMolTest {
 	}
 	@Test
 	public void test3() {
-		Int_Vect avoid = new Int_Vect();
-		Int_Vect picks1 = RDKFuncs.pickUsingFingerprints(fps,5,-1);
-		Int_Vect picks2 = RDKFuncs.pickUsingFingerprints(fps,5,-1);
-		assertEquals(picks1.size(),5);
-		assertEquals(picks2.size(),5);
-		boolean allEqual=true;
-		for(int i=0;i<picks1.size();++i){
-			if(picks1.get(i)!=picks2.get(i)) allEqual=false;
+		// The seed controls the (randomized) starting point of the pick. Verify
+		// this deterministically: the same seed reproduces the same picks, and
+		// a different seed produces different picks. (Replaces an older check that
+		// used a random seed of -1, which was flaky.)
+		Int_Vect picksA1 = RDKFuncs.pickUsingFingerprints(fps,5,42);
+		Int_Vect picksA2 = RDKFuncs.pickUsingFingerprints(fps,5,42);
+		Int_Vect picksB  = RDKFuncs.pickUsingFingerprints(fps,5,43);
+		assertEquals(picksA1.size(),5);
+		assertEquals(picksA2.size(),5);
+		assertEquals(picksB.size(),5);
+
+		// same seed => identical picks
+		boolean sameSeedEqual=true;
+		for(int i=0;i<picksA1.size();++i){
+			if(picksA1.get(i)!=picksA2.get(i)) sameSeedEqual=false;
 		}
-		assertFalse(allEqual);
+		assertTrue(sameSeedEqual);
+
+		// different seed => at least one pick differs
+		boolean diffSeedEqual=true;
+		for(int i=0;i<picksA1.size();++i){
+			if(picksA1.get(i)!=picksB.get(i)) diffSeedEqual=false;
+		}
+		assertFalse(diffSeedEqual);
 	}
 
 	public static void main(String args[]) {


### PR DESCRIPTION
#### Reference Issue
[build failure](https://dev.azure.com/rdkit-builds/RDKit/_build/results?buildId=9088&view=logs&j=c3f36e38-df14-5980-350d-4b7755aad098&t=365d5905-c645-5052-00ff-6de503e5c589)
[build log](https://github.com/user-attachments/files/29969948/58.txt)

 JavaDiversityPickerTests.test3 fails intermittently in CI (DiversityPickerTests.java:163). 
```
Int_Vect picks1 = RDKFuncs.pickUsingFingerprints(fps,5,-1);
Int_Vect picks2 = RDKFuncs.pickUsingFingerprints(fps,5,-1);
...
assertFalse(allEqual);   // expects two random-seeded runs to differ                                                                                                                        
```
A seed of -1 seeds the RNG from std::random_device() (Code/SimDivPickers/MaxMinPicker.h:177). Only the first pick is random; the other 4 are deterministic MaxMin selections from that starting point. So there is roughly a 1-in-100 chance both runs draw the same first pick, produce identical results, and fail assertFalse(allEqual). That is what happened in CI.     

#### What does this implement/fix? Explain your changes.
Test the same premise — that the seed controls the pick order — using fixed seeds instead of a random one, so the result is fully deterministic (always passes when the code is correct, always fails when it is broken):
1. Reproducibility: the same fixed seed produces identical picks.
3. Seed sensitivity: two different fixed seeds produce different picks (the deterministic analog of "repeated random runs differ").

#### Any other comments?

