### PR TITLE
Guard the BCUT2D test with RDK_HAS_EIGEN3

### DIFF
--- a/Code/GraphMol/Descriptors/catch_tests.cpp
+++ b/Code/GraphMol/Descriptors/catch_tests.cpp
@@ -681,6 +681,7 @@ TEST_CASE("DCLV") {
   }
 }
 
+#ifdef RDK_HAS_EIGEN3
 TEST_CASE("Github #7364: BCUT descriptors failing for moleucles with Hs") {
   SECTION("as reported") {
     auto m = "CCOC#CCC(C(=O)c1ccc(C)cc1)N1CCCC1"_smiles;
@@ -693,6 +694,7 @@ TEST_CASE("Github #7364: BCUT descriptors failing for moleucles with Hs") {
     CHECK(ref == val);
   }
 }
+#endif
 
 TEST_CASE(
     "Github #6757: numAtomStereoCenters fails if molecule is sanitized a second time") {


### PR DESCRIPTION
BCUT.h and BCUT.cpp wrap their entire contents in #ifdef RDK_HAS_EIGEN3, so Descriptors::BCUT2D does not exist in a build without Eigen. The test case added for #7364 calls it unconditionally, which breaks the build of Code/GraphMol/Descriptors/catch_tests.cpp:

  error: 'BCUT2D' is not a member of 'RDKit::Descriptors'

This happens when Eigen is neither installed nor downloaded, i.e. when find_package(Eigen3) fails and RDK_BUILD_DESCRIPTORS3D is off, so the External/Eigen fallback never runs and nothing defines RDK_HAS_EIGEN3. It is easy to miss because a system Eigen makes find_package(Eigen3) succeed regardless of the option.

<!--
Thanks for contributing a pull request! 
-->
#### Reference Issue
<!-- Example: Fixes #1234 -->


#### What does this implement/fix? Explain your changes.

Fixes a test that uses BCUT.

#### Any other comments?

