### PR TITLE
Fix RascalMCES crash

### DIFF
--- a/Code/GraphMol/RascalMCES/LONG_TEST_mces_catch.cpp
+++ b/Code/GraphMol/RascalMCES/LONG_TEST_mces_catch.cpp
@@ -115,7 +115,7 @@ TEST_CASE("timeout") {
     opts.maxBondMatchPairs = 2000;
     auto res = rascalMCES(*m1, *m2, opts);
     REQUIRE(res.size() == 1);
-    REQUIRE(res.front().getBondMatches().size() >= 39);
+    CHECK(res.front().getBondMatches().size() >= 39);
     check_smarts_ok(*m1, *m2, res.front());
   }
   {
@@ -124,7 +124,7 @@ TEST_CASE("timeout") {
     opts.maxBondMatchPairs = 2000;
     auto res = rascalMCES(*m1, *m2, opts);
     REQUIRE(res.size() == 1);
-    REQUIRE(res.front().getBondMatches().size() >= 44);
+    CHECK(res.front().getBondMatches().size() >= 44);
     check_smarts_ok(*m1, *m2, res.front());
   }
   {
@@ -133,7 +133,7 @@ TEST_CASE("timeout") {
     opts.maxBondMatchPairs = 2000;
     auto res = rascalMCES(*m1, *m2, opts);
     REQUIRE(res.size() == 1);
-    REQUIRE(res.front().getBondMatches().size() >= 44);
+    CHECK(res.front().getBondMatches().size() >= 44);
     check_smarts_ok(*m1, *m2, res.front());
   }
 }

--- a/Code/GraphMol/RascalMCES/RascalResult.cpp
+++ b/Code/GraphMol/RascalMCES/RascalResult.cpp
@@ -384,8 +384,8 @@ void RascalResult::matchCliqueAtoms(
 }
 
 void RascalResult::applyMaxFragSep() {
-  std::unique_ptr<RDKit::ROMol> mol1_frags(makeMolFrags(1));
-  auto frags1 = RDKit::MolOps::getMolFrags(*mol1_frags, false);
+  std::unique_ptr<RDKit::ROMol> mol1Frags(makeMolFrags(1));
+  auto frags1 = RDKit::MolOps::getMolFrags(*mol1Frags, false);
   if (frags1.size() < 2) {
     return;
   }
@@ -416,25 +416,21 @@ void RascalResult::applyMaxFragSep() {
 
   bool deletedFrag = false;
   for (size_t i = 0; i < frags1.size() - 1; ++i) {
-    if (!frags1[i]) {
-      continue;
-    }
     for (size_t j = i + 1; j < frags1.size(); ++j) {
-      if (!frags1[j]) {
-        continue;
-      }
-      int mol1Dist =
-          fragFragDist(frags1[i], frags1[j], mol1Dists, d_mol1->getNumAtoms());
-      int mol2Dist =
-          fragFragDist(frags2[i], frags2[j], mol2Dists, d_mol2->getNumAtoms());
-      if (mol1Dist > d_maxFragSep || mol2Dist > d_maxFragSep) {
-        deletedFrag = true;
-        if (frags1[i]->getNumAtoms() < frags1[j]->getNumAtoms()) {
-          frags1[i].reset();
-          frags2[i].reset();
-        } else {
-          frags1[j].reset();
-          frags2[j].reset();
+      if (frags1[i] && frags1[j]) {
+        int mol1Dist = fragFragDist(frags1[i], frags1[j], mol1Dists,
+                                    d_mol1->getNumAtoms());
+        int mol2Dist = fragFragDist(frags2[i], frags2[j], mol2Dists,
+                                    d_mol2->getNumAtoms());
+        if (mol1Dist > d_maxFragSep || mol2Dist > d_maxFragSep) {
+          deletedFrag = true;
+          if (frags1[i]->getNumAtoms() < frags1[j]->getNumAtoms()) {
+            frags1[i].reset();
+            frags2[i].reset();
+          } else {
+            frags1[j].reset();
+            frags2[j].reset();
+          }
         }
       }
     }

--- a/Code/GraphMol/RascalMCES/mces_catch.cpp
+++ b/Code/GraphMol/RascalMCES/mces_catch.cpp
@@ -561,7 +561,7 @@ TEST_CASE("maximum fragment separation") {
     }
     {
       opts.maxFragSeparation = 3;
-      opts.timeout = 3;
+      opts.timeout = 300;
       auto res = rascalMCES(*m1, *m2, opts);
       REQUIRE(res.size() == 1);
       REQUIRE(res.front().getBondMatches().size() == std::get<3>(test));

--- a/Code/GraphMol/RascalMCES/mces_catch.cpp
+++ b/Code/GraphMol/RascalMCES/mces_catch.cpp
@@ -561,7 +561,7 @@ TEST_CASE("maximum fragment separation") {
     }
     {
       opts.maxFragSeparation = 3;
-      opts.timeout = 300;
+      opts.timeout = 3;
       auto res = rascalMCES(*m1, *m2, opts);
       REQUIRE(res.size() == 1);
       REQUIRE(res.front().getBondMatches().size() == std::get<3>(test));
@@ -1558,4 +1558,26 @@ TEST_CASE("Github8645 - memory blows up") {
   auto res = rascalMCES(*m1, *m2, opts);
   REQUIRE(res.size() == 1);
   CHECK(res.front().getBondMatches().size() == 1);
+}
+
+TEST_CASE("Github9418 - maxFragSep crash") {
+  // This isn't the molecule pair in the original report.  That didn't
+  // timeout on my machine.  This pair is from the timeout test in
+  // LONG_TEST_mces_catch.cpp.
+  // The actual result we get here will depend on the speed of the machine
+  // running the test, so just check the key thing which is no crash.
+  auto m1 =
+      "O[C@@H]1CC[C@H](C[C@H]1OC)C[C@@H](C)[C@@H]4CC(=O)[C@H](C)/C=C(\\C)[C@@H](O)[C@@H](OC)C(=O)[C@H](C)C[C@H](C)\\C=C\\C=C\\C=C(/C)[C@@H](OC)C[C@@H]2CC[C@@H](C)[C@@](O)(O2)C(=O)C(=O)N3CCCC[C@H]3C(=O)O4"_smiles;
+  REQUIRE(m1);
+  auto m2 =
+      "CCC1C=C(CC(CC(C2C(CC(C(O2)(C(=O)C(=O)N3CCCCC3C(=O)OC(C(C(CC1=O)O)C)C(=CC4CCC(C(C4)OC)O)C)O)C)OC)OC)C)C"_smiles;
+  REQUIRE(m2);
+
+  RascalOptions opts;
+  opts.timeout = 1;
+  opts.maxBondMatchPairs = 2000;
+  opts.maxFragSeparation = 2;
+  auto res = rascalMCES(*m1, *m2, opts);
+  CHECK(res.size() == 1);
+  check_smarts_ok(*m1, *m2, res.front());
 }


### PR DESCRIPTION
#### Reference Issue
Fixes #9418


#### What does this implement/fix? Explain your changes.
When checking maxFragSep, elements of frags1 and frags2 are reset, but the test for null pointers in subsequent loops was in the wrong place.

#### Any other comments?
The test uses different molecules from the original report, that were known to give a timeout.  Changes in LONG_TEST_mces_catch.cpp are not really relevant to the bug but seemed sensible in passing.
