### PR TITLE
nanobind: Prevent LogToPythonLogger from leaking at Python termination

### DIFF
--- a/Code/RDBoost/nbWrap/RDBase.cpp
+++ b/Code/RDBoost/nbWrap/RDBase.cpp
@@ -27,14 +27,11 @@ namespace nb = nanobind;
 using namespace nb::literals;
 namespace logging = boost::logging;
 
-static constexpr unsigned bufferChunkSize = 1024;
-
 // std::ostream wrapper around Python's stderr stream
 struct PyErrStream : std::ostream, std::streambuf {
   static thread_local std::string buffer;
 
   PyErrStream() : std::ostream(this) {
-    buffer.reserve(bufferChunkSize);
     // All done!
   }
 
@@ -49,9 +46,6 @@ struct PyErrStream : std::ostream, std::streambuf {
       PySys_WriteStderr("%s\n", buffer.c_str());
       buffer.clear();
     } else {
-      if (buffer.size() == buffer.capacity()) {
-        buffer.reserve(buffer.capacity() + bufferChunkSize);
-      }
       buffer += c;
     }
   }
@@ -79,7 +73,6 @@ struct PyLogStream : std::ostream, std::streambuf {
     if (PyErr_Occurred()) {
       PyErr_Print();
     }
-    buffer.reserve(bufferChunkSize);
   }
 
   ~PyLogStream() override {
@@ -105,9 +98,6 @@ struct PyLogStream : std::ostream, std::streambuf {
       Py_XDECREF(result);
       buffer.clear();
     } else {
-      if (buffer.size() == buffer.capacity()) {
-        buffer.reserve(buffer.capacity() + bufferChunkSize);
-      }
       buffer += c;
     }
   }

--- a/Code/RDBoost/nbWrap/RDBase.cpp
+++ b/Code/RDBoost/nbWrap/RDBase.cpp
@@ -7,12 +7,14 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
+#include <array>
+#include <cstdlib>
 #include <fstream>
 #include <RDBoost/Wrap_nb.h>
+#include <RDBoost/python_capsule_nb.h>
 #include <RDBoost/python_streambuf_nb.h>
 #include <RDGeneral/versions.h>
 #include <RDGeneral/Invariant.h>
-#include <cstdlib>
 
 #include <nanobind/nanobind.h>
 #include <nanobind/operators.h>
@@ -25,11 +27,14 @@ namespace nb = nanobind;
 using namespace nb::literals;
 namespace logging = boost::logging;
 
+static constexpr unsigned bufferChunkSize = 1024;
+
 // std::ostream wrapper around Python's stderr stream
 struct PyErrStream : std::ostream, std::streambuf {
   static thread_local std::string buffer;
 
   PyErrStream() : std::ostream(this) {
+    buffer.reserve(bufferChunkSize);
     // All done!
   }
 
@@ -44,6 +49,9 @@ struct PyErrStream : std::ostream, std::streambuf {
       PySys_WriteStderr("%s\n", buffer.c_str());
       buffer.clear();
     } else {
+      if (buffer.size() == buffer.capacity()) {
+        buffer.reserve(buffer.capacity() + bufferChunkSize);
+      }
       buffer += c;
     }
   }
@@ -54,7 +62,7 @@ struct PyLogStream : std::ostream, std::streambuf {
   static thread_local std::string buffer;
   PyObject *logfn = nullptr;
 
-  PyLogStream(std::string level) : std::ostream(this) {
+  PyLogStream(const std::string &level) : std::ostream(this) {
     PyObject *module = PyImport_ImportModule("logging");
     PyObject *logger = nullptr;
 
@@ -71,16 +79,14 @@ struct PyLogStream : std::ostream, std::streambuf {
     if (PyErr_Occurred()) {
       PyErr_Print();
     }
+    buffer.reserve(bufferChunkSize);
   }
 
   ~PyLogStream() override {
-#if PY_VERSION_HEX < 0x30d0000
-    if (!_Py_IsFinalizing()) {
-#else
-    if (!Py_IsFinalizing()) {
-#endif
-      Py_XDECREF(logfn);
+    if (!nb::is_alive()) {
+      return;
     }
+    Py_XDECREF(logfn);
   }
 
   int overflow(int c) override {
@@ -99,6 +105,9 @@ struct PyLogStream : std::ostream, std::streambuf {
       Py_XDECREF(result);
       buffer.clear();
     } else {
+      if (buffer.size() == buffer.capacity()) {
+        buffer.reserve(buffer.capacity() + bufferChunkSize);
+      }
       buffer += c;
     }
   }
@@ -109,15 +118,61 @@ thread_local std::string PyErrStream::buffer;
 thread_local std::string PyLogStream::buffer;
 
 void LogToPythonLogger() {
-  static PyLogStream debug("debug");
-  static PyLogStream info("info");
-  static PyLogStream warning("warning");
-  static PyLogStream error("error");
+  using logger_array_t = std::array<std::shared_ptr<logging::rdLogger>, 4>;
 
-  rdDebugLog = std::make_shared<logging::rdLogger>(&debug);
-  rdInfoLog = std::make_shared<logging::rdLogger>(&info);
-  rdWarningLog = std::make_shared<logging::rdLogger>(&warning);
-  rdErrorLog = std::make_shared<logging::rdLogger>(&error);
+  constexpr const char *rdkLoggerCapsule = "__rdkit_loggers__";
+
+  auto capsuleData = getCapsulePtr(rdkLoggerCapsule);
+  if (capsuleData) {
+    // We already created the loggers, so just reenable them
+    auto loggers = static_cast<logger_array_t *>(capsuleData);
+
+    rdDebugLog = (*loggers)[0];
+    rdInfoLog = (*loggers)[1];
+    rdWarningLog = (*loggers)[2];
+    rdErrorLog = (*loggers)[3];
+
+  } else {
+    // Create the loggers and store them in a capsule that will
+    // destroy them when Python is shutting down, and also allows
+    // us to retrieve them later if we need to reenable them.
+
+    auto makeLogger = [](const char *level) {
+      return std::make_shared<logging::rdLogger>(new PyLogStream(level), true);
+    };
+
+    auto cleanUpFn = [](void *ptr) noexcept {
+      // Reset log endpoints to stdout/stderr before destroying
+      // the current loggers
+      RDLog::InitLogs();
+
+      auto loggers = static_cast<logger_array_t *>(ptr);
+      if (!loggers) {
+        return;
+      }
+
+      // By this point, this should be the only instance
+      // of the loggers shared_ptrs, but reset them to make
+      // sure the streams are destroyed.
+      for (auto logger : *loggers) {
+        logger.reset();
+      }
+
+      delete loggers;
+    };
+
+    rdDebugLog = makeLogger("debug");
+    rdInfoLog = makeLogger("info");
+    rdWarningLog = makeLogger("warning");
+    rdErrorLog = makeLogger("error");
+
+    auto logStreamV =
+        new logger_array_t{rdDebugLog, rdInfoLog, rdWarningLog, rdErrorLog};
+
+    // Store the loggers in a capsule so we can retrieve them later
+    nb::capsule loggerCapsule(logStreamV, cleanUpFn);
+    installCapsule(loggerCapsule, rdkLoggerCapsule);
+  }
 }
 
 void LogToPythonStderr() {
@@ -232,113 +287,12 @@ struct PyCaptureErrorLog : boost::noncopyable {
 namespace {
 
 void seedRNG(unsigned int seed) { std::srand(seed); }
-#if 0
-/// Simple Boost.Python custom converter from pathlib.Path to std::string
-template <typename T = std::string>
-struct path_converter {
-  path_converter() {
-    python::converter::registry::push_back(&path_converter::convertible,
-                                           &path_converter::construct,
-                                           boost::python::type_id<T>());
-  }
-
-  /// Check PyObject is a pathlib.Path
-  static void *convertible(PyObject *object) {
-    // paranoia
-    if (object == nullptr) {
-      return nullptr;
-    }
-    python::object boost_object(python::handle<>(python::borrowed(object)));
-
-    std::string object_classname = boost::python::extract<std::string>(
-        boost_object.attr("__class__").attr("__name__"));
-    // pathlib.Path is always specialized to the below derived classes
-    if (object_classname == "WindowsPath" || object_classname == "PosixPath") {
-      return object;
-    }
-
-    return nullptr;
-  }
-
-  /// Construct a std::string from pathlib.Path using its own __str__ attribute
-  static void construct(
-      PyObject *object,
-      boost::python::converter::rvalue_from_python_stage1_data *data) {
-    void *storage =
-        ((boost::python::converter::rvalue_from_python_storage<T> *)data)
-            ->storage.bytes;
-    python::object boost_object{python::handle<>{python::borrowed(object)}};
-    new (storage)
-        T{boost::python::extract<std::string>{boost_object.attr("__str__")()}};
-    data->convertible = storage;
-  }
-};
-
-/// Convert a Python str to a std::string_view
-template <typename T = std::string_view>
-struct string_view_from_python_converter {
-  string_view_from_python_converter() {
-    python::converter::registry::push_back(
-        &string_view_from_python_converter::convertible,
-        &string_view_from_python_converter::construct, python::type_id<T>());
-  }
-
-  /// Check PyObject is a str
-  static void *convertible(PyObject *object) {
-    if (object != nullptr && PyUnicode_Check(object)) {
-      return object;
-    }
-    return nullptr;
-  }
-
-  /// Construct a std::string_view from the internal string of the PyObject.
-  /// This shouldn´t fail, as we block the Python thread until the C++ code
-  /// returns, so the PyObject and the internal string should remain valid.
-  static void construct(
-      PyObject *object,
-      python::converter::rvalue_from_python_stage1_data *data) {
-    const char *tmp = PyUnicode_AsUTF8(object);
-
-    void *storage = ((python::converter::rvalue_from_python_storage<T> *)data)
-                        ->storage.bytes;
-    new (storage) T{tmp};
-    data->convertible = storage;
-  }
-};
-
-struct string_view_to_python_converter {
-  static PyObject *convert(const std::string_view &s) {
-    return python::incref(python::str(s.data(), s.size()).ptr());
-  }
-};
-#endif
 
 }  // namespace
 
 NB_MODULE(rdBase, m) {
   m.doc() = "Module containing basic definitions for wrapped C++ code";
   RDLog::InitLogs();
-  // RegisterVectorConverter<int>();
-  // RegisterVectorConverter<unsigned>();
-  // RegisterVectorConverter<size_t>("UnsignedLong_Vect");
-  // RegisterVectorConverter<boost::uint64_t>("VectSizeT");
-
-  // RegisterVectorConverter<double>();
-  // RegisterVectorConverter<std::string>(1);
-  // RegisterVectorConverter<std::vector<int>>();
-  // RegisterVectorConverter<std::vector<unsigned>>();
-  // RegisterVectorConverter<std::vector<double>>();
-  // RegisterVectorConverter<std::vector<std::string>>("VectorOfStringVectors");
-
-  // RegisterVectorConverter<std::pair<int, int>>("MatchTypeVect");
-
-  // path_converter();
-  // string_view_from_python_converter();
-
-  // RegisterListConverter<int>();
-  // RegisterListConverter<std::vector<int>>();
-  // RegisterListConverter<std::vector<unsigned int>>();
-
   nb::exception<IndexErrorException>(m, "IndexErrorException",
                                      PyExc_IndexError);
   nb::exception<ValueErrorException>(m, "ValueErrorException",
@@ -361,12 +315,6 @@ NB_MODULE(rdBase, m) {
         }
       });
 #endif
-
-  // boost::python::to_python_converter<std::string_view,
-  //                                    string_view_to_python_converter>();
-
-  // python::def("_version", _version,
-  //             "Deprecated, use the constant rdkitVersion instead");
 
   m.attr("rdkitVersion") = RDKit::rdkitVersion;
   m.attr("boostVersion") = RDKit::boostVersion;

--- a/Code/RDBoost/python_capsule_nb.h
+++ b/Code/RDBoost/python_capsule_nb.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <Python.h>
+
+#include <nanobind/nanobind.h>
+
+namespace nb = nanobind;
+
+nb::dict getBuiltinsDict() {
+  // PyEval_GetBuiltins only gets the builtins for the current thread,
+// which may not be the main thread.
+#if defined(PYPY_VERSION)
+  PyObject *dict = PyEval_GetBuiltins();
+#else
+  PyObject *dict = PyInterpreterState_GetDict(PyInterpreterState_Get());
+#endif
+  if (!dict) {
+    throw std::runtime_error("Failed to get Python builtins dictionary");
+  }
+
+  return nb::borrow<nb::dict>(dict);
+}
+
+void installCapsule(nb::capsule capsule, const char *name) {
+  nb::dict builtins = getBuiltinsDict();
+  builtins[name] = capsule;
+}
+
+void *getCapsulePtr(const char *name) {
+  nb::dict builtins = getBuiltinsDict();
+  if (!builtins.contains(name)) {
+    return nullptr;
+  }
+
+  auto capsule = nb::borrow<nb::capsule>(builtins[name]);
+  if (!capsule) {
+    throw std::runtime_error(std::string("Capsule ") + name +
+                             " exists, but we could not retrieve it.");
+  }
+  return capsule.data();
+}

--- a/Code/RDBoost/python_capsule_nb.h
+++ b/Code/RDBoost/python_capsule_nb.h
@@ -6,7 +6,7 @@
 
 namespace nb = nanobind;
 
-nb::dict getBuiltinsDict() {
+inline nb::dict getBuiltinsDict() {
   // PyEval_GetBuiltins only gets the builtins for the current thread,
 // which may not be the main thread.
 #if defined(PYPY_VERSION)
@@ -21,12 +21,12 @@ nb::dict getBuiltinsDict() {
   return nb::borrow<nb::dict>(dict);
 }
 
-void installCapsule(nb::capsule capsule, const char *name) {
+inline void installCapsule(nb::capsule capsule, const char *name) {
   nb::dict builtins = getBuiltinsDict();
   builtins[name] = capsule;
 }
 
-void *getCapsulePtr(const char *name) {
+inline void *getCapsulePtr(const char *name) {
   nb::dict builtins = getBuiltinsDict();
   if (!builtins.contains(name)) {
     return nullptr;

--- a/Code/RDBoost/python_capsule_nb.h
+++ b/Code/RDBoost/python_capsule_nb.h
@@ -1,3 +1,16 @@
+//
+// Copyright (C)  2026 Greg Landrum and other RDKit contributors
+//
+//  @@ All Rights Reserved @@
+//  This file is part of the RDKit.
+//  The contents are covered by the terms of the BSD license
+//  which is included in the file license.txt, found at the root
+//  of the RDKit source tree.
+//
+//  The idea of inserting a capsule into the builtins dictionary
+//  was taken from nanobind, as well as the mechanism to capture
+//  the builtins dict object.
+//
 #pragma once
 
 #include <Python.h>
@@ -7,7 +20,7 @@
 namespace nb = nanobind;
 
 inline nb::dict getBuiltinsDict() {
-  // PyEval_GetBuiltins only gets the builtins for the current thread,
+// PyEval_GetBuiltins only gets the builtins for the current thread,
 // which may not be the main thread.
 #if defined(PYPY_VERSION)
   PyObject *dict = PyEval_GetBuiltins();

--- a/Code/RDGeneral/RDLog.h
+++ b/Code/RDGeneral/RDLog.h
@@ -12,7 +12,6 @@
 #ifndef RDLOG_H_29JUNE2005
 #define RDLOG_H_29JUNE2005
 
-#if 1
 #include "BoostStartInclude.h"
 #include <boost/iostreams/tee.hpp>
 #include <boost/iostreams/stream.hpp>
@@ -121,16 +120,6 @@ RDKIT_RDGENERAL_EXPORT extern RDLogger rdErrorLog;
 RDKIT_RDGENERAL_EXPORT extern RDLogger rdWarningLog;
 RDKIT_RDGENERAL_EXPORT extern RDLogger rdStatusLog;
 
-#else
-#define BOOST_LOG_NO_LIB
-#include <boost/log/log.hpp>
-BOOST_DECLARE_LOG(rdAppLog)
-BOOST_DECLARE_LOG(rdDebugLog)
-BOOST_DECLARE_LOG(rdInfoLog)
-BOOST_DECLARE_LOG(rdErrorLog)
-BOOST_DECLARE_LOG(rdWarningLog)
-BOOST_DECLARE_LOG(rdStatusLog)
-#endif
 namespace RDLog {
 RDKIT_RDGENERAL_EXPORT void InitLogs();
 


### PR DESCRIPTION
This implements a capsule-based mechanism that forces the `LogToPythonLogger` loggers to clean up when Python shuts down.

The loggers are currently declared as `static PyLogStream` (or `static std::shared_ptr<logging::rdLogger>`) and as I already mentioned in https://github.com/rdkit/rdkit/pull/9529, the static objects are destroyed after Python has shut down, so any Python objects that are still alive at that point will be leaked. This is annoying because leaked Python objects are reported as memory leaked by the Python process, without an indication of where the leak happened. This makes investigating these leaks quite tiresome, because you have to guess where the leak is happening and what is leaking, so we want to get rid of as many leaks as we can.

Infrastructure for the capsules mechanism is implemented in a separate file so that we can leverage it in other files.

Finally, this also cleans up some unused code, improves the behavior of the `PyErrStream` and `PyLogStream'  by having them allocate memory in chunks instead of having them grow character by character, and 

