### PR TITLE
Prefer retained stereochemistry when breaking canonical-tautomer score ties

### DIFF
--- a/Code/GraphMol/MolStandardize/Tautomer.cpp
+++ b/Code/GraphMol/MolStandardize/Tautomer.cpp
@@ -860,21 +860,41 @@ ROMol *TautomerEnumerator::pickCanonical(
   } else {
     // Calculate score for each tautomer
     int bestScore = std::numeric_limits<int>::min();
+    unsigned int bestStereo = 0;
     std::string bestSmiles = "";
     for (const auto &t : tautRes.d_tautomers) {
       auto score = scoreFunc(*t.second.tautomer);
 #ifdef VERBOSE_ENUMERATION
       std::cerr << "  " << t.first << " " << score << std::endl;
 #endif
+      if (score < bestScore) {
+        continue;
+      }
+      auto nStereo = detail::countSpecifiedStereo(*t.second.tautomer);
+      bool better = false;
       if (score > bestScore) {
+        better = true;
+      } else {
+        // Break the tie on retained stereochemistry before falling back to
+        // lexicographic SMILES order. A transform that destroys and then
+        // regenerates an sp3 stereocentre puts a stereo-unspecified twin of an
+        // equally-scoring tautomer into the pool, and '[' (0x5B) sorts after
+        // every atom letter, so the lexicographic comparison alone always
+        // prefers the twin: "CC(=O)C(C)O" beats "CC(=O)[C@H](C)O". That silently
+        // merged both acetoin enantiomers even with tautomerRemoveSp3Stereo set
+        // to false. Comparing stereo first keeps the result canonical, since
+        // the count is a property of the tautomer rather than of the input.
+        if (nStereo > bestStereo) {
+          better = true;
+        } else if (nStereo == bestStereo && t.first < bestSmiles) {
+          better = true;
+        }
+      }
+      if (better) {
         bestScore = score;
+        bestStereo = nStereo;
         bestSmiles = t.first;
         bestMol = t.second.tautomer;
-      } else if (score == bestScore) {
-        if (t.first < bestSmiles) {
-          bestSmiles = t.first;
-          bestMol = t.second.tautomer;
-        }
       }
     }
   }

--- a/Code/GraphMol/MolStandardize/Tautomer.h
+++ b/Code/GraphMol/MolStandardize/Tautomer.h
@@ -149,12 +149,18 @@ namespace detail {
 inline unsigned int countSpecifiedStereo(const ROMol &mol) {
   unsigned int nSpecified = 0;
   for (const auto atom : mol.atoms()) {
+    // CHI_UNSPECIFIED is the only "none" value on the atom side; ChiralType has no
+    // analogue of STEREOANY, so a simple inequality is right here.
     if (atom->getChiralTag() != Atom::CHI_UNSPECIFIED) {
       ++nSpecified;
     }
   }
   for (const auto bond : mol.bonds()) {
-    if (bond->getStereo() != Bond::STEREONONE) {
+    // STEREOANY is *intentionally unspecified*, not retained stereochemistry, and
+    // getClearedTautomerBondStereo() assigns it to cleared acyclic double bonds, so
+    // counting it would let a tautomer win a tie on unknown stereo. The enum is
+    // ordered so that "> STEREOANY" is the idiomatic test; see Bond.h.
+    if (bond->getStereo() > Bond::STEREOANY) {
       ++nSpecified;
     }
   }

--- a/Code/GraphMol/MolStandardize/Tautomer.h
+++ b/Code/GraphMol/MolStandardize/Tautomer.h
@@ -16,6 +16,7 @@
 #include <utility>
 #include <iterator>
 #include <Catalogs/Catalog.h>
+#include <GraphMol/ROMol.h>
 #include <GraphMol/MolStandardize/MolStandardize.h>
 #include <GraphMol/MolStandardize/TautomerCatalog/TautomerCatalogEntry.h>
 #include <GraphMol/MolStandardize/TautomerCatalog/TautomerCatalogParams.h>
@@ -137,6 +138,29 @@ inline boost::function<int(const ROMol &)> makeOptimizedScorer(
   };
 }
 }  // namespace TautomerScoringFunctions
+
+namespace detail {
+//! Number of explicitly specified stereo descriptors on a molecule.
+/*!
+  Used only to break score ties when picking the canonical tautomer, where a
+  lexicographic comparison of SMILES would otherwise be systematically biased
+  against stereochemistry.
+*/
+inline unsigned int countSpecifiedStereo(const ROMol &mol) {
+  unsigned int nSpecified = 0;
+  for (const auto atom : mol.atoms()) {
+    if (atom->getChiralTag() != Atom::CHI_UNSPECIFIED) {
+      ++nSpecified;
+    }
+  }
+  for (const auto bond : mol.bonds()) {
+    if (bond->getStereo() != Bond::STEREONONE) {
+      ++nSpecified;
+    }
+  }
+  return nSpecified;
+}
+}  // namespace detail
 
 enum class TautomerEnumeratorStatus {
   Completed = 0,
@@ -464,22 +488,41 @@ class RDKIT_MOLSTANDARDIZE_EXPORT TautomerEnumerator {
     } else {
       // Calculate score for each tautomer
       int bestScore = std::numeric_limits<int>::min();
+      unsigned int bestStereo = 0;
       std::string bestSmiles = "";
       for (const auto &t : tautomers) {
         auto score = scoreFunc(*t);
 #ifdef VERBOSE_ENUMERATION
         std::cerr << "  " << MolToSmiles(*t) << " " << score << std::endl;
 #endif
+        if (score < bestScore) {
+          // cannot win, so do not pay for its SMILES
+          continue;
+        }
+        // See the comment in the pickCanonical overload in Tautomer.cpp: the
+        // lexicographic tie-break is biased against stereochemistry, so compare
+        // the amount of retained stereo first.
+        auto nStereo = detail::countSpecifiedStereo(*t);
+        bool better = false;
+        bool haveSmiles = false;
+        std::string smiles;
         if (score > bestScore) {
-          bestScore = score;
-          bestSmiles = MolToSmiles(*t);
-          bestMol = t;
-        } else if (score == bestScore) {
-          auto smiles = MolToSmiles(*t);
-          if (smiles < bestSmiles) {
-            bestSmiles = smiles;
-            bestMol = t;
+          better = true;
+        } else if (nStereo > bestStereo) {
+          better = true;
+        } else if (nStereo == bestStereo) {
+          smiles = MolToSmiles(*t);
+          haveSmiles = true;
+          better = smiles < bestSmiles;
+        }
+        if (better) {
+          if (!haveSmiles) {
+            smiles = MolToSmiles(*t);
           }
+          bestScore = score;
+          bestStereo = nStereo;
+          bestSmiles = std::move(smiles);
+          bestMol = t;
         }
       }
     }

--- a/Code/GraphMol/MolStandardize/catch_tests.cpp
+++ b/Code/GraphMol/MolStandardize/catch_tests.cpp
@@ -1881,3 +1881,62 @@ M  END
     }
   }
 }
+
+TEST_CASE("canonical tautomer keeps stereo on an equal-score tie",
+          "[tautomer][stereo]") {
+  // A transform that destroys and regenerates an sp3 stereocentre puts a
+  // stereo-unspecified twin of an equally-scoring tautomer into the pool. The
+  // tie-break used to be lexicographic on canonical SMILES only, and '[' (0x5B)
+  // sorts after every atom letter, so the twin always won:
+  //   "CC(=O)C(C)O" < "CC(=O)[C@H](C)O"
+  // Both acetoin enantiomers therefore canonicalized to the same achiral SMILES
+  // even with tautomerRemoveSp3Stereo set to false. See GitHub #7969.
+  CleanupParameters params;
+  params.tautomerRemoveSp3Stereo = false;
+  params.tautomerRemoveBondStereo = false;
+  params.tautomerRemoveIsotopicHs = false;
+  TautomerEnumerator te(params);
+
+  SECTION("acetoin enantiomers stay distinct") {
+    for (const auto &smi :
+         std::vector<std::string>{"CC(=O)[C@H](C)O", "CC(=O)[C@@H](C)O"}) {
+      std::unique_ptr<RWMol> m{SmilesToMol(smi)};
+      REQUIRE(m);
+      const auto expected = MolToSmiles(*m);
+      std::unique_ptr<ROMol> canon{te.canonicalize(*m)};
+      REQUIRE(canon);
+      CHECK(MolToSmiles(*canon) == expected);
+    }
+  }
+
+  SECTION("the two enantiomers do not collapse onto each other") {
+    std::unique_ptr<RWMol> r{SmilesToMol("CC(=O)[C@H](C)O")};
+    std::unique_ptr<RWMol> s{SmilesToMol("CC(=O)[C@@H](C)O")};
+    std::unique_ptr<ROMol> cr{te.canonicalize(*r)};
+    std::unique_ptr<ROMol> cs{te.canonicalize(*s)};
+    CHECK(MolToSmiles(*cr) != MolToSmiles(*cs));
+  }
+
+  SECTION("open-chain D-fructose keeps all three centres") {
+    std::unique_ptr<RWMol> m{
+        SmilesToMol("O=C(CO)[C@@H](O)[C@H](O)[C@H](O)CO")};
+    REQUIRE(m);
+    std::unique_ptr<ROMol> canon{te.canonicalize(*m)};
+    REQUIRE(canon);
+    CHECK(MolToSmiles(*canon) == MolToSmiles(*m));
+  }
+
+  SECTION("result is independent of input atom ordering") {
+    std::unique_ptr<RWMol> m{SmilesToMol("CCC(=O)[C@H](O)CC")};
+    REQUIRE(m);
+    std::unique_ptr<ROMol> ref{te.canonicalize(*m)};
+    const auto refSmi = MolToSmiles(*ref);
+    std::vector<unsigned int> order(m->getNumAtoms());
+    for (unsigned int i = 0; i < order.size(); ++i) {
+      order[i] = (i + 3) % order.size();
+    }
+    std::unique_ptr<ROMol> renumbered{MolOps::renumberAtoms(*m, order)};
+    std::unique_ptr<ROMol> got{te.canonicalize(*renumbered)};
+    CHECK(MolToSmiles(*got) == refSmi);
+  }
+}

--- a/Code/GraphMol/MolStandardize/catch_tests.cpp
+++ b/Code/GraphMol/MolStandardize/catch_tests.cpp
@@ -1890,12 +1890,12 @@ TEST_CASE("canonical tautomer keeps stereo on an equal-score tie",
   // sorts after every atom letter, so the twin always won:
   //   "CC(=O)C(C)O" < "CC(=O)[C@H](C)O"
   // Both acetoin enantiomers therefore canonicalized to the same achiral SMILES
-  // even with tautomerRemoveSp3Stereo set to false. See GitHub #7969.
-  CleanupParameters params;
+  // even with tautomerRemoveSp3Stereo set to false. See GitHub #9518 and #7969.
+  MolStandardize::CleanupParameters params;
   params.tautomerRemoveSp3Stereo = false;
   params.tautomerRemoveBondStereo = false;
   params.tautomerRemoveIsotopicHs = false;
-  TautomerEnumerator te(params);
+  MolStandardize::TautomerEnumerator te(params);
 
   SECTION("acetoin enantiomers stay distinct") {
     for (const auto &smi :


### PR DESCRIPTION
#### Reference Issue
Fixes #9518

#### What does this implement/fix?

`pickCanonical` broke an equal-score tie on lexicographic canonical SMILES alone:

```cpp
} else if (score == bestScore) {
  if (t.first < bestSmiles) { ... }
}
```

`[` is 0x5B, so it sorts after every uppercase atom letter and a stereo-annotated SMILES
always loses to its unannotated twin — `"CC(=O)C(C)O" < "CC(=O)[C@H](C)O"`. The tie-break
was systematically biased against stereochemistry rather than arbitrary.

That bias becomes visible whenever a transform destroys and then regenerates an sp3
stereocentre, because the ketone -> enediol -> ketone round trip puts a stereo-*unspecified*
twin of an equally-scoring tautomer into the pool:

```
CC(=O)C(C)O                score=5   centres=[(3, '?')]     <-- won the tie
CC(=O)[C@H](C)O            score=5   centres=[(3, 'S')]     <-- the input
CC(O)=C(C)O                score=2   centres=[]             <-- centre destroyed here
```

So both acetoin enantiomers canonicalized to the same achiral SMILES even with
`tautomerRemoveSp3Stereo = false`, and open-chain D-fructose was converted into a different
sugar with one fewer stereocentre. In each case the *selected* tautomer still carries the
stereocentre — `FindMolChiralCenters(includeUnassigned=True)` reports it as a potential
centre — so nothing structural justified dropping the configuration.

**Fix:** compare the number of specified stereo descriptors before falling back to
lexicographic order. The count is a property of the tautomer rather than of the input, so
the result remains canonical and independent of atom ordering; the lexicographic comparison
is retained underneath it, so behaviour is unchanged for every tie that does not involve
stereo. Applied to both the non-templated overload in `Tautomer.cpp` and the templated one
in `Tautomer.h`, which shared the comparison. The helper is `inline` in `namespace detail`
in the header so both can use one definition.

#### Tests

`catch_tests.cpp` gains `"canonical tautomer keeps stereo on an equal-score tie"` with four
sections: both acetoin enantiomers round-trip; the two do not collapse onto each other;
open-chain D-fructose keeps all three centres; and the result is invariant under atom
renumbering.

#### Validation and its limits

I could not complete a local C++ build in the time available, so **the C++ has not been
compiled — please let CI be the judge of that.**

What I did verify, by reimplementing this exact selection loop in Python and running it over
the real enumerated pools: the change recovers stereo on 8 of 10 affected molecules, returns
the input unchanged in all 10 (the input already was the correct canonical tautomer in each
case), and is stable across 10 random atom-order permutations for each of 6 molecules.

Scope of the problem, from scanning 34,671 molecules (9,671 flavour/fragrance materials plus
25,000 ChEMBL 37 compounds) with the stereo flags off: 48 lose an assigned sp3 centre while
the potential-centre count stays the same. A separate and larger group loses stereo
legitimately, because the carbon becomes sp2 or aromatic and the centre genuinely stops
existing — 50 of 60 in the fragrance subset. This PR deliberately does not touch those.

#### Any other comments?

Distinct from #9129 / #9130, which restore CHI on sp3 atoms **not** modified by the
transform, inside `setTautomerStereoAndIsoHs` during enumeration. Here the atom *is* on the
tautomeric path, both forms are already present in the pool, and the loss happens in the
final `pickCanonical` selection. The two changes are complementary and touch different code.

#7969 reported the same symptom in October 2024 and was closed by the stale bot on
2026-07-02 without a fix. Its examples involve a centre becoming aromatic, where one can
argue the centre legitimately ceases to exist; acetoin is the sharper case because the
chosen tautomer retains the centre.

An alternative design would keep the ordering as-is and instead avoid inserting the
stereo-stripped twin into the pool. I preferred fixing the comparison because the twin is a
legitimate tautomer in its own right when the input has no stereo assigned, and because
this keeps the change confined to selection.


#### Acknowledging the usage of AI tools

Adding this per the [AI-acknowledgement request](https://github.com/rdkit/rdkit/blob/master/Docs/Book/GettingStartedWithContributing.md#acknowledging-the-usage-of-ai-tools)
in the contributing guide — thanks for the pointer, @greglandrum.

I made significant use of **Claude Code** (Anthropic) on this contribution: the C++ patch and
the `detail` helper, the Catch2 test, the Python reimplementation of the selection loop used
for validation, the 34,671-molecule scan, and the drafting of this description and the
comments above.

I have read the diff line by line and understand what it does. The design choice — fix the
comparison in `pickCanonical` rather than keep the stereo-stripped twin out of the pool during
enumeration — was a deliberate one, and it is stated with its trade-off at the end of the
section above. The empirical claims here are from runs on my own machine and I can reproduce
any of them on request: the 8/10 stereo recovery and 10/10 unchanged inputs, the
atom-permutation stability, the 48-of-34,671 scan counts, and the release-vs-master
`getClearedTautomerBondStereo` / `STEREOANY` table that explains why my testing did not catch
the `!= STEREONONE` predicate that the review flagged.
