### PR TITLE
Allow attachment-point bonds to be excluded from wedging

### DIFF
--- a/Code/GraphMol/Chirality.h
+++ b/Code/GraphMol/Chirality.h
@@ -223,6 +223,9 @@ RDKIT_GRAPHMOL_EXPORT std::ostream &operator<<(std::ostream &oss,
                                                const StereoType &s);
 
 struct RDKIT_GRAPHMOL_EXPORT BondWedgingParameters {
+  bool wedgeAttachmentPointBonds =
+      true;  //!< If false, bonds to atoms with the _fromAttachPoint property
+             //!< will not be wedged
   bool wedgeTwoBondsIfPossible =
       false;  //!< If this is enabled then two bonds will be wedged at chiral
               //!< centers subject to the following constraints:
@@ -298,6 +301,11 @@ RDKIT_GRAPHMOL_EXPORT int pickBondToWedge(
     const std::map<int, std::unique_ptr<RDKit::Chirality::WedgeInfoBase>>
         &resSoFar,
     int noNbrs);
+RDKIT_GRAPHMOL_EXPORT int pickBondToWedge(
+    const Atom *atom, const ROMol &mol, const INT_VECT &nChiralNbrs,
+    const std::map<int, std::unique_ptr<RDKit::Chirality::WedgeInfoBase>>
+        &resSoFar,
+    int noNbrs, const BondWedgingParameters &params);
 
 //! If useCXSmilesOrdering is true, the stereo will be assigned relative to the
 /// lowest-numbered neighbor of each double bond atom.

--- a/Code/GraphMol/WedgeBonds.cpp
+++ b/Code/GraphMol/WedgeBonds.cpp
@@ -276,6 +276,14 @@ int pickBondToWedge(
     const Atom *atom, const ROMol &mol, const INT_VECT &nChiralNbrs,
     const std::map<int, std::unique_ptr<Chirality::WedgeInfoBase>> &wedgeBonds,
     int noNbrs) {
+  const Chirality::BondWedgingParameters params;
+  return pickBondToWedge(atom, mol, nChiralNbrs, wedgeBonds, noNbrs, params);
+}
+
+int pickBondToWedge(
+    const Atom *atom, const ROMol &mol, const INT_VECT &nChiralNbrs,
+    const std::map<int, std::unique_ptr<Chirality::WedgeInfoBase>> &wedgeBonds,
+    int noNbrs, const Chirality::BondWedgingParameters &params) {
   // here is what we are going to do
   // - at each chiral center look for a bond that is begins at the atom and
   //   is not yet picked to be wedged for a different chiral center, preferring
@@ -300,8 +308,12 @@ int pickBondToWedge(
 
     int bid = bond->getIdx();
     if (wedgeBonds.find(bid) == wedgeBonds.end()) {
-      // very strong preference for Hs:
       auto *oatom = bond->getOtherAtom(atom);
+      if (!params.wedgeAttachmentPointBonds &&
+          oatom->hasProp(common_properties::_fromAttachPoint)) {
+        continue;
+      }
+      // very strong preference for Hs:
       if (oatom->getAtomicNum() == 1) {
         nbrScores.emplace_back(-1000000,
                                bid);  // lower than anything else can be
@@ -399,8 +411,8 @@ std::map<int, std::unique_ptr<Chirality::WedgeInfoBase>> pickBondsToWedge(
     if (type != Atom::CHI_TETRAHEDRAL_CW && type != Atom::CHI_TETRAHEDRAL_CCW) {
       break;
     }
-    auto bnd1 =
-        detail::pickBondToWedge(atom, mol, nChiralNbrs, wedgeInfo, noNbrs);
+    auto bnd1 = detail::pickBondToWedge(atom, mol, nChiralNbrs, wedgeInfo,
+                                        noNbrs, *params);
     if (bnd1 >= 0) {
       auto wi = std::unique_ptr<RDKit::Chirality::WedgeInfoChiral>(
           new RDKit::Chirality::WedgeInfoChiral(idx));
@@ -417,8 +429,8 @@ namespace {
 // 1. only degree four atoms (IUPAC)
 // 2. no ring bonds (IUPAC)
 // 3. not to chiral atoms (general IUPAC wedging rule)
-void addSecondWedgeAroundAtom(ROMol &mol, Bond *refBond,
-                              const Conformer *conf) {
+void addSecondWedgeAroundAtom(ROMol &mol, Bond *refBond, const Conformer *conf,
+                              bool wedgeAttachmentPointBonds) {
   PRECONDITION(refBond, "no reference bond provided");
   PRECONDITION(conf, "no conformer provided");
   auto atom = refBond->getBeginAtom();
@@ -435,10 +447,12 @@ void addSecondWedgeAroundAtom(ROMol &mol, Bond *refBond,
   unsigned int bestDegree = 100;
   Bond *bondToWedge = nullptr;
   for (auto bond : mol.atomBonds(atom)) {
+    const auto otherAtom = bond->getOtherAtom(atom);
     if (bond == refBond || bond->getBondType() != Bond::BondType::SINGLE ||
         bond->getBondDir() != Bond::BondDir::NONE ||
-        bond->getOtherAtom(atom)->getChiralTag() !=
-            Atom::ChiralType::CHI_UNSPECIFIED ||
+        otherAtom->getChiralTag() != Atom::ChiralType::CHI_UNSPECIFIED ||
+        (!wedgeAttachmentPointBonds &&
+         otherAtom->hasProp(common_properties::_fromAttachPoint)) ||
         mol.getRingInfo()->numBondRings(bond->getIdx())) {
       continue;
     }
@@ -531,7 +545,8 @@ void wedgeMolBonds(ROMol &mol, const Conformer *conf,
         }
       }
       if (numWedged == 1) {
-        addSecondWedgeAroundAtom(mol, wedgedBond, conf);
+        addSecondWedgeAroundAtom(mol, wedgedBond, conf,
+                                 params->wedgeAttachmentPointBonds);
       }
     }
   }

--- a/Code/GraphMol/Wrap/MolOps.cpp
+++ b/Code/GraphMol/Wrap/MolOps.cpp
@@ -2699,6 +2699,10 @@ ARGUMENTS:\n\
         "BondWedgingParameters",
         "Parameters controlling how bond wedging is done.")
         .def_readwrite(
+            "wedgeAttachmentPointBonds",
+            &Chirality::BondWedgingParameters::wedgeAttachmentPointBonds,
+            "If false, bonds to marked attachment points will not be wedged")
+        .def_readwrite(
             "wedgeTwoBondsIfPossible",
             &Chirality::BondWedgingParameters::wedgeTwoBondsIfPossible,
             R"DOC(If this is enabled then two bonds will be wedged at chiral

--- a/Code/GraphMol/Wrap/MolOps.cpp
+++ b/Code/GraphMol/Wrap/MolOps.cpp
@@ -2708,6 +2708,10 @@ ARGUMENTS:\n\
         "BondWedgingParameters",
         "Parameters controlling how bond wedging is done.")
         .def_readwrite(
+            "wedgeAttachmentPointBonds",
+            &Chirality::BondWedgingParameters::wedgeAttachmentPointBonds,
+            "If false, bonds to marked attachment points will not be wedged")
+        .def_readwrite(
             "wedgeTwoBondsIfPossible",
             &Chirality::BondWedgingParameters::wedgeTwoBondsIfPossible,
             R"DOC(If this is enabled then two bonds will be wedged at chiral

--- a/Code/GraphMol/catch_chirality.cpp
+++ b/Code/GraphMol/catch_chirality.cpp
@@ -1564,6 +1564,30 @@ TEST_CASE("pickBondsToWedge() should avoid double bonds") {
   }
 }
 
+TEST_CASE("pickBondsToWedge() can exclude marked attachment points") {
+  auto mol = "F[C@](Cl)(Br)*"_smiles;
+  REQUIRE(mol);
+  const auto chiralAtom = mol->getAtomWithIdx(1);
+  const auto attachmentPoint = mol->getAtomWithIdx(4);
+  attachmentPoint->setProp(common_properties::_fromAttachPoint, 1);
+
+  // Leave the attachment-point bond as the only wedgeable single bond.
+  for (auto bond : mol->atomBonds(chiralAtom)) {
+    if (bond->getOtherAtom(chiralAtom) != attachmentPoint) {
+      bond->setBondType(Bond::BondType::DOUBLE);
+    }
+  }
+
+  auto wedgedBonds = Chirality::pickBondsToWedge(*mol);
+  REQUIRE(wedgedBonds.size() == 1);
+  CHECK(wedgedBonds.begin()->first ==
+        static_cast<int>(mol->getBondBetweenAtoms(1, 4)->getIdx()));
+
+  Chirality::BondWedgingParameters params;
+  params.wedgeAttachmentPointBonds = false;
+  CHECK(Chirality::pickBondsToWedge(*mol, &params).empty());
+}
+
 TEST_CASE("addWavyBondsForStereoAny()") {
   SECTION("simplest") {
     auto mol = "CC=CC"_smiles;

--- a/Code/GraphMol/catch_chirality.cpp
+++ b/Code/GraphMol/catch_chirality.cpp
@@ -1539,6 +1539,30 @@ TEST_CASE("pickBondsToWedge() should avoid double bonds") {
   }
 }
 
+TEST_CASE("pickBondsToWedge() can exclude marked attachment points") {
+  auto mol = "F[C@](Cl)(Br)*"_smiles;
+  REQUIRE(mol);
+  const auto chiralAtom = mol->getAtomWithIdx(1);
+  const auto attachmentPoint = mol->getAtomWithIdx(4);
+  attachmentPoint->setProp(common_properties::_fromAttachPoint, 1);
+
+  // Leave the attachment-point bond as the only wedgeable single bond.
+  for (auto bond : mol->atomBonds(chiralAtom)) {
+    if (bond->getOtherAtom(chiralAtom) != attachmentPoint) {
+      bond->setBondType(Bond::BondType::DOUBLE);
+    }
+  }
+
+  auto wedgedBonds = Chirality::pickBondsToWedge(*mol);
+  REQUIRE(wedgedBonds.size() == 1);
+  CHECK(wedgedBonds.begin()->first ==
+        static_cast<int>(mol->getBondBetweenAtoms(1, 4)->getIdx()));
+
+  Chirality::BondWedgingParameters params;
+  params.wedgeAttachmentPointBonds = false;
+  CHECK(Chirality::pickBondsToWedge(*mol, &params).empty());
+}
+
 TEST_CASE("addWavyBondsForStereoAny()") {
   SECTION("simplest") {
     auto mol = "CC=CC"_smiles;


### PR DESCRIPTION
## Summary

RDKit currently gives bonds to atoms marked with _fromAttachPoint a large score penalty when selecting bonds to wedge, but may still wedge one if there is no alternative.

This adds a wedgeAttachmentPointBonds option to BondWedgingParameters. It defaults to true, preserving existing behavior. When false, marked attachment-point bonds are excluded from both the primary and optional secondary wedge selection paths.

The option is also exposed on the Python BondWedgingParameters class.

This complements #9454, which proposes a public attachment-point identity predicate, but does not depend on it.

## Testing

- Focused regression test: 4 assertions passed
- Full chiralityTestsCatch suite: 88 test cases and 2,458 assertions passed
- Python wrapper target compiled successfully

## Draft status

Opening as a draft to get feedback on whether this belongs in BondWedgingParameters and on the option name/default before expanding coverage or documentation.