### PR TITLE
Fixes #9468

### DIFF
--- a/Code/GraphMol/ChemTransforms/MolFragmenter.cpp
+++ b/Code/GraphMol/ChemTransforms/MolFragmenter.cpp
@@ -559,11 +559,10 @@ ROMol *fragmentOnBonds(
         conf->setAtomPos(idx2, conf->getAtomPos(eidx));
       }
     }
-    for (auto idx : {bidx, eidx}) {
-      // keep track of the atoms so that we can adjust H counts later
-      atomsToUpdate.insert(idx);
-    }
-  }
+    // keep track of the atoms so that we can adjust H counts later
+    atomsToUpdate.insert(bidx);
+    atomsToUpdate.insert(eidx);
+}
   res->commitBatchEdit();
   res->clearComputedProps();
   if (!atomsToUpdate.empty()) {

--- a/Code/GraphMol/ChemTransforms/MolFragmenter.cpp
+++ b/Code/GraphMol/ChemTransforms/MolFragmenter.cpp
@@ -460,7 +460,7 @@ ROMol *fragmentOnBonds(
   for (auto bondIdx : bondIndices) {
     bondsToRemove.push_back(res->getBondWithIdx(bondIdx));
   }
-  boost::dynamic_bitset<> atomsToUpdate(res->getNumAtoms());
+  std::unordered_set<unsigned int> atomsToUpdate;
   res->beginBatchEdit();
   for (unsigned int i = 0; i < bondsToRemove.size(); ++i) {
     const Bond *bond = bondsToRemove[i];
@@ -559,18 +559,16 @@ ROMol *fragmentOnBonds(
     }
     for (auto idx : {bidx, eidx}) {
       // keep track of the atoms so that we can adjust H counts later
-      atomsToUpdate.set(idx);
+      atomsToUpdate.insert(idx);
     }
   }
   res->commitBatchEdit();
   res->clearComputedProps();
-  if (atomsToUpdate.any()) {
+  if (!atomsToUpdate.empty()) {
     // Adjust H counts on atoms where bonds were broken.
     // was github issues 429, 6034
-    std::ranges::for_each(res->atoms(), [&](Atom *atom) {
-      if (!atomsToUpdate[atom->getIdx()]) {
-        return;
-      }
+    std::ranges::for_each(atomsToUpdate, [&](unsigned int idx) {
+      Atom *atom = res->getAtomWithIdx(idx);
       if (!addDummies &&
           (atom->getNoImplicit() ||
            (atom->getIsAromatic() && atom->getAtomicNum() != 6))) {

--- a/Code/GraphMol/ChemTransforms/MolFragmenter.cpp
+++ b/Code/GraphMol/ChemTransforms/MolFragmenter.cpp
@@ -492,6 +492,7 @@ ROMol *fragmentOnBonds(
         at2->setIsotope(eidx);
       }
       unsigned int idx1 = res->addAtom(at1.release(), false, true);
+      atomsToUpdate.insert(idx1);
       if (bondTypes) {
         bT = (*bondTypes)[i];
       }
@@ -510,6 +511,7 @@ ROMol *fragmentOnBonds(
       }
 
       unsigned int idx2 = res->addAtom(at2.release(), false, true);
+      atomsToUpdate.insert(idx2);
       bondidx = res->addBond(bidx, idx2, bT) - 1;
       // this bond starts at the same atom, so its direction should always be
       // correct:
@@ -565,7 +567,7 @@ ROMol *fragmentOnBonds(
   res->commitBatchEdit();
   res->clearComputedProps();
   if (!atomsToUpdate.empty()) {
-    // Adjust H counts on atoms where bonds were broken.
+    // Adjust H counts on dummies and atoms where bonds were broken.
     // was github issues 429, 6034
     std::ranges::for_each(atomsToUpdate, [&](unsigned int idx) {
       Atom *atom = res->getAtomWithIdx(idx);

--- a/Code/GraphMol/ChemTransforms/MolFragmenter.cpp
+++ b/Code/GraphMol/ChemTransforms/MolFragmenter.cpp
@@ -460,6 +460,7 @@ ROMol *fragmentOnBonds(
   for (auto bondIdx : bondIndices) {
     bondsToRemove.push_back(res->getBondWithIdx(bondIdx));
   }
+  boost::dynamic_bitset<> atomsToUpdate(res->getNumAtoms());
   res->beginBatchEdit();
   for (unsigned int i = 0; i < bondsToRemove.size(); ++i) {
     const Bond *bond = bondsToRemove[i];
@@ -555,21 +556,30 @@ ROMol *fragmentOnBonds(
         conf->setAtomPos(idx1, conf->getAtomPos(bidx));
         conf->setAtomPos(idx2, conf->getAtomPos(eidx));
       }
-    } else {
-      // was github issues 429, 6034
-      for (auto idx : {bidx, eidx}) {
-        if (auto tatom = res->getAtomWithIdx(idx);
-            tatom->getNoImplicit() ||
-            (tatom->getIsAromatic() && tatom->getAtomicNum() != 6)) {
-          tatom->setNumExplicitHs(tatom->getNumExplicitHs() + 1);
-        } else {
-          tatom->updatePropertyCache(false);
-        }
-      }
+    }
+    for (auto idx : {bidx, eidx}) {
+      // keep track of the atoms so that we can adjust H counts later
+      atomsToUpdate.set(idx);
     }
   }
   res->commitBatchEdit();
   res->clearComputedProps();
+  if (atomsToUpdate.any()) {
+    // Adjust H counts on atoms where bonds were broken.
+    // was github issues 429, 6034
+    std::ranges::for_each(res->atoms(), [&](Atom *atom) {
+      if (!atomsToUpdate[atom->getIdx()]) {
+        return;
+      }
+      if (!addDummies &&
+          (atom->getNoImplicit() ||
+           (atom->getIsAromatic() && atom->getAtomicNum() != 6))) {
+        atom->setNumExplicitHs(atom->getNumExplicitHs() + 1);
+      }
+      atom->updatePropertyCache(false);
+    });
+  }
+
   return static_cast<ROMol *>(res.release());
 }
 

--- a/Code/GraphMol/ChemTransforms/catch_tests.cpp
+++ b/Code/GraphMol/ChemTransforms/catch_tests.cpp
@@ -811,6 +811,10 @@ TEST_CASE("github #9468") {
       CHECK(res->getAtomWithIdx(i)->getTotalNumHs() ==
             m->getAtomWithIdx(i)->getTotalNumHs());
     }
+    // make sure dummies have implicit props too
+    for (unsigned int i = m->getNumAtoms(); i < res->getNumAtoms(); ++i) {
+      CHECK(res->getAtomWithIdx(i)->getTotalNumHs() == 0);
+    }
   }
   SECTION("test case from Rachel Walker") {
     auto mol = "c1ccccc1CC"_smiles;

--- a/Code/GraphMol/ChemTransforms/catch_tests.cpp
+++ b/Code/GraphMol/ChemTransforms/catch_tests.cpp
@@ -812,4 +812,40 @@ TEST_CASE("github #9468") {
             m->getAtomWithIdx(i)->getTotalNumHs());
     }
   }
+  SECTION("test case from Rachel Walker") {
+    auto mol = "c1ccccc1CC"_smiles;
+    REQUIRE(mol);
+    const auto *coreBond = mol->getBondBetweenAtoms(5, 6);
+    const auto *sidechainBond = mol->getBondBetweenAtoms(6, 7);
+    REQUIRE(coreBond);
+    REQUIRE(sidechainBond);
+    bool addDummies = false;
+    std::unique_ptr<ROMol> splitMol(MolFragmenter::fragmentOnBonds(
+        *mol, {coreBond->getIdx(), sidechainBond->getIdx()}, addDummies));
+    REQUIRE(splitMol);
+    CHECK(splitMol->getAtomWithIdx(5)->getTotalNumHs() == 1);
+    CHECK(splitMol->getAtomWithIdx(6)->getTotalNumHs() == 4);
+    CHECK(splitMol->getAtomWithIdx(7)->getTotalNumHs() == 4);
+  }
+  SECTION("breaking double bonds") {
+    auto mol = "C=CC"_smiles;
+    REQUIRE(mol);
+    std::vector<unsigned int> bonds{0};
+    {
+      bool addDummies = false;
+      std::unique_ptr<ROMol> splitMol(
+          MolFragmenter::fragmentOnBonds(*mol, bonds, addDummies));
+      REQUIRE(splitMol);
+      CHECK(splitMol->getAtomWithIdx(0)->getTotalNumHs() == 4);
+      CHECK(splitMol->getAtomWithIdx(1)->getTotalNumHs() == 3);
+    }
+    {
+      bool addDummies = true;
+      std::unique_ptr<ROMol> splitMol(
+          MolFragmenter::fragmentOnBonds(*mol, bonds, addDummies));
+      REQUIRE(splitMol);
+      CHECK(splitMol->getAtomWithIdx(0)->getTotalNumHs() == 2);
+      CHECK(splitMol->getAtomWithIdx(1)->getTotalNumHs() == 1);
+    }
+  }
 }

--- a/Code/GraphMol/ChemTransforms/catch_tests.cpp
+++ b/Code/GraphMol/ChemTransforms/catch_tests.cpp
@@ -769,3 +769,47 @@ O      3.100000    0.000000    0.000000
     }
   }
 }
+
+TEST_CASE("github #9468") {
+  SECTION("as reported") {
+    auto m = "CCCCC(=O)N1CCCC1"_smiles;
+    REQUIRE(m);
+    std::vector<unsigned int> bonds{{0, 1, 2, 3}};
+    bool addDummies = false;
+    std::unique_ptr<ROMol> res{
+        MolFragmenter::fragmentOnBonds(*m, bonds, addDummies)};
+    REQUIRE(res);
+    CHECK(res->getNumAtoms() == m->getNumAtoms());
+    CHECK(res->getAtomWithIdx(0)->getTotalNumHs() == 4);
+    CHECK(res->getAtomWithIdx(1)->getTotalNumHs() == 4);
+    CHECK(res->getAtomWithIdx(2)->getTotalNumHs() == 4);
+    CHECK(res->getAtomWithIdx(3)->getTotalNumHs() == 4);
+  }
+  SECTION("aromaticity") {
+    auto m = "Cn1cccc1"_smiles;
+    REQUIRE(m);
+    std::vector<unsigned int> bonds = {0};
+    bool addDummies = false;
+    std::unique_ptr<ROMol> res{
+        MolFragmenter::fragmentOnBonds(*m, bonds, addDummies)};
+    REQUIRE(res);
+    CHECK(res->getNumAtoms() == m->getNumAtoms());
+    CHECK(res->getAtomWithIdx(0)->getTotalNumHs() == 4);
+    CHECK(res->getAtomWithIdx(1)->getTotalNumHs() == 1);
+    CHECK(res->getAtomWithIdx(1)->getNumExplicitHs() == 1);
+  }
+  SECTION("no changes to H counts if dummies are added") {
+    auto m = "CCCCC(=O)N1CCCC1"_smiles;
+    REQUIRE(m);
+    std::vector<unsigned int> bonds{{0, 1, 2, 3}};
+    bool addDummies = true;
+    std::unique_ptr<ROMol> res{
+        MolFragmenter::fragmentOnBonds(*m, bonds, addDummies)};
+    REQUIRE(res);
+    CHECK(res->getNumAtoms() > m->getNumAtoms());
+    for (unsigned int i = 0; i < 4; ++i) {
+      CHECK(res->getAtomWithIdx(i)->getTotalNumHs() ==
+            m->getAtomWithIdx(i)->getTotalNumHs());
+    }
+  }
+}


### PR DESCRIPTION
We switched to using batch molecule editing in #9430 and that resulted in atoms not having their H counts updated after bonds were broken.

The fix is to track which atoms are modified and call `updatePropertyCache()` on them after removing bonds.