### PR TITLE
Only use ignoreAtomMapNumbers if canonicalising.

### DIFF
--- a/Code/GraphMol/SmilesParse/SmilesWrite.cpp
+++ b/Code/GraphMol/SmilesParse/SmilesWrite.cpp
@@ -544,7 +544,7 @@ std::string MolToSmiles(const ROMol &mol, const SmilesWriteParams &params,
     // update property cache
     std::vector<int> atomMapNums(tmol->getNumAtoms(), 0);
     for (auto atom : tmol->atoms()) {
-      if (params.ignoreAtomMapNumbers) {
+      if (params.canonical && params.ignoreAtomMapNumbers) {
         atomMapNums[atom->getIdx()] = atom->getAtomMapNum();
         atom->setAtomMapNum(0);
       }
@@ -639,7 +639,7 @@ std::string MolToSmiles(const ROMol &mol, const SmilesWriteParams &params,
                           includeIsotopes, includeAtomMaps,
                           includeChiralPresence, includeStereoGroups,
                           useNonStereoRanks);
-      if (params.ignoreAtomMapNumbers) {
+      if (params.canonical && params.ignoreAtomMapNumbers) {
         for (auto atom : tmol->atoms()) {
           atom->setAtomMapNum(atomMapNums[atom->getIdx()]);
         }

--- a/Code/GraphMol/SmilesParse/catch_tests.cpp
+++ b/Code/GraphMol/SmilesParse/catch_tests.cpp
@@ -3027,8 +3027,8 @@ TEST_CASE("Ignore atom map numbers") {
   // if ignoreAtomMapNumbers is true as the latter should only apply if
   // canonicalising. (Github 9225).
   auto m3 = "c1ccc([NH2:1])cc1"_smiles;
-  CHECK(MolToSmiles(*m3, true, false, -1, false, false, false, false, true) ==
-        "c1ccc([NH2:1])cc1");
+  SmilesWriteParams params2{.canonical = false, .ignoreAtomMapNumbers = true};
+  CHECK(MolToSmiles(*m3, params2) == "c1ccc([NH2:1])cc1");
 }
 
 TEST_CASE("Github #7340", "[Reaction][CX][CXSmiles]") {

--- a/Code/GraphMol/SmilesParse/catch_tests.cpp
+++ b/Code/GraphMol/SmilesParse/catch_tests.cpp
@@ -3022,6 +3022,13 @@ TEST_CASE("Ignore atom map numbers") {
   CHECK(MolToSmiles(*m1, params) == MolToSmiles(*m2, params));
   CHECK(MolToSmiles(*m1, true, false, -1, true, false, false, false, true) ==
         MolToSmiles(*m2, true, false, -1, true, false, false, false, true));
+
+  // If not doing canonical SMILES, the map numbers should not be removed
+  // if ignoreAtomMapNumbers is true as the latter should only apply if
+  // canonicalising. (Github 9225).
+  auto m3 = "c1ccc([NH2:1])cc1"_smiles;
+  CHECK(MolToSmiles(*m3, true, false, -1, false, false, false, false, true) ==
+        "c1ccc([NH2:1])cc1");
 }
 
 TEST_CASE("Github #7340", "[Reaction][CX][CXSmiles]") {

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -19,6 +19,7 @@ Eigen dense modules (LU/QR/SVD/etc.) must now include `<Eigen/Dense>` directly.
 takes arguments in C++. If you want to initialize data members to non-default
 values, use the designated initialization syntax. This change does not affect
 Python.
+- MolToSmiles with canonical=false, ignoreAtomMapNumbers=true no longer strips out the atom map numbers.
 
 ## Code removed in this release:
 - The version of hanoiSort() that takes raw pointers has been removed. Please use


### PR DESCRIPTION
#### Reference Issue
Fixes #9225


#### What does this implement/fix? Explain your changes.
As the issue says, the atom map numbers should not be removed  if not canonicalising.

#### Any other comments?

