### PR TITLE
Enable numpy's "modern" API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -336,6 +336,7 @@ if(RDK_BUILD_NANOBIND_WRAPPERS)
 
   find_package(Python 3.9 COMPONENTS Interpreter ${DEV_MODULE} NumPy REQUIRED)
   target_include_directories(rdkit_py_base INTERFACE ${Python_NumPy_INCLUDE_DIRS})
+  target_compile_definitions(rdkit_py_base INTERFACE "-DNPY_NO_DEPRECATED_API=NPY_1_7_API_VERSION")
 
   # Detect the installed nanobind package and import it into CMake
   execute_process(
@@ -405,6 +406,7 @@ if(RDK_BUILD_BOOST_PYTHON_WRAPPERS)
   find_package(Python COMPONENTS Interpreter Development.Module NumPy)
   target_include_directories(rdkit_py_base INTERFACE ${Python_INCLUDE_DIRS})
   target_include_directories(rdkit_py_base INTERFACE ${Python_NumPy_INCLUDE_DIRS})
+  target_compile_definitions(rdkit_py_base INTERFACE "-DNPY_NO_DEPRECATED_API=NPY_1_7_API_VERSION")
 
   # determine linkage of python
   execute_process(


### PR DESCRIPTION
If Python wrappers are enabled, this warning pops up several times during builds:
```
/usr/lib/python3/dist-packages/numpy/core/include/numpy/npy_1_7_deprecated_api.h:17:2: warning: #warning "Using deprecated NumPy API, disable it with " "#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION" [-Wcpp]
   17 | #warning "Using deprecated NumPy API, disable it with " \
      |  ^~~~~~~
```
The warning itself suggests setting up this macro to avoid using NumPy's deprecated API. Apparently, no further code changes are required (see https://stackoverflow.com/questions/72775454/how-to-modernize-code-that-uses-deprecated-numpy-c-api and https://github.com/numpy/numpy/issues/21865).