### PR TITLE
Fix a couple of bugs in DCLV GetSurfacePoints() function

### DIFF
--- a/Code/GraphMol/Descriptors/DCLV.cpp
+++ b/Code/GraphMol/Descriptors/DCLV.cpp
@@ -361,9 +361,10 @@ bool DoubleCubicLatticeVolume::testPoint(
 double DoubleCubicLatticeVolume::getAtomSurfaceArea(unsigned int atomIdx) {
   // surface area for single atom
 
-  // clear our current surface points
-  surfacePoints[atomIdx].clear();
-
+  // clear our current surface points, if there are any
+  if (surfacePoints.find(atomIdx) != surfacePoints.end()) {
+    surfacePoints[atomIdx].clear();
+  }
   const auto rad = radii_[atomIdx];
   if (rad == 0.0) {
     return 0.0;  // don't include if radius = 0, masked atom

--- a/Code/GraphMol/Descriptors/DCLV.cpp
+++ b/Code/GraphMol/Descriptors/DCLV.cpp
@@ -361,6 +361,9 @@ bool DoubleCubicLatticeVolume::testPoint(
 double DoubleCubicLatticeVolume::getAtomSurfaceArea(unsigned int atomIdx) {
   // surface area for single atom
 
+  // clear our current surface points
+  surfacePoints[atomIdx].clear();
+
   const auto rad = radii_[atomIdx];
   if (rad == 0.0) {
     return 0.0;  // don't include if radius = 0, masked atom
@@ -380,10 +383,10 @@ double DoubleCubicLatticeVolume::getAtomSurfaceArea(unsigned int atomIdx) {
     const Point3D &dots =
         Point3D(standardDots[i][0], standardDots[i][1], standardDots[i][2]);
     const auto vect = pos + dots * factor;
-    surfacePoints[atomIdx].push_back(vect);
-
     if (testPoint(vect, probeRadius, nbr)) {
       atomSurfaceArea += dotArea;
+      // save the surface point
+      surfacePoints[atomIdx].push_back(vect);
     }
   }
   atomSurfaceArea *= ((4.0 * M_PI) * (factor * factor)) / standardArea;
@@ -434,28 +437,36 @@ double DoubleCubicLatticeVolume::getPolarSurfaceArea(bool includeSandP,
 }
 
 std::map<unsigned int, std::vector<RDGeom::Point3D>> &
-DoubleCubicLatticeVolume::getSurfacePoints() {
-  if (!surfacePoints.empty()) {
+DoubleCubicLatticeVolume::getSurfacePoints(bool allPoints) {
+  if (!allPoints && !surfacePoints.empty()) {
     return surfacePoints;
+  }
+  if (allPoints && !allSurfacePoints.empty()) {
+    return allSurfacePoints;
   }
 
   for (const auto atom : mol.atoms()) {
     const auto atomIdx = atom->getIdx();
-    if (radii_[atomIdx] != 0.0) {
-      const Point3D &pos = positions[atomIdx];
-      const double factor = radii_[atomIdx] + probeRadius;
+    if (allPoints) {
+      allSurfacePoints[atomIdx].clear();
+      if (radii_[atomIdx] != 0.0) {
+        const Point3D &pos = positions[atomIdx];
+        const double factor = radii_[atomIdx] + probeRadius;
 
-      // standard dots has fixed NUMDOTS entries
-      // using precomputed dots in DCLV_dots.h
-      for (int i = 0; i < NUMDOTS; i++) {
-        const Point3D &dots =
-            Point3D(standardDots[i][0], standardDots[i][1], standardDots[i][2]);
-        const auto vect = pos + dots * factor;
-        surfacePoints[atomIdx].push_back(vect);
+        // standard dots has fixed NUMDOTS entries
+        // using precomputed dots in DCLV_dots.h
+        for (int i = 0; i < NUMDOTS; i++) {
+          const Point3D &dots = Point3D(standardDots[i][0], standardDots[i][1],
+                                        standardDots[i][2]);
+          const auto vect = pos + dots * factor;
+          allSurfacePoints[atomIdx].push_back(vect);
+        }
       }
+    } else {
+      getAtomSurfaceArea(atomIdx);
     }
   }
-  return surfacePoints;
+  return allPoints ? allSurfacePoints : surfacePoints;
 }
 
 double DoubleCubicLatticeVolume::getAtomVolume(unsigned int atomIdx,

--- a/Code/GraphMol/Descriptors/DCLV.h
+++ b/Code/GraphMol/Descriptors/DCLV.h
@@ -85,7 +85,8 @@ class RDKIT_DESCRIPTORS_EXPORT DoubleCubicLatticeVolume {
   double getAtomSurfaceArea(unsigned int atomIdx);
 
   /*! \return Set of Points representing the surface */
-  std::map<unsigned int, std::vector<RDGeom::Point3D>> &getSurfacePoints();
+  std::map<unsigned int, std::vector<RDGeom::Point3D>> &getSurfacePoints(
+      bool allPoints = false);
 
   /*! \return Volume bound by probe sphere */
   double getVolume();
@@ -120,6 +121,7 @@ class RDKIT_DESCRIPTORS_EXPORT DoubleCubicLatticeVolume {
   double totalVolume = 0.0;
   double vdwVolume = 0.0;
   std::map<unsigned int, std::vector<RDGeom::Point3D>> surfacePoints;
+  std::map<unsigned int, std::vector<RDGeom::Point3D>> allSurfacePoints;
 
   // helpers
   bool testPoint(const RDGeom::Point3D &vect, double solvrad,

--- a/Code/GraphMol/Descriptors/Wrap/rdMolDescriptors.cpp
+++ b/Code/GraphMol/Descriptors/Wrap/rdMolDescriptors.cpp
@@ -943,9 +943,9 @@ double getPartialVolumeHelper(
 }
 
 python::dict getSurfacePointsHelper(
-    RDKit::Descriptors::DoubleCubicLatticeVolume &self) {
+    RDKit::Descriptors::DoubleCubicLatticeVolume &self, bool allPoints) {
   const std::map<unsigned int, std::vector<RDGeom::Point3D>> &points =
-      self.getSurfacePoints();
+      self.getSurfacePoints(allPoints);
   python::dict surfacePoints;
 
   for (const auto &it : points) {
@@ -1742,8 +1742,10 @@ BOOST_PYTHON_MODULE(rdMolDescriptors) {
           "GetPartialSurfaceArea", &getPartialSurfaceAreaHelper,
           (python::arg("atomIndices")),
           "Get the Partial Surface Area of the Molecule or Protein for specified subset of atoms")
-      .def("GetSurfacePoints", &getSurfacePointsHelper,
-           "Get the set of points representing the surface")
+      .def(
+          "GetSurfacePoints", &getSurfacePointsHelper,
+          (python::arg("self"), python::arg("allPoints") = false),
+          "Get the set of points representing the surface. If allPoints is True, returns all surface points; otherwise, returns the standard surface points.")
       .def("GetVolume",
            &RDKit::Descriptors::DoubleCubicLatticeVolume::getVolume,
            "Get the Total Volume of the Molecule or Protein")

--- a/Code/GraphMol/Descriptors/Wrap/testMolDescriptors.py
+++ b/Code/GraphMol/Descriptors/Wrap/testMolDescriptors.py
@@ -804,6 +804,24 @@ class TestCase(unittest.TestCase):
       self.assertTrue(abs(sdf.GetVDWVolume() - 119.296) < 0.05)
       self.assertTrue(abs(sdf.GetPolarVolume() - 21.35) < 0.05)
 
+      pts = sdf.GetSurfacePoints()
+      self.assertTrue(len(pts) == mol2.GetNumAtoms())
+      for i in range(len(pts)):
+        self.assertTrue(len(pts[i]) > 0)
+      # make sure calling the function again doesn't change the result
+      pts2 = sdf.GetSurfacePoints()
+      self.assertTrue(len(pts2) == mol2.GetNumAtoms())
+      for i in range(len(pts2)):
+        self.assertTrue(len(pts2[i]) == len(pts[i]))
+      # check getting all of the points (including those not on the surface)
+      all_pts = sdf.GetSurfacePoints(allPoints=True)
+      self.assertTrue(len(all_pts) == mol2.GetNumAtoms())
+      for i in range(len(all_pts)):
+        self.assertTrue(len(all_pts[i]) == 320)
+        self.assertTrue(len(all_pts[i]) >= len(pts[i]))
+
+        
+
 
 if __name__ == '__main__':
   unittest.main()

--- a/Code/GraphMol/Descriptors/catch_tests.cpp
+++ b/Code/GraphMol/Descriptors/catch_tests.cpp
@@ -679,8 +679,29 @@ TEST_CASE("DCLV") {
           dclv.getPartialSurfaceArea(partialAtoms2));
     CHECK(dclv.getPartialSurfaceArea(partialAtoms3) == dclv.getSurfaceArea());
   }
-}
 
+  SECTION("Surface points") {
+    std::string sdfName =
+        pathName + "/Code/GraphMol/Descriptors/test_data/ethane.sdf";
+    auto m = v2::FileParsers::MolFromMolFile(sdfName);
+    REQUIRE(m);
+    Descriptors::DoubleCubicLatticeVolume dclv(*m);
+    auto surfacePoints = dclv.getSurfacePoints();
+    CHECK(surfacePoints.size() == m->getNumAtoms());
+    auto allSurfacePoints = dclv.getSurfacePoints(true);
+    CHECK(allSurfacePoints.size() == surfacePoints.size());
+    for (size_t i = 0; i < surfacePoints.size(); ++i) {
+      CHECK(allSurfacePoints[i].size() == 320);
+      CHECK(surfacePoints[i].size() < allSurfacePoints[i].size());
+    }
+    // make sure calling the function again doesn't change the result
+    auto surfacePoints2 = dclv.getSurfacePoints();
+    CHECK(surfacePoints2.size() == m->getNumAtoms());
+    for (size_t i = 0; i < surfacePoints2.size(); ++i) {
+      CHECK(surfacePoints2[i].size() == surfacePoints[i].size());
+    }
+  }
+}
 #ifdef RDK_HAS_EIGEN3
 TEST_CASE("Github #7364: BCUT descriptors failing for moleucles with Hs") {
   SECTION("as reported") {

--- a/Code/GraphMol/Descriptors/nbWrap/rdMolDescriptors.cpp
+++ b/Code/GraphMol/Descriptors/nbWrap/rdMolDescriptors.cpp
@@ -958,9 +958,9 @@ double getPartialVolumeHelper(
 }
 
 nb::dict getSurfacePointsHelper(
-    RDKit::Descriptors::DoubleCubicLatticeVolume &self) {
+    RDKit::Descriptors::DoubleCubicLatticeVolume &self, bool allPoints) {
   const std::map<unsigned int, std::vector<RDGeom::Point3D>> &points =
-      self.getSurfacePoints();
+      self.getSurfacePoints(allPoints);
   nb::dict surfacePoints;
 
   for (const auto &it : points) {
@@ -1605,8 +1605,9 @@ query.Match( mol ))DOC",
            "atomIndices"_a,
            "Get the Partial Surface Area of the Molecule or Protein for "
            "specified subset of atoms")
-      .def("GetSurfacePoints", &getSurfacePointsHelper,
-           "Get the set of points representing the surface")
+      .def(
+          "GetSurfacePoints", &getSurfacePointsHelper, "allPoints"_a = false,
+          "Get the set of points representing the surface. If allPoints is True, returns all surface points; otherwise, returns the standard surface points. ")
       .def("GetVolume",
            &RDKit::Descriptors::DoubleCubicLatticeVolume::getVolume,
            "Get the Total Volume of the Molecule or Protein")

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -45,6 +45,10 @@ GitHub)
   `RDK_USE_LEGACY_RING_FINDING` to 1 or by calling
   `MolOps::setUseLegacyRingFinding(true)` (`Chem.SetUseLegacyRingFinding(True)`
   from Python).
+- The GetSurfacePoints() function of DoubleCubicLatticeVolume by default now
+  returns only points which are actually on the surface. Previously all
+  potential surface points for each atom were returned. You can get the old
+  result by setting the `allPoints` argument to true.
 
 ## Code removed in this release:
 - The version of hanoiSort() that takes raw pointers has been removed. Please use


### PR DESCRIPTION
The original two bugs:
1. The `GetSurfacePoints()` method was returning all of the points generated for each atom, not just those on the surface.
2. Calling `GetAtomSurfaceArea()` repeatedly (which can also happen by calling `GetSurfacePoints()` or any of the other methods that call `GetAtomSurfaceArea()` resulted in the set of surface points for each atom growing with each call.

Fix here:
1. Add optional argument to `GetSurfacePoints()` so that it can return either all points for each atom or only the ones on the surface. The default is only the ones on the surface.
2. Make sure repeated calls to `GetAtomSurfaceArea()` re-initialize the surface points each time instead of appending.