### PR TITLE
Some minor clean ups

### DIFF
--- a/Code/GraphMol/ChemReactions/CMakeLists.txt
+++ b/Code/GraphMol/ChemReactions/CMakeLists.txt
@@ -2,7 +2,7 @@ if(NOT RDK_USE_BOOST_SERIALIZATION)
     message("== Making EnumerateLibrary without boost Serialization support")
 endif()
 
-if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 5)
+if(NOT MSVC AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 5)
   if(Boost_VERSION LESS  106200)
     set_property(SOURCE Enumerate/Enumerate.cpp APPEND_STRING PROPERTY COMPILE_FLAGS " -fpermissive ")
   endif()

--- a/Code/GraphMol/ChemReactions/ReactionFingerprints.cpp
+++ b/Code/GraphMol/ChemReactions/ReactionFingerprints.cpp
@@ -30,7 +30,9 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
+#if defined(__clang__) || defined(__GNUC__)
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
 
 #include <GraphMol/RDKitBase.h>
 #include <DataStructs/ExplicitBitVect.h>

--- a/Code/GraphMol/Fingerprints/AtomPairs.cpp
+++ b/Code/GraphMol/Fingerprints/AtomPairs.cpp
@@ -7,7 +7,9 @@
 //  which is included in the file license.txt, found at the root
 //  of the RDKit source tree.
 //
+#if defined(__clang__) || defined(__GNUC__)
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
 
 #include <GraphMol/RDKitBase.h>
 #include <GraphMol/Fingerprints/AtomPairs.h>

--- a/Code/GraphMol/Wrap/MolOps.cpp
+++ b/Code/GraphMol/Wrap/MolOps.cpp
@@ -425,16 +425,6 @@ MolOps::SanitizeFlags sanitizeMol(ROMol &mol, boost::uint64_t sanitizeOps,
   return static_cast<MolOps::SanitizeFlags>(operationThatFailed);
 }
 
-RWMol *getEditable(const ROMol &mol) {
-  auto *res = new RWMol(mol, false);
-  return res;
-}
-
-ROMol *getNormal(const RWMol &mol) {
-  auto *res = static_cast<ROMol *>(new RWMol(mol));
-  return res;
-}
-
 void kekulizeMol(ROMol &mol, bool clearAromaticFlags = false,
                  bool canonical = true) {
   auto &wmol = static_cast<RWMol &>(mol);

--- a/Code/GraphMol/nbWrap/MolOps.cpp
+++ b/Code/GraphMol/nbWrap/MolOps.cpp
@@ -437,16 +437,6 @@ MolOps::SanitizeFlags sanitizeMol(ROMol &mol, boost::uint64_t sanitizeOps,
   return static_cast<MolOps::SanitizeFlags>(operationThatFailed);
 }
 
-RWMol *getEditable(const ROMol &mol) {
-  auto *res = new RWMol(mol, false);
-  return res;
-}
-
-ROMol *getNormal(const RWMol &mol) {
-  auto *res = static_cast<ROMol *>(new RWMol(mol));
-  return res;
-}
-
 void kekulizeMol(ROMol &mol, bool clearAromaticFlags = false,
                  bool canonical = true) {
   auto &wmol = static_cast<RWMol &>(mol);

--- a/Code/JavaWrappers/csharp_wrapper/GraphMolCSharp.i
+++ b/Code/JavaWrappers/csharp_wrapper/GraphMolCSharp.i
@@ -115,7 +115,7 @@
       SWIG_CSharpSetPendingException(SWIG_CSharpApplicationException, err.c_str());
       return $null;
     }
-    catch (std::exception &e) {
+    catch (std::exception &) {
       SWIG_CSharpSetPendingException(SWIG_CSharpApplicationException, "error");
       return $null;
     }


### PR DESCRIPTION
These are some minor clean ups I tried to sneak into https://github.com/rdkit/rdkit/pull/9547, now posting them separately.

Except for the functions removed in the wrapper files, which are never used, they clean up warnings that pop up on the windows builds: `-fpermissive` does not seem to be accepted by MSVC, and it also doesn't like `#pragma GCC`. The `e` variable in `GraphMolCSharp.i` generates a real wall of warnings in the `Windows_VS2022_x64_swig` build due to that code snipped being inserted in basically all exported function definitions and `e` not being used after being caught.