### PR TITLE
MacroMol Local Library

### DIFF
--- a/Code/GraphMol/MacroMol.cpp
+++ b/Code/GraphMol/MacroMol.cpp
@@ -47,16 +47,15 @@ MacroMol &MacroMol::operator=(const MacroMol &other) {
   return *this;
 }
 
-void MacroMol::addLocalTemplate(
-    std::unique_ptr<MacroMolTemplate> macroMolTemplate) {
-  dp_localTemplateLibrary->addTemplate(std::move(macroMolTemplate));
+MacroMolTemplateLibrary &MacroMol::getLocalTemplateLibrary() {
+  return *dp_localTemplateLibrary;
 }
 
 const MacroMolTemplateLibrary &MacroMol::getLocalTemplateLibrary() const {
   return *dp_localTemplateLibrary;
 }
 
-bool MacroMol::hasValidLocalTemplateReferences() const {
+bool MacroMol::checkLocalTemplateReferences() const {
   for (const auto *atom : atoms()) {
     const auto *macroAtomInfo = atom->getMacroAtomInfo();
     if (!macroAtomInfo) {

--- a/Code/GraphMol/MacroMol.cpp
+++ b/Code/GraphMol/MacroMol.cpp
@@ -22,6 +22,56 @@ bool isMacroAtom(const Atom *atom) {
 }
 }  // namespace
 
+MacroMol::MacroMol()
+    : dp_localTemplateLibrary(
+          std::make_unique<MacroMolTemplateLibrary>()) {}
+
+MacroMol::MacroMol(
+    std::unique_ptr<MacroMolTemplateLibrary> localTemplateLibrary)
+    : dp_localTemplateLibrary(std::move(localTemplateLibrary)) {
+  PRECONDITION(dp_localTemplateLibrary, "local template library is null");
+}
+
+MacroMol::MacroMol(const MacroMol &other)
+    : RWMol(other),
+      dp_localTemplateLibrary(std::make_unique<MacroMolTemplateLibrary>(
+          *other.dp_localTemplateLibrary)) {}
+
+MacroMol &MacroMol::operator=(const MacroMol &other) {
+  if (this != &other) {
+    auto localTemplateLibrary = std::make_unique<MacroMolTemplateLibrary>(
+        *other.dp_localTemplateLibrary);
+    RWMol::operator=(other);
+    dp_localTemplateLibrary = std::move(localTemplateLibrary);
+  }
+  return *this;
+}
+
+void MacroMol::addLocalTemplate(
+    std::unique_ptr<MacroMolTemplate> macroMolTemplate) {
+  dp_localTemplateLibrary->addTemplate(std::move(macroMolTemplate));
+}
+
+const MacroMolTemplateLibrary &MacroMol::getLocalTemplateLibrary() const {
+  return *dp_localTemplateLibrary;
+}
+
+bool MacroMol::hasValidLocalTemplateReferences() const {
+  for (const auto *atom : atoms()) {
+    const auto *macroAtomInfo = atom->getMacroAtomInfo();
+    if (!macroAtomInfo) {
+      continue;
+    }
+    const auto monomerClass = macroAtomInfo->getMonomerClass();
+    const auto &symbol = macroAtomInfo->getSymbol();
+    if (!dp_localTemplateLibrary->getBySymbol(monomerClass, symbol) &&
+        !dp_localTemplateLibrary->getByName(monomerClass, symbol)) {
+      return false;
+    }
+  }
+  return true;
+}
+
 unsigned int MacroMol::addMacroAtom(std::string symbol,
                                     MonomerClass monomerClass) {
   auto atom = new Atom(0);

--- a/Code/GraphMol/MacroMol.cpp
+++ b/Code/GraphMol/MacroMol.cpp
@@ -47,6 +47,12 @@ MacroMol &MacroMol::operator=(const MacroMol &other) {
   return *this;
 }
 
+void MacroMol::setLocalTemplateLibrary(
+    std::unique_ptr<MacroMolTemplateLibrary> newTemplateLibrary) {
+  PRECONDITION(newTemplateLibrary, "local template library is null");
+  dp_localTemplateLibrary = std::move(newTemplateLibrary);
+}
+
 MacroMolTemplateLibrary &MacroMol::getLocalTemplateLibrary() {
   return *dp_localTemplateLibrary;
 }

--- a/Code/GraphMol/MacroMol.h
+++ b/Code/GraphMol/MacroMol.h
@@ -37,6 +37,13 @@ class RDKIT_GRAPHMOL_EXPORT MacroMol : public RWMol {
   MacroMol(MacroMol &&other) noexcept = default;
   MacroMol &operator=(MacroMol &&other) noexcept = default;
 
+  //! Replaces the local template library and takes ownership of it.
+  /*!
+    \param newTemplateLibrary the non-null library to take ownership of
+  */
+  void setLocalTemplateLibrary(
+      std::unique_ptr<MacroMolTemplateLibrary> newTemplateLibrary);
+
   //! Returns this molecule's local template library.
   MacroMolTemplateLibrary &getLocalTemplateLibrary();
   //! Returns this molecule's local template library.

--- a/Code/GraphMol/MacroMol.h
+++ b/Code/GraphMol/MacroMol.h
@@ -11,15 +11,50 @@
 #ifndef RD_MACROMOL_H
 #define RD_MACROMOL_H
 
+#include <memory>
 #include <string>
 
 #include "MacroAtomInfo.h"
+#include "MacroMolTemplate.h"
 #include "RWMol.h"
 
 namespace RDKit {
 
 class RDKIT_GRAPHMOL_EXPORT MacroMol : public RWMol {
  public:
+  //! Constructs a MacroMol with an empty local template library.
+  MacroMol();
+
+  //! Constructs a MacroMol that takes ownership of a local template library.
+  /*!
+    \param localTemplateLibrary the non-null library to take ownership of
+  */
+  explicit MacroMol(
+      std::unique_ptr<MacroMolTemplateLibrary> localTemplateLibrary);
+
+  MacroMol(const MacroMol &other);
+  MacroMol &operator=(const MacroMol &other);
+  MacroMol(MacroMol &&other) noexcept = default;
+  MacroMol &operator=(MacroMol &&other) noexcept = default;
+
+  //! Adds a template to this molecule's local template library.
+  /*!
+    \param macroMolTemplate the completed template; ownership is transferred
+                            to this molecule's local library
+  */
+  void addLocalTemplate(
+      std::unique_ptr<MacroMolTemplate> macroMolTemplate);
+
+  //! Returns this molecule's local template library.
+  const MacroMolTemplateLibrary &getLocalTemplateLibrary() const;
+
+  //! Checks that every macro atom resolves in the local template library.
+  /*!
+    Macro atoms are looked up by monomer class and symbol, then by monomer
+    class and template name. Ordinary atoms are ignored.
+  */
+  bool hasValidLocalTemplateReferences() const;
+
   //! Adds a new macro atom to the molecule.
   /*!
     \param symbol       the symbol (dummy label) used to identify the monomer
@@ -104,6 +139,8 @@ class RDKIT_GRAPHMOL_EXPORT MacroMol : public RWMol {
                                   unsigned int endAtomIdx, int beginAttachPt,
                                   int endAttachPt,
                                   Bond::BondType bondType = Bond::SINGLE);
+
+  std::unique_ptr<MacroMolTemplateLibrary> dp_localTemplateLibrary;
 };
 }  // namespace RDKit
 

--- a/Code/GraphMol/MacroMol.h
+++ b/Code/GraphMol/MacroMol.h
@@ -37,14 +37,8 @@ class RDKIT_GRAPHMOL_EXPORT MacroMol : public RWMol {
   MacroMol(MacroMol &&other) noexcept = default;
   MacroMol &operator=(MacroMol &&other) noexcept = default;
 
-  //! Adds a template to this molecule's local template library.
-  /*!
-    \param macroMolTemplate the completed template; ownership is transferred
-                            to this molecule's local library
-  */
-  void addLocalTemplate(
-      std::unique_ptr<MacroMolTemplate> macroMolTemplate);
-
+  //! Returns this molecule's local template library.
+  MacroMolTemplateLibrary &getLocalTemplateLibrary();
   //! Returns this molecule's local template library.
   const MacroMolTemplateLibrary &getLocalTemplateLibrary() const;
 
@@ -53,7 +47,7 @@ class RDKIT_GRAPHMOL_EXPORT MacroMol : public RWMol {
     Macro atoms are looked up by monomer class and symbol, then by monomer
     class and template name. Ordinary atoms are ignored.
   */
-  bool hasValidLocalTemplateReferences() const;
+  bool checkLocalTemplateReferences() const;
 
   //! Adds a new macro atom to the molecule.
   /*!

--- a/Code/GraphMol/MacroMolTemplate.cpp
+++ b/Code/GraphMol/MacroMolTemplate.cpp
@@ -178,6 +178,26 @@ std::unique_ptr<MacroMolTemplate> MacroMolTemplateBuilder::build() const {
       d_mainAtomIdxs, d_leavingGroups, mainSgroupIdx));
 }
 
+MacroMolTemplateLibrary::MacroMolTemplateLibrary(
+    const MacroMolTemplateLibrary &other) {
+  *this = other;
+}
+
+MacroMolTemplateLibrary &MacroMolTemplateLibrary::operator=(
+    const MacroMolTemplateLibrary &other) {
+  if (this == &other) {
+    return *this;
+  }
+
+  MacroMolTemplateLibrary copy;
+  for (const auto &entry : other.byName) {
+    copy.addTemplate(std::make_unique<MacroMolTemplate>(*entry.second));
+  }
+  byName.swap(copy.byName);
+  bySymbol.swap(copy.bySymbol);
+  return *this;
+}
+
 void MacroMolTemplateLibrary::addTemplate(
     std::unique_ptr<MacroMolTemplate> macroMolTemplate) {
   PRECONDITION(macroMolTemplate, "cannot add a null MacroMolTemplate");

--- a/Code/GraphMol/MacroMolTemplate.cpp
+++ b/Code/GraphMol/MacroMolTemplate.cpp
@@ -118,6 +118,12 @@ MacroMolTemplateBuilder &MacroMolTemplateBuilder::addLeavingGroup(
   return *this;
 }
 
+MacroMolTemplateBuilder &MacroMolTemplateBuilder::setSubclass(
+    std::string subclass) {
+  d_subclass = std::move(subclass);
+  return *this;
+}
+
 std::unique_ptr<MacroMolTemplate> MacroMolTemplateBuilder::build() const {
   if (d_name.empty()) {
     invalidTemplate("name cannot be empty");
@@ -175,7 +181,7 @@ std::unique_ptr<MacroMolTemplate> MacroMolTemplateBuilder::build() const {
 
   return std::unique_ptr<MacroMolTemplate>(new MacroMolTemplate(
       std::move(mol), d_monomerClass, d_name, d_symbol, d_originalData,
-      d_mainAtomIdxs, d_leavingGroups, mainSgroupIdx));
+      d_subclass, d_mainAtomIdxs, d_leavingGroups, mainSgroupIdx));
 }
 
 MacroMolTemplateLibrary::MacroMolTemplateLibrary(

--- a/Code/GraphMol/MacroMolTemplate.h
+++ b/Code/GraphMol/MacroMolTemplate.h
@@ -146,9 +146,9 @@ class RDKIT_GRAPHMOL_EXPORT MacroMolTemplateBuilder {
 class RDKIT_GRAPHMOL_EXPORT MacroMolTemplateLibrary {
  public:
   MacroMolTemplateLibrary() = default;
-  MacroMolTemplateLibrary(const MacroMolTemplateLibrary &) = delete;
+  MacroMolTemplateLibrary(const MacroMolTemplateLibrary &other);
   MacroMolTemplateLibrary(MacroMolTemplateLibrary &&) noexcept = default;
-  MacroMolTemplateLibrary &operator=(const MacroMolTemplateLibrary &) = delete;
+  MacroMolTemplateLibrary &operator=(const MacroMolTemplateLibrary &other);
   MacroMolTemplateLibrary &operator=(MacroMolTemplateLibrary &&) noexcept =
       default;
 

--- a/Code/GraphMol/MacroMolTemplate.h
+++ b/Code/GraphMol/MacroMolTemplate.h
@@ -67,6 +67,8 @@ class RDKIT_GRAPHMOL_EXPORT MacroMolTemplate final {
   const std::string &getSymbol() const { return d_symbol; }
   //! Returns the original template definition (SMILES, SDF, etc.).
   const std::string &getOriginalData() const { return d_originalData; }
+  //! Returns the SCSR subclass, or an empty string if unspecified.
+  const std::string &getSubclass() const { return d_subclass; }
   //! Returns the atom indices belonging to the retained monomer group.
   const std::vector<unsigned int> &getMainAtomIdxs() const {
     return d_mainAtomIdxs;
@@ -83,7 +85,7 @@ class RDKIT_GRAPHMOL_EXPORT MacroMolTemplate final {
 
   MacroMolTemplate(RWMol mol, MonomerClass monomerClass,
                    std::string name, std::string symbol,
-                   std::string originalData,
+                   std::string originalData, std::string subclass,
                    std::vector<unsigned int> mainAtomIdxs,
                    std::vector<MacroMolLeavingGroup> leavingGroups,
                    unsigned int mainSgroupIdx)
@@ -92,6 +94,7 @@ class RDKIT_GRAPHMOL_EXPORT MacroMolTemplate final {
         d_name(std::move(name)),
         d_symbol(std::move(symbol)),
         d_originalData(std::move(originalData)),
+        d_subclass(std::move(subclass)),
         d_mainAtomIdxs(std::move(mainAtomIdxs)),
         d_leavingGroups(std::move(leavingGroups)),
         d_mainSgroupIdx(mainSgroupIdx) {}
@@ -101,6 +104,7 @@ class RDKIT_GRAPHMOL_EXPORT MacroMolTemplate final {
   std::string d_name;
   std::string d_symbol;
   std::string d_originalData;
+  std::string d_subclass;
   std::vector<unsigned int> d_mainAtomIdxs;
   std::vector<MacroMolLeavingGroup> d_leavingGroups;
   unsigned int d_mainSgroupIdx;
@@ -129,6 +133,8 @@ class RDKIT_GRAPHMOL_EXPORT MacroMolTemplateBuilder {
   //! Adds a leaving group and its attachment-point definition.
   MacroMolTemplateBuilder &addLeavingGroup(
       MacroMolLeavingGroup &&leavingGroup);
+  //! Sets the optional SCSR subclass.
+  MacroMolTemplateBuilder &setSubclass(std::string subclass);
   //! Validates the complete definition and returns an immutable template.
   std::unique_ptr<MacroMolTemplate> build() const;
 
@@ -138,6 +144,7 @@ class RDKIT_GRAPHMOL_EXPORT MacroMolTemplateBuilder {
   std::string d_name;
   std::string d_symbol;
   std::string d_originalData;
+  std::string d_subclass;
   std::vector<unsigned int> d_mainAtomIdxs;
   std::vector<MacroMolLeavingGroup> d_leavingGroups;
   bool d_mainGroupSet = false;

--- a/Code/GraphMol/MacroMolTemplate.h
+++ b/Code/GraphMol/MacroMolTemplate.h
@@ -128,6 +128,13 @@ class RDKIT_GRAPHMOL_EXPORT MacroMolTemplateBuilder {
         d_symbol(std::move(symbol)),
         d_originalData(std::move(originalData)) {}
 
+  //! Returns the mutable molecule being prepared for the template.
+  /*!
+    Structural edits should be completed before defining the main and
+    leaving groups.
+  */
+  RWMol &getMol() { return d_mol; }
+
   //! Defines the atoms retained as the main monomer group.
   MacroMolTemplateBuilder &setMainGroup(std::vector<unsigned int> &&atomIdxs);
   //! Adds a leaving group and its attachment-point definition.

--- a/Code/GraphMol/testMacroMol.cpp
+++ b/Code/GraphMol/testMacroMol.cpp
@@ -15,7 +15,33 @@
 #include <GraphMol/SmilesParse/SmilesWrite.h>
 #include <catch2/catch_all.hpp>
 
+#include <memory>
+#include <string>
+#include <type_traits>
+#include <utility>
+
 using namespace RDKit;
+
+namespace {
+
+std::unique_ptr<MacroMolTemplate> makeMacroMolTemplate(
+    const std::string &name, const std::string &symbol,
+    MonomerClass monomerClass = MonomerClass::AminoAcid) {
+  RWMol mol;
+  mol.addAtom(new Atom(6), false, true);
+  MacroMolTemplateBuilder builder(mol, monomerClass, name, symbol, "");
+  builder.setMainGroup({0});
+  return builder.build();
+}
+
+}  // namespace
+
+static_assert(std::is_same_v<
+              decltype(std::declval<const MacroMol &>()
+                           .getLocalTemplateLibrary()),
+              const MacroMolTemplateLibrary &>);
+static_assert(std::is_nothrow_move_constructible_v<MacroMol>);
+static_assert(std::is_nothrow_move_assignable_v<MacroMol>);
 
 TEST_CASE("testBuildMacroMol") {
   // Build a simple MacroMol with three macro atoms and two bonds, and check
@@ -192,4 +218,149 @@ TEST_CASE("testAddBond") {
   auto second_regular_atom = macro_mol->getAtomWithIdx(second_atom_idx);
   CHECK(macro_mol->addBond(regular_atom, second_regular_atom) == 1);
   CHECK(macro_mol->getNumBonds() == 1);
+}
+
+TEST_CASE("MacroMol owns a local template library") {
+  SECTION("default construction") {
+    MacroMol macroMol;
+    CHECK(macroMol.getLocalTemplateLibrary().getByName(
+              MonomerClass::AminoAcid, "ALA") == nullptr);
+
+    auto alanine = makeMacroMolTemplate("ALA", "A");
+    const auto *alaninePtr = alanine.get();
+    macroMol.addLocalTemplate(std::move(alanine));
+
+    CHECK(alanine == nullptr);
+    CHECK(macroMol.getLocalTemplateLibrary().getBySymbol(
+              MonomerClass::AminoAcid, "A") == alaninePtr);
+    CHECK(macroMol.getLocalTemplateLibrary().getByName(
+              MonomerClass::AminoAcid, "ALA") == alaninePtr);
+  }
+
+  SECTION("ownership transfer") {
+    auto localTemplateLibrary =
+        std::make_unique<MacroMolTemplateLibrary>();
+    auto alanine = makeMacroMolTemplate("ALA", "A");
+    const auto *alaninePtr = alanine.get();
+    localTemplateLibrary->addTemplate(std::move(alanine));
+
+    MacroMol macroMol(std::move(localTemplateLibrary));
+
+    CHECK(localTemplateLibrary == nullptr);
+    CHECK(macroMol.getLocalTemplateLibrary().getBySymbol(
+              MonomerClass::AminoAcid, "A") == alaninePtr);
+  }
+
+  SECTION("null library") {
+    CHECK_THROWS_AS(
+        MacroMol(std::unique_ptr<MacroMolTemplateLibrary>{}),
+        Invar::Invariant);
+  }
+}
+
+TEST_CASE("MacroMol validates references against only its local library") {
+  SECTION("empty and ordinary-atom-only molecules are valid") {
+    MacroMol macroMol;
+    CHECK(macroMol.hasValidLocalTemplateReferences());
+    macroMol.addAtom(new Atom(6), false, true);
+    CHECK(macroMol.hasValidLocalTemplateReferences());
+  }
+
+  SECTION("symbol lookup") {
+    MacroMol macroMol;
+    macroMol.addLocalTemplate(makeMacroMolTemplate("ALA", "A"));
+    macroMol.addMacroAtom("A", MonomerClass::AminoAcid);
+    CHECK(macroMol.hasValidLocalTemplateReferences());
+  }
+
+  SECTION("template-name lookup") {
+    MacroMol macroMol;
+    macroMol.addLocalTemplate(makeMacroMolTemplate("ALA", "A"));
+    macroMol.addMacroAtom("ALA", MonomerClass::AminoAcid);
+    CHECK(macroMol.hasValidLocalTemplateReferences());
+  }
+
+  SECTION("missing template") {
+    MacroMol macroMol;
+    macroMol.addMacroAtom("A", MonomerClass::AminoAcid);
+    CHECK_FALSE(macroMol.hasValidLocalTemplateReferences());
+  }
+
+  SECTION("monomer class is part of the lookup key") {
+    MacroMol macroMol;
+    macroMol.addLocalTemplate(makeMacroMolTemplate("ALA", "A"));
+    macroMol.addMacroAtom("A", MonomerClass::NucleicAcid);
+    CHECK_FALSE(macroMol.hasValidLocalTemplateReferences());
+  }
+
+  SECTION("one unresolved macro atom invalidates the molecule") {
+    MacroMol macroMol;
+    macroMol.addLocalTemplate(makeMacroMolTemplate("ALA", "A"));
+    macroMol.addMacroAtom("A", MonomerClass::AminoAcid);
+    macroMol.addMacroAtom("C", MonomerClass::AminoAcid);
+    CHECK_FALSE(macroMol.hasValidLocalTemplateReferences());
+  }
+}
+
+TEST_CASE("MacroMol local-template library rejects null templates") {
+  MacroMol macroMol;
+  CHECK_THROWS_AS(macroMol.addLocalTemplate(nullptr),
+                  Invar::Invariant);
+}
+
+TEST_CASE("MacroMol copies have independent local template libraries") {
+  MacroMol source;
+  source.addLocalTemplate(makeMacroMolTemplate("ALA", "A"));
+  source.addMacroAtom("A", MonomerClass::AminoAcid);
+  const auto *sourceTemplate = source.getLocalTemplateLibrary().getBySymbol(
+      MonomerClass::AminoAcid, "A");
+  REQUIRE(sourceTemplate);
+
+  MacroMol copy(source);
+  CHECK(&copy.getLocalTemplateLibrary() !=
+        &source.getLocalTemplateLibrary());
+  const auto *copiedTemplate = copy.getLocalTemplateLibrary().getBySymbol(
+      MonomerClass::AminoAcid, "A");
+  REQUIRE(copiedTemplate);
+  CHECK(copiedTemplate != sourceTemplate);
+  CHECK(copiedTemplate->getName() == sourceTemplate->getName());
+  CHECK(copy.hasValidLocalTemplateReferences());
+
+  MacroMol assigned;
+  assigned.addLocalTemplate(makeMacroMolTemplate("CYS", "C"));
+  assigned = source;
+  CHECK(&assigned.getLocalTemplateLibrary() !=
+        &source.getLocalTemplateLibrary());
+  const auto *assignedTemplate = assigned.getLocalTemplateLibrary().getBySymbol(
+      MonomerClass::AminoAcid, "A");
+  REQUIRE(assignedTemplate);
+  CHECK(assignedTemplate != sourceTemplate);
+  CHECK(assignedTemplate != copiedTemplate);
+  CHECK(assigned.getLocalTemplateLibrary().getBySymbol(
+            MonomerClass::AminoAcid, "C") == nullptr);
+  CHECK(assigned.hasValidLocalTemplateReferences());
+}
+
+TEST_CASE("MacroMol moves its local template library") {
+  MacroMol source;
+  source.addLocalTemplate(makeMacroMolTemplate("ALA", "A"));
+  source.addMacroAtom("A", MonomerClass::AminoAcid);
+  const auto *sourceLibrary = &source.getLocalTemplateLibrary();
+  const auto *sourceTemplate = sourceLibrary->getBySymbol(
+      MonomerClass::AminoAcid, "A");
+  REQUIRE(sourceTemplate);
+
+  MacroMol moved(std::move(source));
+  CHECK(&moved.getLocalTemplateLibrary() == sourceLibrary);
+  CHECK(moved.getLocalTemplateLibrary().getBySymbol(
+            MonomerClass::AminoAcid, "A") == sourceTemplate);
+  CHECK(moved.hasValidLocalTemplateReferences());
+
+  MacroMol assigned;
+  assigned.addLocalTemplate(makeMacroMolTemplate("CYS", "C"));
+  assigned = std::move(moved);
+  CHECK(&assigned.getLocalTemplateLibrary() == sourceLibrary);
+  CHECK(assigned.getLocalTemplateLibrary().getBySymbol(
+            MonomerClass::AminoAcid, "A") == sourceTemplate);
+  CHECK(assigned.hasValidLocalTemplateReferences());
 }

--- a/Code/GraphMol/testMacroMol.cpp
+++ b/Code/GraphMol/testMacroMol.cpp
@@ -37,6 +37,9 @@ std::unique_ptr<MacroMolTemplate> makeMacroMolTemplate(
 }  // namespace
 
 static_assert(std::is_same_v<
+              decltype(std::declval<MacroMol &>().getLocalTemplateLibrary()),
+              MacroMolTemplateLibrary &>);
+static_assert(std::is_same_v<
               decltype(std::declval<const MacroMol &>()
                            .getLocalTemplateLibrary()),
               const MacroMolTemplateLibrary &>);
@@ -228,7 +231,7 @@ TEST_CASE("MacroMol owns a local template library") {
 
     auto alanine = makeMacroMolTemplate("ALA", "A");
     const auto *alaninePtr = alanine.get();
-    macroMol.addLocalTemplate(std::move(alanine));
+    macroMol.getLocalTemplateLibrary().addTemplate(std::move(alanine));
 
     CHECK(alanine == nullptr);
     CHECK(macroMol.getLocalTemplateLibrary().getBySymbol(
@@ -261,56 +264,61 @@ TEST_CASE("MacroMol owns a local template library") {
 TEST_CASE("MacroMol validates references against only its local library") {
   SECTION("empty and ordinary-atom-only molecules are valid") {
     MacroMol macroMol;
-    CHECK(macroMol.hasValidLocalTemplateReferences());
+    CHECK(macroMol.checkLocalTemplateReferences());
     macroMol.addAtom(new Atom(6), false, true);
-    CHECK(macroMol.hasValidLocalTemplateReferences());
+    CHECK(macroMol.checkLocalTemplateReferences());
   }
 
   SECTION("symbol lookup") {
     MacroMol macroMol;
-    macroMol.addLocalTemplate(makeMacroMolTemplate("ALA", "A"));
+    macroMol.getLocalTemplateLibrary().addTemplate(
+        makeMacroMolTemplate("ALA", "A"));
     macroMol.addMacroAtom("A", MonomerClass::AminoAcid);
-    CHECK(macroMol.hasValidLocalTemplateReferences());
+    CHECK(macroMol.checkLocalTemplateReferences());
   }
 
   SECTION("template-name lookup") {
     MacroMol macroMol;
-    macroMol.addLocalTemplate(makeMacroMolTemplate("ALA", "A"));
+    macroMol.getLocalTemplateLibrary().addTemplate(
+        makeMacroMolTemplate("ALA", "A"));
     macroMol.addMacroAtom("ALA", MonomerClass::AminoAcid);
-    CHECK(macroMol.hasValidLocalTemplateReferences());
+    CHECK(macroMol.checkLocalTemplateReferences());
   }
 
   SECTION("missing template") {
     MacroMol macroMol;
     macroMol.addMacroAtom("A", MonomerClass::AminoAcid);
-    CHECK_FALSE(macroMol.hasValidLocalTemplateReferences());
+    CHECK_FALSE(macroMol.checkLocalTemplateReferences());
   }
 
   SECTION("monomer class is part of the lookup key") {
     MacroMol macroMol;
-    macroMol.addLocalTemplate(makeMacroMolTemplate("ALA", "A"));
+    macroMol.getLocalTemplateLibrary().addTemplate(
+        makeMacroMolTemplate("ALA", "A"));
     macroMol.addMacroAtom("A", MonomerClass::NucleicAcid);
-    CHECK_FALSE(macroMol.hasValidLocalTemplateReferences());
+    CHECK_FALSE(macroMol.checkLocalTemplateReferences());
   }
 
   SECTION("one unresolved macro atom invalidates the molecule") {
     MacroMol macroMol;
-    macroMol.addLocalTemplate(makeMacroMolTemplate("ALA", "A"));
+    macroMol.getLocalTemplateLibrary().addTemplate(
+        makeMacroMolTemplate("ALA", "A"));
     macroMol.addMacroAtom("A", MonomerClass::AminoAcid);
     macroMol.addMacroAtom("C", MonomerClass::AminoAcid);
-    CHECK_FALSE(macroMol.hasValidLocalTemplateReferences());
+    CHECK_FALSE(macroMol.checkLocalTemplateReferences());
   }
 }
 
 TEST_CASE("MacroMol local-template library rejects null templates") {
   MacroMol macroMol;
-  CHECK_THROWS_AS(macroMol.addLocalTemplate(nullptr),
+  CHECK_THROWS_AS(macroMol.getLocalTemplateLibrary().addTemplate(nullptr),
                   Invar::Invariant);
 }
 
 TEST_CASE("MacroMol copies have independent local template libraries") {
   MacroMol source;
-  source.addLocalTemplate(makeMacroMolTemplate("ALA", "A"));
+  source.getLocalTemplateLibrary().addTemplate(
+      makeMacroMolTemplate("ALA", "A"));
   source.addMacroAtom("A", MonomerClass::AminoAcid);
   const auto *sourceTemplate = source.getLocalTemplateLibrary().getBySymbol(
       MonomerClass::AminoAcid, "A");
@@ -324,10 +332,11 @@ TEST_CASE("MacroMol copies have independent local template libraries") {
   REQUIRE(copiedTemplate);
   CHECK(copiedTemplate != sourceTemplate);
   CHECK(copiedTemplate->getName() == sourceTemplate->getName());
-  CHECK(copy.hasValidLocalTemplateReferences());
+  CHECK(copy.checkLocalTemplateReferences());
 
   MacroMol assigned;
-  assigned.addLocalTemplate(makeMacroMolTemplate("CYS", "C"));
+  assigned.getLocalTemplateLibrary().addTemplate(
+      makeMacroMolTemplate("CYS", "C"));
   assigned = source;
   CHECK(&assigned.getLocalTemplateLibrary() !=
         &source.getLocalTemplateLibrary());
@@ -338,12 +347,13 @@ TEST_CASE("MacroMol copies have independent local template libraries") {
   CHECK(assignedTemplate != copiedTemplate);
   CHECK(assigned.getLocalTemplateLibrary().getBySymbol(
             MonomerClass::AminoAcid, "C") == nullptr);
-  CHECK(assigned.hasValidLocalTemplateReferences());
+  CHECK(assigned.checkLocalTemplateReferences());
 }
 
 TEST_CASE("MacroMol moves its local template library") {
   MacroMol source;
-  source.addLocalTemplate(makeMacroMolTemplate("ALA", "A"));
+  source.getLocalTemplateLibrary().addTemplate(
+      makeMacroMolTemplate("ALA", "A"));
   source.addMacroAtom("A", MonomerClass::AminoAcid);
   const auto *sourceLibrary = &source.getLocalTemplateLibrary();
   const auto *sourceTemplate = sourceLibrary->getBySymbol(
@@ -354,13 +364,14 @@ TEST_CASE("MacroMol moves its local template library") {
   CHECK(&moved.getLocalTemplateLibrary() == sourceLibrary);
   CHECK(moved.getLocalTemplateLibrary().getBySymbol(
             MonomerClass::AminoAcid, "A") == sourceTemplate);
-  CHECK(moved.hasValidLocalTemplateReferences());
+  CHECK(moved.checkLocalTemplateReferences());
 
   MacroMol assigned;
-  assigned.addLocalTemplate(makeMacroMolTemplate("CYS", "C"));
+  assigned.getLocalTemplateLibrary().addTemplate(
+      makeMacroMolTemplate("CYS", "C"));
   assigned = std::move(moved);
   CHECK(&assigned.getLocalTemplateLibrary() == sourceLibrary);
   CHECK(assigned.getLocalTemplateLibrary().getBySymbol(
             MonomerClass::AminoAcid, "A") == sourceTemplate);
-  CHECK(assigned.hasValidLocalTemplateReferences());
+  CHECK(assigned.checkLocalTemplateReferences());
 }

--- a/Code/GraphMol/testMacroMol.cpp
+++ b/Code/GraphMol/testMacroMol.cpp
@@ -254,9 +254,29 @@ TEST_CASE("MacroMol owns a local template library") {
               MonomerClass::AminoAcid, "A") == alaninePtr);
   }
 
+  SECTION("replacement ownership transfer") {
+    MacroMol macroMol;
+    auto localTemplateLibrary =
+        std::make_unique<MacroMolTemplateLibrary>();
+    auto alanine = makeMacroMolTemplate("ALA", "A");
+    const auto *alaninePtr = alanine.get();
+    localTemplateLibrary->addTemplate(std::move(alanine));
+
+    macroMol.setLocalTemplateLibrary(std::move(localTemplateLibrary));
+
+    CHECK(localTemplateLibrary == nullptr);
+    CHECK(macroMol.getLocalTemplateLibrary().getBySymbol(
+              MonomerClass::AminoAcid, "A") == alaninePtr);
+  }
+
   SECTION("null library") {
     CHECK_THROWS_AS(
         MacroMol(std::unique_ptr<MacroMolTemplateLibrary>{}),
+        Invar::Invariant);
+    MacroMol macroMol;
+    CHECK_THROWS_AS(
+        macroMol.setLocalTemplateLibrary(
+            std::unique_ptr<MacroMolTemplateLibrary>{}),
         Invar::Invariant);
   }
 }

--- a/Code/GraphMol/testMacroMolTemplate.cpp
+++ b/Code/GraphMol/testMacroMolTemplate.cpp
@@ -93,6 +93,19 @@ TEST_CASE("MacroMolTemplate preserves its SCSR subclass") {
   CHECK(copied.getSubclass() == "AA");
 }
 
+TEST_CASE("MacroMolTemplateBuilder provides mutable molecule access") {
+  RWMol mol;
+  mol.addAtom(new Atom(6), false, true);
+  MacroMolTemplateBuilder builder(mol, MonomerClass::Chemical, "CARBON", "C",
+                                  "C");
+
+  builder.getMol().getAtomWithIdx(0)->setIsotope(13);
+  builder.setMainGroup({0});
+  auto templ = builder.build();
+
+  CHECK(templ->getMol().getAtomWithIdx(0)->getIsotope() == 13);
+}
+
 TEST_CASE("MacroMolTemplate mirrors typed main and leaving groups") {
   auto templ = makeAnnotatedAlanineTemplate();
 

--- a/Code/GraphMol/testMacroMolTemplate.cpp
+++ b/Code/GraphMol/testMacroMolTemplate.cpp
@@ -8,6 +8,7 @@
 //  of the RDKit source tree.
 //
 
+#include <GraphMol/Atom.h>
 #include <GraphMol/MacroMolTemplate.h>
 #include <GraphMol/SmilesParse/SmilesParse.h>
 #include <RDGeneral/Invariant.h>
@@ -68,6 +69,7 @@ TEST_CASE("MacroMolTemplate owns a logically read-only molecule and metadata") {
   CHECK(templ->getName() == "ALA");
   CHECK(templ->getSymbol() == "A");
   CHECK(templ->getOriginalData() == "C");
+  CHECK(templ->getSubclass().empty());
   CHECK(templ->getMainAtomIdxs() == std::vector<unsigned int>{0});
   CHECK(templ->getLeavingGroups().empty());
 
@@ -75,6 +77,20 @@ TEST_CASE("MacroMolTemplate owns a logically read-only molecule and metadata") {
   MacroMolTemplate copied(*templ);
   CHECK(copied.getMol().getNumAtoms() == 1);
   CHECK(&copied.getMainSgroup().getOwningMol() == &copied.getMol());
+}
+
+TEST_CASE("MacroMolTemplate preserves its SCSR subclass") {
+  RWMol mol;
+  mol.addAtom(new Atom(6), false, true);
+  MacroMolTemplateBuilder builder(mol, MonomerClass::AminoAcid, "ALA", "A",
+                                  "C");
+  builder.setMainGroup({0}).setSubclass("AA");
+
+  auto templ = builder.build();
+
+  CHECK(templ->getSubclass() == "AA");
+  MacroMolTemplate copied(*templ);
+  CHECK(copied.getSubclass() == "AA");
 }
 
 TEST_CASE("MacroMolTemplate mirrors typed main and leaving groups") {


### PR DESCRIPTION
#### Reference Issue
MacroMol/MonomerMol

Adds a per-MacroMol *local* template library, letting each MacroMol carry its own set of templates.

#### Description
This is PR 3 of 6
[MacroMol core](https://github.com/rdkit/rdkit/pull/9373)
[MacroMolTemplate](https://github.com/rdkit/rdkit/pull/9485)
[MacroMol Local Library](https://github.com/rdkit/rdkit/pull/9486) ⬅️
[MacroMol Global Library](https://github.com/rdkit/rdkit/pull/9487)
[MolToMacroMol](https://github.com/rdkit/rdkit/pull/9488)
[MolFromMacroMol](https://github.com/rdkit/rdkit/pull/9489)
