### PR TITLE
Pin random seed in testGithub1990 to fix flaky conformer embedding

### DIFF
--- a/Code/GraphMol/DistGeomHelpers/testDgeomHelpers.cpp
+++ b/Code/GraphMol/DistGeomHelpers/testDgeomHelpers.cpp
@@ -1584,7 +1584,8 @@ TEST_CASE("testGithub1990") {
     MolOps::addHs(*mol);
     MolOps::removeHs(*mol);
     const bool legacyETKDG = GENERATE(true, false);
-    DGeomHelpers::EmbedParameters params{.useLegacyImplementation =
+    DGeomHelpers::EmbedParameters params{.randomSeed = 0xf00d,
+                                         .useLegacyImplementation =
                                              legacyETKDG};
     int cid = DGeomHelpers::EmbedMolecule(*mol, params);
     CHECK(cid >= 0);


### PR DESCRIPTION
## Problem

The `testGithub1990` "Reported Problem" section (in `testDgeomHelpers.cpp`) fails intermittently in CI:

```
CHECK( cid >= 0 )
with expansion:
  -1 >= 0
```

`cid == -1` means `EmbedMolecule` failed to generate a conformer.

## Root cause

That section embeds a large, floppy conjugated molecule (a carotenoid diester, 76 heavy atoms) with a **default, non-deterministic random seed** (`EmbedParameters::randomSeed` defaults to `-1`). For this hard-to-embed molecule the embedding occasionally fails to converge, so the check flakes depending on which seed a given CI run happens to draw.

Measured failure rate (RDKit 2026.03.3, 50 attempts per configuration, same molecule and prep as the test):

| configuration | failures |
|---|---|
| `randomSeed = -1` (default) | ~4% |
| `randomSeed = 0xf00d` | 0% |

0/50 held for both the legacy implementation and the new ETDG/ETKDG/ETKDGv3 paths — i.e. both branches the section exercises via `GENERATE(true, false)`.

## Fix

Pin `randomSeed = 0xf00d` (a seed already used elsewhere in this file, e.g. `testProvideBoundsMatrix`) so the embedding is deterministic and reliably succeeds.

`maxIterations` is intentionally left at its default (`10 × numAtoms`): this molecule needs the full iteration budget, and lowering it makes the embedding fail regardless of seed.

The change is limited to the flaky "Reported Problem" section; the "Mol ops check" section embeds a trivial 4-atom molecule that does not flake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
