### PR TITLE
Fix 64-bit fingerprint bit ID truncation in AdditionalOutput on 32-bit targets

### DIFF
--- a/Code/GraphMol/Fingerprints/AtomPairGenerator.cpp
+++ b/Code/GraphMol/Fingerprints/AtomPairGenerator.cpp
@@ -106,7 +106,7 @@ void AtomPairArguments::fromJSON(const boost::property_tree::ptree &pt) {
 
 template <typename OutputType>
 void AtomPairAtomEnv<OutputType>::updateAdditionalOutput(
-    AdditionalOutput *additionalOutput, size_t bitId) const {
+    AdditionalOutput *additionalOutput, std::uint64_t bitId) const {
   PRECONDITION(additionalOutput, "bad output pointer");
   if (additionalOutput->bitInfoMap) {
     (*additionalOutput->bitInfoMap)[bitId].emplace_back(d_atomIdFirst,

--- a/Code/GraphMol/Fingerprints/AtomPairGenerator.h
+++ b/Code/GraphMol/Fingerprints/AtomPairGenerator.h
@@ -108,7 +108,7 @@ class RDKIT_FINGERPRINTS_EXPORT AtomPairAtomEnv
       const std::uint64_t fpSize = 0  // unused
   ) const override;
   void updateAdditionalOutput(AdditionalOutput *output,
-                              size_t bitId) const override;
+                              std::uint64_t bitId) const override;
 
   /*!
     \brief construct a new AtomPairAtomEnv object

--- a/Code/GraphMol/Fingerprints/FingerprintGenerator.h
+++ b/Code/GraphMol/Fingerprints/FingerprintGenerator.h
@@ -148,7 +148,7 @@ class RDKIT_FINGERPRINTS_EXPORT AtomEnvironment : private boost::noncopyable {
                               const bool hashResults = false,
                               const std::uint64_t fpSize = 0) const = 0;
   virtual void updateAdditionalOutput(AdditionalOutput *AdditionalOutput,
-                                      size_t bitId) const = 0;
+                                      std::uint64_t bitId) const = 0;
 
   virtual ~AtomEnvironment() {}
 };

--- a/Code/GraphMol/Fingerprints/MorganGenerator.cpp
+++ b/Code/GraphMol/Fingerprints/MorganGenerator.cpp
@@ -234,7 +234,7 @@ void MorganArguments::fromJSON(const boost::property_tree::ptree &pt) {
 
 template <typename OutputType>
 void MorganAtomEnv<OutputType>::updateAdditionalOutput(
-    AdditionalOutput *additionalOutput, size_t bitId) const {
+    AdditionalOutput *additionalOutput, std::uint64_t bitId) const {
   PRECONDITION(additionalOutput, "bad output pointer");
   PRECONDITION(d_mol, "bad mol pointer");
   if (additionalOutput->bitInfoMap) {

--- a/Code/GraphMol/Fingerprints/MorganGenerator.h
+++ b/Code/GraphMol/Fingerprints/MorganGenerator.h
@@ -179,7 +179,7 @@ class RDKIT_FINGERPRINTS_EXPORT MorganAtomEnv
       const std::uint64_t fpSize = 0                     // unused
   ) const override;
   void updateAdditionalOutput(AdditionalOutput *output,
-                              size_t bitId) const override;
+                              std::uint64_t bitId) const override;
 
   /**
    \brief Construct a new MorganAtomEnv object

--- a/Code/GraphMol/Fingerprints/RDKitFPGenerator.cpp
+++ b/Code/GraphMol/Fingerprints/RDKitFPGenerator.cpp
@@ -118,7 +118,7 @@ RDKitFPArguments::RDKitFPArguments(unsigned int minPath, unsigned int maxPath,
 
 template <typename OutputType>
 void RDKitFPAtomEnv<OutputType>::updateAdditionalOutput(
-    AdditionalOutput *additionalOutput, size_t bitId) const {
+    AdditionalOutput *additionalOutput, std::uint64_t bitId) const {
   PRECONDITION(additionalOutput, "bad output pointer");
   if (additionalOutput->bitPaths) {
     (*additionalOutput->bitPaths)[bitId].push_back(d_bondPath);

--- a/Code/GraphMol/Fingerprints/RDKitFPGenerator.h
+++ b/Code/GraphMol/Fingerprints/RDKitFPGenerator.h
@@ -87,7 +87,7 @@ class RDKIT_FINGERPRINTS_EXPORT RDKitFPAtomEnv
       const std::uint64_t fpSize = 0                     // unused
   ) const override;
   void updateAdditionalOutput(AdditionalOutput *output,
-                              size_t bitId) const override;
+                              std::uint64_t bitId) const override;
 
   /**
   \brief Construct a new RDKitFPAtomEnv object

--- a/Code/GraphMol/Fingerprints/TopologicalTorsionGenerator.cpp
+++ b/Code/GraphMol/Fingerprints/TopologicalTorsionGenerator.cpp
@@ -66,7 +66,7 @@ void TopologicalTorsionArguments::fromJSON(
 
 template <typename OutputType>
 void TopologicalTorsionAtomEnv<OutputType>::updateAdditionalOutput(
-    AdditionalOutput *additionalOutput, size_t bitId) const {
+    AdditionalOutput *additionalOutput, std::uint64_t bitId) const {
   PRECONDITION(additionalOutput, "bad output pointer");
   if (additionalOutput->atomToBits || additionalOutput->atomCounts) {
     for (auto aid : d_atomPath) {

--- a/Code/GraphMol/Fingerprints/TopologicalTorsionGenerator.h
+++ b/Code/GraphMol/Fingerprints/TopologicalTorsionGenerator.h
@@ -63,7 +63,7 @@ class RDKIT_FINGERPRINTS_EXPORT TopologicalTorsionAtomEnv
       const std::uint64_t fpSize = 0                     // unused
   ) const override;
   void updateAdditionalOutput(AdditionalOutput *output,
-                              size_t bitId) const override;
+                              std::uint64_t bitId) const override;
   /**
    \brief Construct a new Topological Torsion Atom Env object
 


### PR DESCRIPTION
We use RDKit in the browser as a wasm. In a recent change, I started to use `bitPaths`. The initial development was done in a 64-bit environment, but when moving the code changes into the WASM code, there were differences in the bits between the fingerprints and the bitPaths. Analysis showed that the differences are caused by converting the 64-bit fingerprint bits to 32-bit. This PR describes the issue and provides a solution. While there are no tests for this, I can confirm that applying these changes in our code base, resolved the problem. 

#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.

Widens the `bitId` parameter of `AtomEnvironment::updateAdditionalOutput` (the
virtual hook in `FingerprintGenerator.h`) and all four overrides — `AtomPair`,
`TopologicalTorsion`, `Morgan`, and `RDKitFP` — from `size_t` to
`std::uint64_t`.

On 32-bit targets (e.g. Emscripten/wasm32, any ILP32 build) `size_t` is 32-bit,
so 64-bit fingerprint bit IDs are truncated when routed into `AdditionalOutput`.
The `AdditionalOutput` containers key bit IDs as `std::uint64_t`
(`bitPathsType` / `bitInfoMapType` / `atomsPerBitType`, and the `atomToBits`
value type), and the fingerprint vector (`SparseIntVect<std::uint64_t>`, via
`res->setVal`) keeps the full 64-bit ID. The two therefore disagree: bit IDs
`>= 2^32` (e.g. `TopologicalTorsion<std::uint64_t>` torsions of length `>= 4`)
collide/shift in `bitPaths` et al. while `getNonzeroElements` keeps the full
value.

The call sites in `FingerprintGenerator.cpp` already pass a `std::uint64_t`
(`OutputType`); they previously narrowed into `size_t`. Native LP64 builds are
unaffected (there `size_t` is already 64-bit).

#### Any other comments?

- **No unit test is included**, because the bug is only observable on ILP32
  builds. On the 64-bit CI, `size_t` and `std::uint64_t` are identical, so the
  code path is bit-for-bit unchanged and any regression test would pass both
  before and after the fix. Happy to add a test if the maintainers can point me
  at an existing 32-bit / wasm test lane where it would be meaningful.
- The change is signature-only (9 lines across 6 files) and ABI-neutral on
  LP64.
- **AI tool acknowledgment:** this change was prepared with the help of Claude
  Code (Claude Opus). All code was reviewed by a human before submission.
