### PR TITLE
Install header for SGroup data label API

### DIFF
--- a/Code/GraphMol/MolDraw2D/CMakeLists.txt
+++ b/Code/GraphMol/MolDraw2D/CMakeLists.txt
@@ -35,6 +35,7 @@ rdkit_headers(MolDraw2D.h
         MolDraw2DJS.h
         MolDraw2DUtils.h
         MolDraw2DHelpers.h
+        MolDraw2DSGroupData.h
         DEST GraphMol/MolDraw2D
 )
 

--- a/Code/GraphMol/MolDraw2D/DrawMol.cpp
+++ b/Code/GraphMol/MolDraw2D/DrawMol.cpp
@@ -29,6 +29,7 @@
 #include <GraphMol/MolDraw2D/DrawShape.h>
 #include <GraphMol/MolDraw2D/DrawText.h>
 #include <GraphMol/MolDraw2D/MolDraw2DDetails.h>
+#include <GraphMol/MolDraw2D/MolDraw2DSGroupData.h>
 #include <GraphMol/MolDraw2D/MolDraw2DUtils.h>
 #include <GraphMol/MolEnumerator/LinkNode.h>
 #include <GraphMol/MolTransforms/MolTransforms.h>

--- a/Code/GraphMol/MolDraw2D/MolDraw2DDetails.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DDetails.cpp
@@ -9,6 +9,7 @@
 //
 
 #include <GraphMol/MolDraw2D/MolDraw2DDetails.h>
+#include <GraphMol/MolDraw2D/MolDraw2DSGroupData.h>
 #include <GraphMol/MolDraw2D/StringRect.h>
 #include <GraphMol/Chirality.h>
 #include <GraphMol/FileParsers/FileParserUtils.h>

--- a/Code/GraphMol/MolDraw2D/MolDraw2DDetails.h
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DDetails.h
@@ -162,25 +162,6 @@ RDKIT_MOLDRAW2D_EXPORT void adjustLineEndForEllipse(const Point2D &centre,
                                                     double yradius, Point2D p1,
                                                     Point2D &p2);
 
-//! Holds the text and position of a DAT SGroup label.
-struct SGroupDataLabel {
-  std::string text;  ///< label text
-  Point2D pos;       ///< position in molecule coordinates
-  bool positioned;   ///< true if pos came from FIELDDISP; false if pos is
-                     ///< the associated atom's conformer position (fallback)
-  int atomIdx;       ///< index of the associated atom (-1 if none)
-};
-
-//! Returns the text and positions of DAT SGroup labels for a molecule,
-//! using the same placement logic as the drawing code.
-/*!
-  \param mol    the molecule
-  \param rotate optional rotation angle in degrees (default 0.0)
-  \return a vector of SGroupDataLabel objects, one per rendered DAT SGroup
-*/
-RDKIT_MOLDRAW2D_EXPORT std::vector<SGroupDataLabel> getSGroupDataLabels(
-    const ROMol &mol, double rotate = 0.0);
-
 }  // namespace MolDraw2D_detail
 }  // namespace RDKit
 

--- a/Code/GraphMol/MolDraw2D/MolDraw2DSGroupData.h
+++ b/Code/GraphMol/MolDraw2D/MolDraw2DSGroupData.h
@@ -1,0 +1,48 @@
+//
+//  Copyright (C) 2026 Greg Landrum and other RDKit contributors
+//
+//   @@ All Rights Reserved @@
+//  This file is part of the RDKit.
+//  The contents are covered by the terms of the BSD license
+//  which is included in the file license.txt, found at the root
+//  of the RDKit source tree.
+//
+
+#include <RDGeneral/export.h>
+#ifndef RDKITMOLDRAW2DSGROUPDATA_H
+#define RDKITMOLDRAW2DSGROUPDATA_H
+
+#include <string>
+#include <vector>
+
+#include <Geometry/point.h>
+
+namespace RDKit {
+
+class ROMol;
+
+namespace MolDraw2D_detail {
+
+//! Holds the text and position of a DAT SGroup label.
+struct SGroupDataLabel {
+  std::string text;     ///< label text
+  RDGeom::Point2D pos;  ///< position in molecule coordinates
+  bool positioned;      ///< true if pos came from FIELDDISP; false if pos is
+                        ///< the associated atom's conformer position (fallback)
+  int atomIdx;          ///< index of the associated atom (-1 if none)
+};
+
+//! Returns the text and positions of DAT SGroup labels for a molecule,
+//! using the same placement logic as the drawing code.
+/*!
+  \param mol    the molecule
+  \param rotate optional rotation angle in degrees (default 0.0)
+  \return a vector of SGroupDataLabel objects, one per rendered DAT SGroup
+*/
+RDKIT_MOLDRAW2D_EXPORT std::vector<SGroupDataLabel> getSGroupDataLabels(
+    const ROMol &mol, double rotate = 0.0);
+
+}  // namespace MolDraw2D_detail
+}  // namespace RDKit
+
+#endif

--- a/Code/GraphMol/MolDraw2D/catch_tests.cpp
+++ b/Code/GraphMol/MolDraw2D/catch_tests.cpp
@@ -20,6 +20,7 @@
 #include <GraphMol/MolDraw2D/MolDraw2DSVG.h>
 #include <GraphMol/MolDraw2D/MolDraw2DUtils.h>
 #include <GraphMol/MolDraw2D/MolDraw2DDetails.h>
+#include <GraphMol/MolDraw2D/MolDraw2DSGroupData.h>
 #include <GraphMol/MolDraw2D/DrawMol.h>
 #include <GraphMol/FileParsers/FileParsers.h>
 #include <GraphMol/FileParsers/PNGParser.h>


### PR DESCRIPTION
#### Reference Issue

Follow-up to #9189.

#### What does this implement/fix? Explain your changes.

The SGroup data label API added in #9189 is exported from the MolDraw2D library, but its declarations are only available through an uninstalled implementation header. This prevents external renderers using an installed RDKit package from calling the API.

This adds a focused installed header containing only the SGroup data label result type and function declaration. The API remains in the `MolDraw2D_detail` namespace, while the broader `MolDraw2DDetails.h` implementation header remains private.

#### Any other comments?

The new public-detail header, its implementation, and the internal drawing caller were syntax-compiled independently. The existing SGroup data label tests now include the installed header directly.