### PR TITLE
Fix syntax errors in generated rdkit-stubs (Fixes #9540)

### DIFF
--- a/.azure-pipelines/linux_build.yml
+++ b/.azure-pipelines/linux_build.yml
@@ -86,6 +86,16 @@ steps:
 - bash: |
     source ${CONDA}/etc/profile.d/conda.sh
     conda activate rdkit_build
+    export RDBASE=`pwd`
+    export PYTHONPATH=${RDBASE}:${PYTHONPATH}
+    export LD_LIBRARY_PATH=${RDBASE}/lib:${LD_LIBRARY_PATH}
+    pip install pybind11_stubgen
+    python -m Scripts.gen_rdkit_stubs rdkit-stubs
+    python Scripts/gen_rdkit_stubs/test_stubs_syntax.py rdkit-stubs
+  displayName: 'Generate and validate rdkit-stubs'
+- bash: |
+    source ${CONDA}/etc/profile.d/conda.sh
+    conda activate rdkit_build
     conda install -c conda-forge --override-channels  ipython=8.12 sphinx myst-parser
     export RDBASE=`pwd`
     export PYTHONPATH=${RDBASE}:${PYTHONPATH}

--- a/.azure-pipelines/linux_build_limitexternal.yml
+++ b/.azure-pipelines/linux_build_limitexternal.yml
@@ -69,3 +69,13 @@ steps:
     testResultsFormat: 'CTest'
     testResultsFiles: 'build/Testing/*/Test.xml'
     testRunTitle: $(system.phasedisplayname) CTest Test Run
+- bash: |
+    source ${CONDA}/etc/profile.d/conda.sh
+    conda activate rdkit_build
+    export RDBASE=`pwd`
+    export PYTHONPATH=${RDBASE}:${PYTHONPATH}
+    export LD_LIBRARY_PATH=${RDBASE}/lib:${LD_LIBRARY_PATH}
+    pip install pybind11_stubgen
+    python -m Scripts.gen_rdkit_stubs rdkit-stubs
+    python Scripts/gen_rdkit_stubs/test_stubs_syntax.py rdkit-stubs
+  displayName: 'Generate and validate rdkit-stubs'

--- a/.azure-pipelines/linux_build_py312.yml
+++ b/.azure-pipelines/linux_build_py312.yml
@@ -83,6 +83,16 @@ steps:
 - bash: |
     source ${CONDA}/etc/profile.d/conda.sh
     conda activate rdkit_build
+    export RDBASE=`pwd`
+    export PYTHONPATH=${RDBASE}:${PYTHONPATH}
+    export LD_LIBRARY_PATH=${RDBASE}/lib:${LD_LIBRARY_PATH}
+    pip install pybind11_stubgen
+    python -m Scripts.gen_rdkit_stubs rdkit-stubs
+    python Scripts/gen_rdkit_stubs/test_stubs_syntax.py rdkit-stubs
+  displayName: 'Generate and validate rdkit-stubs'
+- bash: |
+    source ${CONDA}/etc/profile.d/conda.sh
+    conda activate rdkit_build
     conda install -c conda-forge --override-channels numpy=1.24 pandas=2.2
     export RDBASE=`pwd`
     export PYTHONPATH=${RDBASE}:${PYTHONPATH}

--- a/.azure-pipelines/mac_build.yml
+++ b/.azure-pipelines/mac_build.yml
@@ -90,11 +90,12 @@ steps:
     ctest -j $( $(number_of_cores) ) --output-on-failure -T Test
   displayName: Run tests
 - bash: |
+    export CONDA=/tmp/miniforge
     source ${CONDA}/etc/profile.d/conda.sh
     conda activate rdkit_build
     export RDBASE=`pwd`
     export PYTHONPATH=${RDBASE}:${PYTHONPATH}
-    export LD_LIBRARY_PATH=${RDBASE}/lib:${LD_LIBRARY_PATH}
+    export DYLD_FALLBACK_LIBRARY_PATH=${RDBASE}/lib:${RDBASE}/rdkit:${CONDA_PREFIX}/lib:${DYLD_FALLBACK_LIBRARY_PATH}
     pip install pybind11_stubgen
     python -m Scripts.gen_rdkit_stubs rdkit-stubs
     python Scripts/gen_rdkit_stubs/test_stubs_syntax.py rdkit-stubs

--- a/.azure-pipelines/mac_build.yml
+++ b/.azure-pipelines/mac_build.yml
@@ -89,6 +89,16 @@ steps:
     cd build
     ctest -j $( $(number_of_cores) ) --output-on-failure -T Test
   displayName: Run tests
+- bash: |
+    source ${CONDA}/etc/profile.d/conda.sh
+    conda activate rdkit_build
+    export RDBASE=`pwd`
+    export PYTHONPATH=${RDBASE}:${PYTHONPATH}
+    export LD_LIBRARY_PATH=${RDBASE}/lib:${LD_LIBRARY_PATH}
+    pip install pybind11_stubgen
+    python -m Scripts.gen_rdkit_stubs rdkit-stubs
+    python Scripts/gen_rdkit_stubs/test_stubs_syntax.py rdkit-stubs
+  displayName: 'Generate and validate rdkit-stubs'
 - task: PublishTestResults@2
   inputs:
     testResultsFormat: 'CTest'

--- a/.azure-pipelines/vs_build.yml
+++ b/.azure-pipelines/vs_build.yml
@@ -69,12 +69,11 @@ steps:
     cd build
     ctest -C Release -j $(number_of_cores) --output-on-failure -R shard -T Test
   displayName: Run sharded tests
-- bash: |
-    source ${CONDA}/etc/profile.d/conda.sh
-    conda activate rdkit_build
-    export RDBASE=`pwd`
-    export PYTHONPATH=${RDBASE}:${PYTHONPATH}
-    export LD_LIBRARY_PATH=${RDBASE}/lib:${LD_LIBRARY_PATH}
+- script: |
+    call activate rdkit_build
+    set RDBASE=%cd%
+    set PYTHONPATH=%RDBASE%;%PYTHONPATH%
+    set PATH=%RDBASE%\lib;%PATH%
     pip install pybind11_stubgen
     python -m Scripts.gen_rdkit_stubs rdkit-stubs
     python Scripts/gen_rdkit_stubs/test_stubs_syntax.py rdkit-stubs

--- a/.azure-pipelines/vs_build.yml
+++ b/.azure-pipelines/vs_build.yml
@@ -69,6 +69,16 @@ steps:
     cd build
     ctest -C Release -j $(number_of_cores) --output-on-failure -R shard -T Test
   displayName: Run sharded tests
+- bash: |
+    source ${CONDA}/etc/profile.d/conda.sh
+    conda activate rdkit_build
+    export RDBASE=`pwd`
+    export PYTHONPATH=${RDBASE}:${PYTHONPATH}
+    export LD_LIBRARY_PATH=${RDBASE}/lib:${LD_LIBRARY_PATH}
+    pip install pybind11_stubgen
+    python -m Scripts.gen_rdkit_stubs rdkit-stubs
+    python Scripts/gen_rdkit_stubs/test_stubs_syntax.py rdkit-stubs
+  displayName: 'Generate and validate rdkit-stubs'
 - script: |
     call activate rdkit_build
     conda install -c conda-forge --override-channels  numpy=1.26 pandas=2.2

--- a/Code/RDBoost/Wrap.h
+++ b/Code/RDBoost/Wrap.h
@@ -7,6 +7,7 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
+#include <cctype>
 #include <RDGeneral/export.h>
 #ifndef _RD_WRAP_H_
 #define _RD_WRAP_H_
@@ -103,7 +104,14 @@ void RegisterVectorConverter(const char *name, bool noproxy = false) {
 template <typename T>
 void RegisterVectorConverter(bool noproxy = false) {
   std::string name = "_vect";
-  name += typeid(T).name();
+  std::string typeName = typeid(T).name();
+  // Sanitize the type name to ensure it's a valid Python identifier
+  for (char &c : typeName) {
+    if (!std::isalnum(static_cast<unsigned char>(c)) && c != '_') {
+      c = '_';
+    }
+  }
+  name += typeName;
   RegisterVectorConverter<T>(name.c_str(), noproxy);
 }
 
@@ -118,7 +126,14 @@ void RegisterListConverter(bool noproxy = false) {
     return;
   }
   std::string name = "_list";
-  name += typeid(T).name();
+  std::string typeName = typeid(T).name();
+  // Sanitize the type name to ensure it's a valid Python identifier
+  for (char &c : typeName) {
+    if (!std::isalnum(static_cast<unsigned char>(c)) && c != '_') {
+      c = '_';
+    }
+  }
+  name += typeName;
 
   if (noproxy) {
     python::class_<std::list<T>>(name.c_str())

--- a/Scripts/gen_rdkit_stubs/__init__.py
+++ b/Scripts/gen_rdkit_stubs/__init__.py
@@ -10,6 +10,7 @@ from multiprocessing.pool import ThreadPool
 import tempfile
 import shutil
 import logging
+import ast
 
 logger = logging.getLogger(__name__)
 
@@ -90,6 +91,42 @@ def patch_stubs(tempdir, src_entry):
         if os.path.exists(patch_file):
             apply_patch(tempdir, patch_file)
 
+def validate_stubs(tempdir, src_dir):
+    """Validate and sanitize generated stubs to ensure they are valid Python syntax."""
+    for pyi in glob.glob(os.path.join(src_dir, "**/*.pyi"), recursive=True):
+        with open(pyi, "r", encoding="utf-8") as f:
+            content = f.read()
+        
+        # Python keyword 'None' used as an attribute name
+        content = re.sub(r'^(\s*)None(\s*:)', r'\1_None\2', content, flags=re.MULTILINE)
+        
+        # Iteratively fix "parameter without a default follows parameter with a default"
+        max_attempts = 20
+        for _ in range(max_attempts):
+            try:
+                ast.parse(content)
+                break  # File is valid, exit the loop!
+            except SyntaxError as e:
+                if "parameter without a default follows parameter with a default" in e.msg:
+                    lines = content.split('\n')
+                    line_idx = e.lineno - 1
+                    line = lines[line_idx]
+                    # Safely replace arguments up to the return type (->) or colon (:)
+                    new_line = re.sub(r'\(.*?\)(?=\s*(?:->|:))', '(*args, **kwargs)', line)
+                    lines[line_idx] = new_line
+                    content = '\n'.join(lines)
+                else:
+                    pyi_rel = os.path.relpath(pyi, tempdir)
+                    raise RuntimeError(
+                        f"Syntax error in generated stub {pyi_rel}:{e.lineno}: {e.msg}\n"
+                        f"Please add a fix to validate_stubs in __init__.py."
+                    )
+        else:
+            pyi_rel = os.path.relpath(pyi, tempdir)
+            raise RuntimeError(f"Failed to fix syntax errors in {pyi_rel} after {max_attempts} attempts.")
+        
+        with open(pyi, "w", encoding="utf-8") as f:
+            f.write(content)
 def copy_stubs(src_entry, outer_dirs):
     """Copy src_entry to each directory in outer_dirs.
     If src_entry is a directory it will be recursively copied.
@@ -189,6 +226,9 @@ def clear_stubs(outer_dir):
             os.remove(entry)
 
 def generate_stubs_internal(modules, outer_dirs, args):
+    if not modules:
+        logger.warning("No modules found to generate stubs for. Exiting.")
+        return
     concurrency = min(args.concurrency, len(modules))
     with tempfile.TemporaryDirectory() as tempdir:
         src_dir = os.path.join(tempdir, RDKIT_MODULE_NAME)
@@ -207,6 +247,7 @@ def generate_stubs_internal(modules, outer_dirs, args):
             logger.warning(concat_out)
         if os.path.isdir(src_dir):
             patch_stubs(tempdir, src_dir)
+            validate_stubs(tempdir, src_dir)  
             for f in os.listdir(src_dir):
                 src_entry = os.path.join(src_dir, f)
                 if os.path.exists(src_entry):

--- a/Scripts/gen_rdkit_stubs/__init__.py
+++ b/Scripts/gen_rdkit_stubs/__init__.py
@@ -225,6 +225,27 @@ def clear_stubs(outer_dir):
         else:
             os.remove(entry)
 
+def is_python_module(path, root):
+    """Check if path is an importable Python module within root.
+
+    Args:
+        path (pathlib.Path): file path to check
+        root (pathlib.Path): root directory of the package (e.g. rdkit directory)
+
+    Returns:
+        bool: True if path is a valid module name and located in a package directory tree
+    """
+    if not path.stem.isidentifier():
+        return False
+    parent = path.parent
+    while parent != root:
+        if not (parent / INIT_PY).is_file():
+            return False
+        if parent == parent.parent:
+            return False
+        parent = parent.parent
+    return True
+
 def generate_stubs_internal(modules, outer_dirs, args):
     if not modules:
         logger.warning("No modules found to generate stubs for. Exiting.")
@@ -241,13 +262,13 @@ def generate_stubs_internal(modules, outer_dirs, args):
         concat_out, concat_err = tuple(zip(*res))
         concat_out = "\n".join(out for out in concat_out if out)
         concat_err = "\n".join(err for err in concat_err if err)
-        if concat_err:
-            logger.critical(concat_err)
         if concat_out and args.verbose:
             logger.warning(concat_out)
+        if concat_err:
+            logger.critical(concat_err)
         if os.path.isdir(src_dir):
             patch_stubs(tempdir, src_dir)
-            validate_stubs(tempdir, src_dir)  
+            validate_stubs(tempdir, src_dir)
             for f in os.listdir(src_dir):
                 src_entry = os.path.join(src_dir, f)
                 if os.path.exists(src_entry):
@@ -270,6 +291,7 @@ def generate_stubs(site_packages_path, args):
     args.concurrency = args.concurrency or 1
     args.verbose = args.verbose or False
     args.keep_incorrect_staticmethods = args.keep_incorrect_staticmethods or False
+    # Phase 1: sub-packages
     modules = {str(p.parent.relative_to(site_packages_path)).replace(os.sep, ".")
                for p in sorted(site_packages_path.joinpath(RDKIT_MODULE_NAME).rglob(INIT_PY))}
     outer_dirs = []
@@ -285,12 +307,21 @@ def generate_stubs(site_packages_path, args):
     generate_stubs_internal(modules, outer_dirs, args)
     pyi_path = pathlib.Path(outer_dirs[0])
     pyi_files = {PYI_TO_PY.sub(".py", str(p.relative_to(pyi_path))) for p in pyi_path.rglob("*.pyi")}
-    modules = {str(p.relative_to(site_packages_path.joinpath(RDKIT_MODULE_NAME)))
-               for p in (
-        sorted(site_packages_path.joinpath(RDKIT_MODULE_NAME).rglob("*.pyd")) +
-        sorted(site_packages_path.joinpath(RDKIT_MODULE_NAME).rglob("*.so")) +
-        sorted(site_packages_path.joinpath(RDKIT_MODULE_NAME).rglob("*.py"))
-    ) if p.name != INIT_PY}.difference(pyi_files)
+    # Phase 2: individual modules (only importable modules; excludes examples, test data, etc.)
+    rdkit_root = site_packages_path.joinpath(RDKIT_MODULE_NAME)
+    candidates = (
+        sorted(rdkit_root.rglob("*.pyd")) +
+        sorted(rdkit_root.rglob("*.so")) +
+        sorted(rdkit_root.rglob("*.py"))
+    )
+    module_paths = [
+        p for p in candidates
+        if p.name != INIT_PY and is_python_module(p, rdkit_root)
+    ]
+    modules = {
+        str(p.relative_to(rdkit_root))
+        for p in module_paths
+    }.difference(pyi_files)
     modules = {RDKIT_MODULE_NAME + "." + os.path.splitext(p.replace(os.sep, "."))[0] for p in modules}
     generate_stubs_internal(modules, outer_dirs, args)
 

--- a/Scripts/gen_rdkit_stubs/test_stubs_syntax.py
+++ b/Scripts/gen_rdkit_stubs/test_stubs_syntax.py
@@ -1,0 +1,34 @@
+"""
+Test to ensure all generated rdkit-stubs .pyi files are syntactically valid Python.
+This prevents regressions where invalid stubs are shipped, breaking mypy for users.
+"""
+import ast
+import pathlib
+import sys
+import unittest
+
+# 1. Capture the argument BEFORE unittest touches sys.argv
+STUBS_DIR = pathlib.Path(sys.argv[1]) if len(sys.argv) > 1 else pathlib.Path("/tmp/stubs_test")
+
+# 2. Truncate sys.argv so unittest doesn't try to interpret the path as a test name
+sys.argv = [sys.argv[0]]
+
+class TestStubsSyntax(unittest.TestCase):
+    def test_all_pyi_files_parse(self):
+        self.assertTrue(STUBS_DIR.exists(), f"Stubs directory not found: {STUBS_DIR}")
+        
+        pyi_files = list(STUBS_DIR.rglob("*.pyi"))
+        self.assertGreater(len(pyi_files), 0, "No .pyi files found to test!")
+        
+        errors = []
+        for pyi_file in pyi_files:
+            try:
+                ast.parse(pyi_file.read_text(encoding="utf-8"))
+            except SyntaxError as e:
+                errors.append(f"{pyi_file.relative_to(STUBS_DIR)}:{e.lineno}: {e.msg}")
+                
+        if errors:
+            self.fail("Found syntax errors in generated stubs:\n" + "\n".join(errors))
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR fixes invalid Python syntax in the generated `.pyi` stub files, which was causing `mypy` to crash.

### Changes

- **`Code/RDBoost/Wrap.h`**: Sanitize `typeid(T).name()` by replacing non-alphanumeric characters with underscores, preventing invalid identifiers such as `_vectunsigned int` on MSVC.
- **`Scripts/gen_rdkit_stubs/__init__.py`**: Added `validate_stubs()` to run `ast.parse` on generated files and automatically fix known edge cases, such as the `None` keyword and invalid default parameter ordering.
- **`Scripts/gen_rdkit_stubs/test_stubs_syntax.py`**: Added a regression test to ensure all generated stubs are syntactically valid.

Fixes #9540