### PR TITLE
Remove extra code after getMolBoundsMatrix nb wrap

### DIFF
--- a/Code/GraphMol/DistGeomHelpers/nbWrap/rdDistGeom.cpp
+++ b/Code/GraphMol/DistGeomHelpers/nbWrap/rdDistGeom.cpp
@@ -229,6 +229,7 @@ static nb::ndarray<nb::numpy, double, nb::ndim<2>> getMolBoundsMatrix2(
   return nb::ndarray<nb::numpy, double, nb::ndim<2>>(resData, {nats, nats},
                                                      owner);
 }
+
 static nb::ndarray<nb::numpy, double, nb::ndim<2>> getMolBoundsMatrix(
     const ROMol &mol, bool set15bounds, bool scaleVDW, bool doTriangleSmoothing,
     bool useMacrocycle14config, bool forceTransAmides, bool set14bounds,
@@ -238,15 +239,6 @@ static nb::ndarray<nb::numpy, double, nb::ndim<2>> getMolBoundsMatrix(
   params.forceTransAmides = forceTransAmides;
   return getMolBoundsMatrix2(mol, params, doTriangleSmoothing, scaleVDW,
                              set15bounds, set14bounds, set13bounds);
-  unsigned int nats = mol.getNumAtoms();
-  DistGeom::BoundsMatPtr mat(new DistGeom::BoundsMatrix(nats));
-  DGeomHelpers::initBoundsMat(mat);
-  DGeomHelpers::setTopolBounds(mol, mat, set15bounds, scaleVDW,
-                               useMacrocycle14config, forceTransAmides,
-                               set14bounds, set13bounds);
-  if (doTriangleSmoothing) {
-    DistGeom::triangleSmoothBounds(mat);
-  }
 }
 
 static nb::list getExpTorsHelper(const ROMol &mol, bool useExpTorsions,


### PR DESCRIPTION
While running a debug build for #9532, I got the following warning:

```
/tmp/rdkit_builder/rdkit/Code/GraphMol/DistGeomHelpers/nbWrap/rdDistGeom.cpp: In function ‘nanobind::ndarray<nanobind::numpy, double, nanobind::detail::shape<-1, -1> > RDKit::getMolBoundsMatrix(const ROMol&, bool, bool, bool, bool, bool, bool, bool)’:
/tmp/rdkit_builder/rdkit/Code/GraphMol/DistGeomHelpers/nbWrap/rdDistGeom.cpp:250:1: warning: control reaches end of non-void function [-Wreturn-type]
  250 | }
      | ^
```

When I looked into it, comparing the nanobind code to the boost one, it seems than rather missing a return statement, there's some extra code in the function. It seems that the AI hallucinated some of the code in the function right above `getMolBoundsMatrix2()`, into `getMolBoundsMatrix()` when generating the wrappers. This PR removes the extra code.

