### PR TITLE
support ignoreAtoms in RDKitFingerprintGenerators

### DIFF
--- a/Code/GraphMol/Fingerprints/FingerprintUtil.cpp
+++ b/Code/GraphMol/Fingerprints/FingerprintUtil.cpp
@@ -282,22 +282,35 @@ void buildDefaultRDKitFingerprintAtomInvariants(
 void enumerateAllPaths(const ROMol &mol, INT_PATH_LIST_MAP &allPaths,
                        const std::vector<std::uint32_t> *fromAtoms,
                        bool branchedPaths, bool useHs, unsigned int minPath,
-                       unsigned int maxPath) {
+                       unsigned int maxPath,
+                       boost::dynamic_bitset<> *ignoreAtoms) {
+  PRECONDITION(!ignoreAtoms || ignoreAtoms->size() == mol.getNumAtoms(),
+               "bad ignoreAtoms size");
   if (!fromAtoms) {
     if (branchedPaths) {
-      allPaths = findAllSubgraphsOfLengthsMtoN(mol, minPath, maxPath, useHs);
+      int rootedAtAtom = -1;
+      allPaths = findAllSubgraphsOfLengthsMtoN(mol, minPath, maxPath, useHs,
+                                               rootedAtAtom, ignoreAtoms);
     } else {
-      allPaths = findAllPathsOfLengthsMtoN(mol, minPath, maxPath, true, useHs);
+      bool useBonds = true;
+      int rootedAtAtom = -1;
+      bool onlyShortestPaths = false;
+      allPaths = findAllPathsOfLengthsMtoN(mol, minPath, maxPath, useBonds,
+                                           useHs, rootedAtAtom,
+                                           onlyShortestPaths, ignoreAtoms);
     }
   } else {
     for (auto aidx : *fromAtoms) {
       INT_PATH_LIST_MAP tPaths;
       if (branchedPaths) {
-        tPaths =
-            findAllSubgraphsOfLengthsMtoN(mol, minPath, maxPath, useHs, aidx);
+        tPaths = findAllSubgraphsOfLengthsMtoN(mol, minPath, maxPath, useHs,
+                                               aidx, ignoreAtoms);
       } else {
+        bool useBonds = true;
+        bool onlyShortestPaths = false;
         tPaths =
-            findAllPathsOfLengthsMtoN(mol, minPath, maxPath, true, useHs, aidx);
+            findAllPathsOfLengthsMtoN(mol, minPath, maxPath, useBonds, useHs,
+                                      aidx, onlyShortestPaths, ignoreAtoms);
       }
       for (INT_PATH_LIST_MAP::const_iterator tpit = tPaths.begin();
            tpit != tPaths.end(); ++tpit) {

--- a/Code/GraphMol/Fingerprints/FingerprintUtil.h
+++ b/Code/GraphMol/Fingerprints/FingerprintUtil.h
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2018 Boran Adas, Google Summer of Code
+//  Copyright (C) 2018-2026 Boran Adas and other RDKit contributors
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -20,6 +20,7 @@
 #include <vector>
 #include <map>
 #include <DataStructs/ExplicitBitVect.h>
+#include <boost/dynamic_bitset.hpp>
 
 #include <GraphMol/Subgraphs/Subgraphs.h>
 
@@ -141,7 +142,8 @@ RDKIT_FINGERPRINTS_EXPORT void buildDefaultRDKitFingerprintAtomInvariants(
 RDKIT_FINGERPRINTS_EXPORT void enumerateAllPaths(
     const ROMol &mol, std::map<int, std::list<std::vector<int>>> &allPaths,
     const std::vector<std::uint32_t> *fromAtoms, bool branchedPaths, bool useHs,
-    unsigned int minPath, unsigned int maxPath);
+    unsigned int minPath, unsigned int maxPath,
+    boost::dynamic_bitset<> *ignoreAtoms = nullptr);
 
 RDKIT_FINGERPRINTS_EXPORT void identifyQueryBonds(
     const ROMol &mol, std::vector<const Bond *> &bondCache,

--- a/Code/GraphMol/Fingerprints/RDKitFPGenerator.cpp
+++ b/Code/GraphMol/Fingerprints/RDKitFPGenerator.cpp
@@ -181,9 +181,9 @@ std::vector<AtomEnvironment<OutputType> *>
 RDKitFPEnvGenerator<OutputType>::getEnvironments(
     const ROMol &mol, FingerprintArguments *arguments,
     const std::vector<std::uint32_t> *fromAtoms,
-    const std::vector<std::uint32_t> *,  // ignoreAtoms
-    const int,                           // confId
-    const AdditionalOutput *,            // additionalOutput
+    const std::vector<std::uint32_t> *ignoreAtoms,
+    const int,                 // confId
+    const AdditionalOutput *,  // additionalOutput
     const std::vector<std::uint32_t> *atomInvariants,
     const std::vector<std::uint32_t> *,  // bondInvariants
     const bool                           // hashResults
@@ -197,9 +197,18 @@ RDKitFPEnvGenerator<OutputType>::getEnvironments(
 
   // get all paths
   INT_PATH_LIST_MAP allPaths;
+
+  boost::dynamic_bitset<> ignoreAtomsBitset;
+  if (ignoreAtoms) {
+    ignoreAtomsBitset.resize(mol.getNumAtoms());
+    std::ranges::for_each(*ignoreAtoms, [&](const auto atomIdx) {
+      ignoreAtomsBitset.set(atomIdx);
+    });
+  }
   RDKitFPUtils::enumerateAllPaths(
       mol, allPaths, fromAtoms, fpArguments->df_branchedPaths,
-      fpArguments->df_useHs, fpArguments->d_minPath, fpArguments->d_maxPath);
+      fpArguments->df_useHs, fpArguments->d_minPath, fpArguments->d_maxPath,
+      ignoreAtoms ? &ignoreAtomsBitset : nullptr);
 
   // identify query bonds
   std::vector<short> isQueryBond(mol.getNumBonds(), 0);

--- a/Code/GraphMol/Fingerprints/RDKitFPGenerator.h
+++ b/Code/GraphMol/Fingerprints/RDKitFPGenerator.h
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2018-2022 Boran Adas and other RDKit contributors
+//  Copyright (C) 2018-2026 Boran Adas and other RDKit contributors
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -108,6 +108,19 @@ template <typename OutputType>
 class RDKIT_FINGERPRINTS_EXPORT RDKitFPEnvGenerator
     : public AtomEnvironmentGenerator<OutputType> {
  public:
+  /**
+   \brief Get the atom environments for a molecule
+
+    \param mol               molecule to generate the atom-environments from
+    \param arguments         fingerprint type specific arguments
+    \param fromAtoms         only generate subgraphs starting at these atoms
+    \param ignoreAtoms      ignore any subgraphs that contain these atoms
+    \param confId           IGNORED
+    \param additionalOutput IGNORED
+    \param atomInvariants   atom invariants to be used
+    \param bondInvariants   IGNORED
+    \param hashResults      IGNORED
+  */
   std::vector<AtomEnvironment<OutputType> *> getEnvironments(
       const ROMol &mol, FingerprintArguments *arguments,
       const std::vector<std::uint32_t> *fromAtoms,

--- a/Code/GraphMol/Fingerprints/Wrap/FingerprintGeneratorWrapper.cpp
+++ b/Code/GraphMol/Fingerprints/Wrap/FingerprintGeneratorWrapper.cpp
@@ -477,154 +477,148 @@ template <typename T>
 void wrapGenerator(const std::string &nm) {
   python::class_<FingerprintGenerator<T>, boost::noncopyable>(nm.c_str(),
                                                               python::no_init)
-      .def("GetSparseCountFingerprint", getSparseCountFingerprint<T>,
-           ((python::arg("self"), python::arg("mol")),
-            python::arg("fromAtoms") = python::list(),
-            python::arg("ignoreAtoms") = python::list(),
-            python::arg("confId") = -1,
-            python::arg("customAtomInvariants") = python::list(),
-            python::arg("customBondInvariants") = python::list(),
-            python::arg("additionalOutput") = python::object()),
-           "Generates a sparse count fingerprint\n\n"
-           "  ARGUMENTS:\n"
-           "    - mol: molecule to be fingerprinted\n"
-           "    - fromAtoms: indices of atoms to use while generating the "
-           "fingerprint\n"
-           "    - ignoreAtoms: indices of atoms to exclude while generating "
-           "the fingerprint\n"
-           "    - confId: 3D confirmation to use, only used by AtomPair "
-           "fingerprint\n"
-           "    - customAtomInvariants: custom atom invariants to be used, "
-           "overrides invariants from the invariant generator\n"
-           "    - customBondInvariants: custom bond invariants to be used, "
-           "overrides invariants from the invariant generator\n\n"
-           "    - additionalOutput: AdditionalOutput instance used to return "
-           "extra information about the bits\n\n"
-           "  RETURNS: a SparseIntVect containing fingerprint\n\n",
-           python::return_value_policy<python::manage_new_object>())
-      .def("GetSparseFingerprint", getSparseFingerprint<T>,
-           ((python::arg("self"), python::arg("mol")),
-            python::arg("fromAtoms") = python::list(),
-            python::arg("ignoreAtoms") = python::list(),
-            python::arg("confId") = -1,
-            python::arg("customAtomInvariants") = python::list(),
-            python::arg("customBondInvariants") = python::list(),
-            python::arg("additionalOutput") = python::object()),
-           "Generates a sparse fingerprint\n\n"
-           "  ARGUMENTS:\n"
-           "    - mol: molecule to be fingerprinted\n"
-           "    - fromAtoms: indices of atoms to use while generating the "
-           "fingerprint\n"
-           "    - ignoreAtoms: indices of atoms to exclude while generating "
-           "the fingerprint\n"
-           "    - confId: 3D confirmation to use, only used by AtomPair "
-           "fingerprint\n"
-           "    - customAtomInvariants: custom atom invariants to be used, "
-           "overrides invariants from the invariant generator\n"
-           "    - customBondInvariants: custom bond invariants to be used, "
-           "overrides invariants from the invariant generator\n\n"
-           "    - additionalOutput: AdditionalOutput instance used to return "
-           "extra information about the bits\n\n"
-           "  RETURNS: a SparseBitVect containing fingerprint\n\n",
-           python::return_value_policy<python::manage_new_object>())
-      .def("GetCountFingerprint", getCountFingerprint<T>,
-           ((python::arg("self"), python::arg("mol")),
-            python::arg("fromAtoms") = python::list(),
-            python::arg("ignoreAtoms") = python::list(),
-            python::arg("confId") = -1,
-            python::arg("customAtomInvariants") = python::list(),
-            python::arg("customBondInvariants") = python::list(),
-            python::arg("additionalOutput") = python::object()),
-           "Generates a count fingerprint\n\n"
-           "  ARGUMENTS:\n"
-           "    - mol: molecule to be fingerprinted\n"
-           "    - fromAtoms: indices of atoms to use while generating the "
-           "fingerprint\n"
-           "    - ignoreAtoms: indices of atoms to exclude while generating "
-           "the fingerprint\n"
-           "    - confId: 3D confirmation to use, only used by AtomPair "
-           "fingerprint\n"
-           "    - customAtomInvariants: custom atom invariants to be used, "
-           "overrides invariants from the invariant generator\n"
-           "    - customBondInvariants: custom bond invariants to be used, "
-           "overrides invariants from the invariant generator\n\n"
-           "    - additionalOutput: AdditionalOutput instance used to return "
-           "extra information about the bits\n\n"
-           "  RETURNS: a SparseIntVect containing fingerprint\n\n",
-           python::return_value_policy<python::manage_new_object>())
-      .def("GetCountFingerprintAsNumPy", getNumPyCountFingerprint<T>,
-           ((python::arg("self"), python::arg("mol")),
-            python::arg("fromAtoms") = python::list(),
-            python::arg("ignoreAtoms") = python::list(),
-            python::arg("confId") = -1,
-            python::arg("customAtomInvariants") = python::list(),
-            python::arg("customBondInvariants") = python::list(),
-            python::arg("additionalOutput") = python::object()),
-           "Generates a count fingerprint\n\n"
-           "  ARGUMENTS:\n"
-           "    - mol: molecule to be fingerprinted\n"
-           "    - fromAtoms: indices of atoms to use while generating the "
-           "fingerprint\n"
-           "    - ignoreAtoms: indices of atoms to exclude while generating "
-           "the fingerprint\n"
-           "    - confId: 3D confirmation to use, only used by AtomPair "
-           "fingerprint\n"
-           "    - customAtomInvariants: custom atom invariants to be used, "
-           "overrides invariants from the invariant generator\n"
-           "    - customBondInvariants: custom bond invariants to be used, "
-           "overrides invariants from the invariant generator\n\n"
-           "    - additionalOutput: AdditionalOutput instance used to return "
-           "extra information about the bits\n\n"
-           "  RETURNS: a numpy array containing the fingerprint\n\n")
-      .def("GetFingerprint", getFingerprint<T>,
-           ((python::arg("self"), python::arg("mol")),
-            python::arg("fromAtoms") = python::list(),
-            python::arg("ignoreAtoms") = python::list(),
-            python::arg("confId") = -1,
-            python::arg("customAtomInvariants") = python::list(),
-            python::arg("customBondInvariants") = python::list(),
-            python::arg("additionalOutput") = python::object()),
-           "Generates a fingerprint\n\n"
-           "  ARGUMENTS:\n"
-           "    - mol: molecule to be fingerprinted\n"
-           "    - fromAtoms: indices of atoms to use while generating the "
-           "fingerprint\n"
-           "    - ignoreAtoms: indices of atoms to exclude while generating "
-           "the fingerprint\n"
-           "    - confId: 3D confirmation to use, only used by AtomPair "
-           "fingerprint\n"
-           "    - customAtomInvariants: custom atom invariants to be used, "
-           "overrides invariants from the invariant generator\n"
-           "    - customBondInvariants: custom bond invariants to be used, "
-           "overrides invariants from the invariant generator\n\n"
-           "    - additionalOutput: AdditionalOutput instance used to return "
-           "extra information about the bits\n\n"
-           "  RETURNS: a ExplicitBitVect containing fingerprint\n\n",
-           python::return_value_policy<python::manage_new_object>())
-      .def("GetFingerprintAsNumPy", getNumPyFingerprint<T>,
-           ((python::arg("self"), python::arg("mol")),
-            python::arg("fromAtoms") = python::list(),
-            python::arg("ignoreAtoms") = python::list(),
-            python::arg("confId") = -1,
-            python::arg("customAtomInvariants") = python::list(),
-            python::arg("customBondInvariants") = python::list(),
-            python::arg("additionalOutput") = python::object()),
-           "Generates a fingerprint\n\n"
-           "  ARGUMENTS:\n"
-           "    - mol: molecule to be fingerprinted\n"
-           "    - fromAtoms: indices of atoms to use while generating the "
-           "fingerprint\n"
-           "    - ignoreAtoms: indices of atoms to exclude while generating "
-           "the fingerprint\n"
-           "    - confId: 3D confirmation to use, only used by AtomPair "
-           "fingerprint\n"
-           "    - customAtomInvariants: custom atom invariants to be used, "
-           "overrides invariants from the invariant generator\n"
-           "    - customBondInvariants: custom bond invariants to be used, "
-           "overrides invariants from the invariant generator\n\n"
-           "    - additionalOutput: AdditionalOutput instance used to return "
-           "extra information about the bits\n\n"
-           "  RETURNS: a numpy array containing the fingerprint\n\n")
+      .def(
+          "GetSparseCountFingerprint", getSparseCountFingerprint<T>,
+          ((python::arg("self"), python::arg("mol")),
+           python::arg("fromAtoms") = python::list(),
+           python::arg("ignoreAtoms") = python::list(),
+           python::arg("confId") = -1,
+           python::arg("customAtomInvariants") = python::list(),
+           python::arg("customBondInvariants") = python::list(),
+           python::arg("additionalOutput") = python::object()),
+          "Generates a sparse count fingerprint\n\n"
+          "  ARGUMENTS:\n"
+          "    - mol: molecule to be fingerprinted\n"
+          "    - fromAtoms: only environments starting at or centered on these atoms will be included\n"
+          "    - ignoreAtoms: environments including these atoms will be excluded\n"
+          "    - confId: 3D confirmation to use, only used by AtomPair "
+          "fingerprint\n"
+          "    - customAtomInvariants: custom atom invariants to be used, "
+          "overrides invariants from the invariant generator\n"
+          "    - customBondInvariants: custom bond invariants to be used, "
+          "overrides invariants from the invariant generator\n\n"
+          "    - additionalOutput: AdditionalOutput instance used to return "
+          "extra information about the bits\n\n"
+          "  RETURNS: a SparseIntVect containing fingerprint\n\n",
+          python::return_value_policy<python::manage_new_object>())
+      .def(
+          "GetSparseFingerprint", getSparseFingerprint<T>,
+          ((python::arg("self"), python::arg("mol")),
+           python::arg("fromAtoms") = python::list(),
+           python::arg("ignoreAtoms") = python::list(),
+           python::arg("confId") = -1,
+           python::arg("customAtomInvariants") = python::list(),
+           python::arg("customBondInvariants") = python::list(),
+           python::arg("additionalOutput") = python::object()),
+          "Generates a sparse fingerprint\n\n"
+          "  ARGUMENTS:\n"
+          "    - mol: molecule to be fingerprinted\n"
+          "    - fromAtoms: only environments starting at or centered on these atoms will be included\n"
+          "    - ignoreAtoms: environments including these atoms will be excluded\n"
+          "    - confId: 3D confirmation to use, only used by AtomPair "
+          "fingerprint\n"
+          "    - customAtomInvariants: custom atom invariants to be used, "
+          "overrides invariants from the invariant generator\n"
+          "    - customBondInvariants: custom bond invariants to be used, "
+          "overrides invariants from the invariant generator\n\n"
+          "    - additionalOutput: AdditionalOutput instance used to return "
+          "extra information about the bits\n\n"
+          "  RETURNS: a SparseBitVect containing fingerprint\n\n",
+          python::return_value_policy<python::manage_new_object>())
+      .def(
+          "GetCountFingerprint", getCountFingerprint<T>,
+          ((python::arg("self"), python::arg("mol")),
+           python::arg("fromAtoms") = python::list(),
+           python::arg("ignoreAtoms") = python::list(),
+           python::arg("confId") = -1,
+           python::arg("customAtomInvariants") = python::list(),
+           python::arg("customBondInvariants") = python::list(),
+           python::arg("additionalOutput") = python::object()),
+          "Generates a count fingerprint\n\n"
+          "  ARGUMENTS:\n"
+          "    - mol: molecule to be fingerprinted\n"
+          "    - fromAtoms: only environments starting at or centered on these atoms will be included\n"
+          "    - ignoreAtoms: environments including these atoms will be excluded\n"
+          "    - confId: 3D confirmation to use, only used by AtomPair "
+          "fingerprint\n"
+          "    - customAtomInvariants: custom atom invariants to be used, "
+          "overrides invariants from the invariant generator\n"
+          "    - customBondInvariants: custom bond invariants to be used, "
+          "overrides invariants from the invariant generator\n\n"
+          "    - additionalOutput: AdditionalOutput instance used to return "
+          "extra information about the bits\n\n"
+          "  RETURNS: a SparseIntVect containing fingerprint\n\n",
+          python::return_value_policy<python::manage_new_object>())
+      .def(
+          "GetCountFingerprintAsNumPy", getNumPyCountFingerprint<T>,
+          ((python::arg("self"), python::arg("mol")),
+           python::arg("fromAtoms") = python::list(),
+           python::arg("ignoreAtoms") = python::list(),
+           python::arg("confId") = -1,
+           python::arg("customAtomInvariants") = python::list(),
+           python::arg("customBondInvariants") = python::list(),
+           python::arg("additionalOutput") = python::object()),
+          "Generates a count fingerprint\n\n"
+          "  ARGUMENTS:\n"
+          "    - mol: molecule to be fingerprinted\n"
+          "    - fromAtoms: only environments starting at or centered on these atoms will be included\n"
+          "    - ignoreAtoms: environments including these atoms will be excluded\n"
+          "    - confId: 3D confirmation to use, only used by AtomPair "
+          "fingerprint\n"
+          "    - customAtomInvariants: custom atom invariants to be used, "
+          "overrides invariants from the invariant generator\n"
+          "    - customBondInvariants: custom bond invariants to be used, "
+          "overrides invariants from the invariant generator\n\n"
+          "    - additionalOutput: AdditionalOutput instance used to return "
+          "extra information about the bits\n\n"
+          "  RETURNS: a numpy array containing the fingerprint\n\n")
+      .def(
+          "GetFingerprint", getFingerprint<T>,
+          ((python::arg("self"), python::arg("mol")),
+           python::arg("fromAtoms") = python::list(),
+           python::arg("ignoreAtoms") = python::list(),
+           python::arg("confId") = -1,
+           python::arg("customAtomInvariants") = python::list(),
+           python::arg("customBondInvariants") = python::list(),
+           python::arg("additionalOutput") = python::object()),
+          "Generates a fingerprint\n\n"
+          "  ARGUMENTS:\n"
+          "    - mol: molecule to be fingerprinted\n"
+          "    - fromAtoms: only environments starting at or centered on these atoms will be included\n"
+          "    - ignoreAtoms: environments including these atoms will be excluded\n"
+          "    - confId: 3D confirmation to use, only used by AtomPair "
+          "fingerprint\n"
+          "    - customAtomInvariants: custom atom invariants to be used, "
+          "overrides invariants from the invariant generator\n"
+          "    - customBondInvariants: custom bond invariants to be used, "
+          "overrides invariants from the invariant generator\n\n"
+          "    - additionalOutput: AdditionalOutput instance used to return "
+          "extra information about the bits\n\n"
+          "  RETURNS: a ExplicitBitVect containing fingerprint\n\n",
+          python::return_value_policy<python::manage_new_object>())
+      .def(
+          "GetFingerprintAsNumPy", getNumPyFingerprint<T>,
+          ((python::arg("self"), python::arg("mol")),
+           python::arg("fromAtoms") = python::list(),
+           python::arg("ignoreAtoms") = python::list(),
+           python::arg("confId") = -1,
+           python::arg("customAtomInvariants") = python::list(),
+           python::arg("customBondInvariants") = python::list(),
+           python::arg("additionalOutput") = python::object()),
+          "Generates a fingerprint\n\n"
+          "  ARGUMENTS:\n"
+          "    - mol: molecule to be fingerprinted\n"
+          "    - fromAtoms: only environments starting at or centered on these atoms will be included\n"
+          "    - ignoreAtoms: environments including these atoms will be excluded\n"
+          "    - confId: 3D confirmation to use, only used by AtomPair "
+          "fingerprint\n"
+          "    - customAtomInvariants: custom atom invariants to be used, "
+          "overrides invariants from the invariant generator\n"
+          "    - customBondInvariants: custom bond invariants to be used, "
+          "overrides invariants from the invariant generator\n\n"
+          "    - additionalOutput: AdditionalOutput instance used to return "
+          "extra information about the bits\n\n"
+          "  RETURNS: a numpy array containing the fingerprint\n\n")
       .def("GetFingerprints", getFingerprints<T>,
            ((python::arg("self"), python::arg("mols")),
             python::arg("numThreads") = 1),

--- a/Code/GraphMol/Fingerprints/Wrap/testGenerators.py
+++ b/Code/GraphMol/Fingerprints/Wrap/testGenerators.py
@@ -396,13 +396,13 @@ class TestCase(unittest.TestCase):
     ao = rdFingerprintGenerator.AdditionalOutput()
     ao.AllocateAtomsPerBit()
     m = Chem.MolFromSmiles('c1ccccn1')
-    fp = fpg.GetFingerprint(m,additionalOutput=ao)
+    fp = fpg.GetFingerprint(m, additionalOutput=ao)
     apb = ao.GetAtomsPerBit()
-    self.assertEqual(fp.GetNumOnBits(),len(apb))
-    self.assertEqual(apb[140],((2, 1, 0, 5), (2, 3, 4, 5)))
+    self.assertEqual(fp.GetNumOnBits(), len(apb))
+    self.assertEqual(apb[140], ((2, 1, 0, 5), (2, 3, 4, 5)))
 
     ao = rdFingerprintGenerator.AdditionalOutput()
-    _ = fpg.GetFingerprint(m,additionalOutput=ao)
+    _ = fpg.GetFingerprint(m, additionalOutput=ao)
     self.assertIsNone(ao.GetAtomsPerBit())
 
   def testJSONSerialization(self):
@@ -414,6 +414,15 @@ class TestCase(unittest.TestCase):
     fp2 = g2.GetFingerprint(m)
     self.assertEqual(fp1, fp2)
 
+  def testRDKitFPGeneratorAndFromAtoms(self):
+    m = Chem.MolFromSmiles('CCCO')
+    g = rdFingerprintGenerator.GetRDKitFPGenerator(numBitsPerFeature=1, minPath=2, maxPath=3)
+    fp = g.GetSparseCountFingerprint(m)
+    nz = fp.GetNonzeroElements()
+    self.assertEqual(len(nz), 3)
+    fp = g.GetSparseCountFingerprint(m, ignoreAtoms=[2])
+    nz = fp.GetNonzeroElements()
+    self.assertEqual(len(nz), 0)
 
 
 if __name__ == '__main__':

--- a/Code/GraphMol/Fingerprints/fpgen_catch_tests.cpp
+++ b/Code/GraphMol/Fingerprints/fpgen_catch_tests.cpp
@@ -531,3 +531,27 @@ TEST_CASE("atomsPerBit") {
     REQUIRE(apb[140][0] == std::vector<int>({2, 1, 0, 5}));
   }
 }
+
+TEST_CASE("RDKit fingerprinter and ignoreAtoms") {
+  auto mol = "CCO"_smiles;
+  REQUIRE(mol);
+  RDKitFP::RDKitFPArguments args;
+  args.d_numBitsPerFeature = 1;
+  auto fpg = RDKitFP::getRDKitFPGenerator<std::uint64_t>(args);
+  REQUIRE(fpg);
+  auto fp1 = fpg->getSparseFingerprint(*mol);
+  CHECK(fp1->getNumOnBits() == 3);
+  std::vector<std::uint32_t> ignoreAtoms = {2};
+  RDKit::FingerprintFuncArguments funcArgs;
+  funcArgs.ignoreAtoms = &ignoreAtoms;
+  auto fp2 = fpg->getSparseFingerprint(*mol, funcArgs);
+  CHECK(fp2->getNumOnBits() == 1);
+  std::vector<int> obl;
+  fp2->getOnBits(obl);
+  REQUIRE(obl.size() == 1);
+  CHECK((*fp1)[obl[0]] == 1);
+  // make sure we continue to ignore the atoms even if they are fromAtoms
+  funcArgs.fromAtoms = &ignoreAtoms;
+  auto fp3 = fpg->getSparseFingerprint(*mol, funcArgs);
+  CHECK(fp3->getNumOnBits() == 0);
+}

--- a/Code/GraphMol/Subgraphs/Subgraphs.cpp
+++ b/Code/GraphMol/Subgraphs/Subgraphs.cpp
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2003-2022 Greg Landrum and other RDKit contributors
+//  Copyright (C) 2003-2026 Greg Landrum and other RDKit contributors
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -126,7 +126,7 @@ void recurseWalkRange(
     unsigned int upperLen,  // the maximum subgraph len we are interested in
     boost::dynamic_bitset<> forbidden,  // bonds that have been covered already
     // we don't want reference passing for forbidden,
-    // it gets altered through the processand we want
+    // it gets altered through the process and we want
     // fresh start every time we buble back up to "FindAllSubGraphs"
     INT_PATH_LIST_MAP &res  // the final list of subgraphs
 ) {
@@ -177,8 +177,11 @@ void recurseWalkRange(
 
 PATH_LIST
 extendPaths(int *adjMat, unsigned int dim, const PATH_LIST &paths,
-            int allowRingClosures = -1, double *distMat = nullptr) {
+            int allowRingClosures, double *distMat,
+            boost::dynamic_bitset<> *ignoreAtoms) {
   PRECONDITION(adjMat, "no matrix");
+  PRECONDITION(!ignoreAtoms || ignoreAtoms->size() == dim,
+               "bad ignoreAtoms size");
   //
   //  extend each of the currently active paths by adding
   //   a single adjacent index to the end of each
@@ -189,6 +192,9 @@ extendPaths(int *adjMat, unsigned int dim, const PATH_LIST &paths,
     unsigned int endIdx = (*path)[path->size() - 1];
     unsigned int iTab = endIdx * dim;
     for (unsigned int otherIdx = 0; otherIdx < dim; otherIdx++) {
+      if (ignoreAtoms && ignoreAtoms->test(otherIdx)) {
+        continue;
+      }
       if (adjMat[iTab + otherIdx] == 1) {
         if (distMat &&
             distMat[path->front() * dim + otherIdx] - path->size() < -0.001) {
@@ -232,9 +238,12 @@ extendPaths(int *adjMat, unsigned int dim, const PATH_LIST &paths,
 
 INT_PATH_LIST_MAP
 pathFinderHelper(int *adjMat, unsigned int dim, unsigned int minLen,
-                 unsigned int maxLen, int rootedAtAtom, double *distMat) {
+                 unsigned int maxLen, int rootedAtAtom, double *distMat,
+                 boost::dynamic_bitset<> *ignoreAtoms) {
   PRECONDITION(adjMat, "no matrix");
   PRECONDITION(minLen <= maxLen, "bad lengths provided");
+  PRECONDITION(!ignoreAtoms || ignoreAtoms->size() == dim,
+               "bad ignoreAtoms size");
   // finds all paths of length N using an adjacency matrix,
   //  which is constructed elsewhere
   INT_PATH_LIST_MAP res;
@@ -244,11 +253,15 @@ pathFinderHelper(int *adjMat, unsigned int dim, unsigned int minLen,
   if (rootedAtAtom < 0) {
     // start a path at each possible index
     for (unsigned int i = 0; i < dim; i++) {
+      if (ignoreAtoms && ignoreAtoms->test(i)) {
+        continue;
+      }
       PATH_TYPE tPath;
       tPath.push_back(i);
       paths.push_back(tPath);
     }
-  } else if (rootedAtAtom < static_cast<int>(dim)) {
+  } else if (rootedAtAtom < static_cast<int>(dim) &&
+             (!ignoreAtoms || !ignoreAtoms->test(rootedAtAtom))) {
     // only start a path at the atom of interest:
     PATH_TYPE tPath;
     tPath.push_back(rootedAtAtom);
@@ -263,7 +276,7 @@ pathFinderHelper(int *adjMat, unsigned int dim, unsigned int minLen,
     if (length >= minLen) {
       res[length] = paths;
     }
-    paths = extendPaths(adjMat, dim, paths, maxLen, distMat);
+    paths = extendPaths(adjMat, dim, paths, maxLen, distMat, ignoreAtoms);
   }
   res[maxLen] = paths;
 
@@ -272,7 +285,8 @@ pathFinderHelper(int *adjMat, unsigned int dim, unsigned int minLen,
 }  // namespace Subgraphs
 
 PATH_LIST findAllSubgraphsOfLengthN(const ROMol &mol, unsigned int targetLen,
-                                    bool useHs, int rootedAtAtom) {
+                                    bool useHs, int rootedAtAtom,
+                                    boost::dynamic_bitset<> *ignoreAtoms) {
   /*********************************************
     FIX: Lots of issues here:
     - pathListType is defined as a container of "pathType", should it be a
@@ -286,7 +300,18 @@ PATH_LIST findAllSubgraphsOfLengthN(const ROMol &mol, unsigned int targetLen,
     it return a "list of paths" instead of a "list of list of paths" (see
     "GetPathsUpTolength" in "molgraphs.cpp")
   ****************************************************************************/
+  PRECONDITION(!ignoreAtoms || ignoreAtoms->size() == mol.getNumAtoms(),
+               "bad ignoreAtoms size");
   boost::dynamic_bitset<> forbidden(mol.getNumBonds());
+  // if there are any ignore atoms, mark any bonds involving them as forbidden
+  if (ignoreAtoms) {
+    for (const auto bond : mol.bonds()) {
+      if (ignoreAtoms->test(bond->getBeginAtomIdx()) ||
+          ignoreAtoms->test(bond->getEndAtomIdx())) {
+        forbidden[bond->getIdx()] = 1;
+      }
+    }
+  }
 
   // this should be the only dependence on mol object:
   INT_INT_VECT_MAP nbrs;
@@ -297,22 +322,21 @@ PATH_LIST findAllSubgraphsOfLengthN(const ROMol &mol, unsigned int targetLen,
 
   // start paths at each bond:
   for (auto nbi = nbrs.begin(); nbi != nbrs.end(); ++nbi) {
-    // don't come back to this bond in the later subgraphs
     int i = (*nbi).first;
+    if (forbidden[i]) {
+      continue;
+    }
+    auto bi = mol.getBondWithIdx(i);
 
     // if we're only returning paths rooted at a particular atom, check now
     // that this bond involves that atom:
     if (rootedAtAtom >= 0 &&
-        mol.getBondWithIdx(i)->getBeginAtomIdx() !=
-            static_cast<unsigned int>(rootedAtAtom) &&
-        mol.getBondWithIdx(i)->getEndAtomIdx() !=
-            static_cast<unsigned int>(rootedAtAtom)) {
+        bi->getBeginAtomIdx() != static_cast<unsigned int>(rootedAtAtom) &&
+        bi->getEndAtomIdx() != static_cast<unsigned int>(rootedAtAtom)) {
       continue;
     }
 
-    if (forbidden[i]) {
-      continue;
-    }
+    // don't come back to this bond in the later subgraphs
     forbidden[i] = 1;
 
     // start the recursive path building with the current bond
@@ -333,12 +357,20 @@ PATH_LIST findAllSubgraphsOfLengthN(const ROMol &mol, unsigned int targetLen,
   return res;
 }
 
-INT_PATH_LIST_MAP findAllSubgraphsOfLengthsMtoN(const ROMol &mol,
-                                                unsigned int lowerLen,
-                                                unsigned int upperLen,
-                                                bool useHs, int rootedAtAtom) {
+INT_PATH_LIST_MAP findAllSubgraphsOfLengthsMtoN(
+    const ROMol &mol, unsigned int lowerLen, unsigned int upperLen, bool useHs,
+    int rootedAtAtom, boost::dynamic_bitset<> *ignoreAtoms) {
   PRECONDITION(lowerLen <= upperLen, "");
   boost::dynamic_bitset<> forbidden(mol.getNumBonds());
+  // if there are any ignore atoms, mark any bonds involving them as forbidden
+  if (ignoreAtoms) {
+    for (const auto bond : mol.bonds()) {
+      if (ignoreAtoms->test(bond->getBeginAtomIdx()) ||
+          ignoreAtoms->test(bond->getEndAtomIdx())) {
+        forbidden[bond->getIdx()] = 1;
+      }
+    }
+  }
 
   INT_INT_VECT_MAP nbrs;
   Subgraphs::getNbrsList(mol, useHs, nbrs);
@@ -353,6 +385,9 @@ INT_PATH_LIST_MAP findAllSubgraphsOfLengthsMtoN(const ROMol &mol,
   // start paths at each bond:
   for (auto nbi = nbrs.begin(); nbi != nbrs.end(); nbi++) {
     int i = (*nbi).first;
+    if (forbidden[i]) {
+      continue;
+    }
 
     // if we're only returning paths rooted at a particular atom, check now
     // that this bond involves that atom:
@@ -365,9 +400,6 @@ INT_PATH_LIST_MAP findAllSubgraphsOfLengthsMtoN(const ROMol &mol,
     }
 
     // don't come back to this bond in the later subgraphs
-    if (forbidden[i]) {
-      continue;
-    }
     forbidden[i] = 1;
 
     // start the recursive path building with the current bond
@@ -390,11 +422,11 @@ INT_PATH_LIST_MAP findAllSubgraphsOfLengthsMtoN(const ROMol &mol,
 }
 
 PATH_LIST findUniqueSubgraphsOfLengthN(const ROMol &mol, unsigned int targetLen,
-                                       bool useHs, bool useBO,
-                                       int rootedAtAtom) {
+                                       bool useHs, bool useBO, int rootedAtAtom,
+                                       boost::dynamic_bitset<> *ignoreAtoms) {
   // start by finding all subgraphs, then uniquify
-  PATH_LIST allSubgraphs =
-      findAllSubgraphsOfLengthN(mol, targetLen, useHs, rootedAtAtom);
+  PATH_LIST allSubgraphs = findAllSubgraphsOfLengthN(mol, targetLen, useHs,
+                                                     rootedAtAtom, ignoreAtoms);
   PATH_LIST res = Subgraphs::uniquifyPaths(mol, allSubgraphs, useBO);
   return res;
 }
@@ -431,7 +463,8 @@ PATH_LIST findUniqueSubgraphsOfLengthN(const ROMol &mol, unsigned int targetLen,
 INT_PATH_LIST_MAP
 findAllPathsOfLengthsMtoN(const ROMol &mol, unsigned int lowerLen,
                           unsigned int upperLen, bool useBonds, bool useHs,
-                          int rootedAtAtom, bool onlyShortestPaths) {
+                          int rootedAtAtom, bool onlyShortestPaths,
+                          boost::dynamic_bitset<> *ignoreAtoms) {
   //
   //  We can't be clever here and just use the bond adjacency matrix
   //  to solve this problem when useBonds is true.  This is because
@@ -482,7 +515,7 @@ findAllPathsOfLengthsMtoN(const ROMol &mol, unsigned int lowerLen,
 
   // find the paths themselves
   INT_PATH_LIST_MAP atomPaths = Subgraphs::pathFinderHelper(
-      adjMat, dim, lowerLen, upperLen, rootedAtAtom, distMat);
+      adjMat, dim, lowerLen, upperLen, rootedAtAtom, distMat, ignoreAtoms);
 
   // clean up the adjacency matrix
   delete[] adjMat;
@@ -537,9 +570,11 @@ findAllPathsOfLengthsMtoN(const ROMol &mol, unsigned int lowerLen,
 }
 PATH_LIST
 findAllPathsOfLengthN(const ROMol &mol, unsigned int targetLen, bool useBonds,
-                      bool useHs, int rootedAtAtom, bool onlyShortestPaths) {
+                      bool useHs, int rootedAtAtom, bool onlyShortestPaths,
+                      boost::dynamic_bitset<> *ignoreAtoms) {
   return findAllPathsOfLengthsMtoN(mol, targetLen, targetLen, useBonds, useHs,
-                                   rootedAtAtom, onlyShortestPaths)[targetLen];
+                                   rootedAtAtom, onlyShortestPaths,
+                                   ignoreAtoms)[targetLen];
 }
 
 PATH_TYPE findAtomEnvironmentOfRadiusN(

--- a/Code/GraphMol/Subgraphs/Subgraphs.cpp
+++ b/Code/GraphMol/Subgraphs/Subgraphs.cpp
@@ -361,6 +361,8 @@ INT_PATH_LIST_MAP findAllSubgraphsOfLengthsMtoN(
     const ROMol &mol, unsigned int lowerLen, unsigned int upperLen, bool useHs,
     int rootedAtAtom, boost::dynamic_bitset<> *ignoreAtoms) {
   PRECONDITION(lowerLen <= upperLen, "");
+  PRECONDITION(!ignoreAtoms || ignoreAtoms->size() == mol.getNumAtoms(),
+               "bad ignoreAtoms size");
   boost::dynamic_bitset<> forbidden(mol.getNumBonds());
   // if there are any ignore atoms, mark any bonds involving them as forbidden
   if (ignoreAtoms) {

--- a/Code/GraphMol/Subgraphs/Subgraphs.h
+++ b/Code/GraphMol/Subgraphs/Subgraphs.h
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2003-2022 Greg Landrum and other RDKit contributors
+//  Copyright (C) 2003-2026 Greg Landrum and other RDKit contributors
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -33,6 +33,7 @@
 #include <list>
 #include <map>
 #include <unordered_map>
+#include <boost/dynamic_bitset.hpp>
 
 namespace RDKit {
 class ROMol;
@@ -62,13 +63,16 @@ typedef INT_PATH_LIST_MAP::iterator INT_PATH_LIST_MAP_I;
  *                      Hs to the graph.
  *   \param rootedAtAtom - if non-negative, only subgraphs that start at
  *                         this atom will be returned.
+ *   \param ignoreAtoms - if provided, any subgraph that contains any of
+ *                        the atoms in this set will be ignored
  *
  *   The result is a map from subgraph size -> list of paths
  *               (i.e. list of list of bond indices)
  */
 RDKIT_SUBGRAPHS_EXPORT INT_PATH_LIST_MAP findAllSubgraphsOfLengthsMtoN(
     const ROMol &mol, unsigned int lowerLen, unsigned int upperLen,
-    bool useHs = false, int rootedAtAtom = -1);
+    bool useHs = false, int rootedAtAtom = -1,
+    boost::dynamic_bitset<> *ignoreAtoms = nullptr);
 
 //! \brief find all bond subgraphs of a particular size
 /*!
@@ -79,13 +83,15 @@ RDKIT_SUBGRAPHS_EXPORT INT_PATH_LIST_MAP findAllSubgraphsOfLengthsMtoN(
  *                      Hs to the graph.
  *   \param rootedAtAtom - if non-negative, only subgraphs that start at
  *                         this atom will be returned.
+ *   \param ignoreAtoms - if provided, any subgraph that contains any of
+ *                        the atoms in this set will be ignored
  *
  *
  *   The result is a list of paths (i.e. list of list of bond indices)
  */
-RDKIT_SUBGRAPHS_EXPORT PATH_LIST
-findAllSubgraphsOfLengthN(const ROMol &mol, unsigned int targetLen,
-                          bool useHs = false, int rootedAtAtom = -1);
+RDKIT_SUBGRAPHS_EXPORT PATH_LIST findAllSubgraphsOfLengthN(
+    const ROMol &mol, unsigned int targetLen, bool useHs = false,
+    int rootedAtAtom = -1, boost::dynamic_bitset<> *ignoreAtoms = nullptr);
 
 //! \brief find unique bond subgraphs of a particular size
 /*!
@@ -97,13 +103,15 @@ findAllSubgraphsOfLengthN(const ROMol &mol, unsigned int targetLen,
  *   \param useBO     - if set, bond orders will be considered when uniquifying
  *                      the paths
  *   \param rootedAtAtom - if non-negative, only subgraphs that start at
- *                         this atom will be returned.
+ *   \param ignoreAtoms - if provided, any subgraph that contains any of
+ *                        the atoms in this set will be ignored
  *
  *   The result is a list of paths (i.e. list of list of bond indices)
  */
 RDKIT_SUBGRAPHS_EXPORT PATH_LIST findUniqueSubgraphsOfLengthN(
     const ROMol &mol, unsigned int targetLen, bool useHs = false,
-    bool useBO = true, int rootedAtAtom = -1);
+    bool useBO = true, int rootedAtAtom = -1,
+    boost::dynamic_bitset<> *ignoreAtoms = nullptr);
 //! \brief find all paths of a particular size
 /*!
  *   \param mol - the molecule to be considered
@@ -118,16 +126,20 @@ RDKIT_SUBGRAPHS_EXPORT PATH_LIST findUniqueSubgraphsOfLengthN(
  *   \param onlyShortestPaths - if set then only paths which are <= the shortest
  *                              path between the begin and end atoms will be
  *                              included in the results
+ *   \param ignoreAtoms - if provided, any subgraph that contains any of
+ *                        the atoms in this set will be ignored
  *
  *   The result is a list of paths (i.e. list of list of bond indices)
  */
 RDKIT_SUBGRAPHS_EXPORT PATH_LIST findAllPathsOfLengthN(
     const ROMol &mol, unsigned int targetLen, bool useBonds = true,
-    bool useHs = false, int rootedAtAtom = -1, bool onlyShortestPaths = false);
+    bool useHs = false, int rootedAtAtom = -1, bool onlyShortestPaths = false,
+    boost::dynamic_bitset<> *ignoreAtoms = nullptr);
 RDKIT_SUBGRAPHS_EXPORT INT_PATH_LIST_MAP findAllPathsOfLengthsMtoN(
     const ROMol &mol, unsigned int lowerLen, unsigned int upperLen,
     bool useBonds = true, bool useHs = false, int rootedAtAtom = -1,
-    bool onlyShortestPaths = false);
+    bool onlyShortestPaths = false,
+    boost::dynamic_bitset<> *ignoreAtoms = nullptr);
 
 //! \brief Find bond subgraphs of a particular radius around an atom.
 //!        Return empty result if there is no bond at the requested radius.

--- a/Code/GraphMol/Subgraphs/catch_tests.cpp
+++ b/Code/GraphMol/Subgraphs/catch_tests.cpp
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2023 Greg Landrum
+//  Copyright (C) 2023-2026 Greg Landrum
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -56,5 +56,97 @@ TEST_CASE("shortestPathsOnly") {
                                    onlyShortestPaths);
     CHECK(ps.size() == 1);
     CHECK(ps[3].size() == 2);
+  }
+}
+
+TEST_CASE("ignoreAtoms") {
+  auto m = "CCCO"_smiles;
+  REQUIRE(m);
+  SECTION("findAllPathsOfLengthN") {
+    bool useBonds = true;
+    bool useHs = false;
+    int rootedAt = -1;
+    bool onlyShortestPaths = true;
+
+    auto ps = findAllPathsOfLengthN(*m, 3, useBonds, useHs, rootedAt,
+                                    onlyShortestPaths);
+    CHECK(ps.size() == 1);
+
+    // check that ignoreAtoms works:
+    boost::dynamic_bitset<> ignoreAtoms(m->getNumAtoms());
+    ignoreAtoms[0] = 1;
+    auto ps2 = findAllPathsOfLengthN(*m, 3, useBonds, useHs, rootedAt,
+                                     onlyShortestPaths, &ignoreAtoms);
+    CHECK(ps2.empty());
+
+    // make sure we ignore it even if we are rooted there.
+    rootedAt = 1;
+    auto ps3 = findAllPathsOfLengthN(*m, 3, useBonds, useHs, rootedAt,
+                                     onlyShortestPaths, &ignoreAtoms);
+    CHECK(ps3.empty());
+  }
+  SECTION("findAllPathsOfLengthsMtoN") {
+    bool useBonds = true;
+    bool useHs = false;
+    int rootedAt = -1;
+    bool onlyShortestPaths = true;
+
+    auto ps = findAllPathsOfLengthsMtoN(*m, 3, 3, useBonds, useHs, rootedAt,
+                                        onlyShortestPaths);
+    CHECK(ps.size() == 1);
+
+    // check that ignoreAtoms works:
+    boost::dynamic_bitset<> ignoreAtoms(m->getNumAtoms());
+    ignoreAtoms[0] = 1;
+    auto ps2 = findAllPathsOfLengthsMtoN(*m, 3, 3, useBonds, useHs, rootedAt,
+                                         onlyShortestPaths, &ignoreAtoms);
+    CHECK(ps2.empty());
+
+    // make sure we ignore it even if we are rooted there.
+    rootedAt = 1;
+    auto ps3 = findAllPathsOfLengthsMtoN(*m, 3, 3, useBonds, useHs, rootedAt,
+                                         onlyShortestPaths, &ignoreAtoms);
+    CHECK(ps3.empty());
+  }
+  SECTION("findAllSubgraphsOfLengthN") {
+    bool useHs = false;
+    int rootedAt = -1;
+
+    auto ps = findAllSubgraphsOfLengthN(*m, 3, useHs, rootedAt);
+    CHECK(ps.size() == 1);
+
+    // check that ignoreAtoms works:
+    boost::dynamic_bitset<> ignoreAtoms(m->getNumAtoms());
+    ignoreAtoms[0] = 1;
+    auto ps2 = findAllSubgraphsOfLengthN(*m, 3, useHs, rootedAt, &ignoreAtoms);
+    CHECK(ps2.empty());
+
+    // make sure we ignore it even if we are rooted there.
+    rootedAt = 1;
+    auto ps3 = findAllSubgraphsOfLengthN(*m, 3, useHs, rootedAt, &ignoreAtoms);
+    CHECK(ps3.empty());
+  }
+  SECTION("findAllSubgraphsOfLengthsMtoN") {
+    bool useHs = false;
+    int rootedAt = -1;
+
+    auto ps = findAllSubgraphsOfLengthsMtoN(*m, 3, 3, useHs, rootedAt);
+    CHECK(ps.size() == 1);
+    CHECK(ps[3].size() == 1);
+
+    // check that ignoreAtoms works:
+    boost::dynamic_bitset<> ignoreAtoms(m->getNumAtoms());
+    ignoreAtoms[0] = 1;
+    auto ps2 =
+        findAllSubgraphsOfLengthsMtoN(*m, 3, 3, useHs, rootedAt, &ignoreAtoms);
+    CHECK(ps2.size() == 1);
+    CHECK(ps2[3].empty());
+
+    // make sure we ignore it even if we are rooted there.
+    rootedAt = 1;
+    auto ps3 =
+        findAllSubgraphsOfLengthsMtoN(*m, 3, 3, useHs, rootedAt, &ignoreAtoms);
+    CHECK(ps3.size() == 1);
+    CHECK(ps3[3].empty());
   }
 }

--- a/Code/GraphMol/Wrap/MolOps.cpp
+++ b/Code/GraphMol/Wrap/MolOps.cpp
@@ -821,6 +821,24 @@ SparseIntVect<boost::uint64_t> *wrapUnfoldedRDKFingerprintMol(
 
   return res;
 }
+PATH_LIST findUniqueSubgraphsOfLengthNHelper(const ROMol &mol,
+                                             unsigned int length, bool useHs,
+                                             bool useBO, int rootedAtAtom) {
+  return findUniqueSubgraphsOfLengthN(mol, length, useHs, useBO, rootedAtAtom);
+}
+
+PATH_LIST findAllSubgraphsOfLengthNHelper(const ROMol &mol, unsigned int length,
+                                          bool useHs, int rootedAtAtom) {
+  return findAllSubgraphsOfLengthN(mol, length, useHs, rootedAtAtom);
+}
+
+PATH_LIST findAllPathsOfLengthNHelper(const ROMol &mol, unsigned int length,
+                                      bool useBonds, bool useHs,
+                                      int rootedAtAtom,
+                                      bool onlyShortestPaths) {
+  return findAllPathsOfLengthN(mol, length, useBonds, useHs, rootedAtAtom,
+                               onlyShortestPaths);
+}
 
 python::object findAllSubgraphsOfLengthsMtoNHelper(const ROMol &mol,
                                                    unsigned int lowerLen,
@@ -2092,7 +2110,7 @@ RETURNS:
   but only 2 _paths_ of length 3: (0,1,3),(2,1,3)\n\
 \n";
     python::def(
-        "FindAllSubgraphsOfLengthN", &findAllSubgraphsOfLengthN,
+        "FindAllSubgraphsOfLengthN", &findAllSubgraphsOfLengthNHelper,
         (python::arg("mol"), python::arg("length"),
          python::arg("useHs") = false, python::arg("rootedAtAtom") = -1),
         docString.c_str());
@@ -2130,7 +2148,8 @@ RETURNS:
   RETURNS: a tuple of tuples with bond IDs\n\
 \n\
 \n";
-    python::def("FindUniqueSubgraphsOfLengthN", &findUniqueSubgraphsOfLengthN,
+    python::def("FindUniqueSubgraphsOfLengthN",
+                &findUniqueSubgraphsOfLengthNHelper,
                 (python::arg("mol"), python::arg("length"),
                  python::arg("useHs") = false, python::arg("useBO") = true,
                  python::arg("rootedAtAtom") = -1),
@@ -2175,7 +2194,7 @@ RETURNS:
        has 3 _subgraphs_ of length 3: (0,1,2),(0,1,3),(2,1,3)\n\
        but only 2 _paths_ of length 3: (0,1,3),(2,1,3)\n\
 \n";
-    python::def("FindAllPathsOfLengthN", &findAllPathsOfLengthN,
+    python::def("FindAllPathsOfLengthN", &findAllPathsOfLengthNHelper,
                 (python::arg("mol"), python::arg("length"),
                  python::arg("useBonds") = true, python::arg("useHs") = false,
                  python::arg("rootedAtAtom") = -1,


### PR DESCRIPTION
The missing support was pointed out by @rkanters in #9426 

The fix is relatively straightforward.