### PR TITLE
SHARED-12489 wedges on bridge

### DIFF
--- a/Code/GraphMol/WedgeBonds.cpp
+++ b/Code/GraphMol/WedgeBonds.cpp
@@ -13,6 +13,9 @@
 #include <sstream>
 #include <set>
 #include <algorithm>
+#include <cmath>
+#include <numeric>
+#include <tuple>
 #include <RDGeneral/utils.h>
 #include <RDGeneral/Invariant.h>
 #include <RDGeneral/RDLog.h>
@@ -50,6 +53,95 @@ std::tuple<unsigned int, unsigned int, unsigned int> getDoubleBondPresence(
 }  // namespace
 
 namespace detail {
+
+namespace {
+// Depictions often contain small coordinate distortions, so do not require an
+// exact regular polygon. A 5% tolerance is tight enough to distinguish rings
+// deliberately drawn as irregular while accepting normal depiction noise.
+constexpr double regularRingRelativeTolerance = 0.05;
+
+bool valuesAreNearlyEqual(const std::vector<double> &values) {
+  PRECONDITION(!values.empty(), "no values provided");
+  const auto mean =
+      std::accumulate(values.begin(), values.end(), 0.0) / values.size();
+  if (mean <= 0.0) {
+    return false;
+  }
+  return std::all_of(values.begin(), values.end(), [mean](double value) {
+    return std::abs(value - mean) <=
+           regularRingRelativeTolerance * mean;
+  });
+}
+
+bool ringIsRegularPolygon(const ROMol &mol, unsigned int ringIdx,
+                          const Conformer *conf) {
+  // This preference is based on the displayed 2D geometry. Without 2D
+  // coordinates, retain the existing bond-selection behavior.
+  if (!conf || conf->is3D()) {
+    return false;
+  }
+  const auto ringInfo = mol.getRingInfo();
+  const auto &atomRings = ringInfo->atomRings();
+  const auto &bondRings = ringInfo->bondRings();
+  PRECONDITION(ringIdx < atomRings.size(), "bad ring index");
+  PRECONDITION(ringIdx < bondRings.size(), "bad ring index");
+  const auto &ringAtoms = atomRings[ringIdx];
+  if (ringAtoms.size() < 3) {
+    return false;
+  }
+
+  RDGeom::Point3D center;
+  for (auto atomIdx : ringAtoms) {
+    auto pos = conf->getAtomPos(atomIdx);
+    pos.z = 0.0;
+    center += pos;
+  }
+  center /= static_cast<double>(ringAtoms.size());
+
+  std::vector<double> radii;
+  radii.reserve(ringAtoms.size());
+  for (auto atomIdx : ringAtoms) {
+    auto radius = conf->getAtomPos(atomIdx) - center;
+    radius.z = 0.0;
+    radii.push_back(radius.length());
+  }
+
+  std::vector<double> bondLengths;
+  bondLengths.reserve(bondRings[ringIdx].size());
+  for (auto bondIdx : bondRings[ringIdx]) {
+    const auto bond = mol.getBondWithIdx(bondIdx);
+    auto bondVector = conf->getAtomPos(bond->getBeginAtomIdx()) -
+                      conf->getAtomPos(bond->getEndAtomIdx());
+    bondVector.z = 0.0;
+    bondLengths.push_back(bondVector.length());
+  }
+
+  // A regular polygon has both equally spaced vertices around its center and
+  // equal sides. Checking both avoids classifying merely cyclic or equilateral
+  // but visibly irregular ring layouts as regular polygons.
+  return valuesAreNearlyEqual(radii) && valuesAreNearlyEqual(bondLengths);
+}
+
+bool bondIsInRegularPolygon(const ROMol &mol, unsigned int bondIdx,
+                            const Conformer *conf) {
+  if (!conf || conf->is3D()) {
+    return false;
+  }
+  const auto ringInfo = mol.getRingInfo();
+  const auto &ringMembership = ringInfo->bondMembers(bondIdx);
+  // In fused systems a bond may belong to multiple perceived rings. Avoid it
+  // if any one of those rings is displayed as a regular polygon.
+  return std::any_of(ringMembership.begin(), ringMembership.end(),
+                     [&](unsigned int ringIdx) {
+                       return ringIsRegularPolygon(mol, ringIdx, conf);
+                     });
+}
+
+int pickBondToWedgeImpl(
+    const Atom *atom, const ROMol &mol, const INT_VECT &nChiralNbrs,
+    const std::map<int, std::unique_ptr<Chirality::WedgeInfoBase>> &wedgeBonds,
+    int noNbrs, const Conformer *conf);
+}  // namespace
 
 std::pair<bool, INT_VECT> countChiralNbrs(const ROMol &mol, int noNbrs) {
   INT_VECT nChiralNbrs(mol.getNumAtoms(), noNbrs);
@@ -276,6 +368,15 @@ int pickBondToWedge(
     const Atom *atom, const ROMol &mol, const INT_VECT &nChiralNbrs,
     const std::map<int, std::unique_ptr<Chirality::WedgeInfoBase>> &wedgeBonds,
     int noNbrs) {
+  return pickBondToWedgeImpl(atom, mol, nChiralNbrs, wedgeBonds, noNbrs,
+                             nullptr);
+}
+
+namespace {
+int pickBondToWedgeImpl(
+    const Atom *atom, const ROMol &mol, const INT_VECT &nChiralNbrs,
+    const std::map<int, std::unique_ptr<Chirality::WedgeInfoBase>> &wedgeBonds,
+    int noNbrs, const Conformer *conf) {
   // here is what we are going to do
   // - at each chiral center look for a bond that is begins at the atom and
   //   is not yet picked to be wedged for a different chiral center, preferring
@@ -291,7 +392,8 @@ int pickBondToWedge(
     MolOps::findSSSR(mol);
   }
 
-  std::vector<std::pair<int, int>> nbrScores;
+  // is-ring-bond, is-in-regular-polygon, existing score, bond id
+  std::vector<std::tuple<bool, bool, int, int>> nbrScores;
   for (const auto bond : mol.atomBonds(atom)) {
     // can only wedge single bonds:
     if (bond->getBondType() != Bond::SINGLE) {
@@ -303,7 +405,7 @@ int pickBondToWedge(
       // very strong preference for Hs:
       auto *oatom = bond->getOtherAtom(atom);
       if (oatom->getAtomicNum() == 1) {
-        nbrScores.emplace_back(-1000000,
+        nbrScores.emplace_back(false, false, -1000000,
                                bid);  // lower than anything else can be
         continue;
       }
@@ -337,7 +439,9 @@ int pickBondToWedge(
       // std::cerr << "    nrbScore: " << idx << " - " << oIdx << " : "
       //           << nbrScore << " nChiralNbrs: " << nChiralNbrs[oIdx]
       //           << std::endl;
-      nbrScores.emplace_back(nbrScore, bid);
+      const auto isRingBond = mol.getRingInfo()->numBondRings(bid) != 0;
+      nbrScores.emplace_back(
+          isRingBond, bondIsInRegularPolygon(mol, bid, conf), nbrScore, bid);
     }
   }
   // There's still one situation where this whole thing can fail: an unlucky
@@ -351,9 +455,28 @@ int pickBondToWedge(
   if (nbrScores.empty()) {
     return -1;
   }
-  auto minPr = std::min_element(nbrScores.begin(), nbrScores.end());
-  return minPr->second;
+  const auto allCandidatesAreRingBonds =
+      std::all_of(nbrScores.begin(), nbrScores.end(), [](const auto &score) {
+        return std::get<0>(score);
+      });
+  const auto minPr = std::min_element(
+      nbrScores.begin(), nbrScores.end(),
+      [allCandidatesAreRingBonds](const auto &lhs, const auto &rhs) {
+        // Preserve the established scoring whenever a non-ring bond is
+        // available. Only when a ring bond is unavoidable do we first prefer
+        // one that is not part of a regularly drawn polygon.
+        if (allCandidatesAreRingBonds) {
+          return std::tie(std::get<1>(lhs), std::get<2>(lhs),
+                          std::get<3>(lhs)) <
+                 std::tie(std::get<1>(rhs), std::get<2>(rhs),
+                          std::get<3>(rhs));
+        }
+        return std::tie(std::get<2>(lhs), std::get<3>(lhs)) <
+               std::tie(std::get<2>(rhs), std::get<3>(rhs));
+      });
+  return std::get<3>(*minPr);
 }
+}  // namespace
 
 }  // namespace detail
 
@@ -399,8 +522,8 @@ std::map<int, std::unique_ptr<Chirality::WedgeInfoBase>> pickBondsToWedge(
     if (type != Atom::CHI_TETRAHEDRAL_CW && type != Atom::CHI_TETRAHEDRAL_CCW) {
       break;
     }
-    auto bnd1 =
-        detail::pickBondToWedge(atom, mol, nChiralNbrs, wedgeInfo, noNbrs);
+    auto bnd1 = detail::pickBondToWedgeImpl(atom, mol, nChiralNbrs, wedgeInfo,
+                                            noNbrs, conf);
     if (bnd1 >= 0) {
       auto wi = std::unique_ptr<RDKit::Chirality::WedgeInfoChiral>(
           new RDKit::Chirality::WedgeInfoChiral(idx));

--- a/Code/GraphMol/catch_chirality.cpp
+++ b/Code/GraphMol/catch_chirality.cpp
@@ -1539,6 +1539,44 @@ TEST_CASE("pickBondsToWedge() should avoid double bonds") {
   }
 }
 
+TEST_CASE("SHARED-12489: avoid wedging bonds in regular polygon rings",
+          "[wedging][regression]") {
+  auto mol = "CN1[C@@H]2CCC[C@H]1C2"_smiles;
+  REQUIRE(mol);
+
+  // Coordinates produced by the 2D depictor for this molecule. Atoms 1-6
+  // form the regular outer polygon, while bonds 6 and 8 point into the
+  // irregular bridged-ring portion of the depiction.
+  auto conf = std::make_unique<Conformer>(mol->getNumAtoms());
+  const std::vector<RDGeom::Point3D> positions = {
+      {0.0, 2.8400034005593087, 0.0},
+      {0.0, 1.42, 0.0},
+      {1.22976, 0.71, 0.0},
+      {1.22976, -0.71, 0.0},
+      {0.0, -1.42, 0.0},
+      {-1.22976, -0.71, 0.0},
+      {-1.22976, 0.71, 0.0},
+      {0.0, 0.21, 0.0},
+  };
+  for (unsigned int atomIdx = 0; atomIdx < positions.size(); ++atomIdx) {
+    conf->setAtomPos(atomIdx, positions[atomIdx]);
+  }
+  conf->set3D(false);
+  mol->addConformer(conf.release(), true);
+
+  const auto wedgeBonds = Chirality::pickBondsToWedge(*mol);
+  REQUIRE(wedgeBonds.size() == 2);
+  std::vector<int> wedgeBondIndices;
+  for (const auto &wedgeBond : wedgeBonds) {
+    wedgeBondIndices.push_back(wedgeBond.first);
+  }
+  CHECK(wedgeBondIndices == std::vector<int>{6, 8});
+
+  Chirality::wedgeMolBonds(*mol, &mol->getConformer());
+  CHECK(mol->getBondWithIdx(6)->getBondDir() == Bond::BEGINWEDGE);
+  CHECK(mol->getBondWithIdx(8)->getBondDir() == Bond::BEGINWEDGE);
+}
+
 TEST_CASE("addWavyBondsForStereoAny()") {
   SECTION("simplest") {
     auto mol = "CC=CC"_smiles;

--- a/Code/MinimalLib/cffi_test.c
+++ b/Code/MinimalLib/cffi_test.c
@@ -336,11 +336,13 @@ M  END",
   assert(pkl2);
   assert(pkl2_size > 0);
   molblock = get_molblock(pkl2, pkl2_size, NULL);
-  assert(strstr(molblock, "4  3  1  6"));
+  assert(strstr(molblock, "4  5  1  6"));
+  assert(strstr(molblock, "8  6  1  6"));
   assert(!strstr(molblock, "H  "));
   free(molblock);
   molblock = get_molblock(pkl2, pkl2_size, "{\"useMolBlockWedging\":true}");
-  assert(!strstr(molblock, "4  3  1  6"));
+  assert(!strstr(molblock, "4  5  1  6"));
+  assert(!strstr(molblock, "8  6  1  6"));
   assert(strstr(molblock, "6  7  1  1"));
   assert(!strstr(molblock, "H  "));
   free(molblock);
@@ -359,7 +361,8 @@ M  END",
   molblock = get_molblock(pkl2, pkl2_size, "{\"useMolBlockWedging\":true}");
   find_wedged_bonds(molblock, &have1, &have6);
   assert(!have1 && have6);
-  assert(!strstr(molblock, "4  3  1  6"));
+  assert(!strstr(molblock, "4  5  1  6"));
+  assert(!strstr(molblock, "8  6  1  6"));
   assert(strstr(molblock, "6  7  1  6"));
   assert(!strstr(molblock, "H  "));
   free(molblock);
@@ -2857,7 +2860,7 @@ M  END\n\
     ptr_end = strstr(ptr, "|");
     assert(ptr_end);
     *ptr_end = '\0';
-    assert(!strcmp(ptr, "wD:3.9,wU:1.0,5.4,6.7"));
+    assert(!strcmp(ptr, "wD:3.2,5.5,wU:1.0,6.7"));
     free(canonical_cxsmiles);
   }
   canonical_cxsmiles =

--- a/Code/MinimalLib/tests/tests.js
+++ b/Code/MinimalLib/tests/tests.js
@@ -1456,9 +1456,12 @@ M  END
     assert(svg2.includes("atom-17"));
     assert(!svg2.includes("atom-18"));
     assert(!svg2.includes("atom-19"));
-    assert(mol.get_molblock().includes("4  3  1  6"));
-    var molblock = mol.get_molblock(JSON.stringify({ useMolBlockWedging: true }));
-    assert(!molblock.includes("4  3  1  6"));
+    var molblock = mol.get_molblock();
+    assert(molblock.includes("4  5  1  6"));
+    assert(molblock.includes("8  6  1  6"));
+    molblock = mol.get_molblock(JSON.stringify({ useMolBlockWedging: true }));
+    assert(!molblock.includes("4  5  1  6"));
+    assert(!molblock.includes("8  6  1  6"));
     assert(molblock.includes("6  7  1  1"));
     // Here we want to test that the original molblock wedging is preserved and inverted
     // as the coordinates are rigid-body rotated
@@ -1468,7 +1471,8 @@ M  END
     molblock = molCopy.get_molblock(JSON.stringify({ useMolBlockWedging: true }));
     assert(molblock.split('\n').some(line => line.match(/^ [1 ]\d [1 ]\d  [12]  6 *$/)));
     assert(!molblock.split('\n').some(line => line.match(/^ [1 ]\d [1 ]\d  [12]  1 *$/)));
-    assert(!molblock.includes("4  3  1  6"));
+    assert(!molblock.includes("4  5  1  6"));
+    assert(!molblock.includes("8  6  1  6"));
     assert(molblock.includes("6  7  1  6"));
     molCopy.delete();
     // Here we want to test that the original molblock wedging gets cleared
@@ -3171,13 +3175,13 @@ M  END
             const canonicalCXSmiles = mol.get_cxsmiles();
             const [_, canonicalSmiles, wedging] = canonicalCXSmiles.match(/^(\S+) \|\([^\)]+\),([^\|]+)\|$/);
             assert(canonicalSmiles === 'N[C@@H]1C[C@@H]2C[C@H]1[C@@H](O)C2');
-            assert(wedging === 'wD:3.9,wU:1.0,5.4,6.7');
+            assert(wedging === 'wD:3.2,5.5,wU:1.0,6.7');
         }
         ['{}', ''].forEach((emptyJson) => {
             const canonicalCXSmiles = mol.get_cxsmiles(emptyJson);
             const [_, canonicalSmiles, wedging] = canonicalCXSmiles.match(/^(\S+) \|\([^\)]+\),([^\|]+)\|$/);
             assert(canonicalSmiles === 'N[C@@H]1C[C@@H]2C[C@H]1[C@@H](O)C2');
-            assert(wedging === 'wD:3.9,wU:1.0,5.4,6.7');
+            assert(wedging === 'wD:3.2,5.5,wU:1.0,6.7');
         });
         {
             const canonicalCXSmiles = mol.get_cxsmiles(JSON.stringify({restoreBondDirOption: 'RestoreBondDirOptionTrue'}));


### PR DESCRIPTION
disfavour putting wedges and dashes on regularly shaped rings, so they end up preferably on bridge rings. note that if any non-ring bonds exist, those will still be picked first.

Here's an example

<img width="342" height="350" alt="Screenshot 2026-08-11 at 12 16 00" src="https://github.com/user-attachments/assets/5d4f299d-b5c4-4af1-903a-f3616892f427" />

added an automated test


updated an existing test molecule from:

<img width="386" height="353" alt="Screenshot 2026-08-11 at 16 40 01" src="https://github.com/user-attachments/assets/6d6d669c-3bc4-4e46-9d10-003105e13a9f" />


to:
<img width="438" height="359" alt="Screenshot 2026-08-11 at 16 39 56" src="https://github.com/user-attachments/assets/c7c4490c-954c-4e23-b95e-fe30b850da4b" />
