### PR TITLE
Fix maeparser includes declaration

### DIFF
--- a/External/CoordGen/CMakeLists.txt
+++ b/External/CoordGen/CMakeLists.txt
@@ -45,7 +45,7 @@ if(RDK_BUILD_MAEPARSER_SUPPORT OR RDK_BUILD_COORDGEN_SUPPORT)
 
   endif(MAEPARSER_FORCE_BUILD OR (NOT maeparser_FOUND))
   # FIX: the INSTALL_INTERFACE here is not correct
-  target_include_directories(maeparser PUBLIC 
+  target_include_directories(maeparser INTERFACE
    $<BUILD_INTERFACE:${maeparser_INCLUDE_DIRS}>
    $<INSTALL_INTERFACE:include>)
 


### PR DESCRIPTION
It seems modern cmake versions do not allow setting "PUBLIC" tags (or at least includes) on external targets. PR #9030 introduced this declaration:
```
target_include_directories(maeparser PUBLIC
   $<BUILD_INTERFACE:${maeparser_INCLUDE_DIRS}>
   $<INSTALL_INTERFACE:include>)
```
which results in this CMake failure when enabling coordgen:
```
CMake Error at External/CoordGen/CMakeLists.txt:48 (target_include_directories):
  target_include_directories may only set INTERFACE properties on IMPORTED
  targets
```
This patch fixes the issue by changing the declaration to "INTERFACE".