### PR TITLE
Restore stereo mode after validation tests

### DIFF
--- a/Code/GraphMol/catch_chirality.cpp
+++ b/Code/GraphMol/catch_chirality.cpp
@@ -3302,7 +3302,7 @@ TEST_CASE(
 void testStereoValidationFromMol(std::string molBlock,
                                  std::string expectedSmiles, bool legacyFlag,
                                  bool canonicalFlag = false) {
-  RDKit::Chirality::setUseLegacyStereoPerception(legacyFlag);
+  UseLegacyStereoPerceptionFixture reset_stereo_perception(legacyFlag);
 
   std::unique_ptr<RWMol> mol(MolBlockToMol(molBlock, true, false, false));
   REQUIRE(mol);
@@ -3323,7 +3323,6 @@ void testStereoValidationFromMol(std::string molBlock,
                        RDKit::SmilesWrite::CXSmilesFields::CX_POLYMER;
 
   auto outSmiles = MolToCXSmiles(*mol, smilesWriteParams, flags);
-  RDKit::Chirality::setUseLegacyStereoPerception(false);
 
   CHECK(outSmiles == expectedSmiles);
 }

--- a/Code/GraphMol/test_fixtures.h
+++ b/Code/GraphMol/test_fixtures.h
@@ -53,7 +53,7 @@ class TestFixtureTemplate {
         m_setter_func{setter_func},
         m_var{std::move(var)} {
     auto evar = std::getenv(m_var.c_str());
-    m_env_var_set = evar == nullptr;
+    m_env_var_set = evar != nullptr;
     m_flag_state = (*m_getter_func)();
   }
 


### PR DESCRIPTION
This was being set globally and not re-set, the RAII wrapper clears it up. 