### PR TITLE
Validate coordinate map entries before distance geometry embedding

### DIFF
--- a/Code/GraphMol/DistGeomHelpers/Embedder.cpp
+++ b/Code/GraphMol/DistGeomHelpers/Embedder.cpp
@@ -38,6 +38,7 @@
 #include <GraphMol/MolAlign/AlignMolecules.h>
 #include <boost/dynamic_bitset.hpp>
 #include <RDGeneral/RDThreads.h>
+#include <cmath>
 #include <cstddef>
 #include <stdexcept>
 #include <vector>
@@ -1764,6 +1765,15 @@ void EmbedMultipleConfs(ROMol &mol, INT_VECT &res, unsigned int numConfs,
   boost::dynamic_bitset<> constrainedAtoms(mol.getNumAtoms());
   if (coordMap) {
     for (const auto &entry : *coordMap) {
+      if (entry.first < 0 ||
+          static_cast<unsigned int>(entry.first) >= mol.getNumAtoms()) {
+        throw ValueErrorException("coordMap atom index is out of range");
+      }
+      const auto &point = entry.second;
+      if (!std::isfinite(point.x) || !std::isfinite(point.y) ||
+          !std::isfinite(point.z)) {
+        throw ValueErrorException("coordMap contains non-finite coordinates");
+      }
       constrainedAtoms.set(entry.first);
     }
   }

--- a/Code/GraphMol/DistGeomHelpers/catch_tests.cpp
+++ b/Code/GraphMol/DistGeomHelpers/catch_tests.cpp
@@ -29,6 +29,7 @@
 #include "BoundsMatrixBuilderDetails.h"
 #include <tuple>
 #include <map>
+#include <limits>
 #include <boost/algorithm/string.hpp>
 #include <boost/algorithm/string/trim.hpp>
 
@@ -39,6 +40,30 @@
 #endif
 
 using namespace RDKit;
+
+TEST_CASE("invalid coordinate maps", "[constrained-embedding]") {
+  auto mol = "CCO"_smiles;
+  REQUIRE(mol);
+  MolOps::addHs(*mol);
+  auto params = DGeomHelpers::ETKDGv3;
+  std::map<int, RDGeom::Point3D> coordMap;
+  params.coordMap = &coordMap;
+
+  SECTION("atom index out of range") {
+    coordMap[mol->getNumAtoms()] = {0.0, 0.0, 0.0};
+    CHECK_THROWS_AS(DGeomHelpers::EmbedMolecule(*mol, params),
+                    ValueErrorException);
+  }
+
+  SECTION("non-finite coordinates") {
+    const auto value = GENERATE(std::numeric_limits<double>::infinity(),
+                                -std::numeric_limits<double>::infinity(),
+                                std::numeric_limits<double>::quiet_NaN());
+    coordMap[0] = {value, 0.0, 0.0};
+    CHECK_THROWS_AS(DGeomHelpers::EmbedMolecule(*mol, params),
+                    ValueErrorException);
+  }
+}
 
 TEST_CASE("Torsions not found in fused macrocycles", "[macrocycles]") {
   RDLog::InitLogs();


### PR DESCRIPTION
#### Reference Issue

None. This is a self-contained input-validation fix.

#### What does this implement/fix? Explain your changes.

Distance-geometry embedding accepted invalid `coordMap` entries and failed later
in inconsistent ways. The embedding entry point now validates every supplied
atom index and coordinate before constructing the constrained-atom bitset.

Before → after:

| Input | Before | After |
|---|---|---|
| Valid finite coordinate | Embedding succeeds | Unchanged |
| Atom index outside the molecule | Public Python API raises `IndexError: vector`; the current C++ path did not raise `ValueErrorException` | Raises `ValueErrorException` with `coordMap atom index is out of range` |
| `NaN` coordinate | Public Python API reaches an obscure `bad bounds` precondition failure; the current C++ path did not raise `ValueErrorException` | Raises `ValueErrorException` with `coordMap contains non-finite coordinates` |
| `+∞` or `-∞` coordinate | Embedding can return failure (`-1`); the current C++ path did not raise `ValueErrorException` | Raises the same explicit `ValueErrorException` as `NaN` |

The patch adds:

- bounds validation for each `coordMap` atom index;
- `std::isfinite()` validation for all three coordinate components;
- a Catch2 regression covering one out-of-range index and `+∞`, `-∞`, and
  `NaN` coordinates.

The work is intentionally limited to malformed coordinate-map inputs. It does
not change embedding behavior for valid constraints or weaken any test
threshold.

#### Validation / Mac reproduction

I downloaded the released package and cloned and built current upstream source
on an Apple Silicon Mac:

- macOS 26.5.1, arm64;
- Apple clang 21.0.0;
- CMake 4.4.0;
- Catch2 3.15.2;
- Boost 1.90.0;
- released RDKit 2026.03.4 installed through conda for public-API reproduction;
- current `master` source at `c9494e534c5b0de81686347347931390e835f7f4`
  built locally for the C++ red/green test.

Measured correctness results:

| Check | Before | After |
|---|---:|---:|
| New `invalid coordinate maps` regression | 4/8 assertions passed; 4/8 failed | 8/8 assertions passed |
| `distGeomHelpersCatch` shards | — | 4/4 passed (100%), 13.02 s total wall time |
| `git diff --check` | — | Passed |
| Changed-line formatting | — | Passed with Xcode `clang-format` |
| Secret-pattern scan of diff | — | Clean |

These are correctness/test metrics, not a performance benchmark. The added
validation is linear in the number of coordinate-map entries and constant work
per entry.

The separate `testDistGeomHelpers` executable completed 3/4 shards. Its only
failure is the untouched, platform-sensitive ETKDGv3 macrocycle tolerance
already tracked in #9406 (observed `0.05809164678485081 < 0.05`) and addressed
separately by #9413. This PR does not modify that test or its gate.

#### Any other comments?

This contribution is part of the Misha Foundation's broader effort to strengthen
open computational infrastructure supporting molecular and therapeutic
research. The concrete claim of this PR remains limited to deterministic
validation of malformed constrained-embedding inputs.

AI assistance disclosure: OpenAI Codex was used for repository inspection,
reproducer development, implementation, and test execution. The final diff and
test evidence were reviewed by a human before submission.
