### PR TITLE
split shard tests into separate block

### DIFF
--- a/.azure-pipelines/linux_build.yml
+++ b/.azure-pipelines/linux_build.yml
@@ -80,7 +80,7 @@ steps:
     echo "LD_LIBRARY_PATH: " $LD_LIBRARY_PATH
     export QT_QPA_PLATFORM='offscreen'
     cd build
-    ctest -j $( $(number_of_cores) ) -V --output-on-failure -R shard -T Test
+    ctest -j $( $(number_of_cores) ) --output-on-failure -R shard -T Test
   displayName: Run sharded tests
 - bash: |
     source ${CONDA}/etc/profile.d/conda.sh

--- a/.azure-pipelines/linux_build.yml
+++ b/.azure-pipelines/linux_build.yml
@@ -70,8 +70,18 @@ steps:
     export QT_QPA_PLATFORM='offscreen'
     cd build
     ctest -j $( $(number_of_cores) ) --output-on-failure -E shard -T Test
-    ctest -j $( $(number_of_cores) ) -V --output-on-failure -R shard -T Test
   displayName: Run tests
+- bash: |
+    source ${CONDA}/etc/profile.d/conda.sh
+    conda activate rdkit_build
+    export RDBASE=`pwd`
+    export PYTHONPATH=${RDBASE}:${PYTHONPATH}
+    export LD_LIBRARY_PATH=${RDBASE}/lib:${CONDA_PREFIX}/lib:${LD_LIBRARY_PATH}
+    echo "LD_LIBRARY_PATH: " $LD_LIBRARY_PATH
+    export QT_QPA_PLATFORM='offscreen'
+    cd build
+    ctest -j $( $(number_of_cores) ) -V --output-on-failure -R shard -T Test
+  displayName: Run sharded tests
 - bash: |
     source ${CONDA}/etc/profile.d/conda.sh
     conda activate rdkit_build

--- a/.azure-pipelines/linux_build_py312.yml
+++ b/.azure-pipelines/linux_build_py312.yml
@@ -67,8 +67,18 @@ steps:
     export QT_QPA_PLATFORM='offscreen'
     cd build
     ctest -j $( $(number_of_cores) ) --output-on-failure -E shard -T Test
-    ctest -j $( $(number_of_cores) ) -V --output-on-failure -R shard -T Test
   displayName: Run tests
+- bash: |
+    source ${CONDA}/etc/profile.d/conda.sh
+    conda activate rdkit_build
+    export RDBASE=`pwd`
+    export PYTHONPATH=${RDBASE}:${PYTHONPATH}
+    export LD_LIBRARY_PATH=${RDBASE}/lib:${CONDA_PREFIX}/lib:${LD_LIBRARY_PATH}
+    echo "LD_LIBRARY_PATH: " $LD_LIBRARY_PATH
+    export QT_QPA_PLATFORM='offscreen'
+    cd build
+    ctest -j $( $(number_of_cores) ) -V --output-on-failure -R shard -T Test
+  displayName: Run sharded tests
 - bash: |
     source ${CONDA}/etc/profile.d/conda.sh
     conda activate rdkit_build

--- a/.azure-pipelines/linux_build_py312.yml
+++ b/.azure-pipelines/linux_build_py312.yml
@@ -77,7 +77,7 @@ steps:
     echo "LD_LIBRARY_PATH: " $LD_LIBRARY_PATH
     export QT_QPA_PLATFORM='offscreen'
     cd build
-    ctest -j $( $(number_of_cores) ) -V --output-on-failure -R shard -T Test
+    ctest -j $( $(number_of_cores) ) --output-on-failure -R shard -T Test
   displayName: Run sharded tests
 - bash: |
     source ${CONDA}/etc/profile.d/conda.sh

--- a/.azure-pipelines/linux_build_py312.yml
+++ b/.azure-pipelines/linux_build_py312.yml
@@ -89,7 +89,7 @@ steps:
     echo "LD_LIBRARY_PATH: " $LD_LIBRARY_PATH
     export QT_QPA_PLATFORM='offscreen'
     cd build
-    ctest -j $( $(number_of_cores) ) --output-on-failure -T Test
+    ctest -j $( $(number_of_cores) ) --output-on-failure -E shard -T Test
   displayName: Run tests with older numpy and pandas
 - bash: |
     source ${CONDA}/etc/profile.d/conda.sh

--- a/.azure-pipelines/vs_build.yml
+++ b/.azure-pipelines/vs_build.yml
@@ -59,8 +59,15 @@ steps:
     set PATH=%RDBASE%\lib;%PATH%
     cd build
     ctest -C Release -j $(number_of_cores) --output-on-failure -E shard -T Test
-    ctest -C Release -j $(number_of_cores) -V --output-on-failure -R shard -T Test
   displayName: Run tests
+- script: |
+    call activate rdkit_build
+    set RDBASE=%cd%
+    set PYTHONPATH=%RDBASE%;%PYTHONPATH%
+    set PATH=%RDBASE%\lib;%PATH%
+    cd build
+    ctest -C Release -j $(number_of_cores) -V --output-on-failure -R shard -T Test
+  displayName: Run sharded tests
 - script: |
     call activate rdkit_build
     conda install -c conda-forge --override-channels  numpy=1.26 pandas=2.2

--- a/.azure-pipelines/vs_build.yml
+++ b/.azure-pipelines/vs_build.yml
@@ -75,7 +75,7 @@ steps:
     set PYTHONPATH=%RDBASE%;%PYTHONPATH%
     set PATH=%RDBASE%\lib;%PATH%
     cd build
-    ctest -C Release -j $(number_of_cores) --output-on-failure -T Test
+    ctest -C Release -j $(number_of_cores) --output-on-failure -E shard -T Test
   displayName: Run with older numpy and pandas
 - script: |
     call activate rdkit_build

--- a/.azure-pipelines/vs_build.yml
+++ b/.azure-pipelines/vs_build.yml
@@ -66,7 +66,7 @@ steps:
     set PYTHONPATH=%RDBASE%;%PYTHONPATH%
     set PATH=%RDBASE%\lib;%PATH%
     cd build
-    ctest -C Release -j $(number_of_cores) -V --output-on-failure -R shard -T Test
+    ctest -C Release -j $(number_of_cores) --output-on-failure -R shard -T Test
   displayName: Run sharded tests
 - script: |
     call activate rdkit_build

--- a/.azure-pipelines/vs_build_dll.yml
+++ b/.azure-pipelines/vs_build_dll.yml
@@ -63,7 +63,7 @@ steps:
     set RDBASE=%cd%
     set PATH=%RDBASE%\lib;%PATH%
     cd build
-    ctest -C Release -j $(number_of_cores) -V --output-on-failure -R shard -T Test
+    ctest -C Release -j $(number_of_cores) --output-on-failure -R shard -T Test
   displayName: Run sharded tests
 - task: PublishTestResults@2
   inputs:

--- a/.azure-pipelines/vs_build_dll.yml
+++ b/.azure-pipelines/vs_build_dll.yml
@@ -57,8 +57,14 @@ steps:
     set PATH=%RDBASE%\lib;%PATH%
     cd build
     ctest -C Release -j $(number_of_cores) --output-on-failure -E shard -T Test
-    ctest -C Release -j $(number_of_cores) -V --output-on-failure -R shard -T Test
   displayName: Run tests
+- script: |
+    call activate rdkit_build
+    set RDBASE=%cd%
+    set PATH=%RDBASE%\lib;%PATH%
+    cd build
+    ctest -C Release -j $(number_of_cores) -V --output-on-failure -R shard -T Test
+  displayName: Run sharded tests
 - task: PublishTestResults@2
   inputs:
     testResultsFormat: 'CTest'


### PR DESCRIPTION
@ricrogz noticed that having two ctest runs (added in #9402) in a single block obscured failures in the first block.
This pulls the shard tests into a separate test block and removes the verbosity flag added to them.