### PR TITLE
Fix mmff parametrization of cyclophosphazene

### DIFF
--- a/Code/GraphMol/ForceFieldHelpers/MMFF/Builder.cpp
+++ b/Code/GraphMol/ForceFieldHelpers/MMFF/Builder.cpp
@@ -752,8 +752,7 @@ void addVdW(const ROMol &mol, int confId, MMFFMolProperties *mmffMolProperties,
   std::ostream &oStream = mmffMolProperties->getMMFFOStream();
   INT_VECT fragMapping;
   if (ignoreInterfragInteractions) {
-    std::vector<ROMOL_SPTR> molFrags =
-        MolOps::getMolFrags(mol, true, &fragMapping);
+    MolOps::getMolFrags(mol, fragMapping);
   }
 
   unsigned int nAtoms = mol.getNumAtoms();
@@ -842,8 +841,7 @@ void addEle(const ROMol &mol, int confId, MMFFMolProperties *mmffMolProperties,
   std::ostream &oStream = mmffMolProperties->getMMFFOStream();
   INT_VECT fragMapping;
   if (ignoreInterfragInteractions) {
-    std::vector<ROMOL_SPTR> molFrags =
-        MolOps::getMolFrags(mol, true, &fragMapping);
+    MolOps::getMolFrags(mol, fragMapping);
   }
   unsigned int nAtoms = mol.getNumAtoms();
   double totalEleEnergy = 0.0;
@@ -931,8 +929,7 @@ void addNonbonded(const ROMol &mol, int confId,
 
   INT_VECT fragMapping;
   if (ignoreInterfragInteractions) {
-    std::vector<ROMOL_SPTR> molFrags =
-        MolOps::getMolFrags(mol, true, &fragMapping);
+    MolOps::getMolFrags(mol, fragMapping);
   }
 
   unsigned int nAtoms = mol.getNumAtoms();

--- a/Code/GraphMol/ForceFieldHelpers/MMFF/testMMFFHelpers.cpp
+++ b/Code/GraphMol/ForceFieldHelpers/MMFF/testMMFFHelpers.cpp
@@ -12,6 +12,8 @@
 #include <RDGeneral/RDLog.h>
 #include <RDGeneral/utils.h>
 
+#include <memory>
+
 #include <GraphMol/RDKitBase.h>
 #include <GraphMol/SmilesParse/SmilesParse.h>
 #include <GraphMol/SmilesParse/SmilesWrite.h>
@@ -1084,6 +1086,29 @@ void testGithub6728() {
   delete field;
 }
 
+void testCyclophosphazeneFragmentMapping() {
+  BOOST_LOG(rdErrorLog) << "-------------------------------------" << std::endl;
+  BOOST_LOG(rdErrorLog)
+      << "    Testing MMFF nonbonded terms for cyclophosphazene."
+      << std::endl;
+  std::unique_ptr<RWMol> mol(
+      SmilesToMol("C1CNP2(=NP=NP=N2)NC1"));
+  TEST_ASSERT(mol);
+  MolOps::addHs(*mol);
+  TEST_ASSERT(DGeomHelpers::EmbedMolecule(*mol) >= 0);
+
+  MMFF::MMFFMolProperties mmffMolProperties(*mol);
+  TEST_ASSERT(mmffMolProperties.isValid());
+  std::unique_ptr<ForceFields::ForceField> field(MMFF::constructForceField(
+      *mol, &mmffMolProperties, 100.0, -1,
+      /*ignoreInterfragInteractions=*/true));
+  TEST_ASSERT(field);
+  field->initialize();
+  TEST_ASSERT(field->minimize(1000) == 0);
+
+  BOOST_LOG(rdErrorLog) << "  done" << std::endl;
+}
+
 //-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
 //
 //-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
@@ -1113,4 +1138,5 @@ int main() {
 #endif
   testGithub224();
   testGithub6728();
+  testCyclophosphazeneFragmentMapping();
 }


### PR DESCRIPTION
Fixes #9473 by moving to non-mutating mol fragment API.
