### PR TITLE
Expose attachment-point labels and identity

### DIFF
--- a/Code/GraphMol/MolOps.cpp
+++ b/Code/GraphMol/MolOps.cpp
@@ -1258,10 +1258,26 @@ unsigned int addExplicitAttachmentPoint(RWMol &mol, unsigned int atomIdx,
 
 }  // namespace details
 
+namespace {
+bool hasAttachmentPointLabel(const Atom *atom) {
+  std::string label;
+  if (!atom->getPropIfPresent(common_properties::atomLabel, label) ||
+      label.size() <= 3 || label.compare(0, 3, "_AP") != 0) {
+    return false;
+  }
+  const auto suffix = label.begin() + 3;
+  return std::all_of(suffix, label.end(),
+                     [](char value) { return value >= '0' && value <= '9'; }) &&
+         std::any_of(suffix, label.end(),
+                     [](char value) { return value != '0'; });
+}
+}  // namespace
+
 bool isMarkedAttachmentPoint(const Atom *atom) {
   PRECONDITION(atom, "bad atom");
   return atom->getAtomicNum() == 0 && atom->getDegree() == 1 &&
-         atom->hasProp(common_properties::_fromAttachPoint);
+         (atom->hasProp(common_properties::_fromAttachPoint) ||
+          hasAttachmentPointLabel(atom));
 }
 
 namespace details {
@@ -1337,12 +1353,18 @@ void collapseAttachmentPoints(RWMol &mol, bool markedOnly) {
   for (auto atom : mol.atoms()) {
     if (details::isAttachmentPoint(atom, markedOnly)) {
       int value = 0;
-      atom->getPropIfPresent(common_properties::_fromAttachPoint, value);
+      const bool hasNativeMarker =
+          atom->getPropIfPresent(common_properties::_fromAttachPoint, value);
       if (markedOnly && (value < 0 || value > 2)) {
         BOOST_LOG(rdWarningLog)
             << "Invalid value for _fromAttachPoint: " << value << " on atom "
             << atom->getIdx() << ". Not collapsing this atom" << std::endl;
         continue;
+      }
+      if (markedOnly && !hasNativeMarker) {
+        // _AP<n> labels identify explicit attachment points, but n is not an
+        // MDL ATTCHPT position. Treat a label-only atom as position 1.
+        value = 1;
       }
       if (!markedOnly && !value) {
         value = 1;

--- a/Code/GraphMol/MolOps.cpp
+++ b/Code/GraphMol/MolOps.cpp
@@ -19,6 +19,7 @@
 
 #include <vector>
 #include <algorithm>
+#include <limits>
 
 #include <RDGeneral/BoostStartInclude.h>
 
@@ -1258,26 +1259,38 @@ unsigned int addExplicitAttachmentPoint(RWMol &mol, unsigned int atomIdx,
 
 }  // namespace details
 
-namespace {
-bool hasAttachmentPointLabel(const Atom *atom) {
+unsigned int getAttachmentPointLabelNumber(const Atom *atom) {
+  PRECONDITION(atom, "bad atom");
+  if (atom->getAtomicNum() != 0 || atom->getDegree() != 1) {
+    return 0;
+  }
   std::string label;
   if (!atom->getPropIfPresent(common_properties::atomLabel, label) ||
-      label.size() <= 3 || label.compare(0, 3, "_AP") != 0) {
-    return false;
+      label.size() <= attachmentPointLabelPrefix.size() ||
+      label.compare(0, attachmentPointLabelPrefix.size(),
+                    attachmentPointLabelPrefix) != 0) {
+    return 0;
   }
-  const auto suffix = label.begin() + 3;
-  return std::all_of(suffix, label.end(),
-                     [](char value) { return value >= '0' && value <= '9'; }) &&
-         std::any_of(suffix, label.end(),
-                     [](char value) { return value != '0'; });
+  unsigned int result = 0;
+  for (auto iter = label.begin() + attachmentPointLabelPrefix.size();
+       iter != label.end(); ++iter) {
+    if (*iter < '0' || *iter > '9') {
+      return 0;
+    }
+    const auto digit = static_cast<unsigned int>(*iter - '0');
+    if (result > (std::numeric_limits<unsigned int>::max() - digit) / 10) {
+      return 0;
+    }
+    result = result * 10 + digit;
+  }
+  return result;
 }
-}  // namespace
 
 bool isMarkedAttachmentPoint(const Atom *atom) {
   PRECONDITION(atom, "bad atom");
   return atom->getAtomicNum() == 0 && atom->getDegree() == 1 &&
          (atom->hasProp(common_properties::_fromAttachPoint) ||
-          hasAttachmentPointLabel(atom));
+          getAttachmentPointLabelNumber(atom));
 }
 
 namespace details {

--- a/Code/GraphMol/MolOps.cpp
+++ b/Code/GraphMol/MolOps.cpp
@@ -19,7 +19,6 @@
 
 #include <vector>
 #include <algorithm>
-#include <limits>
 
 #include <RDGeneral/BoostStartInclude.h>
 
@@ -35,6 +34,7 @@
 
 #include <boost/config.hpp>
 #include <boost/graph/adjacency_list.hpp>
+#include <boost/lexical_cast.hpp>
 #include <boost/tokenizer.hpp>
 #include <Geometry/point.h>
 #include <GraphMol/QueryOps.h>
@@ -1272,16 +1272,11 @@ unsigned int getAttachmentPointLabelNumber(const Atom *atom) {
     return 0;
   }
   unsigned int result = 0;
-  for (auto iter = label.begin() + attachmentPointLabelPrefix.size();
-       iter != label.end(); ++iter) {
-    if (*iter < '0' || *iter > '9') {
-      return 0;
-    }
-    const auto digit = static_cast<unsigned int>(*iter - '0');
-    if (result > (std::numeric_limits<unsigned int>::max() - digit) / 10) {
-      return 0;
-    }
-    result = result * 10 + digit;
+  try {
+    result = boost::lexical_cast<unsigned int>(
+        label.substr(attachmentPointLabelPrefix.size()));
+  } catch (const boost::bad_lexical_cast &) {
+    return 0;
   }
   return result;
 }

--- a/Code/GraphMol/MolOps.cpp
+++ b/Code/GraphMol/MolOps.cpp
@@ -1256,13 +1256,23 @@ unsigned int addExplicitAttachmentPoint(RWMol &mol, unsigned int atomIdx,
   return idx;
 }
 
+}  // namespace details
+
+bool isMarkedAttachmentPoint(const Atom *atom) {
+  PRECONDITION(atom, "bad atom");
+  return atom->getAtomicNum() == 0 && atom->getDegree() == 1 &&
+         atom->hasProp(common_properties::_fromAttachPoint);
+}
+
+namespace details {
+
 bool isAttachmentPoint(const Atom *atom, bool markedOnly) {
   PRECONDITION(atom, "bad atom");
   PRECONDITION(atom->hasOwningMol(), "atom not associated with a molecule");
   if (atom->getAtomicNum() != 0 || atom->getDegree() != 1) {
     return false;
   }
-  if (markedOnly && !atom->hasProp(common_properties::_fromAttachPoint)) {
+  if (markedOnly && !isMarkedAttachmentPoint(atom)) {
     return false;
   }
   // we know that the atom is degree 1

--- a/Code/GraphMol/MolOps.cpp
+++ b/Code/GraphMol/MolOps.cpp
@@ -1271,10 +1271,14 @@ unsigned int getAttachmentPointLabelNumber(const Atom *atom) {
                     attachmentPointLabelPrefix) != 0) {
     return 0;
   }
+  // lexical_cast accepts a leading sign, so check the suffix ourselves
+  const auto suffix = label.substr(attachmentPointLabelPrefix.size());
+  if (suffix.find_first_not_of("0123456789") != std::string::npos) {
+    return 0;
+  }
   unsigned int result = 0;
   try {
-    result = boost::lexical_cast<unsigned int>(
-        label.substr(attachmentPointLabelPrefix.size()));
+    result = boost::lexical_cast<unsigned int>(suffix);
   } catch (const boost::bad_lexical_cast &) {
     return 0;
   }

--- a/Code/GraphMol/MolOps.h
+++ b/Code/GraphMol/MolOps.h
@@ -14,6 +14,7 @@
 #include <vector>
 #include <map>
 #include <list>
+#include <string_view>
 #include <RDGeneral/BoostStartInclude.h>
 #include <boost/smart_ptr.hpp>
 #include <boost/dynamic_bitset.hpp>
@@ -1396,6 +1397,22 @@ RDKIT_GRAPHMOL_EXPORT void expandAttachmentPoints(RWMol &mol,
  */
 RDKIT_GRAPHMOL_EXPORT void collapseAttachmentPoints(RWMol &mol,
                                                     bool markedOnly = true);
+
+//! prefix used for numbered explicit attachment-point atom labels
+inline constexpr std::string_view attachmentPointLabelPrefix = "_AP";
+
+//! returns the positive integer from a valid _AP<n> attachment-point label
+/*!
+ * The atom must be a degree-one dummy atom whose atomLabel consists of
+ * attachmentPointLabelPrefix followed by a positive decimal integer. Returns
+ * 0 if the atom does not have a valid numbered attachment-point label.
+ *
+ * This number is a label identifier, not an MDL ATTCHPT position.
+ *
+ * @param atom the atom to inspect
+ */
+RDKIT_GRAPHMOL_EXPORT unsigned int getAttachmentPointLabelNumber(
+    const Atom *atom);
 
 //! returns whether an atom is a marked explicit attachment point
 /*!

--- a/Code/GraphMol/MolOps.h
+++ b/Code/GraphMol/MolOps.h
@@ -1385,7 +1385,8 @@ RDKIT_GRAPHMOL_EXPORT void expandAttachmentPoints(RWMol &mol,
  *
  * @param mol the molecule of interest
  * @param markedOnly if true, only dummy atoms with the _fromAttachPoint
- *    property will be collapsed
+ *    property or a valid _AP<n> atom label will be collapsed. The numeric
+ *    suffix of an atom label is an identifier, not an MDL ATTCHPT position.
  *
  * In order for a dummy atom to be considered for collapsing it must have:
  * - degree 1 with a single or unspecified bond
@@ -1399,7 +1400,8 @@ RDKIT_GRAPHMOL_EXPORT void collapseAttachmentPoints(RWMol &mol,
 //! returns whether an atom is a marked explicit attachment point
 /*!
  * A marked explicit attachment point is a degree-one dummy atom with the
- * _fromAttachPoint property. This checks attachment-point identity only; it
+ * _fromAttachPoint property or a valid _AP<n> atom label, where n is a
+ * positive decimal integer. This checks attachment-point identity only; it
  * does not check whether the atom can currently be collapsed. In particular,
  * an attachment point connected by a wedged bond is still considered marked.
  *
@@ -1430,8 +1432,7 @@ RDKIT_GRAPHMOL_EXPORT unsigned int addExplicitAttachmentPoint(
 /*!
  *
  * @param atom the atom to inspect
- * @param markedOnly if true, only dummy atoms with the _fromAttachPoint
- *    property will be collapsed
+ * @param markedOnly if true, only marked attachment points will be collapsed
  *
  * In order for a dummy atom to be considered for collapsing it must have:
  * - degree 1 with a single or unspecified bond

--- a/Code/GraphMol/MolOps.h
+++ b/Code/GraphMol/MolOps.h
@@ -1396,6 +1396,17 @@ RDKIT_GRAPHMOL_EXPORT void expandAttachmentPoints(RWMol &mol,
 RDKIT_GRAPHMOL_EXPORT void collapseAttachmentPoints(RWMol &mol,
                                                     bool markedOnly = true);
 
+//! returns whether an atom is a marked explicit attachment point
+/*!
+ * A marked explicit attachment point is a degree-one dummy atom with the
+ * _fromAttachPoint property. This checks attachment-point identity only; it
+ * does not check whether the atom can currently be collapsed. In particular,
+ * an attachment point connected by a wedged bond is still considered marked.
+ *
+ * @param atom the atom to inspect
+ */
+RDKIT_GRAPHMOL_EXPORT bool isMarkedAttachmentPoint(const Atom *atom);
+
 namespace details {
 //! attachment points encoded as attachPt properties are added to the graph as
 /// dummy atoms
@@ -1415,10 +1426,10 @@ RDKIT_GRAPHMOL_EXPORT unsigned int addExplicitAttachmentPoint(
     RWMol &mol, unsigned int atomIdx, unsigned int val, bool addAsQuery = true,
     bool addCoords = true);
 
-//! returns whether or not an atom is an attachment point
+//! returns whether an atom is eligible to be collapsed as an attachment point
 /*!
  *
- * @param mol the molecule of interest
+ * @param atom the atom to inspect
  * @param markedOnly if true, only dummy atoms with the _fromAttachPoint
  *    property will be collapsed
  *

--- a/Code/GraphMol/SmilesParse/CXSmilesOps.cpp
+++ b/Code/GraphMol/SmilesParse/CXSmilesOps.cpp
@@ -16,6 +16,7 @@
 #include <GraphMol/FileParsers/MolFileStereochem.h>
 #include <GraphMol/Atropisomers.h>
 #include <GraphMol/Chirality.h>
+#include <GraphMol/MolOps.h>
 
 #include "SmilesWrite.h"
 #include "SmilesParse.h"
@@ -1943,8 +1944,9 @@ std::string get_atomlabel_block(const ROMol &mol,
                atom->getPropIfPresent(common_properties::_fromAttachPoint,
                                       val) &&
                (val == 1 || val == 2)) {
-      res +=
-          quote_string("_AP" + std::to_string(val), labelAllowedSpecialChars);
+      res += quote_string(
+          std::string(MolOps::attachmentPointLabelPrefix) + std::to_string(val),
+          labelAllowedSpecialChars);
     } else if (atom->getPropIfPresent(common_properties::atomLabel, lbl)) {
       res += quote_string(lbl, labelAllowedSpecialChars);
     }

--- a/Code/GraphMol/SmilesParse/SmilesParseOps.cpp
+++ b/Code/GraphMol/SmilesParse/SmilesParseOps.cpp
@@ -11,6 +11,7 @@
 #include <GraphMol/RDKitQueries.h>
 #include <GraphMol/Canon.h>
 #include <GraphMol/Chirality.h>
+#include <GraphMol/MolOps.h>
 #include "SmilesParse.h"
 #include "SmilesParseOps.h"
 #include <list>
@@ -640,13 +641,14 @@ void CleanupAfterParsing(RWMol *mol) {
     std::string label;
     if (atom->getAtomicNum() == 0 &&
         atom->getPropIfPresent(common_properties::atomLabel, label)) {
-      // marvinsketch can output higher labels than _AP1 and _AP2, but they
-      // aren't part of the MOL file spec so we don't treat them as attachment
-      // points
-      if (label == "_AP1") {
-        atom->setProp(common_properties::_fromAttachPoint, 1);
-      } else if (label == "_AP2") {
-        atom->setProp(common_properties::_fromAttachPoint, 2);
+      // marvinsketch can output higher labels than _AP1 and _AP2, but those
+      // labels aren't MOL-file ATTCHPT positions, so don't copy their numbers
+      // to _fromAttachPoint
+      const auto attachmentPointNumber =
+          MolOps::getAttachmentPointLabelNumber(atom);
+      if (attachmentPointNumber == 1 || attachmentPointNumber == 2) {
+        atom->setProp(common_properties::_fromAttachPoint,
+                      attachmentPointNumber);
       }
     }
   }

--- a/Code/GraphMol/Wrap/MolOps.cpp
+++ b/Code/GraphMol/Wrap/MolOps.cpp
@@ -3407,6 +3407,20 @@ A note on the flags controlling which atoms/bonds are modified:
    - either no query or be an AtomNullQuery
 )DOC");
     python::def(
+        "GetAttachmentPointLabelNumber", MolOps::getAttachmentPointLabelNumber,
+        python::arg("atom"),
+        R"DOC(returns the positive integer from a valid _AP<n> attachment-point label
+
+  The atom must be a degree-one dummy atom. Returns 0 if it does not have a
+  valid numbered attachment-point label. The returned number is a label
+  identifier, not an MDL ATTCHPT position.
+
+  Arguments:
+   - atom: the atom to inspect
+)DOC");
+    python::scope().attr("ATTACHMENT_POINT_LABEL_PREFIX") =
+        std::string(MolOps::attachmentPointLabelPrefix);
+    python::def(
         "IsMarkedAttachmentPoint", MolOps::isMarkedAttachmentPoint,
         python::arg("atom"),
         R"DOC(returns whether an atom is a marked explicit attachment point

--- a/Code/GraphMol/Wrap/MolOps.cpp
+++ b/Code/GraphMol/Wrap/MolOps.cpp
@@ -3406,6 +3406,18 @@ A note on the flags controlling which atoms/bonds are modified:
    - either no query or be an AtomNullQuery
 )DOC");
     python::def(
+        "IsMarkedAttachmentPoint", MolOps::isMarkedAttachmentPoint,
+        python::arg("atom"),
+        R"DOC(returns whether an atom is a marked explicit attachment point
+
+  This checks attachment-point identity only, not whether the atom can
+  currently be collapsed. In particular, an attachment point connected by a
+  wedged bond is still considered marked.
+
+  Arguments:
+   - atom: the atom to inspect
+)DOC");
+    python::def(
         "AddStereoAnnotations", Chirality::addStereoAnnotations,
         (python::arg("mol"), python::arg("absLabel") = "abs ({cip})",
          python::arg("orLabel") = "or{id}", python::arg("andLabel") = "and{id}",

--- a/Code/GraphMol/Wrap/MolOps.cpp
+++ b/Code/GraphMol/Wrap/MolOps.cpp
@@ -3397,8 +3397,9 @@ A note on the flags controlling which atoms/bonds are modified:
 
   Arguments:
    - mol: molecule to be modified
-   - markedOnly: if true, only dummy atoms with the _fromAttachPoint
-     property will be collapsed
+   - markedOnly: if true, only dummy atoms with the _fromAttachPoint property
+     or a valid _AP<n> atom label will be collapsed. The label suffix is not
+     interpreted as an MDL attachment-point position.
 
   In order for a dummy atom to be considered for collapsing it must have:
    - degree 1 with a single or unspecified bond
@@ -3410,9 +3411,11 @@ A note on the flags controlling which atoms/bonds are modified:
         python::arg("atom"),
         R"DOC(returns whether an atom is a marked explicit attachment point
 
-  This checks attachment-point identity only, not whether the atom can
-  currently be collapsed. In particular, an attachment point connected by a
-  wedged bond is still considered marked.
+  A marked attachment point is a degree-one dummy atom with the
+  _fromAttachPoint property or a valid _AP<n> atom label, where n is a
+  positive decimal integer. This checks attachment-point identity only, not
+  whether the atom can currently be collapsed. In particular, an attachment
+  point connected by a wedged bond is still considered marked.
 
   Arguments:
    - atom: the atom to inspect

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -8506,6 +8506,18 @@ M  END
     Chem.CollapseAttachmentPoints(mol, markedOnly=False)
     self.assertEqual(mol.GetNumAtoms(), 2)
 
+  def testIsMarkedAttachmentPoint(self):
+    mol = Chem.MolFromSmiles("CC")
+    mol.GetAtomWithIdx(1).SetIntProp("molAttchpt", 1)
+    Chem.ExpandAttachmentPoints(mol)
+    attachment = mol.GetAtomWithIdx(2)
+    self.assertTrue(Chem.IsMarkedAttachmentPoint(attachment))
+
+    bond = mol.GetBondBetweenAtoms(1, 2)
+    bond.SetBondDir(Chem.BondDir.BEGINWEDGE)
+    self.assertTrue(Chem.IsMarkedAttachmentPoint(attachment))
+    self.assertFalse(Chem.IsMarkedAttachmentPoint(mol.GetAtomWithIdx(0)))
+
   def testAddStereoAnnotations(self):
     mol = Chem.MolFromSmiles(
       "C[C@@H]1N[C@H](C)[C@@H]([C@H](C)[C@@H]1C)C1[C@@H](C)O[C@@H](C)[C@@H](C)[C@H]1C/C=C/C |a:5,o1:1,8,o2:14,16,&1:11,18,&2:3,6,r|"

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -8518,6 +8518,12 @@ M  END
     self.assertTrue(Chem.IsMarkedAttachmentPoint(attachment))
     self.assertFalse(Chem.IsMarkedAttachmentPoint(mol.GetAtomWithIdx(0)))
 
+    legacy = Chem.MolFromSmiles("*C |$_AP37;$|")
+    self.assertTrue(Chem.IsMarkedAttachmentPoint(legacy.GetAtomWithIdx(0)))
+    Chem.CollapseAttachmentPoints(legacy)
+    self.assertEqual(legacy.GetNumAtoms(), 1)
+    self.assertEqual(legacy.GetAtomWithIdx(0).GetIntProp("molAttchpt"), 1)
+
   def testAddStereoAnnotations(self):
     mol = Chem.MolFromSmiles(
       "C[C@@H]1N[C@H](C)[C@@H]([C@H](C)[C@@H]1C)C1[C@@H](C)O[C@@H](C)[C@@H](C)[C@H]1C/C=C/C |a:5,o1:1,8,o2:14,16,&1:11,18,&2:3,6,r|"

--- a/Code/GraphMol/Wrap/rough_test.py
+++ b/Code/GraphMol/Wrap/rough_test.py
@@ -8519,6 +8519,9 @@ M  END
     self.assertFalse(Chem.IsMarkedAttachmentPoint(mol.GetAtomWithIdx(0)))
 
     legacy = Chem.MolFromSmiles("*C |$_AP37;$|")
+    self.assertEqual(Chem.ATTACHMENT_POINT_LABEL_PREFIX, "_AP")
+    self.assertEqual(
+      Chem.GetAttachmentPointLabelNumber(legacy.GetAtomWithIdx(0)), 37)
     self.assertTrue(Chem.IsMarkedAttachmentPoint(legacy.GetAtomWithIdx(0)))
     Chem.CollapseAttachmentPoints(legacy)
     self.assertEqual(legacy.GetNumAtoms(), 1)

--- a/Code/GraphMol/catch_graphmol.cpp
+++ b/Code/GraphMol/catch_graphmol.cpp
@@ -3865,6 +3865,27 @@ TEST_CASE("expand and remove AttachmentPoints") {
     CHECK(!MolOps::isMarkedAttachmentPoint(mol->getAtomWithIdx(0)));
     attachment->clearProp(common_properties::_fromAttachPoint);
     CHECK(!MolOps::isMarkedAttachmentPoint(attachment));
+
+    attachment->setProp(common_properties::atomLabel, "_AP37");
+    CHECK(MolOps::isMarkedAttachmentPoint(attachment));
+    CHECK(!MolOps::details::isAttachmentPoint(attachment));
+    attachment->setProp(common_properties::atomLabel, "_AP0");
+    CHECK(!MolOps::isMarkedAttachmentPoint(attachment));
+    attachment->setProp(common_properties::atomLabel, "_AP3x");
+    CHECK(!MolOps::isMarkedAttachmentPoint(attachment));
+  }
+  SECTION("collapse label-only attachment point") {
+    auto mol = "*C |$_AP37;$|"_smiles;
+    REQUIRE(mol);
+    REQUIRE(mol->getNumAtoms() == 2);
+    CHECK(MolOps::isMarkedAttachmentPoint(mol->getAtomWithIdx(0)));
+
+    MolOps::collapseAttachmentPoints(*mol);
+    REQUIRE(mol->getNumAtoms() == 1);
+    int value = 0;
+    CHECK(mol->getAtomWithIdx(0)->getPropIfPresent(
+        common_properties::molAttachPoint, value));
+    CHECK(value == 1);
   }
 }
 

--- a/Code/GraphMol/catch_graphmol.cpp
+++ b/Code/GraphMol/catch_graphmol.cpp
@@ -3845,6 +3845,27 @@ TEST_CASE("expand and remove AttachmentPoints") {
     // marked as an attachment point, but at end of a double bond
     CHECK(!MolOps::details::isAttachmentPoint(mol->getAtomWithIdx(4)));
   }
+  SECTION("marked attachment point identity") {
+    auto mol = "CC"_smiles;
+    REQUIRE(mol);
+    auto attachmentIdx =
+        MolOps::details::addExplicitAttachmentPoint(*mol, 1, 1, true, false);
+    auto attachment = mol->getAtomWithIdx(attachmentIdx);
+    auto attachmentBond = mol->getBondBetweenAtoms(1, attachmentIdx);
+
+    CHECK(MolOps::isMarkedAttachmentPoint(attachment));
+    CHECK(MolOps::details::isAttachmentPoint(attachment));
+
+    attachmentBond->setBondDir(Bond::BondDir::BEGINWEDGE);
+    CHECK(MolOps::isMarkedAttachmentPoint(attachment));
+    CHECK(!MolOps::details::isAttachmentPoint(attachment));
+
+    CHECK(!MolOps::isMarkedAttachmentPoint(mol->getAtomWithIdx(0)));
+    mol->getAtomWithIdx(0)->setProp(common_properties::_fromAttachPoint, 1);
+    CHECK(!MolOps::isMarkedAttachmentPoint(mol->getAtomWithIdx(0)));
+    attachment->clearProp(common_properties::_fromAttachPoint);
+    CHECK(!MolOps::isMarkedAttachmentPoint(attachment));
+  }
 }
 
 TEST_CASE("bond output") {

--- a/Code/GraphMol/catch_graphmol.cpp
+++ b/Code/GraphMol/catch_graphmol.cpp
@@ -3865,13 +3865,21 @@ TEST_CASE("expand and remove AttachmentPoints") {
     CHECK(!MolOps::isMarkedAttachmentPoint(mol->getAtomWithIdx(0)));
     attachment->clearProp(common_properties::_fromAttachPoint);
     CHECK(!MolOps::isMarkedAttachmentPoint(attachment));
+    CHECK(MolOps::getAttachmentPointLabelNumber(attachment) == 0);
 
     attachment->setProp(common_properties::atomLabel, "_AP37");
+    CHECK(MolOps::getAttachmentPointLabelNumber(attachment) == 37);
     CHECK(MolOps::isMarkedAttachmentPoint(attachment));
     CHECK(!MolOps::details::isAttachmentPoint(attachment));
     attachment->setProp(common_properties::atomLabel, "_AP0");
+    CHECK(MolOps::getAttachmentPointLabelNumber(attachment) == 0);
     CHECK(!MolOps::isMarkedAttachmentPoint(attachment));
     attachment->setProp(common_properties::atomLabel, "_AP3x");
+    CHECK(MolOps::getAttachmentPointLabelNumber(attachment) == 0);
+    CHECK(!MolOps::isMarkedAttachmentPoint(attachment));
+    attachment->setProp(common_properties::atomLabel,
+                        "_AP999999999999999999999999999999999999");
+    CHECK(MolOps::getAttachmentPointLabelNumber(attachment) == 0);
     CHECK(!MolOps::isMarkedAttachmentPoint(attachment));
   }
   SECTION("collapse label-only attachment point") {

--- a/Code/GraphMol/catch_graphmol.cpp
+++ b/Code/GraphMol/catch_graphmol.cpp
@@ -3877,6 +3877,15 @@ TEST_CASE("expand and remove AttachmentPoints") {
     attachment->setProp(common_properties::atomLabel, "_AP3x");
     CHECK(MolOps::getAttachmentPointLabelNumber(attachment) == 0);
     CHECK(!MolOps::isMarkedAttachmentPoint(attachment));
+    attachment->setProp(common_properties::atomLabel, "_AP+1");
+    CHECK(MolOps::getAttachmentPointLabelNumber(attachment) == 0);
+    CHECK(!MolOps::isMarkedAttachmentPoint(attachment));
+    attachment->setProp(common_properties::atomLabel, "_AP-1");
+    CHECK(MolOps::getAttachmentPointLabelNumber(attachment) == 0);
+    CHECK(!MolOps::isMarkedAttachmentPoint(attachment));
+    attachment->setProp(common_properties::atomLabel, "_AP 1");
+    CHECK(MolOps::getAttachmentPointLabelNumber(attachment) == 0);
+    CHECK(!MolOps::isMarkedAttachmentPoint(attachment));
     attachment->setProp(common_properties::atomLabel,
                         "_AP999999999999999999999999999999999999");
     CHECK(MolOps::getAttachmentPointLabelNumber(attachment) == 0);


### PR DESCRIPTION
#### Reference Issue

N/A

#### What does this implement/fix? Explain your changes.

RDKit reads and writes numbered _AP<n> atom labels, but the label prefix and number parsing were not exposed publicly. MolOps::details::isAttachmentPoint() also answers whether an atom is currently eligible for collapseAttachmentPoints(), not whether it is an attachment point; bond-direction, bond-type, and query restrictions therefore make it unsuitable as an identity check.

This centralizes the label representation and exposes:

- MolOps::attachmentPointLabelPrefix in C++ and Chem.ATTACHMENT_POINT_LABEL_PREFIX in Python
- MolOps::getAttachmentPointLabelNumber() and Chem.GetAttachmentPointLabelNumber(), returning 0 for an invalid or absent label
- MolOps::isMarkedAttachmentPoint() and Chem.IsMarkedAttachmentPoint(), recognizing degree-one dummy atoms carrying _fromAttachPoint or a valid _AP<n> label

The CXSMILES reader and writer now use the shared label API. Label parsing validates the complete positive decimal suffix and rejects overflow.

collapseAttachmentPoints(markedOnly=true) now also collapses label-only _AP<n> atoms. The label suffix is an identifier, not an MDL ATTCHPT position, so a label-only attachment point collapses to position 1. Higher labels are supported without changing the MDL representation's 1/2 semantics.

The existing internal collapse predicate reuses the public identity check.

#### Testing

- Focused attachment-point test: 146 assertions passed
- Full graphmolTestsCatch suite: 117 test cases and 4,651 assertions passed
- Full cxsmilesTest suite: 36 test cases and 2,543 assertions passed
- Direct Python prefix, label-number, identity, and collapse smoke test passed

#### Any other comments?

Assignment of new _AP<n> identifiers and molecule-wide renumbering are intentionally not included; those are application policy. This complements #9455, which proposes an independent wedging option.
