### PR TITLE
Add a colourScheme option to the MolDrawOptions JSON parser

### DIFF
--- a/Code/GraphMol/MolDraw2D/MolDrawOptionsJSONParsers.cpp
+++ b/Code/GraphMol/MolDraw2D/MolDrawOptionsJSONParsers.cpp
@@ -124,6 +124,23 @@ void get_legend_position_option(const boost::property_tree::ptree &pt,
   }
 }
 
+void get_colour_scheme_option(const boost::property_tree::ptree &pt,
+                              const char *pnm, MolDrawOptions &opts) {
+  PRECONDITION(pnm && strlen(pnm), "bad property name");
+  if (pt.find(pnm) == pt.not_found()) {
+    return;
+  }
+  const auto &node = pt.get_child(pnm);
+  auto schemeName = node.get_value<std::string>();
+  boost::algorithm::to_lower(schemeName);
+  if (schemeName == "dark" || schemeName == "darkmode") {
+    setDarkMode(opts);
+  } else if (schemeName == "monochrome") {
+    setMonochromeMode(opts, DrawColour{0.0, 0.0, 0.0, 1.0},
+                      DrawColour{1.0, 1.0, 1.0, 1.0});
+  }
+}
+
 void updateMolDrawOptionsFromJSON(MolDrawOptions &opts,
                                   const std::string &json) {
   if (json.empty()) {
@@ -193,6 +210,10 @@ void updateMolDrawOptionsFromJSON(MolDrawOptions &opts,
   PT_OPT_GET(useComplexQueryAtomSymbols);
   PT_OPT_GET(bracketsAroundAtomLists);
   PT_OPT_GET(standardColoursForHighlightedAtoms);
+
+  // this sets a whole family of colours at once, so it has to be applied
+  // before the individual colour options, which are allowed to override it
+  get_colour_scheme_option(pt, "colourScheme", opts);
 
   get_colour_option(pt, "highlightColour", opts.highlightColour);
   get_colour_option(pt, "backgroundColour", opts.backgroundColour);

--- a/Code/GraphMol/MolDraw2D/catch_tests.cpp
+++ b/Code/GraphMol/MolDraw2D/catch_tests.cpp
@@ -11676,3 +11676,93 @@ TEST_CASE("Configurable Stereo Labels") {
     CHECK(under_count == 0);
   }
 }
+
+TEST_CASE("colourScheme option from JSON", "[drawing]") {
+  auto m1 = "c1ccccc1CO"_smiles;
+  REQUIRE(m1);
+  SECTION("dark sets the whole colour family, not just the palette") {
+    MolDrawOptions defaults;
+    MolDrawOptions reference;
+    setDarkMode(reference);
+
+    MolDrawOptions opts;
+    MolDraw2DUtils::updateMolDrawOptionsFromJSON(
+        opts, R"({"colourScheme": "dark"})");
+    CHECK(opts.backgroundColour == reference.backgroundColour);
+    CHECK(opts.backgroundColour != defaults.backgroundColour);
+    CHECK(opts.legendColour == reference.legendColour);
+    CHECK(opts.symbolColour == reference.symbolColour);
+    CHECK(opts.annotationColour == reference.annotationColour);
+    CHECK(opts.atomNoteColour == reference.atomNoteColour);
+    CHECK(opts.variableAttachmentColour == reference.variableAttachmentColour);
+    CHECK(opts.atomColourPalette == reference.atomColourPalette);
+
+    MolDraw2DSVG drawer(250, 200, -1, -1, NO_FREETYPE);
+    drawer.drawOptions() = opts;
+    MolDraw2DUtils::prepareAndDrawMolecule(drawer, *m1);
+    drawer.finishDrawing();
+    auto text = drawer.getDrawingText();
+    std::ofstream outs("testColourSchemeDark.svg");
+    outs << text;
+    outs.close();
+    // the background rect is drawn with the background colour
+    CHECK(text.find("fill:#000000") != std::string::npos);
+  }
+  SECTION("scheme name is case-insensitive and darkmode is an alias") {
+    MolDrawOptions reference;
+    setDarkMode(reference);
+    for (const auto *json : {R"({"colourScheme": "Dark"})",
+                             R"({"colourScheme": "DARKMODE"})"}) {
+      MolDrawOptions opts;
+      MolDraw2DUtils::updateMolDrawOptionsFromJSON(opts, json);
+      CHECK(opts.backgroundColour == reference.backgroundColour);
+      CHECK(opts.atomColourPalette == reference.atomColourPalette);
+    }
+  }
+  SECTION("individual colour options override the scheme") {
+    const DrawColour blue{0.0, 0.0, 1.0, 1.0};
+    MolDrawOptions reference;
+    setDarkMode(reference);
+
+    MolDrawOptions opts;
+    MolDraw2DUtils::updateMolDrawOptionsFromJSON(
+        opts,
+        R"({"colourScheme": "dark", "backgroundColour": [0, 0, 1, 1]})");
+    CHECK(opts.backgroundColour == blue);
+    // everything else still comes from the scheme
+    CHECK(opts.legendColour == reference.legendColour);
+    CHECK(opts.atomColourPalette == reference.atomColourPalette);
+  }
+  SECTION("an explicit palette overrides the one set by the scheme") {
+    ColourPalette bwPalette;
+    assignBWPalette(bwPalette);
+
+    MolDrawOptions opts;
+    MolDraw2DUtils::updateMolDrawOptionsFromJSON(
+        opts, R"({"colourScheme": "dark", "atomColourPalette": "bw"})");
+    CHECK(opts.atomColourPalette == bwPalette);
+    // but the scheme still supplied the background
+    MolDrawOptions reference;
+    setDarkMode(reference);
+    CHECK(opts.backgroundColour == reference.backgroundColour);
+  }
+  SECTION("monochrome") {
+    MolDrawOptions opts;
+    MolDraw2DUtils::updateMolDrawOptionsFromJSON(
+        opts, R"({"colourScheme": "monochrome"})");
+    const DrawColour black{0.0, 0.0, 0.0, 1.0};
+    const DrawColour white{1.0, 1.0, 1.0, 1.0};
+    CHECK(opts.backgroundColour == white);
+    CHECK(opts.symbolColour == black);
+    CHECK(opts.atomColourPalette.size() == 1);
+    CHECK(opts.atomColourPalette.at(-1) == black);
+  }
+  SECTION("an unknown scheme name is ignored") {
+    MolDrawOptions defaults;
+    MolDrawOptions opts;
+    MolDraw2DUtils::updateMolDrawOptionsFromJSON(
+        opts, R"({"colourScheme": "chartreuse"})");
+    CHECK(opts.backgroundColour == defaults.backgroundColour);
+    CHECK(opts.atomColourPalette == defaults.atomColourPalette);
+  }
+}


### PR DESCRIPTION
#### Reference Issue
<!-- none -->

#### What does this implement/fix? Explain your changes.

This adds a `colourScheme` key to the JSON accepted by
`MolDraw2DUtils::updateMolDrawOptionsFromJSON()`:

```json
{"colourScheme": "dark"}
{"colourScheme": "monochrome"}
```

`"dark"` (alias `"darkmode"`) calls `setDarkMode()` and `"monochrome"` calls
`setMonochromeMode()` with black on white. The name is matched
case-insensitively and an unrecognised name is ignored, which is consistent
with how the parser already treats the other enum-like options
(`legendPosition`, `multiColourHighlightStyle`).

**Motivation.** The parser could already select a preset palette through
`atomColourPalette` (`"default"`, `"avalon"`, `"cdk"`, `"darkmode"`, `"bw"`),
but a palette is only part of a dark theme. `setDarkMode()` also sets
`backgroundColour`, `legendColour`, `symbolColour`, `annotationColour`,
`atomNoteColour` and `variableAttachmentColour`. Reproducing that from JSON
meant writing seven keys and hard-coding the colour values, which then drift if
the dark palette is ever adjusted:

```json
{"atomColourPalette": "darkmode", "backgroundColour": [0, 0, 0, 1],
 "atomNoteColour": [0.9, 0.9, 0.9, 1], "annotationColour": [0.9, 0.9, 0.9, 1],
 "legendColour": [0.9, 0.9, 0.9, 1], "symbolColour": [0.9, 0.9, 0.9, 1],
 "variableAttachmentColour": [0.3, 0.3, 0.3, 1]}
```

Monochrome mode could not be reproduced from JSON at all:
`setMonochromeMode()` clears the palette and then sets entry `-1`, whereas
`get_colour_palette_option()` can only add or overwrite individual entries.

**Ordering.** The scheme is applied *before* the individual colour options, so
a scheme can still be adjusted key by key:

```json
{"colourScheme": "dark", "backgroundColour": [0.05, 0.07, 0.18, 1]}
{"colourScheme": "dark", "atomColourPalette": "bw"}
```

**Reach.** Because this sits in the shared JSON parser, it reaches the Python
wrapper (`MolDraw2DUtils.UpdateDrawerParamsFromJSON`), the CFFI library and
MinimalLib with no binding changes. In MinimalLib the details JSON is passed
straight through `DrawerFromDetails::updateDrawerParamsFromJSON()`, so
`get_svg_with_highlights()` and `draw_to_canvas_with_highlights()` pick it up
as-is:

```js
mol.get_svg_with_highlights(JSON.stringify({width: 300, height: 250,
                                            colourScheme: "dark"}))
```

**Tests.** A new `TEST_CASE("colourScheme option from JSON")` in
`Code/GraphMol/MolDraw2D/catch_tests.cpp` covers the full colour family set by
the scheme, the rendered SVG background, case-insensitivity and the `darkmode`
alias, per-key overrides of both a colour and the palette, monochrome, and that
an unknown scheme name is a no-op.

Local results:

| | |
|---|---|
| new test case | 30 assertions passed |
| `moldraw2DTestCatch` regression | 128 cases / 2487 assertions passed |

Built with g++ 13.3, boost 1.83, `CMAKE_BUILD_TYPE=Release`.

#### Any other comments?

Happy to add a Python-side test in `Wrap/testMolDraw2D.py` if that is wanted —
the option works there through the existing `UpdateDrawerParamsFromJSON`
binding, but this PR does not add a test for it.


#### Acknowledging the usage of AI tools

I'm a long-time and enthusiastic RDKit user, and I used Claude Code
(Anthropic's Claude) to help with this contribution. I reviewed all of the
generated code and tests myself, built the change locally, and ran the tests
whose results are reported above before opening this PR.
