### PR TITLE
nanobind: fix ownership issue when using AtomCoordsMatchFunctor for extraAtomCheck

### DIFF
--- a/Code/GraphMol/GenericGroups/generic_tests.cpp
+++ b/Code/GraphMol/GenericGroups/generic_tests.cpp
@@ -172,12 +172,12 @@ M  END
 }
 
 namespace {
-bool no_match(const ROMol &mol, const std::span<const unsigned int> &ids) {
+bool no_match(const ROMol &mol, const std::span<const unsigned int> ids) {
   RDUNUSED_PARAM(mol);
   RDUNUSED_PARAM(ids);
   return false;
 }
-bool always_match(const ROMol &mol, const std::span<const unsigned int> &ids) {
+bool always_match(const ROMol &mol, const std::span<const unsigned int> ids) {
   RDUNUSED_PARAM(mol);
   RDUNUSED_PARAM(ids);
   return true;

--- a/Code/GraphMol/GenericGroups/generic_tests.cpp
+++ b/Code/GraphMol/GenericGroups/generic_tests.cpp
@@ -172,12 +172,12 @@ M  END
 }
 
 namespace {
-bool no_match(const ROMol &mol, const std::span<const unsigned int> ids) {
+bool no_match(const ROMol &mol, const std::span<const unsigned int> &ids) {
   RDUNUSED_PARAM(mol);
   RDUNUSED_PARAM(ids);
   return false;
 }
-bool always_match(const ROMol &mol, const std::span<const unsigned int> ids) {
+bool always_match(const ROMol &mol, const std::span<const unsigned int> &ids) {
   RDUNUSED_PARAM(mol);
   RDUNUSED_PARAM(ids);
   return true;

--- a/Code/GraphMol/Substruct/SubstructMatch.cpp
+++ b/Code/GraphMol/Substruct/SubstructMatch.cpp
@@ -387,7 +387,7 @@ class AtomLabelFunctor {
  public:
   AtomLabelFunctor(const ROMol &query, const ROMol &mol,
                    const SubstructMatchParameters &ps)
-      : d_query(query), d_mol(mol), d_params(ps) {};
+      : d_query(query), d_mol(mol), d_params(ps){};
 
   bool operator()(unsigned int i, unsigned int j) const {
     bool res = false;
@@ -416,7 +416,7 @@ class BondLabelFunctor {
  public:
   BondLabelFunctor(const ROMol &query, const ROMol &mol,
                    const SubstructMatchParameters &ps)
-      : d_query(query), d_mol(mol), d_params(ps) {};
+      : d_query(query), d_mol(mol), d_params(ps){};
   bool operator()(MolGraph::edge_descriptor i,
                   MolGraph::edge_descriptor j) const {
     if (d_params.useChirality) {
@@ -758,7 +758,6 @@ void MatchSubqueries(const ROMol &mol, QueryAtom::QUERYATOM_QUERY *query,
        ++childIt) {
     MatchSubqueries(mol, childIt->get(), params, subqueryMap, locked);
   }
-  // std::cout << "<<- back " << (int)query << std::endl;
 }
 
 }  // end of namespace detail

--- a/Code/GraphMol/Substruct/SubstructMatch.h
+++ b/Code/GraphMol/Substruct/SubstructMatch.h
@@ -63,7 +63,7 @@ struct RDKIT_SUBSTRUCTMATCH_EXPORT SubstructMatchParameters {
   std::vector<std::string> bondProperties;  //!< bond properties that must be
                                             //!< equivalent in order to match
   std::function<bool(const ROMol &mol,
-                     const std::span<const unsigned int> &match)>
+                     std::span<const unsigned int> match)>
       extraFinalCheck;  //!< a function to be called at the end to validate a
                         //!< match
   unsigned int maxRecursiveMatches =

--- a/Code/GraphMol/Substruct/SubstructMatch.h
+++ b/Code/GraphMol/Substruct/SubstructMatch.h
@@ -63,7 +63,7 @@ struct RDKIT_SUBSTRUCTMATCH_EXPORT SubstructMatchParameters {
   std::vector<std::string> bondProperties;  //!< bond properties that must be
                                             //!< equivalent in order to match
   std::function<bool(const ROMol &mol,
-                     std::span<const unsigned int> match)>
+                     const std::span<const unsigned int> &match)>
       extraFinalCheck;  //!< a function to be called at the end to validate a
                         //!< match
   unsigned int maxRecursiveMatches =
@@ -110,9 +110,6 @@ RDKIT_SUBSTRUCTMATCH_EXPORT std::vector<MatchVectType> SubstructMatch(
 //! Count substructure matches for a query in a molecule without materializing
 //! the full match vectors.
 /*!
-    
-    
-    
   \param mol         The ROMol to be searched
   \param query       The query ROMol
   \param matchParams Parameters controlling the matching
@@ -121,8 +118,8 @@ RDKIT_SUBSTRUCTMATCH_EXPORT std::vector<MatchVectType> SubstructMatch(
 
 */
 RDKIT_SUBSTRUCTMATCH_EXPORT unsigned int SubstructMatchCount(
-  const ROMol &mol, const ROMol &query,
-  const SubstructMatchParameters &params = SubstructMatchParameters());
+    const ROMol &mol, const ROMol &query,
+    const SubstructMatchParameters &params = SubstructMatchParameters());
 
 //! Find all substructure matches for a query in a ResonanceMolSupplier object
 /*!
@@ -292,9 +289,7 @@ struct RDKIT_SUBSTRUCTMATCH_EXPORT AtomCoordsMatchFunctor {
   double d_tol2 = 1e-8;  //< squared distance tolerance
   AtomCoordsMatchFunctor(int refConfId = -1, int queryConfId = -1,
                          double tol = 1e-4)
-      : d_refConfId(refConfId),
-        d_queryConfId(queryConfId),
-        d_tol2(tol * tol) {};
+      : d_refConfId(refConfId), d_queryConfId(queryConfId), d_tol2(tol * tol){};
 
   bool operator()(const Atom &queryAtom, const Atom &targetAtom) const;
 };

--- a/Code/GraphMol/Wrap/Mol.cpp
+++ b/Code/GraphMol/Wrap/Mol.cpp
@@ -121,20 +121,18 @@ void MolDebug(const ROMol &mol, bool useStdout) {
 QueryAtomIterSeq *MolGetAromaticAtoms(const ROMOL_SPTR &mol) {
   auto *qa = new QueryAtom();
   qa->setQuery(makeAtomAromaticQuery());
-  QueryAtomIterSeq *res =
-      new QueryAtomIterSeq(mol, mol->beginQueryAtoms(qa), mol->endQueryAtoms(),
-                           AtomCountFunctor(mol));
+  auto res = new QueryAtomIterSeq(mol, mol->beginQueryAtoms(qa),
+                                  mol->endQueryAtoms(), AtomCountFunctor(mol));
   return res;
 }
 QueryAtomIterSeq *MolGetQueryAtoms(const ROMOL_SPTR &mol, QueryAtom *qa) {
-  QueryAtomIterSeq *res =
-      new QueryAtomIterSeq(mol, mol->beginQueryAtoms(qa), mol->endQueryAtoms(),
-                           AtomCountFunctor(mol));
+  auto res = new QueryAtomIterSeq(mol, mol->beginQueryAtoms(qa),
+                                  mol->endQueryAtoms(), AtomCountFunctor(mol));
   return res;
 }
 
 ConformerIterSeq *GetMolConformers(const ROMOL_SPTR &mol) {
-  ConformerIterSeq *res =
+  auto res =
       new ConformerIterSeq(mol, mol->beginConformers(), mol->endConformers(),
                            ConformerCountFunctor(mol));
   return res;
@@ -174,9 +172,9 @@ void setExtraBondCheckFunc(SubstructMatchParameters &ps, python::object func) {
 
 class ReadWriteMol : public RWMol {
  public:
-  ReadWriteMol() {};
+  ReadWriteMol(){};
   ReadWriteMol(const ROMol &m, bool quickCopy = false, int confId = -1)
-      : RWMol(m, quickCopy, confId) {};
+      : RWMol(m, quickCopy, confId){};
 
   void RemoveAtom(unsigned int idx) { removeAtom(idx); };
   void RemoveBond(unsigned int idx1, unsigned int idx2) {
@@ -770,8 +768,7 @@ struct mol_wrapper {
         .def(
             "GetProp", GetPyPropOrDefault<ROMol>,
             (python::arg("self"), python::arg("key"),
-             python::arg("autoConvert") = false,
-             python::arg("default")),
+             python::arg("autoConvert") = false, python::arg("default")),
             "Returns the value of the property.\n\n"
             "  ARGUMENTS:\n"
             "    - key: the name of the property to return (a string).\n\n"
@@ -789,14 +786,15 @@ struct mol_wrapper {
              "    - If the property has not been set, a KeyError exception "
              "will be raised.\n",
              boost::python::return_value_policy<return_pyobject_passthrough>())
-        .def("GetDoubleProp", GetPropOrDefault<ROMol, double>,
-             (python::arg("self"), python::arg("key"), python::arg("default")),
-             "Returns the double value of the property if possible.\n\n"
-             "  ARGUMENTS:\n"
-             "    - key: the name of the property to return (a string).\n\n"
-             "    - default: value to return if the property is not present.\n\n"
-             "  RETURNS: a double, or default if the property is not present.\n",
-             boost::python::return_value_policy<return_pyobject_passthrough>())
+        .def(
+            "GetDoubleProp", GetPropOrDefault<ROMol, double>,
+            (python::arg("self"), python::arg("key"), python::arg("default")),
+            "Returns the double value of the property if possible.\n\n"
+            "  ARGUMENTS:\n"
+            "    - key: the name of the property to return (a string).\n\n"
+            "    - default: value to return if the property is not present.\n\n"
+            "  RETURNS: a double, or default if the property is not present.\n",
+            boost::python::return_value_policy<return_pyobject_passthrough>())
         .def("GetIntProp", GetProp<ROMol, int>, python::args("self", "key"),
              "Returns the integer value of the property if possible.\n\n"
              "  ARGUMENTS:\n"
@@ -806,14 +804,15 @@ struct mol_wrapper {
              "    - If the property has not been set, a KeyError exception "
              "will be raised.\n",
              boost::python::return_value_policy<return_pyobject_passthrough>())
-        .def("GetIntProp", GetPropOrDefault<ROMol, int>,
-             (python::arg("self"), python::arg("key"), python::arg("default")),
-             "Returns the integer value of the property if possible.\n\n"
-             "  ARGUMENTS:\n"
-             "    - key: the name of the property to return (a string).\n\n"
-             "    - default: value to return if the property is not present.\n\n"
-             "  RETURNS: an integer, or default if the property is not present.\n",
-             boost::python::return_value_policy<return_pyobject_passthrough>())
+        .def(
+            "GetIntProp", GetPropOrDefault<ROMol, int>,
+            (python::arg("self"), python::arg("key"), python::arg("default")),
+            "Returns the integer value of the property if possible.\n\n"
+            "  ARGUMENTS:\n"
+            "    - key: the name of the property to return (a string).\n\n"
+            "    - default: value to return if the property is not present.\n\n"
+            "  RETURNS: an integer, or default if the property is not present.\n",
+            boost::python::return_value_policy<return_pyobject_passthrough>())
         .def("GetUnsignedProp", GetProp<ROMol, unsigned int>,
              python::args("self", "key"),
              "Returns the unsigned int value of the property if possible.\n\n"
@@ -824,14 +823,15 @@ struct mol_wrapper {
              "    - If the property has not been set, a KeyError exception "
              "will be raised.\n",
              boost::python::return_value_policy<return_pyobject_passthrough>())
-        .def("GetUnsignedProp", GetPropOrDefault<ROMol, unsigned int>,
-             (python::arg("self"), python::arg("key"), python::arg("default")),
-             "Returns the unsigned int value of the property if possible.\n\n"
-             "  ARGUMENTS:\n"
-             "    - key: the name of the property to return (a string).\n\n"
-             "    - default: value to return if the property is not present.\n\n"
-             "  RETURNS: an unsigned integer, or default if the property is not present.\n",
-             boost::python::return_value_policy<return_pyobject_passthrough>())
+        .def(
+            "GetUnsignedProp", GetPropOrDefault<ROMol, unsigned int>,
+            (python::arg("self"), python::arg("key"), python::arg("default")),
+            "Returns the unsigned int value of the property if possible.\n\n"
+            "  ARGUMENTS:\n"
+            "    - key: the name of the property to return (a string).\n\n"
+            "    - default: value to return if the property is not present.\n\n"
+            "  RETURNS: an unsigned integer, or default if the property is not present.\n",
+            boost::python::return_value_policy<return_pyobject_passthrough>())
         .def("GetBoolProp", GetProp<ROMol, bool>, python::args("self", "key"),
              "Returns the Bool value of the property if possible.\n\n"
              "  ARGUMENTS:\n"
@@ -841,14 +841,15 @@ struct mol_wrapper {
              "    - If the property has not been set, a KeyError exception "
              "will be raised.\n",
              boost::python::return_value_policy<return_pyobject_passthrough>())
-        .def("GetBoolProp", GetPropOrDefault<ROMol, bool>,
-             (python::arg("self"), python::arg("key"), python::arg("default")),
-             "Returns the Bool value of the property if possible.\n\n"
-             "  ARGUMENTS:\n"
-             "    - key: the name of the property to return (a string).\n\n"
-             "    - default: value to return if the property is not present.\n\n"
-             "  RETURNS: a bool, or default if the property is not present.\n",
-             boost::python::return_value_policy<return_pyobject_passthrough>())
+        .def(
+            "GetBoolProp", GetPropOrDefault<ROMol, bool>,
+            (python::arg("self"), python::arg("key"), python::arg("default")),
+            "Returns the Bool value of the property if possible.\n\n"
+            "  ARGUMENTS:\n"
+            "    - key: the name of the property to return (a string).\n\n"
+            "    - default: value to return if the property is not present.\n\n"
+            "  RETURNS: a bool, or default if the property is not present.\n",
+            boost::python::return_value_policy<return_pyobject_passthrough>())
         .def("ClearProp", MolClearProp<ROMol>, python::args("self", "key"),
              "Removes a property from the molecule.\n\n"
              "  ARGUMENTS:\n"

--- a/Code/GraphMol/Wrap/substructmethods.h
+++ b/Code/GraphMol/Wrap/substructmethods.h
@@ -24,8 +24,8 @@ class pyFunctor {
 class pyFinalMatchFunctor : public pyFunctor {
  public:
   pyFinalMatchFunctor(python::object obj) : dp_obj(std::move(obj)) {}
-  ~pyFinalMatchFunctor() = default;
-  bool operator()(const ROMol &m, std::span<const unsigned int> match) {
+  ~pyFinalMatchFunctor() override = default;
+  bool operator()(const ROMol &m, const std::span<const unsigned int> &match) {
     // grab the GIL
     PyGILStateHolder h;
     // boost::python doesn't handle std::span, so we need to convert the span to
@@ -41,7 +41,7 @@ template <typename T>
 class pyMatchFunctor : public pyFunctor {
  public:
   pyMatchFunctor(python::object obj) : dp_obj(std::move(obj)) {}
-  ~pyMatchFunctor() = default;
+  ~pyMatchFunctor() override = default;
   bool operator()(const T &a1, const T &a2) {
     // grab the GIL
     PyGILStateHolder h;

--- a/Code/GraphMol/nbWrap/Mol.cpp
+++ b/Code/GraphMol/nbWrap/Mol.cpp
@@ -89,20 +89,16 @@ namespace {
 
 void setSubstructMatchFinalCheck(SubstructMatchParameters &ps,
                                  nb::object func) {
-  ps.extraFinalCheck = pyFinalMatchFunctor(func);
+  ps.extraFinalCheck =
+      pyMatchFunctor<ROMol, std::span<const unsigned int>>(func);
 }
 
 void setExtraAtomCheckFunc(SubstructMatchParameters &ps, nb::object func) {
-  ps.extraAtomCheck = pyMatchFunctor<Atom>(func);
+  ps.extraAtomCheck = pyMatchFunctor<Atom, Atom>(func);
 }
 
-void setExtraAtomCheckFunc2(SubstructMatchParameters &ps,
-                            const AtomCoordsMatchFunctor &ftor) {
-  ps.extraAtomCheck = std::bind(&AtomCoordsMatchFunctor::operator(), &ftor,
-                                std::placeholders::_1, std::placeholders::_2);
-}
 void setExtraBondCheckFunc(SubstructMatchParameters &ps, nb::object func) {
-  ps.extraBondCheck = pyMatchFunctor<Bond>(func);
+  ps.extraBondCheck = pyMatchFunctor<Bond, Bond>(func);
 }
 
 void MolDebug(const ROMol &mol, bool useStdout) {
@@ -312,24 +308,13 @@ struct mol_wrapper {
             &RDKit::SubstructMatchParameters::
                 specifiedStereoQueryMatchesUnspecified,
             "If set, query atoms and bonds with specified stereochemistry will match atoms and bonds with unspecified stereochemistry.")
-        .def("setExtraFinalCheck", setSubstructMatchFinalCheck,
-             // FIX: This probably doesn't have the right custodian/ward
-             "func"_a,
+        .def("setExtraFinalCheck", setSubstructMatchFinalCheck, "func"_a,
              R"DOC(allows you to provide a function that will be called
                with the molecule
            and a vector of atom IDs containing a potential match.
            The function should return true or false indicating whether or not
            that match should be accepted.)DOC")
-        .def(
-            "setExtraAtomCheckFunc", setExtraAtomCheckFunc2,
-            // FIX: This probably doesn't have the right custodian/ward
-            "atomCoordsMatcher"_a,
-            R"DOC(allows you to provide an AtomCoordsMatcher that will be called
-              for each atom pair that matches during substructure searching,
-              after all other comparisons have passed.)DOC")
-        .def("setExtraAtomCheckFunc", setExtraAtomCheckFunc,
-             // FIX: This probably doesn't have the right custodian/ward
-             "func"_a,
+        .def("setExtraAtomCheckFunc", setExtraAtomCheckFunc, "func"_a,
              R"DOC(allows you to provide a function that will be called
            for each atom pair that matches during substructure searching,
            after all other comparisons have passed.
@@ -340,9 +325,7 @@ struct mol_wrapper {
             &RDKit::SubstructMatchParameters::
                 extraAtomCheckOverridesDefaultCheck,
             "if set, only the extraAtomCheck will be used to determine whether or not atoms match")
-        .def("setExtraBondCheckFunc", setExtraBondCheckFunc,
-             // FIX: This probably doesn't have the right custodian/ward
-             "func"_a,
+        .def("setExtraBondCheckFunc", setExtraBondCheckFunc, "func"_a,
              R"DOC(allows you to provide a function that will be called
            for each bond pair that matches during substructure searching,
            after all other comparisons have passed.

--- a/Code/GraphMol/nbWrap/Mol.cpp
+++ b/Code/GraphMol/nbWrap/Mol.cpp
@@ -33,6 +33,7 @@ namespace nb = nanobind;
 using namespace nb::literals;
 
 namespace RDKit {
+
 template <typename T>
 std::string MolToString(const T &self) {
   std::string res;
@@ -42,6 +43,7 @@ std::string MolToString(const T &self) {
   }
   return res;
 }
+
 nb::bytes MolToBinary(const ROMol &self) {
   std::string res;
   {
@@ -51,6 +53,7 @@ nb::bytes MolToBinary(const ROMol &self) {
   nb::bytes retval = nb::bytes(res.c_str(), res.length());
   return retval;
 }
+
 nb::bytes MolToBinaryWithProps(const ROMol &self, unsigned int props) {
   std::string res;
   {
@@ -60,6 +63,7 @@ nb::bytes MolToBinaryWithProps(const ROMol &self, unsigned int props) {
   nb::bytes retval = nb::bytes(res.c_str(), res.length());
   return retval;
 }
+
 bool HasSubstructMatchStr(nb::bytes pkl, const ROMol &query,
                           bool recursionPossible = true,
                           bool useChirality = false,
@@ -80,68 +84,8 @@ bool HasSubstructMatchStr(nb::bytes pkl, const ROMol &query,
                              useQueryQueryMatches);
   return hasM;
 }
-#if 0
-void MolClearComputedPropsHelper(const ROMol &mol, bool includeRings) {
-  mol.clearComputedProps(includeRings);
-}
-
-
-//
-// allows molecules to be pickled.
-//  since molecules have a constructor that takes a binary string
-//  we only need to provide getinitargs()
-//
-struct mol_pickle_suite : rdkit_pickle_suite {
-  static python::tuple getinitargs(const ROMol &self) {
-    return python::make_tuple(MolToBinary(self));
-  };
-};
-
-
-unsigned int AddMolConformer(ROMol &mol, Conformer *conf,
-                             bool assignId = false) {
-  auto *nconf = new Conformer(*conf);
-  return mol.addConformer(nconf, assignId);
-}
-
-Conformer *GetMolConformer(ROMol &mol, int id = -1) {
-  return &(mol.getConformer(id));
-}
-
-
-ConformerIterSeq *GetMolConformers(const ROMOL_SPTR &mol) {
-  ConformerIterSeq *res =
-      new ConformerIterSeq(mol, mol->beginConformers(), mol->endConformers(),
-                           ConformerCountFunctor(mol));
-  return res;
-}
-
-int getMolNumAtoms(const ROMol &mol, int onlyHeavy, bool onlyExplicit) {
-  if (onlyHeavy > -1) {
-    BOOST_LOG(rdWarningLog)
-        << "WARNING: the onlyHeavy argument to mol.GetNumAtoms() has been "
-           "deprecated. Please use the onlyExplicit argument instead or "
-           "mol.GetNumHeavyAtoms() if you want the heavy atom count."
-        << std::endl;
-    return mol.getNumAtoms(onlyHeavy);
-  }
-  return mol.getNumAtoms(onlyExplicit);
-}
-#endif
 
 namespace {
-
-// QueryAtomIterSeq &MolGetAromaticAtoms(ROMol &mol) {
-//   auto *qa = new QueryAtom();
-//   qa->setQuery(makeAtomAromaticQuery());
-//   return QueryAtomIterSeq(mol, qa);
-// }
-// QueryAtomIterSeq *MolGetQueryAtoms(ROMol &mol, QueryAtom *qa) {
-//   QueryAtomIterSeq *res = new QueryAtomIterSeq(
-//       mol, mol.beginQueryAtoms(qa), mol.endQueryAtoms(),
-//       AtomCountFunctor(mol));
-//   return res;
-// }
 
 void setSubstructMatchFinalCheck(SubstructMatchParameters &ps,
                                  nb::object func) {
@@ -161,8 +105,6 @@ void setExtraBondCheckFunc(SubstructMatchParameters &ps, nb::object func) {
   ps.extraBondCheck = pyMatchFunctor<Bond>(func);
 }
 
-}  // namespace
-namespace {
 void MolDebug(const ROMol &mol, bool useStdout) {
   if (useStdout) {
     mol.debugMol(std::cout);
@@ -183,9 +125,9 @@ void MolDebug(const ROMol &mol, bool useStdout) {
 
 class ReadWriteMol : public RWMol {
  public:
-  ReadWriteMol() {};
+  ReadWriteMol(){};
   ReadWriteMol(const ROMol &m, bool quickCopy = false, int confId = -1)
-      : RWMol(m, quickCopy, confId) {};
+      : RWMol(m, quickCopy, confId){};
 
   void RemoveAtom(unsigned int idx) { removeAtom(idx); };
   void RemoveBond(unsigned int idx1, unsigned int idx2) {
@@ -252,7 +194,7 @@ class ReadWriteMol : public RWMol {
   std::shared_ptr<RWMol> dp_mol;
 };
 
-std::string molClassDoc = R"DOC(The Molecule class.
+constexpr const char *molClassDoc = R"DOC(The Molecule class.
 
      In addition to the expected Atoms and Bonds, molecules contain:
           - a collection of Atom and Bond bookmarks indexed with integers
@@ -267,13 +209,13 @@ std::string molClassDoc = R"DOC(The Molecule class.
                     Molecules also have the concept of *private* properties, which are tagged
                          by beginning the property name with an underscore (_).
 )DOC";
-std::string rwmolClassDoc = R"DOC(The RW molecule class (read/write)
+constexpr const char *rwmolClassDoc = R"DOC(The RW molecule class (read/write)
 
      This class is a more-performant version of the EditableMolecule class in that
      it is a 'live' molecule and shares the interface from the Mol class.
      All changes are performed without the need to create a copy of the
      molecule using GetMol() (this is still available, however).
-  
+
      n.b. Eventually this class may become a direct replacement for EditableMol)DOC";
 
 struct mol_wrapper {
@@ -580,7 +522,7 @@ struct mol_wrapper {
             "AddConformer",
             [](ROMol &mol, Conformer &conf, bool assignId) {
       // C++ takes ownership of the new Conformer.
-      // There's no way for python to relenquish ownerhship,
+      // There's no way for python to relinquish ownership,
       // so we need to copy.
       return mol.addConformer(new Conformer(conf), assignId);
             },
@@ -1018,25 +960,11 @@ struct mol_wrapper {
         .def("GetPropsAsDict", GetPropsAsDict<ROMol>,
              "includePrivate"_a = false, "includeComputed"_a = false,
              "autoConvertStrings"_a = true, getPropsAsDictDocString.c_str())
-        //         .def(
-        //             "GetStereoGroups", [](nb::object &self) {
-        //                ROMol *m = nb::cast<ROMol *>(self);
-        //                nb::list result;
-        //                for(auto &sg : m->getStereoGroups()) {
-        //                  result.append(
-        //                      nb::cast(&sg,
-        //                      nb::rv_policy::reference_internal,self));
-        //                }
-        //                return result;
-        //             },
-        //             R"DOC(Returns a list of StereoGroups defining the
-        //             relative stereochemistry of the atoms.
-        // )DOC")
         .def(
             "GetStereoGroups", &ROMol::getStereoGroups,
             nb::rv_policy::reference_internal,
             R"DOC(Returns a list of StereoGroups defining the relative stereochemistry of the atoms.))DOC")
-#if 1
+
            .def("GetAromaticAtoms", [](const ROMol &self) {
       auto *qa = new QueryAtom();
       qa->setQuery(makeAtomAromaticQuery());
@@ -1044,19 +972,6 @@ struct mol_wrapper {
       return QueryAtomIterSeq(self, qa, ownsQa);
             }, nb::keep_alive<0,1>(),
                 "Returns a read-only sequence containing all of the molecule's aromatic Atoms.\n")
-
-        //    .def(
-        //        "GetAtomsMatchingQuery", [](ROMol &self, QueryAtom *qa ) {
-        //            return QueryAtomIterSeq(
-        //  self, self.beginQueryAtoms(qa), self.endQueryAtoms(),
-        //  AtomCountFunctor(self));
-        //        },
-        //        "qa"_a,
-        //        nb::keep_alive<0, 1>(),
-        //        R"DOC(Returns a read-only sequence containing all of the atoms
-        //        in a molecule that match the query atom.
-        //              Atom query options are defined in the
-        //              rdkit.Chem.rdqueries module. )DOC")
         .def(
             "GetAtomsMatchingQuery",
             [](const ROMol &self, const QueryAtom *qa) {
@@ -1064,11 +979,11 @@ struct mol_wrapper {
       return QueryAtomIterSeq(self, qa, ownsQa);
             },
             "qa"_a, nb::keep_alive<0, 1>(),
-            R"DOC(Returns a read-only sequence containing all of the atoms in a molecule that match the query atom. 
+            R"DOC(Returns a read-only sequence containing all of the atoms in a molecule that match the query atom.
                   Atom query options are defined in the rdkit.Chem.rdqueries module.
                   )DOC")
 
-#endif
+
         .def("ClearComputedProps", &ROMol::clearComputedProps,
              "includeRings"_a = true,
              R"DOC(Removes all computed properties from the molecule.
@@ -1112,7 +1027,7 @@ struct mol_wrapper {
 
         .def("__getstate__", getObjectState<ROMol, MolToString<ROMol>>)
         .def("__setstate__", setObjectState<ROMol>)
-        .doc() = molClassDoc.c_str();
+        .doc() = molClassDoc;
 
     m.def(
         "_HasSubstructMatchStr", HasSubstructMatchStr, "pkl"_a, "query"_a,
@@ -1206,7 +1121,8 @@ it's probably not of general interest.
              "finishes batch editing and makes the actual changes")
         .def("__getstate__",
              getObjectState<ReadWriteMol, MolToString<ReadWriteMol>>)
-        .def("__setstate__", setObjectState<ReadWriteMol>);
+        .def("__setstate__", setObjectState<ReadWriteMol>)
+        .doc() = rwmolClassDoc;
   }
 };
 }  // namespace RDKit

--- a/Code/GraphMol/nbWrap/substructmethods.h
+++ b/Code/GraphMol/nbWrap/substructmethods.h
@@ -45,23 +45,23 @@ class pyMatchFunctor {
       // on the nanobind version.
       std::vector<unsigned int> matchVec(a2.begin(), a2.end());
       return nb::cast<bool>(dp_callable(&a1, &matchVec));
-    }
-
-    if constexpr (std::is_same_v<T, Atom> && std::is_same_v<U, Atom>) {
-      // If the callable is a subclass of AtomCoordsMatchFunctor,
-      // we can take a shortcut and avoid passing the args through
-      // the nanobind wrappers twice.
-      if (dp_coordsMatchedFunc) {
-        return (*dp_coordsMatchedFunc)(a1, a2);
+    } else {
+      if constexpr (std::is_same_v<T, Atom> && std::is_same_v<U, Atom>) {
+        // If the callable is a subclass of AtomCoordsMatchFunctor,
+        // we can take a shortcut and avoid passing the args through
+        // the nanobind wrappers twice.
+        if (dp_coordsMatchedFunc) {
+          return (*dp_coordsMatchedFunc)(a1, a2);
+        }
       }
-    }
 
-    // We want to pass pointers to the callable: the args will
-    // be passed through the nanobind wrappers (twice?), and
-    // it seems there are copies made along the way. If we pass
-    // Atom or Bond references, they seem to lose Mol ownership
-    // info, resulting in an exception during the fn call.
-    return nb::cast<bool>(dp_callable(&a1, &a2));
+      // We want to pass pointers to the callable: the args will
+      // be passed through the nanobind wrappers (twice?), and
+      // it seems there are copies made along the way. If we pass
+      // Atom or Bond references, they seem to lose Mol ownership
+      // info, resulting in an exception during the fn call.
+      return nb::cast<bool>(dp_callable(&a1, &a2));
+    }
   }
 
  private:

--- a/Code/GraphMol/nbWrap/substructmethods.h
+++ b/Code/GraphMol/nbWrap/substructmethods.h
@@ -44,7 +44,7 @@ class pyMatchFunctor {
       // a vector before calling into python. This might be dependent
       // on the nanobind version.
       std::vector<unsigned int> matchVec(a2.begin(), a2.end());
-      return nb::cast<bool>(dp_callable(&a1, &matchVec));
+      return nb::cast<bool>(dp_callable(&a1, matchVec));
     } else {
       if constexpr (std::is_same_v<T, Atom> && std::is_same_v<U, Atom>) {
         // If the callable is a subclass of AtomCoordsMatchFunctor,

--- a/Code/GraphMol/nbWrap/substructmethods.h
+++ b/Code/GraphMol/nbWrap/substructmethods.h
@@ -38,6 +38,15 @@ class pyMatchFunctor {
     // grab the GIL
     PyGILStateHolder h;
 
+    if constexpr (std::is_same_v<T, ROMol> &&
+                  std::is_same_v<U, std::span<const unsigned int>>) {
+      // nanobind doesn't support std::span, so we need to convert the span to
+      // a vector before calling into python. This might be dependent
+      // on the nanobind version.
+      std::vector<unsigned int> matchVec(a2.begin(), a2.end());
+      return nb::cast<bool>(dp_callable(&a1, &matchVec));
+    }
+
     if constexpr (std::is_same_v<T, Atom> && std::is_same_v<U, Atom>) {
       // If the callable is a subclass of AtomCoordsMatchFunctor,
       // we can take a shortcut and avoid passing the args through

--- a/Code/GraphMol/nbWrap/substructmethods.h
+++ b/Code/GraphMol/nbWrap/substructmethods.h
@@ -18,40 +18,50 @@
 
 namespace RDKit {
 
-class pyFunctor {
+template <typename T, typename U>
+class pyMatchFunctor {
  public:
-  virtual ~pyFunctor() = default;
-};
+  pyMatchFunctor(nb::object obj) : dp_callable(nb::borrow<nb::callable>(obj)) {
+    if (!dp_callable.is_valid()) {
+      throw std::runtime_error("Matcher object is not callable");
+    }
 
-class pyFinalMatchFunctor : public pyFunctor {
- public:
-  pyFinalMatchFunctor(nb::object obj) : dp_obj(std::move(obj)) {}
-  ~pyFinalMatchFunctor() = default;
-  bool operator()(const ROMol &m, std::span<const unsigned int> match) {
-    // grab the GIL
-    PyGILStateHolder h;
-    // boost::python doesn't handle std::span, so we need to convert the span to
-    // a vector before calling into python:
-    std::vector<unsigned int> matchVec(match.begin(), match.end());
-    return nb::cast<bool>(dp_obj(m, matchVec));
+    // Special case to create a shortcut for AtomCoordsMatchFunctors:
+    if constexpr (std::is_same_v<T, Atom> && std::is_same_v<U, Atom>) {
+      nb::try_cast<AtomCoordsMatchFunctor *>(obj, dp_coordsMatchedFunc);
+    }
   }
 
- private:
-  nb::object dp_obj;
-};
-template <typename T>
-class pyMatchFunctor : public pyFunctor {
- public:
-  pyMatchFunctor(nb::object obj) : dp_obj(std::move(obj)) {}
   ~pyMatchFunctor() = default;
-  bool operator()(const T &a1, const T &a2) {
+
+  bool operator()(const T &a1, const U &a2) const {
     // grab the GIL
     PyGILStateHolder h;
-    return nb::cast<bool>(dp_obj(a1, a2));
+
+    if constexpr (std::is_same_v<T, Atom> && std::is_same_v<U, Atom>) {
+      // If the callable is a subclass of AtomCoordsMatchFunctor,
+      // we can take a shortcut and avoid passing the args through
+      // the nanobind wrappers twice.
+      if (dp_coordsMatchedFunc) {
+        return (*dp_coordsMatchedFunc)(a1, a2);
+      }
+    }
+
+    // We want to pass pointers to the callable: the args will
+    // be passed through the nanobind wrappers (twice?), and
+    // it seems there are copies made along the way. If we pass
+    // Atom or Bond references, they seem to lose Mol ownership
+    // info, resulting in an exception during the fn call.
+    return nb::cast<bool>(dp_callable(&a1, &a2));
   }
 
  private:
-  nb::object dp_obj;
+  // The callable is borrowed, so ownership of the Python function
+  // is shared with instances.
+  nb::callable dp_callable;
+
+  // This function is guaranteed to exist for the lifetime of the callable.
+  AtomCoordsMatchFunctor *dp_coordsMatchedFunc = nullptr;
 };
 
 inline std::vector<int> convertMatch(const MatchVectType &match) {

--- a/Code/GraphMol/nbWrap/substructmethods.h
+++ b/Code/GraphMol/nbWrap/substructmethods.h
@@ -61,20 +61,6 @@ inline std::vector<int> convertMatch(const MatchVectType &match) {
   return res;
 }
 
-#if 0
-inline PyObject *convertMatchesToTupleOfPairs(const MatchVectType &matches) {
-  PyObject *res = PyTuple_New(matches.size());
-  std::for_each(matches.begin(), matches.end(),
-  [res, &matches](const auto &pair) {
-    PyObject *pyPair = PyTuple_New(2);
-    PyTuple_SetItem(pyPair, 0, PyInt_FromLong(pair.first));
-                  PyTuple_SetItem(pyPair, 1, PyInt_FromLong(pair.second));
-                  PyTuple_SetItem(res, &pair - &matches.front(), pyPair);
-                });
-  return res;
-}
-#endif
-
 template <typename T1, typename T2>
 void pySubstructHelper(T1 &mol, T2 &query,
                        const SubstructMatchParameters &params,


### PR DESCRIPTION
Running the tests under Asan reveled a "heap-use-after-free" problem in `testSubstructureMatch.py::Test::testCoordsFunctor`, specifically in the "lifetime management 1" block.

This happens because the overload we use to handle an `AtomCoordsMatchFunctor` object being passed to `setExtraAtomCheckFunc()`. In that overload, lifetime of the functor is not managed, so when the Python object holding it is set to `None`, the functor is freed, triggerin the Asan detectin.

This patch removes the overload while preserving the "shortcut" that calls `AtomCoordsMatchFunctor::operator()` directly from C++ (without having to go through the nanobind wrappers twice). It also folds `pyFinalMatchFunctor` into `pyMatchFunctor`, and checks that whatever Python object is passed to the extra check matches is callable. Plus some cleaning up of the code around the wrappers.