### PR TITLE
Use boost::small_vector to remove heap allocations in new_canon

### DIFF
--- a/Code/GraphMol/new_canon.cpp
+++ b/Code/GraphMol/new_canon.cpp
@@ -483,7 +483,7 @@ bondholder makeBondHolder(const Bond *bond, unsigned int otherIdx,
   }
   return res;
 }
-void getBonds(const ROMol &mol, const Atom *at, bondholder_vector &nbrs,
+void getBonds(const ROMol &mol, const Atom *at, BondholderVector &nbrs,
               bool includeChirality,
               const std::vector<Canon::canon_atom> &atoms) {
   PRECONDITION(at, "bad pointer");
@@ -499,7 +499,7 @@ void getBonds(const ROMol &mol, const Atom *at, bondholder_vector &nbrs,
 }
 
 void getChiralBonds(const ROMol &mol, const Atom *at,
-                    bondholder_vector &nbrs) {
+                    BondholderVector &nbrs) {
   PRECONDITION(at, "bad pointer");
   ROMol::OEDGE_ITER beg, end;
   boost::tie(beg, end) = mol.getAtomBonds(at);
@@ -699,7 +699,8 @@ void initChiralCanonAtoms(const ROMol &mol,
 }
 
 }  // namespace detail
-void updateAtomNeighborIndex(canon_atom *atoms, bondholder_vector &nbrs) {
+template <typename Bondholders>
+void updateAtomNeighborIndexImpl(canon_atom *atoms, Bondholders &nbrs) {
   PRECONDITION(atoms, "bad pointer");
   for (auto &nbr : nbrs) {
     unsigned nbrIdx = nbr.nbrIdx;
@@ -707,6 +708,15 @@ void updateAtomNeighborIndex(canon_atom *atoms, bondholder_vector &nbrs) {
     nbr.nbrSymClass = newSymClass;
   }
   std::sort(nbrs.begin(), nbrs.end(), bondholder::greater);
+}
+
+void updateAtomNeighborIndex(canon_atom *atoms,
+                             std::vector<bondholder> &nbrs) {
+  updateAtomNeighborIndexImpl(atoms, nbrs);
+}
+
+void updateAtomNeighborIndex(canon_atom *atoms, BondholderVector &nbrs) {
+  updateAtomNeighborIndexImpl(atoms, nbrs);
 }
 
 // This routine calculates the number of swaps that would be required to
@@ -721,8 +731,9 @@ void updateAtomNeighborIndex(canon_atom *atoms, bondholder_vector &nbrs) {
 // that have the same priority so far.  If any two are the same, we do NOT use
 // that neighbor to determine the priority of the atom of interest.
 
-void updateAtomNeighborNumSwaps(
-    canon_atom *atoms, bondholder_vector &nbrs, unsigned int atomIdx,
+template <typename Bondholders>
+void updateAtomNeighborNumSwapsImpl(
+    canon_atom *atoms, Bondholders &nbrs, unsigned int atomIdx,
     std::vector<std::pair<unsigned int, unsigned int>> &result) {
   bool isRingAtom = queryIsAtomInRing(atoms[atomIdx].atom);
   for (auto &nbr : nbrs) {
@@ -777,6 +788,18 @@ void updateAtomNeighborNumSwaps(
     }
   }
   sort(result.begin(), result.end());
+}
+
+void updateAtomNeighborNumSwaps(
+    canon_atom *atoms, std::vector<bondholder> &nbrs, unsigned int atomIdx,
+    std::vector<std::pair<unsigned int, unsigned int>> &result) {
+  updateAtomNeighborNumSwapsImpl(atoms, nbrs, atomIdx, result);
+}
+
+void updateAtomNeighborNumSwaps(
+    canon_atom *atoms, BondholderVector &nbrs, unsigned int atomIdx,
+    std::vector<std::pair<unsigned int, unsigned int>> &result) {
+  updateAtomNeighborNumSwapsImpl(atoms, nbrs, atomIdx, result);
 }
 
 void rankMolAtoms(const ROMol &mol, std::vector<unsigned int> &res,

--- a/Code/GraphMol/new_canon.cpp
+++ b/Code/GraphMol/new_canon.cpp
@@ -483,7 +483,7 @@ bondholder makeBondHolder(const Bond *bond, unsigned int otherIdx,
   }
   return res;
 }
-void getBonds(const ROMol &mol, const Atom *at, std::vector<bondholder> &nbrs,
+void getBonds(const ROMol &mol, const Atom *at, bondholder_vector &nbrs,
               bool includeChirality,
               const std::vector<Canon::canon_atom> &atoms) {
   PRECONDITION(at, "bad pointer");
@@ -499,7 +499,7 @@ void getBonds(const ROMol &mol, const Atom *at, std::vector<bondholder> &nbrs,
 }
 
 void getChiralBonds(const ROMol &mol, const Atom *at,
-                    std::vector<bondholder> &nbrs) {
+                    bondholder_vector &nbrs) {
   PRECONDITION(at, "bad pointer");
   ROMol::OEDGE_ITER beg, end;
   boost::tie(beg, end) = mol.getAtomBonds(at);
@@ -699,7 +699,7 @@ void initChiralCanonAtoms(const ROMol &mol,
 }
 
 }  // namespace detail
-void updateAtomNeighborIndex(canon_atom *atoms, std::vector<bondholder> &nbrs) {
+void updateAtomNeighborIndex(canon_atom *atoms, bondholder_vector &nbrs) {
   PRECONDITION(atoms, "bad pointer");
   for (auto &nbr : nbrs) {
     unsigned nbrIdx = nbr.nbrIdx;
@@ -722,7 +722,7 @@ void updateAtomNeighborIndex(canon_atom *atoms, std::vector<bondholder> &nbrs) {
 // that neighbor to determine the priority of the atom of interest.
 
 void updateAtomNeighborNumSwaps(
-    canon_atom *atoms, std::vector<bondholder> &nbrs, unsigned int atomIdx,
+    canon_atom *atoms, bondholder_vector &nbrs, unsigned int atomIdx,
     std::vector<std::pair<unsigned int, unsigned int>> &result) {
   bool isRingAtom = queryIsAtomInRing(atoms[atomIdx].atom);
   for (auto &nbr : nbrs) {

--- a/Code/GraphMol/new_canon.h
+++ b/Code/GraphMol/new_canon.h
@@ -20,6 +20,7 @@
 #include <RDGeneral/BoostStartInclude.h>
 #include <cstdint>
 #include <boost/dynamic_bitset.hpp>
+#include <boost/container/small_vector.hpp>
 #include <RDGeneral/BoostEndInclude.h>
 #include <cstring>
 #include <cassert>
@@ -99,6 +100,7 @@ struct RDKIT_GRAPHMOL_EXPORT bondholder {
     return 0;
   }
 };
+using bondholder_vector = boost::container::small_vector<bondholder, 4>;
 struct RDKIT_GRAPHMOL_EXPORT canon_atom {
   const Atom *atom{nullptr};
   int index{-1};
@@ -113,14 +115,14 @@ struct RDKIT_GRAPHMOL_EXPORT canon_atom {
       nullptr};  // if provided, this is used to order atoms
   std::vector<int> neighborNum;
   std::vector<int> revistedNeighbors;
-  std::vector<bondholder> bonds;
+  bondholder_vector bonds;
 };
 
 RDKIT_GRAPHMOL_EXPORT void updateAtomNeighborIndex(
-    canon_atom *atoms, std::vector<bondholder> &nbrs);
+    canon_atom *atoms, bondholder_vector &nbrs);
 
 RDKIT_GRAPHMOL_EXPORT void updateAtomNeighborNumSwaps(
-    canon_atom *atoms, std::vector<bondholder> &nbrs, unsigned int atomIdx,
+    canon_atom *atoms, bondholder_vector &nbrs, unsigned int atomIdx,
     std::vector<std::pair<unsigned int, unsigned int>> &result);
 
 /*
@@ -571,7 +573,7 @@ class RDKIT_GRAPHMOL_EXPORT AtomCompareFunctor {
 
 const unsigned int ATNUM_CLASS_OFFSET = 10000;
 class RDKIT_GRAPHMOL_EXPORT ChiralAtomCompareFunctor {
-  void getAtomNeighborhood(std::vector<bondholder> &nbrs) const {
+  void getAtomNeighborhood(bondholder_vector &nbrs) const {
     for (unsigned j = 0; j < nbrs.size(); ++j) {
       unsigned int nbrIdx = nbrs[j].nbrIdx;
       if (nbrIdx == ATNUM_CLASS_OFFSET) {

--- a/Code/GraphMol/new_canon.h
+++ b/Code/GraphMol/new_canon.h
@@ -100,7 +100,7 @@ struct RDKIT_GRAPHMOL_EXPORT bondholder {
     return 0;
   }
 };
-using bondholder_vector = boost::container::small_vector<bondholder, 4>;
+using BondholderVector = boost::container::small_vector<bondholder, 4>;
 struct RDKIT_GRAPHMOL_EXPORT canon_atom {
   const Atom *atom{nullptr};
   int index{-1};
@@ -115,14 +115,19 @@ struct RDKIT_GRAPHMOL_EXPORT canon_atom {
       nullptr};  // if provided, this is used to order atoms
   std::vector<int> neighborNum;
   std::vector<int> revistedNeighbors;
-  bondholder_vector bonds;
+  BondholderVector bonds;
 };
 
 RDKIT_GRAPHMOL_EXPORT void updateAtomNeighborIndex(
-    canon_atom *atoms, bondholder_vector &nbrs);
+    canon_atom *atoms, std::vector<bondholder> &nbrs);
+RDKIT_GRAPHMOL_EXPORT void updateAtomNeighborIndex(canon_atom *atoms,
+                                                   BondholderVector &nbrs);
 
 RDKIT_GRAPHMOL_EXPORT void updateAtomNeighborNumSwaps(
-    canon_atom *atoms, bondholder_vector &nbrs, unsigned int atomIdx,
+    canon_atom *atoms, std::vector<bondholder> &nbrs, unsigned int atomIdx,
+    std::vector<std::pair<unsigned int, unsigned int>> &result);
+RDKIT_GRAPHMOL_EXPORT void updateAtomNeighborNumSwaps(
+    canon_atom *atoms, BondholderVector &nbrs, unsigned int atomIdx,
     std::vector<std::pair<unsigned int, unsigned int>> &result);
 
 /*
@@ -573,7 +578,7 @@ class RDKIT_GRAPHMOL_EXPORT AtomCompareFunctor {
 
 const unsigned int ATNUM_CLASS_OFFSET = 10000;
 class RDKIT_GRAPHMOL_EXPORT ChiralAtomCompareFunctor {
-  void getAtomNeighborhood(bondholder_vector &nbrs) const {
+  void getAtomNeighborhood(BondholderVector &nbrs) const {
     for (unsigned j = 0; j < nbrs.size(); ++j) {
       unsigned int nbrIdx = nbrs[j].nbrIdx;
       if (nbrIdx == ATNUM_CLASS_OFFSET) {

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -9,9 +9,9 @@ GitHub)
 ## Highlights
 
 ## Backwards incompatible changes:
-- `Canon::canon_atom::bonds` now uses `boost::container::small_vector` instead
-  of `std::vector`. Its vector-like interface is unchanged, but C++ code which
-  relies on the member's exact type must be updated.
+- `Canon::canon_atom::bonds` has changed from
+  `std::vector<Canon::bondholder>` to `Canon::BondholderVector`, an alias for
+  `boost::container::small_vector<Canon::bondholder, 4>`.
 - Since #9208, atom rings are "normalized" so that the first atom in the ring
 definition is the one with the lowest index, and the second one is the neighbor
 to the first which also has the lowest index.

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -9,6 +9,9 @@ GitHub)
 ## Highlights
 
 ## Backwards incompatible changes:
+- `Canon::canon_atom::bonds` now uses `boost::container::small_vector` instead
+  of `std::vector`. Its vector-like interface is unchanged, but C++ code which
+  relies on the member's exact type must be updated.
 - Since #9208, atom rings are "normalized" so that the first atom in the ring
 definition is the one with the lowest index, and the second one is the neighbor
 to the first which also has the lowest index.

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -9,9 +9,7 @@ GitHub)
 ## Highlights
 
 ## Backwards incompatible changes:
-- `Canon::canon_atom::bonds` has changed from
-  `std::vector<Canon::bondholder>` to `Canon::BondholderVector`, an alias for
-  `boost::container::small_vector<Canon::bondholder, 4>`.
+- `Canon::canon_atom::bonds` now uses `boost::container::small_vector`.
 - Since #9208, atom rings are "normalized" so that the first atom in the ring
 definition is the one with the lowest index, and the second one is the neighbor
 to the first which also has the lowest index.


### PR DESCRIPTION
boost::small_vector is stack allocated for up to 4 elements, so avoids allocating in 99% of use cases. It still safely handles allocation past this at a performance cost, so expanded octets are still supported. 

PR 4 for #9475 