### PR TITLE
Really fix 8644

### DIFF
--- a/Code/GraphMol/FileParsers/MultithreadedMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/MultithreadedMolSupplier.cpp
@@ -134,7 +134,10 @@ void MultithreadedMolSupplier::writer() {
       auto temp = std::tuple<RWMol *, std::string, unsigned int>{
           mol.release(), std::get<0>(r), std::get<2>(r)};
 
-      d_outputQueue->push(temp);
+      if (!d_outputQueue->push(temp)) {
+        // temp was rejected by the queue, clean up the mol pointer
+        delete std::get<0>(temp);
+      }
     } catch (...) {
       // fill the queue wih a null value
       auto nullValue = std::tuple<RWMol *, std::string, unsigned int>{

--- a/Code/GraphMol/FileParsers/MultithreadedMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/MultithreadedMolSupplier.cpp
@@ -119,7 +119,6 @@ void MultithreadedMolSupplier::reader() {
       d_inputQueue->push(r);
     }
   }
-  df_readerDone = true;
   d_inputQueue->setDone();
 }
 

--- a/Code/GraphMol/FileParsers/MultithreadedMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/MultithreadedMolSupplier.cpp
@@ -235,6 +235,27 @@ std::string MultithreadedMolSupplier::getLastItemText() const {
   return d_lastItemText;
 }
 
+void MultithreadedMolSupplier::setNextCallback(nextCallBackFn_t cb) {
+  if (df_started) {
+    throw std::runtime_error("Cannot set callbacks after threads have started");
+  }
+  nextCallback = cb;
+}
+
+void MultithreadedMolSupplier::setWriteCallback(writeCallBackFn_t cb) {
+  if (df_started) {
+    throw std::runtime_error("Cannot set callbacks after threads have started");
+  }
+  writeCallback = cb;
+}
+
+void MultithreadedMolSupplier::setReadCallback(readCallBackFn_t cb) {
+  if (df_started) {
+    throw std::runtime_error("Cannot set callbacks after threads have started");
+  }
+  readCallback = cb;
+}
+
 void MultithreadedMolSupplier::reset() {
   UNDER_CONSTRUCTION("reset() not supported for MultithreadedMolSupplier();");
 }

--- a/Code/GraphMol/FileParsers/MultithreadedMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/MultithreadedMolSupplier.cpp
@@ -22,6 +22,8 @@ namespace FileParsers {
 
 void MultithreadedMolSupplier::initFromSettings(bool takeOwnership,
                                                 const Parameters &params) {
+  PRECONDITION(params.sizeInputQueue > 0, "invalid input queue capacity");
+  PRECONDITION(params.sizeOutputQueue > 0, "invalid output queue capacity");
   df_owner = takeOwnership;
   d_params = params;
   d_params.numWriterThreads = getNumThreadsToUse(params.numWriterThreads);

--- a/Code/GraphMol/FileParsers/MultithreadedMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/MultithreadedMolSupplier.cpp
@@ -117,6 +117,7 @@ void MultithreadedMolSupplier::reader() {
       d_inputQueue->push(r);
     }
   }
+  df_readerDone = true;
   d_inputQueue->setDone();
 }
 
@@ -169,7 +170,7 @@ std::unique_ptr<RWMol> MultithreadedMolSupplier::next() {
   std::tuple<RWMol *, std::string, unsigned int> r;
   if (!df_forceStop && d_outputQueue->pop(r)) {
     d_lastItemText = std::get<1>(r);
-    d_lastRecordId = std::get<2>(r);
+    d_lastReturnedRecordId = std::get<2>(r);
     std::unique_ptr<RWMol> res{std::get<0>(r)};
     if (res && nextCallback) {
       try {
@@ -178,6 +179,7 @@ std::unique_ptr<RWMol> MultithreadedMolSupplier::next() {
         // Ignore exception and proceed with mol as is.
       }
     }
+    ++d_returnedCount;
     return res;
   }
   return nullptr;
@@ -210,11 +212,23 @@ void MultithreadedMolSupplier::startThreads() {
 }
 
 bool MultithreadedMolSupplier::atEnd() {
-  return (d_outputQueue->isEmpty() && d_outputQueue->getDone());
+  // Check reader completion first: this is only set after the final
+  // update to d_lastReadRecordId and all input-queue pushes, so it
+  // being set guarantees that the record count below is final.
+  if (!df_readerDone) {
+    return false;
+  }
+  return d_returnedCount == d_lastReadRecordId;
+}
+
+bool MultithreadedMolSupplier::getEOFHitOnRead() const {
+  // Do not return 'true' until the output queue is empty,
+  // otherwise the mols still in the pipeline will leak.
+  return df_eofHitOnRead.load() && d_returnedCount == d_lastReadRecordId;
 }
 
 unsigned int MultithreadedMolSupplier::getLastRecordId() const {
-  return d_lastRecordId;
+  return d_lastReturnedRecordId;
 }
 
 std::string MultithreadedMolSupplier::getLastItemText() const {

--- a/Code/GraphMol/FileParsers/MultithreadedMolSupplier.h
+++ b/Code/GraphMol/FileParsers/MultithreadedMolSupplier.h
@@ -134,6 +134,7 @@ class RDKIT_FILEPARSERS_EXPORT MultithreadedMolSupplier : public MolSupplier {
 
   int d_line = 0;  //!< line number we are currently on
 
+  std::atomic<bool> df_started = false;
   std::atomic<bool> df_eofHitOnRead = false;
   std::atomic<bool> df_readerDone = false;
 
@@ -171,7 +172,6 @@ class RDKIT_FILEPARSERS_EXPORT MultithreadedMolSupplier : public MolSupplier {
   MultithreadedMolSupplier &operator=(const MultithreadedMolSupplier &) =
       delete;
 
-  std::atomic<bool> df_started = false;
   std::atomic<bool> df_forceStop = false;
 
   std::mutex d_threadCounterMutex;

--- a/Code/GraphMol/FileParsers/MultithreadedMolSupplier.h
+++ b/Code/GraphMol/FileParsers/MultithreadedMolSupplier.h
@@ -74,7 +74,7 @@ class RDKIT_FILEPARSERS_EXPORT MultithreadedMolSupplier : public MolSupplier {
 
   //! included for the interface. Python wrappers check this
   //! each time next() is called.  It is not used in the C++ code.
-  virtual bool getEOFHitOnRead() const = 0;
+  virtual bool getEOFHitOnRead() const;
 
   //! returns the record id of the last extracted item
   //! Note: d_LastRecordId = 0, initially therefore the value 0 is returned
@@ -113,7 +113,7 @@ class RDKIT_FILEPARSERS_EXPORT MultithreadedMolSupplier : public MolSupplier {
   void setReadCallback(readCallBackFn_t cb) { readCallback = cb; }
 
   //! not yet implemented
-  void init() final{};
+  void init() final {};
 
   //! not yet implemented
   void reset() final;
@@ -130,10 +130,12 @@ class RDKIT_FILEPARSERS_EXPORT MultithreadedMolSupplier : public MolSupplier {
       const std::string &record, unsigned int lineNum) = 0;
 
   //!< stores last extracted record id
-  std::atomic<unsigned int> d_lastRecordId = 0;
+  std::atomic<unsigned int> d_lastReadRecordId = 0;
 
-  int d_line = 0;                      //!< line number we are currently on
-  unsigned int d_currentRecordId = 1;  //!< current record id
+  int d_line = 0;  //!< line number we are currently on
+
+  std::atomic<bool> df_eofHitOnRead = false;
+  std::atomic<bool> df_readerDone = false;
 
   //!< concurrent input queue
   std::unique_ptr<inputQueue_t> d_inputQueue;
@@ -177,7 +179,9 @@ class RDKIT_FILEPARSERS_EXPORT MultithreadedMolSupplier : public MolSupplier {
   std::vector<std::thread> d_writerThreads;  //!< vector writer threads
   std::thread d_readerThread;                //!< single reader thread
 
-  std::string d_lastItemText;  //!< stores last extracted record
+  std::string d_lastItemText;               //!< stores last extracted record
+  unsigned int d_lastReturnedRecordId = 0;  //!< stores last extracted record id
+  unsigned int d_returnedCount = 0;
 
   readCallBackFn_t readCallback = nullptr;
   nextCallBackFn_t nextCallback = nullptr;

--- a/Code/GraphMol/FileParsers/MultithreadedMolSupplier.h
+++ b/Code/GraphMol/FileParsers/MultithreadedMolSupplier.h
@@ -93,16 +93,17 @@ class RDKIT_FILEPARSERS_EXPORT MultithreadedMolSupplier : public MolSupplier {
     place
 
    */
-  void setNextCallback(nextCallBackFn_t cb) { nextCallback = cb; }
+  void setNextCallback(nextCallBackFn_t cb);
 
-  //! sets the callback to be applied to molecules after they are processed, but
+  //! sets the callback to be applied to molecules after they are processed,
+  //! but
   ///! before they are written to the output queue
   /*!
-    \param cb: a function that takes a reference to an RWMol, a const reference
-    to the string record, and an unsigned int record id. This can modify the
-    molecule in place
+    \param cb: a function that takes a reference to an RWMol, a const
+    reference to the string record, and an unsigned int record id. This can
+    modify the molecule in place
   */
-  void setWriteCallback(writeCallBackFn_t cb) { writeCallback = cb; }
+  void setWriteCallback(writeCallBackFn_t cb);
 
   //! sets the callback to be applied to input text records before they are
   ///! added to the input queue
@@ -110,8 +111,7 @@ class RDKIT_FILEPARSERS_EXPORT MultithreadedMolSupplier : public MolSupplier {
     \param cb: a function that takes a const reference to the string record and
     an unsigned int record id and returns the modified string record
   */
-  void setReadCallback(readCallBackFn_t cb) { readCallback = cb; }
-
+  void setReadCallback(readCallBackFn_t cb);
   //! not yet implemented
   void init() final {};
 

--- a/Code/GraphMol/FileParsers/MultithreadedSDMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/MultithreadedSDMolSupplier.cpp
@@ -58,6 +58,7 @@ bool MultithreadedSDMolSupplier::extractNextRecord(std::string &record,
     return false;
   }
 
+  bool readAnyLine = false;
   std::string currentStr;
   std::string prevStr;
   record.clear();
@@ -70,18 +71,30 @@ bool MultithreadedSDMolSupplier::extractNextRecord(std::string &record,
            prevStr.find("M  END") != 0) ||
           !currentStr.starts_with("$$$$"))) {
     std::swap(prevStr, currentStr);
-    std::getline(*dp_inStream, currentStr);
+    if (std::getline(*dp_inStream, currentStr)) {
+      readAnyLine = true;
+    }
     record += currentStr + "\n";
     ++d_line;
   }
 
-  // ignore trailing new lines
-  if (record.find_first_not_of("\n\r") == std::string::npos) {
+  // A truly empty stream is logical EOF. If getline() successfully read one
+  // or more blank lines, preserve them as a null record, matching
+  // ForwardSDMolSupplier.
+  if (record.find_first_not_of(" \t\r\n") == std::string::npos &&
+      !readAnyLine) {
+    if (dp_inStream->eof() && d_lastReadRecordId == 0) {
+      // Match ForwardSDMolSupplier's empty-input behavior. Do not set this
+      // after a real record: the multithreaded supplier has already prefetched
+      // EOF at that point, and the Python wrapper would otherwise discard the
+      // final molecule.
+      df_eofHitOnRead = true;
+    }
     return false;
   }
 
-  index = d_currentRecordId;
-  ++d_currentRecordId;
+  ++d_lastReadRecordId;
+  index = d_lastReadRecordId;
   return true;
 }
 

--- a/Code/GraphMol/FileParsers/MultithreadedSDMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/MultithreadedSDMolSupplier.cpp
@@ -209,6 +209,15 @@ std::unique_ptr<RWMol> MultithreadedSDMolSupplier::processMoleculeRecord(
   }
   return res;
 }
+
+void MultithreadedSDMolSupplier::setProcessPropertyLists(bool val) {
+  if (df_started) {
+    throw std::runtime_error(
+        "Cannot set property lists after threads have started");
+  }
+  df_processPropertyLists.store(val);
+}
+
 }  // namespace FileParsers
 }  // namespace v2
 }  // namespace RDKit

--- a/Code/GraphMol/FileParsers/MultithreadedSDMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/MultithreadedSDMolSupplier.cpp
@@ -55,6 +55,7 @@ bool MultithreadedSDMolSupplier::extractNextRecord(std::string &record,
                                                    unsigned int &index) {
   PRECONDITION(dp_inStream, "no stream");
   if (dp_inStream->eof()) {
+    df_readerDone = true;
     return false;
   }
 
@@ -90,6 +91,7 @@ bool MultithreadedSDMolSupplier::extractNextRecord(std::string &record,
       // final molecule.
       df_eofHitOnRead = true;
     }
+    df_readerDone = true;
     return false;
   }
 

--- a/Code/GraphMol/FileParsers/MultithreadedSDMolSupplier.h
+++ b/Code/GraphMol/FileParsers/MultithreadedSDMolSupplier.h
@@ -42,8 +42,6 @@ class RDKIT_FILEPARSERS_EXPORT MultithreadedSDMolSupplier final
 
   bool getProcessPropertyLists() const { return df_processPropertyLists; }
 
-  bool getEOFHitOnRead() const final { return df_eofHitOnRead; }
-
   //! reads next record and returns whether or not EOF was hit
   bool extractNextRecord(std::string &record, unsigned int &lineNum,
                          unsigned int &index) final;
@@ -59,7 +57,6 @@ class RDKIT_FILEPARSERS_EXPORT MultithreadedSDMolSupplier final
   void readMolProps(RWMol &mol, std::istringstream &inStream);
 
   bool df_processPropertyLists = true;
-  bool df_eofHitOnRead = false;
   MolFileParserParams d_parseParams;
 };
 }  // namespace FileParsers

--- a/Code/GraphMol/FileParsers/MultithreadedSDMolSupplier.h
+++ b/Code/GraphMol/FileParsers/MultithreadedSDMolSupplier.h
@@ -38,9 +38,11 @@ class RDKIT_FILEPARSERS_EXPORT MultithreadedSDMolSupplier final
 
   ~MultithreadedSDMolSupplier() final { close(); }
 
-  void setProcessPropertyLists(bool val) { df_processPropertyLists = val; }
+  void setProcessPropertyLists(bool val);
 
-  bool getProcessPropertyLists() const { return df_processPropertyLists; }
+  bool getProcessPropertyLists() const {
+    return df_processPropertyLists.load();
+  }
 
   //! reads next record and returns whether or not EOF was hit
   bool extractNextRecord(std::string &record, unsigned int &lineNum,
@@ -56,7 +58,7 @@ class RDKIT_FILEPARSERS_EXPORT MultithreadedSDMolSupplier final
 
   void readMolProps(RWMol &mol, std::istringstream &inStream);
 
-  bool df_processPropertyLists = true;
+  std::atomic<bool> df_processPropertyLists = true;
   MolFileParserParams d_parseParams;
 };
 }  // namespace FileParsers

--- a/Code/GraphMol/FileParsers/MultithreadedSmilesMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/MultithreadedSmilesMolSupplier.cpp
@@ -142,6 +142,7 @@ bool MultithreadedSmilesMolSupplier::extractNextRecord(std::string &record,
                                                        unsigned int &index) {
   PRECONDITION(dp_inStream, "bad stream");
   if (dp_inStream->eof()) {
+    df_readerDone = true;
     return false;
   }
 
@@ -163,6 +164,7 @@ bool MultithreadedSmilesMolSupplier::extractNextRecord(std::string &record,
     if (d_lastReadRecordId == 0) {
       df_eofHitOnRead = true;
     }
+    df_readerDone = true;
     return false;
   }
 

--- a/Code/GraphMol/FileParsers/MultithreadedSmilesMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/MultithreadedSmilesMolSupplier.cpp
@@ -37,7 +37,10 @@ MultithreadedSmilesMolSupplier::MultithreadedSmilesMolSupplier(
   CHECK_INVARIANT(!(dp_inStream->eof()), "early EOF");
   // set df_takeOwnership = true
   initFromSettings(true, params, parseParams);
-  POSTCONDITION(dp_inStream, "bad instream");
+  skipComments();
+  if (d_parseParams.titleLine) {
+    processTitleLine();
+  }
 }
 
 MultithreadedSmilesMolSupplier::MultithreadedSmilesMolSupplier(
@@ -47,7 +50,10 @@ MultithreadedSmilesMolSupplier::MultithreadedSmilesMolSupplier(
   CHECK_INVARIANT(!(inStream->eof()), "early EOF");
   dp_inStream = inStream;
   initFromSettings(takeOwnership, params, parseParams);
-  POSTCONDITION(dp_inStream, "bad instream");
+  skipComments();
+  if (d_parseParams.titleLine) {
+    processTitleLine();
+  }
 }
 
 MultithreadedSmilesMolSupplier::MultithreadedSmilesMolSupplier() {
@@ -63,18 +69,62 @@ void MultithreadedSmilesMolSupplier::initFromSettings(
   d_line = -1;
 }
 
+void MultithreadedSmilesMolSupplier::skipComments() {
+  PRECONDITION(dp_inStream, "bad stream");
+  if (this->atEnd()) {
+    return;
+  }
+
+  // Peek at the first character of each line until we we find one
+  // that is not a comment. We can't look at the full line and then
+  // rewind, because the stream might not support it.
+  std::string tempStr;
+  while (!dp_inStream->eof() && !dp_inStream->fail()) {
+    auto peek = dp_inStream->peek();
+    if (dp_inStream->eof()) {
+      // No next line, this is the end of the file
+      df_readerDone = true;
+      break;
+    }
+    if (peek != '#' && peek != '\r' && peek != '\n') {
+      // Not a comment or empty line, leave
+      break;
+    }
+    // Consume the comment line
+    if (!std::getline(*dp_inStream, tempStr)) {
+      // shouldn´t happen, since we were able to peek
+      df_readerDone = true;
+      break;
+    }
+    ++d_line;
+  }
+}
+
 // --------------------------------------------------
 //
 //  Reads and processes the title line
 //
 void MultithreadedSmilesMolSupplier::processTitleLine() {
   PRECONDITION(dp_inStream, "bad stream");
+  if (this->atEnd()) {
+    // We expected some data, but didn't get any!
+    df_eofHitOnRead = true;
+    return;
+  }
 
-  // loop until we get a valid line
+  // loop until we get a valid line. Since we already
+  // called skipComments() before this, we shouldn't see
+  // any comments
   std::string tempStr;
   while (!dp_inStream->eof() && !dp_inStream->fail() &&
          lineIsEmptyOrComment(tempStr)) {
     tempStr = getLine(dp_inStream);
+    ++d_line;
+  }
+  if (tempStr.empty()) {
+    // We expected some data, but didn't get any!
+    df_eofHitOnRead = true;
+    return;
   }
 
   boost::char_separator<char> sep(d_parseParams.delimiter.c_str(), "",
@@ -95,26 +145,31 @@ bool MultithreadedSmilesMolSupplier::extractNextRecord(std::string &record,
     return false;
   }
 
-  // need to process title line
-  // if we have not called next yet and the current record id = 1
-  // then we are seeking the first record
-  if (d_lastRecordId == 0 && d_currentRecordId == 1) {
-    if (d_parseParams.titleLine) {
-      this->processTitleLine();
-    }
-  }
-
   record.clear();
   std::string tempStr;
   while (!dp_inStream->eof() && !dp_inStream->fail() &&
          lineIsEmptyOrComment(tempStr)) {
-    tempStr = getLine(dp_inStream);
+    if (!std::getline(*dp_inStream, tempStr)) {
+      // We expected some data, but didn't get any!
+      break;
+    };
+    ++d_line;
+  }
+
+  // SmilesMolSupplier skips comments and blank lines and does not expose an
+  // extra null record when none remain.
+  if (lineIsEmptyOrComment(tempStr) &&
+      (dp_inStream->eof() || dp_inStream->fail())) {
+    if (d_lastReadRecordId == 0) {
+      df_eofHitOnRead = true;
+    }
+    return false;
   }
 
   record = tempStr;
   lineNum = d_line;
-  index = d_currentRecordId;
-  ++d_currentRecordId;
+  ++d_lastReadRecordId;
+  index = d_lastReadRecordId;
   return true;
 }
 

--- a/Code/GraphMol/FileParsers/MultithreadedSmilesMolSupplier.h
+++ b/Code/GraphMol/FileParsers/MultithreadedSmilesMolSupplier.h
@@ -37,8 +37,6 @@ class RDKIT_FILEPARSERS_EXPORT MultithreadedSmilesMolSupplier final
 
   ~MultithreadedSmilesMolSupplier() final { close(); };
 
-  bool getEOFHitOnRead() const final { return false; }
-
   //! reads next record and returns whether or not EOF was hit
   bool extractNextRecord(std::string &record, unsigned int &lineNum,
                          unsigned int &index) final;
@@ -54,6 +52,9 @@ class RDKIT_FILEPARSERS_EXPORT MultithreadedSmilesMolSupplier final
 
   //! reads and processes the title line
   void processTitleLine();
+
+  //! skip lines that start with a comment character or are empty
+  void skipComments();
 
   STR_VECT d_props;  //!< vector of property names
   SmilesMolSupplierParams d_parseParams;

--- a/Code/GraphMol/FileParsers/testMultithreadedMolSupplier.cpp
+++ b/Code/GraphMol/FileParsers/testMultithreadedMolSupplier.cpp
@@ -467,6 +467,80 @@ void testThrowSmiles() {
   TEST_ASSERT(ok);
 }
 
+void testEmptySuppliers() {
+  {
+    std::istringstream forwardStrm("");
+    std::istringstream multiStrm("");
+    ForwardSDMolSupplier forwardSup(&forwardStrm, false);
+    MultithreadedSDMolSupplier sup(&multiStrm, false);
+    TEST_ASSERT(!forwardSup.atEnd());
+    TEST_ASSERT(!sup.atEnd());
+    std::unique_ptr<ROMol> forwardMol{forwardSup.next()};
+    std::unique_ptr<ROMol> mol{sup.next()};
+    TEST_ASSERT(!forwardMol);
+    TEST_ASSERT(!mol);
+    TEST_ASSERT(forwardSup.atEnd());
+    TEST_ASSERT(sup.atEnd());
+    TEST_ASSERT(forwardSup.getEOFHitOnRead());
+    TEST_ASSERT(sup.getEOFHitOnRead());
+  }
+  {
+    std::istringstream forwardStrm("\n");
+    std::istringstream multiStrm("\n");
+    ForwardSDMolSupplier forwardSup(&forwardStrm, false);
+    MultithreadedSDMolSupplier sup(&multiStrm, false);
+    std::unique_ptr<ROMol> forwardMol{forwardSup.next()};
+    std::unique_ptr<ROMol> mol{sup.next()};
+    TEST_ASSERT(!forwardMol);
+    TEST_ASSERT(!mol);
+    TEST_ASSERT(forwardSup.atEnd());
+    TEST_ASSERT(sup.atEnd());
+    TEST_ASSERT(!forwardSup.getEOFHitOnRead());
+    TEST_ASSERT(!sup.getEOFHitOnRead());
+  }
+  {
+    std::istringstream smiStrm("");
+    std::istringstream multiStrm("");
+    SmilesMolSupplier smiSup(&smiStrm, false, " ", 0, -1, false);
+    MultithreadedSmilesMolSupplier multiSup(&multiStrm, false, " ", 0, -1,
+                                            false);
+    TEST_ASSERT(smiSup.atEnd());
+    TEST_ASSERT(multiSup.atEnd());
+  }
+  {
+    std::istringstream smiStrm("\n");
+    std::istringstream multiStrm("\n");
+    SmilesMolSupplier smiSup(&smiStrm, false, " ", 0, -1, false);
+    MultithreadedSmilesMolSupplier sup(&multiStrm, false, " ", 0, -1, false);
+    TEST_ASSERT(smiSup.atEnd());
+    TEST_ASSERT(sup.atEnd());
+  }
+}
+
+void testSmilesSupplierConsistency() {
+  const std::string text =
+      "# comment\n"
+      "SMILES,name,\n"
+      "C,carbon,value\n";
+  std::istringstream singleStrm(text);
+  std::istringstream multiStrm(text);
+  SmilesMolSupplier singleSup(&singleStrm, false, ",", 0, -1, true);
+  MultithreadedSmilesMolSupplier multiSup(&multiStrm, false, ",", 0, -1, true);
+  std::unique_ptr<ROMol> singleMol{singleSup.next()};
+  std::unique_ptr<ROMol> multiMol{multiSup.next()};
+  TEST_ASSERT(singleMol);
+  TEST_ASSERT(multiMol);
+
+  TEST_ASSERT(singleMol->getProp<std::string>(common_properties::_Name) == "2");
+  TEST_ASSERT(singleMol->getProp<std::string>(common_properties::_Name) ==
+              multiMol->getProp<std::string>(common_properties::_Name));
+
+  TEST_ASSERT(singleMol->getProp<std::string>("name") ==
+              multiMol->getProp<std::string>("name"));
+  TEST_ASSERT(singleMol->getProp<std::string>("Column_2") ==
+              multiMol->getProp<std::string>("Column_2"));
+}
+
 int main() {
   RDLog::InitLogs();
 
@@ -490,6 +564,14 @@ int main() {
   BOOST_LOG(rdErrorLog) << "\n-----------------------------------------\n";
   testThrowSmiles();
   BOOST_LOG(rdErrorLog) << "Finished: testThrowSmiles()\n";
+  BOOST_LOG(rdErrorLog) << "-----------------------------------------\n\n";
+
+  testEmptySuppliers();
+  BOOST_LOG(rdErrorLog) << "Finished: testEmptySuppliers()\n";
+  BOOST_LOG(rdErrorLog) << "-----------------------------------------\n\n";
+
+  testSmilesSupplierConsistency();
+  BOOST_LOG(rdErrorLog) << "Finished: testSmilesSupplierConsistency()\n";
   BOOST_LOG(rdErrorLog) << "-----------------------------------------\n\n";
 
   /*

--- a/Code/GraphMol/MolProcessing/MolProcessing.cpp
+++ b/Code/GraphMol/MolProcessing/MolProcessing.cpp
@@ -51,15 +51,15 @@ std::vector<std::unique_ptr<T>> mtWorker(
   };
   suppl->setWriteCallback(workerfunc);
   // loop over the supplier to make sure we read everything
+  auto maxRecordId = 0u;
   while (!suppl->atEnd()) {
     auto mol = suppl->next();
+    maxRecordId = std::max(maxRecordId, suppl->getLastRecordId());
   }
   // convert the map to a vector and get the results in the input order
-  auto maxv = 0u;
-  for (const auto &pr : accum) {
-    maxv = std::max(maxv, pr.first);
-  }
-  std::vector<std::unique_ptr<T>> results(maxv);
+  // The write callback is not called for records that fail to parse, so use
+  // the IDs of all consumed records to preserve trailing null entries.
+  std::vector<std::unique_ptr<T>> results(maxRecordId);
   for (auto &pr : accum) {
     results[pr.first - 1] = std::move(pr.second);
   }

--- a/Code/GraphMol/Wrap/testMultithreadedMolSupplier.py
+++ b/Code/GraphMol/Wrap/testMultithreadedMolSupplier.py
@@ -166,6 +166,23 @@ class TestCase(unittest.TestCase):
 
     self.assertRaises(ValueError, helper, sdSup)
 
+  def testGitHubIssue8644(self):
+    fileN = os.path.join(RDConfig.RDBaseDir, 'Code', 'GraphMol', 'FileParsers', 'test_data',
+                         'CH.mol')
+    noneMols = 0
+    notNoneMols = 0
+    # this is usually enough to hit the async issue described in the PR
+    # without the test taking forever
+    numIters = 100
+    for i in range(numIters):
+      for m in Chem.MultithreadedSDMolSupplier(fileN, numWriterThreads=100):
+        if m is None:
+          noneMols += 1
+        else:
+          notNoneMols += 1
+    self.assertEqual(notNoneMols, numIters)
+    self.assertEqual(noneMols, 0)
+
 
 if __name__ == '__main__':
   unittest.main()

--- a/Code/GraphMol/Wrap/testMultithreadedMolSupplier.py
+++ b/Code/GraphMol/Wrap/testMultithreadedMolSupplier.py
@@ -1,5 +1,6 @@
 import gzip
 import os
+import tempfile
 import unittest
 
 from rdkit import Chem, RDConfig
@@ -182,6 +183,56 @@ class TestCase(unittest.TestCase):
           notNoneMols += 1
     self.assertEqual(notNoneMols, numIters)
     self.assertEqual(noneMols, 0)
+
+  def testEmptySDEOFMatchesForwardSupplier(self):
+
+    with tempfile.TemporaryDirectory() as tmpDir:
+      fileN = os.path.join(tmpDir, 'empty.sdf')
+
+      # create an empty file
+      with open(fileN, 'wb'):
+        pass
+
+      with self.assertRaises(OSError):
+        Chem.MultithreadedSDMolSupplier(fileN)
+
+      with open(fileN, 'wb') as tmp:
+        tmp.write(b'\n')
+
+      with open(fileN, 'rb') as forwardInput:
+        forwardMols = list(Chem.ForwardSDMolSupplier(forwardInput))
+
+      multithreadedMols = list(Chem.MultithreadedSDMolSupplier(fileN))
+
+      # The ForwardSDMolSupplier returns None (parse failure)
+      # for whitespace at the end of the file
+      self.assertEqual(forwardMols, [None])
+      self.assertEqual(multithreadedMols, forwardMols)
+
+  def testEmptySmilesEOFMatchesSupplier(self):
+
+    with tempfile.TemporaryDirectory() as tmpDir:
+      fileN = os.path.join(tmpDir, 'empty.smi')
+
+      # create an empty file
+      with open(fileN, 'wb'):
+        pass
+
+      with self.assertRaises(OSError):
+        Chem.SmilesMolSupplier(fileN, titleLine=False)
+
+      with self.assertRaises(OSError):
+        Chem.MultithreadedSmilesMolSupplier(fileN, titleLine=False)
+
+      for content in (b'\n', b'# comment\n'):
+        with self.subTest(content=content):
+          with open(fileN, 'wb') as tmp:
+            tmp.write(content)
+
+        singleMols = list(Chem.SmilesMolSupplier(fileN, titleLine=False))
+        multithreadedMols = list(Chem.MultithreadedSmilesMolSupplier(fileN, titleLine=False))
+        self.assertEqual(singleMols, [])
+        self.assertEqual(multithreadedMols, singleMols)
 
 
 if __name__ == '__main__':

--- a/Code/RDGeneral/ConcurrentQueue.h
+++ b/Code/RDGeneral/ConcurrentQueue.h
@@ -40,7 +40,7 @@ class ConcurrentQueue {
   //! tries to push an element into the queue if it is not full without
   //! modifying the variable element, if the queue is full then pushing an
   //! element will result in blocking
-  void push(const E &element);
+  bool push(const E &element);
 
   //! tries to pop an element from the queue if it is not empty and not done
   //! the boolean value indicates the whether popping is successful, if the
@@ -62,7 +62,7 @@ class ConcurrentQueue {
 };
 
 template <typename E>
-void ConcurrentQueue<E>::push(const E &element) {
+bool ConcurrentQueue<E>::push(const E &element) {
   std::unique_lock<std::mutex> lk(d_lock);
   //! concurrent queue is full so we wait until
   //! it is not full
@@ -71,10 +71,9 @@ void ConcurrentQueue<E>::push(const E &element) {
     d_notFull.wait(lk);
   }
   if (d_done) {
-    if constexpr (std::is_pointer_v<E>) {
-      delete element;
-    }
-    return;
+    // Notify the caller that the element was not
+    // accepted into the queue
+    return false;
   }
   bool wasEmpty = (d_head == d_tail);
   d_elements.at(d_tail % d_capacity) = element;
@@ -85,6 +84,9 @@ void ConcurrentQueue<E>::push(const E &element) {
   if (wasEmpty) {
     d_notEmpty.notify_all();
   }
+
+  // The element was accepted into the queue
+  return true;
 }
 
 template <typename E>

--- a/Code/RDGeneral/ConcurrentQueue.h
+++ b/Code/RDGeneral/ConcurrentQueue.h
@@ -66,8 +66,11 @@ void ConcurrentQueue<E>::push(const E &element) {
   //! concurrent queue is full so we wait until
   //! it is not full
 
-  while (d_head + d_capacity == d_tail) {
+  while (d_head + d_capacity == d_tail && !d_done) {
     d_notFull.wait(lk);
+  }
+  if (d_done) {
+    return;
   }
   bool wasEmpty = (d_head == d_tail);
   d_elements.at(d_tail % d_capacity) = element;
@@ -120,6 +123,7 @@ void ConcurrentQueue<E>::setDone() {
   std::unique_lock<std::mutex> lk(d_lock);
   d_done = true;
   d_notEmpty.notify_all();
+  d_notFull.notify_all();
 }
 
 template <typename E>

--- a/Code/RDGeneral/ConcurrentQueue.h
+++ b/Code/RDGeneral/ConcurrentQueue.h
@@ -12,6 +12,7 @@
 #define CONCURRENT_QUEUE
 #include <condition_variable>
 #include <thread>
+#include <type_traits>
 #include <vector>
 
 namespace RDKit {
@@ -70,6 +71,9 @@ void ConcurrentQueue<E>::push(const E &element) {
     d_notFull.wait(lk);
   }
   if (d_done) {
+    if constexpr (std::is_pointer_v<E>) {
+      delete element;
+    }
     return;
   }
   bool wasEmpty = (d_head == d_tail);


### PR DESCRIPTION
Ok, here comes my second attempt at fixing #8644 (we merged the first one, but then had to revert it because of randomly failing related tests).

This fixes the issue of the "extra" `None` entries by keeping track of the number of entries seen by the "read" thread and how many mols have been returned.

It also ensures that the first-entry behavior of the derived `MultithreadedSDMolSupplier` and `MultithreadedSDMolSupplier` classes ` is consistent with `ForwardSDSupplier` and `SmilesMolSupplier` (at least for empty files and those containing just an empty line).

It also fixes the issue in `MolProcessing` where it uses a multithreded supplier's callback to calculate the number of entries being processed (which might be wrong, because the callback would not execute on molecules that fail to parse). I mentioned this issue in https://github.com/rdkit/rdkit/pull/9452, and saved this fix for the moment that #8644 could be resolved.

Additionally, this patch hardens the multithreaded suppliers a bit by:
- Preventing updates to callbacks and the SD property lists once the threads have started.
- Ensure that the input and output queues can hold at least one entry each.
- Preventing deadlocks on shutdown by having the `ConcurrentQueues` ignore pushes after being done, and notifiying all clients when terminating.
