### PR TITLE
fragmentOnBonds: enfore unique bondIndices on input

### DIFF
--- a/Code/GraphMol/ChemTransforms/MolFragmenter.cpp
+++ b/Code/GraphMol/ChemTransforms/MolFragmenter.cpp
@@ -318,10 +318,10 @@ void fragmentOnSomeBonds(
                "bad dummyLabel vector");
   PRECONDITION((!bondTypes || bondTypes->size() == bondIndices.size()),
                "bad bondType vector");
-  PRECONDITION(
-      std::set<unsigned int>(bondIndices.begin(), bondIndices.end()).size() ==
-          bondIndices.size(),
-      "bondIndices contains duplicates");
+  if (std::unordered_set<unsigned int>(bondIndices.begin(), bondIndices.end())
+          .size() < bondIndices.size()) {
+    throw ValueErrorException("bondIndices contains duplicates");
+  }
   if (bondIndices.size() > 63) {
     throw ValueErrorException("currently can only fragment on up to 63 bonds");
   }
@@ -440,10 +440,10 @@ ROMol *fragmentOnBonds(
                "bad bondType vector");
   PRECONDITION((!nCutsPerAtom || nCutsPerAtom->size() == mol.getNumAtoms()),
                "bad nCutsPerAtom vector");
-  PRECONDITION(
-      std::set<unsigned int>(bondIndices.begin(), bondIndices.end()).size() ==
-          bondIndices.size(),
-      "bondIndices contains duplicates");
+  if (std::unordered_set<unsigned int>(bondIndices.begin(), bondIndices.end())
+          .size() < bondIndices.size()) {
+    throw ValueErrorException("bondIndices contains duplicates");
+  }
   if (nCutsPerAtom) {
     for (auto &nCuts : *nCutsPerAtom) {
       nCuts = 0;

--- a/Code/GraphMol/ChemTransforms/MolFragmenter.cpp
+++ b/Code/GraphMol/ChemTransforms/MolFragmenter.cpp
@@ -318,6 +318,10 @@ void fragmentOnSomeBonds(
                "bad dummyLabel vector");
   PRECONDITION((!bondTypes || bondTypes->size() == bondIndices.size()),
                "bad bondType vector");
+  PRECONDITION(
+      std::set<unsigned int>(bondIndices.begin(), bondIndices.end()).size() ==
+          bondIndices.size(),
+      "bondIndices contains duplicates");
   if (bondIndices.size() > 63) {
     throw ValueErrorException("currently can only fragment on up to 63 bonds");
   }
@@ -328,14 +332,15 @@ void fragmentOnSomeBonds(
   std::uint64_t state = (0x1L << maxToCut) - 1;
   std::uint64_t stop = 0x1L << bondIndices.size();
   std::vector<unsigned int> fragmentHere(maxToCut);
-  std::vector<std::pair<unsigned int, unsigned int>> *dummyLabelsHere = nullptr;
+  std::unique_ptr<std::vector<std::pair<unsigned int, unsigned int>>>
+      dummyLabelsHere;
   if (dummyLabels) {
-    dummyLabelsHere =
-        new std::vector<std::pair<unsigned int, unsigned int>>(maxToCut);
+    dummyLabelsHere.reset(
+        new std::vector<std::pair<unsigned int, unsigned int>>(maxToCut));
   }
-  std::vector<Bond::BondType> *bondTypesHere = nullptr;
+  std::unique_ptr<std::vector<Bond::BondType>> bondTypesHere;
   if (bondTypes) {
-    bondTypesHere = new std::vector<Bond::BondType>(maxToCut);
+    bondTypesHere.reset(new std::vector<Bond::BondType>(maxToCut));
   }
   while (state < stop) {
     unsigned int nSeen = 0;
@@ -356,14 +361,12 @@ void fragmentOnSomeBonds(
       nCutsPerAtom->push_back(std::vector<unsigned int>(mol.getNumAtoms()));
       lCutsPerAtom = &(nCutsPerAtom->back());
     }
-    ROMol *nm = fragmentOnBonds(mol, fragmentHere, addDummies, dummyLabelsHere,
-                                bondTypesHere, lCutsPerAtom);
-    resMols.emplace_back(nm);
+    resMols.emplace_back(fragmentOnBonds(mol, fragmentHere, addDummies,
+                                         dummyLabelsHere.get(),
+                                         bondTypesHere.get(), lCutsPerAtom));
 
     state = nextBitCombo(state);
   }
-  delete dummyLabelsHere;
-  delete bondTypesHere;
 }
 
 namespace {
@@ -437,14 +440,18 @@ ROMol *fragmentOnBonds(
                "bad bondType vector");
   PRECONDITION((!nCutsPerAtom || nCutsPerAtom->size() == mol.getNumAtoms()),
                "bad nCutsPerAtom vector");
+  PRECONDITION(
+      std::set<unsigned int>(bondIndices.begin(), bondIndices.end()).size() ==
+          bondIndices.size(),
+      "bondIndices contains duplicates");
   if (nCutsPerAtom) {
     for (auto &nCuts : *nCutsPerAtom) {
       nCuts = 0;
     }
   }
-  auto *res = new RWMol(mol);
-  if (!mol.getNumAtoms()) {
-    return res;
+  std::unique_ptr<RWMol> res(new RWMol(mol));
+  if (!mol.getNumAtoms() || bondIndices.empty()) {
+    return res.release();
   }
 
   std::vector<Bond *> bondsToRemove;
@@ -452,6 +459,7 @@ ROMol *fragmentOnBonds(
   for (auto bondIdx : bondIndices) {
     bondsToRemove.push_back(res->getBondWithIdx(bondIdx));
   }
+  res->beginBatchEdit();
   for (unsigned int i = 0; i < bondsToRemove.size(); ++i) {
     const Bond *bond = bondsToRemove[i];
     unsigned int bidx = bond->getBeginAtomIdx();
@@ -472,9 +480,8 @@ ROMol *fragmentOnBonds(
       (*nCutsPerAtom)[eidx] += 1;
     }
     if (addDummies) {
-      Atom *at1, *at2;
-      at1 = new Atom(0);
-      at2 = new Atom(0);
+      std::unique_ptr<Atom> at1(new Atom(0));
+      std::unique_ptr<Atom> at2(new Atom(0));
       if (dummyLabels) {
         at1->setIsotope((*dummyLabels)[i].first);
         at2->setIsotope((*dummyLabels)[i].second);
@@ -482,11 +489,11 @@ ROMol *fragmentOnBonds(
         at1->setIsotope(bidx);
         at2->setIsotope(eidx);
       }
-      unsigned int idx1 = res->addAtom(at1, false, true);
+      unsigned int idx1 = res->addAtom(at1.release(), false, true);
       if (bondTypes) {
         bT = (*bondTypes)[i];
       }
-      bondidx = res->addBond(at1->getIdx(), eidx, bT) - 1;
+      bondidx = res->addBond(idx1, eidx, bT) - 1;
       // the dummy replaces the original start atom, so the
       // direction will be ok as long as it's one of the
       // states associated with double bond stereo
@@ -500,8 +507,8 @@ ROMol *fragmentOnBonds(
         res->replaceBond(bondidx, qb.get());
       }
 
-      unsigned int idx2 = res->addAtom(at2, false, true);
-      bondidx = res->addBond(bidx, at2->getIdx(), bT) - 1;
+      unsigned int idx2 = res->addAtom(at2.release(), false, true);
+      bondidx = res->addBond(bidx, idx2, bT) - 1;
       // this bond starts at the same atom, so its direction should always be
       // correct:
       res->getBondWithIdx(bondidx)->setBondDir(bD);
@@ -560,8 +567,9 @@ ROMol *fragmentOnBonds(
       }
     }
   }
+  res->commitBatchEdit();
   res->clearComputedProps();
-  return static_cast<ROMol *>(res);
+  return static_cast<ROMol *>(res.release());
 }
 
 ROMol *fragmentOnBonds(const ROMol &mol,

--- a/Code/GraphMol/ChemTransforms/catch_tests.cpp
+++ b/Code/GraphMol/ChemTransforms/catch_tests.cpp
@@ -652,6 +652,19 @@ TEST_CASE(
   CHECK(!nb8->hasQuery());
 }
 
+TEST_CASE("fragmentOnBonds should not segfault on duplicate bondIndices") {
+  // Basic test
+  auto mol = "NCCO"_smiles;
+  REQUIRE(mol);
+  REQUIRE(mol->getBondWithIdx(0));
+  REQUIRE(mol->getBondWithIdx(2));
+  std::unique_ptr<ROMol> splitMol;
+  CHECK_THROWS_AS(splitMol.reset(MolFragmenter::fragmentOnBonds(
+                      *mol, std::vector<unsigned int>{0, 2, 2})),
+                  Invar::Invariant);
+  REQUIRE(!splitMol);
+}
+
 TEST_CASE("align fragments") {
   SECTION("basics") {
     auto m = "CC[1*].O[1*] |(1,0,0;2,0,0;3.5,0,0;0,1,0;0,2.1,0)|"_smiles;

--- a/Code/GraphMol/ChemTransforms/catch_tests.cpp
+++ b/Code/GraphMol/ChemTransforms/catch_tests.cpp
@@ -661,7 +661,7 @@ TEST_CASE("fragmentOnBonds should not segfault on duplicate bondIndices") {
   std::unique_ptr<ROMol> splitMol;
   CHECK_THROWS_AS(splitMol.reset(MolFragmenter::fragmentOnBonds(
                       *mol, std::vector<unsigned int>{0, 2, 2})),
-                  Invar::Invariant);
+                  ValueErrorException);
   REQUIRE(!splitMol);
 }
 

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -3574,6 +3574,10 @@ CAS<~>
     m = Chem.MolFromSmiles('OCCCCN')
     self.assertRaises(ValueError, lambda: Chem.FragmentOnBonds(m, ()))
 
+    # duplicate bond indices
+    m = Chem.MolFromSmiles('OCCN')
+    self.assertRaises(ValueError, lambda: Chem.FragmentOnBonds(m, (0, 2, 2)))
+
   def test88QueryAtoms(self):
     from rdkit.Chem import rdqueries
     m = Chem.MolFromSmiles('c1nc(C)n(CC)c1')


### PR DESCRIPTION
Currently, `fragmentOnBond` segfaults when `bondIndices` contains multiple bonds, because `Bond` pointers are pushed to a vector upfront, and the attempt to to dereference the duplicate `Bond` after it has already been deleted causes a crash.
This PR catches `bondIndices` containing duplicate bonds in a `PRECONDITION`, avoiding the crash.
I think duplicate `bondIndices` are most likely the consequence of a mistake, and hence should be explicitly caught by a `PRECONDITION` rather than silently accepted by simply roundtripping the input vector through a `std::set` to remove duplicate indices.