### PR TITLE
Fix #9464 : Out-of-bounds read in CMLWriter for chiral centers with implicit hydrogens

### DIFF
--- a/Code/GraphMol/FileParsers/CMLWriter.cpp
+++ b/Code/GraphMol/FileParsers/CMLWriter.cpp
@@ -132,7 +132,7 @@ boost::property_tree::ptree molToPTree(const ROMol &mol, int confId,
         neighbors.push_back(at->getIdx());
       }
 
-      // FIX: CML spec requires exactly 4 atomRefs. If there are only 3 
+      //CML spec requires exactly 4 atomRefs. If there are only 3 
       // explicit neighbors (e.g., the 4th ligand is an implicit hydrogen), 
       // the current atom itself should be used as the 4th reference.
       unsigned int centralAtomIdx = a->getIdx();

--- a/Code/GraphMol/FileParsers/CMLWriter.cpp
+++ b/Code/GraphMol/FileParsers/CMLWriter.cpp
@@ -132,6 +132,14 @@ boost::property_tree::ptree molToPTree(const ROMol &mol, int confId,
         neighbors.push_back(at->getIdx());
       }
 
+      // FIX: CML spec requires exactly 4 atomRefs. If there are only 3 
+      // explicit neighbors (e.g., the 4th ligand is an implicit hydrogen), 
+      // the current atom itself should be used as the 4th reference.
+      unsigned int centralAtomIdx = a->getIdx();
+      while (neighbors.size() < 4) {
+        neighbors.push_back(centralAtomIdx);
+      }
+
       auto &atomParity = atom.add("atomParity", parity);
       atomParity.put("<xmlattr>.atomRefs4",
                      boost::format{"%1%%2% %1%%3% %1%%4% %1%%5%"} %

--- a/Code/GraphMol/FileParsers/file_parsers_catch.cpp
+++ b/Code/GraphMol/FileParsers/file_parsers_catch.cpp
@@ -8161,50 +8161,12 @@ M  END)CTAB";
   }
 }
 
-TEST_CASE("CMLWriter handles chiral centers with implicit hydrogens correctly") {
-
-  
+TEST_CASE(
+    "CMLWriter handles chiral centers with implicit hydrogens correctly") {
   auto mol = v2::SmilesParse::MolFromSmiles("F[C@H](Br)Cl");
   REQUIRE(mol);
-  
-  mol->updatePropertyCache();
-  MolOps::assignStereochemistry(*mol, true, true);
-  
-  std::string cml = MolToCMLBlock(*mol);
-  
-  REQUIRE(cml.find("atomParity") != std::string::npos);
-  
-  size_t pos = cml.find("atomRefs4=\"");
-  REQUIRE(pos != std::string::npos);
-  size_t end_pos = cml.find("\"", pos + 12);
-  std::string refs = cml.substr(pos + 12, end_pos - (pos + 12));
-  
-  int ref_count = 1;
-  for (char c : refs) {
-    if (c == ' ') ref_count++;
-  }
-  
-  CHECK(ref_count == 4);
-  
 
-TEST_CASE("CMLWriter handles chiral centers with implicit hydrogens correctly") {
-  auto mol = v2::SmilesParse::MolFromSmiles("F[C@H](Br)Cl");
-  REQUIRE(mol);
-  
   std::string cml = MolToCMLBlock(*mol);
-  REQUIRE(cml.find("atomParity") != std::string::npos);
-  
-  size_t pos = cml.find("atomRefs4=\"");
-  REQUIRE(pos != std::string::npos);
-  size_t end_pos = cml.find("\"", pos + 12);
-  std::string refs = cml.substr(pos + 12, end_pos - (pos + 12));
-  
-  int ref_count = 1;
-  for (auto c : refs) {
-    if (c == ' ') {
-      ref_count++;
-    }
-  }
-  
-  CHECK(ref_count == 4);
+  REQUIRE(cml.find("atomParity atomRefs4=\"a0 a2 a3 a1\"") !=
+          std::string::npos);
 }

--- a/Code/GraphMol/FileParsers/file_parsers_catch.cpp
+++ b/Code/GraphMol/FileParsers/file_parsers_catch.cpp
@@ -8160,3 +8160,31 @@ M  END)CTAB";
                       FileParseException);
   }
 }
+
+TEST_CASE("CMLWriter handles chiral centers with implicit hydrogens correctly") {
+
+  
+  auto mol = v2::SmilesParse::MolFromSmiles("F[C@H](Br)Cl");
+  REQUIRE(mol);
+  
+  mol->updatePropertyCache();
+  MolOps::assignStereochemistry(*mol, true, true);
+  
+  std::string cml = MolToCMLBlock(*mol);
+  
+  REQUIRE(cml.find("atomParity") != std::string::npos);
+  
+  size_t pos = cml.find("atomRefs4=\"");
+  REQUIRE(pos != std::string::npos);
+  size_t end_pos = cml.find("\"", pos + 12);
+  std::string refs = cml.substr(pos + 12, end_pos - (pos + 12));
+  
+  int ref_count = 1;
+  for (char c : refs) {
+    if (c == ' ') ref_count++;
+  }
+  
+  CHECK(ref_count == 4);
+  
+  CHECK(refs.find("a1") != std::string::npos);
+}

--- a/Code/GraphMol/FileParsers/file_parsers_catch.cpp
+++ b/Code/GraphMol/FileParsers/file_parsers_catch.cpp
@@ -8186,5 +8186,25 @@ TEST_CASE("CMLWriter handles chiral centers with implicit hydrogens correctly") 
   
   CHECK(ref_count == 4);
   
-  CHECK(refs.find("a1") != std::string::npos);
+
+TEST_CASE("CMLWriter handles chiral centers with implicit hydrogens correctly") {
+  auto mol = v2::SmilesParse::MolFromSmiles("F[C@H](Br)Cl");
+  REQUIRE(mol);
+  
+  std::string cml = MolToCMLBlock(*mol);
+  REQUIRE(cml.find("atomParity") != std::string::npos);
+  
+  size_t pos = cml.find("atomRefs4=\"");
+  REQUIRE(pos != std::string::npos);
+  size_t end_pos = cml.find("\"", pos + 12);
+  std::string refs = cml.substr(pos + 12, end_pos - (pos + 12));
+  
+  int ref_count = 1;
+  for (auto c : refs) {
+    if (c == ' ') {
+      ref_count++;
+    }
+  }
+  
+  CHECK(ref_count == 4);
 }


### PR DESCRIPTION
### Summary

This PR fixes a bug in the CML writer ( issue #9464 ) where the `atomRefs4` attribute could read out of bounds for chiral centers with fewer than 4 explicit neighbors, for example when the 4th ligand is an implicit hydrogen.

### The Bug

In `Code/GraphMol/FileParsers/CMLWriter.cpp`, the code unconditionally accessed `neighbors[3u]` when generating the `atomRefs4` attribute for chiral centers. When a chiral center had only 3 explicit neighbors, this resulted in an out-of-bounds read.

This could cause garbage memory to be written to the CML file, such as repeating the central atom ID or referencing unrelated atoms, resulting in invalid CML output.

### The Fix

The CML specification explicitly states:

> *"If there are only 3 ligands, the current atom should be included in the 4 atomRefs."*

To follow this requirement, this patch pads the `neighbors` vector with the central atom's own index until it contains exactly 4 elements before formatting the `atomRefs4` string.

This prevents the out-of-bounds read and ensures that the generated CML remains valid and compliant with the specification.

### Testing

- Verified that `fileParsersTest1`, `fileParsersCatchTest`, and `v2FileParsersCatchTest` all pass without regressions.
- Confirmed that chiral centers with 4 explicit neighbors retain the existing behavior.
- Confirmed that chiral centers with 3 explicit neighbors are handled safely, preventing the out-of-bounds read and resulting garbage output.