### PR TITLE
Refactor multithread suppliers

### DIFF
--- a/Code/GraphMol/FileParsers/MultithreadedMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/MultithreadedMolSupplier.cpp
@@ -137,18 +137,21 @@ void MultithreadedMolSupplier::writer() {
     }
   }
 
-  // we need a lock here otherwise two threads
-  //  can increment d_threadCounter even though it's
-  //  atomic.
+  // Protect the shared writer-thread counter.
+  // Note that d_threadEndCounter starts at 1, so that the last thread
+  // to finish will set the output queue to done.
+  // We can't use d_writerThreads.size() here because for the case
+  // of many threads and a small number of records, some threads may
+  // finish before others have started.
   d_threadCounterMutex.lock();
-  if (d_threadCounter < d_params.numWriterThreads) {
-    ++d_threadCounter;
+  if (d_threadEndCounter < d_params.numWriterThreads) {
+    ++d_threadEndCounter;
     d_threadCounterMutex.unlock();
   } else {
     // Here we need to unlock the threadCounterMutex before we setDone on the
-    //  outputQueue.  This causes a notification to the queue which may actually
-    //  have elements in it.  This notification may unblock the queue which
-    //  allows waiting threads to get their last attempt at adding to it
+    //  outputQueue.  This causes a notification to the queue which may
+    //  actually have elements in it.  This notification may unblock the queue
+    //  which allows waiting threads to get their last attempt at adding to it
     //  which will end up here and deadlock.
     d_threadCounterMutex.unlock();
     d_outputQueue->setDone();

--- a/Code/GraphMol/FileParsers/MultithreadedMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/MultithreadedMolSupplier.cpp
@@ -79,6 +79,15 @@ void MultithreadedMolSupplier::close() {
   df_started = false;
 }
 
+void MultithreadedMolSupplier::closeStreams() {
+  if (df_owner && dp_inStream) {
+    delete dp_inStream;
+    df_owner = false;
+    dp_inStream = nullptr;
+  }
+  df_started = false;
+}
+
 void MultithreadedMolSupplier::reader() {
   std::string record;
   unsigned int lineNum, index;
@@ -177,9 +186,9 @@ void MultithreadedMolSupplier::endThreads() {
 }
 
 void MultithreadedMolSupplier::startThreads() {
-  // run the reader function in a seperate thread
+  // run the reader function in a separate thread
   d_readerThread = std::thread(&MultithreadedMolSupplier::reader, this);
-  // run the writer function in seperate threads
+  // run the writer function in separate threads
   for (unsigned int i = 0; i < d_params.numWriterThreads; i++) {
     d_writerThreads.emplace_back(
         std::thread(&MultithreadedMolSupplier::writer, this));

--- a/Code/GraphMol/FileParsers/MultithreadedMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/MultithreadedMolSupplier.cpp
@@ -22,12 +22,8 @@ void MultithreadedMolSupplier::initFromSettings(bool takeOwnership,
   df_owner = takeOwnership;
   d_params = params;
   d_params.numWriterThreads = getNumThreadsToUse(params.numWriterThreads);
-  d_inputQueue.reset(
-      new ConcurrentQueue<std::tuple<std::string, unsigned int, unsigned int>>(
-          d_params.sizeInputQueue));
-  d_outputQueue.reset(
-      new ConcurrentQueue<std::tuple<RWMol *, std::string, unsigned int>>(
-          d_params.sizeOutputQueue));
+  d_inputQueue.reset(new inputQueue_t(d_params.sizeInputQueue));
+  d_outputQueue.reset(new outputQueue_t(d_params.sizeOutputQueue));
 }
 
 void MultithreadedMolSupplier::close() {

--- a/Code/GraphMol/FileParsers/MultithreadedMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/MultithreadedMolSupplier.cpp
@@ -12,6 +12,9 @@
 
 #include <RDGeneral/RDLog.h>
 
+#include <exception>
+#include <ostream>
+
 namespace RDKit {
 
 namespace v2 {

--- a/Code/GraphMol/FileParsers/MultithreadedMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/MultithreadedMolSupplier.cpp
@@ -121,8 +121,7 @@ void MultithreadedMolSupplier::writer() {
   std::tuple<std::string, unsigned int, unsigned int> r;
   while (!df_forceStop && d_inputQueue->pop(r)) {
     try {
-      std::unique_ptr<RWMol> mol(
-          processMoleculeRecord(std::get<0>(r), std::get<1>(r)));
+      auto mol = processMoleculeRecord(std::get<0>(r), std::get<1>(r));
       if (!df_forceStop && mol && writeCallback) {
         writeCallback(*mol, std::get<0>(r), std::get<2>(r));
       }

--- a/Code/GraphMol/FileParsers/MultithreadedMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/MultithreadedMolSupplier.cpp
@@ -17,6 +17,19 @@ namespace RDKit {
 namespace v2 {
 namespace FileParsers {
 
+void MultithreadedMolSupplier::initFromSettings(bool takeOwnership,
+                                                const Parameters &params) {
+  df_owner = takeOwnership;
+  d_params = params;
+  d_params.numWriterThreads = getNumThreadsToUse(params.numWriterThreads);
+  d_inputQueue.reset(
+      new ConcurrentQueue<std::tuple<std::string, unsigned int, unsigned int>>(
+          d_params.sizeInputQueue));
+  d_outputQueue.reset(
+      new ConcurrentQueue<std::tuple<RWMol *, std::string, unsigned int>>(
+          d_params.sizeOutputQueue));
+}
+
 void MultithreadedMolSupplier::close() {
   df_forceStop = true;
 

--- a/Code/GraphMol/FileParsers/MultithreadedMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/MultithreadedMolSupplier.cpp
@@ -19,21 +19,32 @@ namespace FileParsers {
 
 void MultithreadedMolSupplier::close() {
   df_forceStop = true;
-  d_outputQueue->setDone();
+
+  // close() is called from the destructor, and will be
+  // triggered if an exception is thrown. If this happens,
+  // the queues might not be initialized, so make sure
+  // they are initialized before dereferencing them.
+  if (d_outputQueue) {
+    d_outputQueue->setDone();
+  }
 
   if (df_started) {
-    // Clear the queues until they are empty
-    //  d_inputQueue->clear is not thread-safe
-    std::tuple<std::string, unsigned int, unsigned int> r;
-    while (d_inputQueue->pop(r)) {
+    if (d_inputQueue) {
+      // Clear the queues until they are empty
+      //  d_inputQueue->clear is not thread-safe
+      std::tuple<std::string, unsigned int, unsigned int> r;
+      while (d_inputQueue->pop(r)) {
+      }
     }
     // clear the output queues, they might be full
     //  and blocking the writer threads, note
     //  that while ending threads the writers may
     //  put a few more items back in the queue
-    std::tuple<RWMol *, std::string, unsigned int> mol_r;
-    while (d_outputQueue->pop(mol_r)) {
-      delete std::get<0>(mol_r);
+    if (d_outputQueue) {
+      std::tuple<RWMol *, std::string, unsigned int> mol_r;
+      while (d_outputQueue->pop(mol_r)) {
+        delete std::get<0>(mol_r);
+      }
     }
   }
 
@@ -41,12 +52,14 @@ void MultithreadedMolSupplier::close() {
 
   // notify the queue again that it is done in case
   //  anyone is waiting on it
-  d_outputQueue->setDone();
+  if (d_outputQueue) {
+    d_outputQueue->setDone();
+  }
 
   // destroy all objects in the input and output queues
   //  and anything missed put in the queues while
   //  the threads were endings
-  if (df_started) {
+  if (d_inputQueue) {
     d_inputQueue->clear();
   }
 

--- a/Code/GraphMol/FileParsers/MultithreadedMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/MultithreadedMolSupplier.cpp
@@ -94,9 +94,9 @@ void MultithreadedMolSupplier::close() {
 void MultithreadedMolSupplier::closeStreams() {
   if (df_owner && dp_inStream) {
     delete dp_inStream;
-    df_owner = false;
-    dp_inStream = nullptr;
   }
+  df_owner = false;
+  dp_inStream = nullptr;
   df_started = false;
 }
 

--- a/Code/GraphMol/FileParsers/MultithreadedMolSupplier.h
+++ b/Code/GraphMol/FileParsers/MultithreadedMolSupplier.h
@@ -115,8 +115,6 @@ class RDKIT_FILEPARSERS_EXPORT MultithreadedMolSupplier : public MolSupplier {
   void reset() final;
 
  protected:
-  virtual bool getEnd() const = 0;
-
   void initFromSettings(bool takeOwnership, const Parameters &params);
 
   //! extracts next record from the input file or stream
@@ -129,6 +127,9 @@ class RDKIT_FILEPARSERS_EXPORT MultithreadedMolSupplier : public MolSupplier {
 
   //!< stores last extracted record id
   std::atomic<unsigned int> d_lastRecordId = 0;
+
+  int d_line = 0;                      //!< line number we are currently on
+  unsigned int d_currentRecordId = 1;  //!< current record id
 
   //!< concurrent input queue
   std::unique_ptr<inputQueue_t> d_inputQueue;

--- a/Code/GraphMol/FileParsers/MultithreadedMolSupplier.h
+++ b/Code/GraphMol/FileParsers/MultithreadedMolSupplier.h
@@ -113,6 +113,8 @@ class RDKIT_FILEPARSERS_EXPORT MultithreadedMolSupplier : public MolSupplier {
  protected:
   virtual bool getEnd() const = 0;
 
+  void initFromSettings(bool takeOwnership, const Parameters &params);
+
   //! extracts next record from the input file or stream
   virtual bool extractNextRecord(std::string &record, unsigned int &lineNum,
                                  unsigned int &index) = 0;

--- a/Code/GraphMol/FileParsers/MultithreadedMolSupplier.h
+++ b/Code/GraphMol/FileParsers/MultithreadedMolSupplier.h
@@ -68,8 +68,9 @@ class RDKIT_FILEPARSERS_EXPORT MultithreadedMolSupplier : public MolSupplier {
   //! returns true when all records have been read from the supplier
   bool atEnd() final;
 
-  //! included for the interface, always returns false
-  bool getEOFHitOnRead() const { return false; }
+  //! included for the interface. Python wrappers check this
+  //! each time next() is called.  It is not used in the C++ code.
+  virtual bool getEOFHitOnRead() const = 0;
 
   //! returns the record id of the last extracted item
   //! Note: d_LastRecordId = 0, initially therefore the value 0 is returned

--- a/Code/GraphMol/FileParsers/MultithreadedMolSupplier.h
+++ b/Code/GraphMol/FileParsers/MultithreadedMolSupplier.h
@@ -35,6 +35,18 @@ class RDKIT_FILEPARSERS_EXPORT MultithreadedMolSupplier : public MolSupplier {
   //! this is an abstract base class to concurrently supply molecules one at a
   //! time
  public:
+  using readCallBackFn_t =
+      std::function<std::string(const std::string &, unsigned int)>;
+  using nextCallBackFn_t =
+      std::function<void(RWMol &, const MultithreadedMolSupplier &)>;
+  using writeCallBackFn_t =
+      std::function<void(RWMol &, const std::string &, unsigned int)>;
+
+  using inputQueue_t =
+      ConcurrentQueue<std::tuple<std::string, unsigned int, unsigned int>>;
+  using outputQueue_t =
+      ConcurrentQueue<std::tuple<RWMol *, std::string, unsigned int>>;
+
   struct Parameters {
     unsigned int numWriterThreads = 1;
     size_t sizeInputQueue = 5;
@@ -76,10 +88,7 @@ class RDKIT_FILEPARSERS_EXPORT MultithreadedMolSupplier : public MolSupplier {
     place
 
    */
-  template <typename T>
-  void setNextCallback(T cb) {
-    nextCallback = cb;
-  }
+  void setNextCallback(nextCallBackFn_t cb) { nextCallback = cb; }
 
   //! sets the callback to be applied to molecules after they are processed, but
   ///! before they are written to the output queue
@@ -88,10 +97,7 @@ class RDKIT_FILEPARSERS_EXPORT MultithreadedMolSupplier : public MolSupplier {
     to the string record, and an unsigned int record id. This can modify the
     molecule in place
   */
-  template <typename T>
-  void setWriteCallback(T cb) {
-    writeCallback = cb;
-  }
+  void setWriteCallback(writeCallBackFn_t cb) { writeCallback = cb; }
 
   //! sets the callback to be applied to input text records before they are
   ///! added to the input queue
@@ -99,10 +105,7 @@ class RDKIT_FILEPARSERS_EXPORT MultithreadedMolSupplier : public MolSupplier {
     \param cb: a function that takes a const reference to the string record and
     an unsigned int record id and returns the modified string record
   */
-  template <typename T>
-  void setReadCallback(T cb) {
-    readCallback = cb;
-  }
+  void setReadCallback(readCallBackFn_t cb) { readCallback = cb; }
 
   //! not yet implemented
   void init() final{};
@@ -126,13 +129,11 @@ class RDKIT_FILEPARSERS_EXPORT MultithreadedMolSupplier : public MolSupplier {
   //!< stores last extracted record id
   std::atomic<unsigned int> d_lastRecordId = 0;
 
-  std::unique_ptr<
-      ConcurrentQueue<std::tuple<std::string, unsigned int, unsigned int>>>
-      d_inputQueue;  //!< concurrent input queue
+  //!< concurrent input queue
+  std::unique_ptr<inputQueue_t> d_inputQueue;
 
-  std::unique_ptr<
-      ConcurrentQueue<std::tuple<RWMol *, std::string, unsigned int>>>
-      d_outputQueue;  //!< concurrent output queue
+  //!< concurrent output queue
+  std::unique_ptr<outputQueue_t> d_outputQueue;
 
   Parameters d_params;
 
@@ -172,12 +173,9 @@ class RDKIT_FILEPARSERS_EXPORT MultithreadedMolSupplier : public MolSupplier {
 
   std::string d_lastItemText;  //!< stores last extracted record
 
-  std::function<void(RWMol &, const MultithreadedMolSupplier &)> nextCallback =
-      nullptr;
-  std::function<void(RWMol &, const std::string &, unsigned int)>
-      writeCallback = nullptr;
-  std::function<std::string(const std::string &, unsigned int)> readCallback =
-      nullptr;
+  readCallBackFn_t readCallback = nullptr;
+  nextCallBackFn_t nextCallback = nullptr;
+  writeCallBackFn_t writeCallback = nullptr;
 };
 }  // namespace FileParsers
 }  // namespace v2

--- a/Code/GraphMol/FileParsers/MultithreadedMolSupplier.h
+++ b/Code/GraphMol/FileParsers/MultithreadedMolSupplier.h
@@ -19,14 +19,18 @@
 #include <RDGeneral/RDThreads.h>
 #include <RDGeneral/StreamOps.h>
 
-#include <functional>
-#include <atomic>
-#include <boost/tokenizer.hpp>
-
 #include "FileParsers.h"
 #include "MolSupplier.h"
 
-typedef boost::tokenizer<boost::char_separator<char>> tokenizer;
+#include <atomic>
+#include <cstddef>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <tuple>
+#include <vector>
 
 namespace RDKit {
 namespace v2 {

--- a/Code/GraphMol/FileParsers/MultithreadedMolSupplier.h
+++ b/Code/GraphMol/FileParsers/MultithreadedMolSupplier.h
@@ -123,8 +123,8 @@ class RDKIT_FILEPARSERS_EXPORT MultithreadedMolSupplier : public MolSupplier {
                                  unsigned int &index) = 0;
 
   //! processes the record into an RWMol object
-  virtual RWMol *processMoleculeRecord(const std::string &record,
-                                       unsigned int lineNum) = 0;
+  virtual std::unique_ptr<RWMol> processMoleculeRecord(
+      const std::string &record, unsigned int lineNum) = 0;
 
   //!< stores last extracted record id
   std::atomic<unsigned int> d_lastRecordId = 0;

--- a/Code/GraphMol/FileParsers/MultithreadedMolSupplier.h
+++ b/Code/GraphMol/FileParsers/MultithreadedMolSupplier.h
@@ -164,38 +164,6 @@ class RDKIT_FILEPARSERS_EXPORT MultithreadedMolSupplier : public MolSupplier {
 };
 }  // namespace FileParsers
 }  // namespace v2
-
-inline namespace v1 {
-class RDKIT_FILEPARSERS_EXPORT MultithreadedMolSupplier : public MolSupplier {
-  //! this is an abstract base class to concurrently supply molecules one at a
-  //! time
- public:
-  using ContainedType = v2::FileParsers::MultithreadedMolSupplier;
-  MultithreadedMolSupplier() {}
-
-  //! included for the interface, always returns false
-  bool getEOFHitOnRead() const {
-    if (dp_supplier) {
-      return static_cast<ContainedType *>(dp_supplier.get())->getEOFHitOnRead();
-    }
-    return false;
-  }
-
-  //! returns the record id of the last extracted item
-  //! Note: d_LastRecordId = 0, initially therefore the value 0 is returned
-  //! if and only if the function is called before extracting the first
-  //! record
-  unsigned int getLastRecordId() const {
-    PRECONDITION(dp_supplier, "no supplier");
-    return static_cast<ContainedType *>(dp_supplier.get())->getLastRecordId();
-  }
-  //! returns the text block for the last extracted item
-  std::string getLastItemText() const {
-    PRECONDITION(dp_supplier, "no supplier");
-    return static_cast<ContainedType *>(dp_supplier.get())->getLastItemText();
-  }
-};
-}  // namespace v1
 }  // namespace RDKit
 #endif
 #endif

--- a/Code/GraphMol/FileParsers/MultithreadedMolSupplier.h
+++ b/Code/GraphMol/FileParsers/MultithreadedMolSupplier.h
@@ -43,18 +43,18 @@ class RDKIT_FILEPARSERS_EXPORT MultithreadedMolSupplier : public MolSupplier {
 
   MultithreadedMolSupplier() {}
 
-  
   // Derived classes MUST have a destructor that calls close
   //  to properly end threads while the instance is alive
-  virtual ~MultithreadedMolSupplier() {close();}
+  ~MultithreadedMolSupplier() override { close(); }
 
   //! shut down the supplier
-  virtual void close() override;
+  void close() final;
+
   //! pop elements from the output queue
-  std::unique_ptr<RWMol> next() override;
+  std::unique_ptr<RWMol> next() final;
 
   //! returns true when all records have been read from the supplier
-  bool atEnd() override;
+  bool atEnd() final;
 
   //! included for the interface, always returns false
   bool getEOFHitOnRead() const { return false; }
@@ -64,6 +64,7 @@ class RDKIT_FILEPARSERS_EXPORT MultithreadedMolSupplier : public MolSupplier {
   //! if and only if the function is called before extracting the first
   //! record
   unsigned int getLastRecordId() const;
+
   //! returns the text block for the last extracted item
   std::string getLastItemText() const;
 
@@ -79,6 +80,7 @@ class RDKIT_FILEPARSERS_EXPORT MultithreadedMolSupplier : public MolSupplier {
   void setNextCallback(T cb) {
     nextCallback = cb;
   }
+
   //! sets the callback to be applied to molecules after they are processed, but
   ///! before they are written to the output queue
   /*!
@@ -90,6 +92,7 @@ class RDKIT_FILEPARSERS_EXPORT MultithreadedMolSupplier : public MolSupplier {
   void setWriteCallback(T cb) {
     writeCallback = cb;
   }
+
   //! sets the callback to be applied to input text records before they are
   ///! added to the input queue
   /*!
@@ -101,66 +104,78 @@ class RDKIT_FILEPARSERS_EXPORT MultithreadedMolSupplier : public MolSupplier {
     readCallback = cb;
   }
 
+  //! not yet implemented
+  void init() final{};
+
+  //! not yet implemented
+  void reset() final;
+
  protected:
+  virtual bool getEnd() const = 0;
+
+  //! extracts next record from the input file or stream
+  virtual bool extractNextRecord(std::string &record, unsigned int &lineNum,
+                                 unsigned int &index) = 0;
+
+  //! processes the record into an RWMol object
+  virtual RWMol *processMoleculeRecord(const std::string &record,
+                                       unsigned int lineNum) = 0;
+
+  //!< stores last extracted record id
+  std::atomic<unsigned int> d_lastRecordId = 0;
+
+  std::unique_ptr<
+      ConcurrentQueue<std::tuple<std::string, unsigned int, unsigned int>>>
+      d_inputQueue;  //!< concurrent input queue
+
+  std::unique_ptr<
+      ConcurrentQueue<std::tuple<RWMol *, std::string, unsigned int>>>
+      d_outputQueue;  //!< concurrent output queue
+
+  Parameters d_params;
+
+ private:
   //! Close down any external streams
-  virtual void closeStreams() {}
+  void closeStreams();
 
   //! starts reader and writer threads
   void startThreads();
+
   //! finalizes the reader and writer threads
   void endThreads();
 
- private:
   //! reads lines from input stream to populate the input queue
   void reader();
+
   //! parses lines from the input queue converting them to RWMol objects
   //! populating the output queue
   void writer();
+
   //! disable automatic copy constructors and assignment operators
   //! for this class and its subclasses.  They will likely be
   //! carrying around stream pointers and copying those is a recipe
   //! for disaster.
-  MultithreadedMolSupplier(const MultithreadedMolSupplier &);
-  MultithreadedMolSupplier &operator=(const MultithreadedMolSupplier &);
-  //! not yet implemented
-  void reset() override;
-  void init() override = 0;
-  virtual bool getEnd() const = 0;
-  //! extracts next record from the input file or stream
-  virtual bool extractNextRecord(std::string &record, unsigned int &lineNum,
-                                 unsigned int &index) = 0;
-  //! processes the record into an RWMol object
-  virtual RWMol *processMoleculeRecord(const std::string &record,
-                                       unsigned int lineNum) = 0;
+  MultithreadedMolSupplier(const MultithreadedMolSupplier &) = delete;
+
+  MultithreadedMolSupplier &operator=(const MultithreadedMolSupplier &) =
+      delete;
+
+  std::atomic<bool> df_started = false;
+  std::atomic<bool> df_forceStop = false;
 
   std::mutex d_threadCounterMutex;
   std::atomic<unsigned int> d_threadCounter{1};  //!< thread counter
   std::vector<std::thread> d_writerThreads;      //!< vector writer threads
   std::thread d_readerThread;                    //!< single reader thread
 
- protected:
-  std::atomic<bool> df_started = false;
-  std::atomic<bool> df_forceStop = false;
-
-  std::atomic<unsigned int> d_lastRecordId =
-      0;                       //!< stores last extracted record id
   std::string d_lastItemText;  //!< stores last extracted record
-  const unsigned int d_numReaderThread = 1;  //!< number of reader thread
 
-  std::unique_ptr<
-      ConcurrentQueue<std::tuple<std::string, unsigned int, unsigned int>>>
-      d_inputQueue;  //!< concurrent input queue
-  std::unique_ptr<
-      ConcurrentQueue<std::tuple<RWMol *, std::string, unsigned int>>>
-      d_outputQueue;  //!< concurrent output queue
-  Parameters d_params;
   std::function<void(RWMol &, const MultithreadedMolSupplier &)> nextCallback =
       nullptr;
   std::function<void(RWMol &, const std::string &, unsigned int)>
       writeCallback = nullptr;
   std::function<std::string(const std::string &, unsigned int)> readCallback =
       nullptr;
-
 };
 }  // namespace FileParsers
 }  // namespace v2

--- a/Code/GraphMol/FileParsers/MultithreadedMolSupplier.h
+++ b/Code/GraphMol/FileParsers/MultithreadedMolSupplier.h
@@ -167,9 +167,9 @@ class RDKIT_FILEPARSERS_EXPORT MultithreadedMolSupplier : public MolSupplier {
   std::atomic<bool> df_forceStop = false;
 
   std::mutex d_threadCounterMutex;
-  std::atomic<unsigned int> d_threadCounter{1};  //!< thread counter
-  std::vector<std::thread> d_writerThreads;      //!< vector writer threads
-  std::thread d_readerThread;                    //!< single reader thread
+  unsigned int d_threadEndCounter{1};        //!< thread counter
+  std::vector<std::thread> d_writerThreads;  //!< vector writer threads
+  std::thread d_readerThread;                //!< single reader thread
 
   std::string d_lastItemText;  //!< stores last extracted record
 

--- a/Code/GraphMol/FileParsers/MultithreadedSDMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/MultithreadedSDMolSupplier.cpp
@@ -41,52 +41,9 @@ void MultithreadedSDMolSupplier::initFromSettings(
     bool takeOwnership, const Parameters &params,
     const MolFileParserParams &parseParams) {
   MultithreadedMolSupplier::initFromSettings(takeOwnership, params);
-  df_end = false;
   d_parseParams = parseParams;
   df_processPropertyLists = true;
   d_line = 0;
-}
-
-// ensures that there is a line available to be read
-// from the file, implementation identical to the method in
-// in ForwardSDMolSupplier
-void MultithreadedSDMolSupplier::checkForEnd() {
-  PRECONDITION(dp_inStream, "no stream");
-  // we will call it end of file if we have more than 4 contiguous empty lines
-  // or we reach end of file in the meantime
-  if (dp_inStream->eof()) {
-    df_end = true;
-    return;
-  }
-
-  /*
-    // we are not at the end of file, check for blank lines
-    unsigned int numEmpty = 0;
-    std::string tempStr;
-    // in case df_end is not set then, reset file pointer
-    std::streampos holder = dp_inStream->tellg();
-          if(static_cast<long int>(holder) == -1){ std::cerr << "putan\n";
-    return;} for (unsigned int i = 0; i < 4; i++) { tempStr =
-    getLine(dp_inStream); if (dp_inStream->eof()) { df_end = true; break;
-      }
-      if (tempStr.find_first_not_of(" \t\r\n") == std::string::npos) {
-        ++numEmpty;
-      }
-    }
-    if (numEmpty == 4) {
-      df_end = true;
-    }
-    // we need to reset the file pointer to read the next record
-    if (!df_end) {
-      dp_inStream->clear();
-      dp_inStream->seekg(holder);
-    }
-  */
-}
-
-bool MultithreadedSDMolSupplier::getEnd() const {
-  PRECONDITION(dp_inStream, "no stream");
-  return df_end;
 }
 
 bool MultithreadedSDMolSupplier::extractNextRecord(std::string &record,
@@ -94,7 +51,6 @@ bool MultithreadedSDMolSupplier::extractNextRecord(std::string &record,
                                                    unsigned int &index) {
   PRECONDITION(dp_inStream, "no stream");
   if (dp_inStream->eof()) {
-    df_end = true;
     return false;
   }
 
@@ -109,10 +65,6 @@ bool MultithreadedSDMolSupplier::extractNextRecord(std::string &record,
     std::getline(*dp_inStream, currentStr);
     record += currentStr + "\n";
     ++d_line;
-    if (prevStr.find_first_not_of(" \t\r\n") == std::string::npos &&
-        currentStr[0] == '$' && currentStr.substr(0, 4) == "$$$$") {
-      this->checkForEnd();
-    }
   }
 
   // ignore trailing new lines

--- a/Code/GraphMol/FileParsers/MultithreadedSDMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/MultithreadedSDMolSupplier.cpp
@@ -12,6 +12,10 @@
 
 #include "FileParserUtils.h"
 
+#include <sstream>
+#include <string>
+#include <utility>
+
 namespace RDKit {
 namespace v2 {
 namespace FileParsers {

--- a/Code/GraphMol/FileParsers/MultithreadedSDMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/MultithreadedSDMolSupplier.cpp
@@ -54,14 +54,18 @@ bool MultithreadedSDMolSupplier::extractNextRecord(std::string &record,
     return false;
   }
 
-  std::string currentStr, prevStr;
-  record = "";
+  std::string currentStr;
+  std::string prevStr;
+  record.clear();
   lineNum = d_line;
+
+  // keep reading while we can, and the current line is not a record separator,
+  // and the previous one is a valid end of a mol block (blank line or M  END)
   while (!dp_inStream->eof() && !dp_inStream->fail() &&
          ((prevStr.find_first_not_of(" \t\r\n") != std::string::npos &&
            prevStr.find("M  END") != 0) ||
-          currentStr[0] != '$' || currentStr.substr(0, 4) != "$$$$")) {
-    prevStr = currentStr;
+          !currentStr.starts_with("$$$$"))) {
+    std::swap(prevStr, currentStr);
     std::getline(*dp_inStream, currentStr);
     record += currentStr + "\n";
     ++d_line;
@@ -87,8 +91,7 @@ void MultithreadedSDMolSupplier::readMolProps(RWMol &mol,
   std::getline(inStream, tempStr);
 
   // FIX: report files missing the $$$$ marker
-  while (!inStream.eof() && !inStream.fail() &&
-         (tempStr[0] != '$' || tempStr.substr(0, 4) != "$$$$")) {
+  while (!inStream.eof() && !inStream.fail() && !tempStr.starts_with("$$$$")) {
     tempStr = strip(tempStr);
     if (tempStr != "") {
       if (tempStr[0] == '>') {  // data header line: start of a data item
@@ -100,9 +103,9 @@ void MultithreadedSDMolSupplier::readMolProps(RWMol &mol,
         // situation - so ignore such data items for now
         hasProp = true;
         warningIssued = false;
-        tempStr.erase(0, 1);            // remove the first ">" sign
-        size_t sl = tempStr.find("<");  // begin datalabel
-        size_t se = tempStr.find(">");  // end datalabel
+        tempStr.erase(0, 1);             // remove the first ">" sign
+        size_t sl = tempStr.find("<");   // begin datalabel
+        size_t se = tempStr.rfind(">");  // end datalabel
         if ((sl == std::string::npos) || (se == std::string::npos) ||
             (se == (sl + 1))) {
           // we either do not have a data label or the label is empty

--- a/Code/GraphMol/FileParsers/MultithreadedSDMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/MultithreadedSDMolSupplier.cpp
@@ -226,7 +226,7 @@ void MultithreadedSDMolSupplier::readMolProps(RWMol &mol,
   }
 }
 
-RWMol *MultithreadedSDMolSupplier::processMoleculeRecord(
+std::unique_ptr<RWMol> MultithreadedSDMolSupplier::processMoleculeRecord(
     const std::string &record, unsigned int lineNum) {
   PRECONDITION(dp_inStream, "no stream");
   std::istringstream inStream(record);
@@ -234,9 +234,8 @@ RWMol *MultithreadedSDMolSupplier::processMoleculeRecord(
       v2::FileParsers::MolFromMolDataStream(inStream, lineNum, d_parseParams);
   if (res) {
     this->readMolProps(*res, inStream);
-    return res.release();
   }
-  return nullptr;
+  return res;
 }
 }  // namespace FileParsers
 }  // namespace v2

--- a/Code/GraphMol/FileParsers/MultithreadedSDMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/MultithreadedSDMolSupplier.cpp
@@ -56,15 +56,6 @@ void MultithreadedSDMolSupplier::initFromSettings(
   df_processPropertyLists = true;
 }
 
-void MultithreadedSDMolSupplier::closeStreams() {
-  if (df_owner && dp_inStream) {
-    delete dp_inStream;
-    df_owner = false;
-    dp_inStream = nullptr;
-  }
-  df_started = false; // this is in the base constructor
-}
-
 // ensures that there is a line available to be read
 // from the file, implementation identical to the method in
 // in ForwardSDMolSupplier

--- a/Code/GraphMol/FileParsers/MultithreadedSDMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/MultithreadedSDMolSupplier.cpp
@@ -40,20 +40,11 @@ MultithreadedSDMolSupplier::MultithreadedSDMolSupplier() {
 void MultithreadedSDMolSupplier::initFromSettings(
     bool takeOwnership, const Parameters &params,
     const MolFileParserParams &parseParams) {
-  df_owner = takeOwnership;
-  d_params = params;
-  d_parseParams = parseParams;
-  d_params.numWriterThreads = getNumThreadsToUse(params.numWriterThreads);
-  d_inputQueue.reset(
-      new ConcurrentQueue<std::tuple<std::string, unsigned int, unsigned int>>(
-          d_params.sizeInputQueue));
-  d_outputQueue.reset(
-      new ConcurrentQueue<std::tuple<RWMol *, std::string, unsigned int>>(
-          d_params.sizeOutputQueue));
-
+  MultithreadedMolSupplier::initFromSettings(takeOwnership, params);
   df_end = false;
-  d_line = 0;
+  d_parseParams = parseParams;
   df_processPropertyLists = true;
+  d_line = 0;
 }
 
 // ensures that there is a line available to be read

--- a/Code/GraphMol/FileParsers/MultithreadedSDMolSupplier.h
+++ b/Code/GraphMol/FileParsers/MultithreadedSDMolSupplier.h
@@ -41,11 +41,11 @@ class RDKIT_FILEPARSERS_EXPORT MultithreadedSDMolSupplier
 
   //! reads next record and returns whether or not EOF was hit
   bool extractNextRecord(std::string &record, unsigned int &lineNum,
-                         unsigned int &index) override;
+                         unsigned int &index) final;
 
   //! parses the record and returns the resulting molecule
-  RWMol *processMoleculeRecord(const std::string &record,
-                               unsigned int lineNum) override;
+  std::unique_ptr<RWMol> processMoleculeRecord(const std::string &record,
+                                               unsigned int lineNum) final;
 
  private:
   void initFromSettings(bool takeOwnership, const Parameters &params,

--- a/Code/GraphMol/FileParsers/MultithreadedSDMolSupplier.h
+++ b/Code/GraphMol/FileParsers/MultithreadedSDMolSupplier.h
@@ -37,7 +37,7 @@ class RDKIT_FILEPARSERS_EXPORT MultithreadedSDMolSupplier
 
   bool getProcessPropertyLists() const { return df_processPropertyLists; }
 
-  bool getEOFHitOnRead() const { return df_eofHitOnRead; }
+  bool getEOFHitOnRead() const final { return df_eofHitOnRead; }
 
   //! reads next record and returns whether or not EOF was hit
   bool extractNextRecord(std::string &record, unsigned int &lineNum,
@@ -109,7 +109,6 @@ class RDKIT_FILEPARSERS_EXPORT MultithreadedSDMolSupplier : public MolSupplier {
         inStream, takeOwnership, params, parseParams));
   }
 
-  //! included for the interface, always returns false
   bool getEOFHitOnRead() const {
     if (dp_supplier) {
       return static_cast<ContainedType *>(dp_supplier.get())->getEOFHitOnRead();

--- a/Code/GraphMol/FileParsers/MultithreadedSDMolSupplier.h
+++ b/Code/GraphMol/FileParsers/MultithreadedSDMolSupplier.h
@@ -51,17 +51,10 @@ class RDKIT_FILEPARSERS_EXPORT MultithreadedSDMolSupplier
   void initFromSettings(bool takeOwnership, const Parameters &params,
                         const MolFileParserParams &parseParams);
 
-  bool getEnd() const override;
-
-  void checkForEnd();
-
   void readMolProps(RWMol &mol, std::istringstream &inStream);
 
-  bool df_end = false;  //!< have we reached the end of the file?
-  int d_line = 0;       //!< line number we are currently on
   bool df_processPropertyLists = true;
   bool df_eofHitOnRead = false;
-  unsigned int d_currentRecordId = 1;  //!< current record id
   MolFileParserParams d_parseParams;
 };
 }  // namespace FileParsers

--- a/Code/GraphMol/FileParsers/MultithreadedSDMolSupplier.h
+++ b/Code/GraphMol/FileParsers/MultithreadedSDMolSupplier.h
@@ -30,28 +30,32 @@ class RDKIT_FILEPARSERS_EXPORT MultithreadedSDMolSupplier
       const MolFileParserParams &parseParams = MolFileParserParams());
 
   MultithreadedSDMolSupplier();
-  virtual ~MultithreadedSDMolSupplier() {close();}
-  void init() override {}
 
-  void checkForEnd();
-  bool getEnd() const override;
+  ~MultithreadedSDMolSupplier() final { close(); }
+
   void setProcessPropertyLists(bool val) { df_processPropertyLists = val; }
+
   bool getProcessPropertyLists() const { return df_processPropertyLists; }
+
   bool getEOFHitOnRead() const { return df_eofHitOnRead; }
 
   //! reads next record and returns whether or not EOF was hit
   bool extractNextRecord(std::string &record, unsigned int &lineNum,
                          unsigned int &index) override;
-  void readMolProps(RWMol &mol, std::istringstream &inStream);
+
   //! parses the record and returns the resulting molecule
   RWMol *processMoleculeRecord(const std::string &record,
                                unsigned int lineNum) override;
- protected:
-    void closeStreams() override;
 
  private:
   void initFromSettings(bool takeOwnership, const Parameters &params,
                         const MolFileParserParams &parseParams);
+
+  bool getEnd() const override;
+
+  void checkForEnd();
+
+  void readMolProps(RWMol &mol, std::istringstream &inStream);
 
   bool df_end = false;  //!< have we reached the end of the file?
   int d_line = 0;       //!< line number we are currently on
@@ -121,16 +125,19 @@ class RDKIT_FILEPARSERS_EXPORT MultithreadedSDMolSupplier : public MolSupplier {
     PRECONDITION(dp_supplier, "no supplier");
     return static_cast<ContainedType *>(dp_supplier.get())->getLastRecordId();
   }
+
   //! returns the text block for the last extracted item
   std::string getLastItemText() const {
     PRECONDITION(dp_supplier, "no supplier");
     return static_cast<ContainedType *>(dp_supplier.get())->getLastItemText();
   }
+
   void setProcessPropertyLists(bool val) {
     PRECONDITION(dp_supplier, "no supplier");
     static_cast<ContainedType *>(dp_supplier.get())
         ->setProcessPropertyLists(val);
   }
+
   bool getProcessPropertyLists() const {
     PRECONDITION(dp_supplier, "no supplier");
     return static_cast<ContainedType *>(dp_supplier.get())

--- a/Code/GraphMol/FileParsers/MultithreadedSDMolSupplier.h
+++ b/Code/GraphMol/FileParsers/MultithreadedSDMolSupplier.h
@@ -10,6 +10,11 @@
 #ifdef RDK_BUILD_THREADSAFE_SSS
 #ifndef MULTITHREADED_SD_MOL_SUPPLIER
 #define MULTITHREADED_SD_MOL_SUPPLIER
+
+#include <iosfwd>
+#include <memory>
+#include <string>
+
 #include "MultithreadedMolSupplier.h"
 namespace RDKit {
 namespace v2 {

--- a/Code/GraphMol/FileParsers/MultithreadedSDMolSupplier.h
+++ b/Code/GraphMol/FileParsers/MultithreadedSDMolSupplier.h
@@ -22,7 +22,7 @@ namespace FileParsers {
 
 //! This class is still a bit experimental and the public API may change
 //! in future releases.
-class RDKIT_FILEPARSERS_EXPORT MultithreadedSDMolSupplier
+class RDKIT_FILEPARSERS_EXPORT MultithreadedSDMolSupplier final
     : public MultithreadedMolSupplier {
  public:
   explicit MultithreadedSDMolSupplier(

--- a/Code/GraphMol/FileParsers/MultithreadedSmilesMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/MultithreadedSmilesMolSupplier.cpp
@@ -106,24 +106,25 @@ bool MultithreadedSmilesMolSupplier::extractNextRecord(std::string &record,
   return true;
 }
 
-RWMol *MultithreadedSmilesMolSupplier::processMoleculeRecord(
+std::unique_ptr<RWMol> MultithreadedSmilesMolSupplier::processMoleculeRecord(
     const std::string &record, unsigned int lineNum) {
   // -----------
   // tokenize the input line:
   // -----------
   boost::char_separator<char> sep(d_parseParams.delimiter.c_str(), "",
                                   boost::keep_empty_tokens);
-  tokenizer tokens(record, sep);
-  STR_VECT recs;
-  for (tokenizer::iterator tokIter = tokens.begin(); tokIter != tokens.end();
-       ++tokIter) {
-    std::string rec = strip(*tokIter);
-    recs.push_back(rec);
-  }
+
+  auto tokens = tokenizer(record, sep);
+  std::vector<std::string> recs(tokens.begin(), tokens.end());
+
   if (recs.size() <= static_cast<unsigned int>(d_parseParams.smilesColumn)) {
     std::ostringstream errout;
     errout << "ERROR: line #" << lineNum << "does not contain enough tokens\n";
     throw FileParseException(errout.str());
+  }
+
+  for (auto &rec : recs) {
+    boost::trim_if(rec, boost::is_any_of(" \t\r\n"));
   }
 
   // -----------
@@ -143,10 +144,7 @@ RWMol *MultithreadedSmilesMolSupplier::processMoleculeRecord(
   // -----------
   if (d_parseParams.nameColumn == -1) {
     // if no name defaults it to the line number we read it from string
-    std::ostringstream tstr;
-    tstr << lineNum;
-    std::string mname = tstr.str();
-    res->setProp(common_properties::_Name, mname);
+    res->setProp(common_properties::_Name, std::to_string(lineNum));
   } else {
     if (d_parseParams.nameColumn >= static_cast<int>(recs.size())) {
       BOOST_LOG(rdWarningLog)
@@ -164,20 +162,15 @@ RWMol *MultithreadedSmilesMolSupplier::processMoleculeRecord(
         static_cast<int>(col) == d_parseParams.nameColumn) {
       continue;
     }
-    std::string pname, pval;
-    if (d_props.size() > col) {
-      pname = d_props[col];
+    if (d_props.size() > col && !d_props[col].empty()) {
+      res->setProp(d_props[col], recs[col]);
     } else {
-      pname = "Column_";
-      std::stringstream ss;
-      ss << col;
-      pname += ss.str();
+      std::string pname = "Column_";
+      pname += std::to_string(col);
+      res->setProp(pname, recs[col]);
     }
-
-    pval = recs[col];
-    res->setProp(pname, pval);
   }
-  return res.release();
+  return res;
 }
 
 }  // namespace FileParsers

--- a/Code/GraphMol/FileParsers/MultithreadedSmilesMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/MultithreadedSmilesMolSupplier.cpp
@@ -44,13 +44,7 @@ void MultithreadedSmilesMolSupplier::initFromSettings(
     const SmilesMolSupplierParams &parseParams) {
   MultithreadedMolSupplier::initFromSettings(takeOwnership, params);
   d_parseParams = parseParams;
-  df_end = false;
   d_line = -1;
-}
-
-bool MultithreadedSmilesMolSupplier::getEnd() const {
-  PRECONDITION(dp_inStream, "no stream");
-  return df_end;
 }
 
 // --------------------------------------------------
@@ -80,7 +74,6 @@ bool MultithreadedSmilesMolSupplier::extractNextRecord(std::string &record,
                                                        unsigned int &index) {
   PRECONDITION(dp_inStream, "bad stream");
   if (dp_inStream->eof()) {
-    df_end = true;
     return false;
   }
 

--- a/Code/GraphMol/FileParsers/MultithreadedSmilesMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/MultithreadedSmilesMolSupplier.cpp
@@ -10,6 +10,16 @@
 //
 #include "MultithreadedSmilesMolSupplier.h"
 
+#include <boost/algorithm/string/classification.hpp>
+#include <boost/algorithm/string/trim.hpp>
+#include <boost/tokenizer.hpp>
+
+#include <sstream>
+#include <string>
+#include <vector>
+
+using tokenizer = boost::tokenizer<boost::char_separator<char>>;
+
 namespace RDKit {
 
 inline static bool lineIsEmptyOrComment(const std::string &line) {

--- a/Code/GraphMol/FileParsers/MultithreadedSmilesMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/MultithreadedSmilesMolSupplier.cpp
@@ -11,6 +11,12 @@
 #include "MultithreadedSmilesMolSupplier.h"
 
 namespace RDKit {
+
+inline static bool lineIsEmptyOrComment(const std::string &line) {
+  return line.empty() || line[0] == '#' ||
+         line.find_first_not_of(" \t\r\n") == std::string::npos;
+}
+
 namespace v2 {
 namespace FileParsers {
 MultithreadedSmilesMolSupplier::MultithreadedSmilesMolSupplier(
@@ -53,19 +59,21 @@ void MultithreadedSmilesMolSupplier::initFromSettings(
 //
 void MultithreadedSmilesMolSupplier::processTitleLine() {
   PRECONDITION(dp_inStream, "bad stream");
-  std::string tempStr = getLine(dp_inStream);
+
   // loop until we get a valid line
+  std::string tempStr;
   while (!dp_inStream->eof() && !dp_inStream->fail() &&
-         ((tempStr[0] == '#') || (strip(tempStr).size() == 0))) {
+         lineIsEmptyOrComment(tempStr)) {
     tempStr = getLine(dp_inStream);
   }
+
   boost::char_separator<char> sep(d_parseParams.delimiter.c_str(), "",
                                   boost::keep_empty_tokens);
-  tokenizer tokens(tempStr, sep);
-  for (tokenizer::iterator tokIter = tokens.begin(); tokIter != tokens.end();
-       ++tokIter) {
-    std::string pname = strip(*tokIter);
-    d_props.push_back(pname);
+
+  auto tokens = tokenizer(tempStr, sep);
+  d_props.assign(tokens.begin(), tokens.end());
+  for (auto &pname : d_props) {
+    boost::trim_if(pname, boost::is_any_of(" \t\r\n"));
   }
 }
 
@@ -85,10 +93,11 @@ bool MultithreadedSmilesMolSupplier::extractNextRecord(std::string &record,
       this->processTitleLine();
     }
   }
-  std::string tempStr = getLine(dp_inStream);
-  record = "";
+
+  record.clear();
+  std::string tempStr;
   while (!dp_inStream->eof() && !dp_inStream->fail() &&
-         ((tempStr[0] == '#') || (strip(tempStr).size() == 0))) {
+         lineIsEmptyOrComment(tempStr)) {
     tempStr = getLine(dp_inStream);
   }
 

--- a/Code/GraphMol/FileParsers/MultithreadedSmilesMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/MultithreadedSmilesMolSupplier.cpp
@@ -39,15 +39,6 @@ MultithreadedSmilesMolSupplier::MultithreadedSmilesMolSupplier() {
   initFromSettings(true, d_params, d_parseParams);
 }
 
-void MultithreadedSmilesMolSupplier::closeStreams() {
-  if (df_owner && dp_inStream) {
-    delete dp_inStream;
-    df_owner = false;
-    dp_inStream = nullptr;
-  }
-  df_started = false;  // this is in the base constructor
-}
-
 void MultithreadedSmilesMolSupplier::initFromSettings(
     bool takeOwnership, const Parameters &params,
     const SmilesMolSupplierParams &parseParams) {

--- a/Code/GraphMol/FileParsers/MultithreadedSmilesMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/MultithreadedSmilesMolSupplier.cpp
@@ -42,16 +42,8 @@ MultithreadedSmilesMolSupplier::MultithreadedSmilesMolSupplier() {
 void MultithreadedSmilesMolSupplier::initFromSettings(
     bool takeOwnership, const Parameters &params,
     const SmilesMolSupplierParams &parseParams) {
-  df_owner = takeOwnership;
-  d_params = params;
+  MultithreadedMolSupplier::initFromSettings(takeOwnership, params);
   d_parseParams = parseParams;
-  d_params.numWriterThreads = getNumThreadsToUse(d_params.numWriterThreads);
-  d_inputQueue.reset(
-      new ConcurrentQueue<std::tuple<std::string, unsigned int, unsigned int>>(
-          d_params.sizeInputQueue));
-  d_outputQueue.reset(
-      new ConcurrentQueue<std::tuple<RWMol *, std::string, unsigned int>>(
-          d_params.sizeOutputQueue));
   df_end = false;
   d_line = -1;
 }

--- a/Code/GraphMol/FileParsers/MultithreadedSmilesMolSupplier.h
+++ b/Code/GraphMol/FileParsers/MultithreadedSmilesMolSupplier.h
@@ -47,16 +47,10 @@ class RDKIT_FILEPARSERS_EXPORT MultithreadedSmilesMolSupplier
       bool takeOwnership, const Parameters &params,
       const SmilesMolSupplierParams &parseParams = SmilesMolSupplierParams());
 
-  //! returns df_end
-  bool getEnd() const override;
-
   //! reads and processes the title line
   void processTitleLine();
 
-  bool df_end = false;                 //!< have we reached the end of the file?
-  int d_line = 0;                      //!< line number we are currently on
-  STR_VECT d_props;                    //!< vector of property names
-  unsigned int d_currentRecordId = 1;  //!< current record id
+  STR_VECT d_props;  //!< vector of property names
   SmilesMolSupplierParams d_parseParams;
 };
 }  // namespace FileParsers

--- a/Code/GraphMol/FileParsers/MultithreadedSmilesMolSupplier.h
+++ b/Code/GraphMol/FileParsers/MultithreadedSmilesMolSupplier.h
@@ -27,30 +27,30 @@ class RDKIT_FILEPARSERS_EXPORT MultithreadedSmilesMolSupplier
       std::istream *inStream, bool takeOwnership = true,
       const Parameters &params = Parameters(),
       const SmilesMolSupplierParams &parseParams = SmilesMolSupplierParams());
-  MultithreadedSmilesMolSupplier();
-  virtual ~MultithreadedSmilesMolSupplier() {close();};
 
-  void init() override {}
-  //! returns df_end
-  bool getEnd() const override;
-  //! reads and processes the title line
-  void processTitleLine();
+  MultithreadedSmilesMolSupplier();
+
+  ~MultithreadedSmilesMolSupplier() final { close(); };
+
   //! reads next record and returns whether or not EOF was hit
   bool extractNextRecord(std::string &record, unsigned int &lineNum,
                          unsigned int &index) override;
+
   //! parses the record and returns the resulting molecule
   RWMol *processMoleculeRecord(const std::string &record,
                                unsigned int lineNum) override;
-
- protected:
-  void closeStreams() override;
 
  private:
   void initFromSettings(
       bool takeOwnership, const Parameters &params,
       const SmilesMolSupplierParams &parseParams = SmilesMolSupplierParams());
 
- private:
+  //! returns df_end
+  bool getEnd() const override;
+
+  //! reads and processes the title line
+  void processTitleLine();
+
   bool df_end = false;                 //!< have we reached the end of the file?
   int d_line = 0;                      //!< line number we are currently on
   STR_VECT d_props;                    //!< vector of property names
@@ -125,6 +125,7 @@ class RDKIT_FILEPARSERS_EXPORT MultithreadedSmilesMolSupplier
     PRECONDITION(dp_supplier, "no supplier");
     return static_cast<ContainedType *>(dp_supplier.get())->getLastRecordId();
   }
+
   //! returns the text block for the last extracted item
   std::string getLastItemText() const {
     PRECONDITION(dp_supplier, "no supplier");

--- a/Code/GraphMol/FileParsers/MultithreadedSmilesMolSupplier.h
+++ b/Code/GraphMol/FileParsers/MultithreadedSmilesMolSupplier.h
@@ -32,6 +32,8 @@ class RDKIT_FILEPARSERS_EXPORT MultithreadedSmilesMolSupplier
 
   ~MultithreadedSmilesMolSupplier() final { close(); };
 
+  bool getEOFHitOnRead() const final { return false; }
+
   //! reads next record and returns whether or not EOF was hit
   bool extractNextRecord(std::string &record, unsigned int &lineNum,
                          unsigned int &index) final;
@@ -109,7 +111,6 @@ class RDKIT_FILEPARSERS_EXPORT MultithreadedSmilesMolSupplier
         inStream, takeOwnership, params, parseParams));
   }
 
-  //! included for the interface, always returns false
   bool getEOFHitOnRead() const {
     if (dp_supplier) {
       return static_cast<ContainedType *>(dp_supplier.get())->getEOFHitOnRead();

--- a/Code/GraphMol/FileParsers/MultithreadedSmilesMolSupplier.h
+++ b/Code/GraphMol/FileParsers/MultithreadedSmilesMolSupplier.h
@@ -10,6 +10,11 @@
 #ifdef RDK_BUILD_THREADSAFE_SSS
 #ifndef MULTITHREADED_SMILES_MOL_SUPPLIER
 #define MULTITHREADED_SMILES_MOL_SUPPLIER
+
+#include <iosfwd>
+#include <memory>
+#include <string>
+
 #include "MultithreadedMolSupplier.h"
 namespace RDKit {
 namespace v2 {

--- a/Code/GraphMol/FileParsers/MultithreadedSmilesMolSupplier.h
+++ b/Code/GraphMol/FileParsers/MultithreadedSmilesMolSupplier.h
@@ -34,11 +34,11 @@ class RDKIT_FILEPARSERS_EXPORT MultithreadedSmilesMolSupplier
 
   //! reads next record and returns whether or not EOF was hit
   bool extractNextRecord(std::string &record, unsigned int &lineNum,
-                         unsigned int &index) override;
+                         unsigned int &index) final;
 
   //! parses the record and returns the resulting molecule
-  RWMol *processMoleculeRecord(const std::string &record,
-                               unsigned int lineNum) override;
+  std::unique_ptr<RWMol> processMoleculeRecord(const std::string &record,
+                                               unsigned int lineNum) final;
 
  private:
   void initFromSettings(

--- a/Code/GraphMol/FileParsers/MultithreadedSmilesMolSupplier.h
+++ b/Code/GraphMol/FileParsers/MultithreadedSmilesMolSupplier.h
@@ -21,7 +21,7 @@ namespace v2 {
 namespace FileParsers {
 //! This class is still a bit experimental and the public API may change
 //! in future releases.
-class RDKIT_FILEPARSERS_EXPORT MultithreadedSmilesMolSupplier
+class RDKIT_FILEPARSERS_EXPORT MultithreadedSmilesMolSupplier final
     : public MultithreadedMolSupplier {
  public:
   explicit MultithreadedSmilesMolSupplier(


### PR DESCRIPTION
This is a somewhat large scale refactor of the multithreaded suppliers ahead of attempting (again) to fix #8644. All changes here should be low-risk, and they should mean no relevant change of functionality.

Spirit of the change is pull as much common functionality as possible into the base `MultithreadedMolSupplier` class, remove anything that's not required. 

It's probably easier to look at this commit by commit rather than looking at the full set of changes as a whole.