### PR TITLE
nanobind: Fix leak in detectChemistryProblems wrapper

### DIFF
--- a/Code/GraphMol/nbWrap/MolOps.cpp
+++ b/Code/GraphMol/nbWrap/MolOps.cpp
@@ -923,8 +923,8 @@ nb::tuple detectChemistryProblemsHelper(const ROMol &mol,
                                         unsigned int sanitizeOps) {
   auto probs = MolOps::detectChemistryProblems(mol, sanitizeOps);
   nb::list res;
-  for (const auto &exc_ptr : probs) {
-    res.append(exc_ptr->copy());
+  for (auto &&exc_ptr : probs) {
+    res.append(std::move(exc_ptr));
   }
   return nb::tuple(res);
 }


### PR DESCRIPTION
Fixes a small leak in `detectChemistryProblemsHelper()` by having nanobind handle `unique_ptr`s instead of raw pointers.