### PR TITLE
Fixes for AI-found medium impact issues (C++ code)

### DIFF
--- a/Code/GraphMol/Depictor/EmbeddedFrag.cpp
+++ b/Code/GraphMol/Depictor/EmbeddedFrag.cpp
@@ -20,8 +20,8 @@
 #include <GraphMol/ROMol.h>
 #include <GraphMol/Bond.h>
 #include "RDDepictor.h"
-#include <list>
 #include <algorithm>
+#include <ranges>
 #include <boost/range/adaptor/reversed.hpp>
 #include <boost/dynamic_bitset.hpp>
 #include <GraphMol/Substruct/SubstructMatch.h>
@@ -108,18 +108,24 @@ void EmbeddedFrag::computeNbrsAndAng(unsigned int aid,
   PRECONDITION(doneNbrs.size() >= 3, "");
   // we will find all the inter nbr angles, pick the one with the largest angle
   // make those neighbors the nbr1 and nbr2 of aid
-  std::list<DOUBLE_INT_PAIR> anglePairs;
-  double ang;
+  double ang = 0.;
+  std::vector<DOUBLE_INT_PAIR> anglePairs;
+  anglePairs.reserve(doneNbrs.size() * (doneNbrs.size() - 1) / 2);
   for (auto nbi1 = doneNbrs.begin(); nbi1 != doneNbrs.end(); ++nbi1) {
-    auto nbi3 = nbi1;
-    for (auto nbi2 = nbi3++; nbi2 != doneNbrs.end(); ++nbi2) {
+    for (auto nbi2 = std::next(nbi1); nbi2 != doneNbrs.end(); ++nbi2) {
       ang = computeAngle(d_eatoms[aid].loc, d_eatoms[*nbi1].loc,
                          d_eatoms[*nbi2].loc);
       auto nbrPair = std::make_pair((*nbi1), (*nbi2));
       anglePairs.emplace_back(ang, nbrPair);
     }
   }
-  anglePairs.sort([](auto pr1, auto pr2) { return pr1.first < pr2.first; });
+
+  std::ranges::sort(anglePairs, [](const auto &pr1, const auto &pr2) {
+    if (pr1.first == pr2.first) {
+      return pr1.second < pr2.second;
+    }
+    return pr1.first < pr2.first;
+  });
 
   // more pain, more pain we unfortunately cannot right away pick the largest
   // angle - it is possible that we pick an angle that is in a fused ring - see
@@ -138,22 +144,20 @@ void EmbeddedFrag::computeNbrsAndAng(unsigned int aid,
   //  by checking that both our neighbors are not involved in more than one
   //  ring. Bridged systems - don't even go there
   auto winner = anglePairs.back();
-  for (auto pr : boost::adaptors::reverse(anglePairs)) {
+  for (const auto &pr : boost::adaptors::reverse(anglePairs)) {
     if ((dp_mol->getRingInfo()->numAtomRings(pr.second.first) <= 1) &&
         (dp_mol->getRingInfo()->numAtomRings(pr.second.second) <= 1)) {
       winner = pr;
       break;
     }
   }
-
-  auto winPair = winner.second;
-  auto wnb1 = winPair.first;
-  auto wnb2 = winPair.second;
+  const auto [wnb1, wnb2] = winner.second;
 
   // now find the smallest angle that contains one of these nbrs
-  int nb2 = -1, nb1 = -1;
-  for (auto anglePair : anglePairs) {
-    auto nbrPair = anglePair.second;
+  int nb2 = -1;
+  int nb1 = -1;
+  for (const auto &anglePair : anglePairs) {
+    const auto nbrPair = anglePair.second;
     if (wnb1 == nbrPair.first) {
       nb2 = wnb1;
       nb1 = nbrPair.second;

--- a/Code/GraphMol/Depictor/Wrap/testDepictor.py
+++ b/Code/GraphMol/Depictor/Wrap/testDepictor.py
@@ -1110,7 +1110,7 @@ $$$$
       coords = mol.GetConformer().GetPositions()
       for bond in mol.GetBonds():
         length = np.linalg.norm(coords[bond.GetBeginAtomIdx()] - coords[bond.GetEndAtomIdx()])
-        if length < 1.0 or length > 2.0:
+        if length < 1.0 or length > 2.1:
           return True
       return False
 

--- a/Code/GraphMol/Depictor/catch_tests.cpp
+++ b/Code/GraphMol/Depictor/catch_tests.cpp
@@ -288,7 +288,7 @@ $$$$
       for (auto bond : mol.bonds()) {
         auto diff =
             coords[bond->getBeginAtomIdx()] - coords[bond->getEndAtomIdx()];
-        if (auto length = diff.length(); length < 1.0 || length > 2.0) {
+        if (auto length = diff.length(); length < 1.0 || length > 2.1) {
           return true;
         }
       };

--- a/Code/GraphMol/FileParsers/MolFileStereochem.cpp
+++ b/Code/GraphMol/FileParsers/MolFileStereochem.cpp
@@ -135,9 +135,10 @@ void addWavyBondsForStereoAny(ROMol &mol, bool clearDoubleBondFlags,
     if (!score) {
       continue;
     }
-    sortedScores.push_back(
-        std::make_tuple(-1 * singleBondNeighbors[i].size(), score, i));
+    sortedScores.push_back(std::make_tuple(
+        -static_cast<int>(singleBondNeighbors[i].size()), score, i));
   }
+
   std::sort(sortedScores.begin(), sortedScores.end());
   for (const auto &tpl : sortedScores) {
     // FIX: check if dir is already set

--- a/Code/GraphMol/GaussianShape/ShapeInput.h
+++ b/Code/GraphMol/GaussianShape/ShapeInput.h
@@ -302,7 +302,7 @@ class RDKIT_GAUSSIANSHAPE_EXPORT ShapeInput {
 
   void calculateExtremes();
 
-  unsigned int d_activeShape;
+  unsigned int d_activeShape{0};
 
   std::vector<std::vector<double>>
       d_coords;  // The coordinates for the atoms and features,
@@ -312,8 +312,8 @@ class RDKIT_GAUSSIANSHAPE_EXPORT ShapeInput {
   // of the atom.  This is not used if using all_atoms_carbon mode.
   std::vector<int> d_types;  // The feature types.  The size is the same
   // as the number of atoms and features, padded with 0 for the atoms.
-  unsigned int d_numAtoms;                     // The number of atoms
-  unsigned int d_numFeats;                     // The number of features
+  unsigned int d_numAtoms{0};                  // The number of atoms
+  unsigned int d_numFeats{0};                  // The number of features
   std::vector<double> d_selfOverlapShapeVols;  // Shape volume
   std::vector<double> d_selfOverlapColorVols;  // Color volume
   // These are the points at the extremes of the x, y and z axes.

--- a/Code/GraphMol/MarvinParse/MarvinDefs.cpp
+++ b/Code/GraphMol/MarvinParse/MarvinDefs.cpp
@@ -762,6 +762,7 @@ MarvinAtom::MarvinAtom()
       y3(DBL_MAX),
       z3(DBL_MAX),
       formalCharge(0),
+      isotope(0),
       mrvValence(-1),
       hydrogenCount(-1),
       mrvMap(0),
@@ -1443,7 +1444,7 @@ std::string MarvinSruCoModSgroup::role() const { return roleName; }
 
 bool MarvinSruCoModSgroup::hasAtomBondBlocks() const { return false; }
 
-MarvinDataSgroup::MarvinDataSgroup(MarvinMolBase *parentInit) {
+MarvinDataSgroup::MarvinDataSgroup(MarvinMolBase *parentInit) : x(0.0), y(0.0) {
   parent = parentInit;
 }
 
@@ -1744,7 +1745,8 @@ ptree MarvinMultipleSgroup::toPtree() const {
   return out;
 }
 
-MarvinMulticenterSgroup::MarvinMulticenterSgroup(MarvinMolBase *parentInit) {
+MarvinMulticenterSgroup::MarvinMulticenterSgroup(MarvinMolBase *parentInit)
+    : center(nullptr) {
   PRECONDITION(parentInit != nullptr, "parentInit cannot be null");
   parent = parentInit;
 }

--- a/Code/GraphMol/MarvinParse/MarvinDefs.cpp
+++ b/Code/GraphMol/MarvinParse/MarvinDefs.cpp
@@ -761,6 +761,7 @@ MarvinAtom::MarvinAtom()
       x3(DBL_MAX),
       y3(DBL_MAX),
       z3(DBL_MAX),
+
       formalCharge(0),
       isotope(0),
       mrvValence(-1),

--- a/Code/GraphMol/MolDraw2D/DrawMol.h
+++ b/Code/GraphMol/MolDraw2D/DrawMol.h
@@ -85,7 +85,7 @@ class DrawMol {
    \param drawOptions  : a MolDrawOptions object from the owning MolDraw2D
    \param textDrawer   : a DrawText object from the owning MolDraw2D
    \param xmin         : minimum value expected in X
-   \param xmax         : miaximum value expected in X
+   \param xmax         : maximum value expected in X
    \param ymin         : minimum value expected in Y
    \param ymax         : maximum value expected in Y
    \param scale        : scale to use
@@ -133,7 +133,7 @@ class DrawMol {
   void draw(MolDraw2D &drawer) const;
   void drawRadicals(MolDraw2D &drawer) const;
   void resetEverything();
-  // reduce width_ and height_ to just accomodate the Xrange_ and YRange_
+  // reduce width_ and height_ to just accommodate the Xrange_ and YRange_
   // at the current scale.  Recentres everything.  So the DrawMol takes up
   // no more screen real estate than it needs.
   void shrinkToFit(bool withPadding = true);
@@ -268,7 +268,7 @@ class DrawMol {
   std::map<int, DrawColour> highlightBondMap_;
   std::vector<std::pair<DrawColour, DrawColour>> bondColours_;
   std::map<int, double> highlightRadii_;
-  bool includeAnnotations_;
+  bool includeAnnotations_ = false;
   bool isReactionMol_;
   std::string legend_;
 
@@ -309,7 +309,7 @@ class DrawMol {
   // for the legend.  For Left/Right, legendWidth_ is the side strip.
   // molWidth_ is the width available for the molecule (drawWidth_ for
   // Bottom/Top, drawWidth_ - legendWidth_ for Left/Right).  In pixels.
-  int molHeight_, legendHeight_ = 0;
+  int molHeight_ = 0, legendHeight_ = 0;
   int molWidth_ = 0, legendWidth_ = 0;
   bool drawingInitialised_ = false;
   // when drawing the atoms and bonds in an SVG, they are given a class

--- a/Code/GraphMol/MolHash/hashfunctions.cpp
+++ b/Code/GraphMol/MolHash/hashfunctions.cpp
@@ -989,13 +989,12 @@ std::string TautomerHashv2(RWMol *mol, bool proto, bool useCXSmiles,
   ps.allBondsExplicit = true;
   ps.allHsExplicit = true;
   result = convertToSmilesWithCXFlags(*mol, useCXSmiles, cxFlagsToSkip, ps);
-  char buffer[32];
   if (!proto) {
-    sprintf(buffer, "_%d_%d", hcount, charge);
+    result += "_" + std::to_string(hcount) + "_" + std::to_string(charge);
   } else {
-    sprintf(buffer, "_%d", hcount - charge);
+    const auto netHydrogens = static_cast<int>(hcount) - charge;
+    result += "_" + std::to_string(netHydrogens);
   }
-  result += buffer;
   if (useCXSmiles) {
     addCXExtensions(mol, result, cxFlagsToSkip | SmilesWrite::CX_RADICALS);
   }

--- a/Code/GraphMol/RGroupDecomposition/RGroupGa.h
+++ b/Code/GraphMol/RGroupDecomposition/RGroupGa.h
@@ -79,7 +79,7 @@ class RGroupDecompositionChromosome : public IntegerStringChromosome {
       delete;
   RGroupDecompositionChromosome &operator=(
       const RGroupDecompositionChromosome &other) = delete;
-  double fitness;
+  double fitness{0.0};
   FingerprintVarianceScoreData fingerprintVarianceScoreData;
   OperationName operationName = Create;
   vector<size_t> permutation;

--- a/Code/GraphMol/RWMol.cpp
+++ b/Code/GraphMol/RWMol.cpp
@@ -154,7 +154,7 @@ void RWMol::insertMol(const ROMol &other) {
         newAt->getPropIfPresent(common_properties::_ringStereoAtoms, nAtoms)) {
       for (auto &val : nAtoms) {
         if (val < 0) {
-          val = -1 * (-val + origNumAtoms);
+          val -= rdcast<int>(origNumAtoms);
         } else {
           val += origNumAtoms;
         }

--- a/Code/GraphMol/Substruct/SubstructUtils.cpp
+++ b/Code/GraphMol/Substruct/SubstructUtils.cpp
@@ -40,8 +40,8 @@ class ScoreMatchesByDegreeOfCoreSubstitution {
         d_minIdx(-1),
         d_isSorted(false) {
     PRECONDITION(!matches.empty(), "matches must not be empty");
-    auto na = d_mol.getNumAtoms();
-    d_sumIndices = static_cast<double>(na * (na + 1) / 2);
+    auto dbl_na = static_cast<double>(d_mol.getNumAtoms());
+    d_sumIndices = std::max(1.0, dbl_na * (dbl_na + 1) / 2.0);
     unsigned int i = 0;
     d_matchIdxVsScore.reserve(d_matches.size());
     for (const auto &match : d_matches) {

--- a/Code/RDBoost/Wrap.cpp
+++ b/Code/RDBoost/Wrap.cpp
@@ -74,41 +74,44 @@ void translate_invariant_error(Invar::Invariant const &e) {
 boost::dynamic_bitset<> pythonObjectToDynBitset(
     const python::object &obj, boost::dynamic_bitset<>::size_type maxV) {
   boost::dynamic_bitset<> res(maxV);
-  if (obj) {
-    python::stl_input_iterator<boost::dynamic_bitset<>::size_type> beg(obj),
-        end;
-    while (beg != end) {
-      auto v = *beg;
-      if (v >= maxV) {
-        throw_value_error("list element larger than allowed value");
-      }
-      res.set(v);
-      ++beg;
-    }
+  if (!obj) {
+    return res;
   }
+
+  using pyItr_t =
+      python::stl_input_iterator<boost::dynamic_bitset<>::size_type>;
+
+  pyItr_t beg(obj);
+  pyItr_t end;
+  while (beg != end) {
+    if (*beg >= maxV) {
+      throw_value_error("list element larger than allowed value");
+    }
+    res.set(*beg);
+    ++beg;
+  }
+
   return res;
 }
 
 std::vector<std::pair<int, int>> *translateAtomMap(
     const python::object &atomMap) {
   PySequenceHolder<python::object> pyAtomMap(atomMap);
-  std::vector<std::pair<int, int>> *res;
-  res = nullptr;
-  unsigned int i;
   unsigned int n = pyAtomMap.size();
-  if (n > 0) {
-    res = new std::vector<std::pair<int, int>>;
-    for (i = 0; i < n; ++i) {
-      PySequenceHolder<int> item(pyAtomMap[i]);
-      if (item.size() != 2) {
-        delete res;
-        res = nullptr;
-        throw_value_error("Incorrect format for an atomMap");
-      }
-      res->push_back(std::pair<int, int>(item[0], item[1]));
-    }
+  if (n == 0) {
+    return nullptr;
   }
-  return res;
+
+  auto res = std::make_unique<std::vector<std::pair<int, int>>>();
+  for (unsigned int i = 0; i < n; ++i) {
+    PySequenceHolder<int> item(pyAtomMap[i]);
+    if (item.size() != 2) {
+      throw_value_error("Incorrect format for an atomMap");
+    }
+    res->push_back(std::pair<int, int>(item[0], item[1]));
+  }
+
+  return res.release();
 }
 
 std::vector<std::vector<std::pair<int, int>>> translateAtomMapSeq(
@@ -116,7 +119,7 @@ std::vector<std::vector<std::pair<int, int>>> translateAtomMapSeq(
   std::vector<std::vector<std::pair<int, int>>> aMapVec;
   PySequenceHolder<python::object> pyAtomMapSeq(atomMapSeq);
   for (size_t i = 0; i < pyAtomMapSeq.size(); ++i) {
-    std::vector<std::pair<int, int>> *res = translateAtomMap(pyAtomMapSeq[i]);
+    auto res = translateAtomMap(pyAtomMapSeq[i]);
     aMapVec.push_back(*res);
     delete res;
   }
@@ -126,12 +129,10 @@ std::vector<std::vector<std::pair<int, int>>> translateAtomMapSeq(
 RDNumeric::DoubleVector *translateDoubleSeq(const python::object &doubleSeq) {
   PySequenceHolder<double> doubles(doubleSeq);
   unsigned int nDoubles = doubles.size();
-  RDNumeric::DoubleVector *doubleVec;
-  doubleVec = nullptr;
-  unsigned int i;
+  RDNumeric::DoubleVector *doubleVec = nullptr;
   if (nDoubles > 0) {
     doubleVec = new RDNumeric::DoubleVector(nDoubles);
-    for (i = 0; i < nDoubles; ++i) {
+    for (unsigned int i = 0; i < nDoubles; ++i) {
       doubleVec->setVal(i, doubles[i]);
     }
   }

--- a/Code/SimDivPickers/HierarchicalClusterPicker.cpp
+++ b/Code/SimDivPickers/HierarchicalClusterPicker.cpp
@@ -27,22 +27,19 @@ RDKit::VECT_INT_VECT HierarchicalClusterPicker::cluster(
   // Do the clustering
   auto method = (long int)d_method;
   long int len = poolSize * (poolSize - 1);
-  auto *ia = (long int *)calloc(poolSize, sizeof(long int));
-  auto *ib = (long int *)calloc(poolSize, sizeof(long int));
-  real *crit = (real *)calloc(poolSize, sizeof(real));
-  CHECK_INVARIANT(ia, "failed to allocate memory");
-  CHECK_INVARIANT(ib, "failed to allocate memory");
-  CHECK_INVARIANT(crit, "failed to allocate memory");
+  std::vector<long int> ia(poolSize, 0);
+  std::vector<long int> ib(poolSize, 0);
+  std::vector<real> crit(poolSize, 0.0);
   auto poolSize2 = static_cast<long int>(poolSize);
 
   distdriver_(&poolSize2,       // number of items in the pool
               &len,             // number of entries in the distance matrix
               (real *)distMat,  // distance matrix
               &method,          // the clustering method (ward, slink etc.)
-              ia,               // int vector with clustering history
-              ib,               // one more clustering history matrix
-              crit  // I believe this is a vector the difference in heights of
-                    // two clusters
+              ia.data(),        // int vector with clustering history
+              ib.data(),        // one more clustering history matrix
+              crit.data()       // I believe this is a vector the difference in
+                                // heights of two clusters
   );
 
   // we have the clusters now merge then until the number of clusters is same
@@ -55,14 +52,15 @@ RDKit::VECT_INT_VECT HierarchicalClusterPicker::cluster(
   //     ia[j] is replaced by the new cluster in the cluster list
   //
   RDKit::VECT_INT_VECT clusters;
+  clusters.reserve(poolSize);
   for (unsigned int i = 0; i < poolSize; i++) {
-    RDKit::INT_VECT cls;
-    cls.push_back(i);
+    RDKit::INT_VECT cls = {static_cast<int>(i)};
     clusters.push_back(cls);
   }
 
   // do the merging, each round of of this loop eliminates one cluster
   RDKit::INT_VECT removed;
+  removed.reserve(poolSize - pickSize);
   for (unsigned int i = 0; i < (poolSize - pickSize); i++) {
     int cx1 = ia[i] - 1;
     int cx2 = ib[i] - 1;
@@ -76,10 +74,6 @@ RDKit::VECT_INT_VECT HierarchicalClusterPicker::cluster(
     // mark the second cluster as removed
     removed.push_back(cx2);
   }
-  free(ia);
-  free(ib);
-  free(crit);
-
   // sort removed so that looping will be easier later
   std::sort(removed.begin(), removed.end());
 
@@ -107,7 +101,7 @@ RDKit::INT_VECT HierarchicalClusterPicker::pick(const double *distMat,
                                                 unsigned int poolSize,
                                                 unsigned int pickSize) const {
   PRECONDITION(distMat, "bad distance matrix");
-  RDKit::VECT_INT_VECT clusters = this->cluster(distMat, poolSize, pickSize);
+  auto clusters = this->cluster(distMat, poolSize, pickSize);
   CHECK_INVARIANT(clusters.size() == pickSize, "");
 
   // the last step: find a representative element from each of the


### PR DESCRIPTION
Another follow up to https://github.com/rdkit/rdkit/pull/9450

As usual, each commit is a fix for one AI detected issue, so better look at it commit per commit.

The last one is worth mentioning because it required a test update. The AI detected that, despite the intention, in `Code/GraphMol/Depictor/EmbeddedFrag.cpp` we were using the same neighboring atom twice to calculate an angle, which results in a 0 degree angle. These 0 degree angles may later be declared "winners" in the algorithm, resulting in distortion of the resulting structure.

When fixing this I had to increase tolerance in tests, since one bond changed from length ~1.5 to ~2.09. However, the new coordinates look nicer (somewhat, both are ugly) to me (left is before the fix, right is after the fix):
<img width="547" height="325" alt="image" src="https://github.com/user-attachments/assets/2dce04f1-5142-4902-9031-f417e51cc9c7" />
