### PR TITLE
Refactoring, bug fixes, and cleanup of setTopolBounds()

### DIFF
--- a/Code/GraphMol/DistGeomHelpers/BoundsMatrixBuilder.cpp
+++ b/Code/GraphMol/DistGeomHelpers/BoundsMatrixBuilder.cpp
@@ -774,8 +774,7 @@ TorsionValue _getTwoInSameRing14Type(const ROMol &mol, const Bond *bnd2,
   Bond::BondStereo stype = _getAtomStereo(bnd2, atm1->getIdx(), atm4->getIdx());
 
   if (preferTrans && (ahyb2 == Atom::SP2) && (ahyb3 == Atom::SP2) &&
-      (stype != Bond::STEREOZ &&
-       stype != Bond::STEREOCIS)) { 
+      (stype != Bond::STEREOZ && stype != Bond::STEREOCIS)) {
     // here we will assume 180 degrees: basically flat ring with an external
     // substituent
     return {TorsionType::TRANS};
@@ -1471,8 +1470,8 @@ void initBoundsMat(DistGeom::BoundsMatPtr mmat, double defaultMin,
 };
 
 void setTopolBounds(const ROMol &mol, DistGeom::BoundsMatPtr mmat,
-                    bool set15bounds, bool scaleVDW, bool useMacrocycle14config,
-                    bool forceTransAmides, bool set14bounds, bool set13bounds) {
+                    const EmbedParameters &params, bool scaleVDW,
+                    bool set15bounds, bool set14bounds, bool set13bounds) {
   PRECONDITION(mmat.get(), "bad pointer");
   unsigned int nb = mol.getNumBonds();
   unsigned int na = mol.getNumAtoms();
@@ -1498,8 +1497,8 @@ void setTopolBounds(const ROMol &mol, DistGeom::BoundsMatPtr mmat,
   }
 
   if (set14bounds) {
-    set14Bounds(mol, mmat, accumData, distMatrix, useMacrocycle14config,
-                forceTransAmides);
+    set14Bounds(mol, mmat, accumData, distMatrix, params.useMacrocycle14config,
+                params.forceTransAmides);
   }
 
   if (set15bounds) {
@@ -1567,38 +1566,13 @@ void collectBondsAndAngles(const ROMol &mol,
 
 void setTopolBounds(const ROMol &mol, DistGeom::BoundsMatPtr mmat,
                     std::vector<std::pair<int, int>> &bonds,
-                    std::vector<std::vector<int>> &angles, bool set15bounds,
-                    bool scaleVDW, bool useMacrocycle14config,
-                    bool forceTransAmides, bool set14bounds, bool set13bounds) {
-  PRECONDITION(mmat.get(), "bad pointer");
+                    std::vector<std::vector<int>> &angles,
+                    const EmbedParameters &params, bool scaleVDW,
+                    bool set15bounds, bool set14bounds, bool set13bounds) {
+  setTopolBounds(mol, mmat, params, scaleVDW, set15bounds, set14bounds,
+                 set13bounds);
   bonds.clear();
   angles.clear();
-  unsigned int nb = mol.getNumBonds();
-  unsigned int na = mol.getNumAtoms();
-  if (!na) {
-    throw ValueErrorException("molecule has no atoms");
-  }
-  ComputedData accumData(na, nb);
-  double *distMatrix = nullptr;
-  distMatrix = MolOps::getDistanceMat(mol);
-
-  set12Bounds(mol, mmat, accumData);
-
-  if (set13bounds) {
-    set13Bounds(mol, mmat, accumData);
-  }
-
-  if (set14bounds) {
-    set14Bounds(mol, mmat, accumData, distMatrix, useMacrocycle14config,
-                forceTransAmides);
-  }
-
-  if (set15bounds) {
-    set15Bounds(mol, mmat, accumData, distMatrix);
-  }
-
-  setLowerBoundVDW(mol, mmat, scaleVDW, distMatrix);
-
   collectBondsAndAngles(mol, bonds, angles);
 }
 

--- a/Code/GraphMol/DistGeomHelpers/BoundsMatrixBuilder.cpp
+++ b/Code/GraphMol/DistGeomHelpers/BoundsMatrixBuilder.cpp
@@ -1494,17 +1494,16 @@ void setTopolBounds(const ROMol &mol, DistGeom::BoundsMatPtr mmat,
   set12Bounds(mol, mmat, accumData);
   if (set13bounds) {
     set13Bounds(mol, mmat, accumData);
-  }
 
-  if (set14bounds) {
-    set14Bounds(mol, mmat, accumData, distMatrix, params.useMacrocycle14config,
-                params.forceTransAmides);
-  }
+    if (set14bounds) {
+      set14Bounds(mol, mmat, accumData, distMatrix,
+                  params.useMacrocycle14config, params.forceTransAmides);
 
-  if (set15bounds) {
-    set15Bounds(mol, mmat, accumData, distMatrix);
+      if (set15bounds) {
+        set15Bounds(mol, mmat, accumData, distMatrix);
+      }
+    }
   }
-
   setLowerBoundVDW(mol, mmat, scaleVDW, distMatrix);
 }
 

--- a/Code/GraphMol/DistGeomHelpers/BoundsMatrixBuilder.h
+++ b/Code/GraphMol/DistGeomHelpers/BoundsMatrixBuilder.h
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2004-2019 Rational Discovery LLC
+//  Copyright (C) 2004-2026 Greg Landrum and other RDKit contributors
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -12,6 +12,7 @@
 #define RD_BOUNDS_MATRIX_BUILDER_H
 
 #include <DistGeom/BoundsMatrix.h>
+#include "Embedder.h"
 
 namespace RDKit {
 class ROMol;
@@ -30,6 +31,11 @@ RDKIT_DISTGEOMHELPERS_EXPORT void initBoundsMat(DistGeom::BoundsMatrix *mmat,
 RDKIT_DISTGEOMHELPERS_EXPORT void initBoundsMat(DistGeom::BoundsMatPtr mmat,
                                                 double defaultMin = 0.0,
                                                 double defaultMax = 1000.0);
+
+RDKIT_DISTGEOMHELPERS_EXPORT void setTopolBounds(
+    const ROMol &mol, DistGeom::BoundsMatPtr mmat,
+    const EmbedParameters &params, bool scaleVDW = false,
+    bool set15bounds = true, bool set14bounds = true, bool set13bounds = true);
 
 //! Set upper and lower distance bounds between atoms in a molecule based on
 /// topology
@@ -53,21 +59,38 @@ RDKIT_DISTGEOMHELPERS_EXPORT void initBoundsMat(DistGeom::BoundsMatPtr mmat,
   it is recommended to back out and recompute the bounds matrix with no 1-5
   bounds and with vdW scaling.
 */
-RDKIT_DISTGEOMHELPERS_EXPORT void setTopolBounds(
-    const ROMol &mol, DistGeom::BoundsMatPtr mmat, bool set15bounds = true,
-    bool scaleVDW = false, bool useMacrocycle14config = false,
-    bool forceTransAmides = true, bool set14bounds = true,
-    bool set13bounds = true);
+inline void setTopolBounds(const ROMol &mol, DistGeom::BoundsMatPtr mmat,
+                           bool set15bounds = true, bool scaleVDW = false,
+                           bool useMacrocycle14config = false,
+                           bool forceTransAmides = true,
+                           bool set14bounds = true, bool set13bounds = true) {
+  EmbedParameters params{.useMacrocycle14config = useMacrocycle14config,
+                         .forceTransAmides = forceTransAmides};
+  setTopolBounds(mol, mmat, params, scaleVDW, set15bounds, set14bounds,
+                 set13bounds);
+}
 
-/*! \overload for experimental torsion angle preferences
- */
+/* ! \overload */
 RDKIT_DISTGEOMHELPERS_EXPORT void setTopolBounds(
     const ROMol &mol, DistGeom::BoundsMatPtr mmat,
     std::vector<std::pair<int, int>> &bonds,
-    std::vector<std::vector<int>> &angles, bool set15bounds = true,
-    bool scaleVDW = false, bool useMacrocycle14config = false,
-    bool forceTransAmides = true, bool set14bounds = true,
+    std::vector<std::vector<int>> &angles, const EmbedParameters &params,
+    bool scaleVDW = false, bool set15bounds = true, bool set14bounds = true,
     bool set13bounds = true);
+/*! \overload for experimental torsion angle preferences
+ */
+inline void setTopolBounds(const ROMol &mol, DistGeom::BoundsMatPtr mmat,
+                           std::vector<std::pair<int, int>> &bonds,
+                           std::vector<std::vector<int>> &angles,
+                           bool set15bounds = true, bool scaleVDW = false,
+                           bool useMacrocycle14config = false,
+                           bool forceTransAmides = true,
+                           bool set14bounds = true, bool set13bounds = true) {
+  EmbedParameters params{.useMacrocycle14config = useMacrocycle14config,
+                         .forceTransAmides = forceTransAmides};
+  setTopolBounds(mol, mmat, bonds, angles, params, scaleVDW, set15bounds,
+                 set14bounds, set13bounds);
+}
 
 //! generate the vectors of bonds and angles used by (ET)KDG
 RDKIT_DISTGEOMHELPERS_EXPORT void collectBondsAndAngles(

--- a/Code/GraphMol/DistGeomHelpers/BoundsMatrixBuilder.h
+++ b/Code/GraphMol/DistGeomHelpers/BoundsMatrixBuilder.h
@@ -48,16 +48,15 @@ RDKIT_DISTGEOMHELPERS_EXPORT void setTopolBounds(
   \param mol          The molecule of interest
   \param mmat         Bounds matrix to the bounds are written
   \param set15bounds  If true try to set 1-5 bounds also based on topology
-  \param scaleVDW     If true scale the sum of the vdW radii while setting lower
-  bounds
-                      so that a smaller value (0.7*(vdw1 + vdw2) ) is used for
-  paths
-                      that are less five bonds apart.
+  \param scaleVDW     Ignored.
   \param useMacrocycle14config  If 1-4 distances bound heuristics for
   macrocycles is used <b>Note</b> For some strained systems the bounds matrix
   resulting from setting 1-5 bounds may fail triangle smoothing. In these cases
   it is recommended to back out and recompute the bounds matrix with no 1-5
   bounds and with vdW scaling.
+  \param forceTransAmides  If true, amide bonds are enforced to be trans
+  \param set14bounds  If true, set 1-4 distance bounds based on topology
+  \param set13bounds  If true, set 1-3 distance bounds based on topology
 */
 inline void setTopolBounds(const ROMol &mol, DistGeom::BoundsMatPtr mmat,
                            bool set15bounds = true, bool scaleVDW = false,

--- a/Code/GraphMol/DistGeomHelpers/Embedder.cpp
+++ b/Code/GraphMol/DistGeomHelpers/Embedder.cpp
@@ -1454,13 +1454,13 @@ bool setupInitialBoundsMatrix(
     ForceFields::CrystalFF::CrystalFFDetails &etkdgDetails) {
   PRECONDITION(mol, "bad molecule");
   unsigned int nAtoms = mol->getNumAtoms();
+  bool set15bounds = true;
+  bool scaleVDW = false;
   if (params.useExpTorsionAnglePrefs || params.useBasicKnowledge) {
-    setTopolBounds(*mol, mmat, etkdgDetails.bonds, etkdgDetails.angles, true,
-                   false, params.useMacrocycle14config,
-                   params.forceTransAmides);
+    setTopolBounds(*mol, mmat, etkdgDetails.bonds, etkdgDetails.angles, params,
+                   scaleVDW, set15bounds);
   } else {
-    setTopolBounds(*mol, mmat, true, false, params.useMacrocycle14config,
-                   params.forceTransAmides);
+    setTopolBounds(*mol, mmat, params, scaleVDW, set15bounds);
   }
   double tol = 0.0;
   if (coordMap) {
@@ -1471,8 +1471,9 @@ bool setupInitialBoundsMatrix(
     // ok this bound matrix failed to triangle smooth - re-compute the
     // bounds matrix without 15 bounds and with VDW scaling
     initBoundsMat(mmat);
-    setTopolBounds(*mol, mmat, false, true, params.useMacrocycle14config,
-                   params.forceTransAmides);
+    bool scaleVDW = true;
+    bool set15bounds = false;
+    setTopolBounds(*mol, mmat, params, scaleVDW, set15bounds);
 
     if (coordMap) {
       adjustBoundsMatFromCoordMap(mmat, nAtoms, coordMap);
@@ -1484,8 +1485,9 @@ bool setupInitialBoundsMatrix(
       if (params.ignoreSmoothingFailures) {
         // proceed anyway with the more relaxed bounds matrix
         initBoundsMat(mmat);
-        setTopolBounds(*mol, mmat, false, true, params.useMacrocycle14config,
-                       params.forceTransAmides);
+        bool scaleVDW = true;
+        bool set15bounds = false;
+        setTopolBounds(*mol, mmat, params, scaleVDW, set15bounds);
 
         if (coordMap) {
           adjustBoundsMatFromCoordMap(mmat, nAtoms, coordMap);

--- a/Code/GraphMol/DistGeomHelpers/Wrap/rdDistGeom.cpp
+++ b/Code/GraphMol/DistGeomHelpers/Wrap/rdDistGeom.cpp
@@ -741,8 +741,7 @@ BOOST_PYTHON_MODULE(rdDistGeom) {
     - mol : the molecule of interest\n\
     - set15bounds : set bounds for 1-5 atom distances based on \n\
                     topology (otherwise stop at 1-4s)\n\
-    - scaleVDW : scale down the sum of VDW radii when setting the \n\
-                 lower bounds for atoms less than 5 bonds apart \n\
+    - scaleVDW : ignored \n\
     - doTriangleSmoothing : run triangle smoothing on the bounds \n\
                  matrix before returning it \n\
     - useMacrocycle14config : use 1-4 distance bound heuristics for macrocycles\n\

--- a/Code/GraphMol/DistGeomHelpers/Wrap/rdDistGeom.cpp
+++ b/Code/GraphMol/DistGeomHelpers/Wrap/rdDistGeom.cpp
@@ -242,10 +242,12 @@ INT_VECT EmbedMultipleConfs2(ROMol &mol, unsigned int numConfs,
   return res;
 }
 
-PyObject *getMolBoundsMatrix(ROMol &mol, bool set15bounds = true,
-                             bool scaleVDW = false,
-                             bool doTriangleSmoothing = true,
-                             bool useMacrocycle14config = false) {
+PyObject *getMolBoundsMatrix2(ROMol &mol,
+                              const DGeomHelpers::EmbedParameters &params,
+                              bool doTriangleSmoothing = true,
+                              bool scaleVDW = false, bool set15bounds = true,
+                              bool set14bounds = true,
+                              bool set13bounds = true) {
   unsigned int nats = mol.getNumAtoms();
   npy_intp dims[2];
   dims[0] = nats;
@@ -253,8 +255,8 @@ PyObject *getMolBoundsMatrix(ROMol &mol, bool set15bounds = true,
 
   DistGeom::BoundsMatPtr mat(new DistGeom::BoundsMatrix(nats));
   DGeomHelpers::initBoundsMat(mat);
-  DGeomHelpers::setTopolBounds(mol, mat, set15bounds, scaleVDW,
-                               useMacrocycle14config);
+  DGeomHelpers::setTopolBounds(mol, mat, params, scaleVDW, set15bounds,
+                               set14bounds, set13bounds);
   if (doTriangleSmoothing) {
     DistGeom::triangleSmoothBounds(mat);
   }
@@ -264,6 +266,20 @@ PyObject *getMolBoundsMatrix(ROMol &mol, bool set15bounds = true,
 
   return PyArray_Return(res);
 }
+
+PyObject *getMolBoundsMatrix(ROMol &mol, bool set15bounds = true,
+                             bool scaleVDW = false,
+                             bool doTriangleSmoothing = true,
+                             bool useMacrocycle14config = false,
+                             bool forceTransAmides = true,
+                             bool set14bounds = true, bool set13bounds = true) {
+  DGeomHelpers::EmbedParameters params{
+      .useMacrocycle14config = useMacrocycle14config,
+      .forceTransAmides = forceTransAmides};
+  return getMolBoundsMatrix2(mol, params, doTriangleSmoothing, scaleVDW,
+                             set15bounds, set14bounds, set13bounds);
+}
+
 PyEmbedParameters *getETKDG() {  // ET version 1
   return new PyEmbedParameters(DGeomHelpers::ETKDG);
 }
@@ -729,16 +745,32 @@ BOOST_PYTHON_MODULE(rdDistGeom) {
                  lower bounds for atoms less than 5 bonds apart \n\
     - doTriangleSmoothing : run triangle smoothing on the bounds \n\
                  matrix before returning it \n\
+    - useMacrocycle14config : use 1-4 distance bound heuristics for macrocycles\n\
+    - forceTransAmides : constrain amide bonds to be trans\n\
+    - set14bounds : set bounds for 1-4 atom distances based on \n\
+                    topology\n\
+    - set13bounds : set bounds for 1-3 atom distances based on \n\
+                    topology\n\
  RETURNS:\n\n\
     the bounds matrix as a Numeric array with lower bounds in \n\
     the lower triangle and upper bounds in the upper triangle\n\
 \n";
-  python::def("GetMoleculeBoundsMatrix", RDKit::getMolBoundsMatrix,
-              (python::arg("mol"), python::arg("set15bounds") = true,
-               python::arg("scaleVDW") = false,
-               python::arg("doTriangleSmoothing") = true,
-               python::arg("useMacrocycle14config") = false),
-              docString.c_str());
+  python::def(
+      "GetMoleculeBoundsMatrix", RDKit::getMolBoundsMatrix,
+      (python::arg("mol"), python::arg("set15bounds") = true,
+       python::arg("scaleVDW") = false,
+       python::arg("doTriangleSmoothing") = true,
+       python::arg("useMacrocycle14config") = false,
+       python::arg("forceTransAmides") = true,
+       python::arg("set14bounds") = true, python::arg("set13bounds") = true),
+      docString.c_str());
+  python::def(
+      "GetMoleculeBoundsMatrix", RDKit::getMolBoundsMatrix2,
+      (python::arg("mol"), python::arg("embedParams"),
+       python::arg("doTriangleSmoothing") = true,
+       python::arg("scaleVDW") = false, python::arg("set15bounds") = true,
+       python::arg("set14bounds") = true, python::arg("set13bounds") = true),
+      docString.c_str());
 
   docString =
       "Returns json string containing embedParameters attributes\n\

--- a/Code/GraphMol/DistGeomHelpers/Wrap/testDistGeom.py
+++ b/Code/GraphMol/DistGeomHelpers/Wrap/testDistGeom.py
@@ -609,6 +609,21 @@ class TestCase(unittest.TestCase):
     bm2 = rdDistGeom.GetMoleculeBoundsMatrix(mol, doTriangleSmoothing=False)
     self.assertTrue(bm1[0, 4] < bm2[0, 4])
 
+  def testGetMolBoundsMatrixParams(self):
+    mol = Chem.MolFromSmiles('CC(=O)NCC')
+    bm1 = rdDistGeom.GetMoleculeBoundsMatrix(mol, forceTransAmides=False)
+    self.assertTrue(bm1[0, 4] - bm1[4, 0] > 0.5)
+    bm2 = rdDistGeom.GetMoleculeBoundsMatrix(mol, forceTransAmides=True)
+    self.assertTrue(bm2[0, 4] - bm2[4, 0] < 0.5)
+
+    ps = rdDistGeom.EmbedParameters()
+    ps.forceTransAmides = False
+    bm1 = rdDistGeom.GetMoleculeBoundsMatrix(mol, ps)
+    self.assertTrue(bm1[0, 4] - bm1[4, 0] > 0.5)
+    ps.forceTransAmides = True
+    bm2 = rdDistGeom.GetMoleculeBoundsMatrix(mol, ps)
+    self.assertTrue(bm2[0, 4] - bm2[4, 0] < 0.5)
+
   def testGithub2057(self):
     # ensure that ETKDG is the default Embedder
     mol = Chem.AddHs(Chem.MolFromSmiles('OCCC'))

--- a/Code/GraphMol/DistGeomHelpers/Wrap/testDistGeom.py
+++ b/Code/GraphMol/DistGeomHelpers/Wrap/testDistGeom.py
@@ -611,18 +611,31 @@ class TestCase(unittest.TestCase):
 
   def testGetMolBoundsMatrixParams(self):
     mol = Chem.MolFromSmiles('CC(=O)NCC')
-    bm1 = rdDistGeom.GetMoleculeBoundsMatrix(mol, forceTransAmides=False)
+    bm1 = rdDistGeom.GetMoleculeBoundsMatrix(mol, forceTransAmides=False, doTriangleSmoothing=False)
     self.assertTrue(bm1[0, 4] - bm1[4, 0] > 0.5)
-    bm2 = rdDistGeom.GetMoleculeBoundsMatrix(mol, forceTransAmides=True)
+    bm2 = rdDistGeom.GetMoleculeBoundsMatrix(mol, forceTransAmides=True, doTriangleSmoothing=False)
     self.assertTrue(bm2[0, 4] - bm2[4, 0] < 0.5)
 
     ps = rdDistGeom.EmbedParameters()
     ps.forceTransAmides = False
-    bm1 = rdDistGeom.GetMoleculeBoundsMatrix(mol, ps)
+    bm1 = rdDistGeom.GetMoleculeBoundsMatrix(mol, ps, doTriangleSmoothing=False)
     self.assertTrue(bm1[0, 4] - bm1[4, 0] > 0.5)
     ps.forceTransAmides = True
-    bm2 = rdDistGeom.GetMoleculeBoundsMatrix(mol, ps)
+    bm2 = rdDistGeom.GetMoleculeBoundsMatrix(mol, ps, doTriangleSmoothing=False)
     self.assertTrue(bm2[0, 4] - bm2[4, 0] < 0.5)
+
+    bm1 = rdDistGeom.GetMoleculeBoundsMatrix(mol, set15bounds=True, doTriangleSmoothing=False)
+    self.assertLess(bm1[0,5],6.0)
+    bm2 = rdDistGeom.GetMoleculeBoundsMatrix(mol, set15bounds=False, doTriangleSmoothing=False)
+    self.assertEqual(bm2[0,5],1000.0)
+
+    bm2 = rdDistGeom.GetMoleculeBoundsMatrix(mol, set14bounds=False, doTriangleSmoothing=False)
+    self.assertEqual(bm2[0,4],1000.0)
+
+    bm2 = rdDistGeom.GetMoleculeBoundsMatrix(mol, set13bounds=False, doTriangleSmoothing=False)
+    self.assertEqual(bm2[0,3],1000.0)
+
+
 
   def testGithub2057(self):
     # ensure that ETKDG is the default Embedder

--- a/Code/GraphMol/DistGeomHelpers/catch_tests.cpp
+++ b/Code/GraphMol/DistGeomHelpers/catch_tests.cpp
@@ -1845,3 +1845,19 @@ TEST_CASE("Github9403: Bug: Overwritten stereo information in rings") {
           2.0 * 0.06 + 0.00001);
   }
 }
+
+TEST_CASE("setTopolBounds with param objects") {
+  SECTION("simple") {
+    auto mol = "CC(=O)NC"_smiles;
+    REQUIRE(mol);
+    DistGeom::BoundsMatPtr bm{new DistGeom::BoundsMatrix(mol->getNumAtoms())};
+    DGeomHelpers::initBoundsMat(bm, 0.0, 1000.0);
+    DGeomHelpers::EmbedParameters ps{.forceTransAmides = false};
+    DGeomHelpers::setTopolBounds(*mol, bm, ps);
+    CHECK(bm->getUpperBound(0, 4) - bm->getLowerBound(0, 4) > 0.5);
+    DGeomHelpers::initBoundsMat(bm, 0.0, 1000.0);
+    ps.forceTransAmides = true;
+    DGeomHelpers::setTopolBounds(*mol, bm, ps);
+    CHECK(bm->getUpperBound(0, 4) - bm->getLowerBound(0, 4) < 0.5);
+  }
+}

--- a/Code/GraphMol/DistGeomHelpers/catch_tests.cpp
+++ b/Code/GraphMol/DistGeomHelpers/catch_tests.cpp
@@ -1860,4 +1860,138 @@ TEST_CASE("setTopolBounds with param objects") {
     DGeomHelpers::setTopolBounds(*mol, bm, ps);
     CHECK(bm->getUpperBound(0, 4) - bm->getLowerBound(0, 4) < 0.5);
   }
+
+  SECTION("additional parameters") {
+    auto mol = "CC(=O)NCC"_smiles;
+    REQUIRE(mol);
+    DistGeom::BoundsMatPtr bm{new DistGeom::BoundsMatrix(mol->getNumAtoms())};
+    DGeomHelpers::initBoundsMat(bm, 0.0, 1000.0);
+    DGeomHelpers::EmbedParameters ps;
+    ps.useMacrocycle14config = true;
+    ps.forceTransAmides = true;
+
+    {
+      // skip setting 1-3 bounds
+      bool set15bounds = true;
+      bool scaleVDW = false;
+      bool useMacrocycle14config = false;
+      bool forceTransAmides = true;
+      bool set14bounds = true;
+      bool set13bounds = false;
+      DGeomHelpers::initBoundsMat(bm, 0.0, 1000.0);
+      DGeomHelpers::setTopolBounds(*mol, bm, set15bounds, scaleVDW,
+                                   useMacrocycle14config, forceTransAmides,
+                                   set14bounds, set13bounds);
+      CHECK(bm->getUpperBound(0, 3) == 1000.0);
+      // make sure 1-4s and 1-5s are also not set:
+      CHECK(bm->getUpperBound(0, 4) == 1000.0);
+      CHECK(bm->getUpperBound(0, 5) == 1000.0);
+
+      DGeomHelpers::initBoundsMat(bm, 0.0, 1000.0);
+      DGeomHelpers::setTopolBounds(*mol, bm, ps, scaleVDW, set15bounds,
+                                   set14bounds, set13bounds);
+      CHECK(bm->getUpperBound(0, 3) == 1000.0);
+      // make sure 1-4s and 1-5s are also not set:
+      CHECK(bm->getUpperBound(0, 4) == 1000.0);
+      CHECK(bm->getUpperBound(0, 5) == 1000.0);
+    }
+    {
+      // skip setting 1-4 bounds
+      bool set15bounds = true;
+      bool scaleVDW = false;
+      bool useMacrocycle14config = false;
+      bool forceTransAmides = true;
+      bool set14bounds = false;
+      bool set13bounds = true;
+      DGeomHelpers::initBoundsMat(bm, 0.0, 1000.0);
+      DGeomHelpers::setTopolBounds(*mol, bm, set15bounds, scaleVDW,
+                                   useMacrocycle14config, forceTransAmides,
+                                   set14bounds, set13bounds);
+      CHECK(bm->getUpperBound(0, 3) < 6.0);
+      CHECK(bm->getUpperBound(0, 4) == 1000.0);
+      // make sure 1-5s are also not set:
+      CHECK(bm->getUpperBound(0, 5) == 1000.0);
+
+      DGeomHelpers::initBoundsMat(bm, 0.0, 1000.0);
+      DGeomHelpers::setTopolBounds(*mol, bm, ps, scaleVDW, set15bounds,
+                                   set14bounds, set13bounds);
+      CHECK(bm->getUpperBound(0, 3) < 6.0);
+      CHECK(bm->getUpperBound(0, 4) == 1000.0);
+      // make sure 1-5s are also not set:
+      CHECK(bm->getUpperBound(0, 5) == 1000.0);
+    }
+    {
+      // skip setting 1-5 bounds
+      bool set15bounds = false;
+      bool scaleVDW = false;
+      bool useMacrocycle14config = false;
+      bool forceTransAmides = true;
+      bool set14bounds = true;
+      bool set13bounds = true;
+      DGeomHelpers::initBoundsMat(bm, 0.0, 1000.0);
+      DGeomHelpers::setTopolBounds(*mol, bm, set15bounds, scaleVDW,
+                                   useMacrocycle14config, forceTransAmides,
+                                   set14bounds, set13bounds);
+      CHECK(bm->getUpperBound(0, 3) < 6.0);
+      CHECK(bm->getUpperBound(0, 4) < 6.0);
+      CHECK(bm->getUpperBound(0, 5) == 1000.0);
+
+      DGeomHelpers::initBoundsMat(bm, 0.0, 1000.0);
+      DGeomHelpers::setTopolBounds(*mol, bm, ps, scaleVDW, set15bounds,
+                                   set14bounds, set13bounds);
+      CHECK(bm->getUpperBound(0, 3) < 6.0);
+      CHECK(bm->getUpperBound(0, 4) < 6.0);
+      CHECK(bm->getUpperBound(0, 5) == 1000.0);
+    }
+    {
+      // set everything
+      bool set15bounds = true;
+      bool scaleVDW = false;
+      bool useMacrocycle14config = false;
+      bool forceTransAmides = true;
+      bool set14bounds = true;
+      bool set13bounds = true;
+      DGeomHelpers::initBoundsMat(bm, 0.0, 1000.0);
+      DGeomHelpers::setTopolBounds(*mol, bm, set15bounds, scaleVDW,
+                                   useMacrocycle14config, forceTransAmides,
+                                   set14bounds, set13bounds);
+      CHECK(bm->getUpperBound(0, 3) < 6.0);
+      CHECK(bm->getUpperBound(0, 4) < 6.0);
+      CHECK(bm->getUpperBound(0, 5) < 6.0);
+
+      DGeomHelpers::initBoundsMat(bm, 0.0, 1000.0);
+      DGeomHelpers::setTopolBounds(*mol, bm, ps, scaleVDW, set15bounds,
+                                   set14bounds, set13bounds);
+      CHECK(bm->getUpperBound(0, 3) < 6.0);
+      CHECK(bm->getUpperBound(0, 4) < 6.0);
+      CHECK(bm->getUpperBound(0, 5) < 6.0);
+    }
+    {
+      // scale VDW is ignored
+      bool set15bounds = false;
+      bool scaleVDW = false;
+      bool useMacrocycle14config = false;
+      bool forceTransAmides = true;
+      bool set14bounds = true;
+      bool set13bounds = true;
+      DGeomHelpers::initBoundsMat(bm, 0.0, 1000.0);
+      DGeomHelpers::setTopolBounds(*mol, bm, set15bounds, scaleVDW,
+                                   useMacrocycle14config, forceTransAmides,
+                                   set14bounds, set13bounds);
+      auto lb = bm->getLowerBound(0, 5);
+      CHECK_THAT(lb, Catch::Matchers::WithinAbs(2.38, 0.01));
+
+      scaleVDW = true;
+      DGeomHelpers::initBoundsMat(bm, 0.0, 1000.0);
+      DGeomHelpers::setTopolBounds(*mol, bm, set15bounds, scaleVDW,
+                                   useMacrocycle14config, forceTransAmides,
+                                   set14bounds, set13bounds);
+      CHECK(lb == bm->getLowerBound(0, 5));
+
+      DGeomHelpers::initBoundsMat(bm, 0.0, 1000.0);
+      DGeomHelpers::setTopolBounds(*mol, bm, ps, scaleVDW, set15bounds,
+                                   set14bounds, set13bounds);
+      CHECK(lb == bm->getLowerBound(0, 5));
+    }
+  }
 }

--- a/Code/JavaWrappers/DistGeom.i
+++ b/Code/JavaWrappers/DistGeom.i
@@ -48,8 +48,10 @@
 // This conflicts with definitions in UFF::, so ignore and make it a method on the bounds matrix
 %ignore DistGeom::constructForceField;
 
-%include <DistGeom/ChiralSet.h>
+%include <DistGeom/ChiralSet.h> 
 %include <DistGeom/BoundsMatrix.h>
+
+%ignore RDKit::DGeomHelpers::setTopolBounds;
 %include <GraphMol/DistGeomHelpers/BoundsMatrixBuilder.h>
 %include <DistGeom/DistGeomUtils.h>
 %include <DistGeom/TriangleSmooth.h>


### PR DESCRIPTION
What's here:
1) a bug fix so that we don't try to set 1 - N bounds if we aren't also setting 1 - (N-1) bounds (this wasn't visible in any release).
2) a new overload of setTopolBounds() that takes an `EmbedParameters` object; `forceTransAmides` and `useMacrocycle14config` are taken from here
3) doc updates and fixes
4) extended testing to make sure that all options behave as expected
