### PR TITLE
Reduce comparisons and branches in bondholder compare

### DIFF
--- a/Code/GraphMol/new_canon.h
+++ b/Code/GraphMol/new_canon.h
@@ -71,7 +71,7 @@ struct RDKIT_GRAPHMOL_EXPORT bondholder {
                      unsigned int div = 1) {
     if (x.p_symbol && y.p_symbol) {
       auto symbolCompare = x.p_symbol->compare(*y.p_symbol);
-      if (symbolCompare) {
+      if (symbolCompare != 0) {
         return symbolCompare;
       }
     }
@@ -356,13 +356,7 @@ class RDKIT_GRAPHMOL_EXPORT AtomCompareFunctor {
       return 1;
     }
     if (dp_atoms[i].p_symbol && dp_atoms[j].p_symbol) {
-      auto symbolCompare =
-          dp_atoms[i].p_symbol->compare(*dp_atoms[j].p_symbol);
-      if (symbolCompare) {
-        return symbolCompare;
-      } else {
-        return 0;
-      }
+      return dp_atoms[i].p_symbol->compare(*dp_atoms[j].p_symbol);
     }
 
     // move onto atomic number

--- a/Code/GraphMol/new_canon.h
+++ b/Code/GraphMol/new_canon.h
@@ -70,10 +70,9 @@ struct RDKIT_GRAPHMOL_EXPORT bondholder {
   static int compare(const bondholder &x, const bondholder &y,
                      unsigned int div = 1) {
     if (x.p_symbol && y.p_symbol) {
-      if ((*x.p_symbol) < (*y.p_symbol)) {
-        return -1;
-      } else if ((*x.p_symbol) > (*y.p_symbol)) {
-        return 1;
+      auto symbolCompare = x.p_symbol->compare(*y.p_symbol);
+      if (symbolCompare) {
+        return symbolCompare;
       }
     }
     if (x.bondType < y.bondType) {
@@ -357,10 +356,10 @@ class RDKIT_GRAPHMOL_EXPORT AtomCompareFunctor {
       return 1;
     }
     if (dp_atoms[i].p_symbol && dp_atoms[j].p_symbol) {
-      if (*(dp_atoms[i].p_symbol) < *(dp_atoms[j].p_symbol)) {
-        return -1;
-      } else if (*(dp_atoms[i].p_symbol) > *(dp_atoms[j].p_symbol)) {
-        return 1;
+      auto symbolCompare =
+          dp_atoms[i].p_symbol->compare(*dp_atoms[j].p_symbol);
+      if (symbolCompare) {
+        return symbolCompare;
       } else {
         return 0;
       }


### PR DESCRIPTION
First instance goes from possibly two compares to always 1. Second instance does the same and also reduces branching.

PR 10 for #9475 
