### PR TITLE
MolToMacroMol

### DIFF
--- a/Code/GraphMol/CMakeLists.txt
+++ b/Code/GraphMol/CMakeLists.txt
@@ -50,6 +50,7 @@ rdkit_headers(Atom.h
         MacroBondInfo.h
         MacroMol.h
         MacroMolTemplate.h
+        MacroMolTemplateLibrary.h
         SanitException.h
         SubstanceGroup.h
         StereoGroup.h
@@ -60,6 +61,10 @@ rdkit_headers(Atom.h
         DEST GraphMol)
 
 add_subdirectory(SmilesParse)
+rdkit_library(MacroMolTemplateLibrary MacroMolTemplateLibrary.cpp
+        SHARED LINK_LIBRARIES GraphMol)
+target_compile_definitions(MacroMolTemplateLibrary PRIVATE RDKIT_GRAPHMOL_BUILD)
+
 add_subdirectory(Depictor)
 add_subdirectory(MarvinParse)
 add_subdirectory(FileParsers)
@@ -227,3 +232,6 @@ rdkit_catch_test(ringSystemsTest ring_systems_test.cpp LINK_LIBRARIES SmilesPars
 
 rdkit_catch_test(testMacroMolTemplate testMacroMolTemplate.cpp
         LINK_LIBRARIES SmilesParse GraphMol)
+
+rdkit_catch_test(testMacroMolTemplateLibrary testMacroMolTemplateLibrary.cpp
+        LINK_LIBRARIES MacroMolTemplateLibrary GraphMol)

--- a/Code/GraphMol/FileParsers/CMakeLists.txt
+++ b/Code/GraphMol/FileParsers/CMakeLists.txt
@@ -48,6 +48,7 @@ rdkit_library(FileParsers
     MultithreadedMolSupplier.cpp
     MultithreadedSmilesMolSupplier.cpp
     MultithreadedSDMolSupplier.cpp
+    MolToMacroMol.cpp
     LINK_LIBRARIES GenericGroups Depictor SmilesParse ChemTransforms GraphMol SubstructMatch ${MAEPARSER_LIB} ${RDK_CHEMDRAW_LIBS} ${STANDALONE_ZLIB_LIBRARY}
 )
 if(STANDALONE_ZLIB_LIBRARY)
@@ -68,6 +69,7 @@ rdkit_headers(CDXMLParser.h
     MultithreadedSmilesMolSupplier.h
     MultithreadedSDMolSupplier.h
     PNGParser.h
+    MolToMacroMol.h
     DEST GraphMol/FileParsers)
 
 rdkit_test(fileParsersTest1 test1.cpp
@@ -105,6 +107,9 @@ rdkit_catch_test(fileParsersCatchTest file_parsers_catch.cpp
     LINK_LIBRARIES FileParsers)
 
 rdkit_catch_test(macromolsCatchTest macromols_catch.cpp
+    LINK_LIBRARIES FileParsers)
+
+rdkit_catch_test(testMolToMacroMol testMolToMacroMol.cpp
     LINK_LIBRARIES FileParsers)
 
 rdkit_catch_test(testPropertyLists testPropertyLists.cpp

--- a/Code/GraphMol/FileParsers/MolToMacroMol.cpp
+++ b/Code/GraphMol/FileParsers/MolToMacroMol.cpp
@@ -1,0 +1,366 @@
+//
+//  Copyright (C) 2026 Tad Hurst, Schrödinger and other RDKit contributors
+//
+#include <GraphMol/FileParsers/MolToMacroMol.h>
+
+#include <GraphMol/Atom.h>
+#include <GraphMol/Bond.h>
+#include <GraphMol/MacroMol.h>
+#include <GraphMol/MacroMolTemplate.h>
+#include <GraphMol/ROMol.h>
+#include <GraphMol/RWMol.h>
+#include <GraphMol/SubstanceGroup.h>
+#include <GraphMol/Substruct/SubstructMatch.h>
+#include <RDGeneral/Exceptions.h>
+#include <RDGeneral/Invariant.h>
+
+#include <algorithm>
+#include <limits>
+#include <memory>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+namespace RDKit {
+namespace {
+
+constexpr const char *MACROMOL_GROUP = "MACROMOL";
+
+struct AttachmentPointSpec {
+  unsigned int sourceAtomIdx;
+  int attachmentIdx;
+};
+
+struct GroupSpec {
+  const MacroMolTemplate *templ = nullptr;
+  std::vector<unsigned int> sourceAtomIndices;
+  std::vector<AttachmentPointSpec> attachmentPoints;
+
+  std::optional<int> getAttachmentIdx(unsigned int atomIdx) const {
+    const auto it = std::find_if(
+        attachmentPoints.begin(), attachmentPoints.end(),
+        [atomIdx](const AttachmentPointSpec &spec) {
+          return spec.sourceAtomIdx == atomIdx;
+        });
+    if (it == attachmentPoints.end()) {
+      return std::nullopt;
+    }
+    return it->attachmentIdx;
+  }
+};
+
+struct MainGroupQuery {
+  std::unique_ptr<RWMol> query;
+  std::vector<unsigned int> queryToTemplateAtom;
+};
+
+MainGroupQuery makeMainGroupQuery(const MacroMolTemplate &templ) {
+  std::vector<unsigned int> mainAtoms(templ.getMainAtomIdxs().begin(),
+                                      templ.getMainAtomIdxs().end());
+  std::sort(mainAtoms.begin(), mainAtoms.end());
+  const std::unordered_set<unsigned int> mainAtomSet(mainAtoms.begin(),
+                                                     mainAtoms.end());
+
+  auto query = std::make_unique<RWMol>(templ.getMol());
+  query->beginBatchEdit();
+  for (auto atom : query->atoms()) {
+    if (!mainAtomSet.count(atom->getIdx())) {
+      query->removeAtom(atom);
+    }
+  }
+  query->commitBatchEdit();
+  query->updatePropertyCache(false);
+  return {std::move(query), std::move(mainAtoms)};
+}
+
+std::vector<MatchVectType> findTemplateMatches(const ROMol &mol,
+                                               const RWMol &query) {
+  SubstructMatchParameters params;
+  params.recursionPossible = false;
+  params.useChirality = true;
+  params.useQueryQueryMatches = false;
+  params.uniquify = false;
+  params.maxMatches = 0;
+  auto matches = SubstructMatch(mol, query, params);
+
+  auto matchKey = [](const MatchVectType &match) {
+    std::vector<int> sourceAtoms;
+    std::vector<std::pair<int, int>> queryToSource;
+    for (const auto &pair : match) {
+      sourceAtoms.push_back(pair.second);
+      queryToSource.push_back(pair);
+    }
+    std::sort(sourceAtoms.begin(), sourceAtoms.end());
+    std::sort(queryToSource.begin(), queryToSource.end());
+    return std::make_pair(sourceAtoms, queryToSource);
+  };
+  std::sort(matches.begin(), matches.end(),
+            [&matchKey](const auto &lhs, const auto &rhs) {
+              return matchKey(lhs) < matchKey(rhs);
+            });
+  return matches;
+}
+
+bool violatesAttachmentInvariant(const ROMol &mol, const GroupSpec &group) {
+  auto atoms = group.sourceAtomIndices;
+  std::sort(atoms.begin(), atoms.end());
+  for (const auto atomIdx : atoms) {
+    unsigned int externalBondCount = 0;
+    for (const auto *bond : mol.atomBonds(mol.getAtomWithIdx(atomIdx))) {
+      if (!std::binary_search(atoms.begin(), atoms.end(),
+                              bond->getOtherAtomIdx(atomIdx))) {
+        ++externalBondCount;
+      }
+    }
+    const unsigned int allowed =
+        group.getAttachmentIdx(atomIdx).has_value() ? 1u : 0u;
+    if (externalBondCount > allowed) {
+      return true;
+    }
+  }
+  return false;
+}
+
+std::optional<GroupSpec> makeGroupForMatch(
+    const MatchVectType &match, const ROMol &mol,
+    const MacroMolTemplate &templ, const MainGroupQuery &mainQuery,
+    const std::vector<bool> &claimed) {
+  GroupSpec group;
+  group.templ = &templ;
+  std::unordered_map<unsigned int, unsigned int> templateToSource;
+  for (const auto &[queryIdx, sourceIdxInt] : match) {
+    const auto sourceIdx = static_cast<unsigned int>(sourceIdxInt);
+    if (claimed[sourceIdx]) {
+      return std::nullopt;
+    }
+    group.sourceAtomIndices.push_back(sourceIdx);
+    templateToSource[mainQuery.queryToTemplateAtom[queryIdx]] = sourceIdx;
+  }
+
+  std::unordered_set<unsigned int> seenAttachAtoms;
+  for (const auto &leavingGroup : templ.getLeavingGroups()) {
+    const auto it = templateToSource.find(leavingGroup.attachAtomIdx);
+    if (it == templateToSource.end()) {
+      return std::nullopt;
+    }
+    if (!seenAttachAtoms.insert(it->second).second) {
+      throw ValueErrorException(
+          "MolToMacroMol does not support multiple attachment points on one "
+          "template atom");
+    }
+    group.attachmentPoints.push_back({it->second, leavingGroup.attachPoint});
+  }
+  if (violatesAttachmentInvariant(mol, group)) {
+    return std::nullopt;
+  }
+  std::sort(group.sourceAtomIndices.begin(), group.sourceAtomIndices.end());
+  return group;
+}
+
+std::vector<GroupSpec> findGroups(const ROMol &mol,
+                                  const MacroMolTemplateLibrary &templates) {
+  std::vector<GroupSpec> groups;
+  std::vector<bool> claimed(mol.getNumAtoms(), false);
+  auto orderedTemplates = templates.getTemplates();
+  std::stable_sort(
+      orderedTemplates.begin(), orderedTemplates.end(),
+      [](const auto *lhs, const auto *rhs) {
+        return lhs->getMainAtomIdxs().size() > rhs->getMainAtomIdxs().size();
+      });
+  for (const auto *templ : orderedTemplates) {
+    const auto mainQuery = makeMainGroupQuery(*templ);
+    for (const auto &match : findTemplateMatches(mol, *mainQuery.query)) {
+      auto group = makeGroupForMatch(match, mol, *templ, mainQuery, claimed);
+      if (!group) {
+        continue;
+      }
+      for (const auto atomIdx : group->sourceAtomIndices) {
+        claimed[atomIdx] = true;
+      }
+      groups.push_back(std::move(*group));
+    }
+  }
+  return groups;
+}
+
+void addGroupMetadata(RWMol &result, const GroupSpec &group) {
+  SubstanceGroup sgroup(&result, "SUP");
+  sgroup.setProp<bool>(MACROMOL_GROUP, true);
+  sgroup.setProp<std::string>("CLASS",
+                              monomerClassToString(group.templ->getMonomerClass()));
+  sgroup.setProp<std::string>("LABEL", group.templ->getSymbol());
+  sgroup.setAtoms(group.sourceAtomIndices);
+  for (const auto &attach : group.attachmentPoints) {
+    sgroup.addAttachPoint(attach.sourceAtomIdx, -1,
+                          std::to_string(attach.attachmentIdx));
+  }
+  addSubstanceGroup(result, std::move(sgroup));
+}
+
+std::unique_ptr<RWMol> annotate(const ROMol &mol,
+                                const std::vector<GroupSpec> &groups) {
+  auto result = std::make_unique<RWMol>(mol);
+  for (const auto &group : groups) {
+    addGroupMetadata(*result, group);
+  }
+  return result;
+}
+
+struct CollapseGroup {
+  std::vector<unsigned int> atoms;
+  std::unordered_map<unsigned int, int> attachmentByAtom;
+  const MacroMolTemplate *templ = nullptr;
+  unsigned int outputAtom = std::numeric_limits<unsigned int>::max();
+};
+
+const MacroMolTemplate *findTemplate(const MacroMolTemplateLibrary &templates,
+                                     const SubstanceGroup &sgroup) {
+  const auto monomerClass = monomerClassFromString(
+      sgroup.getProp<std::string>("CLASS"));
+  const auto label = sgroup.getProp<std::string>("LABEL");
+  auto *templ = templates.getBySymbol(monomerClass, label);
+  if (!templ) {
+    templ = templates.getByName(monomerClass, label);
+  }
+  return templ;
+}
+
+void copyRegularBond(MacroMol &result, const Bond &source,
+                     unsigned int beginIdx, unsigned int endIdx,
+                     const std::vector<unsigned int> &outputForAtom) {
+  std::unique_ptr<Bond> bond(source.copy());
+  bond->setBeginAtomIdx(beginIdx);
+  bond->setEndAtomIdx(endIdx);
+  for (auto &stereoAtom : bond->getStereoAtoms()) {
+    if (stereoAtom >= 0 &&
+        static_cast<unsigned int>(stereoAtom) < outputForAtom.size()) {
+      stereoAtom = static_cast<int>(
+          outputForAtom[static_cast<unsigned int>(stereoAtom)]);
+    }
+  }
+  result.addBond(bond.get(), true);
+  bond.release();
+}
+
+}  // namespace
+
+std::unique_ptr<RWMol> MolToMacroMol(
+    const ROMol &mol, const MacroMolTemplateLibrary &templates) {
+  return annotate(mol, findGroups(mol, templates));
+}
+
+std::unique_ptr<MacroMol> CollapseMacroMol(
+    const ROMol &groupedMol, const MacroMolTemplateLibrary &templates) {
+  auto result = std::make_unique<MacroMol>();
+  std::vector<int> groupForAtom(groupedMol.getNumAtoms(), -1);
+  std::vector<CollapseGroup> groups;
+
+  for (const auto &sgroup : getSubstanceGroups(groupedMol)) {
+    bool isMacroGroup = false;
+    if (!sgroup.getPropIfPresent<bool>(MACROMOL_GROUP, isMacroGroup) ||
+        !isMacroGroup) {
+      continue;
+    }
+    CollapseGroup group;
+    group.atoms = sgroup.getAtoms();
+    group.templ = findTemplate(templates, sgroup);
+    if (!group.templ || group.atoms.empty()) {
+      throw ValueErrorException("invalid MacroMol SubstanceGroup");
+    }
+    for (const auto atomIdx : group.atoms) {
+      if (atomIdx >= groupedMol.getNumAtoms() || groupForAtom[atomIdx] != -1) {
+        throw ValueErrorException("overlapping or invalid MacroMol groups");
+      }
+      groupForAtom[atomIdx] = static_cast<int>(groups.size());
+    }
+    for (const auto &attach : sgroup.getAttachPoints()) {
+      if (attach.aIdx >= groupedMol.getNumAtoms() ||
+          groupForAtom[attach.aIdx] != static_cast<int>(groups.size()) ||
+          attach.lvIdx != -1) {
+        throw ValueErrorException("invalid MacroMol attachment point");
+      }
+      int attachmentIdx = 0;
+      try {
+        attachmentIdx = std::stoi(attach.id);
+      } catch (const std::exception &) {
+        throw ValueErrorException("invalid MacroMol attachment point ID");
+      }
+      group.attachmentByAtom.emplace(attach.aIdx, attachmentIdx);
+    }
+    groups.push_back(std::move(group));
+  }
+
+  std::vector<unsigned int> outputForAtom(groupedMol.getNumAtoms());
+  for (const auto *atom : groupedMol.atoms()) {
+    const auto atomIdx = atom->getIdx();
+    const auto groupIdx = groupForAtom[atomIdx];
+    if (groupIdx >= 0) {
+      auto &group = groups[static_cast<unsigned int>(groupIdx)];
+      if (group.outputAtom == std::numeric_limits<unsigned int>::max()) {
+        group.outputAtom = result->addMacroAtom(group.templ->getSymbol(),
+                                                group.templ->getMonomerClass());
+      }
+      outputForAtom[atomIdx] = group.outputAtom;
+    } else {
+      auto copy = std::unique_ptr<Atom>(atom->copy());
+      outputForAtom[atomIdx] = result->addAtom(copy.get(), true, true);
+      copy.release();
+    }
+  }
+
+  for (const auto *bond : groupedMol.bonds()) {
+    const auto begin = bond->getBeginAtomIdx();
+    const auto end = bond->getEndAtomIdx();
+    const auto beginGroup = groupForAtom[begin];
+    const auto endGroup = groupForAtom[end];
+    if (beginGroup >= 0 && beginGroup == endGroup) {
+      continue;
+    }
+
+    const auto beginAttach = beginGroup >= 0
+                                 ? groups[static_cast<unsigned int>(beginGroup)]
+                                       .attachmentByAtom.find(begin)
+                                 : decltype(groups.front().attachmentByAtom)::const_iterator{};
+    const auto endAttach = endGroup >= 0
+                               ? groups[static_cast<unsigned int>(endGroup)]
+                                     .attachmentByAtom.find(end)
+                               : decltype(groups.front().attachmentByAtom)::const_iterator{};
+    const bool hasBeginAttach =
+        beginGroup >= 0 && beginAttach !=
+                              groups[static_cast<unsigned int>(beginGroup)]
+                                  .attachmentByAtom.end();
+    const bool hasEndAttach =
+        endGroup >= 0 && endAttach !=
+                            groups[static_cast<unsigned int>(endGroup)]
+                                .attachmentByAtom.end();
+
+    if (beginGroup >= 0 || endGroup >= 0) {
+      if ((beginGroup >= 0 && !hasBeginAttach) ||
+          (endGroup >= 0 && !hasEndAttach)) {
+        throw ValueErrorException(
+            "MacroMol group has an unannotated crossing bond");
+      }
+      const auto bondType = bond->getBondType();
+      if (beginGroup >= 0 && endGroup >= 0) {
+        result->addMacroBond(outputForAtom[begin], outputForAtom[end],
+                             beginAttach->second, endAttach->second,
+                             bondType);
+      } else if (beginGroup >= 0) {
+        result->addMacroAtomToAtomBond(outputForAtom[begin], outputForAtom[end],
+                                       beginAttach->second, bondType);
+      } else {
+        result->addAtomToMacroAtomBond(outputForAtom[begin], outputForAtom[end],
+                                       endAttach->second, bondType);
+      }
+    } else {
+      copyRegularBond(*result, *bond, outputForAtom[begin],
+                      outputForAtom[end], outputForAtom);
+    }
+  }
+  return result;
+}
+
+}  // namespace RDKit

--- a/Code/GraphMol/FileParsers/MolToMacroMol.h
+++ b/Code/GraphMol/FileParsers/MolToMacroMol.h
@@ -1,0 +1,26 @@
+//
+//  Copyright (C) 2026 Tad Hurst, Schrödinger and other RDKit contributors
+//
+#ifndef RD_MOLTOMACROMOL_H
+#define RD_MOLTOMACROMOL_H
+
+#include <GraphMol/MacroMol.h>
+#include <GraphMol/MacroMolTemplate.h>
+#include <GraphMol/RWMol.h>
+#include <RDGeneral/export.h>
+
+#include <memory>
+
+namespace RDKit {
+
+//! Annotates template matches on a complete atomistic molecule.
+RDKIT_FILEPARSERS_EXPORT std::unique_ptr<RWMol> MolToMacroMol(
+    const ROMol &mol, const MacroMolTemplateLibrary &templates);
+
+//! Collapses MacroMol SubstanceGroups into macro atoms and macro bonds.
+RDKIT_FILEPARSERS_EXPORT std::unique_ptr<MacroMol> CollapseMacroMol(
+    const ROMol &groupedMol, const MacroMolTemplateLibrary &templates);
+
+}  // namespace RDKit
+
+#endif

--- a/Code/GraphMol/FileParsers/testMolToMacroMol.cpp
+++ b/Code/GraphMol/FileParsers/testMolToMacroMol.cpp
@@ -1,0 +1,122 @@
+// Copyright (C) 2026 Schrödinger and other RDKit contributors
+
+#include <GraphMol/FileParsers/MolToMacroMol.h>
+#include <GraphMol/MacroMolTemplate.h>
+#include <GraphMol/SmilesParse/SmilesParse.h>
+#include <GraphMol/SubstanceGroup.h>
+#include <catch2/catch_all.hpp>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+using namespace RDKit;
+
+namespace {
+
+std::unique_ptr<MacroMolTemplate> makeTemplate(
+    const std::string &name, const std::string &symbol,
+    const std::string &smiles, const std::vector<unsigned int> &mainAtoms,
+    const std::vector<MacroMolLeavingGroup> &leavingGroups = {}) {
+  auto parsed = std::unique_ptr<RWMol>(SmilesToMol(smiles));
+  MacroMolTemplateBuilder builder(*parsed, MonomerClass::Other, name, symbol,
+                                  smiles);
+  auto mainAtomsCopy = mainAtoms;
+  builder.setMainGroup(std::move(mainAtomsCopy));
+  for (const auto &leavingGroup : leavingGroups) {
+    auto leavingGroupCopy = leavingGroup;
+    builder.addLeavingGroup(std::move(leavingGroupCopy));
+  }
+  return builder.build();
+}
+
+}  // namespace
+
+TEST_CASE("MolToMacroMol annotates complete atomistic molecules") {
+  MacroMolTemplateLibrary templates;
+  templates.addTemplate(
+      makeTemplate("ETHYL", "Et", "CCO", {0, 1}, {{{2}, 1, 2, 1}}));
+
+  auto mol = std::unique_ptr<RWMol>(SmilesToMol("CCC"));
+  auto grouped = MolToMacroMol(*mol, templates);
+
+  REQUIRE(grouped);
+  CHECK(grouped->getNumAtoms() == mol->getNumAtoms());
+  CHECK(grouped->getNumBonds() == mol->getNumBonds());
+  const auto &groups = getSubstanceGroups(*grouped);
+  REQUIRE(groups.size() == 1);
+  CHECK(groups[0].getProp<std::string>("CLASS") == "Other");
+  CHECK(groups[0].getProp<std::string>("LABEL") == "Et");
+  CHECK(groups[0].getAtoms() == std::vector<unsigned int>({0, 1}));
+  REQUIRE(groups[0].getAttachPoints().size() == 1);
+  CHECK(groups[0].getAttachPoints()[0].aIdx == 1);
+  CHECK(groups[0].getAttachPoints()[0].lvIdx == -1);
+  CHECK(groups[0].getAttachPoints()[0].id == "1");
+}
+
+TEST_CASE("MolToMacroMol keeps deterministic largest-first grouping") {
+  MacroMolTemplateLibrary templates;
+  templates.addTemplate(makeTemplate("SMALL", "S", "CC", {0, 1}));
+  templates.addTemplate(makeTemplate("LARGE", "L", "CCC", {0, 1, 2}));
+
+  auto mol = std::unique_ptr<RWMol>(SmilesToMol("CCC"));
+  auto grouped = MolToMacroMol(*mol, templates);
+
+  REQUIRE(grouped);
+  const auto &groups = getSubstanceGroups(*grouped);
+  REQUIRE(groups.size() == 1);
+  CHECK(groups[0].getProp<std::string>("LABEL") == "L");
+}
+
+TEST_CASE("CollapseMacroMol collapses a grouped unit and preserves neighbors") {
+  MacroMolTemplateLibrary templates;
+  templates.addTemplate(
+      makeTemplate("ETHYL", "Et", "CCO", {0, 1}, {{{2}, 1, 2, 1}}));
+  auto mol = std::unique_ptr<RWMol>(SmilesToMol("CCC"));
+  auto grouped = MolToMacroMol(*mol, templates);
+
+  auto collapsed = CollapseMacroMol(*grouped, templates);
+  REQUIRE(collapsed);
+  CHECK(collapsed->getNumAtoms() == 2);
+  CHECK(collapsed->getNumBonds() == 1);
+  const auto *macroInfo = collapsed->getAtomWithIdx(0)->getMacroAtomInfo();
+  REQUIRE(macroInfo);
+  CHECK(macroInfo->getSymbol() == "Et");
+  const auto *bondInfo = collapsed->getBondWithIdx(0)->getMacroBondInfo();
+  REQUIRE(bondInfo);
+  CHECK(bondInfo->getBond(0).beginAttachPt == 1);
+  CHECK(bondInfo->getBond(0).endAttachPt == -1);
+}
+
+TEST_CASE("CollapseMacroMol creates macro bonds between grouped units") {
+  MacroMolTemplateLibrary templates;
+  templates.addTemplate(makeTemplate("UNIT", "X", "NCON", {1, 2},
+                                      {{{0}, 1, 0, 1}, {{3}, 2, 3, 2}}));
+  auto mol = std::unique_ptr<RWMol>(SmilesToMol("COCO"));
+  auto grouped = MolToMacroMol(*mol, templates);
+  REQUIRE(getSubstanceGroups(*grouped).size() == 2);
+
+  auto collapsed = CollapseMacroMol(*grouped, templates);
+  REQUIRE(collapsed);
+  CHECK(collapsed->getNumAtoms() == 2);
+  REQUIRE(collapsed->getNumBonds() == 1);
+  const auto *info = collapsed->getBondWithIdx(0)->getMacroBondInfo();
+  REQUIRE(info);
+  CHECK(info->getBond(0).beginAttachPt == 2);
+  CHECK(info->getBond(0).endAttachPt == 1);
+}
+
+TEST_CASE("MolToMacroMol leaves unmatched molecules atomistic") {
+  MacroMolTemplateLibrary templates;
+  auto mol = std::unique_ptr<RWMol>(SmilesToMol("C/C=C/C"));
+  mol->getBondBetweenAtoms(1, 2)->setProp<int>("customTag", 7);
+  auto grouped = MolToMacroMol(*mol, templates);
+
+  REQUIRE(grouped);
+  CHECK(getSubstanceGroups(*grouped).empty());
+  CHECK(grouped->getNumAtoms() == 4);
+  CHECK(grouped->getNumBonds() == 3);
+  CHECK(grouped->getBondBetweenAtoms(1, 2)->getStereo() ==
+        mol->getBondBetweenAtoms(1, 2)->getStereo());
+  CHECK(grouped->getBondBetweenAtoms(1, 2)->getProp<int>("customTag") == 7);
+}

--- a/Code/GraphMol/MacroMol.cpp
+++ b/Code/GraphMol/MacroMol.cpp
@@ -47,16 +47,15 @@ MacroMol &MacroMol::operator=(const MacroMol &other) {
   return *this;
 }
 
-void MacroMol::addLocalTemplate(
-    std::unique_ptr<MacroMolTemplate> macroMolTemplate) {
-  dp_localTemplateLibrary->addTemplate(std::move(macroMolTemplate));
+MacroMolTemplateLibrary &MacroMol::getLocalTemplateLibrary() {
+  return *dp_localTemplateLibrary;
 }
 
 const MacroMolTemplateLibrary &MacroMol::getLocalTemplateLibrary() const {
   return *dp_localTemplateLibrary;
 }
 
-bool MacroMol::hasValidLocalTemplateReferences() const {
+bool MacroMol::checkLocalTemplateReferences() const {
   for (const auto *atom : atoms()) {
     const auto *macroAtomInfo = atom->getMacroAtomInfo();
     if (!macroAtomInfo) {

--- a/Code/GraphMol/MacroMol.cpp
+++ b/Code/GraphMol/MacroMol.cpp
@@ -22,6 +22,56 @@ bool isMacroAtom(const Atom *atom) {
 }
 }  // namespace
 
+MacroMol::MacroMol()
+    : dp_localTemplateLibrary(
+          std::make_unique<MacroMolTemplateLibrary>()) {}
+
+MacroMol::MacroMol(
+    std::unique_ptr<MacroMolTemplateLibrary> localTemplateLibrary)
+    : dp_localTemplateLibrary(std::move(localTemplateLibrary)) {
+  PRECONDITION(dp_localTemplateLibrary, "local template library is null");
+}
+
+MacroMol::MacroMol(const MacroMol &other)
+    : RWMol(other),
+      dp_localTemplateLibrary(std::make_unique<MacroMolTemplateLibrary>(
+          *other.dp_localTemplateLibrary)) {}
+
+MacroMol &MacroMol::operator=(const MacroMol &other) {
+  if (this != &other) {
+    auto localTemplateLibrary = std::make_unique<MacroMolTemplateLibrary>(
+        *other.dp_localTemplateLibrary);
+    RWMol::operator=(other);
+    dp_localTemplateLibrary = std::move(localTemplateLibrary);
+  }
+  return *this;
+}
+
+void MacroMol::addLocalTemplate(
+    std::unique_ptr<MacroMolTemplate> macroMolTemplate) {
+  dp_localTemplateLibrary->addTemplate(std::move(macroMolTemplate));
+}
+
+const MacroMolTemplateLibrary &MacroMol::getLocalTemplateLibrary() const {
+  return *dp_localTemplateLibrary;
+}
+
+bool MacroMol::hasValidLocalTemplateReferences() const {
+  for (const auto *atom : atoms()) {
+    const auto *macroAtomInfo = atom->getMacroAtomInfo();
+    if (!macroAtomInfo) {
+      continue;
+    }
+    const auto monomerClass = macroAtomInfo->getMonomerClass();
+    const auto &symbol = macroAtomInfo->getSymbol();
+    if (!dp_localTemplateLibrary->getBySymbol(monomerClass, symbol) &&
+        !dp_localTemplateLibrary->getByName(monomerClass, symbol)) {
+      return false;
+    }
+  }
+  return true;
+}
+
 unsigned int MacroMol::addMacroAtom(std::string symbol,
                                     MonomerClass monomerClass) {
   auto atom = new Atom(0);

--- a/Code/GraphMol/MacroMol.cpp
+++ b/Code/GraphMol/MacroMol.cpp
@@ -47,6 +47,12 @@ MacroMol &MacroMol::operator=(const MacroMol &other) {
   return *this;
 }
 
+void MacroMol::setLocalTemplateLibrary(
+    std::unique_ptr<MacroMolTemplateLibrary> newTemplateLibrary) {
+  PRECONDITION(newTemplateLibrary, "local template library is null");
+  dp_localTemplateLibrary = std::move(newTemplateLibrary);
+}
+
 MacroMolTemplateLibrary &MacroMol::getLocalTemplateLibrary() {
   return *dp_localTemplateLibrary;
 }

--- a/Code/GraphMol/MacroMol.h
+++ b/Code/GraphMol/MacroMol.h
@@ -37,6 +37,13 @@ class RDKIT_GRAPHMOL_EXPORT MacroMol : public RWMol {
   MacroMol(MacroMol &&other) noexcept = default;
   MacroMol &operator=(MacroMol &&other) noexcept = default;
 
+  //! Replaces the local template library and takes ownership of it.
+  /*!
+    \param newTemplateLibrary the non-null library to take ownership of
+  */
+  void setLocalTemplateLibrary(
+      std::unique_ptr<MacroMolTemplateLibrary> newTemplateLibrary);
+
   //! Returns this molecule's local template library.
   MacroMolTemplateLibrary &getLocalTemplateLibrary();
   //! Returns this molecule's local template library.

--- a/Code/GraphMol/MacroMol.h
+++ b/Code/GraphMol/MacroMol.h
@@ -11,15 +11,50 @@
 #ifndef RD_MACROMOL_H
 #define RD_MACROMOL_H
 
+#include <memory>
 #include <string>
 
 #include "MacroAtomInfo.h"
+#include "MacroMolTemplate.h"
 #include "RWMol.h"
 
 namespace RDKit {
 
 class RDKIT_GRAPHMOL_EXPORT MacroMol : public RWMol {
  public:
+  //! Constructs a MacroMol with an empty local template library.
+  MacroMol();
+
+  //! Constructs a MacroMol that takes ownership of a local template library.
+  /*!
+    \param localTemplateLibrary the non-null library to take ownership of
+  */
+  explicit MacroMol(
+      std::unique_ptr<MacroMolTemplateLibrary> localTemplateLibrary);
+
+  MacroMol(const MacroMol &other);
+  MacroMol &operator=(const MacroMol &other);
+  MacroMol(MacroMol &&other) noexcept = default;
+  MacroMol &operator=(MacroMol &&other) noexcept = default;
+
+  //! Adds a template to this molecule's local template library.
+  /*!
+    \param macroMolTemplate the completed template; ownership is transferred
+                            to this molecule's local library
+  */
+  void addLocalTemplate(
+      std::unique_ptr<MacroMolTemplate> macroMolTemplate);
+
+  //! Returns this molecule's local template library.
+  const MacroMolTemplateLibrary &getLocalTemplateLibrary() const;
+
+  //! Checks that every macro atom resolves in the local template library.
+  /*!
+    Macro atoms are looked up by monomer class and symbol, then by monomer
+    class and template name. Ordinary atoms are ignored.
+  */
+  bool hasValidLocalTemplateReferences() const;
+
   //! Adds a new macro atom to the molecule.
   /*!
     \param symbol       the symbol (dummy label) used to identify the monomer
@@ -104,6 +139,8 @@ class RDKIT_GRAPHMOL_EXPORT MacroMol : public RWMol {
                                   unsigned int endAtomIdx, int beginAttachPt,
                                   int endAttachPt,
                                   Bond::BondType bondType = Bond::SINGLE);
+
+  std::unique_ptr<MacroMolTemplateLibrary> dp_localTemplateLibrary;
 };
 }  // namespace RDKit
 

--- a/Code/GraphMol/MacroMol.h
+++ b/Code/GraphMol/MacroMol.h
@@ -37,14 +37,8 @@ class RDKIT_GRAPHMOL_EXPORT MacroMol : public RWMol {
   MacroMol(MacroMol &&other) noexcept = default;
   MacroMol &operator=(MacroMol &&other) noexcept = default;
 
-  //! Adds a template to this molecule's local template library.
-  /*!
-    \param macroMolTemplate the completed template; ownership is transferred
-                            to this molecule's local library
-  */
-  void addLocalTemplate(
-      std::unique_ptr<MacroMolTemplate> macroMolTemplate);
-
+  //! Returns this molecule's local template library.
+  MacroMolTemplateLibrary &getLocalTemplateLibrary();
   //! Returns this molecule's local template library.
   const MacroMolTemplateLibrary &getLocalTemplateLibrary() const;
 
@@ -53,7 +47,7 @@ class RDKIT_GRAPHMOL_EXPORT MacroMol : public RWMol {
     Macro atoms are looked up by monomer class and symbol, then by monomer
     class and template name. Ordinary atoms are ignored.
   */
-  bool hasValidLocalTemplateReferences() const;
+  bool checkLocalTemplateReferences() const;
 
   //! Adds a new macro atom to the molecule.
   /*!

--- a/Code/GraphMol/MacroMolTemplate.cpp
+++ b/Code/GraphMol/MacroMolTemplate.cpp
@@ -178,6 +178,26 @@ std::unique_ptr<MacroMolTemplate> MacroMolTemplateBuilder::build() const {
       d_mainAtomIdxs, d_leavingGroups, mainSgroupIdx));
 }
 
+MacroMolTemplateLibrary::MacroMolTemplateLibrary(
+    const MacroMolTemplateLibrary &other) {
+  *this = other;
+}
+
+MacroMolTemplateLibrary &MacroMolTemplateLibrary::operator=(
+    const MacroMolTemplateLibrary &other) {
+  if (this == &other) {
+    return *this;
+  }
+
+  MacroMolTemplateLibrary copy;
+  for (const auto &entry : other.byName) {
+    copy.addTemplate(std::make_unique<MacroMolTemplate>(*entry.second));
+  }
+  byName.swap(copy.byName);
+  bySymbol.swap(copy.bySymbol);
+  return *this;
+}
+
 void MacroMolTemplateLibrary::addTemplate(
     std::unique_ptr<MacroMolTemplate> macroMolTemplate) {
   PRECONDITION(macroMolTemplate, "cannot add a null MacroMolTemplate");

--- a/Code/GraphMol/MacroMolTemplate.cpp
+++ b/Code/GraphMol/MacroMolTemplate.cpp
@@ -247,4 +247,14 @@ const MacroMolTemplate *MacroMolTemplateLibrary::getBySymbol(
   return nullptr;
 }
 
+std::vector<const MacroMolTemplate *>
+MacroMolTemplateLibrary::getTemplates() const {
+  std::vector<const MacroMolTemplate *> templates;
+  templates.reserve(byName.size());
+  for (const auto &entry : byName) {
+    templates.push_back(entry.second.get());
+  }
+  return templates;
+}
+
 }  // namespace RDKit

--- a/Code/GraphMol/MacroMolTemplate.cpp
+++ b/Code/GraphMol/MacroMolTemplate.cpp
@@ -118,6 +118,12 @@ MacroMolTemplateBuilder &MacroMolTemplateBuilder::addLeavingGroup(
   return *this;
 }
 
+MacroMolTemplateBuilder &MacroMolTemplateBuilder::setSubclass(
+    std::string subclass) {
+  d_subclass = std::move(subclass);
+  return *this;
+}
+
 std::unique_ptr<MacroMolTemplate> MacroMolTemplateBuilder::build() const {
   if (d_name.empty()) {
     invalidTemplate("name cannot be empty");
@@ -175,7 +181,7 @@ std::unique_ptr<MacroMolTemplate> MacroMolTemplateBuilder::build() const {
 
   return std::unique_ptr<MacroMolTemplate>(new MacroMolTemplate(
       std::move(mol), d_monomerClass, d_name, d_symbol, d_originalData,
-      d_mainAtomIdxs, d_leavingGroups, mainSgroupIdx));
+      d_subclass, d_mainAtomIdxs, d_leavingGroups, mainSgroupIdx));
 }
 
 MacroMolTemplateLibrary::MacroMolTemplateLibrary(

--- a/Code/GraphMol/MacroMolTemplate.h
+++ b/Code/GraphMol/MacroMolTemplate.h
@@ -146,9 +146,9 @@ class RDKIT_GRAPHMOL_EXPORT MacroMolTemplateBuilder {
 class RDKIT_GRAPHMOL_EXPORT MacroMolTemplateLibrary {
  public:
   MacroMolTemplateLibrary() = default;
-  MacroMolTemplateLibrary(const MacroMolTemplateLibrary &) = delete;
+  MacroMolTemplateLibrary(const MacroMolTemplateLibrary &other);
   MacroMolTemplateLibrary(MacroMolTemplateLibrary &&) noexcept = default;
-  MacroMolTemplateLibrary &operator=(const MacroMolTemplateLibrary &) = delete;
+  MacroMolTemplateLibrary &operator=(const MacroMolTemplateLibrary &other);
   MacroMolTemplateLibrary &operator=(MacroMolTemplateLibrary &&) noexcept =
       default;
 

--- a/Code/GraphMol/MacroMolTemplate.h
+++ b/Code/GraphMol/MacroMolTemplate.h
@@ -175,6 +175,8 @@ class RDKIT_GRAPHMOL_EXPORT MacroMolTemplateLibrary {
   //! Returns a matching template, or nullptr if none has been added.
   const MacroMolTemplate *getBySymbol(
       MonomerClass monomerClass, const std::string &symbol) const;
+  //! Returns non-owning views of all templates in key order.
+  std::vector<const MacroMolTemplate *> getTemplates() const;
 
  private:
   using MacroMolTemplateKey = std::pair<MonomerClass, std::string>;

--- a/Code/GraphMol/MacroMolTemplate.h
+++ b/Code/GraphMol/MacroMolTemplate.h
@@ -67,6 +67,8 @@ class RDKIT_GRAPHMOL_EXPORT MacroMolTemplate final {
   const std::string &getSymbol() const { return d_symbol; }
   //! Returns the original template definition (SMILES, SDF, etc.).
   const std::string &getOriginalData() const { return d_originalData; }
+  //! Returns the SCSR subclass, or an empty string if unspecified.
+  const std::string &getSubclass() const { return d_subclass; }
   //! Returns the atom indices belonging to the retained monomer group.
   const std::vector<unsigned int> &getMainAtomIdxs() const {
     return d_mainAtomIdxs;
@@ -83,7 +85,7 @@ class RDKIT_GRAPHMOL_EXPORT MacroMolTemplate final {
 
   MacroMolTemplate(RWMol mol, MonomerClass monomerClass,
                    std::string name, std::string symbol,
-                   std::string originalData,
+                   std::string originalData, std::string subclass,
                    std::vector<unsigned int> mainAtomIdxs,
                    std::vector<MacroMolLeavingGroup> leavingGroups,
                    unsigned int mainSgroupIdx)
@@ -92,6 +94,7 @@ class RDKIT_GRAPHMOL_EXPORT MacroMolTemplate final {
         d_name(std::move(name)),
         d_symbol(std::move(symbol)),
         d_originalData(std::move(originalData)),
+        d_subclass(std::move(subclass)),
         d_mainAtomIdxs(std::move(mainAtomIdxs)),
         d_leavingGroups(std::move(leavingGroups)),
         d_mainSgroupIdx(mainSgroupIdx) {}
@@ -101,6 +104,7 @@ class RDKIT_GRAPHMOL_EXPORT MacroMolTemplate final {
   std::string d_name;
   std::string d_symbol;
   std::string d_originalData;
+  std::string d_subclass;
   std::vector<unsigned int> d_mainAtomIdxs;
   std::vector<MacroMolLeavingGroup> d_leavingGroups;
   unsigned int d_mainSgroupIdx;
@@ -129,6 +133,8 @@ class RDKIT_GRAPHMOL_EXPORT MacroMolTemplateBuilder {
   //! Adds a leaving group and its attachment-point definition.
   MacroMolTemplateBuilder &addLeavingGroup(
       MacroMolLeavingGroup &&leavingGroup);
+  //! Sets the optional SCSR subclass.
+  MacroMolTemplateBuilder &setSubclass(std::string subclass);
   //! Validates the complete definition and returns an immutable template.
   std::unique_ptr<MacroMolTemplate> build() const;
 
@@ -138,6 +144,7 @@ class RDKIT_GRAPHMOL_EXPORT MacroMolTemplateBuilder {
   std::string d_name;
   std::string d_symbol;
   std::string d_originalData;
+  std::string d_subclass;
   std::vector<unsigned int> d_mainAtomIdxs;
   std::vector<MacroMolLeavingGroup> d_leavingGroups;
   bool d_mainGroupSet = false;

--- a/Code/GraphMol/MacroMolTemplate.h
+++ b/Code/GraphMol/MacroMolTemplate.h
@@ -128,6 +128,13 @@ class RDKIT_GRAPHMOL_EXPORT MacroMolTemplateBuilder {
         d_symbol(std::move(symbol)),
         d_originalData(std::move(originalData)) {}
 
+  //! Returns the mutable molecule being prepared for the template.
+  /*!
+    Structural edits should be completed before defining the main and
+    leaving groups.
+  */
+  RWMol &getMol() { return d_mol; }
+
   //! Defines the atoms retained as the main monomer group.
   MacroMolTemplateBuilder &setMainGroup(std::vector<unsigned int> &&atomIdxs);
   //! Adds a leaving group and its attachment-point definition.

--- a/Code/GraphMol/MacroMolTemplateLibrary.cpp
+++ b/Code/GraphMol/MacroMolTemplateLibrary.cpp
@@ -1,0 +1,698 @@
+//
+//  Copyright (C) 2026 Schrödinger and other RDKit contributors
+//
+//   @@ All Rights Reserved @@
+//  This file is part of the RDKit.
+//
+#include "MacroMolTemplateLibrary.h"
+
+#include <array>
+#include <cstddef>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace RDKit {
+namespace {
+
+// Generated from the validated built-in template graphs; no parser is used at runtime.
+struct DirectAtomDef { unsigned atomicNum; int formalCharge; unsigned isotope; Atom::ChiralType chiralTag; unsigned explicitHs; bool noImplicit; const char *pdbName; };
+struct DirectBondDef { unsigned beginAtomIdx; unsigned endAtomIdx; Bond::BondType type; bool aromatic; Bond::BondStereo stereo; std::vector<unsigned int> stereoAtoms; };
+struct BuiltinTemplateDef { const char *symbol; const char *name; MonomerClass monomerClass; const char *originalData; std::vector<DirectAtomDef> atoms; std::vector<DirectBondDef> bonds; std::vector<unsigned int> mainAtomIdxs; std::vector<MacroMolLeavingGroup> leavingGroups; };
+
+
+const std::array<BuiltinTemplateDef, 22> builtinTemplates{{
+    {"A", "ALA", MonomerClass::AminoAcid, "C[C@H](N[H])C(=O)[OH] |atomProp:0.pdbName. CB :1.pdbName. CA :2.pdbName. N :3.pdbName. H :4.pdbName. C :5.pdbName. O :6.pdbName. OXT|",
+     {
+      {6, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "CB "},
+      {6, 0, 0, static_cast<Atom::ChiralType>(2), 1, true, "CA "},
+      {7, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "N "},
+      {1, 0, 0, static_cast<Atom::ChiralType>(0), 0, true, "H "},
+      {6, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "C "},
+      {8, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "O "},
+      {8, 0, 0, static_cast<Atom::ChiralType>(0), 1, true, "OXT"},
+     }, {
+      {0, 1, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {1, 2, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {2, 3, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {1, 4, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {4, 5, static_cast<Bond::BondType>(2), false, static_cast<Bond::BondStereo>(0), {}},
+      {4, 6, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+     }, {0, 1, 2, 4, 5}, {
+      {{3}, 2, 3, 1},
+      {{6}, 4, 6, 2},
+     }},
+    {"R", "ARG", MonomerClass::AminoAcid, "N=C(N)NCCC[C@H](N[H])C(=O)[OH] |atomProp:0.pdbName. NH2:1.pdbName. CZ :2.pdbName. NH1:3.pdbName. NE :4.pdbName. CD :5.pdbName. CG :6.pdbName. CB :7.pdbName. CA :8.pdbName. N :9.pdbName. H :10.pdbName. C :11.pdbName. O :12.pdbName. OXT|",
+     {
+      {7, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "NH2"},
+      {6, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "CZ "},
+      {7, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "NH1"},
+      {7, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "NE "},
+      {6, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "CD "},
+      {6, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "CG "},
+      {6, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "CB "},
+      {6, 0, 0, static_cast<Atom::ChiralType>(2), 1, true, "CA "},
+      {7, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "N "},
+      {1, 0, 0, static_cast<Atom::ChiralType>(0), 0, true, "H "},
+      {6, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "C "},
+      {8, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "O "},
+      {8, 0, 0, static_cast<Atom::ChiralType>(0), 1, true, "OXT"},
+     }, {
+      {0, 1, static_cast<Bond::BondType>(2), false, static_cast<Bond::BondStereo>(0), {}},
+      {1, 2, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {1, 3, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {3, 4, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {4, 5, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {5, 6, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {6, 7, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {7, 8, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {8, 9, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {7, 10, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {10, 11, static_cast<Bond::BondType>(2), false, static_cast<Bond::BondStereo>(0), {}},
+      {10, 12, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+     }, {0, 1, 2, 3, 4, 5, 6, 7, 8, 10, 11}, {
+      {{9}, 8, 9, 1},
+      {{12}, 10, 12, 2},
+     }},
+    {"N", "ASN", MonomerClass::AminoAcid, "NC(=O)C[C@H](N[H])C(=O)[OH] |atomProp:0.pdbName. ND2:1.pdbName. CG :2.pdbName. OD1:3.pdbName. CB :4.pdbName. CA :5.pdbName. N :6.pdbName. H :7.pdbName. C :8.pdbName. O :9.pdbName. OXT|",
+     {
+      {7, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "ND2"},
+      {6, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "CG "},
+      {8, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "OD1"},
+      {6, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "CB "},
+      {6, 0, 0, static_cast<Atom::ChiralType>(2), 1, true, "CA "},
+      {7, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "N "},
+      {1, 0, 0, static_cast<Atom::ChiralType>(0), 0, true, "H "},
+      {6, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "C "},
+      {8, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "O "},
+      {8, 0, 0, static_cast<Atom::ChiralType>(0), 1, true, "OXT"},
+     }, {
+      {0, 1, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {1, 2, static_cast<Bond::BondType>(2), false, static_cast<Bond::BondStereo>(0), {}},
+      {1, 3, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {3, 4, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {4, 5, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {5, 6, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {4, 7, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {7, 8, static_cast<Bond::BondType>(2), false, static_cast<Bond::BondStereo>(0), {}},
+      {7, 9, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+     }, {0, 1, 2, 3, 4, 5, 7, 8}, {
+      {{6}, 5, 6, 1},
+      {{9}, 7, 9, 2},
+     }},
+    {"D", "ASP", MonomerClass::AminoAcid, "O=C([C@H](CC(=O)[OH])N[H])[OH] |atomProp:0.pdbName. O :1.pdbName. C :2.pdbName. CA :3.pdbName. CB :4.pdbName. CG :5.pdbName. OD1:6.pdbName. OD2:7.pdbName. N :8.pdbName. H :9.pdbName. OXT|",
+     {
+      {8, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "O "},
+      {6, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "C "},
+      {6, 0, 0, static_cast<Atom::ChiralType>(2), 1, true, "CA "},
+      {6, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "CB "},
+      {6, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "CG "},
+      {8, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "OD1"},
+      {8, 0, 0, static_cast<Atom::ChiralType>(0), 1, true, "OD2"},
+      {7, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "N "},
+      {1, 0, 0, static_cast<Atom::ChiralType>(0), 0, true, "H "},
+      {8, 0, 0, static_cast<Atom::ChiralType>(0), 1, true, "OXT"},
+     }, {
+      {0, 1, static_cast<Bond::BondType>(2), false, static_cast<Bond::BondStereo>(0), {}},
+      {1, 2, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {2, 3, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {3, 4, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {4, 5, static_cast<Bond::BondType>(2), false, static_cast<Bond::BondStereo>(0), {}},
+      {4, 6, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {2, 7, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {7, 8, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {1, 9, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+     }, {0, 1, 2, 3, 4, 5, 7}, {
+      {{8}, 7, 8, 1},
+      {{9}, 1, 9, 2},
+      {{6}, 4, 6, 3},
+     }},
+    {"C", "CYS", MonomerClass::AminoAcid, "O=C([C@H](CS[H])N[H])[OH] |atomProp:0.pdbName. O :1.pdbName. C :2.pdbName. CA :3.pdbName. CB :4.pdbName. SG :5.pdbName. HG :6.pdbName. N :7.pdbName. H :8.pdbName. OXT|",
+     {
+      {8, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "O "},
+      {6, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "C "},
+      {6, 0, 0, static_cast<Atom::ChiralType>(2), 1, true, "CA "},
+      {6, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "CB "},
+      {16, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "SG "},
+      {1, 0, 0, static_cast<Atom::ChiralType>(0), 0, true, "HG "},
+      {7, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "N "},
+      {1, 0, 0, static_cast<Atom::ChiralType>(0), 0, true, "H "},
+      {8, 0, 0, static_cast<Atom::ChiralType>(0), 1, true, "OXT"},
+     }, {
+      {0, 1, static_cast<Bond::BondType>(2), false, static_cast<Bond::BondStereo>(0), {}},
+      {1, 2, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {2, 3, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {3, 4, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {4, 5, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {2, 6, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {6, 7, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {1, 8, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+     }, {0, 1, 2, 3, 4, 6}, {
+      {{7}, 6, 7, 1},
+      {{8}, 1, 8, 2},
+      {{5}, 4, 5, 3},
+     }},
+    {"Q", "GLN", MonomerClass::AminoAcid, "NC(=O)CC[C@H](N[H])C(=O)[OH] |atomProp:0.pdbName. NE2:1.pdbName. CD :2.pdbName. OE1:3.pdbName. CG :4.pdbName. CB :5.pdbName. CA :6.pdbName. N :7.pdbName. H :8.pdbName. C :9.pdbName. O :10.pdbName. OXT|",
+     {
+      {7, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "NE2"},
+      {6, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "CD "},
+      {8, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "OE1"},
+      {6, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "CG "},
+      {6, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "CB "},
+      {6, 0, 0, static_cast<Atom::ChiralType>(2), 1, true, "CA "},
+      {7, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "N "},
+      {1, 0, 0, static_cast<Atom::ChiralType>(0), 0, true, "H "},
+      {6, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "C "},
+      {8, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "O "},
+      {8, 0, 0, static_cast<Atom::ChiralType>(0), 1, true, "OXT"},
+     }, {
+      {0, 1, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {1, 2, static_cast<Bond::BondType>(2), false, static_cast<Bond::BondStereo>(0), {}},
+      {1, 3, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {3, 4, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {4, 5, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {5, 6, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {6, 7, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {5, 8, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {8, 9, static_cast<Bond::BondType>(2), false, static_cast<Bond::BondStereo>(0), {}},
+      {8, 10, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+     }, {0, 1, 2, 3, 4, 5, 6, 8, 9}, {
+      {{7}, 6, 7, 1},
+      {{10}, 8, 10, 2},
+     }},
+    {"E", "GLU", MonomerClass::AminoAcid, "O=C([C@H](CCC(=O)[OH])N[H])[OH] |atomProp:0.pdbName. O :1.pdbName. C :2.pdbName. CA :3.pdbName. CB :4.pdbName. CG :5.pdbName. CD :6.pdbName. OE1:7.pdbName. OE2:8.pdbName. N :9.pdbName. H :10.pdbName. OXT|",
+     {
+      {8, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "O "},
+      {6, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "C "},
+      {6, 0, 0, static_cast<Atom::ChiralType>(2), 1, true, "CA "},
+      {6, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "CB "},
+      {6, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "CG "},
+      {6, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "CD "},
+      {8, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "OE1"},
+      {8, 0, 0, static_cast<Atom::ChiralType>(0), 1, true, "OE2"},
+      {7, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "N "},
+      {1, 0, 0, static_cast<Atom::ChiralType>(0), 0, true, "H "},
+      {8, 0, 0, static_cast<Atom::ChiralType>(0), 1, true, "OXT"},
+     }, {
+      {0, 1, static_cast<Bond::BondType>(2), false, static_cast<Bond::BondStereo>(0), {}},
+      {1, 2, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {2, 3, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {3, 4, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {4, 5, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {5, 6, static_cast<Bond::BondType>(2), false, static_cast<Bond::BondStereo>(0), {}},
+      {5, 7, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {2, 8, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {8, 9, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {1, 10, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+     }, {0, 1, 2, 3, 4, 5, 6, 8}, {
+      {{9}, 8, 9, 1},
+      {{10}, 1, 10, 2},
+      {{7}, 5, 7, 3},
+     }},
+    {"G", "GLY", MonomerClass::AminoAcid, "O=C(CN[H])[OH] |atomProp:0.pdbName. O :1.pdbName. C :2.pdbName. CA :3.pdbName. N :4.pdbName. H :5.pdbName. OXT|",
+     {
+      {8, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "O "},
+      {6, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "C "},
+      {6, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "CA "},
+      {7, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "N "},
+      {1, 0, 0, static_cast<Atom::ChiralType>(0), 0, true, "H "},
+      {8, 0, 0, static_cast<Atom::ChiralType>(0), 1, true, "OXT"},
+     }, {
+      {0, 1, static_cast<Bond::BondType>(2), false, static_cast<Bond::BondStereo>(0), {}},
+      {1, 2, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {2, 3, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {3, 4, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {1, 5, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+     }, {0, 1, 2, 3}, {
+      {{4}, 3, 4, 1},
+      {{5}, 1, 5, 2},
+     }},
+    {"H", "HIS", MonomerClass::AminoAcid, "O=C([C@H](Cc1cnc[nH]1)N[H])[OH] |atomProp:0.pdbName. O :1.pdbName. C :2.pdbName. CA :3.pdbName. CB :4.pdbName. CG :5.pdbName. CD2:6.pdbName. NE2:7.pdbName. CE1:8.pdbName. ND1:9.pdbName. N :10.pdbName. H :11.pdbName. OXT|",
+     {
+      {8, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "O "},
+      {6, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "C "},
+      {6, 0, 0, static_cast<Atom::ChiralType>(2), 1, true, "CA "},
+      {6, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "CB "},
+      {6, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "CG "},
+      {6, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "CD2"},
+      {7, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "NE2"},
+      {6, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "CE1"},
+      {7, 0, 0, static_cast<Atom::ChiralType>(0), 1, false, "ND1"},
+      {7, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "N "},
+      {1, 0, 0, static_cast<Atom::ChiralType>(0), 0, true, "H "},
+      {8, 0, 0, static_cast<Atom::ChiralType>(0), 1, true, "OXT"},
+     }, {
+      {0, 1, static_cast<Bond::BondType>(2), false, static_cast<Bond::BondStereo>(0), {}},
+      {1, 2, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {2, 3, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {3, 4, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {4, 5, static_cast<Bond::BondType>(12), true, static_cast<Bond::BondStereo>(0), {}},
+      {5, 6, static_cast<Bond::BondType>(12), true, static_cast<Bond::BondStereo>(0), {}},
+      {6, 7, static_cast<Bond::BondType>(12), true, static_cast<Bond::BondStereo>(0), {}},
+      {7, 8, static_cast<Bond::BondType>(12), true, static_cast<Bond::BondStereo>(0), {}},
+      {2, 9, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {9, 10, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {1, 11, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {8, 4, static_cast<Bond::BondType>(12), true, static_cast<Bond::BondStereo>(0), {}},
+     }, {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, {
+      {{10}, 9, 10, 1},
+      {{11}, 1, 11, 2},
+     }},
+    {"I", "ILE", MonomerClass::AminoAcid, "CC[C@H](C)[C@H](N[H])C(=O)[OH] |atomProp:0.pdbName. CD1:1.pdbName. CG1:2.pdbName. CB :3.pdbName. CG2:4.pdbName. CA :5.pdbName. N :6.pdbName. H :7.pdbName. C :8.pdbName. O :9.pdbName. OXT|",
+     {
+      {6, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "CD1"},
+      {6, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "CG1"},
+      {6, 0, 0, static_cast<Atom::ChiralType>(2), 1, true, "CB "},
+      {6, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "CG2"},
+      {6, 0, 0, static_cast<Atom::ChiralType>(2), 1, true, "CA "},
+      {7, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "N "},
+      {1, 0, 0, static_cast<Atom::ChiralType>(0), 0, true, "H "},
+      {6, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "C "},
+      {8, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "O "},
+      {8, 0, 0, static_cast<Atom::ChiralType>(0), 1, true, "OXT"},
+     }, {
+      {0, 1, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {1, 2, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {2, 3, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {2, 4, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {4, 5, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {5, 6, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {4, 7, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {7, 8, static_cast<Bond::BondType>(2), false, static_cast<Bond::BondStereo>(0), {}},
+      {7, 9, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+     }, {0, 1, 2, 3, 4, 5, 7, 8}, {
+      {{6}, 5, 6, 1},
+      {{9}, 7, 9, 2},
+     }},
+    {"L", "LEU", MonomerClass::AminoAcid, "CC(C)C[C@H](N[H])C(=O)[OH] |atomProp:0.pdbName. CD1:1.pdbName. CG :2.pdbName. CD2:3.pdbName. CB :4.pdbName. CA :5.pdbName. N :6.pdbName. H :7.pdbName. C :8.pdbName. O :9.pdbName. OXT|",
+     {
+      {6, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "CD1"},
+      {6, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "CG "},
+      {6, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "CD2"},
+      {6, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "CB "},
+      {6, 0, 0, static_cast<Atom::ChiralType>(2), 1, true, "CA "},
+      {7, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "N "},
+      {1, 0, 0, static_cast<Atom::ChiralType>(0), 0, true, "H "},
+      {6, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "C "},
+      {8, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "O "},
+      {8, 0, 0, static_cast<Atom::ChiralType>(0), 1, true, "OXT"},
+     }, {
+      {0, 1, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {1, 2, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {1, 3, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {3, 4, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {4, 5, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {5, 6, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {4, 7, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {7, 8, static_cast<Bond::BondType>(2), false, static_cast<Bond::BondStereo>(0), {}},
+      {7, 9, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+     }, {0, 1, 2, 3, 4, 5, 7, 8}, {
+      {{6}, 5, 6, 1},
+      {{9}, 7, 9, 2},
+     }},
+    {"K", "LYS", MonomerClass::AminoAcid, "O=C([C@H](CCCCN[H])N[H])[OH] |atomProp:0.pdbName. O :1.pdbName. C :2.pdbName. CA :3.pdbName. CB :4.pdbName. CG :5.pdbName. CD :6.pdbName. CE :7.pdbName. NZ :8.pdbName. HZ1:9.pdbName. N :10.pdbName. H :11.pdbName. OXT|",
+     {
+      {8, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "O "},
+      {6, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "C "},
+      {6, 0, 0, static_cast<Atom::ChiralType>(2), 1, true, "CA "},
+      {6, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "CB "},
+      {6, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "CG "},
+      {6, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "CD "},
+      {6, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "CE "},
+      {7, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "NZ "},
+      {1, 0, 0, static_cast<Atom::ChiralType>(0), 0, true, "HZ1"},
+      {7, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "N "},
+      {1, 0, 0, static_cast<Atom::ChiralType>(0), 0, true, "H "},
+      {8, 0, 0, static_cast<Atom::ChiralType>(0), 1, true, "OXT"},
+     }, {
+      {0, 1, static_cast<Bond::BondType>(2), false, static_cast<Bond::BondStereo>(0), {}},
+      {1, 2, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {2, 3, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {3, 4, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {4, 5, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {5, 6, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {6, 7, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {7, 8, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {2, 9, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {9, 10, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {1, 11, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+     }, {0, 1, 2, 3, 4, 5, 6, 7, 9}, {
+      {{10}, 9, 10, 1},
+      {{11}, 1, 11, 2},
+      {{8}, 7, 8, 3},
+     }},
+    {"M", "MET", MonomerClass::AminoAcid, "CSCC[C@H](N[H])C(=O)[OH] |atomProp:0.pdbName. CE :1.pdbName. SD :2.pdbName. CG :3.pdbName. CB :4.pdbName. CA :5.pdbName. N :6.pdbName. H :7.pdbName. C :8.pdbName. O :9.pdbName. OXT|",
+     {
+      {6, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "CE "},
+      {16, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "SD "},
+      {6, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "CG "},
+      {6, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "CB "},
+      {6, 0, 0, static_cast<Atom::ChiralType>(2), 1, true, "CA "},
+      {7, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "N "},
+      {1, 0, 0, static_cast<Atom::ChiralType>(0), 0, true, "H "},
+      {6, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "C "},
+      {8, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "O "},
+      {8, 0, 0, static_cast<Atom::ChiralType>(0), 1, true, "OXT"},
+     }, {
+      {0, 1, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {1, 2, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {2, 3, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {3, 4, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {4, 5, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {5, 6, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {4, 7, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {7, 8, static_cast<Bond::BondType>(2), false, static_cast<Bond::BondStereo>(0), {}},
+      {7, 9, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+     }, {0, 1, 2, 3, 4, 5, 7, 8}, {
+      {{6}, 5, 6, 1},
+      {{9}, 7, 9, 2},
+     }},
+    {"F", "PHE", MonomerClass::AminoAcid, "O=C([C@H](Cc1ccccc1)N[H])[OH] |atomProp:0.pdbName. O :1.pdbName. C :2.pdbName. CA :3.pdbName. CB :4.pdbName. CG :5.pdbName. CD1:6.pdbName. CE1:7.pdbName. CZ :8.pdbName. CE2:9.pdbName. CD2:10.pdbName. N :11.pdbName. H :12.pdbName. OXT|",
+     {
+      {8, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "O "},
+      {6, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "C "},
+      {6, 0, 0, static_cast<Atom::ChiralType>(2), 1, true, "CA "},
+      {6, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "CB "},
+      {6, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "CG "},
+      {6, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "CD1"},
+      {6, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "CE1"},
+      {6, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "CZ "},
+      {6, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "CE2"},
+      {6, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "CD2"},
+      {7, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "N "},
+      {1, 0, 0, static_cast<Atom::ChiralType>(0), 0, true, "H "},
+      {8, 0, 0, static_cast<Atom::ChiralType>(0), 1, true, "OXT"},
+     }, {
+      {0, 1, static_cast<Bond::BondType>(2), false, static_cast<Bond::BondStereo>(0), {}},
+      {1, 2, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {2, 3, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {3, 4, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {4, 5, static_cast<Bond::BondType>(12), true, static_cast<Bond::BondStereo>(0), {}},
+      {5, 6, static_cast<Bond::BondType>(12), true, static_cast<Bond::BondStereo>(0), {}},
+      {6, 7, static_cast<Bond::BondType>(12), true, static_cast<Bond::BondStereo>(0), {}},
+      {7, 8, static_cast<Bond::BondType>(12), true, static_cast<Bond::BondStereo>(0), {}},
+      {8, 9, static_cast<Bond::BondType>(12), true, static_cast<Bond::BondStereo>(0), {}},
+      {2, 10, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {10, 11, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {1, 12, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {9, 4, static_cast<Bond::BondType>(12), true, static_cast<Bond::BondStereo>(0), {}},
+     }, {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, {
+      {{11}, 10, 11, 1},
+      {{12}, 1, 12, 2},
+     }},
+    {"P", "PRO", MonomerClass::AminoAcid, "O=C([C@@H]1CCCN1[H])[OH] |atomProp:0.pdbName. O :1.pdbName. C :2.pdbName. CA :3.pdbName. CB :4.pdbName. CG :5.pdbName. CD :6.pdbName. N :7.pdbName. H :8.pdbName. OXT|",
+     {
+      {8, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "O "},
+      {6, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "C "},
+      {6, 0, 0, static_cast<Atom::ChiralType>(2), 1, true, "CA "},
+      {6, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "CB "},
+      {6, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "CG "},
+      {6, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "CD "},
+      {7, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "N "},
+      {1, 0, 0, static_cast<Atom::ChiralType>(0), 0, true, "H "},
+      {8, 0, 0, static_cast<Atom::ChiralType>(0), 1, true, "OXT"},
+     }, {
+      {0, 1, static_cast<Bond::BondType>(2), false, static_cast<Bond::BondStereo>(0), {}},
+      {1, 2, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {2, 3, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {3, 4, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {4, 5, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {5, 6, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {6, 7, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {1, 8, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {6, 2, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+     }, {0, 1, 2, 3, 4, 5, 6}, {
+      {{7}, 6, 7, 1},
+      {{8}, 1, 8, 2},
+     }},
+    {"S", "SER", MonomerClass::AminoAcid, "O=C([C@H](CO)N[H])[OH] |atomProp:0.pdbName. O :1.pdbName. C :2.pdbName. CA :3.pdbName. CB :4.pdbName. OG :5.pdbName. N :6.pdbName. H :7.pdbName. OXT|",
+     {
+      {8, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "O "},
+      {6, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "C "},
+      {6, 0, 0, static_cast<Atom::ChiralType>(2), 1, true, "CA "},
+      {6, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "CB "},
+      {8, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "OG "},
+      {7, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "N "},
+      {1, 0, 0, static_cast<Atom::ChiralType>(0), 0, true, "H "},
+      {8, 0, 0, static_cast<Atom::ChiralType>(0), 1, true, "OXT"},
+     }, {
+      {0, 1, static_cast<Bond::BondType>(2), false, static_cast<Bond::BondStereo>(0), {}},
+      {1, 2, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {2, 3, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {3, 4, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {2, 5, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {5, 6, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {1, 7, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+     }, {0, 1, 2, 3, 4, 5}, {
+      {{6}, 5, 6, 1},
+      {{7}, 1, 7, 2},
+     }},
+    {"T", "THR", MonomerClass::AminoAcid, "C[C@@H](O)[C@H](N[H])C(=O)[OH] |atomProp:0.pdbName. CG2:1.pdbName. CB :2.pdbName. OG1:3.pdbName. CA :4.pdbName. N :5.pdbName. H :6.pdbName. C :7.pdbName. O :8.pdbName. OXT|",
+     {
+      {6, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "CG2"},
+      {6, 0, 0, static_cast<Atom::ChiralType>(1), 1, true, "CB "},
+      {8, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "OG1"},
+      {6, 0, 0, static_cast<Atom::ChiralType>(2), 1, true, "CA "},
+      {7, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "N "},
+      {1, 0, 0, static_cast<Atom::ChiralType>(0), 0, true, "H "},
+      {6, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "C "},
+      {8, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "O "},
+      {8, 0, 0, static_cast<Atom::ChiralType>(0), 1, true, "OXT"},
+     }, {
+      {0, 1, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {1, 2, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {1, 3, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {3, 4, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {4, 5, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {3, 6, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {6, 7, static_cast<Bond::BondType>(2), false, static_cast<Bond::BondStereo>(0), {}},
+      {6, 8, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+     }, {0, 1, 2, 3, 4, 6, 7}, {
+      {{5}, 4, 5, 1},
+      {{8}, 6, 8, 2},
+     }},
+    {"W", "TRP", MonomerClass::AminoAcid, "O=C([C@H](Cc1c[nH]c2ccccc12)N[H])[OH] |atomProp:0.pdbName. O :1.pdbName. C :2.pdbName. CA :3.pdbName. CB :4.pdbName. CG :5.pdbName. CD1:6.pdbName. NE1:7.pdbName. CE2:8.pdbName. CZ2:9.pdbName. CH2:10.pdbName. CZ3:11.pdbName. CE3:12.pdbName. CD2:13.pdbName. N :14.pdbName. H :15.pdbName. OXT|",
+     {
+      {8, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "O "},
+      {6, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "C "},
+      {6, 0, 0, static_cast<Atom::ChiralType>(2), 1, true, "CA "},
+      {6, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "CB "},
+      {6, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "CG "},
+      {6, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "CD1"},
+      {7, 0, 0, static_cast<Atom::ChiralType>(0), 1, false, "NE1"},
+      {6, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "CE2"},
+      {6, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "CZ2"},
+      {6, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "CH2"},
+      {6, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "CZ3"},
+      {6, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "CE3"},
+      {6, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "CD2"},
+      {7, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "N "},
+      {1, 0, 0, static_cast<Atom::ChiralType>(0), 0, true, "H "},
+      {8, 0, 0, static_cast<Atom::ChiralType>(0), 1, true, "OXT"},
+     }, {
+      {0, 1, static_cast<Bond::BondType>(2), false, static_cast<Bond::BondStereo>(0), {}},
+      {1, 2, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {2, 3, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {3, 4, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {4, 5, static_cast<Bond::BondType>(12), true, static_cast<Bond::BondStereo>(0), {}},
+      {5, 6, static_cast<Bond::BondType>(12), true, static_cast<Bond::BondStereo>(0), {}},
+      {6, 7, static_cast<Bond::BondType>(12), true, static_cast<Bond::BondStereo>(0), {}},
+      {7, 8, static_cast<Bond::BondType>(12), true, static_cast<Bond::BondStereo>(0), {}},
+      {8, 9, static_cast<Bond::BondType>(12), true, static_cast<Bond::BondStereo>(0), {}},
+      {9, 10, static_cast<Bond::BondType>(12), true, static_cast<Bond::BondStereo>(0), {}},
+      {10, 11, static_cast<Bond::BondType>(12), true, static_cast<Bond::BondStereo>(0), {}},
+      {11, 12, static_cast<Bond::BondType>(12), true, static_cast<Bond::BondStereo>(0), {}},
+      {2, 13, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {13, 14, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {1, 15, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {12, 4, static_cast<Bond::BondType>(12), true, static_cast<Bond::BondStereo>(0), {}},
+      {12, 7, static_cast<Bond::BondType>(12), true, static_cast<Bond::BondStereo>(0), {}},
+     }, {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13}, {
+      {{14}, 13, 14, 1},
+      {{15}, 1, 15, 2},
+     }},
+    {"Y", "TYR", MonomerClass::AminoAcid, "O=C([C@H](Cc1ccc(O)cc1)N[H])[OH] |atomProp:0.pdbName. O :1.pdbName. C :2.pdbName. CA :3.pdbName. CB :4.pdbName. CG :5.pdbName. CD1:6.pdbName. CE1:7.pdbName. CZ :8.pdbName. OH :9.pdbName. CE2:10.pdbName. CD2:11.pdbName. N :12.pdbName. H :13.pdbName. OXT|",
+     {
+      {8, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "O "},
+      {6, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "C "},
+      {6, 0, 0, static_cast<Atom::ChiralType>(2), 1, true, "CA "},
+      {6, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "CB "},
+      {6, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "CG "},
+      {6, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "CD1"},
+      {6, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "CE1"},
+      {6, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "CZ "},
+      {8, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "OH "},
+      {6, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "CE2"},
+      {6, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "CD2"},
+      {7, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "N "},
+      {1, 0, 0, static_cast<Atom::ChiralType>(0), 0, true, "H "},
+      {8, 0, 0, static_cast<Atom::ChiralType>(0), 1, true, "OXT"},
+     }, {
+      {0, 1, static_cast<Bond::BondType>(2), false, static_cast<Bond::BondStereo>(0), {}},
+      {1, 2, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {2, 3, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {3, 4, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {4, 5, static_cast<Bond::BondType>(12), true, static_cast<Bond::BondStereo>(0), {}},
+      {5, 6, static_cast<Bond::BondType>(12), true, static_cast<Bond::BondStereo>(0), {}},
+      {6, 7, static_cast<Bond::BondType>(12), true, static_cast<Bond::BondStereo>(0), {}},
+      {7, 8, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {7, 9, static_cast<Bond::BondType>(12), true, static_cast<Bond::BondStereo>(0), {}},
+      {9, 10, static_cast<Bond::BondType>(12), true, static_cast<Bond::BondStereo>(0), {}},
+      {2, 11, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {11, 12, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {1, 13, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {10, 4, static_cast<Bond::BondType>(12), true, static_cast<Bond::BondStereo>(0), {}},
+     }, {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}, {
+      {{12}, 11, 12, 1},
+      {{13}, 1, 13, 2},
+     }},
+    {"V", "VAL", MonomerClass::AminoAcid, "CC(C)[C@H](N[H])C(=O)[OH] |atomProp:0.pdbName. CG1:1.pdbName. CB :2.pdbName. CG2:3.pdbName. CA :4.pdbName. N :5.pdbName. H :6.pdbName. C :7.pdbName. O :8.pdbName. OXT|",
+     {
+      {6, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "CG1"},
+      {6, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "CB "},
+      {6, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "CG2"},
+      {6, 0, 0, static_cast<Atom::ChiralType>(2), 1, true, "CA "},
+      {7, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "N "},
+      {1, 0, 0, static_cast<Atom::ChiralType>(0), 0, true, "H "},
+      {6, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "C "},
+      {8, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "O "},
+      {8, 0, 0, static_cast<Atom::ChiralType>(0), 1, true, "OXT"},
+     }, {
+      {0, 1, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {1, 2, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {1, 3, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {3, 4, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {4, 5, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {3, 6, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {6, 7, static_cast<Bond::BondType>(2), false, static_cast<Bond::BondStereo>(0), {}},
+      {6, 8, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+     }, {0, 1, 2, 3, 4, 6, 7}, {
+      {{5}, 4, 5, 1},
+      {{8}, 6, 8, 2},
+     }},
+    {"U", "SEC", MonomerClass::AminoAcid, "O=C([C@H](C[SeH])N[H])[OH] |atomProp:0.pdbName. O :1.pdbName. C :2.pdbName. CA :3.pdbName. CB :4.pdbName. SE :5.pdbName. N :6.pdbName. H :7.pdbName. OXT|",
+     {
+      {8, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "O "},
+      {6, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "C "},
+      {6, 0, 0, static_cast<Atom::ChiralType>(2), 1, true, "CA "},
+      {6, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "CB "},
+      {34, 0, 0, static_cast<Atom::ChiralType>(0), 1, true, "SE "},
+      {7, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "N "},
+      {1, 0, 0, static_cast<Atom::ChiralType>(0), 0, true, "H "},
+      {8, 0, 0, static_cast<Atom::ChiralType>(0), 1, true, "OXT"},
+     }, {
+      {0, 1, static_cast<Bond::BondType>(2), false, static_cast<Bond::BondStereo>(0), {}},
+      {1, 2, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {2, 3, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {3, 4, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {2, 5, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {5, 6, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {1, 7, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+     }, {0, 1, 2, 3, 4, 5}, {
+      {{6}, 5, 6, 1},
+      {{7}, 1, 7, 2},
+     }},
+    {"O", "PYL", MonomerClass::AminoAcid, "C[C@@H]1CC=N[C@H]1C(=O)NCCCC[C@H](N[H])C(=O)[OH] |atomProp:0.pdbName. CB2:1.pdbName. CG2:2.pdbName. CD2:3.pdbName. CE2:4.pdbName. N2 :5.pdbName. CA2:6.pdbName. C2 :7.pdbName. O2 :8.pdbName. NZ :9.pdbName. CE :10.pdbName. CD :11.pdbName. CG :12.pdbName. CB :13.pdbName. CA :14.pdbName. N :15.pdbName. H :16.pdbName. C :17.pdbName. O :18.pdbName. OXT|",
+     {
+      {6, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "CB2"},
+      {6, 0, 0, static_cast<Atom::ChiralType>(2), 1, true, "CG2"},
+      {6, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "CD2"},
+      {6, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "CE2"},
+      {7, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "N2 "},
+      {6, 0, 0, static_cast<Atom::ChiralType>(1), 1, true, "CA2"},
+      {6, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "C2 "},
+      {8, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "O2 "},
+      {7, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "NZ "},
+      {6, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "CE "},
+      {6, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "CD "},
+      {6, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "CG "},
+      {6, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "CB "},
+      {6, 0, 0, static_cast<Atom::ChiralType>(2), 1, true, "CA "},
+      {7, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "N "},
+      {1, 0, 0, static_cast<Atom::ChiralType>(0), 0, true, "H "},
+      {6, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "C "},
+      {8, 0, 0, static_cast<Atom::ChiralType>(0), 0, false, "O "},
+      {8, 0, 0, static_cast<Atom::ChiralType>(0), 1, true, "OXT"},
+     }, {
+      {0, 1, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {1, 2, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {2, 3, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {3, 4, static_cast<Bond::BondType>(2), false, static_cast<Bond::BondStereo>(0), {}},
+      {4, 5, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {5, 6, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {6, 7, static_cast<Bond::BondType>(2), false, static_cast<Bond::BondStereo>(0), {}},
+      {6, 8, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {8, 9, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {9, 10, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {10, 11, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {11, 12, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {12, 13, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {13, 14, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {14, 15, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {13, 16, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {16, 17, static_cast<Bond::BondType>(2), false, static_cast<Bond::BondStereo>(0), {}},
+      {16, 18, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+      {5, 1, static_cast<Bond::BondType>(1), false, static_cast<Bond::BondStereo>(0), {}},
+     }, {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 16, 17}, {
+      {{15}, 14, 15, 1},
+      {{18}, 16, 18, 2},
+     }},
+}};
+
+std::unique_ptr<MacroMolTemplate> makeBuiltinTemplate(
+    const BuiltinTemplateDef &def) {
+  RWMol mol;
+  for (const auto &atomDef : def.atoms) {
+    auto *atom = new Atom(atomDef.atomicNum);
+    atom->setFormalCharge(atomDef.formalCharge);
+    atom->setIsotope(atomDef.isotope);
+    atom->setChiralTag(atomDef.chiralTag);
+    atom->setNumExplicitHs(atomDef.explicitHs);
+    atom->setNoImplicit(atomDef.noImplicit);
+    if (atomDef.pdbName) atom->setProp("pdbName", std::string(atomDef.pdbName));
+    mol.addAtom(atom, true);
+  }
+  for (const auto &bondDef : def.bonds) {
+    auto *bond = new Bond(bondDef.type);
+    bond->setIsAromatic(bondDef.aromatic);
+    if (bondDef.stereoAtoms.size() == 2) bond->setStereoAtoms(bondDef.stereoAtoms[0], bondDef.stereoAtoms[1]);
+    bond->setStereo(bondDef.stereo);
+    bond->setBeginAtomIdx(bondDef.beginAtomIdx);
+    bond->setEndAtomIdx(bondDef.endAtomIdx);
+    mol.addBond(bond, true);
+  }
+  MacroMolTemplateBuilder builder(mol, def.monomerClass, def.name, def.symbol, def.originalData);
+  auto mainAtomIdxs = def.mainAtomIdxs;
+  builder.setMainGroup(std::move(mainAtomIdxs));
+  for (const auto &leavingGroup : def.leavingGroups) {
+    auto leavingGroupCopy = leavingGroup;
+    builder.addLeavingGroup(std::move(leavingGroupCopy));
+  }
+  return builder.build();
+}
+
+const std::array<std::unique_ptr<const MacroMolTemplate>, builtinTemplates.size()> &getBuiltinTemplates() {
+  static const auto templates = [] {
+    std::array<std::unique_ptr<const MacroMolTemplate>, builtinTemplates.size()> result{};
+    for (std::size_t i = 0; i < builtinTemplates.size(); ++i) result[i] = makeBuiltinTemplate(builtinTemplates[i]);
+    return result;
+  }();
+  return templates;
+}
+
+}  // namespace
+
+void addBuiltinMacroMolTemplates(MacroMolTemplateLibrary &templates) {
+  for (const auto &builtinTemplate : getBuiltinTemplates()) templates.addTemplate(std::make_unique<MacroMolTemplate>(*builtinTemplate));
+}
+
+MacroMolTemplateLibrary &getGlobalMacroMolTemplateLibrary() {
+  static MacroMolTemplateLibrary templates;
+  static std::once_flag initialized;
+  std::call_once(initialized, []() { addBuiltinMacroMolTemplates(templates); });
+  return templates;
+}
+
+}  // namespace RDKit

--- a/Code/GraphMol/MacroMolTemplateLibrary.h
+++ b/Code/GraphMol/MacroMolTemplateLibrary.h
@@ -1,0 +1,25 @@
+//
+//  Copyright (C) 2026 Schrödinger and other RDKit contributors
+//
+//   @@ All Rights Reserved @@
+//  This file is part of the RDKit.
+//
+#ifndef RD_MACROMOLTEMPLATELIBRARY_H
+#define RD_MACROMOLTEMPLATELIBRARY_H
+
+#include <GraphMol/MacroMolTemplate.h>
+#include <RDGeneral/export.h>
+
+namespace RDKit {
+
+//! Returns the process-wide library of built-in MacroMol templates.
+RDKIT_GRAPHMOL_EXPORT MacroMolTemplateLibrary &
+getGlobalMacroMolTemplateLibrary();
+
+//! Adds copies of all built-in MacroMol templates to a caller-owned library.
+RDKIT_GRAPHMOL_EXPORT void addBuiltinMacroMolTemplates(
+    MacroMolTemplateLibrary &templates);
+
+}  // namespace RDKit
+
+#endif

--- a/Code/GraphMol/testMacroMol.cpp
+++ b/Code/GraphMol/testMacroMol.cpp
@@ -15,7 +15,33 @@
 #include <GraphMol/SmilesParse/SmilesWrite.h>
 #include <catch2/catch_all.hpp>
 
+#include <memory>
+#include <string>
+#include <type_traits>
+#include <utility>
+
 using namespace RDKit;
+
+namespace {
+
+std::unique_ptr<MacroMolTemplate> makeMacroMolTemplate(
+    const std::string &name, const std::string &symbol,
+    MonomerClass monomerClass = MonomerClass::AminoAcid) {
+  RWMol mol;
+  mol.addAtom(new Atom(6), false, true);
+  MacroMolTemplateBuilder builder(mol, monomerClass, name, symbol, "");
+  builder.setMainGroup({0});
+  return builder.build();
+}
+
+}  // namespace
+
+static_assert(std::is_same_v<
+              decltype(std::declval<const MacroMol &>()
+                           .getLocalTemplateLibrary()),
+              const MacroMolTemplateLibrary &>);
+static_assert(std::is_nothrow_move_constructible_v<MacroMol>);
+static_assert(std::is_nothrow_move_assignable_v<MacroMol>);
 
 TEST_CASE("testBuildMacroMol") {
   // Build a simple MacroMol with three macro atoms and two bonds, and check
@@ -192,4 +218,149 @@ TEST_CASE("testAddBond") {
   auto second_regular_atom = macro_mol->getAtomWithIdx(second_atom_idx);
   CHECK(macro_mol->addBond(regular_atom, second_regular_atom) == 1);
   CHECK(macro_mol->getNumBonds() == 1);
+}
+
+TEST_CASE("MacroMol owns a local template library") {
+  SECTION("default construction") {
+    MacroMol macroMol;
+    CHECK(macroMol.getLocalTemplateLibrary().getByName(
+              MonomerClass::AminoAcid, "ALA") == nullptr);
+
+    auto alanine = makeMacroMolTemplate("ALA", "A");
+    const auto *alaninePtr = alanine.get();
+    macroMol.addLocalTemplate(std::move(alanine));
+
+    CHECK(alanine == nullptr);
+    CHECK(macroMol.getLocalTemplateLibrary().getBySymbol(
+              MonomerClass::AminoAcid, "A") == alaninePtr);
+    CHECK(macroMol.getLocalTemplateLibrary().getByName(
+              MonomerClass::AminoAcid, "ALA") == alaninePtr);
+  }
+
+  SECTION("ownership transfer") {
+    auto localTemplateLibrary =
+        std::make_unique<MacroMolTemplateLibrary>();
+    auto alanine = makeMacroMolTemplate("ALA", "A");
+    const auto *alaninePtr = alanine.get();
+    localTemplateLibrary->addTemplate(std::move(alanine));
+
+    MacroMol macroMol(std::move(localTemplateLibrary));
+
+    CHECK(localTemplateLibrary == nullptr);
+    CHECK(macroMol.getLocalTemplateLibrary().getBySymbol(
+              MonomerClass::AminoAcid, "A") == alaninePtr);
+  }
+
+  SECTION("null library") {
+    CHECK_THROWS_AS(
+        MacroMol(std::unique_ptr<MacroMolTemplateLibrary>{}),
+        Invar::Invariant);
+  }
+}
+
+TEST_CASE("MacroMol validates references against only its local library") {
+  SECTION("empty and ordinary-atom-only molecules are valid") {
+    MacroMol macroMol;
+    CHECK(macroMol.hasValidLocalTemplateReferences());
+    macroMol.addAtom(new Atom(6), false, true);
+    CHECK(macroMol.hasValidLocalTemplateReferences());
+  }
+
+  SECTION("symbol lookup") {
+    MacroMol macroMol;
+    macroMol.addLocalTemplate(makeMacroMolTemplate("ALA", "A"));
+    macroMol.addMacroAtom("A", MonomerClass::AminoAcid);
+    CHECK(macroMol.hasValidLocalTemplateReferences());
+  }
+
+  SECTION("template-name lookup") {
+    MacroMol macroMol;
+    macroMol.addLocalTemplate(makeMacroMolTemplate("ALA", "A"));
+    macroMol.addMacroAtom("ALA", MonomerClass::AminoAcid);
+    CHECK(macroMol.hasValidLocalTemplateReferences());
+  }
+
+  SECTION("missing template") {
+    MacroMol macroMol;
+    macroMol.addMacroAtom("A", MonomerClass::AminoAcid);
+    CHECK_FALSE(macroMol.hasValidLocalTemplateReferences());
+  }
+
+  SECTION("monomer class is part of the lookup key") {
+    MacroMol macroMol;
+    macroMol.addLocalTemplate(makeMacroMolTemplate("ALA", "A"));
+    macroMol.addMacroAtom("A", MonomerClass::NucleicAcid);
+    CHECK_FALSE(macroMol.hasValidLocalTemplateReferences());
+  }
+
+  SECTION("one unresolved macro atom invalidates the molecule") {
+    MacroMol macroMol;
+    macroMol.addLocalTemplate(makeMacroMolTemplate("ALA", "A"));
+    macroMol.addMacroAtom("A", MonomerClass::AminoAcid);
+    macroMol.addMacroAtom("C", MonomerClass::AminoAcid);
+    CHECK_FALSE(macroMol.hasValidLocalTemplateReferences());
+  }
+}
+
+TEST_CASE("MacroMol local-template library rejects null templates") {
+  MacroMol macroMol;
+  CHECK_THROWS_AS(macroMol.addLocalTemplate(nullptr),
+                  Invar::Invariant);
+}
+
+TEST_CASE("MacroMol copies have independent local template libraries") {
+  MacroMol source;
+  source.addLocalTemplate(makeMacroMolTemplate("ALA", "A"));
+  source.addMacroAtom("A", MonomerClass::AminoAcid);
+  const auto *sourceTemplate = source.getLocalTemplateLibrary().getBySymbol(
+      MonomerClass::AminoAcid, "A");
+  REQUIRE(sourceTemplate);
+
+  MacroMol copy(source);
+  CHECK(&copy.getLocalTemplateLibrary() !=
+        &source.getLocalTemplateLibrary());
+  const auto *copiedTemplate = copy.getLocalTemplateLibrary().getBySymbol(
+      MonomerClass::AminoAcid, "A");
+  REQUIRE(copiedTemplate);
+  CHECK(copiedTemplate != sourceTemplate);
+  CHECK(copiedTemplate->getName() == sourceTemplate->getName());
+  CHECK(copy.hasValidLocalTemplateReferences());
+
+  MacroMol assigned;
+  assigned.addLocalTemplate(makeMacroMolTemplate("CYS", "C"));
+  assigned = source;
+  CHECK(&assigned.getLocalTemplateLibrary() !=
+        &source.getLocalTemplateLibrary());
+  const auto *assignedTemplate = assigned.getLocalTemplateLibrary().getBySymbol(
+      MonomerClass::AminoAcid, "A");
+  REQUIRE(assignedTemplate);
+  CHECK(assignedTemplate != sourceTemplate);
+  CHECK(assignedTemplate != copiedTemplate);
+  CHECK(assigned.getLocalTemplateLibrary().getBySymbol(
+            MonomerClass::AminoAcid, "C") == nullptr);
+  CHECK(assigned.hasValidLocalTemplateReferences());
+}
+
+TEST_CASE("MacroMol moves its local template library") {
+  MacroMol source;
+  source.addLocalTemplate(makeMacroMolTemplate("ALA", "A"));
+  source.addMacroAtom("A", MonomerClass::AminoAcid);
+  const auto *sourceLibrary = &source.getLocalTemplateLibrary();
+  const auto *sourceTemplate = sourceLibrary->getBySymbol(
+      MonomerClass::AminoAcid, "A");
+  REQUIRE(sourceTemplate);
+
+  MacroMol moved(std::move(source));
+  CHECK(&moved.getLocalTemplateLibrary() == sourceLibrary);
+  CHECK(moved.getLocalTemplateLibrary().getBySymbol(
+            MonomerClass::AminoAcid, "A") == sourceTemplate);
+  CHECK(moved.hasValidLocalTemplateReferences());
+
+  MacroMol assigned;
+  assigned.addLocalTemplate(makeMacroMolTemplate("CYS", "C"));
+  assigned = std::move(moved);
+  CHECK(&assigned.getLocalTemplateLibrary() == sourceLibrary);
+  CHECK(assigned.getLocalTemplateLibrary().getBySymbol(
+            MonomerClass::AminoAcid, "A") == sourceTemplate);
+  CHECK(assigned.hasValidLocalTemplateReferences());
 }

--- a/Code/GraphMol/testMacroMol.cpp
+++ b/Code/GraphMol/testMacroMol.cpp
@@ -37,6 +37,9 @@ std::unique_ptr<MacroMolTemplate> makeMacroMolTemplate(
 }  // namespace
 
 static_assert(std::is_same_v<
+              decltype(std::declval<MacroMol &>().getLocalTemplateLibrary()),
+              MacroMolTemplateLibrary &>);
+static_assert(std::is_same_v<
               decltype(std::declval<const MacroMol &>()
                            .getLocalTemplateLibrary()),
               const MacroMolTemplateLibrary &>);
@@ -228,7 +231,7 @@ TEST_CASE("MacroMol owns a local template library") {
 
     auto alanine = makeMacroMolTemplate("ALA", "A");
     const auto *alaninePtr = alanine.get();
-    macroMol.addLocalTemplate(std::move(alanine));
+    macroMol.getLocalTemplateLibrary().addTemplate(std::move(alanine));
 
     CHECK(alanine == nullptr);
     CHECK(macroMol.getLocalTemplateLibrary().getBySymbol(
@@ -261,56 +264,61 @@ TEST_CASE("MacroMol owns a local template library") {
 TEST_CASE("MacroMol validates references against only its local library") {
   SECTION("empty and ordinary-atom-only molecules are valid") {
     MacroMol macroMol;
-    CHECK(macroMol.hasValidLocalTemplateReferences());
+    CHECK(macroMol.checkLocalTemplateReferences());
     macroMol.addAtom(new Atom(6), false, true);
-    CHECK(macroMol.hasValidLocalTemplateReferences());
+    CHECK(macroMol.checkLocalTemplateReferences());
   }
 
   SECTION("symbol lookup") {
     MacroMol macroMol;
-    macroMol.addLocalTemplate(makeMacroMolTemplate("ALA", "A"));
+    macroMol.getLocalTemplateLibrary().addTemplate(
+        makeMacroMolTemplate("ALA", "A"));
     macroMol.addMacroAtom("A", MonomerClass::AminoAcid);
-    CHECK(macroMol.hasValidLocalTemplateReferences());
+    CHECK(macroMol.checkLocalTemplateReferences());
   }
 
   SECTION("template-name lookup") {
     MacroMol macroMol;
-    macroMol.addLocalTemplate(makeMacroMolTemplate("ALA", "A"));
+    macroMol.getLocalTemplateLibrary().addTemplate(
+        makeMacroMolTemplate("ALA", "A"));
     macroMol.addMacroAtom("ALA", MonomerClass::AminoAcid);
-    CHECK(macroMol.hasValidLocalTemplateReferences());
+    CHECK(macroMol.checkLocalTemplateReferences());
   }
 
   SECTION("missing template") {
     MacroMol macroMol;
     macroMol.addMacroAtom("A", MonomerClass::AminoAcid);
-    CHECK_FALSE(macroMol.hasValidLocalTemplateReferences());
+    CHECK_FALSE(macroMol.checkLocalTemplateReferences());
   }
 
   SECTION("monomer class is part of the lookup key") {
     MacroMol macroMol;
-    macroMol.addLocalTemplate(makeMacroMolTemplate("ALA", "A"));
+    macroMol.getLocalTemplateLibrary().addTemplate(
+        makeMacroMolTemplate("ALA", "A"));
     macroMol.addMacroAtom("A", MonomerClass::NucleicAcid);
-    CHECK_FALSE(macroMol.hasValidLocalTemplateReferences());
+    CHECK_FALSE(macroMol.checkLocalTemplateReferences());
   }
 
   SECTION("one unresolved macro atom invalidates the molecule") {
     MacroMol macroMol;
-    macroMol.addLocalTemplate(makeMacroMolTemplate("ALA", "A"));
+    macroMol.getLocalTemplateLibrary().addTemplate(
+        makeMacroMolTemplate("ALA", "A"));
     macroMol.addMacroAtom("A", MonomerClass::AminoAcid);
     macroMol.addMacroAtom("C", MonomerClass::AminoAcid);
-    CHECK_FALSE(macroMol.hasValidLocalTemplateReferences());
+    CHECK_FALSE(macroMol.checkLocalTemplateReferences());
   }
 }
 
 TEST_CASE("MacroMol local-template library rejects null templates") {
   MacroMol macroMol;
-  CHECK_THROWS_AS(macroMol.addLocalTemplate(nullptr),
+  CHECK_THROWS_AS(macroMol.getLocalTemplateLibrary().addTemplate(nullptr),
                   Invar::Invariant);
 }
 
 TEST_CASE("MacroMol copies have independent local template libraries") {
   MacroMol source;
-  source.addLocalTemplate(makeMacroMolTemplate("ALA", "A"));
+  source.getLocalTemplateLibrary().addTemplate(
+      makeMacroMolTemplate("ALA", "A"));
   source.addMacroAtom("A", MonomerClass::AminoAcid);
   const auto *sourceTemplate = source.getLocalTemplateLibrary().getBySymbol(
       MonomerClass::AminoAcid, "A");
@@ -324,10 +332,11 @@ TEST_CASE("MacroMol copies have independent local template libraries") {
   REQUIRE(copiedTemplate);
   CHECK(copiedTemplate != sourceTemplate);
   CHECK(copiedTemplate->getName() == sourceTemplate->getName());
-  CHECK(copy.hasValidLocalTemplateReferences());
+  CHECK(copy.checkLocalTemplateReferences());
 
   MacroMol assigned;
-  assigned.addLocalTemplate(makeMacroMolTemplate("CYS", "C"));
+  assigned.getLocalTemplateLibrary().addTemplate(
+      makeMacroMolTemplate("CYS", "C"));
   assigned = source;
   CHECK(&assigned.getLocalTemplateLibrary() !=
         &source.getLocalTemplateLibrary());
@@ -338,12 +347,13 @@ TEST_CASE("MacroMol copies have independent local template libraries") {
   CHECK(assignedTemplate != copiedTemplate);
   CHECK(assigned.getLocalTemplateLibrary().getBySymbol(
             MonomerClass::AminoAcid, "C") == nullptr);
-  CHECK(assigned.hasValidLocalTemplateReferences());
+  CHECK(assigned.checkLocalTemplateReferences());
 }
 
 TEST_CASE("MacroMol moves its local template library") {
   MacroMol source;
-  source.addLocalTemplate(makeMacroMolTemplate("ALA", "A"));
+  source.getLocalTemplateLibrary().addTemplate(
+      makeMacroMolTemplate("ALA", "A"));
   source.addMacroAtom("A", MonomerClass::AminoAcid);
   const auto *sourceLibrary = &source.getLocalTemplateLibrary();
   const auto *sourceTemplate = sourceLibrary->getBySymbol(
@@ -354,13 +364,14 @@ TEST_CASE("MacroMol moves its local template library") {
   CHECK(&moved.getLocalTemplateLibrary() == sourceLibrary);
   CHECK(moved.getLocalTemplateLibrary().getBySymbol(
             MonomerClass::AminoAcid, "A") == sourceTemplate);
-  CHECK(moved.hasValidLocalTemplateReferences());
+  CHECK(moved.checkLocalTemplateReferences());
 
   MacroMol assigned;
-  assigned.addLocalTemplate(makeMacroMolTemplate("CYS", "C"));
+  assigned.getLocalTemplateLibrary().addTemplate(
+      makeMacroMolTemplate("CYS", "C"));
   assigned = std::move(moved);
   CHECK(&assigned.getLocalTemplateLibrary() == sourceLibrary);
   CHECK(assigned.getLocalTemplateLibrary().getBySymbol(
             MonomerClass::AminoAcid, "A") == sourceTemplate);
-  CHECK(assigned.hasValidLocalTemplateReferences());
+  CHECK(assigned.checkLocalTemplateReferences());
 }

--- a/Code/GraphMol/testMacroMol.cpp
+++ b/Code/GraphMol/testMacroMol.cpp
@@ -254,9 +254,29 @@ TEST_CASE("MacroMol owns a local template library") {
               MonomerClass::AminoAcid, "A") == alaninePtr);
   }
 
+  SECTION("replacement ownership transfer") {
+    MacroMol macroMol;
+    auto localTemplateLibrary =
+        std::make_unique<MacroMolTemplateLibrary>();
+    auto alanine = makeMacroMolTemplate("ALA", "A");
+    const auto *alaninePtr = alanine.get();
+    localTemplateLibrary->addTemplate(std::move(alanine));
+
+    macroMol.setLocalTemplateLibrary(std::move(localTemplateLibrary));
+
+    CHECK(localTemplateLibrary == nullptr);
+    CHECK(macroMol.getLocalTemplateLibrary().getBySymbol(
+              MonomerClass::AminoAcid, "A") == alaninePtr);
+  }
+
   SECTION("null library") {
     CHECK_THROWS_AS(
         MacroMol(std::unique_ptr<MacroMolTemplateLibrary>{}),
+        Invar::Invariant);
+    MacroMol macroMol;
+    CHECK_THROWS_AS(
+        macroMol.setLocalTemplateLibrary(
+            std::unique_ptr<MacroMolTemplateLibrary>{}),
         Invar::Invariant);
   }
 }

--- a/Code/GraphMol/testMacroMolTemplate.cpp
+++ b/Code/GraphMol/testMacroMolTemplate.cpp
@@ -93,6 +93,19 @@ TEST_CASE("MacroMolTemplate preserves its SCSR subclass") {
   CHECK(copied.getSubclass() == "AA");
 }
 
+TEST_CASE("MacroMolTemplateBuilder provides mutable molecule access") {
+  RWMol mol;
+  mol.addAtom(new Atom(6), false, true);
+  MacroMolTemplateBuilder builder(mol, MonomerClass::Chemical, "CARBON", "C",
+                                  "C");
+
+  builder.getMol().getAtomWithIdx(0)->setIsotope(13);
+  builder.setMainGroup({0});
+  auto templ = builder.build();
+
+  CHECK(templ->getMol().getAtomWithIdx(0)->getIsotope() == 13);
+}
+
 TEST_CASE("MacroMolTemplate mirrors typed main and leaving groups") {
   auto templ = makeAnnotatedAlanineTemplate();
 

--- a/Code/GraphMol/testMacroMolTemplate.cpp
+++ b/Code/GraphMol/testMacroMolTemplate.cpp
@@ -8,6 +8,7 @@
 //  of the RDKit source tree.
 //
 
+#include <GraphMol/Atom.h>
 #include <GraphMol/MacroMolTemplate.h>
 #include <GraphMol/SmilesParse/SmilesParse.h>
 #include <RDGeneral/Invariant.h>
@@ -68,6 +69,7 @@ TEST_CASE("MacroMolTemplate owns a logically read-only molecule and metadata") {
   CHECK(templ->getName() == "ALA");
   CHECK(templ->getSymbol() == "A");
   CHECK(templ->getOriginalData() == "C");
+  CHECK(templ->getSubclass().empty());
   CHECK(templ->getMainAtomIdxs() == std::vector<unsigned int>{0});
   CHECK(templ->getLeavingGroups().empty());
 
@@ -75,6 +77,20 @@ TEST_CASE("MacroMolTemplate owns a logically read-only molecule and metadata") {
   MacroMolTemplate copied(*templ);
   CHECK(copied.getMol().getNumAtoms() == 1);
   CHECK(&copied.getMainSgroup().getOwningMol() == &copied.getMol());
+}
+
+TEST_CASE("MacroMolTemplate preserves its SCSR subclass") {
+  RWMol mol;
+  mol.addAtom(new Atom(6), false, true);
+  MacroMolTemplateBuilder builder(mol, MonomerClass::AminoAcid, "ALA", "A",
+                                  "C");
+  builder.setMainGroup({0}).setSubclass("AA");
+
+  auto templ = builder.build();
+
+  CHECK(templ->getSubclass() == "AA");
+  MacroMolTemplate copied(*templ);
+  CHECK(copied.getSubclass() == "AA");
 }
 
 TEST_CASE("MacroMolTemplate mirrors typed main and leaving groups") {

--- a/Code/GraphMol/testMacroMolTemplateLibrary.cpp
+++ b/Code/GraphMol/testMacroMolTemplateLibrary.cpp
@@ -1,0 +1,40 @@
+// Copyright (C) 2026 Schrödinger and other RDKit contributors
+
+#include <GraphMol/MacroMol.h>
+#include <GraphMol/MacroMolTemplateLibrary.h>
+#include <GraphMol/SubstanceGroup.h>
+#include <catch2/catch_all.hpp>
+
+#include <algorithm>
+#include <set>
+#include <string>
+#include <vector>
+
+using namespace RDKit;
+
+TEST_CASE("global MacroMol template library contains valid built-ins") {
+  const auto &library = getGlobalMacroMolTemplateLibrary();
+  REQUIRE(library.getTemplates().size() == 22);
+
+  std::set<std::string> symbols;
+  std::set<std::string> names;
+  for (const auto *templ : library.getTemplates()) {
+    REQUIRE(templ);
+    CHECK(symbols.insert(templ->getSymbol()).second);
+    CHECK(names.insert(templ->getName()).second);
+    CHECK(templ->getMol().getNumAtoms() > 0);
+    CHECK(!templ->getMainAtomIdxs().empty());
+    CHECK(getSubstanceGroups(templ->getMol()).size() ==
+          templ->getLeavingGroups().size() + 1);
+    CHECK(library.getBySymbol(templ->getMonomerClass(), templ->getSymbol()) ==
+          templ);
+    CHECK(library.getByName(templ->getMonomerClass(), templ->getName()) ==
+          templ);
+  }
+}
+
+TEST_CASE("built-in MacroMol templates can populate a local library") {
+  MacroMolTemplateLibrary local;
+  addBuiltinMacroMolTemplates(local);
+  REQUIRE(local.getTemplates().size() == 22);
+}


### PR DESCRIPTION
#### Reference Issue
MacroMol/MonomerMol

Adds the MolToMacroMol / CollapseMacroMol converter, which collapses an ROMol into a MacroMol using an explicitly supplied template library.

#### Description
This is PR 5 of 6
[MacroMol core](https://github.com/rdkit/rdkit/pull/9373)
[MacroMolTemplate](https://github.com/rdkit/rdkit/pull/9485)
[MacroMol Local Library](https://github.com/rdkit/rdkit/pull/9486)
[MacroMol Global Library](https://github.com/rdkit/rdkit/pull/9487)
[MolToMacroMol](https://github.com/rdkit/rdkit/pull/9488) ⬅️
[MolFromMacroMol](https://github.com/rdkit/rdkit/pull/9489)