### PR TITLE
Pin nanobind dependency version to 2.x

### DIFF
--- a/.azure-pipelines/linux_build_nb.yml
+++ b/.azure-pipelines/linux_build_nb.yml
@@ -10,7 +10,7 @@ steps:
         libboost-devel=$(boost_version) \
         libboost=$(boost_version) \
         libboost-headers=$(boost_version) \
-        nanobind \
+        nanobind=2 \
         numpy=2.4 pillow eigen pandas=3 matplotlib-base=3.10 \
         cairo
     conda activate rdkit_build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -342,7 +342,7 @@ if(RDK_BUILD_NANOBIND_WRAPPERS)
   execute_process(
     COMMAND "${Python_EXECUTABLE}" -m nanobind --cmake_dir
     OUTPUT_STRIP_TRAILING_WHITESPACE OUTPUT_VARIABLE nanobind_ROOT)
-  find_package(nanobind CONFIG REQUIRED)
+  find_package(nanobind 2 CONFIG REQUIRED)
   if(RDK_INSTALL_INTREE)
     set(RDKit_PythonDir "${CMAKE_SOURCE_DIR}/rdkit")
   else(RDK_INSTALL_INTREE)


### PR DESCRIPTION
Nanobind v3 was release a few days ago, and it includes some backwards incompatible changes that break the current build (See e.g. https://dev.azure.com/rdkit-builds/RDKit/_build/results?buildId=9542&view=logs&j=5f81272d-5984-5f4b-30f4-e2a482f090ab&t=9cedb7d7-8329-52f6-71a0-6114b93e4c85=)

This patch pins the dependency to releases in the v2 branch, which seems to the the one we've used to set up initial nanobind support. I don't know if there's a minor version we require, so this is the best I can do for now.