### PR TITLE
CIP labeler: fix Mancude calculation

### DIFF
--- a/Code/GraphMol/CIPLabeler/CIPMol.cpp
+++ b/Code/GraphMol/CIPLabeler/CIPMol.cpp
@@ -21,7 +21,7 @@ CIPMol::CIPMol(ROMol &mol) : d_mol{mol} {
   std::ranges::copy(mol.bonds(), std::back_inserter(d_bonds));
 }
 
-boost::rational<int> CIPMol::getFractionalAtomicNum(Atom *atom) const {
+const FractionalAtomicNum &CIPMol::getFractionalAtomicNum(Atom *atom) const {
   PRECONDITION(atom, "bad atom")
   if (d_atomnums.empty()) {
     const_cast<CIPMol *>(this)->d_atomnums = calcFracAtomNums(*this);

--- a/Code/GraphMol/CIPLabeler/CIPMol.h
+++ b/Code/GraphMol/CIPLabeler/CIPMol.h
@@ -71,7 +71,7 @@ class CIPMol {
 
   // Average atomic number with other atoms that are in an
   // aromatic ring with this one.
-  boost::rational<int> getFractionalAtomicNum(Atom *atom) const;
+  const FractionalAtomicNum &getFractionalAtomicNum(Atom *atom) const;
 
   unsigned getNumAtoms() const;
 
@@ -96,7 +96,7 @@ class CIPMol {
  private:
   ROMol &d_mol;
   std::vector<RDKit::Bond::BondType> d_kekulized_bonds;
-  std::vector<boost::rational<int>> d_atomnums;
+  std::vector<FractionalAtomicNum> d_atomnums;
   std::vector<RDKit::Bond* > d_bonds;
 };
 

--- a/Code/GraphMol/CIPLabeler/Digraph.cpp
+++ b/Code/GraphMol/CIPLabeler/Digraph.cpp
@@ -161,7 +161,7 @@ void Digraph::expand(Node *beg) {
       // for example >S=O
       if (dp_origin != beg || d_atropisomerMode) {
         if (atom->getFormalCharge() < 0 &&
-            d_mol.getFractionalAtomicNum(atom).denominator() > 1) {
+            d_mol.getFractionalAtomicNum(atom).isAveraged()) {
           end = beg->newBondDuplicateChild(nbrIdx, nbr);
           addEdge(beg, bond, end);
         } else {
@@ -183,7 +183,7 @@ void Digraph::expand(Node *beg) {
       addEdge(beg, bond, end);
 
       if (atom->getFormalCharge() < 0 &&
-          d_mol.getFractionalAtomicNum(atom).denominator() > 1) {
+          d_mol.getFractionalAtomicNum(atom).isAveraged()) {
         end = beg->newBondDuplicateChild(nbrIdx, nbr);
         addEdge(beg, bond, end);
       } else {

--- a/Code/GraphMol/CIPLabeler/Mancude.cpp
+++ b/Code/GraphMol/CIPLabeler/Mancude.cpp
@@ -104,24 +104,40 @@ void RelaxTypes(std::vector<Type> &types, const CIPMol &mol) {
   auto counts = std::vector<int>(mol.getNumAtoms());
   for (auto atom : mol.atoms()) {
     const auto aidx = atom->getIdx();
-    for (const auto &nbr : mol.getNeighbors(atom)) {
+    if (types[aidx] == Type::Other) {
+      continue;
+    }
+    for (const auto &bond : mol.getBonds(atom)) {
+      if (!mol.isInRing(bond)) {
+        continue;
+      }
+      const auto nbr = bond->getOtherAtom(atom);
       if (types[nbr->getIdx()] != Type::Other) {
         ++counts[aidx];
       }
     }
 
-    if (counts[aidx] == 1) {
+    if (counts[aidx] <= 1) {
       queue.push_back(atom);
     }
   }
 
-  for (const auto &atom : queue) {
+  while (!queue.empty()) {
+    const auto atom = queue.front();
+    queue.pop_front();
     const auto aidx = atom->getIdx();
     if (types[aidx] != Type::Other) {
       types[aidx] = Type::Other;
 
-      for (auto &nbr : mol.getNeighbors(atom)) {
-        auto nbridx = nbr->getIdx();
+      for (const auto &bond : mol.getBonds(atom)) {
+        if (!mol.isInRing(bond)) {
+          continue;
+        }
+        const auto nbr = bond->getOtherAtom(atom);
+        const auto nbridx = nbr->getIdx();
+        if (types[nbridx] == Type::Other) {
+          continue;
+        }
         --counts[nbridx];
         if (counts[nbridx] == 1) {
           queue.push_back(nbr);
@@ -174,9 +190,9 @@ int VisitParts(std::vector<int> &parts, const std::vector<Type> &types,
 
 }  // namespace
 
-std::vector<boost::rational<int>> calcFracAtomNums(const CIPMol &mol) {
+std::vector<FractionalAtomicNum> calcFracAtomNums(const CIPMol &mol) {
   const auto num_atoms = mol.getNumAtoms();
-  std::vector<boost::rational<int>> fractions;
+  std::vector<FractionalAtomicNum> fractions;
   fractions.reserve(num_atoms);
   for (const auto &atom : mol.atoms()) {
     fractions.emplace_back(atom->getAtomicNum(), 1);
@@ -194,8 +210,7 @@ std::vector<boost::rational<int>> calcFracAtomNums(const CIPMol &mol) {
     auto parts = std::vector<int>(num_atoms);
     int numparts = VisitParts(parts, types, mol);
 
-    auto resparts = std::vector<int>(numparts);
-    int numres = 0;
+    auto resonance_parts = std::vector<bool>(numparts + 1);
 
     if (numparts > 0) {
       for (auto i = 0u; i < num_atoms; ++i) {
@@ -206,16 +221,7 @@ std::vector<boost::rational<int>> calcFracAtomNums(const CIPMol &mol) {
 
         // Find resonant structures caused by relocation of a negative charge.
         if (types[i] == Type::Cv3D3Minus || types[i] == Type::Nv2D2Minus) {
-          int j = 0;
-          for (; j < numres; ++j) {
-            if (resparts[j] == parts[i]) {
-              break;
-            }
-          }
-          if (j >= numres) {
-            resparts[numres] = parts[i];
-            ++numres;
-          }
+          resonance_parts[parts[i]] = true;
         }
 
         int numerator = 0;
@@ -227,11 +233,11 @@ std::vector<boost::rational<int>> calcFracAtomNums(const CIPMol &mol) {
           }
         }
 
-        // boost::rational does not accept 0 as denominator.
-        if (denominator == 0) {
-          fractions[i].assign(0, 1);
-        } else {
-          fractions[i].assign(numerator, denominator);
+        // A retained type is in the ring 2-core, so this should not be zero.
+        // Keep the ordinary atomic number if malformed input violates that
+        // invariant.
+        if (denominator != 0) {
+          fractions[i] = FractionalAtomicNum(numerator, denominator);
         }
       }
     }
@@ -239,31 +245,32 @@ std::vector<boost::rational<int>> calcFracAtomNums(const CIPMol &mol) {
     // If there are any resonant structures due to negative charges,
     // recalculate the average atomic number considering relocation
     // of the charge through higher order bonds.
-    if (numres > 0) {
-      for (int j = 0; j < numres; ++j) {
-        int numerator = 0;
-        int denominator = 0;
-        int part = resparts[j];
-        for (auto i = 0u; i < num_atoms; ++i) {
-          if (parts[i] == part) {
-            // boost::rational does not accept 0 as denominator
-            if (denominator == 0) {
-              fractions[i].assign(0, 1);
-            } else {
-              fractions[i].assign(numerator, denominator);
-            }
-
-            ++denominator;
-            auto atom = mol.getAtom(i);
-            for (auto &bond : mol.getBonds(atom)) {
-              auto nbr = bond->getOtherAtom(atom);
-              int bord = mol.getBondOrder(bond);
-              if (bord > 1 && parts[nbr->getIdx()] == part) {
-                numerator += (bord - 1) * nbr->getAtomicNum();
-              }
-            }
-          }
+    auto numerators = std::vector<int>(numparts + 1);
+    auto denominators = std::vector<int>(numparts + 1);
+    for (auto i = 0u; i < num_atoms; ++i) {
+      const auto part = parts[i];
+      if (part == 0 || !resonance_parts[part]) {
+        continue;
+      }
+      ++denominators[part];
+      const auto atom = mol.getAtom(i);
+      for (const auto &bond : mol.getBonds(atom)) {
+        const auto nbr = bond->getOtherAtom(atom);
+        const auto bord = mol.getBondOrder(bond);
+        if (bord > 1 && parts[nbr->getIdx()] == part) {
+          numerators[part] += (bord - 1) * nbr->getAtomicNum();
         }
+      }
+    }
+
+    // Every atom in a negative-charge resonance component shares one final
+    // Fraction object in Java. Assigning the final value in a separate pass
+    // reproduces that behavior without accidentally storing running prefixes.
+    for (auto i = 0u; i < num_atoms; ++i) {
+      const auto part = parts[i];
+      if (part != 0 && resonance_parts[part] && denominators[part] != 0) {
+        fractions[i] =
+            FractionalAtomicNum(numerators[part], denominators[part]);
       }
     }
   }

--- a/Code/GraphMol/CIPLabeler/Mancude.cpp
+++ b/Code/GraphMol/CIPLabeler/Mancude.cpp
@@ -29,6 +29,16 @@ namespace CIPLabeler {
 
 namespace {
 
+enum class Type : uint8_t {
+  Cv4D3,       // =C(X)-
+  Nv3D2,       // =N-
+  Nv4D3Plus,   // =[N+]<
+  Nv2D2Minus,  // -[N-]-
+  Cv3D3Minus,  // -[C(X)-]-
+  Ov3D2Plus,   // -[O+]=
+  Other
+};
+
 // Initialize atom types for ring atoms, looking at connectivity,
 // bond orders, atomic number and charge.
 bool SeedTypes(std::vector<Type> &types, const CIPMol &mol) {

--- a/Code/GraphMol/CIPLabeler/Mancude.cpp
+++ b/Code/GraphMol/CIPLabeler/Mancude.cpp
@@ -213,80 +213,91 @@ std::vector<FractionalAtomicNum> calcFracAtomNums(const CIPMol &mol) {
 
   // Mark all atoms which are potentially part of a resonance system.
   auto types = std::vector<Type>(num_atoms, Type::Other);
-  if (SeedTypes(types, mol)) {
-    // Filter out atoms which cannot be resonant because
-    // of not having the proper environment.
-    RelaxTypes(types, mol);
+  if (!SeedTypes(types, mol)) {
+    // No relevant rings.
+    return fractions;
+  }
 
-    // Find resonant systems: parts stores the ids of the
-    // systems each atom is involved in.
-    auto parts = std::vector<int>(num_atoms);
-    int numparts = VisitParts(parts, types, mol);
+  // Filter out atoms which cannot be resonant because
+  // of not having the proper environment.
+  RelaxTypes(types, mol);
 
-    auto resonance_parts = std::vector<bool>(numparts + 1);
+  // Find resonant systems: parts stores the ids of the
+  // systems each atom is involved in.
+  std::vector<int> parts(num_atoms);
+  int numparts = VisitParts(parts, types, mol);
 
-    if (numparts > 0) {
-      for (auto i = 0u; i < num_atoms; ++i) {
-        if (parts[i] == 0) {
-          continue;
-        }
-        auto atom = mol.getAtom(i);
+  if (numparts <= 0) {
+    // No rings (shouldn't happen, we'd seen it before)
+    return fractions;
+  }
 
-        // Find resonant structures caused by relocation of a negative charge.
-        if (types[i] == Type::Cv3D3Minus || types[i] == Type::Nv2D2Minus) {
-          resonance_parts[parts[i]] = true;
-        }
+  // parts are 1-based, so we need to allocate one extra element.
+  // This means that resonant_parts[0] will never be used, and
+  // we can use it as a shortcut to check whether any resonant
+  // systems were found.
+  std::vector<bool> resonant_parts(numparts + 1, false);
 
-        int numerator = 0;
-        int denominator = 0;
-        for (const auto &nbr : mol.getNeighbors(atom)) {
-          if (parts[nbr->getIdx()] == parts[i]) {
-            numerator += nbr->getAtomicNum();
-            ++denominator;
-          }
-        }
+  for (auto i = 0u; i < num_atoms; ++i) {
+    if (parts[i] == 0) {
+      continue;
+    }
+    auto atom = mol.getAtom(i);
 
-        // A retained type is in the ring 2-core, so this should not be zero.
-        // Keep the ordinary atomic number if malformed input violates that
-        // invariant.
-        if (denominator != 0) {
-          fractions[i] = FractionalAtomicNum(numerator, denominator);
-        }
-      }
+    // Find resonant structures caused by relocation of a negative charge.
+    if (types[i] == Type::Cv3D3Minus || types[i] == Type::Nv2D2Minus) {
+      resonant_parts[parts[i]] = true;
+      resonant_parts[0] = true;
     }
 
-    // If there are any resonant structures due to negative charges,
-    // recalculate the average atomic number considering relocation
-    // of the charge through higher order bonds.
-    auto numerators = std::vector<int>(numparts + 1);
-    auto denominators = std::vector<int>(numparts + 1);
-    for (auto i = 0u; i < num_atoms; ++i) {
-      const auto part = parts[i];
-      if (part == 0 || !resonance_parts[part]) {
-        continue;
-      }
-      ++denominators[part];
-      const auto atom = mol.getAtom(i);
-      for (const auto &bond : mol.getBonds(atom)) {
-        const auto nbr = bond->getOtherAtom(atom);
-        const auto bord = mol.getBondOrder(bond);
-        if (bord > 1 && parts[nbr->getIdx()] == part) {
-          numerators[part] += (bord - 1) * nbr->getAtomicNum();
-        }
+    int numerator = 0;
+    int denominator = 0;
+    for (const auto &nbr : mol.getNeighbors(atom)) {
+      if (parts[nbr->getIdx()] == parts[i]) {
+        numerator += nbr->getAtomicNum();
+        ++denominator;
       }
     }
+    fractions[i] = FractionalAtomicNum(numerator, denominator);
+  }
 
-    // Every atom in a negative-charge resonance component shares one final
-    // Fraction object in Java. Assigning the final value in a separate pass
-    // reproduces that behavior without accidentally storing running prefixes.
-    for (auto i = 0u; i < num_atoms; ++i) {
-      const auto part = parts[i];
-      if (part != 0 && resonance_parts[part] && denominators[part] != 0) {
-        fractions[i] =
-            FractionalAtomicNum(numerators[part], denominators[part]);
+  if (!resonant_parts[0]) {
+    // No resonant systems.
+    return fractions;
+  }
+
+  // If there are any resonant parts due to negative charges,
+  // update the average atomic number considering relocation
+  // of the charge through higher order bonds.
+  std::vector<int> numerators(numparts + 1);
+  std::vector<int> denominators(numparts + 1);
+  for (auto i = 0u; i < num_atoms; ++i) {
+    const auto part = parts[i];
+    if (part == 0 || !resonant_parts[part]) {
+      continue;
+    }
+
+    ++denominators[part];
+    const auto atom = mol.getAtom(i);
+    for (const auto &bond : mol.getBonds(atom)) {
+      const auto nbr = bond->getOtherAtom(atom);
+      const auto bord = mol.getBondOrder(bond);
+      if (bord > 1 && parts[nbr->getIdx()] == part) {
+        numerators[part] += (bord - 1) * nbr->getAtomicNum();
       }
     }
   }
+
+  // Once all the numerators and denominators for the different
+  // resonant parts of the mol have been calculated, distribute
+  // the values to the atoms in the corresponding parts.
+  for (auto i = 0u; i < num_atoms; ++i) {
+    const auto part = parts[i];
+    if (part != 0 && resonant_parts[part] && denominators[part] != 0) {
+      fractions[i] = FractionalAtomicNum(numerators[part], denominators[part]);
+    }
+  }
+
   return fractions;
 }
 

--- a/Code/GraphMol/CIPLabeler/Mancude.cpp
+++ b/Code/GraphMol/CIPLabeler/Mancude.cpp
@@ -96,19 +96,21 @@ bool SeedTypes(std::vector<Type> &types, const CIPMol &mol) {
   return result;
 }
 
-// Reset atom types for atoms that have been given a type,
-// but cannot be part of a mancude system (more than one
-// typed neighbor is required for resonance to be possible)
+// Reset (to Type::Other) atom types for atoms that have been
+//  given a type but cannot be part of a mancude system (more
+//  than one typed neighbor is required for resonance to be possible)
 void RelaxTypes(std::vector<Type> &types, const CIPMol &mol) {
   std::list<Atom *> queue;
-  auto counts = std::vector<int>(mol.getNumAtoms());
+  std::vector<int> counts(mol.getNumAtoms(), 0);
   for (auto atom : mol.atoms()) {
     const auto aidx = atom->getIdx();
     if (types[aidx] == Type::Other) {
+      // This is already Type::Other, no need to reset it!
       continue;
     }
     for (const auto &bond : mol.getBonds(atom)) {
       if (!mol.isInRing(bond)) {
+        // No non-ring bonds are Type::Other already
         continue;
       }
       const auto nbr = bond->getOtherAtom(atom);
@@ -117,6 +119,8 @@ void RelaxTypes(std::vector<Type> &types, const CIPMol &mol) {
       }
     }
 
+    // Atoms that do not have at least two typed neighbors
+    // go to the queue to be reset to Type::Other.
     if (counts[aidx] <= 1) {
       queue.push_back(atom);
     }
@@ -125,23 +129,32 @@ void RelaxTypes(std::vector<Type> &types, const CIPMol &mol) {
   while (!queue.empty()) {
     const auto atom = queue.front();
     queue.pop_front();
-    const auto aidx = atom->getIdx();
-    if (types[aidx] != Type::Other) {
-      types[aidx] = Type::Other;
 
-      for (const auto &bond : mol.getBonds(atom)) {
-        if (!mol.isInRing(bond)) {
-          continue;
-        }
-        const auto nbr = bond->getOtherAtom(atom);
-        const auto nbridx = nbr->getIdx();
-        if (types[nbridx] == Type::Other) {
-          continue;
-        }
-        --counts[nbridx];
-        if (counts[nbridx] == 1) {
-          queue.push_back(nbr);
-        }
+    const auto aidx = atom->getIdx();
+    if (types[aidx] == Type::Other) {
+      // shouldn't happen, we only enqueue
+      // typed atoms
+      continue;
+    }
+
+    // the actual reset
+    types[aidx] = Type::Other;
+
+    // Update the counts for the neighbors, and check
+    // whether they need to be reset too.
+    for (const auto &bond : mol.getBonds(atom)) {
+      if (!mol.isInRing(bond)) {
+        continue;
+      }
+      const auto nbr = bond->getOtherAtom(atom);
+      const auto nbridx = nbr->getIdx();
+      if (types[nbridx] == Type::Other) {
+        continue;
+      }
+
+      --counts[nbridx];
+      if (counts[nbridx] == 1) {
+        queue.push_back(nbr);
       }
     }
   }

--- a/Code/GraphMol/CIPLabeler/Mancude.h
+++ b/Code/GraphMol/CIPLabeler/Mancude.h
@@ -31,6 +31,29 @@ namespace CIPLabeler {
 
 class CIPMol;
 
+// boost::rational reduces its numerator and denominator on construction. The
+// unreduced denominator is also significant here: it records that an atomic
+// number was averaged over a Mancude system, even when the average happens to
+// be an integer (for example, 12/3). Keep both the value used for comparison
+// and that metadata.
+class FractionalAtomicNum {
+ public:
+  FractionalAtomicNum(int numerator, int denominator)
+      : d_numerator{numerator}, d_denominator{denominator} {}
+
+  boost::rational<int> value() const {
+    return {d_numerator, d_denominator};
+  }
+
+  int numerator() const { return d_numerator; }
+  int denominator() const { return d_denominator; }
+  bool isAveraged() const { return d_denominator > 1; }
+
+ private:
+  int d_numerator;
+  int d_denominator;
+};
+
 enum class Type {
   Cv4D3,       // =C(X)-
   Nv3D2,       // =N-
@@ -48,7 +71,7 @@ enum class Type {
  * priority.
  *
  */
-std::vector<boost::rational<int>> calcFracAtomNums(const CIPMol &mol);
+std::vector<FractionalAtomicNum> calcFracAtomNums(const CIPMol &mol);
 
 }  // namespace CIPLabeler
 }  // namespace RDKit

--- a/Code/GraphMol/CIPLabeler/Mancude.h
+++ b/Code/GraphMol/CIPLabeler/Mancude.h
@@ -52,16 +52,6 @@ class FractionalAtomicNum {
   int d_denominator = 0;
 };
 
-enum class Type : uint8_t {
-  Cv4D3,       // =C(X)-
-  Nv3D2,       // =N-
-  Nv4D3Plus,   // =[N+]<
-  Nv2D2Minus,  // -[N-]-
-  Cv3D3Minus,  // -[C(X)-]-
-  Ov3D2Plus,   // -[O+]=
-  Other
-};
-
 /**
  * Calculate fractional atomic numbers for all atoms in the mol.
  * Using fractional atomic numbers makes sure that atoms in rings

--- a/Code/GraphMol/CIPLabeler/Mancude.h
+++ b/Code/GraphMol/CIPLabeler/Mancude.h
@@ -41,20 +41,18 @@ class FractionalAtomicNum {
   FractionalAtomicNum(int numerator, int denominator)
       : d_numerator{numerator}, d_denominator{denominator} {}
 
-  boost::rational<int> value() const {
-    return {d_numerator, d_denominator};
-  }
+  boost::rational<int> value() const { return {d_numerator, d_denominator}; }
 
   int numerator() const { return d_numerator; }
   int denominator() const { return d_denominator; }
   bool isAveraged() const { return d_denominator > 1; }
 
  private:
-  int d_numerator;
-  int d_denominator;
+  int d_numerator = 0;
+  int d_denominator = 0;
 };
 
-enum class Type {
+enum class Type : uint8_t {
   Cv4D3,       // =C(X)-
   Nv3D2,       // =N-
   Nv4D3Plus,   // =[N+]<

--- a/Code/GraphMol/CIPLabeler/Node.cpp
+++ b/Code/GraphMol/CIPLabeler/Node.cpp
@@ -23,9 +23,9 @@ Node *Node::newTerminalChild(int idx, Atom *atom, int flags) const {
   std::vector<char> new_visit;
 
   if (flags & BOND_DUPLICATE) {
-    auto frac = dp_g->getMol().getFractionalAtomicNum(dp_atom);
-    if (frac.denominator() > 1) {
-      return &dp_g->addNode(std::move(new_visit), atom, std::move(frac),
+    const auto &frac = dp_g->getMol().getFractionalAtomicNum(dp_atom);
+    if (frac.isAveraged()) {
+      return &dp_g->addNode(std::move(new_visit), atom, frac.value(),
                             new_dist, flags);
     }
   }

--- a/Code/GraphMol/CIPLabeler/catch_tests.cpp
+++ b/Code/GraphMol/CIPLabeler/catch_tests.cpp
@@ -161,6 +161,68 @@ TEST_CASE("Digraph", "[accurateCIP]") {
   check_incoming_edge_count(current_root);
 }
 
+TEST_CASE("Mancude fractional atomic numbers", "[accurateCIP]") {
+  SECTION("negative resonance component gets one final fraction") {
+    auto mol = "[CH-]1C=CC=C1"_smiles;
+    CIPLabeler::CIPMol cipmol(*mol);
+
+    for (const auto atom : mol->atoms()) {
+      const auto &frac = cipmol.getFractionalAtomicNum(atom);
+      CHECK(frac.numerator() == 24);
+      CHECK(frac.denominator() == 5);
+      CHECK(frac.value() == boost::rational<int>(24, 5));
+      CHECK(frac.isAveraged());
+    }
+  }
+
+  SECTION("unreduced denominator remains available to graph expansion") {
+    auto mol = "[CH-]1C=C1"_smiles;
+    CIPLabeler::CIPMol cipmol(*mol);
+
+    for (const auto atom : mol->atoms()) {
+      const auto &frac = cipmol.getFractionalAtomicNum(atom);
+      CHECK(frac.numerator() == 12);
+      CHECK(frac.denominator() == 3);
+      CHECK(frac.value() == boost::rational<int>(4, 1));
+      CHECK(frac.isAveraged());
+    }
+
+    Digraph graph(cipmol, cipmol.getAtom(1));
+    Node *negative_node = nullptr;
+    for (const auto edge : graph.getOriginalRoot()->getEdges()) {
+      if (edge->isBeg(graph.getOriginalRoot()) &&
+          edge->getEnd()->getAtom() == cipmol.getAtom(0) &&
+          !edge->getEnd()->isDuplicate()) {
+        negative_node = edge->getEnd();
+        break;
+      }
+    }
+    REQUIRE(negative_node != nullptr);
+
+    int bond_duplicates = 0;
+    for (const auto edge : negative_node->getEdges()) {
+      const auto end = edge->getEnd();
+      if (edge->isBeg(negative_node) &&
+          end->isSet(Node::BOND_DUPLICATE)) {
+        ++bond_duplicates;
+        CHECK(end->getAtomicNumFraction() == boost::rational<int>(4, 1));
+      }
+    }
+    CHECK(bond_duplicates == 1);
+  }
+
+  SECTION("typed atom outside the ring two-core is relaxed") {
+    auto mol = "[N-]1CCC1"_smiles;
+    CIPLabeler::CIPMol cipmol(*mol);
+
+    const auto &frac = cipmol.getFractionalAtomicNum(cipmol.getAtom(0));
+    CHECK(frac.numerator() == 7);
+    CHECK(frac.denominator() == 1);
+    CHECK(frac.value() == boost::rational<int>(7, 1));
+    CHECK_FALSE(frac.isAveraged());
+  }
+}
+
 TEST_CASE("Rule1a", "[accurateCIP]") {
   SECTION("Compare equal") {
     auto mol = "COC"_smiles;


### PR DESCRIPTION
I asked the AI to compare the C++ implementation here and the Java code of the original algorithm in https://github.com/SiMolecule/centres and find differences in the implemented functionality. This is one of the problems it detected.

The original report by the AI is below. The patch and the tests are AI generated. I have reviewed the changes and refactored them a bit, and they make sense to me.

Interestingly, this fix doesn't seem to break any existing tests.

#### Original bug report:

Java creates one mutable Fraction for each negatively charged resonant component, assigns the same object reference to every member, and then accumulates into it. All members consequently observe the final component fraction (Mancude.java:222-240).

C++ initializes a running numerator and denominator, assigns their current value by value to an atom, and only then incorporates that atom (Mancude.cpp:239-267). Different atoms in one delocalized component receive different prefixes. For [CH-]1C=CC=C1, the current C++ library produced:

atom 0: 0/1
atom 1: 0/1
atom 2: 3/1
atom 3: 4/1
atom 4: 9/2

Java semantics give every atom 24/5. The result is atom-index dependent and violates the algorithm's purpose of giving resonance-equivalent atoms equal priority. It also changes graph topology: Digraph checks whether the fractional denominator is greater than one to decide how negative-charge duplicate nodes are made (Digraph.cpp:163-171,185-193). In the example, only a subset is recognized as fractional.

Recommended fix: collect component members and calculate the final numerator/denominator first; assign the same final value to every member in a second pass. Test equality and CIP-label invariance before/after atom renumbering.
