### PR TITLE
Fix implicit H updates after fragment batch edits

### DIFF
--- a/Code/GraphMol/ChemTransforms/MolFragmenter.cpp
+++ b/Code/GraphMol/ChemTransforms/MolFragmenter.cpp
@@ -460,6 +460,7 @@ ROMol *fragmentOnBonds(
   for (auto bondIdx : bondIndices) {
     bondsToRemove.push_back(res->getBondWithIdx(bondIdx));
   }
+  std::unordered_set<unsigned int> atomsToUpdate;
   res->beginBatchEdit();
   for (unsigned int i = 0; i < bondsToRemove.size(); ++i) {
     const Bond *bond = bondsToRemove[i];
@@ -563,12 +564,15 @@ ROMol *fragmentOnBonds(
             (tatom->getIsAromatic() && tatom->getAtomicNum() != 6)) {
           tatom->setNumExplicitHs(tatom->getNumExplicitHs() + 1);
         } else {
-          tatom->updatePropertyCache(false);
+          atomsToUpdate.insert(idx);
         }
       }
     }
   }
   res->commitBatchEdit();
+  for (auto idx : atomsToUpdate) {
+    res->getAtomWithIdx(idx)->updatePropertyCache(false);
+  }
   res->clearComputedProps();
   return static_cast<ROMol *>(res.release());
 }

--- a/Code/GraphMol/ChemTransforms/catch_tests.cpp
+++ b/Code/GraphMol/ChemTransforms/catch_tests.cpp
@@ -665,6 +665,21 @@ TEST_CASE("fragmentOnBonds should not segfault on duplicate bondIndices") {
   REQUIRE(!splitMol);
 }
 
+TEST_CASE("fragmentOnBonds updates implicit Hs after batch bond removal") {
+  auto mol = "c1ccccc1CC"_smiles;
+  REQUIRE(mol);
+  const auto *coreBond = mol->getBondBetweenAtoms(5, 6);
+  const auto *sidechainBond = mol->getBondBetweenAtoms(6, 7);
+  REQUIRE(coreBond);
+  REQUIRE(sidechainBond);
+  std::unique_ptr<ROMol> splitMol(MolFragmenter::fragmentOnBonds(
+      *mol, {coreBond->getIdx(), sidechainBond->getIdx()}, false));
+  REQUIRE(splitMol);
+  CHECK(splitMol->getAtomWithIdx(5)->getTotalNumHs() == 1);
+  CHECK(splitMol->getAtomWithIdx(6)->getTotalNumHs() == 4);
+  CHECK(splitMol->getAtomWithIdx(7)->getTotalNumHs() == 4);
+}
+
 TEST_CASE("align fragments") {
   SECTION("basics") {
     auto m = "CC[1*].O[1*] |(1,0,0;2,0,0;3.5,0,0;0,1,0;0,2.1,0)|"_smiles;


### PR DESCRIPTION
#### Reference Issue
Regression introduced by #9430

#### What does this implement/fix? Explain your changes.
`fragmentOnBonds()` was updating atom property caches before batched bond removals were committed. With `addDummies=false`, this left implicit hydrogen counts based on the original, unfragmented molecular graph.
This change records the affected atoms and updates their property caches after `commitBatchEdit()`. I also added a regression test covering multiple cuts in an ethylbenzene sidechain.

We could also walk back this being a batch edit (that was just added in #9430)

#### Any other comments?

Generated with Sol 5.6