### PR TITLE
CI: Show the current build's ccache stats in addition to the global ones

### DIFF
--- a/.azure-pipelines/linux_build.yml
+++ b/.azure-pipelines/linux_build.yml
@@ -67,6 +67,9 @@ steps:
 - bash: |
     source ${CONDA}/etc/profile.d/conda.sh
     conda activate rdkit_build
+    echo -e "Current build stats:"
+    ccache --show-log-stats
+    echo -e "Global stats:"
     ccache -s
   displayName: "Show ccache stats"
 - bash: |

--- a/.azure-pipelines/linux_build_cartridge.yml
+++ b/.azure-pipelines/linux_build_cartridge.yml
@@ -55,6 +55,9 @@ steps:
 - bash: |
     source ${CONDA}/etc/profile.d/conda.sh
     conda activate rdkit_build
+    echo -e "Current build stats:"
+    ccache --show-log-stats
+    echo -e "Global stats:"
     ccache -s
   displayName: "Show ccache stats"
 - bash: |

--- a/.azure-pipelines/linux_build_java.yml
+++ b/.azure-pipelines/linux_build_java.yml
@@ -51,6 +51,9 @@ steps:
 - bash: |
     source ${CONDA}/etc/profile.d/conda.sh
     conda activate rdkit_build
+    echo -e "Current build stats:"
+    ccache --show-log-stats
+    echo -e "Global stats:"
     ccache -s
   displayName: "Show ccache stats"
 - bash: |

--- a/.azure-pipelines/linux_build_limitexternal.yml
+++ b/.azure-pipelines/linux_build_limitexternal.yml
@@ -59,6 +59,9 @@ steps:
 - bash: |
     source ${CONDA}/etc/profile.d/conda.sh
     conda activate rdkit_build
+    echo -e "Current build stats:"
+    ccache --show-log-stats
+    echo -e "Global stats:"
     ccache -s
   displayName: "Show ccache stats"
 - bash: |

--- a/.azure-pipelines/linux_build_nb.yml
+++ b/.azure-pipelines/linux_build_nb.yml
@@ -63,6 +63,9 @@ steps:
 - bash: |
     source ${CONDA}/etc/profile.d/conda.sh
     conda activate rdkit_build
+    echo -e "Current build stats:"
+    ccache --show-log-stats
+    echo -e "Global stats:"
     ccache -s
   displayName: "Show ccache stats"
 - bash: |

--- a/.azure-pipelines/linux_build_py312.yml
+++ b/.azure-pipelines/linux_build_py312.yml
@@ -65,6 +65,9 @@ steps:
 - bash: |
     source ${CONDA}/etc/profile.d/conda.sh
     conda activate rdkit_build
+    echo -e "Current build stats:"
+    ccache --show-log-stats
+    echo -e "Global stats:"
     ccache -s
   displayName: "Show ccache stats"
 - bash: |

--- a/.azure-pipelines/mac_build.yml
+++ b/.azure-pipelines/mac_build.yml
@@ -83,6 +83,9 @@ steps:
     export CONDA=/tmp/miniforge
     source ${CONDA}/etc/profile.d/conda.sh
     conda activate rdkit_build
+    echo -e "Current build stats:"
+    ccache --show-log-stats
+    echo -e "Global stats:"
     ccache -s
   displayName: "Show ccache stats"
 - bash: |

--- a/.azure-pipelines/mac_build_java.yml
+++ b/.azure-pipelines/mac_build_java.yml
@@ -76,6 +76,9 @@ steps:
     export CONDA=/tmp/miniforge
     source ${CONDA}/etc/profile.d/conda.sh
     conda activate rdkit_build
+    echo -e "Current build stats:"
+    ccache --show-log-stats
+    echo -e "Global stats:"
     ccache -s
   displayName: "Show ccache stats"
 - bash: |

--- a/.azure-pipelines/vs_build.yml
+++ b/.azure-pipelines/vs_build.yml
@@ -58,9 +58,9 @@ steps:
   displayName: Build
 - script: |
     call activate rdkit_build
-    echo -e "Current build stats:"
+    echo Current build stats:
     ccache --show-log-stats
-    echo -e "Global stats:"
+    echo Global stats:
     ccache -s
   displayName: "Show ccache stats"
 - script: |

--- a/.azure-pipelines/vs_build.yml
+++ b/.azure-pipelines/vs_build.yml
@@ -58,6 +58,9 @@ steps:
   displayName: Build
 - script: |
     call activate rdkit_build
+    echo -e "Current build stats:"
+    ccache --show-log-stats
+    echo -e "Global stats:"
     ccache -s
   displayName: "Show ccache stats"
 - script: |

--- a/.azure-pipelines/vs_build_dll.yml
+++ b/.azure-pipelines/vs_build_dll.yml
@@ -57,9 +57,9 @@ steps:
   displayName: Build
 - script: |
     call activate rdkit_build
-    echo -e "Current build stats:"
+    echo Current build stats:
     ccache --show-log-stats
-    echo -e "Global stats:"
+    echo Global stats:
     ccache -s
   displayName: "Show ccache stats"
 - script: |

--- a/.azure-pipelines/vs_build_dll.yml
+++ b/.azure-pipelines/vs_build_dll.yml
@@ -57,6 +57,9 @@ steps:
   displayName: Build
 - script: |
     call activate rdkit_build
+    echo -e "Current build stats:"
+    ccache --show-log-stats
+    echo -e "Global stats:"
     ccache -s
   displayName: "Show ccache stats"
 - script: |

--- a/.azure-pipelines/vs_build_swig.yml
+++ b/.azure-pipelines/vs_build_swig.yml
@@ -60,9 +60,9 @@ steps:
   displayName: Build
 - script: |
     call activate rdkit_build
-    echo -e "Current build stats:"
+    echo Current build stats:
     ccache --show-log-stats
-    echo -e "Global stats:"
+    echo Global stats:
     ccache -s
   displayName: "Show ccache stats"
 - script: |

--- a/.azure-pipelines/vs_build_swig.yml
+++ b/.azure-pipelines/vs_build_swig.yml
@@ -60,6 +60,9 @@ steps:
   displayName: Build
 - script: |
     call activate rdkit_build
+    echo -e "Current build stats:"
+    ccache --show-log-stats
+    echo -e "Global stats:"
     ccache -s
   displayName: "Show ccache stats"
 - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,6 +6,7 @@ trigger:
 variables:
   CCACHE_DIR: "$(Build.ArtifactStagingDirectory)/.ccache"
   CCACHE_BASEDIR: "$(Build.Repository.LocalPath)"
+  CCACHE_STATSLOG: "$(Build.ArtifactStagingDirectory)/ccache_current_build_stats.log"
   CCACHE_NOHASHDIR: yes
   CCACHE_NAMESPACE: "$(System.JobDisplayName)"
   CCACHE_MAXSIZE: 1G


### PR DESCRIPTION
The current caching infra prints the global ccache stats after the build.

This PR is to store the stats for the current build separately, and print both the global and current build stats after the build. This might be helpful in the future to make decisions about the caching (e.g. changing the max size of the cache dir, etc).