### PR TITLE
Fix leaks in 2 tests

### DIFF
--- a/Code/GraphMol/DistGeomHelpers/BoundsMatrixBuilder.cpp
+++ b/Code/GraphMol/DistGeomHelpers/BoundsMatrixBuilder.cpp
@@ -720,8 +720,8 @@ void set13Bounds(const ROMol &mol, DistGeom::BoundsMatPtr mmat,
         }  // while loop over second bond
         ++beg1;
       }  // while loop over first bond
-    }  // done with non-ring atoms
-  }  // done with all atoms
+    }    // done with non-ring atoms
+  }      // done with all atoms
 }  // done with 13 distance setting
 
 Bond::BondStereo _getAtomStereo(const Bond *bnd, unsigned int aid1,
@@ -1412,7 +1412,7 @@ void set14Bounds(const ROMol &mol, DistGeom::BoundsMatPtr mmat,
 
       bid1 = bid2;
     }  // loop over bonds in the ring
-  }  // end of all rings
+  }    // end of all rings
   for (const auto bond : mol.bonds()) {
     auto bid2 = bond->getIdx();
     auto aid2 = bond->getBeginAtomIdx();
@@ -1513,9 +1513,9 @@ void setTopolBounds(const ROMol &mol, DistGeom::BoundsMatPtr mmat,
   if (!na) {
     throw ValueErrorException("molecule has no atoms");
   }
-  // this is 2.6 million bonds, so it's extremly unlikely to ever occur, but
+  // this is 2.6 million bonds, so it's extremely unlikely to ever occur, but
   // we might as well check:
-  const size_t MAX_NUM_BONDS = static_cast<size_t>(
+  const auto MAX_NUM_BONDS = static_cast<size_t>(
       std::pow(std::numeric_limits<std::uint64_t>::max(), 1. / 3));
   if (mol.getNumBonds() >= MAX_NUM_BONDS) {
     throw ValueErrorException(

--- a/Code/GraphMol/DistGeomHelpers/testDgeomHelpers.cpp
+++ b/Code/GraphMol/DistGeomHelpers/testDgeomHelpers.cpp
@@ -136,11 +136,10 @@ void compareConfs(const RWMol *m, const RWMol *expected, int molConfId = -1,
     RDGeom::Point3D pt1i = conf1.getAtomPos(i);
     RDGeom::Point3D pt2i = conf2.getAtomPos(i);
 
-
-  // Increased tolerance from 0.05 to 0.1. 
-  // This prevents false test failures on systems using -march=native, 
-  // where compiler optimizations cause tiny, harmless math differences.
-  // (See issue #[9406])
+    // Increased tolerance from 0.05 to 0.1.
+    // This prevents false test failures on systems using -march=native,
+    // where compiler optimizations cause tiny, harmless math differences.
+    // (See issue #[9406])
     CHECK((pt1i - pt2i).length() < 0.1);
   }
 }
@@ -1304,7 +1303,7 @@ TEST_CASE("testGithub697") {
       "C(COC(=O)C(N)CCCNC(=N)N)NC(=O)C(C(C)C)NC1=O"};
 
   for (const auto &smi : smis) {
-    ROMol *m = SmilesToMol(smi);
+    auto m = v2::SmilesParse::MolFromSmiles(smi);
     REQUIRE(m);
     DistGeom::BoundsMatPtr bm;
     bm.reset(new DistGeom::BoundsMatrix(m->getNumAtoms()));

--- a/External/ChemDraw/test.cpp
+++ b/External/ChemDraw/test.cpp
@@ -1390,7 +1390,6 @@ TEST_CASE("Round TRIP") {
             continue;
           }
 
-
           auto smi2 = MolToSmiles(*mols[0]);
           if (smi1 != smi2) {
             // std::cerr <<
@@ -1406,23 +1405,27 @@ TEST_CASE("Round TRIP") {
             // std::cerr << "PASS:" << entry.path() << std::endl;
           }
           // CHECK(smi1 == smi2);
-	  SmilesWriteParams ps;
+          SmilesWriteParams ps;
 
-	  unsigned int flags = SmilesWrite::CXSmilesFields::CX_BOND_ATROPISOMER |
-	                       SmilesWrite::CXSmilesFields::CX_ENHANCEDSTEREO;
-	  auto cxsmi1 = MolToCXSmiles(*mol, ps, flags);
-	  auto cxsmi2 = MolToCXSmiles(*mols[0], ps, flags);
-	  if(cxsmi1 != cxsmi2) {
-	    std::cerr << "CXFAIL:" << entry.path() << " (mol)" << cxsmi1
+          unsigned int flags =
+              SmilesWrite::CXSmilesFields::CX_BOND_ATROPISOMER |
+              SmilesWrite::CXSmilesFields::CX_ENHANCEDSTEREO;
+          auto cxsmi1 = MolToCXSmiles(*mol, ps, flags);
+          auto cxsmi2 = MolToCXSmiles(*mols[0], ps, flags);
+          if (cxsmi1 != cxsmi2) {
+            std::cerr << "CXFAIL:" << entry.path() << " (mol)" << cxsmi1
                       << " != (mol-cdxml)" << cxsmi2 << std::endl;
             failed++;
-	    std::cerr << "========================================" << std::endl;
-	    mol->debugMol(std::cerr);
-	    std::cerr << "----------------------------------------" << std::endl;
-	    mols[0]->debugMol(std::cerr);
-	    std::cerr << "<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<" << std::endl;
-	    std::cerr << cdx << std::endl;
-	  }
+            std::cerr << "========================================"
+                      << std::endl;
+            mol->debugMol(std::cerr);
+            std::cerr << "----------------------------------------"
+                      << std::endl;
+            mols[0]->debugMol(std::cerr);
+            std::cerr << "<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<"
+                      << std::endl;
+            std::cerr << cdx << std::endl;
+          }
           delete mol;
         }
       }
@@ -1457,8 +1460,8 @@ TEST_CASE("Geometry") {
 TEST_CASE("Bond stereo") {
   std::string path =
       std::string(getenv("RDBASE")) + "/External/ChemDraw/test_data/";
-  const auto checkOximeStereoFixture =
-      [&](const std::string &fname, Bond::BondStereo expectedStereo) {
+  const auto checkOximeStereoFixture = [&](const std::string &fname,
+                                           Bond::BondStereo expectedStereo) {
     auto mols = MolsFromChemDrawFile(fname);
     REQUIRE(mols.size() == 1);
 
@@ -1476,7 +1479,7 @@ TEST_CASE("Bond stereo") {
     CHECK(bond->getStereo() == expectedStereo);
     CHECK(bond->getStereoAtoms() == INT_VECT({0, 10}));
 
-    auto roundtrip = MolBlockToMol(MolToV3KMolBlock(mol));
+    auto roundtrip = v2::FileParsers::MolFromMolBlock(MolToV3KMolBlock(mol));
     REQUIRE(roundtrip);
     Bond *roundtripBond = nullptr;
     for (auto candidate : roundtrip->bonds()) {
@@ -1587,9 +1590,10 @@ TEST_CASE("NeedsClean hydrogens") {
     params.needsCleanPolicy = NeedsCleanPolicy::TrustExplicitHydrogens;
     auto trust = MolsFromChemDrawFile(fname);
     auto preserve = MolsFromChemDrawFile(fname, params);
-    REQUIRE(molSmiles(trust) ==
-            std::vector<std::string>{
-                "CC(=O)S[C@H]1CC2=CC(=O)CC[C@@]2(C)[C@@H]2CC[C@]3(C)[C@H](CC[C@]34CCC(=O)O4)[C@@H]12"});
+    REQUIRE(
+        molSmiles(trust) ==
+        std::vector<std::string>{
+            "CC(=O)S[C@H]1CC2=CC(=O)CC[C@@]2(C)[C@@H]2CC[C@]3(C)[C@H](CC[C@]34CCC(=O)O4)[C@@H]12"});
     CHECK(molSmiles(preserve) == molSmiles(trust));
   }
   SECTION(


### PR DESCRIPTION
I reran the tests under asan, and all I found was a couple of molecules being leaked in tests. This fixes these leaks by using `v2` functions to parse these molecules.