### PR TITLE
Fix bug with basic substructure highlighting in the IPythonConsole code

### DIFF
--- a/rdkit/Chem/Draw/IPythonConsole.py
+++ b/rdkit/Chem/Draw/IPythonConsole.py
@@ -172,9 +172,7 @@ the py3Dmol.view object containing the drawing'''
       m = Chem.RemoveHs(m)
     addMolToView(m, view, confId)
   for i in range(len(mols)):
-    style = {
-          'colorscheme': colors[i % len(colors)]
-        }
+    style = {'colorscheme': colors[i % len(colors)]}
     if drawAs[i] == "sphere":
       style["radius"] = 0.5
     view.setStyle({
@@ -262,7 +260,8 @@ def listToLists(lst):
 def _toPNG(mol):
   if hasattr(mol, '__sssAtoms'):
     highlightAtoms = listToLists(mol.__sssAtoms)
-    return Draw.DrawMolWithMatches(mol, highlightAtoms, molSize=molSize, qry=mol.__sssQry, label='',
+    return Draw.DrawMolWithMatches(mol, highlightAtoms, molSize=molSize,
+                                   qry=getattr(mol, '__sssQry', None), label='',
                                    options=drawOptions, doPNG=True, kekulize=kekulizeStructures)
   else:
     highlightAtoms = []
@@ -276,7 +275,8 @@ def _toSVG(mol):
     return None
   if hasattr(mol, '__sssAtoms'):
     highlightAtoms = listToLists(mol.__sssAtoms)
-    return Draw.DrawMolWithMatches(mol, highlightAtoms, molSize=molSize, qry=mol.__sssQry, label='',
+    return Draw.DrawMolWithMatches(mol, highlightAtoms, molSize=molSize,
+                                   qry=getattr(mol, '__sssQry', None), label='',
                                    options=drawOptions, doPNG=False, kekulize=kekulizeStructures)
   else:
     highlightAtoms = []
@@ -556,4 +556,3 @@ def UninstallIPythonRenderer():
 
 
 InstallIPythonRenderer()
-

--- a/rdkit/Chem/Draw/UnitTestIPython.py
+++ b/rdkit/Chem/Draw/UnitTestIPython.py
@@ -128,6 +128,14 @@ class TestCase(unittest.TestCase):
     d = Draw.MolsMatrixToGridImage(molsMatrix, useSVG=True, legendsMatrix=legendsMatrix)
     self.assertIsNotNone(d)
 
+  @unittest.skipIf(IPythonConsole is None, 'IPython not available')
+  def testSimpleHighlighting(self):
+    m = Chem.MolFromSmiles('c1ccccc1O')
+    m.__sssAtoms = [0, 1, 2]
+    # These two calls should fail if the methods haven't ben updated
+    png = IPythonConsole._toPNG(m)
+    svg = IPythonConsole._toSVG(m)
+
 
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
Just providing the list of atoms to highlight (`mol.__sssAtoms`) was no longer working
