### PR TITLE
Improve finding of expat headers

### DIFF
--- a/External/ChemDraw/CMakeLists.txt
+++ b/External/ChemDraw/CMakeLists.txt
@@ -63,7 +63,7 @@ if(RDK_BUILD_CHEMDRAW_SUPPORT)
   file(GLOB CHEMDRAW_SOURCE "chemdraw/chemdraw/*.cpp")
   rdkit_library(ChemDraw ${CHEMDRAW_SOURCE} SHARED)
   target_compile_definitions(ChemDraw PRIVATE CHEMDRAW_BUILD)
-  target_link_libraries(ChemDraw PRIVATE expatpp)
+  target_link_libraries(ChemDraw PRIVATE expatpp EXPAT::EXPAT)
 
   # export all the symbols for ChemDraw on MSVC
   if((MSVC AND RDK_INSTALL_DLLS_MSVC) OR((NOT MSVC) AND WIN32))


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

After https://github.com/rdkit/rdkit/pull/9572 this is a second issue that arose during the building of rdkit with emscripten. The issue is that otherwise, cmake does detect the expat.h headers correctly but does not point to them during compilation.

Tested in https://github.com/fxcoudert/rdkit-pypi/pull/2/changes/3e12b93380a27ec42637e484f89337bc8d7efb01 and allows compilation to proceed.
