### PR TITLE
nanobind: fix moldescriptors leaking PythonPropertyFunctor

### DIFF
--- a/Code/GraphMol/Descriptors/Property.h
+++ b/Code/GraphMol/Descriptors/Property.h
@@ -60,6 +60,9 @@ struct RDKIT_DESCRIPTORS_EXPORT PropertyFunctor {
 
   //! Compute the value of the property
   virtual double operator()(const RDKit::ROMol &mol) const {
+    if (d_dataFunc == nullptr) {
+      throw ValueErrorException("PropertyFunctor has no data function");
+    }
     return (*d_dataFunc)(mol);
   }
 

--- a/Code/GraphMol/Descriptors/Wrap/testMolDescriptors.py
+++ b/Code/GraphMol/Descriptors/Wrap/testMolDescriptors.py
@@ -1,7 +1,8 @@
-import unittest
+import gc
 from os import environ
 from pathlib import Path
 import re
+import unittest
 
 from rdkit import rdBase
 from rdkit import Chem, DataStructs
@@ -525,69 +526,30 @@ class TestCase(unittest.TestCase):
 
   def testPythonDescriptorFunctor(self):
 
-    if hasattr(rdBase, '_wrapperType') and rdBase._wrapperType == 'nanobind':
-
-      def numAtoms(mol):
-        return mol.GetNumAtoms()
-
-      class NumAtoms(rdMD.PythonPropertyFunctor):
-
-        def __init__(self):
-          rdMD.PythonPropertyFunctor.__init__(self, numAtoms, "CustomNumAtoms", "1.0.0")
-    else:
-
-      class NumAtoms(Descriptors.PropertyFunctor):
-
-        def __init__(self):
-          Descriptors.PropertyFunctor.__init__(self, "CustomNumAtoms", "1.0.0")
-
-        def __call__(self, mol):
-          return mol.GetNumAtoms()
-
-    numAtoms = NumAtoms()
-    # numAtoms2 = NumAtoms()
-    rdMD.Properties.RegisterProperty(numAtoms)
-    props = rdMD.Properties(["CustomNumAtoms"])
-    self.assertEqual(1, props.ComputeProperties(Chem.MolFromSmiles("C"))[0])
-
-    self.assertTrue("CustomNumAtoms" in rdMD.Properties.GetAvailableProperties())
-    # check memory
-    del numAtoms
-    self.assertEqual(1, props.ComputeProperties(Chem.MolFromSmiles("C"))[0])
-    self.assertTrue("CustomNumAtoms" in rdMD.Properties.GetAvailableProperties())
-
-    m = Chem.MolFromSmiles("c1ccccc1")
-    properties = rdMD.Properties()
-    for name, value in zip(properties.GetPropertyNames(), properties.ComputeProperties(m)):
-      print(name, value)
-
-    properties = rdMD.Properties(['exactmw', 'lipinskiHBA'])
-    for name, value in zip(properties.GetPropertyNames(), properties.ComputeProperties(m)):
-      print(name, value)
-
-  def testPythonDescriptorFunctor2(self):
-    ''' NOTE: this test causes leak warnings in the nanobind wrappers '''
-
-    class NumAtoms2(Descriptors.PropertyFunctor):
+    class NumAtoms(Descriptors.PropertyFunctor):
 
       def __init__(self):
-        Descriptors.PropertyFunctor.__init__(self, "CustomNumAtoms2", "1.0.0")
+        Descriptors.PropertyFunctor.__init__(self, "CustomNumAtoms", "1.0.0")
 
       def __call__(self, mol):
         return mol.GetNumAtoms()
 
-    numAtoms2 = NumAtoms2()
-    # numAtoms2 = NumAtoms()
-    rdMD.Properties.RegisterProperty(numAtoms2)
-    props = rdMD.Properties(["CustomNumAtoms2"])
-    self.assertEqual(1, props.ComputeProperties(Chem.MolFromSmiles("C"))[0])
-
-    self.assertTrue("CustomNumAtoms2" in rdMD.Properties.GetAvailableProperties())
-    # check memory
-    self.assertEqual(1, props.ComputeProperties(Chem.MolFromSmiles("C"))[0])
-    self.assertTrue("CustomNumAtoms2" in rdMD.Properties.GetAvailableProperties())
-
     m = Chem.MolFromSmiles("c1ccccc1")
+    numAtoms = NumAtoms()
+    self.assertEqual(6, numAtoms(m))
+
+    rdMD.Properties.RegisterProperty(numAtoms)
+    props = rdMD.Properties(["CustomNumAtoms"])
+    self.assertTrue("CustomNumAtoms" in rdMD.Properties.GetAvailableProperties())
+    self.assertEqual(1, props.ComputeProperties(Chem.MolFromSmiles("C"))[0])
+
+    # check memory
+    del numAtoms
+    gc.collect()
+
+    self.assertEqual(1, props.ComputeProperties(Chem.MolFromSmiles("C"))[0])
+    self.assertTrue("CustomNumAtoms" in rdMD.Properties.GetAvailableProperties())
+
     properties = rdMD.Properties()
     for name, value in zip(properties.GetPropertyNames(), properties.ComputeProperties(m)):
       print(name, value)
@@ -595,8 +557,6 @@ class TestCase(unittest.TestCase):
     properties = rdMD.Properties(['exactmw', 'lipinskiHBA'])
     for name, value in zip(properties.GetPropertyNames(), properties.ComputeProperties(m)):
       print(name, value)
-    import gc
-    gc.collect()
 
   def testPropertyRanges(self):
     query = rdMD.MakePropertyRangeQuery("exactmw", 0, 1000)

--- a/Code/GraphMol/Descriptors/nbWrap/rdMolDescriptors.cpp
+++ b/Code/GraphMol/Descriptors/nbWrap/rdMolDescriptors.cpp
@@ -15,8 +15,10 @@
 #include <nanobind/stl/pair.h>
 #include <nanobind/stl/map.h>
 #include <nanobind/stl/tuple.h>
-#include <nanobind/stl/shared_ptr.h>
+#include <nanobind/trampoline.h>
+
 #include <RDBoost/Wrap_nb.h>
+#include <RDBoost/boost_shared_ptr.h>
 #include <GraphMol/Atom.h>
 #include <GraphMol/GraphMol.h>
 
@@ -45,6 +47,7 @@
 
 #include <boost/dynamic_bitset.hpp>
 #include <optional>
+#include <ranges>
 #include <vector>
 
 namespace nb = nanobind;
@@ -53,6 +56,54 @@ using namespace nb::literals;
 struct AtomPairsParameters {};
 
 namespace {
+
+static std::string nanobindInternalsKeyName;
+
+nb::dict getBuiltinsDict() {
+  // PyEval_GetBuiltins only gets the builtins for the current thread,
+// which may not be the main thread.
+#if defined(PYPY_VERSION)
+  PyObject *dict = PyEval_GetBuiltins();
+#else
+  PyObject *dict = PyInterpreterState_GetDict(PyInterpreterState_Get());
+#endif
+  return nb::borrow<nb::dict>(dict);
+}
+
+void getNanobindInternalsKeyName() {
+  if (!nanobindInternalsKeyName.empty()) {
+    return;
+  }
+  auto builtins = getBuiltinsDict();
+  if (!builtins.is_valid()) {
+    return;
+  }
+
+  std::string keyStr;
+  for (const auto &key : builtins.keys()) {
+    if (nb::try_cast<std::string>(key, keyStr) &&
+        keyStr.starts_with("__nb_internals_")) {
+      nanobindInternalsKeyName = std::move(keyStr);
+      return;
+    }
+  }
+}
+
+bool isNanobindFinalized() {
+  // If something goes wrong, and we can't tell,
+  // then assume nanobind is still there
+  if (nanobindInternalsKeyName.empty()) {
+    return false;
+  }
+  auto builtins = getBuiltinsDict();
+  if (!builtins.is_valid()) {
+    return false;
+  }
+
+  // We've seen the internals key before, so if we can't
+  // see it anymore, then nanobind has been finalized.
+  return !builtins.contains(nanobindInternalsKeyName);
+}
 
 std::vector<unsigned int> atomPairTypes(
     RDKit::AtomPairs::atomNumberTypes,
@@ -828,23 +879,81 @@ unsigned int numBridgeheadAtoms(const RDKit::ROMol &mol, nb::object pyatoms) {
 
 // Python-callable property functor that delegates __call__ to a Python callback
 struct PythonPropertyFunctor : public RDKit::Descriptors::PropertyFunctor {
-  nb::object callback;
-
-  PythonPropertyFunctor(nb::object cb, const std::string &name,
-                        const std::string &version)
-      : PropertyFunctor(name, version), callback(cb) {}
+  NB_TRAMPOLINE(RDKit::Descriptors::PropertyFunctor, 1);
 
   double operator()(const RDKit::ROMol &mol) const override {
-    return nb::cast<double>(callback(mol));
+    NB_OVERRIDE_NAME("__call__", operator(), mol);
   }
 };
 
-int registerPropertyHelper(std::shared_ptr<PythonPropertyFunctor> ptr) {
-  ptr->callback
-      .inc_ref();  // Increment reference count to ensure it stays alive
-  auto ppf = new PythonPropertyFunctor(ptr->callback, ptr->getName(),
-                                       ptr->getVersion());
-  auto res = RDKit::Descriptors::Properties::registerProperty(ppf);
+// This is adapted from
+// https://nanobind.readthedocs.io/en/latest/refleaks.html#fixing-reference-leaks
+// The trampoline takes care of the clean up the Python objects as long as
+// the functor is not registered. But once the functor is registered,
+// the shared pointer will keep the functor alive, and the trampoline will
+// in turn keep the Python object alive. The problem is that, since the registry
+// is static, it will be destructed after Python has terminated, potentially
+// leaking any registered PythonPropertyFunctor objects. To remedy that,
+// we keep track of the nanobind internals object: we capture the name
+// of the key that holds it when the first PythonPropertyFunctor is registered,
+// and on each visit of the collector we check if the nanobind internals object
+// is still alive. When it is not, it means that Python is shutting down, so
+// we should pop the functor so it can be destroyed too.
+int ppf_tp_traverse(PyObject *self, visitproc visit, void *arg) {
+  // We must traverse the implicit dependency of an object on its
+  // associated type object.
+  Py_VISIT(Py_TYPE(self));
+
+  // The tp_traverse method may be called after __new__ but before or during
+  // __init__, before the C++ constructor has been completed. We must not
+  // inspect the C++ state if the constructor has not yet completed.
+  if (!nb::inst_ready(self)) {
+    return 0;
+  }
+
+  // Get the C++ object associated with 'self' (this always succeeds)
+  auto ppf = nb::inst_ptr<PythonPropertyFunctor>(self);
+
+  // Get the Python object at the base of the trampoline, and
+  // let the GC know about it.
+  auto base = ppf->nb_trampoline.base();
+
+  Py_VISIT(base.ptr());
+
+  return 0;
+}
+
+int ppf_tp_clear(PyObject *self) {
+  if (!isNanobindFinalized()) {
+    // nanobind is still there, so we're not being terminated yet.
+    return 0;
+  }
+
+  // ok, nanobind is gone. Time to pop this object from the registry
+  // so that it can be destructed-
+  auto &registry = RDKit::Descriptors::Properties::registry;
+  auto it = std::ranges::find_if(registry, [self](const auto &pf) {
+    return pf.get() == nb::inst_ptr<PythonPropertyFunctor>(self);
+  });
+
+  if (it != registry.end()) {
+    registry.erase(it);
+  }
+
+  return 0;
+}
+
+// Don't forget to install in the class declaration for PythonPropertyFunctor !
+PyType_Slot pyPropFunctor_slots[] = {
+    {Py_tp_traverse, (void *)ppf_tp_traverse},
+    {Py_tp_clear, (void *)ppf_tp_clear},
+    {0, 0},  // slots termination mark
+};
+
+int registerPropertyHelper(
+    boost::shared_ptr<RDKit::Descriptors::PropertyFunctor> ptr) {
+  getNanobindInternalsKeyName();
+  auto res = RDKit::Descriptors::Properties::registerProperty(ptr);
   return res;
 }
 
@@ -1431,18 +1540,6 @@ assigning hybridization)DOC");
         RDKit::Descriptors::numUnspecifiedAtomStereoCenters, "mol"_a,
         "Returns the number of unspecified atomic stereocenters");
 
-  nb::class_<RDKit::Descriptors::PropertyFunctor>(
-      m, "PropertyFunctor",
-      R"DOC(Property computation class stored in the property registry.
-See rdkit.Chem.rdMolDescriptor.Properties.GetProperty and
-rdkit.Chem.Descriptor.Properties.PropertyFunctor for creating new ones)DOC")
-      .def("__call__", &RDKit::Descriptors::PropertyFunctor::operator(),
-           "mol"_a, "Compute the property for the specified molecule")
-      .def("GetName", &RDKit::Descriptors::PropertyFunctor::getName,
-           "Return the name of the property to calculate")
-      .def("GetVersion", &RDKit::Descriptors::PropertyFunctor::getVersion,
-           "Return the version of the calculated property");
-
   nb::class_<RDKit::Descriptors::Properties>(
       m, "Properties",
       R"DOC(Property computation and registry system.  To compute all registered properties:
@@ -1483,12 +1580,16 @@ for name, value in zip(properties.GetPropertyNames(), properties.ComputeProperti
                   "propertyFunctor"_a,
                   "Register a new property object (not thread safe)");
 
-  nb::class_<PythonPropertyFunctor, RDKit::Descriptors::PropertyFunctor>(
-      m, "PythonPropertyFunctor", nb::is_weak_referenceable())
-      .def(nb::init<nb::object, const std::string &, const std::string &>(),
-           "callback"_a, "name"_a, "version"_a)
-      .def("__call__", &PythonPropertyFunctor::operator(), "mol"_a,
-           "Compute the property for the specified molecule");
+  nb::class_<RDKit::Descriptors::PropertyFunctor, PythonPropertyFunctor>(
+      m, "PythonPropertyFunctor", nb::is_weak_referenceable(),
+      nb::type_slots(pyPropFunctor_slots))
+      .def(nb::init<std::string, std::string>(), "name"_a, "version"_a)
+      .def("__call__", &RDKit::Descriptors::PropertyFunctor::operator(),
+           "mol"_a, "Compute the property for the specified molecule")
+      .def("GetName", &RDKit::Descriptors::PropertyFunctor::getName,
+           "Return the name of the property to calculate")
+      .def("GetVersion", &RDKit::Descriptors::PropertyFunctor::getVersion,
+           "Return the version of the calculated property");
 
   nb::class_<Queries::RangeQuery<double, RDKit::ROMol const &, true>>(
       m, "PropertyRangeQuery",

--- a/Code/GraphMol/Descriptors/nbWrap/rdMolDescriptors.cpp
+++ b/Code/GraphMol/Descriptors/nbWrap/rdMolDescriptors.cpp
@@ -19,6 +19,7 @@
 
 #include <RDBoost/Wrap_nb.h>
 #include <RDBoost/boost_shared_ptr.h>
+#include <RDBoost/python_capsule_nb.h>
 #include <GraphMol/Atom.h>
 #include <GraphMol/GraphMol.h>
 
@@ -886,74 +887,31 @@ struct PythonPropertyFunctor : public RDKit::Descriptors::PropertyFunctor {
   }
 };
 
-// This is adapted from
-// https://nanobind.readthedocs.io/en/latest/refleaks.html#fixing-reference-leaks
-// The trampoline takes care of the clean up the Python objects as long as
-// the functor is not registered. But once the functor is registered,
-// the shared pointer will keep the functor alive, and the trampoline will
-// in turn keep the Python object alive. The problem is that, since the registry
-// is static, it will be destructed after Python has terminated, potentially
-// leaking any registered PythonPropertyFunctor objects. To remedy that,
-// we keep track of the nanobind internals object: we capture the name
-// of the key that holds it when the first PythonPropertyFunctor is registered,
-// and on each visit of the collector we check if the nanobind internals object
-// is still alive. When it is not, it means that Python is shutting down, so
-// we should pop the functor so it can be destroyed too.
-int ppf_tp_traverse(PyObject *self, visitproc visit, void *arg) {
-  // We must traverse the implicit dependency of an object on its
-  // associated type object.
-  Py_VISIT(Py_TYPE(self));
-
-  // The tp_traverse method may be called after __new__ but before or during
-  // __init__, before the C++ constructor has been completed. We must not
-  // inspect the C++ state if the constructor has not yet completed.
-  if (!nb::inst_ready(self)) {
-    return 0;
-  }
-
-  // Get the C++ object associated with 'self' (this always succeeds)
-  auto ppf = nb::inst_ptr<PythonPropertyFunctor>(self);
-
-  // Get the Python object at the base of the trampoline, and
-  // let the GC know about it.
-  auto base = ppf->nb_trampoline.base();
-
-  Py_VISIT(base.ptr());
-
-  return 0;
-}
-
-int ppf_tp_clear(PyObject *self) {
-  if (!isNanobindFinalized()) {
-    // nanobind is still there, so we're not being terminated yet.
-    return 0;
-  }
-
-  // ok, nanobind is gone. Time to pop this object from the registry
-  // so that it can be destructed-
-  auto &registry = RDKit::Descriptors::Properties::registry;
-  auto it = std::ranges::find_if(registry, [self](const auto &pf) {
-    return pf.get() == nb::inst_ptr<PythonPropertyFunctor>(self);
-  });
-
-  if (it != registry.end()) {
-    registry.erase(it);
-  }
-
-  return 0;
-}
-
-// Don't forget to install in the class declaration for PythonPropertyFunctor !
-PyType_Slot pyPropFunctor_slots[] = {
-    {Py_tp_traverse, (void *)ppf_tp_traverse},
-    {Py_tp_clear, (void *)ppf_tp_clear},
-    {0, 0},  // slots termination mark
-};
-
 int registerPropertyHelper(
-    boost::shared_ptr<RDKit::Descriptors::PropertyFunctor> ptr) {
+    boost::shared_ptr<RDKit::Descriptors::PropertyFunctor> ppf) {
   getNanobindInternalsKeyName();
-  auto res = RDKit::Descriptors::Properties::registerProperty(ptr);
+
+  namespace rdkDesc = RDKit::Descriptors;
+
+  // Set up pruning of Python functions for when Python shuts down.
+  // This needs to be done only once.
+  constexpr const char *capsuleName = "__rdkit_DescPropRegistry__";
+  if (getCapsulePtr(capsuleName) == nullptr) {
+    auto cleanUpFn = [](void *ptr) noexcept {
+      using propFtor_t = boost::shared_ptr<rdkDesc::PropertyFunctor>;
+      auto registry = static_cast<std::vector<propFtor_t> *>(ptr);
+      std::erase_if(*registry, [](const auto &propFunc) {
+        return nb::find(propFunc).is_valid();
+      });
+
+      // DO NOT delete p: it's a static object owned by the C++ code.
+    };
+
+    nb::capsule regCapsule(&rdkDesc::Properties::registry, cleanUpFn);
+    installCapsule(regCapsule, capsuleName);
+  }
+
+  auto res = RDKit::Descriptors::Properties::registerProperty(ppf);
   return res;
 }
 
@@ -1581,8 +1539,7 @@ for name, value in zip(properties.GetPropertyNames(), properties.ComputeProperti
                   "Register a new property object (not thread safe)");
 
   nb::class_<RDKit::Descriptors::PropertyFunctor, PythonPropertyFunctor>(
-      m, "PythonPropertyFunctor", nb::is_weak_referenceable(),
-      nb::type_slots(pyPropFunctor_slots))
+      m, "PythonPropertyFunctor", nb::is_weak_referenceable())
       .def(nb::init<std::string, std::string>(), "name"_a, "version"_a)
       .def("__call__", &RDKit::Descriptors::PropertyFunctor::operator(),
            "mol"_a, "Compute the property for the specified molecule")

--- a/Code/RDBoost/nbWrap/RDBase.cpp
+++ b/Code/RDBoost/nbWrap/RDBase.cpp
@@ -10,17 +10,17 @@
 #include <array>
 #include <cstdlib>
 #include <fstream>
-#include <RDBoost/Wrap_nb.h>
-#include <RDBoost/python_capsule_nb.h>
-#include <RDBoost/python_streambuf_nb.h>
-#include <RDGeneral/versions.h>
-#include <RDGeneral/Invariant.h>
 
 #include <nanobind/nanobind.h>
 #include <nanobind/operators.h>
 #include <nanobind/stl/tuple.h>
 #include <nanobind/stl/string.h>
 
+#include <RDBoost/Wrap_nb.h>
+#include <RDBoost/python_capsule_nb.h>
+#include <RDBoost/python_streambuf_nb.h>
+#include <RDGeneral/versions.h>
+#include <RDGeneral/Invariant.h>
 #include <RDGeneral/RDLog.h>
 
 namespace nb = nanobind;

--- a/rdkit/Chem/Descriptors.py
+++ b/rdkit/Chem/Descriptors.py
@@ -12,6 +12,7 @@ from collections import \
 
 import rdkit.Chem.ChemUtils.DescriptorUtilities as _du
 from rdkit import Chem
+from rdkit import rdBase
 from rdkit.Chem import rdMolDescriptors
 from rdkit.Chem import rdMolDescriptors as _rdMolDescriptors
 from rdkit.Chem import rdPartialCharges
@@ -277,20 +278,13 @@ class PropertyFunctor(rdMolDescriptors.PythonPropertyFunctor):
 
       numAtoms = NumAtoms()
       rdMolDescriptors.Properties.RegisterProperty(numAtoms)
-
-    NOTE: using this class will add a cyclic reference to the property functor. This will
-    lead to warnings when the interpreter is shutting down with the nanobind wrappers.
-    To avoid the problem just use PythonPropertyFunctor directly and register it like this:
-    
-      def NumAtoms(mol):
-        return mol.GetNumAtoms()
-
-      numAtoms = rdMolDescriptors.PythonPropertyFunctor(NumAtoms, "NumAtoms", "1.0.0")
-      rdMolDescriptors.Properties.RegisterProperty(numAtoms)
     """
 
   def __init__(self, name, version):
-    rdMolDescriptors.PythonPropertyFunctor.__init__(self, self, name, version)
+    if hasattr(rdBase, '_wrapperType') and rdBase._wrapperType == 'nanobind':
+      rdMolDescriptors.PythonPropertyFunctor.__init__(self, name, version)
+    else:
+      rdMolDescriptors.PythonPropertyFunctor.__init__(self, self, name, version)
 
   def __call__(self, mol):
     raise NotImplementedError("Please implement the __call__ method")


### PR DESCRIPTION
There's 2 issues associated to the usage of `PythonPropertyFunctor`s with nanobind and the "classic" usage pattern of writing a Python class subclassing the wrapped `PythonPropertyFunctor` to provide the callback function:

- The cyclic dependency between the Python class instance and the C++ base class. We currently have at least a couple of warnings in docstrings about this one. It's easily fixed using nanobind's trampoline feature (see https://nanobind.readthedocs.io/en/latest/classes.html#overriding-virtual-functions-in-python).

- Even after the issue above is solved, registering a `PythonPropertyFunctor` causes it to leak at program termination. This happens because registering the functor gives the static `RDKit::Descriptors::Properties::registry` ownership of the functor. And, due to being static, the registry will be destroyed only after Python has terminated, so the Python objects can no longer be destroyed, so they are never cleaned up, and are reported as leaked by nanobind:

```
nanobind: leaked 1 instances!
 - leaked instance 0x60c000195748 of type "__main__.NumAtoms2"
nanobind: leaked 2 types!
 - leaked type "rdkit.Chem.rdMolDescriptors.PythonPropertyFunctor"
 - leaked type "rdkit.Chem.rdMolDescriptors.PropertyFunctor"
nanobind: leaked 5 functions!
 - leaked function "GetName"
 - leaked function "__init__"
 - leaked function "__call__"
 - leaked function "__call__"
 - leaked function "GetVersion"
nanobind: this is likely caused by a reference counting issue in the binding code.
See https://nanobind.readthedocs.io/en/latest/refleaks.html
```
This leak is not really relevant (after all, the registered functors are expected to be preserved until process termination anyway), but the nanobind notification of the leak is unnerving, as well as the leak reports in asan or valgrind make it harder to notice and investigate other leaks, so I think it would be preferrable it if we could have them fixed.

~In this PR, this is done by using the slots mechanism described in nanobind's section about leaks (see the link in the comment in the code) to detect whether Python is shutting down by using nanboind's internals object as sentinel. And when we're shutting down, we pop the `PythonPropertyFunctor` from the registry, so that the ownership is released and the Python objects can be cleaned up before Python is completely terminated.~

I changed the approach. It is now based on the capsule mechanism I added to https://github.com/rdkit/rdkit/pull/9541. It now uses a capsule with a pointer to the Property functor registry. Once the destructor function is triggered, the registry vector is scanned to erase all `PythonPropertyFunctor`s. This will free all of them in one shot, and the mechanism is only triggered if any functors are registered via the Python mechanism.

Once these issues are solved, we can remove the warning message in `Descriptors.PropertyFunctor`'s docstring, and after a small adaptation there, we no longer need to split `testPythonDescriptorFunctor` in two, nor the warning at the top of it. I also made a couple changes to the test to better test the survivability of the `PropertyFunctor` once it's been registered and the original Python object is deleted.

I have reverted this PR to "draft" status to wait for #9541 to be merged first.