### PR TITLE
Mols with lots of rings may trigger a stack overflow (and segfault)

### DIFF
--- a/Code/GraphMol/Aromaticity.cpp
+++ b/Code/GraphMol/Aromaticity.cpp
@@ -77,7 +77,7 @@ void pickFusedRings(int curr, const INT_INT_VECT_MAP &neighMap, INT_VECT &res,
 
     // We haven't seen this ring yet, so add it to the stack
     pos = neighMap.find(neigh);
-    PRECONDITION(pos != neighMap.end(), "bad argument");
+    CHECK_INVARIANT(pos != neighMap.end(), "neighboring ring not found");
     done[neigh] = 1;
     res.push_back(neigh);
     stack.emplace_back(neigh, 0);

--- a/Code/GraphMol/Aromaticity.cpp
+++ b/Code/GraphMol/Aromaticity.cpp
@@ -41,17 +41,46 @@ namespace RingUtils {
 using namespace RDKit;
 
 void pickFusedRings(int curr, const INT_INT_VECT_MAP &neighMap, INT_VECT &res,
-                    boost::dynamic_bitset<> &done, int depth) {
+                    boost::dynamic_bitset<> &done, int /* depth */) {
+  // Use an explicit DFS stack instead of recursion. Large fused systems can
+  // contain thousands of rings, which overflows the comparatively small
+  // default thread stack on Windows.
   auto pos = neighMap.find(curr);
   PRECONDITION(pos != neighMap.end(), "bad argument");
   done[curr] = 1;
   res.push_back(curr);
 
-  const auto &neighs = pos->second;
-  for (int neigh : neighs) {
-    if (!done[neigh]) {
-      pickFusedRings(neigh, neighMap, res, done, depth + 1);
+  // Each entry stores a ring index and the next neighbor to visit. Advancing
+  // neighbors one at a time preserves the preorder traversal of the old
+  // recursive implementation.
+  std::vector<std::pair<int, unsigned>> stack;
+  stack.emplace_back(curr, 0);
+  while (!stack.empty()) {
+    auto &[ringIdx, nextNeighbor] = stack.back();
+    const auto &neighs = neighMap.find(ringIdx)->second;
+    if (nextNeighbor == neighs.size()) {
+      // No more neighbors to visit for this ring
+      stack.pop_back();
+      continue;
     }
+
+    const auto neigh = neighs[nextNeighbor];
+
+    // this advances the "neighbor to visit" index in the current
+    // element in the stack (note that nextNeighbor is a reference,
+    // and that we haven't popped the stack!)
+    ++nextNeighbor;
+
+    if (done[neigh]) {
+      continue;
+    }
+
+    // We haven't seen this ring yet, so add it to the stack
+    pos = neighMap.find(neigh);
+    PRECONDITION(pos != neighMap.end(), "bad argument");
+    done[neigh] = 1;
+    res.push_back(neigh);
+    stack.emplace_back(neigh, 0);
   }
 }
 
@@ -71,8 +100,7 @@ bool checkFused(const INT_VECT &rids, INT_INT_VECT_MAP &ringNeighs) {
 
   // then pick a fused system from the remaining (i.e. rids)
   // If the rings in rids are fused we should get back all of them
-  // in fused
-  // if we get a smaller number in fused then rids are not fused
+  // in fused if we get a smaller number in fused then rids are not fused
   pickFusedRings(rids.front(), ringNeighs, fused, done);
 
   CHECK_INVARIANT(fused.size() <= rids.size(), "");
@@ -402,7 +430,7 @@ void applyHuckelToFused(
       std::copy(curRs.begin(), curRs.end(),
                 std::inserter(aromRings, aromRings.begin()));
     }  // end check huckel rule
-  }  // end while(1)
+  }    // end while(1)
   narom += rdcast<int>(aromRings.size());
 }
 

--- a/Code/GraphMol/Rings.h
+++ b/Code/GraphMol/Rings.h
@@ -33,16 +33,15 @@ typedef std::map<int, std::vector<int>> INT_INT_VECT_MAP;
 //! Pick a set of rings that are fused together and contain a specified ring
 /*!
 
-   \param curr      the ID for the irng that should be in the fused system
+   \param curr      the ID for the ring that should be in the fused system
    \param neighMap  adjacency lists for for all rings in the molecule.
            See documentation for makeNeighMap
    \param res       used to return the results: a list of rings that are fused
            with curr in them
    \param done      a bit vector recording the rings that are already dealt with
            this also can be used to avoid any rings that should not be included
-   in
-           the fused system
-   \param depth used to track recursion depth
+           in the fused system
+   \param depth retained for API compatibility; no longer used
 
 */
 RDKIT_GRAPHMOL_EXPORT void pickFusedRings(int curr,
@@ -54,7 +53,7 @@ RDKIT_GRAPHMOL_EXPORT void pickFusedRings(int curr,
 //! \brief For each ring in bring compute and store the ring that are fused
 //! (share at least one bond with it).
 /*!
-  Useful both for the keulization stuff and aromaticity perception.
+  Useful both for the kekulization stuff and aromaticity perception.
 
   \param brings   list of rings - each ring is specified as a list of bond IDs
   \param neighMap an STL map into which the results are stored. Each entry in

--- a/Code/GraphMol/molopstest.cpp
+++ b/Code/GraphMol/molopstest.cpp
@@ -22,6 +22,7 @@
 #include <GraphMol/RDKitBase.h>
 #include <GraphMol/RDKitQueries.h>
 #include <GraphMol/Chirality.h>
+#include <GraphMol/Rings.h>
 #include <GraphMol/SmilesParse/SmilesParse.h>
 #include <GraphMol/SmilesParse/SmilesWrite.h>
 #include <GraphMol/SmilesParse/SmartsWrite.h>
@@ -493,6 +494,31 @@ TEST_CASE("test3") {
   REQUIRE(m->getRingInfo()->numAtomRings(4) == 3);
   REQUIRE(m->getRingInfo()->isAtomInRingOfSize(4, 4));
   delete m;
+}
+
+TEST_CASE("pickFusedRings handles deeply fused systems without recursion") {
+  // Set this to a large number to make sure mols with lots of rings
+  // don't trigger a stack overflow in pickFusedRings.
+  constexpr int numRings = 10000;
+
+  INT_INT_VECT_MAP neighMap;
+  for (int ring = 0; ring < numRings; ++ring) {
+    if (ring) {
+      neighMap[ring].push_back(ring - 1);
+    }
+    if (ring + 1 < numRings) {
+      neighMap[ring].push_back(ring + 1);
+    }
+  }
+
+  INT_VECT fused;
+  boost::dynamic_bitset<> done(numRings);
+  RingUtils::pickFusedRings(0, neighMap, fused, done);
+
+  REQUIRE(fused.size() == numRings);
+  REQUIRE(done.count() == numRings);
+  REQUIRE(fused.front() == 0);
+  REQUIRE(fused.back() == numRings - 1);
 }
 
 TEST_CASE("test4") {
@@ -4928,9 +4954,7 @@ TEST_CASE("Testing github issue 418: removeHs not updating H count") {
     REQUIRE(m->getAtomWithIdx(0)->getNumExplicitHs() == 4);
     delete m;
   }
-  {
-    REQUIRE_THROWS_AS(SmilesToMol("[H]N([H])([H])[H]"), MolSanitizeException);
-  }
+  { REQUIRE_THROWS_AS(SmilesToMol("[H]N([H])([H])[H]"), MolSanitizeException); }
 }
 
 TEST_CASE(


### PR DESCRIPTION
After https://github.com/rdkit/rdkit/pull/9105 `SymmSSSR() ` can find more rings than with the previous algorithm. In some pathological cases like the ones in some tests in `graphmolMolOpsTest`, we can see thousands of rings. This, besides making aromaticity detection way slower, may lead to a stack overflow failure due to the recursive algorithm used in `pickFusedRings()` due to the increased depth of the recursion caused by the many rings.

This is actually something that is currently happening in the Windows CI runners (Windows has a smaller stack size than linux and Mac, so it's easier to overflow). The failure is currently hidden by https://github.com/rdkit/rdkit/pull/9402 (the second `ctest` calls added there hide the return code of the first one, making the CI pass if the shard tests don't fail).

This patch refactors `pickFusedRings()` to use a queue-based approach instead of a recursive one, effectively avoiding the stack overflows.

The patch was first generated by AI, and then edited by me for clarity and fixing a few typos.