### PR TITLE
Adjust distdriver_() return type

### DIFF
--- a/Code/ML/Cluster/Murtagh/Clustering.cpp
+++ b/Code/ML/Cluster/Murtagh/Clustering.cpp
@@ -17,9 +17,9 @@ namespace python = boost::python;
 
 typedef double real;
 
-extern "C" void distdriver_(boost::int64_t *n, boost::int64_t *len, real *dists,
-                            boost::int64_t *toggle, boost::int64_t *ia,
-                            boost::int64_t *ib, real *crit);
+extern "C" int distdriver_(boost::int64_t *n, boost::int64_t *len, real *dists,
+                           boost::int64_t *toggle, boost::int64_t *ia,
+                           boost::int64_t *ib, real *crit);
 
 //
 // Rather than deal with any nonsense like trying to get

--- a/Code/ML/Cluster/Murtagh/nbClustering.cpp
+++ b/Code/ML/Cluster/Murtagh/nbClustering.cpp
@@ -18,8 +18,8 @@ typedef double real;
 namespace nb = nanobind;
 using namespace nb::literals;
 
-extern "C" void distdriver_(long *n, long *len, real *dists, long *toggle,
-                            long *ia, long *ib, real *crit);
+extern "C" int distdriver_(long *n, long *len, real *dists, long *toggle,
+                           long *ia, long *ib, real *crit);
 
 //
 // Rather than deal with any nonsense like trying to get

--- a/Code/SimDivPickers/HierarchicalClusterPicker.cpp
+++ b/Code/SimDivPickers/HierarchicalClusterPicker.cpp
@@ -12,9 +12,9 @@
 #include <RDGeneral/types.h>
 
 typedef double real;
-extern "C" void distdriver_(long int *n, long int *len, real *dists,
-                            long int *toggle, long int *ia, long int *ib,
-                            real *crit);
+extern "C" int distdriver_(long int *n, long int *len, real *dists,
+                           long int *toggle, long int *ia, long int *ib,
+                           real *crit);
 
 namespace RDPickers {
 


### PR DESCRIPTION
#### Reference Issue
This is only a partial fix for https://github.com/rdkit/rdkit/issues/9575

#### What does this implement/fix? Explain your changes.
It fixes the return type of the `distdriver_()` function, because it's the part of the ABI mismatch that actually is blocking emscripten compilation. It makes sures the function returns an `int` (even though that value is always zero, and never used).

#### Any other comments?
The other part of the fix, to match the correct integer sizes, is less trivial.
