### PR TITLE
Some optimization of the sanitization code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,6 +114,8 @@ __pycache__/
 /Code/GraphMol/FileParsers/test_data/outSmiles_molwriter.csv
 /Code/GraphMol/FileParsers/test_data/testSGroupsSample_V?000.mol
 /Code/GraphMol/FileParsers/test_data/testSubstanceGroupsSample_V?000.mol
+/Code/GraphMol/FileParsers/test_data/atropisomers/*.NEW*
+/Code/GraphMol/MarvinParse/test_data/*.NEW.*
 
 /Code/GraphMol/ForceFieldHelpers/UFF/test_data/Issue62.sdf
 

--- a/Code/GraphMol/FindRings.cpp
+++ b/Code/GraphMol/FindRings.cpp
@@ -19,7 +19,6 @@
 #include <boost/dynamic_bitset.hpp>
 #include <cstdint>
 #include <queue>
-#include <chrono>
 
 using RINGINVAR = boost::dynamic_bitset<>;
 using RINGINVAR_SET = std::set<RINGINVAR>;

--- a/Code/GraphMol/FindRings.cpp
+++ b/Code/GraphMol/FindRings.cpp
@@ -19,6 +19,7 @@
 #include <boost/dynamic_bitset.hpp>
 #include <cstdint>
 #include <queue>
+#include <chrono>
 
 using RINGINVAR = boost::dynamic_bitset<>;
 using RINGINVAR_SET = std::set<RINGINVAR>;
@@ -1087,7 +1088,8 @@ int symmetrizeSSSR(ROMol &mol, VECT_INT_VECT &res,
                    bool includeHydrogenBonds) {
   auto ringInfo = mol.getRingInfo();
   if (ringInfo->isInitialized()) {
-    ringInfo->reset();
+    bool resetRingFamilies = false;
+    ringInfo->reset(resetRingFamilies);
   }
   ringInfo->initialize(FIND_RING_TYPE_SYMM_SSSR);
 
@@ -1097,8 +1099,10 @@ int symmetrizeSSSR(ROMol &mol, VECT_INT_VECT &res,
   }
 
   if (algorithm != SymmetrizeSSSRAlgorithm::LEGACY) {
-    ringInfo->preallocate(mol.getNumAtoms(), mol.getNumBonds());
-    findRingFamilies(mol, includeDativeBonds, includeHydrogenBonds);
+    if (!ringInfo->areRingFamiliesInitialized()) {
+      ringInfo->preallocate(mol.getNumAtoms(), mol.getNumBonds());
+      findRingFamilies(mol, includeDativeBonds, includeHydrogenBonds);
+    }
     res = ringInfo->atomRelevantCycles();
     for (const auto &atomRing : res) {
       INT_VECT bondRing;

--- a/Code/GraphMol/FindRings.cpp
+++ b/Code/GraphMol/FindRings.cpp
@@ -1083,12 +1083,11 @@ void legacySymmetrizeSSSR(ROMol &mol, VECT_INT_VECT &res,
 }
 }  // namespace
 int symmetrizeSSSR(ROMol &mol, VECT_INT_VECT &res,
-                   SymmetrizeSSSRAlgorithm algorithm, bool includeDativeBonds,
-                   bool includeHydrogenBonds) {
+                   SymmetrizeSSSRAlgorithm algorithm, bool recalcSSSR,
+                   bool includeDativeBonds, bool includeHydrogenBonds) {
   auto ringInfo = mol.getRingInfo();
   if (ringInfo->isInitialized()) {
-    bool resetRingFamilies = false;
-    ringInfo->reset(resetRingFamilies);
+    ringInfo->reset(recalcSSSR);
   }
   ringInfo->initialize(FIND_RING_TYPE_SYMM_SSSR);
 

--- a/Code/GraphMol/MolOps.cpp
+++ b/Code/GraphMol/MolOps.cpp
@@ -606,16 +606,16 @@ void sanitizeMol(RWMol &mol, unsigned int &operationThatFailed,
     mol.updatePropertyCache(false);
   }
 
-  operationThatFailed = SANITIZE_SYMMRINGS;
-  if (sanitizeOps & operationThatFailed) {
-    VECT_INT_VECT arings;
-    MolOps::symmetrizeSSSR(mol, arings);
-  }
-
   // kekulizations
   operationThatFailed = SANITIZE_KEKULIZE;
   if (sanitizeOps & operationThatFailed) {
     kekulizeForSanitize(mol);
+  }
+
+  operationThatFailed = SANITIZE_SYMMRINGS;
+  if (sanitizeOps & operationThatFailed) {
+    VECT_INT_VECT arings;
+    MolOps::symmetrizeSSSR(mol, arings);
   }
 
   // look for radicals:

--- a/Code/GraphMol/MolOps.cpp
+++ b/Code/GraphMol/MolOps.cpp
@@ -615,7 +615,9 @@ void sanitizeMol(RWMol &mol, unsigned int &operationThatFailed,
   operationThatFailed = SANITIZE_SYMMRINGS;
   if (sanitizeOps & operationThatFailed) {
     VECT_INT_VECT arings;
-    MolOps::symmetrizeSSSR(mol, arings);
+    bool recalcSSSR = false;
+    MolOps::symmetrizeSSSR(mol, arings, SymmetrizeSSSRAlgorithm::DEFAULT,
+                           recalcSSSR);
   }
 
   // look for radicals:

--- a/Code/GraphMol/MolOps.h
+++ b/Code/GraphMol/MolOps.h
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2001-2024 Greg Landrum and other RDKit contributors
+//  Copyright (C) 2001-2026 Greg Landrum and other RDKit contributors
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -540,8 +540,8 @@ BETTER_ENUM(SanitizeFlags, unsigned int,
    This functions calls the following in sequence
      -# MolOps::cleanUp()
      -# mol.updatePropertyCache()
-     -# MolOps::symmetrizeSSSR()
      -# MolOps::Kekulize()
+     -# MolOps::symmetrizeSSSR()
      -# MolOps::assignRadicals()
      -# MolOps::setAromaticity()
      -# MolOps::setConjugation()
@@ -911,6 +911,8 @@ enum class SymmetrizeSSSRAlgorithm {
       RingInfo structure, so this argument is optional (see overload)
   \param algorithm - determines which algorithm is used to find the rings and
       do the symmetrization
+  \param recalcSSSR - if set, the SSSR set will be recalculated, otherwise if
+      there is an existing SSSR set, it will be used
   \param includeDativeBonds - determines whether or not dative bonds are used
   in the ring finding.
   \param includeHydrogenBonds - determines whether or not hydrogen bonds are
@@ -925,14 +927,16 @@ enum class SymmetrizeSSSRAlgorithm {
 RDKIT_GRAPHMOL_EXPORT int symmetrizeSSSR(
     ROMol &mol, std::vector<std::vector<int>> &res,
     SymmetrizeSSSRAlgorithm algorithm = SymmetrizeSSSRAlgorithm::DEFAULT,
-    bool includeDativeBonds = false, bool includeHydrogenBonds = false);
+    bool recalcSSSR = true, bool includeDativeBonds = false,
+    bool includeHydrogenBonds = false);
 //! \overload
 inline int symmetrizeSSSR(
     ROMol &mol,
     SymmetrizeSSSRAlgorithm algorithm = SymmetrizeSSSRAlgorithm::DEFAULT,
-    bool includeDativeBonds = false, bool includeHydrogenBonds = false) {
+    bool recalcSSSR = true, bool includeDativeBonds = false,
+    bool includeHydrogenBonds = false) {
   std::vector<std::vector<int>> res;
-  return symmetrizeSSSR(mol, res, algorithm, includeDativeBonds,
+  return symmetrizeSSSR(mol, res, algorithm, recalcSSSR, includeDativeBonds,
                         includeHydrogenBonds);
 }
 
@@ -940,14 +944,16 @@ inline int symmetrizeSSSR(
 inline int symmetrizeSSSR(ROMol &mol, std::vector<std::vector<int>> &res,
                           bool includeDativeBonds,
                           bool includeHydrogenBonds = false) {
-  return symmetrizeSSSR(mol, res, SymmetrizeSSSRAlgorithm::DEFAULT,
+  bool recalcSSSR = true;
+  return symmetrizeSSSR(mol, res, SymmetrizeSSSRAlgorithm::DEFAULT, recalcSSSR,
                         includeDativeBonds, includeHydrogenBonds);
 }
 //! \overload
 inline int symmetrizeSSSR(ROMol &mol, bool includeDativeBonds,
                           bool includeHydrogenBonds = false) {
   std::vector<std::vector<int>> res;
-  return symmetrizeSSSR(mol, res, SymmetrizeSSSRAlgorithm::DEFAULT,
+  bool recalcSSSR = true;
+  return symmetrizeSSSR(mol, res, SymmetrizeSSSRAlgorithm::DEFAULT, recalcSSSR,
                         includeDativeBonds, includeHydrogenBonds);
 }
 

--- a/Code/GraphMol/RingInfo.cpp
+++ b/Code/GraphMol/RingInfo.cpp
@@ -300,7 +300,7 @@ void RingInfo::initialize(RDKit::FIND_RING_TYPE ringType) {
   df_init = true;
   df_find_type_type = ringType;
 };
-void RingInfo::reset() {
+void RingInfo::reset(bool doRingFamilies) {
   if (!df_init) {
     return;
   }
@@ -310,7 +310,9 @@ void RingInfo::reset() {
   d_bondMembers.clear();
   d_atomRings.clear();
   d_bondRings.clear();
-  resetRingFamilies();
+  if (doRingFamilies) {
+    resetRingFamilies();
+  }
 }
 void RingInfo::preallocate(unsigned int numAtoms, unsigned int numBonds) {
   d_atomMembers.resize(numAtoms);

--- a/Code/GraphMol/RingInfo.h
+++ b/Code/GraphMol/RingInfo.h
@@ -52,7 +52,7 @@ class RDKIT_GRAPHMOL_EXPORT RingInfo {
       RDKit::FIND_RING_TYPE ringType = FIND_RING_TYPE_OTHER_OR_UNKNOWN);
   RDKit::FIND_RING_TYPE getRingType() const { return df_find_type_type; };
   //! blows out all current data and de-initializes
-  void reset();
+  void reset(bool resetRingFamilies = true);
 
   bool isFindFastOrBetter() const {
     return df_init && (df_find_type_type == FIND_RING_TYPE_FAST ||

--- a/Code/GraphMol/RingInfo.h
+++ b/Code/GraphMol/RingInfo.h
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2004-2022 Greg Landrum and other RDKit contributors
+//  Copyright (C) 2004-2026 Greg Landrum and other RDKit contributors
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.

--- a/Code/GraphMol/Wrap/MolOps.cpp
+++ b/Code/GraphMol/Wrap/MolOps.cpp
@@ -498,9 +498,10 @@ void cleanupAtropisomersMol(ROMol &mol) {
 
 VECT_INT_VECT getSymmSSSR(ROMol &mol, bool includeDativeBonds,
                           bool includeHydrogenBonds,
-                          MolOps::SymmetrizeSSSRAlgorithm algorithm) {
+                          MolOps::SymmetrizeSSSRAlgorithm algorithm,
+                          bool recalcSSSR) {
   VECT_INT_VECT rings;
-  MolOps::symmetrizeSSSR(mol, rings, algorithm, includeDativeBonds,
+  MolOps::symmetrizeSSSR(mol, rings, algorithm, recalcSSSR, includeDativeBonds,
                          includeHydrogenBonds);
   return rings;
 }
@@ -1296,6 +1297,7 @@ struct molops_wrapper {
     - includeDativeBonds: whether or not dative bonds should be included in the ring finding.\n\
     - includeHydrogenBonds: whether or not hydrogen bonds should be included in the ring finding.\n\
     - algorithm: the algorithm to use for symmetrizing the SSSR.\n\
+    - recalcSSSR: whether or not to recalculate the SSSR before symmetrizing it.\n\
 \n\
   RETURNS: a sequence of sequences containing the rings found as atom ids\n\
 \n";
@@ -1303,7 +1305,8 @@ struct molops_wrapper {
         "GetSymmSSSR", getSymmSSSR,
         (python::arg("mol"), python::arg("includeDativeBonds") = false,
          python::arg("includeHydrogenBonds") = false,
-         python::arg("algorithm") = MolOps::SymmetrizeSSSRAlgorithm::DEFAULT),
+         python::arg("algorithm") = MolOps::SymmetrizeSSSRAlgorithm::DEFAULT,
+         python::arg("recalcSSSR") = true),
         docString.c_str());
 
     // ------------------------------------------------------------------------

--- a/Docs/Book/GettingStartedInPython.rst
+++ b/Docs/Book/GettingStartedInPython.rst
@@ -3667,7 +3667,8 @@ cubane only contains 5 rings, even though there are
 “obviously” 6. This problem can be fixed by implementing a *small*
 (instead of *smallest*) set of smallest rings algorithm that returns
 symmetric results. This is the approach that we took with the RDKit
-in :py:func:`rdkit.Chem.GetSymmSSSR`.
+in :py:func:`rdkit.Chem.GetSymmSSSR`; we return the set of "Relevant 
+Cycles" calculated by the RingDecomposerLib library [#RDL]_.
 
 Because it is sometimes useful to know the "true" SSSR rings, there
 is a :py:func:`rdkit.Chem.GetSSSR` function which returns this
@@ -4068,7 +4069,7 @@ All of the available filters can also be considered at once. Additional informat
 .. [#brenk] Brenk, R.; Schipani, A.; James, D.; Krasowski, A.; Gilbert, I. H.; Frearson, J.; Wyatt, P. G. "Lessons Learnt from Assembling Screening Libraries for Drug Discovery for Neglected Diseases." *ChemMedChem* **3**:435–444 (2008)
 .. [#jadhav] Jadhav, A.; Ferreira, R. S.; Klumpp, C.; Mott, B. T.; Austin, C. P.; Inglese, J.; Thomas, C. J.; Maloney, D. J.; Shoichet, B. K.; Simeonov, A. "Quantitative Analyses of Aggregation, Autofluorescence, and Reactivity Artifacts in a Screen for Inhibitors of a Thiol Protease." *J. Med. Chem.* **53**:37–51 (2010)
 .. [#doveston] Doveston, R. G.; Tosatti, P.; Dow, M.; Foley, D. J.; Li, H. Y.; Campbell, A. J.; House, D.; Churcher, I.; Marsden, S. P.; Nelson, A. "A Unified Lead-Oriented Synthesis of over Fifty Molecular Scaffolds." *Org. Biomol. Chem.* **13**:859–865. (2014)
-
+.. [#RDL] Flachsenberg, F.; Andresen, N.; Rarey, M. "RingDecomposerLib: An Open-Source Implementation of Unique Ring Families and Other Cycle Bases." *J. Chem. Inf. Model.* **57**:122-126 (2017)
 
 License
 *******

--- a/Docs/Book/RDKit_Book.rst
+++ b/Docs/Book/RDKit_Book.rst
@@ -1803,12 +1803,13 @@ Here are the steps involved, in order.
      valence states. This step is always performed, but if it is "skipped"
      the test for non-standard valences will not be carried out.
 
-  5. ``symmetrizeSSSR``: calls the symmetrized smallest set of smallest rings
-     algorithm (discussed in the Getting Started document).
 
-  6. ``Kekulize``: converts aromatic rings to their Kekule form. Will raise an
+  5. ``Kekulize``: converts aromatic rings to their Kekule form. Will raise an
      exception if a ring cannot be kekulized or if aromatic bonds are found
      outside of rings.
+
+  6. ``symmetrizeSSSR``: calls the symmetrized smallest set of smallest rings
+     algorithm (discussed in the Getting Started document).
 
   7. ``assignRadicals``: determines the number of radical electrons (if any) on
      each atom.


### PR DESCRIPTION
The new symmetric ring finding code can, in certain pathological cases, generate *a lot* more rings than the older code did. Since the kekulization code explores all rings on the molecule, this can lead to a dramatic (orders of magnitude) increase in the time required to kekulize. One good example of this from our tests is in the test `Testing sf.net issue 249: finding rings consumes all memory` in `molopstest.cpp`.

Kekulization doesn't actually need the symmetric rings and the above test runs in a reasonable (i.e. orders of magnitude faster) amount of time when we just do `FindSSSR()` before kekulization. 

What this PR does:
1) Move the call to find symmetric rings to after the call to kekulization
2) Call FindSSSR in the Kekulization code (if it needs to be called)
3) Modify the symmetric rings code to not repeat the call to `findRingFamilies()` if the ring families are already present (no need to repeat that work).

I benchmarked this against a set of 1.07 million compounds from the PubChem Compound SDF and compared to using legacy ring finding. Sanitizing from the SDF structure takes, on average, about 15% less time with the new code. Sanitizing from the RDKit SMILES generated from the SDF is about 23% faster (there's a bigger difference here because the SDF doesn't have aromaticity and the SMILES does). The same number of molecules fail sanitization in each case.

Unfortunately the same trick doesn't work for the aromaticity perception code: there we still need the symmetric rings.

*Review note:* there will be a couple of tests that fail related to coordinate generation and drawing (probably because the kekulization done during sanitization now puts bonds in different places). I will clean these up if we agree that the changes are a good idea.

*More info on the benchmarking*:
- Second sanitization timing across the 1.07million compounds:
	- The average runtime is 23% faster
	- There are only 20K examples where things are slower
	- Only 9(!) have a runtime difference of more than 1ms. Only 7600 have a difference of more than 10us.
	- Here are the largest differences, the worse is 0.55s
```
sqlite>  select *,ntime-otime diff from foo2 order by diff desc limit 10;
57765142|0.0215458869934082|0.570484161376953|25.4776363837557|0.548938274383545
57397126|0.00139522552490234|0.206063508987427|146.691900205058|0.204668283462524
57397127|0.00139641761779785|0.203990459442139|145.081270274885|0.202594041824341
57765143|0.0119733810424805|0.101653337478638|7.48994424532059|0.0896799564361572
57765144|0.0109996795654297|0.0988872051239014|7.99000780301717|0.0878875255584717
57765147|0.0111310482025146|0.0948450565338135|7.52076595197807|0.0837140083312988
57536079|0.000592947006225586|0.00432252883911133|6.28990751909932|0.00372958183288574
57257237|0.000176906585693359|0.00127673149108887|6.21698113207547|0.00109982490539551
57857931|0.000943899154663086|0.00197148323059082|1.08865875221015|0.00102758407592773
57413438|0.00692486763000488|0.00770139694213867|0.112136340161818|0.000776529312133789
```
columns are: `CID, legacy runtime, new runtime, fractional difference, absolute difference`
