### PR TITLE
Fix build issue with TBB in debug builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -689,6 +689,11 @@ if (MSVC)
   add_definitions( "/wd4267" )
 endif(MSVC)
 
+find_package(TBB)
+if(TBB_FOUND)
+    set(TBB_DEP TBB::tbb)
+endif()
+
 add_subdirectory(External)
 add_subdirectory(Code)
 

--- a/Code/GraphMol/CMakeLists.txt
+++ b/Code/GraphMol/CMakeLists.txt
@@ -57,11 +57,6 @@ rdkit_headers(Atom.h
 	Subset.h
         DEST GraphMol)
 
-find_package(TBB)
-if(TBB_FOUND)
-    set(TBB_DEP TBB::tbb)
-endif()
-
 add_subdirectory(SmilesParse)
 add_subdirectory(Depictor)
 add_subdirectory(MarvinParse)

--- a/Code/GraphMol/CMakeLists.txt
+++ b/Code/GraphMol/CMakeLists.txt
@@ -57,6 +57,11 @@ rdkit_headers(Atom.h
 	Subset.h
         DEST GraphMol)
 
+find_package(TBB)
+if(TBB_FOUND)
+    set(TBB_DEP TBB::tbb)
+endif()
+
 add_subdirectory(SmilesParse)
 add_subdirectory(Depictor)
 add_subdirectory(MarvinParse)
@@ -220,5 +225,5 @@ rdkit_catch_test(molopsTestsCatch catch_molops.cpp
 
 rdkit_catch_test(testMacroMol testMacroMol.cpp
         LINK_LIBRARIES SmilesParse GraphMol)
-        
+
 rdkit_catch_test(ringSystemsTest ring_systems_test.cpp LINK_LIBRARIES SmilesParse GraphMol RDStreams)

--- a/Code/GraphMol/FileParsers/CMakeLists.txt
+++ b/Code/GraphMol/FileParsers/CMakeLists.txt
@@ -131,15 +131,8 @@ rdkit_catch_test(v2FileParsersCatchTest v2_file_parsers_catch.cpp
 rdkit_catch_test(atropisomersCatch atropisomers_catch.cpp
     LINK_LIBRARIES FileParsers)
 
-find_package(TBB )
-if(TBB_FOUND)
 rdkit_catch_test(fileParsersIteratorsTest fileParsersIterTest.cpp
-    LINK_LIBRARIES SmilesParse FileParsers SubstructMatch TBB::tbb)
-else()
-rdkit_catch_test(fileParsersIteratorsTest fileParsersIterTest.cpp
-    LINK_LIBRARIES SmilesParse FileParsers SubstructMatch)
-endif()
-
+    LINK_LIBRARIES SmilesParse FileParsers SubstructMatch ${TBB_DEP})
 
 if(RDK_TEST_MULTITHREADED AND RDK_BUILD_THREADSAFE_SSS)
 rdkit_catch_test(multithreadedSupplierCatchTest multithreaded_supplier_catch.cpp

--- a/Code/GraphMol/GaussianShape/CMakeLists.txt
+++ b/Code/GraphMol/GaussianShape/CMakeLists.txt
@@ -14,7 +14,7 @@ target_compile_definitions(GaussianShape PRIVATE RDKIT_GAUSSIANSHAPE_BUILD)
 rdkit_headers(GaussianShape.h ShapeInput.h ShapeOverlayOptions.h)
 
 rdkit_catch_test(testGaussianShape catch_tests.cpp LINK_LIBRARIES GaussianShape
-        FileParsers MolAlign MolTransforms DistGeomHelpers DistGeometry)
+        FileParsers MolAlign MolTransforms DistGeomHelpers DistGeometry ${TBB_DEP})
 
 if(RDK_BUILD_BOOST_PYTHON_WRAPPERS)
     add_subdirectory(Wrap)

--- a/Code/GraphMol/catch_moliterators.cpp
+++ b/Code/GraphMol/catch_moliterators.cpp
@@ -16,7 +16,6 @@
 #include <algorithm>
 #include <ranges>
 #include <filesystem>
-#include <execution>
 
 using namespace RDKit;
 


### PR DESCRIPTION
Ever since PR #9230 was merged, my unoptimized debug builds failed due to missing symbols when building `testGaussianShape` and `moliteratorTestsCatch`:

```
FAILED: Code/GraphMol/moliteratorTestsCatch 
: && /usr/lib/ccache/c++ -mpopcnt -Wno-deprecated -Wno-unused-function -fno-strict-aliasing -Wall -Wextra -fPIC -g -Wl,--dependency-file=Code/GraphMol/CMakeFiles/moliteratorTestsCatch.dir/link.d Code/GraphMol/CMakeFiles/moliteratorTestsCatch.dir/catch_moliterators.cpp.o -o Code/GraphMol/moliteratorTestsCatch  -Wl,-rpath,/tmp/rdkit_builder/rdkit/build/lib:/usr/local/lib  Code/RDGeneral/librdkitCatch.a  lib/libRDKitSubstructMatch.so.1.2026.09.1pre  lib/libRDKitSmilesParse.so.1.2026.09.1pre  _deps/catch2-build/src/libCatch2d.a  lib/libRDKitGenericGroups.so.1.2026.09.1pre  lib/libRDKitGraphMol.so.1.2026.09.1pre  lib/libRDKitRDGeometryLib.so.1.2026.09.1pre  lib/libRDKitDataStructs.so.1.2026.09.1pre  lib/libRDKitRingDecomposerLib.so.1.2026.09.1pre  lib/libRDKitRDGeneral.so.1.2026.09.1pre  /usr/local/lib/libboost_serialization.so.1.91.0  /usr/local/lib/libboost_iostreams.so.1.91.0  /usr/local/lib/libboost_random.so.1.91.0  /usr/local/lib/libboost_regex.so.1.91.0 && :
/usr/bin/ld: Code/GraphMol/CMakeFiles/moliteratorTestsCatch.dir/catch_moliterators.cpp.o: in function `tbb::detail::d1::execution_slot(tbb::detail::d1::execution_data const&)':
/usr/include/oneapi/tbb/detail/_task.h:169:(.text._ZN3tbb6detail2d114execution_slotERKNS1_14execution_dataE[_ZN3tbb6detail2d114execution_slotERKNS1_14execution_dataE]+0x14): undefined reference to `tbb::detail::r1::execution_slot(tbb::detail::d1::execution_data const*)'
/usr/bin/ld: Code/GraphMol/CMakeFiles/moliteratorTestsCatch.dir/catch_moliterators.cpp.o: in function `tbb::detail::d1::current_thread_index()':
/usr/include/oneapi/tbb/task_arena.h:451:(.text._ZN3tbb6detail2d120current_thread_indexEv[_ZN3tbb6detail2d120current_thread_indexEv]+0xe): undefined reference to `tbb::detail::r1::execution_slot(tbb::detail::d1::execution_data const*)'
collect2: error: ld returned 1 exit status
```

Note the missing symbols are under the `tbb` namespace, and indeed, the problems went away as soon as I added the TBB dependency to the linking of those tests. This shouldn't be happening, since TBB was just introduced as a linked dependency to a test, not to any libraries, and no includes were added.

The only thing these 3 tests have in common (the one where TBB was added in #9230, plus the two that refuse to build without it), is that the three of them have a `#include <execution>` line, and indeed `moliteratorTestsCatch` builds again when that line is removed (the test doesn't seem to be using threads or execution policies, so it seems that can be done without any harm). So, I have no idea how, but it seems that when the TBB dependency present, it is somehow overriding the include paths for the whole project so that the TBB headers have preference over the compiler-included ones.

This patch adds the TBB dependency to `testGaussianShape` (since threads are used there), and remoes the  apparently unrequired `<execution> include from `moliteratorTestsCatch` so that debug builds work again.



 

