### PR TITLE
Revert "Fix radical information passed to InChI"

### DIFF
--- a/External/INCHI-API/inchi.cpp
+++ b/External/INCHI-API/inchi.cpp
@@ -1832,19 +1832,15 @@ std::string MolToInchi(const ROMol &mol, ExtraInchiReturnValues &rv,
     inchiAtoms[i].num_iso_H[3] = 0;
 
     // radical
-    inchiAtoms[i].radical = INCHI_RADICAL_NONE;
-    switch (atom->getNumRadicalElectrons()) {
-      case 1:
-        inchiAtoms[i].radical = INCHI_RADICAL_DOUBLET;
-        break;
-      default:
-        // InChI uses the MDL singlet/doublet/triplet representation, so there
-        // is no safe direct mapping from other radical-electron counts.
-        // Preserve the existing implicit-H fallback for those cases.
-        if (atom->getNumRadicalElectrons()) {
-          inchiAtoms[i].num_iso_H[0] = atom->getTotalNumHs();
-        }
-        break;
+    inchiAtoms[i].radical = 0;
+    if (atom->getNumRadicalElectrons()) {
+      // the direct specification of radicals in InChI is tricky since they use
+      // the MDL representation (singlet, double, triplet) and we just have the
+      // number of unpaired electrons. Instead we set the number of implicit Hs
+      // here, that together with the atom identity and charge should be
+      // sufficient
+      inchiAtoms[i].num_iso_H[0] = atom->getTotalNumHs();
+    } else {
     }
 
     // convert tetrahedral chirality info to Stereo0D

--- a/External/INCHI-API/test.cpp
+++ b/External/INCHI-API/test.cpp
@@ -824,26 +824,6 @@ void testGithub3365() {
   BOOST_LOG(rdInfoLog) << "done" << std::endl;
 }
 
-void testGithub9431() {
-  BOOST_LOG(rdErrorLog) << "-------------------------------------" << std::endl;
-  BOOST_LOG(rdInfoLog)
-      << "testing github #9431: resonating radical double-bond stereo"
-      << std::endl;
-
-  auto m = "F/C=C/[CH]Cl"_smiles;
-  TEST_ASSERT(m);
-
-  ExtraInchiReturnValues directResult;
-  const auto direct = MolToInchi(*m, directResult);
-
-  ExtraInchiReturnValues molBlockResult;
-  const auto molBlock = MolBlockToInchi(MolToMolBlock(*m), molBlockResult);
-  TEST_ASSERT(direct == molBlock);
-  TEST_ASSERT(direct.find("/b") == std::string::npos);
-
-  BOOST_LOG(rdInfoLog) << "done" << std::endl;
-}
-
 void testGithub3645() {
   BOOST_LOG(rdErrorLog) << "-------------------------------------" << std::endl;
   BOOST_LOG(rdInfoLog) << "testing github #3645: Seg fault when parsing InChI"
@@ -1082,7 +1062,6 @@ int main() {
   testMolBlockToInchi();
   testGithubIssue562();
   testGithub3365();
-  testGithub9431();
   testGithub3645();
   test_clean_up_on_kekulization_error();
   testGithub6172();


### PR DESCRIPTION
I thought the CI builds had passed, but that was apparently false.

Reverting this until we clarify the failures in UnitTestInchi.py

Reverts rdkit/rdkit#9512