### PR TITLE
Fixes a leak in SynthonSpaceShapeSearcher

### DIFF
--- a/Code/GraphMol/GaussianShape/ShapeInput.h
+++ b/Code/GraphMol/GaussianShape/ShapeInput.h
@@ -43,7 +43,7 @@ template <class Archive, typename Block, typename Allocator>
 void serialize(Archive &ar, dynamic_bitset<Block, Allocator> &bs,
                const unsigned int /*version*/) {
   size_t num_bits = bs.size();
-  ar & num_bits;
+  ar &num_bits;
 
   std::vector<Block> blocks;
 
@@ -51,7 +51,7 @@ void serialize(Archive &ar, dynamic_bitset<Block, Allocator> &bs,
     to_block_range(bs, std::back_inserter(blocks));
   }
 
-  ar & blocks;
+  ar &blocks;
 
   if (Archive::is_loading::value) {
     bs.resize(num_bits);
@@ -347,22 +347,22 @@ class RDKIT_GAUSSIANSHAPE_EXPORT ShapeInput {
 #ifdef RDK_USE_BOOST_SERIALIZATION
 template <class Archive>
 void ShapeInput::serialize(Archive &ar, const unsigned int) {
-  ar & d_activeShape;
-  ar & d_coords;
-  ar & d_alphas;
-  ar & d_types;
-  ar & d_numAtoms;
-  ar & d_numFeats;
-  ar & d_selfOverlapShapeVols;
-  ar & d_selfOverlapColorVols;
-  ar & d_extremePointss;
-  ar & d_carbonRadii;
-  ar & d_smiles;
-  ar & d_normalizeds;
-  ar & d_normalizationOKs;
-  ar & d_canonRots;
-  ar & d_canonTranss;
-  ar & d_eigenValuess;
+  ar &d_activeShape;
+  ar &d_coords;
+  ar &d_alphas;
+  ar &d_types;
+  ar &d_numAtoms;
+  ar &d_numFeats;
+  ar &d_selfOverlapShapeVols;
+  ar &d_selfOverlapColorVols;
+  ar &d_extremePointss;
+  ar &d_carbonRadii;
+  ar &d_smiles;
+  ar &d_normalizeds;
+  ar &d_normalizationOKs;
+  ar &d_canonRots;
+  ar &d_canonTranss;
+  ar &d_eigenValuess;
 }
 #endif
 

--- a/Code/GraphMol/SynthonSpaceSearch/SynthonSpaceFingerprintSearcher.cpp
+++ b/Code/GraphMol/SynthonSpaceSearch/SynthonSpaceFingerprintSearcher.cpp
@@ -271,22 +271,22 @@ double SynthonSpaceFingerprintSearcher::approxSimilarity(
 }
 
 bool SynthonSpaceFingerprintSearcher::verifyHit(
-    ROMol &hit, const std::string &rxnId,
+    std::unique_ptr<ROMol> &hit, const std::string &rxnId,
     const std::vector<const std::string *> &synthNames) {
   if (!SynthonSpaceSearcher::verifyHit(hit, rxnId, synthNames)) {
     return false;
   }
-  const std::unique_ptr<ExplicitBitVect> fp(d_fpGen.getFingerprint(hit));
+  const std::unique_ptr<ExplicitBitVect> fp(d_fpGen.getFingerprint(*hit));
   const auto sim = TanimotoSimilarity(*fp, *d_queryFP);
   if (sim > getBestSimilaritySoFar()) {
     const auto prodName = details::buildProductName(rxnId, synthNames);
-    hit.setProp<std::string>(common_properties::_Name, prodName);
-    updateBestHitSoFar(hit, sim);
+    hit->setProp<std::string>(common_properties::_Name, prodName);
+    updateBestHitSoFar(*hit, sim);
   }
   if (sim >= getParams().similarityCutoff) {
-    hit.setProp<double>("Similarity", sim);
+    hit->setProp<double>("Similarity", sim);
     const auto prodName = details::buildProductName(rxnId, synthNames);
-    hit.setProp<std::string>(common_properties::_Name, prodName);
+    hit->setProp<std::string>(common_properties::_Name, prodName);
     return true;
   }
   return false;

--- a/Code/GraphMol/SynthonSpaceSearch/SynthonSpaceFingerprintSearcher.h
+++ b/Code/GraphMol/SynthonSpaceSearch/SynthonSpaceFingerprintSearcher.h
@@ -31,7 +31,7 @@ class SynthonSpaceFingerprintSearcher : public SynthonSpaceSearcher {
       const std::vector<std::shared_ptr<ROMol>> &fragSet,
       const SynthonSet &reaction) const override;
 
-  bool verifyHit(ROMol &hit, const std::string &rxnId,
+  bool verifyHit(std::unique_ptr<ROMol> &hit, const std::string &rxnId,
                  const std::vector<const std::string *> &synthNames) override;
 
  protected:

--- a/Code/GraphMol/SynthonSpaceSearch/SynthonSpaceRascalSearcher.cpp
+++ b/Code/GraphMol/SynthonSpaceSearch/SynthonSpaceRascalSearcher.cpp
@@ -223,25 +223,25 @@ double SynthonSpaceRascalSearcher::approxSimilarity(
 }
 
 bool SynthonSpaceRascalSearcher::verifyHit(
-    ROMol &hit, const std::string &rxnId,
+    std::unique_ptr<ROMol> &hit, const std::string &rxnId,
     const std::vector<const std::string *> &synthNames) {
   if (!SynthonSpaceSearcher::verifyHit(hit, rxnId, synthNames)) {
     return false;
   }
-  auto res = RascalMCES::rascalMCES(hit, getQuery(), d_rascalOptions);
+  auto res = RascalMCES::rascalMCES(*hit, getQuery(), d_rascalOptions);
   // Rascal reports all matches that proceed to full MCES elucidation,
   // even if the final similarity value ends up below the threshold.
   // We only want those over the threshold.
   if (!res.empty()) {
     if (res.front().getSimilarity() > getBestSimilaritySoFar()) {
       const auto prodName = details::buildProductName(rxnId, synthNames);
-      hit.setProp<std::string>(common_properties::_Name, prodName);
-      updateBestHitSoFar(hit, res.front().getSimilarity());
+      hit->setProp<std::string>(common_properties::_Name, prodName);
+      updateBestHitSoFar(*hit, res.front().getSimilarity());
     }
     if (res.front().getSimilarity() >= d_rascalOptions.similarityThreshold) {
-      hit.setProp<double>("Similarity", res.front().getSimilarity());
+      hit->setProp<double>("Similarity", res.front().getSimilarity());
       const auto prodName = details::buildProductName(rxnId, synthNames);
-      hit.setProp<std::string>(common_properties::_Name, prodName);
+      hit->setProp<std::string>(common_properties::_Name, prodName);
       return true;
     }
   }

--- a/Code/GraphMol/SynthonSpaceSearch/SynthonSpaceRascalSearcher.h
+++ b/Code/GraphMol/SynthonSpaceSearch/SynthonSpaceRascalSearcher.h
@@ -37,7 +37,7 @@ class SynthonSpaceRascalSearcher : public SynthonSpaceSearcher {
       const std::vector<std::shared_ptr<ROMol>> &fragSet,
       const SynthonSet &reaction) const override;
 
-  bool verifyHit(ROMol &hit, const std::string &rxnId,
+  bool verifyHit(std::unique_ptr<ROMol> &hit, const std::string &rxnId,
                  const std::vector<const std::string *> &synthNames) override;
 
  protected:

--- a/Code/GraphMol/SynthonSpaceSearch/SynthonSpaceSearcher.cpp
+++ b/Code/GraphMol/SynthonSpaceSearch/SynthonSpaceSearcher.cpp
@@ -231,7 +231,7 @@ void checkPossibleHitsPart(
     std::vector<std::string> synthNames;
     std::vector<const std::string *> synthNamePtrs;
     dismantleName(name, rxnId, synthNames, synthNamePtrs);
-    if (searcher->verifyHit(*prod, rxnId, synthNamePtrs)) {
+    if (searcher->verifyHit(prod, rxnId, synthNamePtrs)) {
       allResultMols[nextLine] = std::move(prod);
     }
     if (pbar) {
@@ -338,7 +338,7 @@ std::unique_ptr<ROMol> SynthonSpaceSearcher::buildAndVerifyHit(
   // when split is a match to the synthons (c1ccc(C[1*])o1 and [1*]N)
   // but the product the hydroxyquinazoline is aromatic, at least in
   // the RDKit model so the N in the query doesn't match.
-  if (!verifyHit(*prod, hitset->d_reaction->getId(), synthNames)) {
+  if (!verifyHit(prod, hitset->d_reaction->getId(), synthNames)) {
     prod.reset();
   }
   return prod;
@@ -589,10 +589,11 @@ void SynthonSpaceSearcher::updateBestHitSoFar(const ROMol &possBest,
 
 // It's conceivable that building the full molecule has changed the
 // chiral atom count.
-bool SynthonSpaceSearcher::verifyHit(ROMol &mol, const std::string &,
+bool SynthonSpaceSearcher::verifyHit(std::unique_ptr<ROMol> &mol,
+                                     const std::string &,
                                      const std::vector<const std::string *> &) {
   if (getParams().minHitChiralAtoms || getParams().maxHitChiralAtoms) {
-    auto numChiralAtoms = details::countChiralAtoms(mol);
+    auto numChiralAtoms = details::countChiralAtoms(*mol);
     if (numChiralAtoms < getParams().minHitChiralAtoms ||
         (getParams().maxHitChiralAtoms > -1 &&
          std::cmp_greater(numChiralAtoms, getParams().maxHitChiralAtoms))) {
@@ -883,8 +884,11 @@ void SynthonSpaceSearcher::sortToTryByApproxSimilarity(
   std::vector<std::pair<const SynthonSpaceHitSet *, std::vector<size_t>>>
       newToTry;
   newToTry.reserve(tmp.size());
-  std::transform(tmp.begin(), tmp.end(), back_inserter(newToTry),
-                 [&](const auto &p) -> auto { return toTry[p.first]; });
+  std::transform(
+      tmp.begin(), tmp.end(),
+      back_inserter(newToTry), [&](const auto &p) -> auto{
+        return toTry[p.first];
+      });
   toTry = newToTry;
 }
 

--- a/Code/GraphMol/SynthonSpaceSearch/SynthonSpaceSearcher.h
+++ b/Code/GraphMol/SynthonSpaceSearch/SynthonSpaceSearcher.h
@@ -18,6 +18,7 @@
 #include <atomic>
 #include <chrono>
 #include <functional>
+#include <memory>
 #include <mutex>
 #include <random>
 
@@ -79,7 +80,7 @@ class SynthonSpaceSearcher {
   // the derived class' criteria.  This function checks the chiralAtomCount
   // if appropriate, which required a non-const ROMol.  Some derived classes
   // will also update d_bestHitFound.
-  virtual bool verifyHit(ROMol &mol, const std::string &,
+  virtual bool verifyHit(std::unique_ptr<ROMol> &mol, const std::string &,
                          const std::vector<const std::string *> &);
 
  protected:

--- a/Code/GraphMol/SynthonSpaceSearch/SynthonSpaceShapeSearcher.cpp
+++ b/Code/GraphMol/SynthonSpaceSearch/SynthonSpaceShapeSearcher.cpp
@@ -8,6 +8,7 @@
 //  of the RDKit source tree.
 //
 
+#include <memory>
 #include <numbers>
 #include <ranges>
 
@@ -804,10 +805,7 @@ bool SynthonSpaceShapeSearcher::quickVerify(
     const std::vector<size_t> &synthNums) const {
   // The approximate similarity should already have been checked in
   // processToTrySet so no need to do it again.
-  if (!SynthonSpaceSearcher::quickVerify(hitset, synthNums)) {
-    return false;
-  }
-  return true;
+  return SynthonSpaceSearcher::quickVerify(hitset, synthNums);
 }
 
 double SynthonSpaceShapeSearcher::approxSimilarity(
@@ -965,26 +963,27 @@ bool checkExcludedVols(const ROMol &mol, const SynthonSpaceSearchParams &params,
 bool finaliseHit(GaussianShape::ShapeInput &hitShapes,
                  const unsigned int hitShapeNum,
                  const std::array<double, 3> &scores, const std::string &rxnId,
-                 const std::vector<const std::string *> &synthNames, ROMol &hit,
+                 const std::vector<const std::string *> &synthNames,
+                 std::unique_ptr<ROMol> &hit,
                  const SynthonSpaceSearchParams &params, double &excludedVol,
                  double &meanExcludedVol) {
   // Copy the conformer into the hit.
   hitShapes.setActiveShape(hitShapeNum);
-  hit = static_cast<ROMol>(*hitShapes.shapeToMol(false, true));
-  if (!checkExcludedVols(hit, params, excludedVol, meanExcludedVol)) {
+  hit.reset(hitShapes.shapeToMol(false, true).release());
+  if (!checkExcludedVols(*hit, params, excludedVol, meanExcludedVol)) {
     return false;
   }
-  hit.setProp<double>("Similarity", scores[0]);
-  hit.setProp<double>("ShapeScore", scores[1]);
-  hit.setProp<double>("ColorScore", scores[2]);
+  hit->setProp<double>("Similarity", scores[0]);
+  hit->setProp<double>("ShapeScore", scores[1]);
+  hit->setProp<double>("ColorScore", scores[2]);
   const auto prodName = details::buildProductName(rxnId, synthNames);
-  hit.setProp<std::string>(common_properties::_Name, prodName);
-  MolOps::assignStereochemistryFrom3D(hit);
+  hit->setProp<std::string>(common_properties::_Name, prodName);
+  MolOps::assignStereochemistryFrom3D(*hit);
   if (excludedVol > -0.5) {
-    hit.setProp<double>("ExcludedVolume", excludedVol);
+    hit->setProp<double>("ExcludedVolume", excludedVol);
   }
   if (meanExcludedVol > -0.5) {
-    hit.setProp<double>("MeanExcludedVolume", meanExcludedVol);
+    hit->setProp<double>("MeanExcludedVolume", meanExcludedVol);
   }
   return true;
 }
@@ -1126,20 +1125,20 @@ bool checkBondLengths(const ROMol &mol) {
 }  // namespace
 
 bool SynthonSpaceShapeSearcher::verifyHit(
-    ROMol &hit, const std::string &rxnId,
+    std::unique_ptr<ROMol> &hit, const std::string &rxnId,
     const std::vector<const std::string *> &synthNames) {
   std::array<double, 3> initScores{-1.0, -1.0, -1.0};
-  if (hit.getNumConformers()) {
+  if (hit->getNumConformers()) {
     initScores = GaussianShape::AlignMolecule(
-        dp_queryShape->getShapes(), hit, GaussianShape::ShapeInputOptions(),
+        dp_queryShape->getShapes(), *hit, GaussianShape::ShapeInputOptions(),
         nullptr, getParams().shapeOverlayOptions);
     double excludedVol{-1.0}, meanExcludedVol{-1.0};
-    if (checkExcludedVols(hit, getParams(), excludedVol, meanExcludedVol)) {
+    if (checkExcludedVols(*hit, getParams(), excludedVol, meanExcludedVol)) {
       // If the excluded vol is also ok, take this hit.  Otherwise, pass it
       // through to conformation expansion to see if it wins there.
-      finaliseHit(hit, initScores, rxnId, synthNames, excludedVol,
+      finaliseHit(*hit, initScores, rxnId, synthNames, excludedVol,
                   meanExcludedVol);
-      if (!getParams().bestHit && checkBondLengths(hit) &&
+      if (!getParams().bestHit && checkBondLengths(*hit) &&
           initScores[0] >= getParams().similarityCutoff) {
         return true;
       }
@@ -1156,7 +1155,7 @@ bool SynthonSpaceShapeSearcher::verifyHit(
   dgParams.timeout = getParams().timeOut;
   UserConfGenerator userConf = getParams().userConformerGenerator;
   auto hitConfs = details::generateIsomerConformers(
-      hit, getParams().numConformers, true, getParams().stereoEnumOpts,
+      *hit, getParams().numConformers, true, getParams().stereoEnumOpts,
       dgParams, userConf);
   bool foundHit = false;
   // Prefer a hit from a generated conf rather than the initial hit
@@ -1188,7 +1187,7 @@ bool SynthonSpaceShapeSearcher::verifyHit(
           continue;
         }
         finalisedHit = true;
-        updateBestHitSoFar(hit, thisScore[0]);
+        updateBestHitSoFar(*hit, thisScore[0]);
       }
       if (thisScore[0] >= bestSim &&
           thisScore[0] > getParams().similarityCutoff) {

--- a/Code/GraphMol/SynthonSpaceSearch/SynthonSpaceShapeSearcher.h
+++ b/Code/GraphMol/SynthonSpaceSearch/SynthonSpaceShapeSearcher.h
@@ -62,7 +62,7 @@ class SynthonSpaceShapeSearcher : public SynthonSpaceSearcher {
       const std::vector<std::shared_ptr<ROMol>> &fragSet,
       const SynthonSet &reaction) const override;
 
-  bool verifyHit(ROMol &hit, const std::string &rxnId,
+  bool verifyHit(std::unique_ptr<ROMol> &hit, const std::string &rxnId,
                  const std::vector<const std::string *> &synthNames) override;
 
   // Use d_fragSynthonSims to decide if the fragment matched the

--- a/Code/GraphMol/SynthonSpaceSearch/SynthonSpaceSubstructureSearcher.cpp
+++ b/Code/GraphMol/SynthonSpaceSearch/SynthonSpaceSubstructureSearcher.cpp
@@ -567,14 +567,14 @@ double SynthonSpaceSubstructureSearcher::approxSimilarity(
 }
 
 bool SynthonSpaceSubstructureSearcher::verifyHit(
-    ROMol &hit, const std::string &rxnId,
+    std::unique_ptr<ROMol> &hit, const std::string &rxnId,
     const std::vector<const std::string *> &synthNames) {
   if (!SynthonSpaceSearcher::verifyHit(hit, rxnId, synthNames)) {
     return false;
   }
-  if (!SubstructMatch(hit, getQuery(), d_matchParams).empty()) {
+  if (!SubstructMatch(*hit, getQuery(), d_matchParams).empty()) {
     const auto prodName = details::buildProductName(rxnId, synthNames);
-    hit.setProp<std::string>(common_properties::_Name, prodName);
+    hit->setProp<std::string>(common_properties::_Name, prodName);
     return true;
   }
   return false;

--- a/Code/GraphMol/SynthonSpaceSearch/SynthonSpaceSubstructureSearcher.h
+++ b/Code/GraphMol/SynthonSpaceSearch/SynthonSpaceSubstructureSearcher.h
@@ -35,7 +35,7 @@ class SynthonSpaceSubstructureSearcher : public SynthonSpaceSearcher {
       const std::vector<std::shared_ptr<ROMol>> &fragSet,
       const SynthonSet &reaction) const override;
 
-  bool verifyHit(ROMol &hit, const std::string &rxnId,
+  bool verifyHit(std::unique_ptr<ROMol> &hit, const std::string &rxnId,
                  const std::vector<const std::string *> &synthNames) override;
 
  protected:


### PR DESCRIPTION
The leak was triggered in line 973 of `SynthonSpaceShapeSearcher.cpp`: despite the assignment operator of `ROMol` is deleted, `hit = static_cast<ROMol>(*hitShapes.shapeToMol(false, true));` was getting around it via the copy constructor. The problem is that when `hit` was replaced, the constructor was never called, because `hit` is actually the molecule inside of a `unique_ptr`, which gets dereferenced and passed around several calls above this function.

The fix to the leak is to pass the mol around as a `unique<ROMol>&` all the way down to `finaliseHit()`. This meant updating a bunch of `verifyHit()` functions due to being declared in a base class with several subclasses.

The formatting in `Code/GraphMol/GaussianShape/ShapeInput.h` is purely accidental.