### PR TITLE
Cache isAtomConjugCand in markConjAtomBonds

### DIFF
--- a/Code/GraphMol/ConjugHybrid.cpp
+++ b/Code/GraphMol/ConjugHybrid.cpp
@@ -19,6 +19,11 @@
 namespace RDKit {
 // local utility namespace:
 namespace {
+struct ConjAtomInfo {
+  bool isCandidate;
+  unsigned int numSubstituents;
+};
+
 bool isAtomConjugCand(const Atom *at) {
   PRECONDITION(at, "bad atom");
   // return false for neutral atoms where the current valence exceeds the
@@ -43,35 +48,35 @@ bool isAtomConjugCand(const Atom *at) {
   return res;
 }
 
-void markConjAtomBonds(Atom *at) {
+void markConjAtomBonds(Atom *at, const std::vector<ConjAtomInfo> &atomInfo) {
   PRECONDITION(at, "bad atom");
-  if (!isAtomConjugCand(at)) {
+  const auto &info = atomInfo[at->getIdx()];
+  if (!info.isCandidate) {
     return;
   }
   auto &mol = at->getOwningMol();
 
   int atx = at->getIdx();
   // make sure that have either 2 or 3 substitutions on this atom
-  int sbo = at->getDegree() + at->getTotalNumHs();
-  if ((sbo < 2) || (sbo > 3)) {
+  if ((info.numSubstituents < 2) || (info.numSubstituents > 3)) {
     return;
   }
 
   for (const auto bnd1 : mol.atomBonds(at)) {
     if (bnd1->getValenceContrib(at) < 1.5 ||
-        !isAtomConjugCand(bnd1->getOtherAtom(at))) {
+        !atomInfo[bnd1->getOtherAtomIdx(atx)].isCandidate) {
       continue;
     }
     for (const auto bnd2 : mol.atomBonds(at)) {
       if (bnd1 == bnd2) {
         continue;
       }
-      auto at2 = mol.getAtomWithIdx(bnd2->getOtherAtomIdx(atx));
-      sbo = at2->getDegree() + at2->getTotalNumHs();
-      if (sbo > 3) {
+      const auto at2Idx = bnd2->getOtherAtomIdx(atx);
+      const auto &at2Info = atomInfo[at2Idx];
+      if (at2Info.numSubstituents > 3) {
         continue;
       }
-      if (isAtomConjugCand(at2)) {
+      if (at2Info.isCandidate) {
         bnd1->setIsConjugated(true);
         bnd2->setIsConjugated(true);
       }
@@ -132,10 +137,16 @@ void setConjugation(ROMol &mol) {
     bond->setIsConjugated(bond->getIsAromatic());
   }
 
+  std::vector<ConjAtomInfo> atomInfo(mol.getNumAtoms());
+  for (const auto atom : mol.atoms()) {
+    atomInfo[atom->getIdx()] = {
+        isAtomConjugCand(atom), atom->getDegree() + atom->getTotalNumHs()};
+  }
+
   // loop over each atom and check if the bonds connecting to it can
   // be conjugated
   for (auto atom : mol.atoms()) {
-    markConjAtomBonds(atom);
+    markConjAtomBonds(atom, atomInfo);
   }
 }
 

--- a/Code/GraphMol/ConjugHybrid.cpp
+++ b/Code/GraphMol/ConjugHybrid.cpp
@@ -59,7 +59,7 @@ void markConjAtomBonds(Atom *at,
   }
   auto &mol = at->getOwningMol();
 
-  int atx = at->getIdx();
+  const auto atx = at->getIdx();
   // make sure that have either 2 or 3 substitutions on this atom
   if ((info.numSubstituents < 2) || (info.numSubstituents > 3)) {
     return;
@@ -85,6 +85,21 @@ void markConjAtomBonds(Atom *at,
       }
     }
   }
+}
+
+// Kept for the Java Atom wrapper, which exposes this atom-level helper.
+// MolOps::setConjugation() builds this cache once for the entire molecule.
+[[maybe_unused]] void markConjAtomBonds(Atom *at) {
+  PRECONDITION(at, "bad atom");
+  auto &mol = at->getOwningMol();
+  std::vector<ConjAtomInfo> atomInfo(mol.getNumAtoms());
+  for (const auto atom : mol.atoms()) {
+    const auto isCandidate = isAtomConjugCand(atom);
+    atomInfo[atom->getIdx()] = {
+        isCandidate ? atom->getDegree() + atom->getTotalNumHs() : 0u,
+        isCandidate};
+  }
+  markConjAtomBonds(at, atomInfo);
 }
 
 int numBondsPlusLonePairs(Atom *at) {

--- a/Code/GraphMol/ConjugHybrid.cpp
+++ b/Code/GraphMol/ConjugHybrid.cpp
@@ -155,13 +155,16 @@ void setConjugation(ROMol &mol) {
     bond->setIsConjugated(bond->getIsAromatic());
   }
 
-  std::vector<ConjAtomInfo> atomInfo(mol.getNumAtoms());
-  for (const auto atom : mol.atoms()) {
-    const auto isCandidate = isAtomConjugCand(atom);
-    atomInfo[atom->getIdx()] = {
-        isCandidate ? atom->getDegree() + atom->getTotalNumHs() : 0u,
-        isCandidate};
-  }
+  std::vector<ConjAtomInfo> atomInfo;
+  atomInfo.reserve(mol.getNumAtoms());
+  std::ranges::transform(
+      mol.atoms(), std::back_inserter(atomInfo), [](const auto atom) {
+        const auto isCandidate = isAtomConjugCand(atom);
+        return ConjAtomInfo{
+            isCandidate ? atom->getDegree() + atom->getTotalNumHs() : 0u,
+            isCandidate};
+      });
+
 
   // loop over each atom and check if the bonds connecting to it can
   // be conjugated

--- a/Code/GraphMol/ConjugHybrid.cpp
+++ b/Code/GraphMol/ConjugHybrid.cpp
@@ -16,12 +16,14 @@
 #include "AtomIterators.h"
 #include "BondIterators.h"
 
+#include <span>
+
 namespace RDKit {
 // local utility namespace:
 namespace {
 struct ConjAtomInfo {
-  bool isCandidate;
   unsigned int numSubstituents;
+  bool isCandidate;
 };
 
 bool isAtomConjugCand(const Atom *at) {
@@ -48,7 +50,8 @@ bool isAtomConjugCand(const Atom *at) {
   return res;
 }
 
-void markConjAtomBonds(Atom *at, const std::vector<ConjAtomInfo> &atomInfo) {
+void markConjAtomBonds(Atom *at,
+                       const std::span<const ConjAtomInfo> atomInfo) {
   PRECONDITION(at, "bad atom");
   const auto &info = atomInfo[at->getIdx()];
   if (!info.isCandidate) {
@@ -139,8 +142,10 @@ void setConjugation(ROMol &mol) {
 
   std::vector<ConjAtomInfo> atomInfo(mol.getNumAtoms());
   for (const auto atom : mol.atoms()) {
+    const auto isCandidate = isAtomConjugCand(atom);
     atomInfo[atom->getIdx()] = {
-        isAtomConjugCand(atom), atom->getDegree() + atom->getTotalNumHs()};
+        isCandidate ? atom->getDegree() + atom->getTotalNumHs() : 0u,
+        isCandidate};
   }
 
   // loop over each atom and check if the bonds connecting to it can


### PR DESCRIPTION
Avoids expensive repeated calls, since every atom is hit once per bond it has.

PR 11 for #9475 , this is the second most impactful change in the stack, with >1% perf improvement in the smiles parse + sanitization workflow
