### PR TITLE
Preserve pubchem-align3d symbols with hidden visibility

### DIFF
--- a/External/pubchem_shape/CMakeLists.txt
+++ b/External/pubchem_shape/CMakeLists.txt
@@ -44,6 +44,10 @@ file(WRITE ${PUBCHEMSHAPE_DIR}/shape_neighbor.cpp "${FILE_CONTENTS}")
 
 rdkit_library(pubchem_align3d ./pubchem-align3d/shape_functions1.cpp
             ./pubchem-align3d/shape_functions2.cpp ./pubchem-align3d/shape_neighbor.cpp SHARED)
+# The external pubchem-align3d sources do not use RDKit export annotations.
+# Keep their symbols visible when RDKit is built with hidden visibility.
+set_target_properties(pubchem_align3d PROPERTIES CXX_VISIBILITY_PRESET default)
+
 if((MSVC AND RDK_INSTALL_DLLS_MSVC) OR ((NOT MSVC) AND WIN32))
   set_target_properties(pubchem_align3d PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
 endif()


### PR DESCRIPTION
#### Reference Issue

No existing issue.

#### What does this implement/fix? Explain your changes.
I recently started building RDKit with hidden visibility on Linux and Mac
to reduce the size of the libraries and fix some symbol collision issues.

The external `pubchem-align3d` sources do not use RDKit export annotations.
When RDKit is configured with `CMAKE_CXX_VISIBILITY_PRESET=hidden`, the
`pubchem_align3d` shared library therefore hides the `Align3D` entry points that
`PubChemShape` uses, producing undefined symbols while linking `PubChemShape`.

```
[720/958] Linking CXX shared library
lib/libRDKitPubChemShape.2026.03.5-sch.dylib

FAILED: [code=1] lib/libRDKitPubChemShape.2026.03.5-sch.dylib

Undefined symbols for architecture x86_64:
  "Align3D::setUseCutOff(bool)", referenced from:
      PrepareConformer(...)
      AlignMolecule(...)

  "Align3D::ComputeShapeOverlap(...)", referenced from:
      PrepareConformer(...)
      ScoreShape(...)

  "Align3D::Neighbor_Conformers(...)", referenced from:
      AlignShape(...)

  "Align3D::VApplyRotTransMatrix(...)", referenced from:
      AlignShape(...)

  "Align3D::ComputeFeatureOverlap(...)", referenced from:
      PrepareConformer(...)
      ScoreShape(...)

ld: symbol(s) not found for architecture x86_64
clang++: error: linker command failed with exit code 1
```

Set `CXX_VISIBILITY_PRESET` to `default` specifically for the external
`pubchem_align3d` target. This preserves hidden visibility for the rest of the
RDKit build while keeping this target's required entry points available.

#### Any other comments?

I didn't post this as a fix to pubchemshape because this is about how RDKit builds
pubchemshape.

See also #9538 which addresses a related issue.

I used OpenAI Codex to help analyze the linker failure and prepare this change.
I reviewed the final diff and validation results.
