### PR TITLE
Speed-up BertzCT, no value changes

### DIFF
--- a/rdkit/Chem/GraphDescriptors.py
+++ b/rdkit/Chem/GraphDescriptors.py
@@ -540,18 +540,14 @@ def _AssignSymmetryClasses(mol, vdList, bdMat, forceBDMat, numAtoms, cutoff):
     bdMat = Chem.GetDistanceMatrix(mol, useBO=1, useAtomWts=0, force=1, prefix="Balaban")
     mol._balabanMat = bdMat
 
-  keysSeen = []
+  # one format call per row instead of one per element, and a dict instead of a
+  # linear scan over the keys seen so far; the keys themselves are unchanged
+  sortedRows = numpy.sort(bdMat, axis=1)[:numAtoms, :cutoff]
+  rowFmt = '%.4f,' * sortedRows.shape[1]
+  keysSeen = {}
   symList = [0] * numAtoms
-  for i in range(numAtoms):
-    tmpList = bdMat[i].tolist()
-    tmpList.sort()
-    theKey = tuple(['%.4f' % x for x in tmpList[:cutoff]])
-    try:
-      idx = keysSeen.index(theKey)
-    except ValueError:
-      idx = len(keysSeen)
-      keysSeen.append(theKey)
-    symList[i] = idx + 1
+  for i, row in enumerate(sortedRows.tolist()):
+    symList[i] = keysSeen.setdefault(rowFmt % tuple(row), len(keysSeen)) + 1
   return tuple(symList)
 
 
@@ -664,17 +660,14 @@ def BertzCT(mol, cutoff=100, dMat=None, forceDMat=1):
   atomTypeDict = {}
   connectionDict = {}
   numAtoms = mol.GetNumAtoms()
-  if forceDMat or dMat is None:
-    if forceDMat:
-      # nope, gotta calculate one
+  # when forceDMat is set _AssignSymmetryClasses() replaces dMat with a freshly
+  # calculated Balaban matrix, so there's no point in calculating one here
+  if not forceDMat and dMat is None:
+    try:
+      dMat = mol._adjMat
+    except AttributeError:
       dMat = Chem.GetDistanceMatrix(mol, useBO=0, useAtomWts=0, force=1)
       mol._adjMat = dMat
-    else:
-      try:
-        dMat = mol._adjMat
-      except AttributeError:
-        dMat = Chem.GetDistanceMatrix(mol, useBO=0, useAtomWts=0, force=1)
-        mol._adjMat = dMat
 
   if numAtoms < 2:
     return 0

--- a/rdkit/Chem/GraphDescriptors.py
+++ b/rdkit/Chem/GraphDescriptors.py
@@ -540,8 +540,6 @@ def _AssignSymmetryClasses(mol, vdList, bdMat, forceBDMat, numAtoms, cutoff):
     bdMat = Chem.GetDistanceMatrix(mol, useBO=1, useAtomWts=0, force=1, prefix="Balaban")
     mol._balabanMat = bdMat
 
-  # one format call per row instead of one per element, and a dict instead of a
-  # linear scan over the keys seen so far; the keys themselves are unchanged
   sortedRows = numpy.sort(bdMat, axis=1)[:numAtoms, :cutoff]
   rowFmt = '%.4f,' * sortedRows.shape[1]
   keysSeen = {}
@@ -660,8 +658,8 @@ def BertzCT(mol, cutoff=100, dMat=None, forceDMat=1):
   atomTypeDict = {}
   connectionDict = {}
   numAtoms = mol.GetNumAtoms()
-  # when forceDMat is set _AssignSymmetryClasses() replaces dMat with a freshly
-  # calculated Balaban matrix, so there's no point in calculating one here
+  # dMat is only used when forceDMat is unset; otherwise _AssignSymmetryClasses()
+  # calculates its own Balaban matrix
   if not forceDMat and dMat is None:
     try:
       dMat = mol._adjMat


### PR DESCRIPTION
#### Reference Issue
N/A — performance only, no associated issue.

#### What does this implement/fix? Explain your changes.

Speeds up `BertzCT` by roughly 1.3–1.5× on drug-like input, with no change to the values it returns.

Two changes, both in `rdkit/Chem/GraphDescriptors.py`:

1. `_AssignSymmetryClasses()` was around 44% of the runtime. It formatted every element of every row of the Balaban matrix with a separate `'%.4f' %` call, then looked the resulting key. It now sorts the matrix once with `numpy.sort(..., axis=1)`, makes one format call per row, and uses a dict. 
2. `BertzCT()` computed a `useBO=0` distance matrix that it never used. With the default `forceDMat=1`, `_AssignSymmetryClasses()` immediately replaces `dMat` with a freshly calculated Balaban matrix, so the first matrix was unused. 

Measured on datasets bundled with RDKit, against the
parent commit:

| dataset | mols | mean / max heavy atoms | before | after | speedup |
|---|---|---|---|---|---|
| `Data/NCI/first_5K.smi` | 4991 | 16.4 / 122 | 0.296 ms | 0.211 ms | 1.40× |
| `Regress/Data/zinc.leads.500.q.smi` | 500 | 16.7 / 26 | 0.279 ms | 0.207 ms | 1.35× |
| `Docs/Book/data/solubility.train.sdf` | 1025 | 13.0 / 47 | 0.209 ms | 0.158 ms | 1.32× |
| `Docs/Book/data/bzr.sdf` | 163 | 22.4 / 29 | 0.415 ms | 0.282 ms | 1.47× |
| `Docs/Book/data/cdk2.sdf` | 47 | 24.5 / 31 | 0.477 ms | 0.320 ms | 1.49× |

The values on these datasets are unchanged. 

One side effect to call out: `BertzCT` no longer sets `mol._adjMat`. `Ipc` reads that as a lazy cache but recomputes on `AttributeError`, so values are unaffected; A `BertzCT`-then-`Ipc` sequence simply recomputes one matrix it used to inherit. Note that `_adjMat` already holds a distance matrix in `Ipc`/`BertzCT` but an adjacency matrix in
`BalabanJ`; both consume it only through a `== 1` comparison, so the mask is the same either way and this does not make that worse.