### PR TITLE
Make checking in checked iterators stricter to avoid heap-use-after-free problems

### DIFF
--- a/Code/GraphMol/ROMol.h
+++ b/Code/GraphMol/ROMol.h
@@ -133,19 +133,25 @@ struct CXXAtomIterator {
     size_t osizeBonds{0};
 
     inline void checkIterator() const {
-      if ((CheckedAtoms && boost::num_vertices(*graph) != osizeAtoms) ||
-          (CheckedBonds && boost::num_edges(*graph) != osizeBonds)) {
-        throw std::runtime_error("molecule modified during iteration");
+      if constexpr (CheckedAtoms) {
+        if (boost::num_vertices(*graph) != osizeAtoms) {
+          throw std::runtime_error("molecule modified during iteration");
+        }
+      }
+      if constexpr (CheckedBonds) {
+        if (boost::num_edges(*graph) != osizeBonds) {
+          throw std::runtime_error("molecule modified during iteration");
+        }
       }
     }
 
-    CXXAtomIter() {};
+    CXXAtomIter(){};
 
     CXXAtomIter(Graph *graph, Iterator pos) : graph(graph), pos(pos) {
-      if (CheckedAtoms) {
+      if constexpr (CheckedAtoms) {
         osizeAtoms = boost::num_vertices(*graph);
       }
-      if (CheckedBonds) {
+      if constexpr (CheckedBonds) {
         osizeBonds = boost::num_edges(*graph);
       }
     }
@@ -165,42 +171,52 @@ struct CXXAtomIterator {
     }
 
     CXXAtomIter &operator++() {
+      checkIterator();
       ++pos;
       return *this;
     }
     CXXAtomIter operator++(int) {
+      checkIterator();
       CXXAtomIter tmp = *this;
       ++(*this);
       return tmp;
     }
     CXXAtomIter &operator--() {
+      checkIterator();
       --pos;
       return *this;
     }
     CXXAtomIter operator+(difference_type n) const {
+      checkIterator();
       return CXXAtomIter(graph, pos + n);
     }
     CXXAtomIter operator-(difference_type n) const {
+      checkIterator();
       return CXXAtomIter(graph, pos - n);
     }
 
     CXXAtomIter operator--(int) {
+      checkIterator();
       CXXAtomIter tmp = *this;
       --(*this);
       return tmp;
     }
     CXXAtomIter &operator+=(difference_type n) {
+      checkIterator();
       pos += n;
       return *this;
     }
     CXXAtomIter &operator-=(difference_type n) {
+      checkIterator();
       pos -= n;
       return *this;
     }
     difference_type operator-(const CXXAtomIter &other) const {
+      checkIterator();
       return pos - other.pos;
     }
     friend CXXAtomIter operator+(difference_type n, const CXXAtomIter &it) {
+      checkIterator();
       return CXXAtomIter(it.graph, it.pos + n);
     }
 
@@ -220,7 +236,7 @@ struct CXXAtomIterator {
     std::tie(vstart, vend) = boost::vertices(*graph);
   }
   CXXAtomIterator(Graph *graph, Iterator start, Iterator end)
-      : graph(graph), vstart(start), vend(end) {};
+      : graph(graph), vstart(start), vend(end){};
   CXXAtomIter begin() { return {graph, vstart}; }
   CXXAtomIter end() { return {graph, vend}; }
   size_t size() const { return vend - vstart; }
@@ -250,37 +266,45 @@ struct CXXBondIterator {
     Iterator pos;
     size_t osize{0};
 
-    CXXBondIter() {};
+    inline void checkIterator() const {
+      if constexpr (Checked) {
+        if (boost::num_edges(*graph) != osize) {
+          throw std::runtime_error("molecule modified during iteration");
+        }
+      }
+    }
+
+    CXXBondIter(){};
 
     CXXBondIter(Graph *graph, Iterator pos) : graph(graph), pos(pos) {
-      if (Checked) {
+      if constexpr (Checked) {
         osize = boost::num_edges(*graph);
       }
     }
     // we only return const references since we don't want clients modifying the
     // graph itself through these iterators
     const_reference operator*() const {
-      if (Checked) {
-        if (boost::num_edges(*graph) != osize) {
-          throw std::runtime_error("molecule modified during iteration");
-        }
-      }
+      checkIterator();
       return (*graph)[*pos];
     }
     CXXBondIter &operator++() {
+      checkIterator();
       ++pos;
       return *this;
     }
     CXXBondIter operator++(int) {
+      checkIterator();
       CXXBondIter tmp = *this;
       ++(*this);
       return tmp;
     }
     CXXBondIter &operator--() {
+      checkIterator();
       --pos;
       return *this;
     }
     CXXBondIter operator--(int) {
+      checkIterator();
       CXXBondIter tmp = *this;
       --(*this);
       return tmp;
@@ -299,7 +323,7 @@ struct CXXBondIterator {
     vend = vs.second;
   }
   CXXBondIterator(Graph *graph, Iterator start, Iterator end)
-      : graph(graph), vstart(start), vend(end) {};
+      : graph(graph), vstart(start), vend(end){};
   CXXBondIter begin() { return {graph, vstart}; }
   CXXBondIter end() { return {graph, vend}; }
   size_t size() const {
@@ -1002,8 +1026,8 @@ class RDKIT_GRAPHMOL_EXPORT ROMol : public RDProps {
 
   friend RDKIT_GRAPHMOL_EXPORT std::vector<SubstanceGroup> &getSubstanceGroups(
       ROMol &);
-  friend RDKIT_GRAPHMOL_EXPORT const std::vector<SubstanceGroup> &
-  getSubstanceGroups(const ROMol &);
+  friend RDKIT_GRAPHMOL_EXPORT const std::vector<SubstanceGroup>
+      &getSubstanceGroups(const ROMol &);
   void clearSubstanceGroups() { d_sgroups.clear(); }
 
  protected:

--- a/Code/GraphMol/ROMol.h
+++ b/Code/GraphMol/ROMol.h
@@ -216,7 +216,7 @@ struct CXXAtomIterator {
       return pos - other.pos;
     }
     friend CXXAtomIter operator+(difference_type n, const CXXAtomIter &it) {
-      checkIterator();
+      it.checkIterator();
       return CXXAtomIter(it.graph, it.pos + n);
     }
 

--- a/Code/GraphMol/ROMol.h
+++ b/Code/GraphMol/ROMol.h
@@ -213,6 +213,7 @@ struct CXXAtomIterator {
     }
     difference_type operator-(const CXXAtomIter &other) const {
       checkIterator();
+      other.checkIterator();
       return pos - other.pos;
     }
     friend CXXAtomIter operator+(difference_type n, const CXXAtomIter &it) {


### PR DESCRIPTION
Nanobind wrappers are more transparent than boost ones, and allow detecting issues that had gone undetected before.

I found that the checked iterators aren't checking strictly enough, since increment and decrement operations on the internal position iterators may still hit invalid iterators before the check.

This was revealed by running the `pyGraphMolWrap` test under the address sanitizer. The end of test `testGithub1366` does this:
https://github.com/rdkit/rdkit/blob/103d1e9b97bc61cce1c41b362093fe73f6641b64/Code/GraphMol/Wrap/rough_test.py#L5026-L5031

Which results in asan flagging this:
```
239: SUMMARY: AddressSanitizer: heap-use-after-free in std::_List_iterator<boost::list_edge<unsigned long, RDKit::Bond*> >::operator++()
```

This PR fixes the issue by extending the checking to all increment/decrement operations in the checked iterators.