### PR TITLE
Correctly handle recursive queries in mol.GetAtomsMatchingQuery()

### DIFF
--- a/Code/GraphMol/Atom.h
+++ b/Code/GraphMol/Atom.h
@@ -273,7 +273,7 @@ class RDKIT_GRAPHMOL_EXPORT Atom : public RDProps {
   //! NOT CALLABLE
   virtual void setQuery(QUERYATOM_QUERY *what);
 
-  //! NOT CALLABLE
+  //! returns nullptr
   virtual QUERYATOM_QUERY *getQuery() const;
   //! NOT CALLABLE
   virtual void expandQuery(

--- a/Code/GraphMol/AtomIterators.cpp
+++ b/Code/GraphMol/AtomIterators.cpp
@@ -393,7 +393,7 @@ QueryAtomIterator_<Atom_, Mol_>::QueryAtomIterator_(Mol_ *mol,
         "QueryAtomIterator does not support uninitialized recursive queries");
   }
   _mol = mol;
-  _qA = static_cast<QueryAtom *>(what->copy());
+  _qA = new QueryAtom(*what);
   _end = mol->getNumAtoms();
   _pos = _findNext(0);
 };

--- a/Code/GraphMol/AtomIterators.cpp
+++ b/Code/GraphMol/AtomIterators.cpp
@@ -386,8 +386,12 @@ int AromaticAtomIterator_<Atom_, Mol_>::_findPrev(int from) {
 //-----------------------------------------
 template <class Atom_, class Mol_>
 QueryAtomIterator_<Atom_, Mol_>::QueryAtomIterator_(Mol_ *mol,
-                                                    QueryAtom const *what) {
+                                                    Atom const *what) {
   PRECONDITION(what, "bad query atom");
+  if (hasUninitializedRecursiveQuery(*what)) {
+    throw ValueErrorException(
+        "QueryAtomIterator does not support uninitialized recursive queries");
+  }
   _mol = mol;
   _qA = static_cast<QueryAtom *>(what->copy());
   _end = mol->getNumAtoms();

--- a/Code/GraphMol/AtomIterators.h
+++ b/Code/GraphMol/AtomIterators.h
@@ -1,5 +1,5 @@
 //
-//  Copyright (C) 2002-2006 Greg Landrum and Rational Discovery LLC
+//  Copyright (C) 2002-2026 Greg Landrum and other RDKit contributors
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -24,6 +24,7 @@
 #endif
 
 namespace RDKit {
+class Atom;
 class QueryAtom;
 
 //! A general random access iterator
@@ -142,7 +143,7 @@ class RDKIT_GRAPHMOL_EXPORT QueryAtomIterator_ {
  public:
   typedef QueryAtomIterator_<Atom_, Mol_> ThisType;
   QueryAtomIterator_() : _mol(nullptr) {}
-  QueryAtomIterator_(Mol_ *mol, QueryAtom const *what);
+  QueryAtomIterator_(Mol_ *mol, Atom const *what);
   QueryAtomIterator_(Mol_ *mol, int pos);
   ~QueryAtomIterator_();
   QueryAtomIterator_(const ThisType &other);

--- a/Code/GraphMol/QueryAtom.cpp
+++ b/Code/GraphMol/QueryAtom.cpp
@@ -1,5 +1,5 @@
-//
-//  Copyright (C) 2001-2006 Greg Landrum and Rational Discovery LLC
+
+//  Copyright (C) 2001-2026 Greg Landrum and other RDKit contributors
 //
 //   @@ All Rights Reserved @@
 //  This file is part of the RDKit.
@@ -192,4 +192,37 @@ bool QueryAtom::QueryMatch(QueryAtom const *what) const {
   }
 }
 
-};  // namespace RDKit
+namespace detail {
+bool hasRecursiveQuery(const QueryAtom::QUERYATOM_QUERY *q,
+                       bool checkInitialized) {
+  if (!q) {
+    return false;
+  }
+  if (q->getDescription() == "RecursiveStructure" &&
+      (!checkInitialized ||
+       !static_cast<RecursiveStructureQuery const *>(q)->getInitialized())) {
+    return true;
+  }
+  for (auto iter = q->beginChildren(); iter != q->endChildren(); ++iter) {
+    if (hasRecursiveQuery(iter->get(), checkInitialized)) {
+      return true;
+    }
+  }
+  return false;
+}
+}  // namespace detail
+
+bool hasUninitializedRecursiveQuery(const Atom &atom) {
+  if (!atom.hasQuery()) {
+    return false;
+  }
+  return detail::hasRecursiveQuery(atom.getQuery(), true);
+}
+bool hasRecursiveQuery(const Atom &atom) {
+  if (!atom.hasQuery()) {
+    return false;
+  }
+  return detail::hasRecursiveQuery(atom.getQuery(), false);
+}
+
+}  // namespace RDKit

--- a/Code/GraphMol/QueryAtom.h
+++ b/Code/GraphMol/QueryAtom.h
@@ -156,6 +156,9 @@ inline std::string describeQuery(const Atom *atom) {
   return res;
 }
 
+RDKIT_GRAPHMOL_EXPORT bool hasRecursiveQuery(const Atom &atom);
+RDKIT_GRAPHMOL_EXPORT bool hasUninitializedRecursiveQuery(const Atom &atom);
+
 };  // namespace RDKit
 
 #endif

--- a/Code/GraphMol/QueryAtom.h
+++ b/Code/GraphMol/QueryAtom.h
@@ -31,20 +31,25 @@ class RDKIT_GRAPHMOL_EXPORT QueryAtom : public Atom {
 
   QueryAtom() : Atom() {}
   explicit QueryAtom(int num) : Atom(num), dp_query(makeAtomNumQuery(num)) {}
-  explicit QueryAtom(const Atom &other)
-      : Atom(other), dp_query(makeAtomNumQuery(other.getAtomicNum())) {
-    if (other.getIsotope()) {
-      this->expandQuery(makeAtomIsotopeQuery(other.getIsotope()),
-                        Queries::CompositeQueryType::COMPOSITE_AND);
-    }
-    if (other.getFormalCharge()) {
-      this->expandQuery(makeAtomFormalChargeQuery(other.getFormalCharge()),
-                        Queries::CompositeQueryType::COMPOSITE_AND);
-    }
-    if (other.getNumRadicalElectrons()) {
-      this->expandQuery(
-          makeAtomNumRadicalElectronsQuery(other.getNumRadicalElectrons()),
-          Queries::CompositeQueryType::COMPOSITE_AND);
+  explicit QueryAtom(const Atom &other) : Atom(other) {
+    if (other.hasQuery()) {
+      dp_query = other.getQuery()->copy();
+    } else {
+      dp_query = makeAtomNumQuery(other.getAtomicNum());
+
+      if (other.getIsotope()) {
+        this->expandQuery(makeAtomIsotopeQuery(other.getIsotope()),
+                          Queries::CompositeQueryType::COMPOSITE_AND);
+      }
+      if (other.getFormalCharge()) {
+        this->expandQuery(makeAtomFormalChargeQuery(other.getFormalCharge()),
+                          Queries::CompositeQueryType::COMPOSITE_AND);
+      }
+      if (other.getNumRadicalElectrons()) {
+        this->expandQuery(
+            makeAtomNumRadicalElectronsQuery(other.getNumRadicalElectrons()),
+            Queries::CompositeQueryType::COMPOSITE_AND);
+      }
     }
   }
   QueryAtom(const QueryAtom &other) : Atom(other) {

--- a/Code/GraphMol/QueryOps.h
+++ b/Code/GraphMol/QueryOps.h
@@ -836,9 +836,12 @@ class RDKIT_GRAPHMOL_EXPORT RecursiveStructureQuery
     res->setNegation(getNegation());
     res->d_description = d_description;
     res->d_serialNumber = d_serialNumber;
+    res->df_initialized = df_initialized;
     return res;
   }
   unsigned int getSerialNumber() const { return d_serialNumber; }
+  void setInitialized(bool initialized) { df_initialized = initialized; }
+  bool getInitialized() const { return df_initialized; }
 
 #ifdef RDK_BUILD_THREADSAFE_SSS
   std::mutex d_mutex;
@@ -846,6 +849,7 @@ class RDKIT_GRAPHMOL_EXPORT RecursiveStructureQuery
  private:
   boost::shared_ptr<const ROMol> dp_queryMol;
   unsigned int d_serialNumber{0};
+  bool df_initialized{false};
 };
 
 template <typename T>

--- a/Code/GraphMol/ROMol.cpp
+++ b/Code/GraphMol/ROMol.cpp
@@ -549,11 +549,10 @@ bool ROMol::hasQuery() const {
   return false;
 }
 
-ROMol::QueryAtomIterator ROMol::beginQueryAtoms(QueryAtom const *what) {
+ROMol::QueryAtomIterator ROMol::beginQueryAtoms(Atom const *what) {
   return QueryAtomIterator(this, what);
 }
-ROMol::ConstQueryAtomIterator ROMol::beginQueryAtoms(
-    QueryAtom const *what) const {
+ROMol::ConstQueryAtomIterator ROMol::beginQueryAtoms(Atom const *what) const {
   return ConstQueryAtomIterator(this, what);
 }
 ROMol::QueryAtomIterator ROMol::endQueryAtoms() {

--- a/Code/GraphMol/ROMol.h
+++ b/Code/GraphMol/ROMol.h
@@ -145,7 +145,7 @@ struct CXXAtomIterator {
       }
     }
 
-    CXXAtomIter(){};
+    CXXAtomIter() {};
 
     CXXAtomIter(Graph *graph, Iterator pos) : graph(graph), pos(pos) {
       if constexpr (CheckedAtoms) {
@@ -237,7 +237,7 @@ struct CXXAtomIterator {
     std::tie(vstart, vend) = boost::vertices(*graph);
   }
   CXXAtomIterator(Graph *graph, Iterator start, Iterator end)
-      : graph(graph), vstart(start), vend(end){};
+      : graph(graph), vstart(start), vend(end) {};
   CXXAtomIter begin() { return {graph, vstart}; }
   CXXAtomIter end() { return {graph, vend}; }
   size_t size() const { return vend - vstart; }
@@ -275,7 +275,7 @@ struct CXXBondIterator {
       }
     }
 
-    CXXBondIter(){};
+    CXXBondIter() {};
 
     CXXBondIter(Graph *graph, Iterator pos) : graph(graph), pos(pos) {
       if constexpr (Checked) {
@@ -324,7 +324,7 @@ struct CXXBondIterator {
     vend = vs.second;
   }
   CXXBondIterator(Graph *graph, Iterator start, Iterator end)
-      : graph(graph), vstart(start), vend(end){};
+      : graph(graph), vstart(start), vend(end) {};
   CXXBondIter begin() { return {graph, vstart}; }
   CXXBondIter end() { return {graph, vend}; }
   size_t size() const {
@@ -919,9 +919,9 @@ class RDKIT_GRAPHMOL_EXPORT ROMol : public RDProps {
   bool hasQuery() const;
 
   //! get an AtomIterator pointing at our first Atom that matches \c query
-  QueryAtomIterator beginQueryAtoms(QueryAtom const *query);
+  QueryAtomIterator beginQueryAtoms(Atom const *query);
   //! \overload
-  ConstQueryAtomIterator beginQueryAtoms(QueryAtom const *) const;
+  ConstQueryAtomIterator beginQueryAtoms(Atom const *query) const;
   //! get an AtomIterator pointing at the end of our Atoms
   QueryAtomIterator endQueryAtoms();
   //! \overload
@@ -1027,8 +1027,8 @@ class RDKIT_GRAPHMOL_EXPORT ROMol : public RDProps {
 
   friend RDKIT_GRAPHMOL_EXPORT std::vector<SubstanceGroup> &getSubstanceGroups(
       ROMol &);
-  friend RDKIT_GRAPHMOL_EXPORT const std::vector<SubstanceGroup>
-      &getSubstanceGroups(const ROMol &);
+  friend RDKIT_GRAPHMOL_EXPORT const std::vector<SubstanceGroup> &
+  getSubstanceGroups(const ROMol &);
   void clearSubstanceGroups() { d_sgroups.clear(); }
 
  protected:

--- a/Code/GraphMol/Substruct/SubstructDetails.h
+++ b/Code/GraphMol/Substruct/SubstructDetails.h
@@ -20,7 +20,7 @@
 namespace RDKit {
 class ROMol;
 class RecursiveStructureQuery;
-class SubstructMatchParameters;
+struct SubstructMatchParameters;
 
 namespace detail {
 struct RecursiveLocker {

--- a/Code/GraphMol/Substruct/SubstructDetails.h
+++ b/Code/GraphMol/Substruct/SubstructDetails.h
@@ -1,0 +1,34 @@
+//
+//  Copyright (C) 2026 Greg Landrum and other RDKit contributors
+//
+//   @@ All Rights Reserved @@
+//  This file is part of the RDKit.
+//  The contents are covered by the terms of the BSD license
+//  which is included in the file license.txt, found at the root
+//  of the RDKit source tree.
+//
+#include <RDGeneral/export.h>
+#ifndef RD_SUBSTRUCTDETAILS_H
+#define RD_SUBSTRUCTDETAILS_H
+
+// std bits
+#include <vector>
+#include <map>
+
+#include <GraphMol/QueryAtom.h>
+
+namespace RDKit {
+class ROMol;
+class RecursiveStructureQuery;
+class SubstructMatchParameters;
+
+namespace detail {
+using SUBQUERY_MAP = std::map<unsigned int, QueryAtom::QUERYATOM_QUERY *>;
+RDKIT_SUBSTRUCTMATCH_EXPORT void MatchSubqueries(
+    const ROMol &mol, QueryAtom::QUERYATOM_QUERY *q,
+    const SubstructMatchParameters &params, SUBQUERY_MAP &subqueryMap,
+    std::vector<RecursiveStructureQuery *> &locked);
+}  // namespace detail
+}  // namespace RDKit
+
+#endif

--- a/Code/GraphMol/Substruct/SubstructDetails.h
+++ b/Code/GraphMol/Substruct/SubstructDetails.h
@@ -23,6 +23,14 @@ class RecursiveStructureQuery;
 class SubstructMatchParameters;
 
 namespace detail {
+struct RecursiveLocker {
+  bool df_clearOnDestruct{true};
+  std::vector<RecursiveStructureQuery *> locked;
+  RecursiveLocker() = default;
+  RecursiveLocker(size_t numAtoms, const bool recursionPossible);
+  ~RecursiveLocker();
+};
+
 using SUBQUERY_MAP = std::map<unsigned int, QueryAtom::QUERYATOM_QUERY *>;
 RDKIT_SUBSTRUCTMATCH_EXPORT void MatchSubqueries(
     const ROMol &mol, QueryAtom::QUERYATOM_QUERY *q,

--- a/Code/GraphMol/Substruct/SubstructMatch.cpp
+++ b/Code/GraphMol/Substruct/SubstructMatch.cpp
@@ -18,6 +18,8 @@
 
 #include "SubstructMatch.h"
 #include "SubstructUtils.h"
+#include "SubstructDetails.h"
+
 #include <GraphMol/GenericGroups/GenericGroups.h>
 #include <boost/smart_ptr.hpp>
 #include <map>
@@ -113,18 +115,11 @@ bool enhancedStereoIsOK(
 
 }  // namespace
 
-typedef std::map<unsigned int, QueryAtom::QUERYATOM_QUERY *> SUBQUERY_MAP;
-
 typedef struct {
   ResonanceMolSupplier &resMolSupplier;
   const ROMol &query;
   const SubstructMatchParameters &params;
 } ResSubstructMatchHelperArgs_;
-
-void MatchSubqueries(const ROMol &mol, QueryAtom::QUERYATOM_QUERY *q,
-                     const SubstructMatchParameters &params,
-                     SUBQUERY_MAP &subqueryMap,
-                     std::vector<RecursiveStructureQuery *> &locked);
 
 bool insertIfNeeded(std::set<MatchVectType> &matches, const MatchVectType &m) {
   bool shouldInsert = true;
@@ -387,7 +382,7 @@ class AtomLabelFunctor {
  public:
   AtomLabelFunctor(const ROMol &query, const ROMol &mol,
                    const SubstructMatchParameters &ps)
-      : d_query(query), d_mol(mol), d_params(ps){};
+      : d_query(query), d_mol(mol), d_params(ps) {};
 
   bool operator()(unsigned int i, unsigned int j) const {
     bool res = false;
@@ -416,7 +411,7 @@ class BondLabelFunctor {
  public:
   BondLabelFunctor(const ROMol &query, const ROMol &mol,
                    const SubstructMatchParameters &ps)
-      : d_query(query), d_mol(mol), d_params(ps){};
+      : d_query(query), d_mol(mol), d_params(ps) {};
   bool operator()(MolGraph::edge_descriptor i,
                   MolGraph::edge_descriptor j) const {
     if (d_params.useChirality) {
@@ -720,6 +715,7 @@ void MatchSubqueries(const ROMol &mol, QueryAtom::QUERYATOM_QUERY *query,
 #endif
     locked.push_back(rsq);
     rsq->clear();
+    rsq->setInitialized(true);
     bool matchDone = false;
     if (rsq->getSerialNumber() &&
         subqueryMap.find(rsq->getSerialNumber()) != subqueryMap.end()) {

--- a/Code/GraphMol/Substruct/SubstructMatch.cpp
+++ b/Code/GraphMol/Substruct/SubstructMatch.cpp
@@ -451,23 +451,24 @@ void ResSubstructMatchHelper_(const ResSubstructMatchHelperArgs_ &args,
   }
 };
 
-struct RecursiveLocker {
-  std::vector<RecursiveStructureQuery *> locked;
-  RecursiveLocker(const ROMol &query, const bool recursionPossible) {
-    if (recursionPossible) {
-      locked.reserve(query.getNumAtoms());
-    }
+std::vector<RecursiveStructureQuery *> locked;
+RecursiveLocker::RecursiveLocker(const size_t numAtoms,
+                                 const bool recursionPossible) {
+  if (recursionPossible) {
+    locked.reserve(numAtoms);
   }
+}
 
-  ~RecursiveLocker() {
-    for (auto v : locked) {
+RecursiveLocker::~RecursiveLocker() {
+  for (auto v : locked) {
+    if (df_clearOnDestruct) {
       v->clear();
-#ifdef RDK_BUILD_THREADSAFE_SSS
-      v->d_mutex.unlock();
-#endif
     }
+#ifdef RDK_BUILD_THREADSAFE_SSS
+    v->d_mutex.unlock();
+#endif
   }
-};
+}
 
 // A minimal container which satisfies the vf2_all() output-sequence interface
 // but only counts matches instead of storing them.
@@ -501,7 +502,7 @@ std::vector<MatchVectType> SubstructMatch(
     return matches;
   }
 
-  detail::RecursiveLocker locker(query, params.recursionPossible);
+  detail::RecursiveLocker locker(query.getNumAtoms(), params.recursionPossible);
 
   if (params.recursionPossible) {
     detail::SUBQUERY_MAP subqueryMap;
@@ -543,7 +544,7 @@ unsigned int SubstructMatchCount(const ROMol &mol, const ROMol &query,
     return 0;
   }
 
-  detail::RecursiveLocker locker(query, params.recursionPossible);
+  detail::RecursiveLocker locker(query.getNumAtoms(), params.recursionPossible);
 
   if (params.recursionPossible) {
     detail::SUBQUERY_MAP subqueryMap;

--- a/Code/GraphMol/Substruct/catch_tests.cpp
+++ b/Code/GraphMol/Substruct/catch_tests.cpp
@@ -25,6 +25,8 @@
 #include <GraphMol/SmilesParse/SmilesParse.h>
 #include <GraphMol/SmilesParse/SmilesWrite.h>
 #include <GraphMol/Substruct/SubstructMatch.h>
+#include <GraphMol/Substruct/SubstructDetails.h>
+
 #include <GraphMol/FileParsers/FileParsers.h>
 #include <GraphMol/QueryOps.h>
 #include <GraphMol/MolPickler.h>
@@ -1244,3 +1246,32 @@ M  END
   interruptThread.join();
 }
 #endif
+
+TEST_CASE("recursive matcher and query initialization") {
+  auto mol = "CC=C"_smiles;
+  REQUIRE(mol);
+  auto qry = "[C;!$(C=C)]C"_smarts;
+  REQUIRE(qry);
+  CHECK(hasUninitializedRecursiveQuery(*qry->getAtomWithIdx(0)));
+  CHECK(!hasUninitializedRecursiveQuery(*qry->getAtomWithIdx(1)));
+  CHECK(!hasRecursiveQuery(*qry->getAtomWithIdx(1)));
+  SECTION("basics") {
+    // do the substructure match
+    SubstructMatchParameters ps;
+    auto matches = SubstructMatch(*mol, *qry, ps);
+    CHECK(matches.size() == 1);
+    // the recursive query should now be initialized
+    CHECK(!hasUninitializedRecursiveQuery(*qry->getAtomWithIdx(0)));
+  }
+  SECTION("MatchSubqueries initializes the recursive query") {
+    // call MatchSubqueries directly, which should initialize the recursive
+    // query
+    SubstructMatchParameters ps;
+    detail::SUBQUERY_MAP subqueryMap;
+    std::vector<RecursiveStructureQuery *> lockedQueries;
+    detail::MatchSubqueries(*mol, qry->getAtomWithIdx(0)->getQuery(), ps,
+                            subqueryMap, lockedQueries);
+    // the recursive query should now be initialized
+    CHECK(!hasUninitializedRecursiveQuery(*qry->getAtomWithIdx(0)));
+  }
+}

--- a/Code/GraphMol/Wrap/CMakeLists.txt
+++ b/Code/GraphMol/Wrap/CMakeLists.txt
@@ -99,3 +99,6 @@ add_pytest(pySubsetTest
 
 add_pytest(pyTestLazyNumpy
          ${CMAKE_CURRENT_SOURCE_DIR}/test_lazy_numpy.py)
+
+add_pytest(pySubstructTest
+         ${CMAKE_CURRENT_SOURCE_DIR}/test_substruct.py)

--- a/Code/GraphMol/Wrap/Mol.cpp
+++ b/Code/GraphMol/Wrap/Mol.cpp
@@ -24,6 +24,7 @@
 #include <GraphMol/RDKitBase.h>
 #include <GraphMol/SmilesParse/SmilesParse.h>
 #include <GraphMol/Substruct/SubstructMatch.h>
+#include <GraphMol/Substruct/SubstructDetails.h>
 #include <RDBoost/Wrap.h>
 #include <RDBoost/pyint_api.h>
 #include <boost/python/copy_non_const_reference.hpp>
@@ -126,6 +127,12 @@ QueryAtomIterSeq *MolGetAromaticAtoms(const ROMOL_SPTR &mol) {
   return res;
 }
 QueryAtomIterSeq *MolGetQueryAtoms(const ROMOL_SPTR &mol, QueryAtom *qa) {
+  if (qa && hasUninitializedRecursiveQuery(*qa)) {
+    SubstructMatchParameters params;
+    detail::SUBQUERY_MAP subqueryMap;
+    std::vector<RecursiveStructureQuery *> locked;
+    detail::MatchSubqueries(*mol, qa->getQuery(), params, subqueryMap, locked);
+  }
   auto res = new QueryAtomIterSeq(mol, mol->beginQueryAtoms(qa),
                                   mol->endQueryAtoms(), AtomCountFunctor(mol));
   return res;
@@ -172,9 +179,9 @@ void setExtraBondCheckFunc(SubstructMatchParameters &ps, python::object func) {
 
 class ReadWriteMol : public RWMol {
  public:
-  ReadWriteMol(){};
+  ReadWriteMol() {};
   ReadWriteMol(const ROMol &m, bool quickCopy = false, int confId = -1)
-      : RWMol(m, quickCopy, confId){};
+      : RWMol(m, quickCopy, confId) {};
 
   void RemoveAtom(unsigned int idx) { removeAtom(idx); };
   void RemoveBond(unsigned int idx1, unsigned int idx2) {

--- a/Code/GraphMol/Wrap/Mol.cpp
+++ b/Code/GraphMol/Wrap/Mol.cpp
@@ -127,11 +127,13 @@ QueryAtomIterSeq *MolGetAromaticAtoms(const ROMOL_SPTR &mol) {
   return res;
 }
 QueryAtomIterSeq *MolGetQueryAtoms(const ROMOL_SPTR &mol, QueryAtom *qa) {
-  if (qa && hasUninitializedRecursiveQuery(*qa)) {
+  if (qa && hasRecursiveQuery(*qa)) {
     SubstructMatchParameters params;
     detail::SUBQUERY_MAP subqueryMap;
-    std::vector<RecursiveStructureQuery *> locked;
-    detail::MatchSubqueries(*mol, qa->getQuery(), params, subqueryMap, locked);
+    detail::RecursiveLocker locker;
+    locker.df_clearOnDestruct = false;
+    detail::MatchSubqueries(*mol, qa->getQuery(), params, subqueryMap,
+                            locker.locked);
   }
   auto res = new QueryAtomIterSeq(mol, mol->beginQueryAtoms(qa),
                                   mol->endQueryAtoms(), AtomCountFunctor(mol));

--- a/Code/GraphMol/Wrap/test_substruct.py
+++ b/Code/GraphMol/Wrap/test_substruct.py
@@ -1,0 +1,43 @@
+#
+#  Copyright (C) 2026 Greg Landrum and other RDKit contributors
+#         All Rights Reserved
+#
+import os
+import unittest
+
+from rdkit import Chem
+
+
+def lists_to_tuple(lst):
+  return tuple(tuple(x) for x in lst)
+
+
+def ats_to_tuple(lst):
+  return tuple(x.GetIdx() for x in lst)
+
+
+class TestCase(unittest.TestCase):
+
+  def test_recursiveatoms(self):
+    m = Chem.MolFromSmiles('CC=C')
+    sma = '[C;!$(C=C)]'
+    p = Chem.MolFromSmarts(sma)
+    tpl = lists_to_tuple(m.GetSubstructMatches(p))
+    self.assertEqual(tpl, ((0, ), ))
+
+    qat = Chem.AtomFromSmarts(sma)
+    self.assertEqual(ats_to_tuple(m.GetAtomsMatchingQuery(qat)), (0, ))
+
+
+if __name__ == '__main__':
+  import os
+  if "RDTESTCASE" in os.environ:
+    suite = unittest.TestSuite()
+    testcases = os.environ["RDTESTCASE"]
+    for name in testcases.split(':'):
+      suite.addTest(TestCase(name))
+
+    runner = unittest.TextTestRunner()
+    runner.run(suite)
+  else:
+    unittest.main()

--- a/Code/GraphMol/catch_queries.cpp
+++ b/Code/GraphMol/catch_queries.cpp
@@ -113,4 +113,20 @@ TEST_CASE("hasRecursiveQuery") {
   REQUIRE(q2);
   CHECK(!hasRecursiveQuery(*q2));
 }
+
+TEST_CASE("copying atom queries") {
+  auto q = v2::SmilesParse::AtomFromSmarts("[C;!$(C=C)]");
+  REQUIRE(q);
+  CHECK(hasRecursiveQuery(*q));
+  QueryAtom q2(*q);
+  CHECK(hasRecursiveQuery(q2));
+}
+
+TEST_CASE("recursive queries should fail with QueryAtomIterator") {
+  auto m = "CC=C"_smiles;
+  REQUIRE(m);
+  auto q = v2::SmilesParse::AtomFromSmarts("[C;!$(C=C)]");
+  REQUIRE(q);
+  CHECK(hasRecursiveQuery(*q));
+  CHECK_THROWS_AS(m->beginQueryAtoms(q.get()), ValueErrorException);
 }

--- a/Code/GraphMol/catch_queries.cpp
+++ b/Code/GraphMol/catch_queries.cpp
@@ -11,6 +11,7 @@
 #include <catch2/catch_all.hpp>
 
 #include <GraphMol/RDKitBase.h>
+#include <GraphMol/QueryAtom.h>
 #include <GraphMol/QueryOps.h>
 #include <GraphMol/SmilesParse/SmilesParse.h>
 
@@ -102,4 +103,14 @@ TEST_CASE("range queries for atom ring membership") {
     CHECK(queryAtomIsInRingOfSize(m->getAtomWithIdx(3), 0, 4) == 4);
     CHECK(queryAtomIsInRingOfSize(m->getAtomWithIdx(5), 0, 4) == -1);
   }
+}
+
+TEST_CASE("hasRecursiveQuery") {
+  auto q = v2::SmilesParse::AtomFromSmarts("[C;!$(C=C)]");
+  REQUIRE(q);
+  CHECK(hasRecursiveQuery(*q));
+  auto q2 = v2::SmilesParse::AtomFromSmarts("[C;CH3]");
+  REQUIRE(q2);
+  CHECK(!hasRecursiveQuery(*q2));
+}
 }

--- a/Code/GraphMol/nbWrap/CMakeLists.txt
+++ b/Code/GraphMol/nbWrap/CMakeLists.txt
@@ -113,3 +113,6 @@ add_pytest(pyCDXMLTest
 
 add_pytest(pySubsetTest
          ${CMAKE_CURRENT_SOURCE_DIR}/../Wrap/test_subset.py)
+
+add_pytest(pySubstructTest
+         ${CMAKE_CURRENT_SOURCE_DIR}/../Wrap/test_substruct.py)

--- a/Code/GraphMol/nbWrap/Mol.cpp
+++ b/Code/GraphMol/nbWrap/Mol.cpp
@@ -960,11 +960,12 @@ struct mol_wrapper {
             "GetAtomsMatchingQuery",
             [](const ROMol &self, const QueryAtom *qa) {
       bool ownsQa = false;
-      if(qa && hasUninitializedRecursiveQuery(*qa)) {
+      if(qa && hasRecursiveQuery(*qa)) {
           SubstructMatchParameters params;
           detail::SUBQUERY_MAP subqueryMap;
-          std::vector<RecursiveStructureQuery *> locked;
-          detail::MatchSubqueries(self, qa->getQuery(), params, subqueryMap, locked);
+          detail::RecursiveLocker locker;
+          locker.df_clearOnDestruct = false;
+          detail::MatchSubqueries(self, qa->getQuery(), params, subqueryMap, locker.locked);
       }
       return QueryAtomIterSeq(self, qa, ownsQa);
             },

--- a/Code/GraphMol/nbWrap/Mol.cpp
+++ b/Code/GraphMol/nbWrap/Mol.cpp
@@ -28,6 +28,7 @@
 #include <GraphMol/QueryOps.h>
 #include <GraphMol/RDKitBase.h>
 #include <GraphMol/Substruct/SubstructMatch.h>
+#include <GraphMol/Substruct/SubstructDetails.h>
 
 namespace nb = nanobind;
 using namespace nb::literals;
@@ -121,9 +122,9 @@ void MolDebug(const ROMol &mol, bool useStdout) {
 
 class ReadWriteMol : public RWMol {
  public:
-  ReadWriteMol(){};
+  ReadWriteMol() {};
   ReadWriteMol(const ROMol &m, bool quickCopy = false, int confId = -1)
-      : RWMol(m, quickCopy, confId){};
+      : RWMol(m, quickCopy, confId) {};
 
   void RemoveAtom(unsigned int idx) { removeAtom(idx); };
   void RemoveBond(unsigned int idx1, unsigned int idx2) {
@@ -959,6 +960,12 @@ struct mol_wrapper {
             "GetAtomsMatchingQuery",
             [](const ROMol &self, const QueryAtom *qa) {
       bool ownsQa = false;
+      if(qa && hasUninitializedRecursiveQuery(*qa)) {
+          SubstructMatchParameters params;
+          detail::SUBQUERY_MAP subqueryMap;
+          std::vector<RecursiveStructureQuery *> locked;
+          detail::MatchSubqueries(self, qa->getQuery(), params, subqueryMap, locked);
+      }
       return QueryAtomIterSeq(self, qa, ownsQa);
             },
             "qa"_a, nb::keep_alive<0, 1>(),


### PR DESCRIPTION
In the current release the recursive queries are not initialized, so they don't impact search results.

Here's a quick illustration of that:
```
In [1]: from rdkit import Chem
   ...: m = Chem.MolFromSmiles('CC=C')
   ...: sma = '[C;!$(C=C)]'
   ...: print(m.GetSubstructMatches(Chem.MolFromSmarts(sma)))
   ...: print(list(x.GetIdx() for x in m.GetAtomsMatchingQuery(Chem.AtomFromSmarts(sma))))
((0,),)
[0, 1, 2]
```
and with this fix applied:
```
In [1]: from rdkit import Chem
   ...: m = Chem.MolFromSmiles('CC=C')
   ...: sma = '[C;!$(C=C)]'
   ...: print(m.GetSubstructMatches(Chem.MolFromSmarts(sma)))
   ...: print(list(x.GetIdx() for x in m.GetAtomsMatchingQuery(Chem.AtomFromSmarts(sma))))
[[0]]
[0]
```