### PR TITLE
docs: fix typo apparant -> apparent

### DIFF
--- a/Docs/Book/Cookbook.rst
+++ b/Docs/Book/Cookbook.rst
@@ -2551,7 +2551,7 @@ To use the EmbedParameter for conformer generation:
 .. testcode::
 
    params.useRandomCoords = True
-   # Note this is only an illustrative example, hydrogens are not added before conformer generation to keep the indices apparant 
+   # Note this is only an illustrative example, hydrogens are not added before conformer generation to keep the indices apparent 
    AllChem.EmbedMultipleConfs(mol, numConfs = 3 , params = params)
 
 Both of these setters can be used to help sampling all kinds of molecules as the users see fit. Nevertheless, to facilitate using them in conformer generation of macrocycles, we devised the python package github.com/rinikerlab/cpeptools to provide chemcially intuitive bound matrices and CPCIs for macrocycles. Example usage cases are shown in the README.


### PR DESCRIPTION
Corrects a single misspelling of `apparant` in `Docs/Book/Cookbook.rst`.

Documentation only, no behaviour change.