### PR TITLE
Fix numpy dtype handling in the InfoTheory wrappers

### DIFF
--- a/Code/ML/InfoTheory/Wrap/rdInfoTheory.cpp
+++ b/Code/ML/InfoTheory/Wrap/rdInfoTheory.cpp
@@ -17,93 +17,47 @@ namespace python = boost::python;
 using namespace RDInfoTheory;
 
 namespace RDInfoTheory {
-double infoEntropy(python::object resArr) {
-  PyObject *matObj = resArr.ptr();
-  if (!PyArray_Check(matObj)) {
+namespace {
+// Dispatching on the input's own type_num used to leave uncommon dtypes
+// (NPY_LONGLONG, i.e. numpy's int64 on Windows, but also int8/uint*/float16)
+// unhandled, which silently produced a result of 0.0 (github #8421).
+PyArrayObject *contiguousDoubles(const python::object &resArr, int minDim,
+                                 int maxDim) {
+  if (!PyArray_Check(resArr.ptr())) {
     throw_value_error("Expecting a Numeric array object");
   }
-  PyArrayObject *copy;
-  copy = (PyArrayObject *)PyArray_ContiguousFromObject(
-      matObj, PyArray_DESCR((PyArrayObject *)matObj)->type_num, 1, 1);
-  double res = 0.0;
-  // we are expecting a 1 dimensional array
-  auto ncols = (long int)PyArray_DIM((PyArrayObject *)matObj, 0);
-  CHECK_INVARIANT(ncols > 0, "");
-  if (PyArray_DESCR((PyArrayObject *)matObj)->type_num == NPY_DOUBLE) {
-    auto *data = (double *)PyArray_DATA(copy);
-    res = InfoEntropy(data, ncols);
-  } else if (PyArray_DESCR((PyArrayObject *)matObj)->type_num == NPY_FLOAT) {
-    auto *data = (float *)PyArray_DATA(copy);
-    res = InfoEntropy(data, ncols);
-  } else if (PyArray_DESCR((PyArrayObject *)matObj)->type_num == NPY_INT) {
-    int *data = (int *)PyArray_DATA(copy);
-    res = InfoEntropy(data, ncols);
-  } else if (PyArray_DESCR((PyArrayObject *)matObj)->type_num == NPY_LONG) {
-    auto *data = (long int *)PyArray_DATA(copy);
-    res = InfoEntropy(data, ncols);
+  auto *copy = (PyArrayObject *)PyArray_ContiguousFromObject(
+      resArr.ptr(), NPY_DOUBLE, minDim, maxDim);
+  if (!copy) {
+    throw_value_error("could not convert argument to an array of doubles");
   }
+  return copy;
+}
+}  // namespace
+
+double infoEntropy(python::object resArr) {
+  PyArrayObject *copy = contiguousDoubles(resArr, 1, 1);
+  auto ncols = (long int)PyArray_DIM(copy, 0);
+  CHECK_INVARIANT(ncols > 0, "");
+  double res = InfoEntropy((double *)PyArray_DATA(copy), ncols);
   Py_DECREF(copy);
   return res;
 }
 
 double infoGain(python::object resArr) {
-  PyObject *matObj = resArr.ptr();
-  if (!PyArray_Check(matObj)) {
-    throw_value_error("Expecting a Numeric array object");
-  }
-  PyArrayObject *copy;
-  copy = (PyArrayObject *)PyArray_ContiguousFromObject(
-      matObj, PyArray_DESCR((PyArrayObject *)matObj)->type_num, 2, 2);
-  auto rows = (long int)PyArray_DIM((PyArrayObject *)matObj, 0);
-  auto cols = (long int)PyArray_DIM((PyArrayObject *)matObj, 1);
-  double res = 0.0;
-  if (PyArray_DESCR((PyArrayObject *)matObj)->type_num == NPY_DOUBLE) {
-    auto *data = (double *)PyArray_DATA(copy);
-    res = InfoEntropyGain(data, rows, cols);
-  } else if (PyArray_DESCR((PyArrayObject *)matObj)->type_num == NPY_FLOAT) {
-    auto *data = (float *)PyArray_DATA(copy);
-    res = InfoEntropyGain(data, rows, cols);
-  } else if (PyArray_DESCR((PyArrayObject *)matObj)->type_num == NPY_INT) {
-    int *data = (int *)PyArray_DATA(copy);
-    res = InfoEntropyGain(data, rows, cols);
-  } else if (PyArray_DESCR((PyArrayObject *)matObj)->type_num == NPY_LONG) {
-    auto *data = (long int *)PyArray_DATA(copy);
-    res = InfoEntropyGain(data, rows, cols);
-  } else {
-    throw_value_error(
-        "Numeric array object of type int or long or float or double");
-  }
+  PyArrayObject *copy = contiguousDoubles(resArr, 2, 2);
+  auto rows = (long int)PyArray_DIM(copy, 0);
+  auto cols = (long int)PyArray_DIM(copy, 1);
+  double res = InfoEntropyGain((double *)PyArray_DATA(copy), rows, cols);
   Py_DECREF(copy);
   return res;
 }
 
 double chiSquare(python::object resArr) {
-  PyObject *matObj = resArr.ptr();
-  if (!PyArray_Check(matObj)) {
-    throw_value_error("Expecting a Numeric array object");
-  }
-  PyArrayObject *copy;
-  copy = (PyArrayObject *)PyArray_ContiguousFromObject(
-      matObj, PyArray_DESCR((PyArrayObject *)matObj)->type_num, 2, 2);
-  auto rows = (long int)PyArray_DIM((PyArrayObject *)matObj, 0);
-  auto cols = (long int)PyArray_DIM((PyArrayObject *)matObj, 1);
-  double res = 0.0;
-  if (PyArray_DESCR((PyArrayObject *)matObj)->type_num == NPY_DOUBLE) {
-    auto *data = (double *)PyArray_DATA(copy);
-    res = ChiSquare(data, rows, cols);
-  } else if (PyArray_DESCR((PyArrayObject *)matObj)->type_num == NPY_FLOAT) {
-    auto *data = (float *)PyArray_DATA(copy);
-    res = ChiSquare(data, rows, cols);
-  } else if (PyArray_DESCR((PyArrayObject *)matObj)->type_num == NPY_INT) {
-    int *data = (int *)PyArray_DATA(copy);
-    res = ChiSquare(data, rows, cols);
-  } else if (PyArray_DESCR((PyArrayObject *)matObj)->type_num == NPY_LONG) {
-    auto *data = (long int *)PyArray_DATA(copy);
-    res = ChiSquare(data, rows, cols);
-  } else {
-    throw_value_error(
-        "Numeric array object of type int or long or float or double");
-  }
+  PyArrayObject *copy = contiguousDoubles(resArr, 2, 2);
+  auto rows = (long int)PyArray_DIM(copy, 0);
+  auto cols = (long int)PyArray_DIM(copy, 1);
+  double res = ChiSquare((double *)PyArray_DATA(copy), rows, cols);
   Py_DECREF(copy);
   return res;
 }

--- a/Code/ML/InfoTheory/Wrap/rdInfoTheory.cpp
+++ b/Code/ML/InfoTheory/Wrap/rdInfoTheory.cpp
@@ -18,46 +18,88 @@ using namespace RDInfoTheory;
 
 namespace RDInfoTheory {
 namespace {
-// Dispatching on the input's own type_num used to leave uncommon dtypes
-// (NPY_LONGLONG, i.e. numpy's int64 on Windows, but also int8/uint*/float16)
-// unhandled, which silently produced a result of 0.0 (github #8421).
-PyArrayObject *contiguousDoubles(const python::object &resArr, int minDim,
-                                 int maxDim) {
+// InfoEntropy(), InfoEntropyGain() and ChiSquare() are instantiated for these
+// dtypes, so arrays using them are read directly. Anything else is converted to
+// doubles. Note that NPY_LONG is only 32 bits wide on Windows, where numpy's
+// default integer is NPY_LONGLONG (github #8421).
+int nativeOrDoubleType(const python::object &resArr) {
   if (!PyArray_Check(resArr.ptr())) {
     throw_value_error("Expecting a Numeric array object");
   }
+  int typeNum = PyArray_DESCR((PyArrayObject *)resArr.ptr())->type_num;
+  switch (typeNum) {
+    case NPY_DOUBLE:
+    case NPY_FLOAT:
+    case NPY_INT:
+    case NPY_LONG:
+    case NPY_LONGLONG:
+      return typeNum;
+    default:
+      return NPY_DOUBLE;
+  }
+}
+
+PyArrayObject *contiguousArray(const python::object &resArr, int typeNum,
+                               int minDim, int maxDim) {
   auto *copy = (PyArrayObject *)PyArray_ContiguousFromObject(
-      resArr.ptr(), NPY_DOUBLE, minDim, maxDim);
+      resArr.ptr(), typeNum, minDim, maxDim);
   if (!copy) {
-    throw_value_error("could not convert argument to an array of doubles");
+    throw_value_error("could not convert argument to a numeric array");
   }
   return copy;
+}
+
+// Calls func with the array's data cast to the pointer type matching typeNum.
+template <typename Func>
+double withTypedData(PyArrayObject *arr, int typeNum, Func func) {
+  void *data = PyArray_DATA(arr);
+  switch (typeNum) {
+    case NPY_FLOAT:
+      return func((float *)data);
+    case NPY_INT:
+      return func((int *)data);
+    case NPY_LONG:
+      return func((long int *)data);
+    case NPY_LONGLONG:
+      return func((long long *)data);
+    default:
+      return func((double *)data);
+  }
 }
 }  // namespace
 
 double infoEntropy(python::object resArr) {
-  PyArrayObject *copy = contiguousDoubles(resArr, 1, 1);
+  int typeNum = nativeOrDoubleType(resArr);
+  PyArrayObject *copy = contiguousArray(resArr, typeNum, 1, 1);
+  // we are expecting a 1 dimensional array
   auto ncols = (long int)PyArray_DIM(copy, 0);
   CHECK_INVARIANT(ncols > 0, "");
-  double res = InfoEntropy((double *)PyArray_DATA(copy), ncols);
+  double res = withTypedData(
+      copy, typeNum, [ncols](auto *data) { return InfoEntropy(data, ncols); });
   Py_DECREF(copy);
   return res;
 }
 
 double infoGain(python::object resArr) {
-  PyArrayObject *copy = contiguousDoubles(resArr, 2, 2);
+  int typeNum = nativeOrDoubleType(resArr);
+  PyArrayObject *copy = contiguousArray(resArr, typeNum, 2, 2);
   auto rows = (long int)PyArray_DIM(copy, 0);
   auto cols = (long int)PyArray_DIM(copy, 1);
-  double res = InfoEntropyGain((double *)PyArray_DATA(copy), rows, cols);
+  double res = withTypedData(copy, typeNum, [rows, cols](auto *data) {
+    return InfoEntropyGain(data, rows, cols);
+  });
   Py_DECREF(copy);
   return res;
 }
 
 double chiSquare(python::object resArr) {
-  PyArrayObject *copy = contiguousDoubles(resArr, 2, 2);
+  int typeNum = nativeOrDoubleType(resArr);
+  PyArrayObject *copy = contiguousArray(resArr, typeNum, 2, 2);
   auto rows = (long int)PyArray_DIM(copy, 0);
   auto cols = (long int)PyArray_DIM(copy, 1);
-  double res = ChiSquare((double *)PyArray_DATA(copy), rows, cols);
+  double res = withTypedData(copy, typeNum, [rows, cols](auto *data) {
+    return ChiSquare(data, rows, cols);
+  });
   Py_DECREF(copy);
   return res;
 }

--- a/Code/ML/InfoTheory/Wrap/testRanker.py
+++ b/Code/ML/InfoTheory/Wrap/testRanker.py
@@ -48,6 +48,18 @@ class TestCase(unittest.TestCase):
     mat6 = numpy.array([[1, 0], [1, 0]],float)
     self.assertTrue(feq(rdit.InfoGain(mat6), 0.0000))
 
+  def testGainFunDtypes(self):
+    # Github #8421: dtypes the wrappers did not recognize used to silently
+    # return 0.0. numpy's default integer is int64, which is NPY_LONGLONG (and
+    # so was not recognized) on Windows.
+    arr = numpy.array([2, 5, 5])
+    mat = numpy.array([[6, 2], [3, 3]])
+    for dtype in ('int8', 'int32', 'int64', 'longlong', 'uint8', 'uint64', 'float16', 'float32',
+                  'float64'):
+      self.assertTrue(feq(rdit.InfoEntropy(arr.astype(dtype)), 1.4834), dtype)
+      self.assertTrue(feq(rdit.InfoGain(mat.astype(dtype)), 0.0481), dtype)
+      self.assertTrue(feq(rdit.ChiSquare(mat.astype(dtype)), 0.9333), dtype)
+
   def test1ranker(self):
     nbits = 100
     ninst = 100

--- a/rdkit/Chem/GraphDescriptors.py
+++ b/rdkit/Chem/GraphDescriptors.py
@@ -320,7 +320,7 @@ def _pyChiNv_(mol, order=2):
                         for hkd in _hkDeltas(mol, skipHs=0)])
   accum = 0.0
   for path in Chem.FindAllPathsOfLengthN(mol, order + 1, useBonds=0):
-    accum += numpy.prod(deltas[numpy.array(path)],float)
+    accum += numpy.prod(deltas[numpy.array(path)], dtype=float)
   return accum
 
 
@@ -391,7 +391,7 @@ def _pyChiNn_(mol, order=2):
   deltas = numpy.array([(1. / numpy.sqrt(x) if x else 0.0) for x in nval])
   accum = 0.0
   for path in Chem.FindAllPathsOfLengthN(mol, order + 1, useBonds=0):
-    accum += numpy.prod(deltas[numpy.array(path)],float)
+    accum += numpy.prod(deltas[numpy.array(path)], dtype=float)
   return accum
 
 

--- a/rdkit/Chem/UnitTestGraphDescriptors_2.py
+++ b/rdkit/Chem/UnitTestGraphDescriptors_2.py
@@ -95,6 +95,13 @@ class TestCase(unittest.TestCase):
       self.__testDesc('PP_descrs_regress.2.csv', 1, GraphDescriptors.BertzCT,
                       molFilter=_hasAromaticAtoms)
 
+  def testGithub8421(self):
+    # BertzCT was platform dependent: the InfoEntropy wrapper silently returned
+    # 0.0 for numpy's default integer dtype on Windows, which dropped the atom
+    # type term of the sum
+    m = Chem.MolFromSmiles('Fc1cccc(C2(c3nnc(Cc4cccc5ccccc45)o3)CCOCC2)c1')
+    self.assertAlmostEqual(GraphDescriptors.BertzCT(m), 1143.0567597744753, delta=1e-4)
+
   def testHallKierAlpha(self):
     self.__testDesc('PP_descrs_regress.csv', 3, GraphDescriptors.HallKierAlpha)
     if doLong:


### PR DESCRIPTION
#### Reference Issue
Fixes #8421, although it is stale. 


#### What does this implement/fix? Explain your changes.

`BertzCT` returned a different value on Windows with numpy 2 (1116.2144 rather than 1143.0568). The root cause seems to be in the InfoTheory wrappers rather than in the descriptor.

`infoEntropy()`, `infoGain()` and `chiSquare()` in `Code/ML/InfoTheory/Wrap/rdInfoTheory.cpp` dispatched on the input array's own `type_num`, with branches for only `NPY_DOUBLE`,
`NPY_FLOAT`, `NPY_INT` and `NPY_LONG`. `infoEntropy()` had no `else`, so an unrecognised dtype silently returned `0.0`.

Rather than adding `NPY_LONGLONG` to the chain, this converts once to `NPY_DOUBLE` with`PyArray_ContiguousFromObject()` and drops the dispatch, so every numeric dtype works and no silent-zero path is left.

#### Any other comments?

The `numpy.array(..., float)` calls added to `_CalculateEntropies()` in #9072 are left in place; they are harmless and explicit now that the wrapper handles every dtype.

Two behaviour changes worth flagging:

- For `float32` input the accumulation now happens in `double`. Integer-valued `float32` is bit-identical; fractional `float32` changes by at most 6.2e-5 relative (worst case over 200k randomized inputs). This removes an existing inconsistency, since the old `float32` and `float64` branches already disagreed on the same mathematical input. 
- Input that cannot be converted, or that has the wrong rank, now raises `ValueError`. Previously `infoEntropy` returned `0.0` for the first and dereferenced a NULL pointer for the second; `infoGain`/`chiSquare` already raised.

Built and tested on Linux with Python 3.13 and numpy 2.5.1; `ctest -R pyRanker` and `ctest -R pythonSourceTests` (714 tests) both pass.