### PR TITLE
Fix pandas version parsing in PandasPatcher and guard a cairo-only test

### DIFF
--- a/rdkit/Chem/Draw/UnitTestIPython.py
+++ b/rdkit/Chem/Draw/UnitTestIPython.py
@@ -133,7 +133,8 @@ class TestCase(unittest.TestCase):
     m = Chem.MolFromSmiles('c1ccccc1O')
     m.__sssAtoms = [0, 1, 2]
     # These two calls should fail if the methods haven't ben updated
-    png = IPythonConsole._toPNG(m)
+    if hasattr(rdMolDraw2D, 'MolDraw2DCairo'):
+      png = IPythonConsole._toPNG(m)
     svg = IPythonConsole._toSVG(m)
 
 

--- a/rdkit/Chem/PandasPatcher.py
+++ b/rdkit/Chem/PandasPatcher.py
@@ -88,12 +88,14 @@ except ImportError:
   log.warning("Failed to import pandas")
   raise
 
-try:
-  if tuple(map(int, (pd.__version__.split(".")))) < (2, 1, 0):
-    dataframe_applymap = pd.DataFrame.applymap
-  else:
-    dataframe_applymap = pd.DataFrame.map
-except:
+# pandas 2.1.0 renamed DataFrame.applymap to DataFrame.map. Look it up by name;
+# pd.__version__ is not always parseable as ints (e.g. "2.1.0rc0").
+dataframe_applymap = None
+for map_func_name in ("map", "applymap"):
+  dataframe_applymap = getattr(pd.DataFrame, map_func_name, None)
+  if dataframe_applymap is not None:
+    break
+if dataframe_applymap is None:
   log.warning("Failed to find a suitable map function for data frames")
 
 orig_to_html = getattr(to_html_class, "to_html")


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

Two unrelated test failures, both affecting macOS build without cairo and pandas `1.5.3+...`

`PandasPatcher` chooses between `DataFrame.applymap` and `DataFrame.map` by parsing `pd.__version__` as ints, which raises on anything that isn't plain `x.y.z` (`2.1.0rc0`, PEP 440 local segments). The bare `except` only warned, leaving `dataframe_applymap` undefined, so `to_html()` then failed with `NameError`. Now the method is looked up by name instead.

`testSimpleHighlighting` calls `_toPNG`, which needs `MolDraw2DCairo`, so it fails on builds without cairo. Added the same `hasattr` guard the rest of the file already uses.