### PR TITLE
Fix pyGaussianShapeAlign test name

### DIFF
--- a/Code/GraphMol/GaussianShape/nbWrap/CMakeLists.txt
+++ b/Code/GraphMol/GaussianShape/nbWrap/CMakeLists.txt
@@ -3,5 +3,5 @@ rdkit_nanobind_extension(rdGaussianShape
         rdGaussianShape.cpp
         DEST Chem
         LINK_LIBRARIES GaussianShape)
-add_pytest(pyShapeAlign
+add_pytest(pyGaussianShapeAlign
         ${CMAKE_CURRENT_SOURCE_DIR}/../Wrap/test_rdgaussian_shape.py)


### PR DESCRIPTION
In the Boost wrappers this test is named "pyGaussianShapeAlign". Also, there's already a `pyShapeAlign` test: https://github.com/rdkit/rdkit/blob/103d1e9b97bc61cce1c41b362093fe73f6641b64/External/pubchem_shape/nbWrap/CMakeLists.txt#L6-L7



