### PR TITLE
CIPLabeler: backport "recent" fixes from https://github.com/SiMolecule/centres

### DIFF
--- a/Code/GraphMol/CIPLabeler/catch_tests.cpp
+++ b/Code/GraphMol/CIPLabeler/catch_tests.cpp
@@ -8,8 +8,10 @@
 //  of the RDKit source tree.
 //
 
+#include <algorithm>
 #include <bitset>
 #include <list>
+#include <ranges>
 #include <string>
 #include <vector>
 
@@ -42,6 +44,7 @@
 #include "rules/Pairlist.h"
 #include "rules/Rule1a.h"
 #include "rules/Rule2.h"
+#include "rules/Rule6.h"
 
 #include "CIPMol.h"
 
@@ -1575,4 +1578,36 @@ $$$$
                                 ranked_anchors) == true);
     CHECK(ranked_anchors == std::vector<unsigned int>{0, Atom::NOATOM});
   }
+}
+
+TEST_CASE("GitHub #9516: update return values for Rule 6") {
+  auto mol = "C(C)(F)Cl"_smiles;
+  REQUIRE(mol);
+
+  CIPMol cipmol(*mol);
+  Digraph digraph(cipmol, mol->getAtomWithIdx(0));
+  auto root = digraph.getCurrentRoot();
+  auto edges = root->getEdges();
+
+  const auto findEdgeTo = [&mol, &edges](unsigned int atomIdx) {
+    const auto atom = mol->getAtomWithIdx(atomIdx);
+    const auto iter = std::ranges::find_if(
+        edges, [atom](auto edge) { return edge->getEnd()->getAtom() == atom; });
+    REQUIRE(iter != edges.end());
+    return *iter;
+  };
+  const auto refEdge = findEdgeTo(1);
+  const auto otherEdge = findEdgeTo(2);
+  digraph.setRule6Ref(refEdge->getEnd()->getAtom());
+
+  const Rule6 rule;
+  CHECK(rule.compare(refEdge, otherEdge) == +2);
+  CHECK(rule.compare(otherEdge, refEdge) == -2);
+
+  Sort sorter(&rule);
+  std::vector<Edge *> toSort{otherEdge, refEdge};
+  const auto priority = sorter.prioritize(root, toSort, false);
+  CHECK(priority.isUnique());
+  CHECK(priority.isPseudoAsymetric());
+  CHECK(toSort == std::vector<Edge *>{refEdge, otherEdge});
 }

--- a/Code/GraphMol/CIPLabeler/rules/Rule4b.cpp
+++ b/Code/GraphMol/CIPLabeler/rules/Rule4b.cpp
@@ -176,17 +176,17 @@ std::vector<std::vector<const Node *>> Rule4b::getNextLevel(
     }
 
     // check sizes
-    int size = -1;
-    for (auto i = 0u; i < tmp.size(); ++i) {
-      int localSize = tmp[0].size();
-      if (size < 0) {
-        size = localSize;
-      } else if (size != localSize) {
-        throw std::runtime_error("Something unexpected!");
+    unsigned int size = 0;
+    if (!tmp.empty()) {
+      size = tmp.front().size();
+      for (const auto &groups : tmp) {
+        if (size != groups.size()) {
+          throw std::runtime_error("Something unexpected!");
+        }
       }
     }
 
-    for (int i = 0; i < size; ++i) {
+    for (unsigned int i = 0; i < size; ++i) {
       std::vector<const Node *> eq;
       for (const auto &aTmp : tmp) {
         auto tmpNodes = toNodeList(aTmp[i]);

--- a/Code/GraphMol/CIPLabeler/rules/Rule6.cpp
+++ b/Code/GraphMol/CIPLabeler/rules/Rule6.cpp
@@ -27,9 +27,9 @@ int Rule6::compare(const Edge *a, const Edge *b) const {
   const auto &aAtom = a->getEnd()->getAtom();
   const auto &bAtom = b->getEnd()->getAtom();
   if (ref == aAtom && ref != bAtom) {
-    return +1;  // a is ref (has priority)
+    return +2;  // a is ref (has priority and Rule 6 follows Rule 5)
   } else if (ref != aAtom && ref == bAtom) {
-    return -1;  // b is ref (has priority)
+    return -2;  // b is ref (has priority and Rule 6 follows Rule 5)
   }
   return 0;
 }


### PR DESCRIPTION
This backports a couple of fixes that were committed into https://github.com/SiMolecule/centres after we ported it to C++:

- Return values in Rule 6 were updated to -2/+2 to reflect that these are pseudochiralities (https://github.com/SiMolecule/centres/commit/def7380a3f14efa08a369c20595adda71603d3f3)

- The size check in Rule 4b was erroneously hardcoded to look only at `tmp[0]`, when it should have checked all elements in `tmp` to have the same size (https://github.com/SiMolecule/centres/commit/ff7dc3e7cec0fec47ff3e736b0ed9b7e291c83c4).