### PR TITLE
test: increase DistGeomHelpers compareConfs tolerance to 0.1

### DIFF
--- a/Code/GraphMol/DistGeomHelpers/testDgeomHelpers.cpp
+++ b/Code/GraphMol/DistGeomHelpers/testDgeomHelpers.cpp
@@ -135,7 +135,13 @@ void compareConfs(const RWMol *m, const RWMol *expected, int molConfId = -1,
 
     RDGeom::Point3D pt1i = conf1.getAtomPos(i);
     RDGeom::Point3D pt2i = conf2.getAtomPos(i);
-    CHECK((pt1i - pt2i).length() < 0.05);
+
+
+  // Increased tolerance from 0.05 to 0.1. 
+  // This prevents false test failures on systems using -march=native, 
+  // where compiler optimizations cause tiny, harmless math differences.
+  // (See issue #[9406])
+    CHECK((pt1i - pt2i).length() < 0.1);
   }
 }
 }  // namespace


### PR DESCRIPTION
### Fix : #9406


This PR fixes the deterministic test failures in testDistGeomHelpers, specifically the predefined ETKDGv3 - macrocycle test, when RDKit is built with compiler optimizations such as -march=native.

Root cause

The compareConfs() helper compares generated 3D coordinates with a reference .mol file. When RDKit is compiled with -march=native, different compiler and CPU optimizations can introduce small floating-point differences in the generated coordinates. In my testing, the largest difference I observed was around 0.07 .

The current tolerance of 0.05 is slightly too strict, so these harmless numerical differences can cause the test to fail even though the generated conformations are still correct.

Change

This PR increases the tolerance in compareConfs() (in Code/GraphMol/DistGeomHelpers/testDgeomHelpers.cpp) from 0.05 to 0.1.

A tolerance of 0.1 is enough to account for these small platform-dependent differences while still being strict enough to catch real regressions.

Testing

I reproduced the failure on Ubuntu 24.04 using GCC 13.3.0 with:

-DCMAKE_CXX_FLAGS_RELEASE="-O2 -march=native -DNDEBUG"

After increasing the tolerance to 0.1, all four testDistGeomHelpers shards pass locally.