### PR TITLE
nanobind: allow boost and std shared_ptr to coexist in wrapper files

### DIFF
--- a/Code/GraphMol/SubstructLibrary/nbWrap/SubstructLibraryWrap.cpp
+++ b/Code/GraphMol/SubstructLibrary/nbWrap/SubstructLibraryWrap.cpp
@@ -584,47 +584,35 @@ void wrap_substructlibrary(nb::module_ &m) {
       }))
       .def(nb::new_([](std::string pkl) { return new SubstructLibrary(pkl); }))
       .def(nb::new_([](nb::handle mols_h) {
-             MolHolderBase *mols = nb::cast<MolHolderBase *>(mols_h);
              return new SubstructLibrary(
-                 nb::detail::shared_from_python<MolHolderBase>(mols, mols_h));
+                 nb::cast<boost::shared_ptr<MolHolderBase>>(mols_h));
            }),
            "molecules"_a)
       .def(nb::new_([](nb::handle mols_h, nb::handle second) {
              // The second arg can be fingerprints (FPHolderBase) or keys
              // (KeyHolderBase) or None.
-             MolHolderBase *mols = nb::cast<MolHolderBase *>(mols_h);
-             boost::shared_ptr<MolHolderBase> molPtr =
-                 nb::detail::shared_from_python<MolHolderBase>(mols, mols_h);
+             auto molPtr = nb::cast<boost::shared_ptr<MolHolderBase>>(mols_h);
              if (second.is_none()) {
                return new SubstructLibrary(molPtr);
              } else if (nb::isinstance<FPHolderBase>(second)) {
-               FPHolderBase *fps = nb::cast<FPHolderBase *>(second);
-               return new SubstructLibrary(
-                   molPtr,
-                   nb::detail::shared_from_python<FPHolderBase>(fps, second));
+               auto fps = nb::cast<boost::shared_ptr<FPHolderBase>>(second);
+               return new SubstructLibrary(molPtr, fps);
              } else {
-               KeyHolderBase *keys = nb::cast<KeyHolderBase *>(second);
-               return new SubstructLibrary(
-                   molPtr,
-                   nb::detail::shared_from_python<KeyHolderBase>(keys, second));
+               auto keys = nb::cast<boost::shared_ptr<KeyHolderBase>>(second);
+               return new SubstructLibrary(molPtr, keys);
              }
            }),
            "molecules"_a, "fingerprints_or_keys"_a.none())
       .def(nb::new_([](nb::handle mols_h, nb::handle fps_h, nb::handle keys_h) {
-             MolHolderBase *mols = nb::cast<MolHolderBase *>(mols_h);
-             boost::shared_ptr<MolHolderBase> molPtr =
-                 nb::detail::shared_from_python<MolHolderBase>(mols, mols_h);
+             auto molPtr = nb::cast<boost::shared_ptr<MolHolderBase>>(mols_h);
+
              boost::shared_ptr<FPHolderBase> fpHolder;
              if (!fps_h.is_none()) {
-               FPHolderBase *fps = nb::cast<FPHolderBase *>(fps_h);
-               fpHolder =
-                   nb::detail::shared_from_python<FPHolderBase>(fps, fps_h);
+               fpHolder = nb::cast<boost::shared_ptr<FPHolderBase>>(fps_h);
              }
              boost::shared_ptr<KeyHolderBase> keyHolder;
              if (!keys_h.is_none()) {
-               KeyHolderBase *keys = nb::cast<KeyHolderBase *>(keys_h);
-               keyHolder =
-                   nb::detail::shared_from_python<KeyHolderBase>(keys, keys_h);
+               keyHolder = nb::cast<boost::shared_ptr<KeyHolderBase>>(keys_h);
              }
              return new SubstructLibrary(molPtr, fpHolder, keyHolder);
            }),

--- a/Code/RDBoost/boost_shared_ptr.h
+++ b/Code/RDBoost/boost_shared_ptr.h
@@ -18,7 +18,7 @@ NAMESPACE_BEGIN(NB_NAMESPACE)
 NAMESPACE_BEGIN(detail)
 
 // shared_ptr deleter that reduces the reference count of a Python object
-struct py_deleter {
+struct boost_py_deleter {
   void operator()(void *) noexcept {
     // Don't run the deleter if the interpreter has been shut down
     if (!is_alive()) return;
@@ -44,16 +44,16 @@ struct py_deleter {
  * single shared_ptr type_caster, which would enlarge the binding size)
  */
 template <typename T>
-inline NB_NOINLINE boost::shared_ptr<T> shared_from_python(T *ptr,
-                                                           handle h) noexcept {
+inline NB_NOINLINE boost::shared_ptr<T> boost_shared_from_python(
+    T *ptr, handle h) noexcept {
   if (ptr)
-    return boost::shared_ptr<T>(ptr, py_deleter{h.inc_ref().ptr()});
+    return boost::shared_ptr<T>(ptr, boost_py_deleter{h.inc_ref().ptr()});
   else
     return boost::shared_ptr<T>(nullptr);
 }
 
-inline NB_NOINLINE void shared_from_cpp(boost::shared_ptr<void> &&ptr,
-                                        PyObject *o) noexcept {
+inline NB_NOINLINE void boost_shared_from_cpp(boost::shared_ptr<void> &&ptr,
+                                              PyObject *o) noexcept {
   keep_alive(o, new boost::shared_ptr<void>(std::move(ptr)),
              [](void *p) noexcept { delete (boost::shared_ptr<void> *)p; });
 }
@@ -85,13 +85,13 @@ struct type_caster<boost::shared_ptr<T>> {
           return true;
         }
       }
-      // Otherwise create a new one. Use shared_from_python<T>(...)
+      // Otherwise create a new one. Use boost_shared_from_python<T>(...)
       // so that future calls to ptr->shared_from_this() can share
       // ownership with it.
-      value = shared_from_python(ptr, src);
+      value = boost_shared_from_python(ptr, src);
     } else {
       value = boost::static_pointer_cast<T>(
-          shared_from_python(static_cast<void *>(ptr), src));
+          boost_shared_from_python(static_cast<void *>(ptr), src));
     }
     return true;
   }
@@ -125,7 +125,7 @@ struct type_caster<boost::shared_ptr<T>> {
             boost::const_pointer_cast<Td>(value));
       else
         pp = boost::static_pointer_cast<void>(value);
-      shared_from_cpp(std::move(pp), result.ptr());
+      boost_shared_from_cpp(std::move(pp), result.ptr());
     }
 
     return result;


### PR DESCRIPTION
The implementation of the caster to/from `boost::shared_ptr` uses the same function names as the ones in `nanobind/stl/shared_ptr.h`, which causes both headers to clash if they are included in the same file.

This PR renames the functions to cast `boost::shared_ptr`s to prevent the clashing.

The `nb::detail::shared_from_python()` function was in use in `Code/GraphMol/SubstructLibrary/nbWrap/SubstructLibraryWrap.cpp`, but instead of just updating the name of the function I changed the code to use `nb::cast` to use the caster mechanism instead of using internal details of nanobind.