### PR TITLE
support building with boost 1.92.0

### DIFF
--- a/Code/RDBoost/list_indexing_suite.hpp
+++ b/Code/RDBoost/list_indexing_suite.hpp
@@ -107,6 +107,8 @@ class list_indexing_suite
     container.erase(beg, end);
   }
 
+  static void clear(Container& container) { container.clear(); }
+
   static size_t size(Container& container) { return container.size(); }
 
   static bool contains(Container& container, key_type const& key) {


### PR DESCRIPTION
#### Reference Issue
n/a

#### What does this implement/fix? Explain your changes.

Fixes build error seen with boost 1.92.0:
```
 error: no member named 'clear' in 'boost::python::detail::final_list_derived_policies<std::list<std::vector<int>>, true>'
  296 |             return DerivedPolicies::clear(container);
      |                    ~~~~~~~~~~~~~~~~~^
```

Due to boostorg/python@c574084154f908a2d14c4c24866982d527c15111

#### Any other comments?

Seen in Homebrew when trying to upgrade Boost to 1.92.0.

With change, I was able to build RDKit using both Boost 1.92.0 and 1.90.0.