### PR TITLE
Fixes for AI-found critical issues

### DIFF
--- a/Code/DataManip/MetricMatrixCalc/MetricMatrixCalc.h
+++ b/Code/DataManip/MetricMatrixCalc/MetricMatrixCalc.h
@@ -38,7 +38,7 @@ class MetricMatrixCalc {
 
   /*! \brief Set the metric function
    *
-   * Set the pointer to the mertic funvtion to be used by the metric calculator
+   * Set the pointer to the metric funCtion to be used by the metric calculator
    *
    * ARGUMENTS:
    *
@@ -54,22 +54,20 @@ class MetricMatrixCalc {
    * ARGUMENTS:
    *
    *  descrips - vectType container with a entryType for each item
-   *  nItems - the number of item in the descripts.
-   *           In several cases this argument is irrelvant since vectType
-   *probably supports
-   *           a size() member function, But we would like this interface to
-   *take for example
-   *           a double** and correctly parse the row and columns.
-   *  dim - the dimension of the sequences
-   *  distMat - pointer to an array to write the distance matrix to
-   *            it is assumed that the right sized array has already be
-   *allocated.
+   *  nItems -   the number of item in the descrips.
+   *             In several cases this argument is irrelevant since vectType
+   *             probably supports a size() member function, But we would like
+   *             this interface to take for example a double** and correctly
+   *             parse the row and columns.
+   *  dim     -  the dimension of the sequences
+   *  distMat -  pointer to an array to write the distance matrix to
+   *             it is assumed that the right sized array has already be
+   *             allocated.
    *
    * FIX: we can probably make this function create the correct sized distMat
-   *and return
-   * it to the caller, but when pushing he result out to a python array not sure
-   *how to
-   * avoid copy the entire distance matrix in that case
+   *      and return it to the caller, but when pushing he result out to a
+   *      python array not sure how to avoid copy the entire distance matrix
+   *      in that case
    *
    * RETURNS:
    *
@@ -79,6 +77,7 @@ class MetricMatrixCalc {
   void calcMetricMatrix(const vectType &descripts, unsigned int nItems,
                         unsigned int dim, double *distMat) {
     CHECK_INVARIANT(distMat, "invalid pointer to a distance matix");
+    CHECK_INVARIANT(dp_metricFunc, "metric function has not been set");
 
     for (unsigned int i = 1; i < nItems; i++) {
       unsigned int itab = i * (i - 1) / 2;
@@ -95,10 +94,11 @@ class MetricMatrixCalc {
    * In several cases the last argument 'dim' should be irrelevant,
    * For example when entryType is a bit vector the size is of the vector
    * or the dimension can be obtained by asking the bit vector itself. However
-   * we woul like this interface to support other containers lines double*
-   * in which case the 'dim' value is useful in cumputing the metric.
+   * we would like this interface to support other containers lines double*
+   * in which case the 'dim' value is useful in computing the metric.
    */
-  double (*dp_metricFunc)(const entryType &, const entryType &, unsigned int);
+  double (*dp_metricFunc)(const entryType &, const entryType &,
+                          unsigned int){nullptr};
 };
 };  // namespace RDDataManip
 

--- a/Code/DataManip/MetricMatrixCalc/MetricMatrixCalc.h
+++ b/Code/DataManip/MetricMatrixCalc/MetricMatrixCalc.h
@@ -25,7 +25,7 @@ namespace RDDataManip {
  *  Examples of the container include PySequenceHolder which is wrapper around
  *  a python sequence objects like lists and tuples.
  *  Examples of the entryType include a sequence of double, floats, and
- *ExplicitBitVects
+ *  ExplicitBitVects
  *
  */
 template <class vectType, class entryType>
@@ -38,7 +38,7 @@ class MetricMatrixCalc {
 
   /*! \brief Set the metric function
    *
-   * Set the pointer to the metric funCtion to be used by the metric calculator
+   * Set the pointer to the metric function to be used by the metric calculator
    *
    * ARGUMENTS:
    *

--- a/Code/GraphMol/AtomIterators.h
+++ b/Code/GraphMol/AtomIterators.h
@@ -97,10 +97,7 @@ class RDKIT_GRAPHMOL_EXPORT HeteroatomIterator_ {
   int _end{-1};
   int _pos{-1};
   Mol_ *_mol;
-  // FIX: somehow changing the following to a pointer make the regression test
-  // pass
-  // QueryAtom _qA;
-  QueryAtom *_qA;
+  QueryAtom *_qA{nullptr};
 
   int _findNext(int from);
   int _findPrev(int from);

--- a/Code/GraphMol/Canon.cpp
+++ b/Code/GraphMol/Canon.cpp
@@ -184,9 +184,9 @@ bool fixConflictAcrossDoubleBond(const Bond &dblBond, const Atom &atom,
 bool handleDirConflictsAcrossDoubleBond(
     const Bond &dblBond, const Atom &atom1, bool atom1DirsAreConsistent,
     const Bond &firstFromAtom1, bool isFirstFromAtom1Flipped,
-    const Bond &secondFromAtom1, bool isSecondFromAtom1Flipped,
+    const Bond *secondFromAtom1, bool isSecondFromAtom1Flipped,
     const Atom &atom2, bool atom2DirsAreConsistent, const Bond &firstFromAtom2,
-    bool isFirstFromAtom2Flipped, const Bond &secondFromAtom2,
+    bool isFirstFromAtom2Flipped, const Bond *secondFromAtom2,
     bool isSecondFromAtom2Flipped, std::vector<int8_t> &bondDirCounts,
     std::vector<int8_t> &atomDirCounts
 
@@ -208,7 +208,7 @@ bool handleDirConflictsAcrossDoubleBond(
     // we know it is not problematic.
     return fixConflictAcrossDoubleBond(
         dblBond, atom2, firstFromAtom2, isFirstFromAtom2Flipped,
-        secondFromAtom2, isSecondFromAtom2Flipped, atom1, firstFromAtom1,
+        *secondFromAtom2, isSecondFromAtom2Flipped, atom1, firstFromAtom1,
         isFirstFromAtom1Flipped, bondDirCounts, atomDirCounts);
 
   } else if (!atom1DirsAreConsistent && atom2DirsAreConsistent) {
@@ -218,7 +218,7 @@ bool handleDirConflictsAcrossDoubleBond(
     // we know it is not problematic.
     return fixConflictAcrossDoubleBond(
         dblBond, atom1, firstFromAtom1, isFirstFromAtom1Flipped,
-        secondFromAtom1, isSecondFromAtom1Flipped, atom2, firstFromAtom2,
+        *secondFromAtom1, isSecondFromAtom1Flipped, atom2, firstFromAtom2,
         isFirstFromAtom2Flipped, bondDirCounts, atomDirCounts);
 
   } else {
@@ -227,33 +227,35 @@ bool handleDirConflictsAcrossDoubleBond(
     // We need to check which directions can be removed, and which need
     // to be removed to end up with a valid across-double-bond configuration.
 
-    for (const auto &[atom1Bond, atom1BondisFlipped] :
-         {std::make_pair(firstFromAtom1, isFirstFromAtom1Flipped),
-          std::make_pair(secondFromAtom1, isSecondFromAtom1Flipped)}) {
-      for (const auto &[atom2Bond, atom2BondisFlipped] :
-           {std::make_pair(firstFromAtom2, isFirstFromAtom2Flipped),
-            std::make_pair(secondFromAtom2, isSecondFromAtom2Flipped)}) {
+    auto atom1Bonds = {
+        std::make_pair(&firstFromAtom1, isFirstFromAtom1Flipped),
+        std::make_pair(secondFromAtom1, isSecondFromAtom1Flipped)};
+    auto atom2Bonds = {
+        std::make_pair(&firstFromAtom2, isFirstFromAtom2Flipped),
+        std::make_pair(secondFromAtom2, isSecondFromAtom2Flipped)};
+    for (const auto &[atom1Bond, atom1BondisFlipped] : atom1Bonds) {
+      for (const auto &[atom2Bond, atom2BondisFlipped] : atom2Bonds) {
         auto expectedAtom2Dir = getReferenceDirection(
-            dblBond, atom1, atom2, atom1Bond, atom1BondisFlipped, atom2Bond,
+            dblBond, atom1, atom2, *atom1Bond, atom1BondisFlipped, *atom2Bond,
             atom2BondisFlipped);
-        if (expectedAtom2Dir == atom2Bond.getBondDir()) {
+        if (expectedAtom2Dir == atom2Bond->getBondDir()) {
           // We have found a combination of directions that are consistent with
           // the double bond's stereo label. Now we need to check if we can
           // remove the other two directions to fix the conflict.
 
           auto atom1OtherBond =
-              (&atom1Bond == &firstFromAtom1 ? secondFromAtom1
-                                             : firstFromAtom1);
-          auto atom1OtherIdx = atom1OtherBond.getOtherAtomIdx(atom1.getIdx());
+              (atom1Bond == &firstFromAtom1 ? secondFromAtom1
+                                            : &firstFromAtom1);
+          auto atom1OtherIdx = atom1OtherBond->getOtherAtomIdx(atom1.getIdx());
           auto canAtom1OtherDirBeRemoved = atomDirCounts[atom1OtherIdx] == 2;
           if (!canAtom1OtherDirBeRemoved) {
             continue;
           }
 
           auto atom2OtherBond =
-              (&atom2Bond == &firstFromAtom2 ? secondFromAtom2
-                                             : firstFromAtom2);
-          auto atom2OtherIdx = atom2OtherBond.getOtherAtomIdx(atom2.getIdx());
+              (atom2Bond == &firstFromAtom2 ? secondFromAtom2
+                                            : &firstFromAtom2);
+          auto atom2OtherIdx = atom2OtherBond->getOtherAtomIdx(atom2.getIdx());
           if (atom1OtherIdx == atom2OtherIdx) {
             // unlikely, but not impossible, so just in case...
             continue;
@@ -264,11 +266,11 @@ bool handleDirConflictsAcrossDoubleBond(
             continue;
           }
 
-          bondDirCounts[atom1OtherBond.getIdx()] = 0;
+          bondDirCounts[atom1OtherBond->getIdx()] = 0;
           --atomDirCounts[atom1.getIdx()];
           --atomDirCounts[atom1OtherIdx];
 
-          bondDirCounts[atom2OtherBond.getIdx()] = 0;
+          bondDirCounts[atom2OtherBond->getIdx()] = 0;
           --atomDirCounts[atom2.getIdx()];
           --atomDirCounts[atom2OtherIdx];
 
@@ -546,9 +548,9 @@ void canonicalizeDoubleBond(Bond *dblBond, const UINT_VECT &bondVisitOrders,
     // with what we see on each end of the double bond
     if (!handleDirConflictsAcrossDoubleBond(
             *dblBond, *atom1, atom1DirsAreConsistent, *firstFromAtom1,
-            isFirstFromAtom1Flipped, *secondFromAtom1, isSecondFromAtom1Flipped,
+            isFirstFromAtom1Flipped, secondFromAtom1, isSecondFromAtom1Flipped,
             *atom2, atom2DirsAreConsistent, *firstFromAtom2,
-            isFirstFromAtom2Flipped, *secondFromAtom2, isSecondFromAtom2Flipped,
+            isFirstFromAtom2Flipped, secondFromAtom2, isSecondFromAtom2Flipped,
             bondDirCounts, atomDirCounts)) {
       logInconsistentBondDirsWarning(dblBond->getIdx());
     }

--- a/Code/GraphMol/Canon.cpp
+++ b/Code/GraphMol/Canon.cpp
@@ -188,9 +188,10 @@ bool handleDirConflictsAcrossDoubleBond(
     const Atom &atom2, bool atom2DirsAreConsistent, const Bond &firstFromAtom2,
     bool isFirstFromAtom2Flipped, const Bond *secondFromAtom2,
     bool isSecondFromAtom2Flipped, std::vector<int8_t> &bondDirCounts,
-    std::vector<int8_t> &atomDirCounts
+    std::vector<int8_t> &atomDirCounts) {
+  PRECONDITION(atom1DirsAreConsistent || secondFromAtom1, "bad second bond");
+  PRECONDITION(atom2DirsAreConsistent || secondFromAtom2, "bad second bond");
 
-) {
   if (atom1DirsAreConsistent && atom2DirsAreConsistent) {
     // The directions on each side are consistent, so if they are also
     // consistent across the double bond, then all is good. But if they

--- a/Code/GraphMol/ChemTransforms/ChemTransforms.cpp
+++ b/Code/GraphMol/ChemTransforms/ChemTransforms.cpp
@@ -24,6 +24,7 @@
 #include <vector>
 #include <algorithm>
 #include <fstream>
+#include <ranges>
 #include <sstream>
 #include <GraphMol/SmilesParse/SmilesParse.h>
 #include <RDGeneral/StreamOps.h>
@@ -495,12 +496,16 @@ ROMol *replaceCore(const ROMol &mol, const ROMol &core,
             "atoms has degree > 1 ");
         auto coreNeighborIdx =
             core[*core.getAtomNeighbors(coreAtom).first]->getIdx();
-        auto molNeighborIdx =
-            std::find_if(matchV.cbegin(), matchV.cend(),
-                         [coreNeighborIdx](std::pair<int, int> p) {
-                           return p.first == static_cast<int>(coreNeighborIdx);
-                         })
-                ->second;
+        auto molNeighborMatch =
+            std::ranges::find_if(matchV, [coreNeighborIdx](auto p) {
+              return p.first == static_cast<int>(coreNeighborIdx);
+            });
+        if (molNeighborMatch == matchV.end()) {
+          throw ValueErrorException(
+              "Supplied MatchVect is missing the neighbor of a multiply "
+              "mapped core atom");
+        }
+        auto molNeighborIdx = molNeighborMatch->second;
         if (molNeighborIdx > -1) {
           auto connectingBond =
               mol.getBondBetweenAtoms(mappingInfo.molIndex, molNeighborIdx);

--- a/Code/GraphMol/ChemTransforms/MolZip.cpp
+++ b/Code/GraphMol/ChemTransforms/MolZip.cpp
@@ -710,7 +710,7 @@ std::unique_ptr<ROMol> molzip(std::vector<ROMOL_SPTR> &decomposition,
   std::optional attachmentMappingOption = std::map<int, int>();
   auto zippedMol = molzip(*combinedMol, b, params, attachmentMappingOption);
 
-  if (params.generateCoordinates && zippedMol->getNumAtoms() > 0) {
+  if (params.generateCoordinates && zippedMol && zippedMol->getNumAtoms() > 0) {
     const auto confId = RDDepict::compute2DCoords(*zippedMol);
     const auto zippedConf = zippedMol->getConformer(confId);
     auto attachmentMapping = *attachmentMappingOption;

--- a/Code/GraphMol/ChemTransforms/MolZip.cpp
+++ b/Code/GraphMol/ChemTransforms/MolZip.cpp
@@ -715,7 +715,7 @@ std::unique_ptr<ROMol> molzip(std::vector<ROMOL_SPTR> &decomposition,
     const auto zippedConf = zippedMol->getConformer(confId);
     auto attachmentMapping = *attachmentMappingOption;
     for (auto &mol : decomposition) {
-      const auto newConf = new Conformer(mol->getNumAtoms());
+      auto newConf = std::make_unique<Conformer>(mol->getNumAtoms());
       newConf->set3D(false);
       for (const auto atom : mol->atoms()) {
         int zippedIndex = atom->getProp<int>(indexPropName);
@@ -725,17 +725,19 @@ std::unique_ptr<ROMol> molzip(std::vector<ROMOL_SPTR> &decomposition,
           zippedIndex = (*attachment).second;
         }
         auto zipppedAtoms = zippedMol->atoms();
-        auto zippedAtom = std::find_if(
-            zipppedAtoms.begin(), zipppedAtoms.end(),
-            [zippedIndex](const Atom *zippedAtom) {
+        auto zippedAtom = std::ranges::find_if(
+            zipppedAtoms, [zippedIndex](const Atom *zippedAtom) {
               const auto index = zippedAtom->getProp<int>(indexPropName);
               return index == zippedIndex;
             });
 
+        CHECK_INVARIANT(zippedAtom != zipppedAtoms.end(),
+                        "molzip: cannot map atom into zipped molecule");
+
         newConf->setAtomPos(atom->getIdx(),
                             zippedConf.getAtomPos((*zippedAtom)->getIdx()));
       }
-      mol->addConformer(newConf, true);
+      mol->addConformer(newConf.release(), true);
     }
     for (const auto atom : zippedMol->atoms()) {
       atom->clearProp(indexPropName);

--- a/Code/GraphMol/Descriptors/GETAWAY.cpp
+++ b/Code/GraphMol/Descriptors/GETAWAY.cpp
@@ -347,10 +347,10 @@ void getGETAWAYDescCustom(MatrixXd H, MatrixXd R, MatrixXd Adj, int numAtoms,
   MatrixXd Bi;
   MatrixXd RBw;
   double HATSc, HATSct, H0ct, R0ct, H0c, R0c, Rkmaxc, tmpc;
-  double HATSk[9];
-  double Hk[9];
-  double Rk[8];
-  double Rp[8];
+  double HATSk[9]{0.0};
+  double Hk[9]{0.0};
+  double Rk[8]{0.0};
+  double Rp[8]{0.0};
 
   double *dist =
       MolOps::getDistanceMat(mol, false);  // need to be be set to false to have

--- a/Code/GraphMol/FMCS/MaximumCommonSubgraph.h
+++ b/Code/GraphMol/FMCS/MaximumCommonSubgraph.h
@@ -40,14 +40,14 @@ class RDKIT_FMCS_EXPORT MaximumCommonSubgraph {
   struct MCS {
     std::vector<const Atom *> Atoms;
     std::vector<const Bond *> Bonds;
-    const ROMol *QueryMolecule;
+    const ROMol *QueryMolecule = nullptr;
     std::vector<Target> Targets;
   };
   unsigned long long To;
   MCSProgressData Stat;
   detail::MCSParametersInternal Parameters;
   // min number of matches
-  unsigned int ThresholdCount;
+  unsigned int ThresholdCount = 0;
   std::vector<const ROMol *> Molecules;
 #ifdef FAST_SUBSTRUCT_CACHE
   // for Morgan code. Value based on current functor and parameters
@@ -61,7 +61,7 @@ class RDKIT_FMCS_EXPORT MaximumCommonSubgraph {
 #ifdef DUP_SUBSTRUCT_CACHE
   DuplicatedSeedCache DuplicateCache;
 #endif
-  const ROMol *QueryMolecule;
+  const ROMol *QueryMolecule = nullptr;
   unsigned int QueryMoleculeMatchedBonds;
   unsigned int QueryMoleculeMatchedAtoms;
   const Atom *QueryMoleculeSingleMatchedAtom;

--- a/Code/GraphMol/MolDraw2D/AtomSymbol.cpp
+++ b/Code/GraphMol/MolDraw2D/AtomSymbol.cpp
@@ -129,6 +129,9 @@ void AtomSymbol::adjustColons() {
       break;
     }
     size_t gtPos = tmpSym.find('>');
+    if (gtPos == std::string::npos) {
+      return;
+    }
     tmpSym = tmpSym.substr(0, ltPos) + tmpSym.substr(gtPos + 1);
   }
   colonPos = tmpSym.find(':');

--- a/Code/GraphMol/MolDraw2D/AtomSymbol.cpp
+++ b/Code/GraphMol/MolDraw2D/AtomSymbol.cpp
@@ -135,10 +135,10 @@ void AtomSymbol::adjustColons() {
   if (colonPos == std::string::npos) {
     return;
   }
-  CHECK_INVARIANT(colonPos <= rects_.size(), "bad rects_ size");
+  CHECK_INVARIANT(colonPos < rects_.size(), "bad rects_ size");
   double leftHeight = colonPos ? rects_[colonPos - 1]->height_ : 0;
   double rightHeight =
-      colonPos < symbol_.size() - 1 ? rects_[colonPos + 1]->height_ : 0;
+      colonPos + 1 < rects_.size() ? rects_[colonPos + 1]->height_ : 0;
   rects_[colonPos]->height_ = std::min(leftHeight, rightHeight);
 }
 

--- a/Code/GraphMol/RascalMCES/RascalMCES.cpp
+++ b/Code/GraphMol/RascalMCES/RascalMCES.cpp
@@ -822,7 +822,7 @@ void checkTimeout(
         if (clique.size() > maxCliques.front().size()) {
           maxCliques.clear();
         }
-        if (clique.size() >= maxCliques.front().size()) {
+        if (maxCliques.empty() || clique.size() >= maxCliques.front().size()) {
           maxCliques.push_back(clique);
         }
       }

--- a/Code/GraphMol/Renumber.cpp
+++ b/Code/GraphMol/Renumber.cpp
@@ -21,11 +21,14 @@ ROMol *renumberAtoms(const ROMol &mol,
   unsigned int nAts = mol.getNumAtoms();
   PRECONDITION(newOrder.size() == nAts, "bad newOrder size");
 
-  std::vector<unsigned int> revOrder(nAts);
+  std::vector<unsigned int> revOrder(nAts, nAts);
   for (unsigned int nIdx = 0; nIdx < nAts; ++nIdx) {
     unsigned int oIdx = newOrder[nIdx];
-    if (oIdx > nAts) {
+    if (oIdx >= nAts) {
       throw ValueErrorException("idx value exceeds numAtoms");
+    }
+    if (revOrder[oIdx] != nAts) {
+      throw ValueErrorException("newOrder contains duplicate indices");
     }
     revOrder[oIdx] = nIdx;
   }

--- a/Code/GraphMol/SmilesParse/SmartsWrite.cpp
+++ b/Code/GraphMol/SmilesParse/SmartsWrite.cpp
@@ -463,7 +463,7 @@ std::string getBondSmartsSimple(const Bond *bond,
   } else {
     std::stringstream msg;
     msg << "Can't write smarts for this query bond type: " << descrip;
-    throw msg.str().c_str();
+    throw ValueErrorException(msg.str());
   }
   return res;
 }

--- a/Code/RDGeneral/utils.h
+++ b/Code/RDGeneral/utils.h
@@ -71,7 +71,7 @@ unsigned int countSwapsToInterconvert(const T &ref, T probe) {
     if ((*probeIt) != (*refIt)) {
       bool foundIt = false;
       probeIt2 = probeIt;
-      while ((*probeIt2) != (*refIt) && probeIt2 != probe.end()) {
+      while (probeIt2 != probe.end() && (*probeIt2) != (*refIt)) {
         ++probeIt2;
       }
       if (probeIt2 != probe.end()) {

--- a/External/pubchem_shape/Wrap/CMakeLists.txt
+++ b/External/pubchem_shape/Wrap/CMakeLists.txt
@@ -9,5 +9,5 @@ rdkit_python_extension(rdShapeAlign
                        DEST Chem
                        LINK_LIBRARIES
                        PubChemShape )
-add_pytest(pyPubhemShapeAlign
+add_pytest(pyPubChemShapeAlign
          ${CMAKE_CURRENT_SOURCE_DIR}/test_rdshapealign.py)


### PR DESCRIPTION
I asked the AI to review the existing codebase and find potential bugs, low-risk potential performance upgrades, and redundant includes. It found a bunch. In this PR I'm submitting fixes for the 14 bugs it ranked as critical. Most of them are about checking for nullptrs or doing range checks before dereferencing or making sure things are initialized before use or deletion. 

Each commit is a separate fix. See the commit messages for a (very) brief description of each issue/fix. All fixes are relatively small, except maybe the ones in `Code/DataManip/MetricMatrixCalc/MetricMatrixCalc.h`, which I made bigger by fixing some typos and alignment in the docstrings, and the one in `Code/GraphMol/Canon.cpp`, which changes argument types in a rather long function, and the call way further down in the file. Also note that `Code/GraphMol/MolDraw2D/AtomSymbol.cpp` contains 2 fixes (range check for `gtPos`, and range check and fixes for `colonPos` range checks).

I also fixes the (typo-ed) name for `pyPubhemShapeAlign` because it was bit of a weird.