### PR TITLE
Fix radical information passed to InChI

### DIFF
--- a/External/INCHI-API/inchi.cpp
+++ b/External/INCHI-API/inchi.cpp
@@ -1832,15 +1832,22 @@ std::string MolToInchi(const ROMol &mol, ExtraInchiReturnValues &rv,
     inchiAtoms[i].num_iso_H[3] = 0;
 
     // radical
-    inchiAtoms[i].radical = 0;
-    if (atom->getNumRadicalElectrons()) {
-      // the direct specification of radicals in InChI is tricky since they use
-      // the MDL representation (singlet, double, triplet) and we just have the
-      // number of unpaired electrons. Instead we set the number of implicit Hs
-      // here, that together with the atom identity and charge should be
-      // sufficient
-      inchiAtoms[i].num_iso_H[0] = atom->getTotalNumHs();
-    } else {
+    inchiAtoms[i].radical = INCHI_RADICAL_NONE;
+    switch (atom->getNumRadicalElectrons()) {
+      case 1:
+        inchiAtoms[i].radical = INCHI_RADICAL_DOUBLET;
+        break;
+      case 2:
+        inchiAtoms[i].radical = INCHI_RADICAL_TRIPLET;
+        break;
+      default:
+        // InChI uses the MDL singlet/doublet/triplet representation, so there
+        // is no direct mapping for higher radical-electron counts. Preserve the
+        // existing implicit-H fallback for those cases.
+        if (atom->getNumRadicalElectrons()) {
+          inchiAtoms[i].num_iso_H[0] = atom->getTotalNumHs();
+        }
+        break;
     }
 
     // convert tetrahedral chirality info to Stereo0D

--- a/External/INCHI-API/inchi.cpp
+++ b/External/INCHI-API/inchi.cpp
@@ -1837,13 +1837,10 @@ std::string MolToInchi(const ROMol &mol, ExtraInchiReturnValues &rv,
       case 1:
         inchiAtoms[i].radical = INCHI_RADICAL_DOUBLET;
         break;
-      case 2:
-        inchiAtoms[i].radical = INCHI_RADICAL_TRIPLET;
-        break;
       default:
         // InChI uses the MDL singlet/doublet/triplet representation, so there
-        // is no direct mapping for higher radical-electron counts. Preserve the
-        // existing implicit-H fallback for those cases.
+        // is no safe direct mapping from other radical-electron counts.
+        // Preserve the existing implicit-H fallback for those cases.
         if (atom->getNumRadicalElectrons()) {
           inchiAtoms[i].num_iso_H[0] = atom->getTotalNumHs();
         }

--- a/External/INCHI-API/test.cpp
+++ b/External/INCHI-API/test.cpp
@@ -824,6 +824,26 @@ void testGithub3365() {
   BOOST_LOG(rdInfoLog) << "done" << std::endl;
 }
 
+void testGithub9431() {
+  BOOST_LOG(rdErrorLog) << "-------------------------------------" << std::endl;
+  BOOST_LOG(rdInfoLog)
+      << "testing github #9431: resonating radical double-bond stereo"
+      << std::endl;
+
+  auto m = "F/C=C/[CH]Cl"_smiles;
+  TEST_ASSERT(m);
+
+  ExtraInchiReturnValues directResult;
+  const auto direct = MolToInchi(*m, directResult);
+
+  ExtraInchiReturnValues molBlockResult;
+  const auto molBlock = MolBlockToInchi(MolToMolBlock(*m), molBlockResult);
+  TEST_ASSERT(direct == molBlock);
+  TEST_ASSERT(direct.find("/b") == std::string::npos);
+
+  BOOST_LOG(rdInfoLog) << "done" << std::endl;
+}
+
 void testGithub3645() {
   BOOST_LOG(rdErrorLog) << "-------------------------------------" << std::endl;
   BOOST_LOG(rdInfoLog) << "testing github #3645: Seg fault when parsing InChI"
@@ -1062,6 +1082,7 @@ int main() {
   testMolBlockToInchi();
   testGithubIssue562();
   testGithub3365();
+  testGithub9431();
   testGithub3645();
   test_clean_up_on_kekulization_error();
   testGithub6172();


### PR DESCRIPTION
## Summary

- pass one radical electron to the InChI API as a doublet
- leave ambiguous two-radical-electron states on the existing implicit-hydrogen fallback
- add a regression test showing that direct `MolToInchi()` agrees with the MolBlock path and does not add a spurious `/b` stereochemistry layer

## Root cause and impact

RDKit retained the radical-electron count internally, but the direct InChI adapter did not pass the safely representable single-radical state through `inchi_Atom.radical`. Without that information, InChI could treat a resonating double bond as stereogenic and generate a different identifier from the already-correct MolBlock route.

## Human review and AI use

OpenAI Codex was used to help investigate, implement, and validate this change. I reviewed the exact two-file diff and understand its bounded scope: RDKit already retained the radical state, and this patch preserves the safe single-radical-electron doublet mapping across the direct InChI adapter while ambiguous two-radical-electron states continue through the existing fallback. The issue reporter had already done most of the detective work here; this change follows that clear isolation and makes the direct path agree with the existing MolBlock path for the reported single-radical case.

## Validation

- Initial patch: `External/INCHI-API/testInchi`
- Initial patch: `Code/GraphMol/SmilesParse/smiTest1` — 73 test cases, 1695 assertions
- Initial patch: `Code/GraphMol/FileParsers/fileParsersTest1`
- Follow-up: `git diff --check`

Fixes #9431
