### PR TITLE
CIP labeler: some bug fixing and refactoring

### DIFF
--- a/Code/GraphMol/CIPLabeler/CIPLabeler.cpp
+++ b/Code/GraphMol/CIPLabeler/CIPLabeler.cpp
@@ -10,12 +10,14 @@
 //
 #include <algorithm>
 #include <memory>
+#include <sstream>
 
 #include <boost/algorithm/string.hpp>
 
 #include "GraphMol/Chirality.h"
 #include "GraphMol/RDKitBase.h"
 #include <RDGeneral/ControlCHandler.h>
+#include <RDGeneral/Exceptions.h>
 
 #include "CIPLabeler.h"
 #include "CIPMol.h"
@@ -39,6 +41,13 @@ namespace CIPLabeler {
 
 namespace {
 
+struct ConfigEntry {
+  std::unique_ptr<Configuration> config;
+  bool selected = false;
+};
+
+using ConfigList = std::vector<ConfigEntry>;
+
 // constitutional rules
 const Rules constitutional_rules({new Rule1a, new Rule1b, new Rule2});
 
@@ -46,24 +55,29 @@ const Rules constitutional_rules({new Rule1a, new Rule1b, new Rule2});
 const Rules all_rules({new Rule1a, new Rule1b, new Rule2, new Rule3, new Rule4a,
                        new Rule4b, new Rule4c, new Rule5New, new Rule6});
 
-std::vector<std::unique_ptr<Configuration>> findConfigs(
-    CIPMol &mol, const boost::dynamic_bitset<> &atoms,
-    const boost::dynamic_bitset<> &bonds) {
-  std::vector<std::unique_ptr<Configuration>> configs;
+bool isSelected(const boost::dynamic_bitset<> &selection, unsigned int index) {
+  return !selection.empty() && selection.test(index);
+}
 
-  for (auto index = atoms.find_first(); index != boost::dynamic_bitset<>::npos;
-       index = atoms.find_next(index)) {
+ConfigList findConfigs(CIPMol &mol, const boost::dynamic_bitset<> &atoms,
+                       const boost::dynamic_bitset<> &bonds) {
+  ConfigList configs;
+
+  // All configurations are required here, including unselected ones: they may
+  // provide auxiliary descriptors needed to label a selected configuration.
+  for (unsigned int index = 0; index < mol.getNumAtoms(); ++index) {
     auto atom = mol.getAtom(index);
     auto chiraltag = atom->getChiralTag();
     if (chiraltag == Atom::CHI_TETRAHEDRAL_CW ||
         chiraltag == Atom::CHI_TETRAHEDRAL_CCW) {
-      std::unique_ptr<Tetrahedral> cfg{new Tetrahedral(mol, atom)};
-      configs.push_back(std::move(cfg));
+      auto cfg = std::make_unique<Tetrahedral>(mol, atom);
+      if (cfg->getCarriers().size() == 4) {
+        configs.push_back({std::move(cfg), isSelected(atoms, index)});
+      }
     }
   }
 
-  for (auto index = bonds.find_first(); index != boost::dynamic_bitset<>::npos;
-       index = bonds.find_next(index)) {
+  for (unsigned int index = 0; index < mol.getNumBonds(); ++index) {
     auto bond = mol.getBond(index);
 
     auto bond_cfg = bond->getStereo();
@@ -80,16 +94,26 @@ std::vector<std::unique_ptr<Configuration>> findConfigs(
     switch (bond_cfg) {
       case Bond::STEREOTRANS:
       case Bond::STEREOCIS: {
-        std::unique_ptr<Sp2Bond> cfg(new Sp2Bond(
-            mol, bond, bond->getBeginAtom(), bond->getEndAtom(), bond_cfg));
-        configs.push_back(std::move(cfg));
+        if (bond->getBondType() != Bond::DOUBLE) {
+          break;
+        }
+        auto cfg = std::make_unique<Sp2Bond>(mol, bond, bond->getBeginAtom(),
+                                             bond->getEndAtom(), bond_cfg);
+        if (cfg->getCarriers().size() == 2) {
+          configs.push_back({std::move(cfg), isSelected(bonds, index)});
+        }
       } break;
 
       case Bond::STEREOATROPCCW:
       case Bond::STEREOATROPCW: {
-        std::unique_ptr<AtropisomerBond> cfgAtrop(new AtropisomerBond(
-            mol, bond, bond->getBeginAtom(), bond->getEndAtom(), bond_cfg));
-        configs.push_back(std::move(cfgAtrop));
+        if (bond->getBondType() != Bond::SINGLE) {
+          break;
+        }
+        auto cfg = std::make_unique<AtropisomerBond>(
+            mol, bond, bond->getBeginAtom(), bond->getEndAtom(), bond_cfg);
+        if (cfg->getCarriers().size() == 2) {
+          configs.push_back({std::move(cfg), isSelected(bonds, index)});
+        }
       } break;
 
       default:
@@ -100,17 +124,16 @@ std::vector<std::unique_ptr<Configuration>> findConfigs(
   return configs;
 }
 
-bool labelAux(std::vector<std::unique_ptr<Configuration>> &configs,
-              const Rules &rules,
-              const std::unique_ptr<Configuration> &center) {
+bool labelAux(ConfigList &configs, const Rules &rules, ConfigEntry &center) {
   using Node_Cfg_Pair = std::pair<Node *, Configuration *>;
   std::vector<Node_Cfg_Pair> aux;
 
-  auto &digraph = center->getDigraph();
-  for (const auto &config : configs) {
-    if (config == center) {
+  auto &digraph = center.config->getDigraph();
+  for (const auto &entry : configs) {
+    if (entry.config.get() == center.config.get()) {
       continue;
     }
+    const auto &config = entry.config;
     // FIXME: specific to each descriptor
     const auto &foci = config->getFoci();
 
@@ -141,7 +164,10 @@ bool labelAux(std::vector<std::unique_ptr<Configuration>> &configs,
   auto farthest = [](const Node_Cfg_Pair &a, const Node_Cfg_Pair &b) {
     return a.first->getDistance() > b.first->getDistance();
   };
-  std::sort(aux.begin(), aux.end(), farthest);
+
+  // this sorting is stable in the original code, so use
+  // stable sorting here too, despite it doesn't seem to be relevant
+  std::stable_sort(aux.begin(), aux.end(), farthest);
 
   // Using a boost::unordered_map because it is more performant
   // than the STL version.
@@ -159,7 +185,9 @@ bool labelAux(std::vector<std::unique_ptr<Configuration>> &configs,
     }
     const auto &config = e.second;
     auto label = config->label(node, digraph, rules);
-    queue.emplace(node, label);
+    // Also match the original code: a later configuration at this distance
+    // "wins" if multiple configurations map to the same digraph node.
+    queue[node] = label;
   }
 
   for (const auto &e : queue) {
@@ -234,16 +262,17 @@ class ScopedPreliminaryBudget {
   ~ScopedPreliminaryBudget() { iterationBudget.endPreliminaryPass(); }
 };
 
-void label(std::vector<std::unique_ptr<Configuration>> &configs,
-           unsigned int maxRecursiveIterations) {
+void label(ConfigList &configs, unsigned int maxRecursiveIterations) {
   const ScopedIterationBudget callBudget(maxRecursiveIterations);
 
   // First, if the specified number of iterations allows it, run all centers
   // through a fast pass with the constitutional rules allow easy stuff to be
   // resolved.
-  for (auto &conf : configs) {
-    // Make sure this stereo center has no label
-    conf->resetPrimaryLabel();
+  for (auto &entry : configs) {
+    if (!entry.selected) {
+      continue;
+    }
+    auto &conf = entry.config;
 
     try {
       const ScopedPreliminaryBudget preliminaryBudget;
@@ -256,7 +285,11 @@ void label(std::vector<std::unique_ptr<Configuration>> &configs,
   }
 
   // try again on everything that hasn't been resolved yet
-  for (const auto &conf : configs) {
+  for (auto &entry : configs) {
+    if (!entry.selected) {
+      continue;
+    }
+    auto &conf = entry.config;
     if (conf->hasPrimaryLabel()) {
       // already resolved!
       continue;
@@ -266,7 +299,7 @@ void label(std::vector<std::unique_ptr<Configuration>> &configs,
     if (desc != Descriptor::UNKNOWN) {
       conf->setPrimaryLabel(desc);
     } else {
-      if (labelAux(configs, all_rules, conf)) {
+      if (labelAux(configs, all_rules, entry)) {
         desc = conf->label(all_rules);
 
         if (desc != Descriptor::UNKNOWN) {
@@ -277,6 +310,50 @@ void label(std::vector<std::unique_ptr<Configuration>> &configs,
   }
 }
 
+void validateSelection(const boost::dynamic_bitset<> &selection,
+                       unsigned int expectedSize, const char *kind) {
+  // Empty bitsets intentionally select none and are part of the public API.
+  if (!selection.empty() && selection.size() != expectedSize) {
+    std::ostringstream msg;
+    msg << "Error: CIP " << kind
+        << " selection bitset does not match the number of " << kind
+        << "s on the mol.";
+    throw ValueErrorException(msg.str());
+  }
+}
+
+template <typename T>
+void clearCIPProperties(T *object) {
+  object->clearProp(common_properties::_CIPCode);
+  object->clearProp(common_properties::_CIPNeighborOrder);
+}
+
+void clearSelectedCIPProperties(ROMol &mol,
+                                const boost::dynamic_bitset<> &atoms,
+                                const boost::dynamic_bitset<> &bonds,
+                                bool fullSelection) {
+  mol.clearProp(common_properties::_CIPComputed);
+
+  if (fullSelection) {
+    for (auto atom : mol.atoms()) {
+      clearCIPProperties(atom);
+    }
+    for (auto bond : mol.bonds()) {
+      clearCIPProperties(bond);
+    }
+    return;
+  }
+
+  for (auto index = atoms.find_first(); index != boost::dynamic_bitset<>::npos;
+       index = atoms.find_next(index)) {
+    clearCIPProperties(mol.getAtomWithIdx(index));
+  }
+  for (auto index = bonds.find_first(); index != boost::dynamic_bitset<>::npos;
+       index = bonds.find_next(index)) {
+    clearCIPProperties(mol.getBondWithIdx(index));
+  }
+}
+
 }  // namespace
 
 void assignCIPLabels(ROMol &mol, const boost::dynamic_bitset<> &atoms,
@@ -284,8 +361,13 @@ void assignCIPLabels(ROMol &mol, const boost::dynamic_bitset<> &atoms,
                      unsigned int maxRecursiveIterations) {
   ControlCHandler hdlr;
 
-  // reset the mark, for the case that this fails
-  mol.clearProp(common_properties::_CIPComputed);
+  validateSelection(atoms, mol.getNumAtoms(), "atom");
+  validateSelection(bonds, mol.getNumBonds(), "bond");
+
+  const bool fullSelection = atoms.all() && bonds.all();
+
+  clearSelectedCIPProperties(mol, atoms, bonds, fullSelection);
+
   CIPMol cipmol{mol};
   auto configs = findConfigs(cipmol, atoms, bonds);
 
@@ -299,8 +381,10 @@ void assignCIPLabels(ROMol &mol, const boost::dynamic_bitset<> &atoms,
     return;
   }
 
-  const bool computed = true;
-  mol.setProp(common_properties::_CIPComputed, true, computed);
+  if (fullSelection) {
+    constexpr bool computed = true;
+    mol.setProp(common_properties::_CIPComputed, true, computed);
+  }
 }
 
 void assignCIPLabels(ROMol &mol, unsigned int maxRecursiveIterations) {

--- a/Code/GraphMol/CIPLabeler/CIPLabeler.cpp
+++ b/Code/GraphMol/CIPLabeler/CIPLabeler.cpp
@@ -169,16 +169,75 @@ bool labelAux(std::vector<std::unique_ptr<Configuration>> &configs,
   return true;
 }
 
-thread_local unsigned int remainingCallCount = 0;
-
 // The chiral centers in current rdkit examples that can be resolved using only
 // the constitutional rules average about 8 iterations (the highest count is
 // 1039, in one of the examples in the CIP validation suite). We use 2000 as
 // threshold to allow some margin.
 constexpr unsigned int constitutionalRuleTimeout = 2000;
 
+struct IterationBudget {
+  void reset(unsigned int maxRecursiveIterations) {
+    hasGlobalLimit = maxRecursiveIterations != 0;
+    remainingGlobal = maxRecursiveIterations;
+    inPreliminaryPass = false;
+    remainingPreliminary = 0;
+  }
+
+  void beginPreliminaryPass() {
+    inPreliminaryPass = true;
+    remainingPreliminary = constitutionalRuleTimeout;
+  }
+
+  void endPreliminaryPass() {
+    inPreliminaryPass = false;
+    remainingPreliminary = 0;
+  }
+
+  bool consume() {
+    if ((inPreliminaryPass && remainingPreliminary == 0) ||
+        (hasGlobalLimit && remainingGlobal == 0)) {
+      return false;
+    }
+    if (inPreliminaryPass) {
+      --remainingPreliminary;
+    }
+    if (hasGlobalLimit) {
+      --remainingGlobal;
+    }
+    return true;
+  }
+
+  bool hasGlobalLimit = false;
+  unsigned int remainingGlobal = 0;
+  bool inPreliminaryPass = false;
+  unsigned int remainingPreliminary = 0;
+};
+
+thread_local IterationBudget iterationBudget;
+
+class ScopedIterationBudget {
+ public:
+  explicit ScopedIterationBudget(unsigned int maxRecursiveIterations)
+      : d_previous{iterationBudget} {
+    iterationBudget.reset(maxRecursiveIterations);
+  }
+
+  ~ScopedIterationBudget() { iterationBudget = d_previous; }
+
+ private:
+  IterationBudget d_previous;
+};
+
+class ScopedPreliminaryBudget {
+ public:
+  ScopedPreliminaryBudget() { iterationBudget.beginPreliminaryPass(); }
+  ~ScopedPreliminaryBudget() { iterationBudget.endPreliminaryPass(); }
+};
+
 void label(std::vector<std::unique_ptr<Configuration>> &configs,
            unsigned int maxRecursiveIterations) {
+  const ScopedIterationBudget callBudget(maxRecursiveIterations);
+
   // First, if the specified number of iterations allows it, run all centers
   // through a fast pass with the constitutional rules allow easy stuff to be
   // resolved.
@@ -186,22 +245,14 @@ void label(std::vector<std::unique_ptr<Configuration>> &configs,
     // Make sure this stereo center has no label
     conf->resetPrimaryLabel();
 
-    remainingCallCount = constitutionalRuleTimeout;
     try {
+      const ScopedPreliminaryBudget preliminaryBudget;
       auto desc = conf->label(constitutional_rules);
       if (desc != Descriptor::UNKNOWN) {
         conf->setPrimaryLabel(desc);
       }
     } catch (const MaxIterationsExceeded &) {
     }
-  }
-
-  // Now, retry everything that hasn't been solved with a more generous
-  // threshold
-  if (maxRecursiveIterations != 0) {
-    remainingCallCount = maxRecursiveIterations;
-  } else {
-    remainingCallCount = UINT_MAX;  // really big - will never be hit
   }
 
   // try again on everything that hasn't been resolved yet
@@ -265,7 +316,7 @@ void assignCIPLabels(ROMol &mol, unsigned int maxRecursiveIterations) {
 namespace CIPLabeler_detail {
 
 bool decrementRemainingCallCountAndCheck() {
-  return (--CIPLabeler::remainingCallCount) > 0;
+  return CIPLabeler::iterationBudget.consume();
 }
 
 }  // namespace CIPLabeler_detail

--- a/Code/GraphMol/CIPLabeler/CIPLabeler.cpp
+++ b/Code/GraphMol/CIPLabeler/CIPLabeler.cpp
@@ -310,18 +310,6 @@ void label(ConfigList &configs, unsigned int maxRecursiveIterations) {
   }
 }
 
-void validateSelection(const boost::dynamic_bitset<> &selection,
-                       unsigned int expectedSize, const char *kind) {
-  // Empty bitsets intentionally select none and are part of the public API.
-  if (!selection.empty() && selection.size() != expectedSize) {
-    std::ostringstream msg;
-    msg << "Error: CIP " << kind
-        << " selection bitset does not match the number of " << kind
-        << "s on the mol.";
-    throw ValueErrorException(msg.str());
-  }
-}
-
 template <typename T>
 void clearCIPProperties(T *object) {
   object->clearProp(common_properties::_CIPCode);
@@ -359,10 +347,12 @@ void clearSelectedCIPProperties(ROMol &mol,
 void assignCIPLabels(ROMol &mol, const boost::dynamic_bitset<> &atoms,
                      const boost::dynamic_bitset<> &bonds,
                      unsigned int maxRecursiveIterations) {
-  ControlCHandler hdlr;
+  PRECONDITION(atoms.size() == mol.getNumAtoms(),
+               "Atoms bitset size does not match number of atoms")
+  PRECONDITION(bonds.size() == mol.getNumBonds(),
+               "Bonds bitset size does not match number of bonds")
 
-  validateSelection(atoms, mol.getNumAtoms(), "atom");
-  validateSelection(bonds, mol.getNumBonds(), "bond");
+  ControlCHandler hdlr;
 
   const bool fullSelection = atoms.all() && bonds.all();
 

--- a/Code/GraphMol/CIPLabeler/CIPLabeler.h
+++ b/Code/GraphMol/CIPLabeler/CIPLabeler.h
@@ -74,8 +74,14 @@ RDKIT_CIPLABELER_EXPORT void assignCIPLabels(
  *   \param mol - the molecule to be labelled.
  *
  *   \param atoms - bitset with the atom indexes to be labeled.
+ *      A nonempty bitset must have mol.getNumAtoms() bits. Unselected atom
+ *      configurations may still be used as auxiliary stereochemical
+ *      dependencies, but their primary labels are not written.
  *
  *   \param bonds - bitset with the bond indexes to be labeled.
+ *      A nonempty bitset must have mol.getNumBonds() bits. Unselected bond
+ *      configurations may still be used as auxiliary stereochemical
+ *      dependencies, but their primary labels are not written.
  *
  *   \param maxRecursiveIterations - maximum total number of recursive
  *      comparisons across the preliminary and full labeling passes. A value
@@ -83,6 +89,9 @@ RDKIT_CIPLABELER_EXPORT void assignCIPLabels(
  *      about 1 second. Most structures require fewer than 10,000 comparisons.
  *      A peptide with MW~3000 took about 100 comparisons, and a 20,000 MW
  *      protein took about 600 comparisons.
+ *
+ *   \note Partial labeling does not set common_properties::_CIPComputed,
+ *      which denotes a complete molecule-wide calculation.
  *
  */
 RDKIT_CIPLABELER_EXPORT void assignCIPLabels(

--- a/Code/GraphMol/CIPLabeler/CIPLabeler.h
+++ b/Code/GraphMol/CIPLabeler/CIPLabeler.h
@@ -27,19 +27,19 @@ RDKIT_CIPLABELER_EXPORT bool decrementRemainingCallCountAndCheck();
 namespace CIPLabeler {
 
 /*
-  Some very symmetrical mols can cause pseudo infinite processing
-  (e.g. dodecahedrane)
-  To avoid this a maxinum number of iterations can be set by the caller as a
-  parameter to assignCIPLabels.
-  If that maximum value is exceeded, the following error is thrown
+  Some very symmetrical mols can cause pseudo-infinite processing
+  (e.g. dodecahedrane). To avoid this, the caller can limit the total number
+  of recursive comparisons performed by assignCIPLabels. The limit applies
+  across both the preliminary and full labeling passes. If the limit is
+  exhausted, the following error is thrown.
 */
 
 class RDKIT_CIPLABELER_EXPORT MaxIterationsExceeded
     : public std::runtime_error {
  public:
   explicit MaxIterationsExceeded()
-      : std::runtime_error("Max Iterations Exceeded in CIP label calculation") {
-        };
+      : std::runtime_error(
+            "Max Iterations Exceeded in CIP label calculation"){};
 };
 
 /**
@@ -61,6 +61,9 @@ class RDKIT_CIPLABELER_EXPORT MaxIterationsExceeded
  *          bond directions will be labelled.
  *   \note Labels will be stored under the common_properties::_CIPCode
  *          property of the relevant atoms/bonds.
+ *   \param maxRecursiveIterations - maximum total number of recursive
+ *          comparisons across all labeling passes; zero means no
+ *          caller-specified limit.
  */
 RDKIT_CIPLABELER_EXPORT void assignCIPLabels(
     ROMol &mol, unsigned int maxRecursiveIterations = 0);
@@ -74,10 +77,12 @@ RDKIT_CIPLABELER_EXPORT void assignCIPLabels(
  *
  *   \param bonds - bitset with the bond indexes to be labeled.
  *
- *   \param maxRecursiveIterations - maximum number of iterations
- *      A value of 1,250,000 take about 1 second.  Most structures requires
- *      less than 10,000 iterations. A peptide with MW~3000 took about
- *      100 iterations, and a 20,000 mw protein took about 600 iterations.
+ *   \param maxRecursiveIterations - maximum total number of recursive
+ *      comparisons across the preliminary and full labeling passes. A value
+ *      of zero means no caller-specified limit. A value of 1,250,000 takes
+ *      about 1 second. Most structures require fewer than 10,000 comparisons.
+ *      A peptide with MW~3000 took about 100 comparisons, and a 20,000 MW
+ *      protein took about 600 comparisons.
  *
  */
 RDKIT_CIPLABELER_EXPORT void assignCIPLabels(

--- a/Code/GraphMol/CIPLabeler/CIPLabeler.h
+++ b/Code/GraphMol/CIPLabeler/CIPLabeler.h
@@ -74,12 +74,12 @@ RDKIT_CIPLABELER_EXPORT void assignCIPLabels(
  *   \param mol - the molecule to be labelled.
  *
  *   \param atoms - bitset with the atom indexes to be labeled.
- *      A nonempty bitset must have mol.getNumAtoms() bits. Unselected atom
+ *      The bitset must have mol.getNumAtoms() bits. Unselected atom
  *      configurations may still be used as auxiliary stereochemical
  *      dependencies, but their primary labels are not written.
  *
  *   \param bonds - bitset with the bond indexes to be labeled.
- *      A nonempty bitset must have mol.getNumBonds() bits. Unselected bond
+ *      The bitset must have mol.getNumBonds() bits. Unselected bond
  *      configurations may still be used as auxiliary stereochemical
  *      dependencies, but their primary labels are not written.
  *

--- a/Code/GraphMol/CIPLabeler/Descriptor.h
+++ b/Code/GraphMol/CIPLabeler/Descriptor.h
@@ -22,7 +22,7 @@ namespace CIPLabeler {
  * Type} which can be useful when comparing centres of different geometry.
  *
  */
-enum class Descriptor {
+enum class Descriptor : uint8_t {
   NONE,  // Unspecified
   UNKNOWN,
   ns,  // Other

--- a/Code/GraphMol/CIPLabeler/Digraph.cpp
+++ b/Code/GraphMol/CIPLabeler/Digraph.cpp
@@ -26,12 +26,12 @@ namespace {
  * Upper limit on the size of the digraph, stops out of memory error with a
  * more graceful failure. 0=Infinite
  */
-const int MAX_NODE_COUNT = 100000;
+constexpr int MAX_NODE_COUNT = 100000;
 
 /**
  * Used for debugging only, 0=Infinite
  */
-const int MAX_NODE_DIST = 0;
+constexpr int MAX_NODE_DIST = 0;
 }  // namespace
 
 Node &Digraph::addNode(std::vector<char> &&visit, Atom *atom,
@@ -136,14 +136,18 @@ void Digraph::expand(Node *beg) {
   const auto &prev =
       edges.size() > 0 && !edges[0]->isBeg(beg) ? edges[0]->getBond() : nullptr;
 
-  if (MAX_NODE_DIST > 0 && beg->getDistance() > MAX_NODE_DIST) {
-    return;
+  if constexpr (MAX_NODE_DIST > 0) {
+    if (beg->getDistance() > MAX_NODE_DIST) {
+      return;
+    }
   }
-  if (MAX_NODE_COUNT > 0 && d_nodes.size() >= MAX_NODE_COUNT) {
-    std::stringstream errmsg;
-    errmsg << "Digraph generation failed: more than " << MAX_NODE_COUNT
-           << "nodes found.";
-    throw TooManyNodesException(errmsg.str());
+  if constexpr (MAX_NODE_COUNT > 0) {
+    if (d_nodes.size() >= MAX_NODE_COUNT) {
+      std::stringstream errmsg;
+      errmsg << "Digraph generation failed: more than " << MAX_NODE_COUNT
+             << " nodes found.";
+      throw TooManyNodesException(errmsg.str());
+    }
   }
 
   // create 'explicit' nodes

--- a/Code/GraphMol/CIPLabeler/Digraph.cpp
+++ b/Code/GraphMol/CIPLabeler/Digraph.cpp
@@ -34,10 +34,20 @@ constexpr int MAX_NODE_COUNT = 100000;
 constexpr int MAX_NODE_DIST = 0;
 }  // namespace
 
-Node &Digraph::addNode(std::vector<char> &&visit, Atom *atom,
-                       boost::rational<int> &&frac, int dist, int flags) {
+Node &Digraph::addNode(std::vector<std::uint32_t> &&visit, Atom *atom,
+                       boost::rational<int> &&frac, int dist, uint8_t flags) {
+  if constexpr (MAX_NODE_COUNT > 0) {
+    if (d_nodes.size() >= MAX_NODE_COUNT) {
+      std::stringstream errmsg;
+      errmsg << "Digraph generation failed: more than " << MAX_NODE_COUNT
+             << " nodes found.";
+      throw TooManyNodesException(errmsg.str());
+    }
+  }
+
   d_nodes.emplace_back(this, std::move(visit), atom, std::move(frac), dist,
                        flags);
+
   return d_nodes.back();
 }
 
@@ -57,7 +67,7 @@ Digraph::Digraph(const CIPMol &mol, Atom *atom, bool atropisomerMode)
     : d_mol{mol} {
   PRECONDITION(atom, "cannot init digraph on a nullptr")
 
-  auto visit = std::vector<char>(d_mol.getNumAtoms());
+  auto visit = std::vector<std::uint32_t>(d_mol.getNumAtoms());
   visit[atom->getIdx()] = 1;
 
   auto dist = 1;
@@ -139,14 +149,6 @@ void Digraph::expand(Node *beg) {
   if constexpr (MAX_NODE_DIST > 0) {
     if (beg->getDistance() > MAX_NODE_DIST) {
       return;
-    }
-  }
-  if constexpr (MAX_NODE_COUNT > 0) {
-    if (d_nodes.size() >= MAX_NODE_COUNT) {
-      std::stringstream errmsg;
-      errmsg << "Digraph generation failed: more than " << MAX_NODE_COUNT
-             << " nodes found.";
-      throw TooManyNodesException(errmsg.str());
     }
   }
 

--- a/Code/GraphMol/CIPLabeler/Digraph.h
+++ b/Code/GraphMol/CIPLabeler/Digraph.h
@@ -17,6 +17,7 @@
 //
 #pragma once
 
+#include <cstdint>
 #include <list>
 #include <vector>
 
@@ -52,6 +53,8 @@ class Digraph {
   Digraph &operator=(const Digraph &) = delete;
 
   Digraph(const CIPMol &mol, Atom *atom, bool atropsomerMode = false);
+  Digraph(CIPMol &&mol, Atom *atom, bool atropsomerMode = false) = delete;
+  Digraph(const CIPMol &&mol, Atom *atom, bool atropsomerMode = false) = delete;
 
   const CIPMol &getMol() const;
 
@@ -91,8 +94,8 @@ class Digraph {
 
   void expand(Node *beg);
 
-  Node &addNode(std::vector<char> &&visit, Atom *atom,
-                boost::rational<int> &&frac, int dist, int flags);
+  Node &addNode(std::vector<std::uint32_t> &&visit, Atom *atom,
+                boost::rational<int> &&frac, int dist, uint8_t flags);
 
   // Has `atom` been seen yet?
   bool seenAtom(Atom *atom) const;

--- a/Code/GraphMol/CIPLabeler/Node.cpp
+++ b/Code/GraphMol/CIPLabeler/Node.cpp
@@ -54,6 +54,10 @@ Node::Node(Digraph *g, std::vector<char> &&visit, Atom *atom,
       d_atomic_mass = table->getAtomicWeight(atomic_number);
     } else {
       d_atomic_mass = table->getMassForIsotope(atomic_number, isotope);
+      // Fall back to the isotope number if we can't get the mass
+      if (atomic_number != 0 && d_atomic_mass == 0.0) {
+        d_atomic_mass = isotope;
+      }
     }
   }
   if (d_visit.empty() || d_flags & DUPLICATE) {

--- a/Code/GraphMol/CIPLabeler/Node.cpp
+++ b/Code/GraphMol/CIPLabeler/Node.cpp
@@ -18,15 +18,15 @@
 namespace RDKit {
 namespace CIPLabeler {
 
-Node *Node::newTerminalChild(int idx, Atom *atom, int flags) const {
+Node *Node::newTerminalChild(int idx, Atom *atom, uint8_t flags) const {
   int new_dist = flags & DUPLICATE ? d_visit[idx] : d_dist + 1;
-  std::vector<char> new_visit;
+  std::vector<std::uint32_t> new_visit;
 
   if (flags & BOND_DUPLICATE) {
     const auto &frac = dp_g->getMol().getFractionalAtomicNum(dp_atom);
     if (frac.isAveraged()) {
-      return &dp_g->addNode(std::move(new_visit), atom, frac.value(),
-                            new_dist, flags);
+      return &dp_g->addNode(std::move(new_visit), atom, frac.value(), new_dist,
+                            flags);
     }
   }
 
@@ -35,8 +35,8 @@ Node *Node::newTerminalChild(int idx, Atom *atom, int flags) const {
                         flags);
 }
 
-Node::Node(Digraph *g, std::vector<char> &&visit, Atom *atom,
-           boost::rational<int> &&frac, int dist, int flags)
+Node::Node(Digraph *g, std::vector<std::uint32_t> &&visit, Atom *atom,
+           boost::rational<int> &&frac, int dist, uint8_t flags)
     : dp_g{g},
       dp_atom{atom},
       d_dist{dist},
@@ -99,7 +99,7 @@ double Node::getAtomicMass() const { return d_atomic_mass; }
 
 Descriptor Node::getAux() const { return d_aux; }
 
-bool Node::isSet(int mask) const { return mask & d_flags; }
+bool Node::isSet(uint8_t mask) const { return mask & d_flags; }
 
 bool Node::isDuplicate() const { return d_flags & DUPLICATE; }
 
@@ -115,7 +115,7 @@ bool Node::isVisited(int idx) const { return d_visit[idx] != 0; }
 
 Node *Node::newChild(int idx, Atom *atom) const {
   auto new_visit = d_visit;
-  new_visit[idx] = static_cast<char>(d_dist + 1);
+  new_visit[idx] = d_dist + 1;
   auto atomic_num = atom ? atom->getAtomicNum() : 1;
   return &dp_g->addNode(std::move(new_visit), atom, atomic_num, d_dist + 1, 0);
 }

--- a/Code/GraphMol/CIPLabeler/Node.h
+++ b/Code/GraphMol/CIPLabeler/Node.h
@@ -10,6 +10,7 @@
 //
 #pragma once
 
+#include <cstdint>
 #include <vector>
 
 #include "Descriptor.h"
@@ -29,45 +30,45 @@ class Node {
   /**
    * Flag indicates whether the node has been expanded.
    */
-  static const int EXPANDED = 0x1;
+  static constexpr uint8_t EXPANDED = 0x1;
 
   /**
    * Flag indicates whether the node was duplicated
    * at a ring closure.
    */
-  static const int RING_DUPLICATE = 0x2;
+  static constexpr uint8_t RING_DUPLICATE = 0x2;
 
   /**
    * Flag indicates whether the node was duplicated
    * at a bond with order &gt; 1.
    */
-  static const int BOND_DUPLICATE = 0x4;
+  static constexpr uint8_t BOND_DUPLICATE = 0x4;
 
   /**
    * Mask to check if a node is duplicated.
    */
 
-  static const int DUPLICATE = RING_DUPLICATE | BOND_DUPLICATE;
+  static constexpr uint8_t DUPLICATE = RING_DUPLICATE | BOND_DUPLICATE;
 
   /**
    * Node was created for an implicit hydrogen,
    * the 'atom' value will be null.
    */
-  static const int IMPL_HYDROGEN = 0x8;
+  static constexpr uint8_t IMPL_HYDROGEN = 0x8;
 
   /**
    * Mask to check if a node is duplicated or created for an implicit H (not a
    * primary node).
    */
-  static const int DUPLICATE_OR_H =
+  static constexpr uint8_t DUPLICATE_OR_H =
       RING_DUPLICATE | BOND_DUPLICATE | IMPL_HYDROGEN;
 
   Node() = delete;
   Node(const Node &) = delete;
   Node &operator=(const Node &) = delete;
 
-  Node(Digraph *g, std::vector<char> &&visit, Atom *atom,
-       boost::rational<int> &&frac, int dist, int flags);
+  Node(Digraph *g, std::vector<std::uint32_t> &&visit, Atom *atom,
+       boost::rational<int> &&frac, int dist, uint8_t flags);
 
   Digraph *getDigraph() const;
 
@@ -87,7 +88,7 @@ class Node {
 
   Descriptor getAux() const;
 
-  bool isSet(int mask) const;
+  bool isSet(uint8_t mask) const;
 
   bool isDuplicate() const;
 
@@ -124,13 +125,13 @@ class Node {
   boost::rational<int> d_atomic_num;
   double d_atomic_mass;
   Descriptor d_aux = Descriptor::NONE;
-  int d_flags = 0x0;
+  uint8_t d_flags = 0x0;
 
   std::vector<Edge *> d_edges;
 
-  std::vector<char> d_visit;
+  std::vector<std::uint32_t> d_visit;
 
-  Node *newTerminalChild(int idx, Atom *atom, int flags) const;
+  Node *newTerminalChild(int idx, Atom *atom, uint8_t flags) const;
 };
 
 }  // namespace CIPLabeler

--- a/Code/GraphMol/CIPLabeler/Wrap/rdCIPLabeler.cpp
+++ b/Code/GraphMol/CIPLabeler/Wrap/rdCIPLabeler.cpp
@@ -72,10 +72,12 @@ BOOST_PYTHON_MODULE(rdCIPLabeler) {
       " - atomsToLabel: (optional) list of atoms to label\n"
       " - bondsToLabel: (optional) list of bonds to label\n"
       " - maxRecursiveIterations: (optional) protects against pseudo-infinite\n"
-      "recursion for highly symmetrical structures.\n A value of 1,250,000 take"
-      " about 1 second.  Most structures requires less than 10,000"
-      "iterations.\n A peptide with MW~3000 took about 100 iterations, and a "
-      "20,000 mw protein took about 600 iterations\n(0 = default - no limit)\n";
+      "recursion for highly symmetrical structures. The limit is shared by "
+      "the preliminary and full labeling passes.\n A value of 1,250,000 takes"
+      " about 1 second. Most structures require fewer than 10,000 recursive "
+      "comparisons.\n A peptide with MW~3000 took about 100 comparisons, and a "
+      "20,000 MW protein took about 600 comparisons\n(0 = default - no "
+      "limit)\n";
 
   python::def(
       "AssignCIPLabels", assignCIPLabelsWrapHelper,

--- a/Code/GraphMol/CIPLabeler/catch_tests.cpp
+++ b/Code/GraphMol/CIPLabeler/catch_tests.cpp
@@ -13,9 +13,8 @@
 #include <list>
 #include <ranges>
 #include <string>
+#include <type_traits>
 #include <vector>
-
-#include <sstream>
 
 #ifdef RDK_TEST_MULTITHREADED
 #include <csignal>
@@ -52,6 +51,10 @@
 
 using namespace RDKit;
 using namespace RDKit::CIPLabeler;
+
+static_assert(std::is_constructible_v<Digraph, const CIPMol &, Atom *>);
+static_assert(!std::is_constructible_v<Digraph, CIPMol &&, Atom *>);
+static_assert(!std::is_constructible_v<Digraph, const CIPMol &&, Atom *>);
 
 TEST_CASE("Rules eagerly initializes its composite sorter", "[accurateCIP]") {
   const Rule1a standaloneRule;
@@ -194,6 +197,48 @@ TEST_CASE("Digraph", "[accurateCIP]") {
   REQUIRE(current_root->getAtom()->getIdx() == new_root_idx);
 
   check_incoming_edge_count(current_root);
+}
+
+TEST_CASE("Digraph safety limits", "[accurateCIP]") {
+  SECTION("visit distances do not wrap on long paths") {
+    RWMol mol;
+    constexpr auto chain_length = 260u;
+    for (auto i = 0u; i < chain_length; ++i) {
+      auto atom = new Atom(6);
+      atom->setNoImplicit(true);
+      mol.addAtom(atom, true, true);
+      if (i != 0u) {
+        mol.addBond(i - 1, i, Bond::SINGLE);
+      }
+    }
+
+    CIPLabeler::CIPMol cipmol(mol);
+    Digraph graph(cipmol, cipmol.getAtom(0));
+    expandAll(graph);
+
+    CHECK(graph.getNumNodes() == chain_length);
+    const auto terminal_nodes =
+        graph.getNodes(cipmol.getAtom(chain_length - 1));
+    REQUIRE(terminal_nodes.size() == 1);
+    CHECK(terminal_nodes.front()->getDistance() == chain_length);
+  }
+
+  SECTION("node cap applies to each insertion") {
+    auto mol = "C"_smiles;
+    CIPLabeler::CIPMol cipmol(*mol);
+    Digraph graph(cipmol, cipmol.getAtom(0));
+
+    constexpr auto max_node_count = 100000;
+    for (auto i = 1; i < max_node_count; ++i) {
+      graph.addNode({}, nullptr, boost::rational<int>(1), 1,
+                    Node::IMPL_HYDROGEN);
+    }
+    CHECK(graph.getNumNodes() == max_node_count);
+    CHECK_THROWS_AS(graph.addNode({}, nullptr, boost::rational<int>(1), 1,
+                                  Node::IMPL_HYDROGEN),
+                    TooManyNodesException);
+    CHECK(graph.getNumNodes() == max_node_count);
+  }
 }
 
 TEST_CASE("Mancude fractional atomic numbers", "[accurateCIP]") {

--- a/Code/GraphMol/CIPLabeler/catch_tests.cpp
+++ b/Code/GraphMol/CIPLabeler/catch_tests.cpp
@@ -9,7 +9,6 @@
 //
 
 #include <algorithm>
-#include <bitset>
 #include <list>
 #include <ranges>
 #include <string>
@@ -538,7 +537,7 @@ TEST_CASE("assign specific atoms and bonds", "[accurateCIP]") {
     atom5->clearProp(common_properties::_CIPCode);
 
     boost::dynamic_bitset<> atoms(mol->getNumAtoms());
-    boost::dynamic_bitset<> bonds;
+    boost::dynamic_bitset<> bonds(mol->getNumBonds());
     atoms.set(1);
     CIPLabeler::assignCIPLabels(*mol, atoms, bonds);
 
@@ -561,7 +560,7 @@ TEST_CASE("assign specific atoms and bonds", "[accurateCIP]") {
     REQUIRE(!bond1->hasProp(common_properties::_CIPCode));
     REQUIRE(!bond3->hasProp(common_properties::_CIPCode));
 
-    boost::dynamic_bitset<> atoms;
+    boost::dynamic_bitset<> atoms(mol->getNumAtoms());
     boost::dynamic_bitset<> bonds(mol->getNumBonds());
     bonds.set(3);
     CIPLabeler::assignCIPLabels(*mol, atoms, bonds);
@@ -587,7 +586,7 @@ TEST_CASE("assign specific atoms and bonds", "[accurateCIP]") {
     mol->clearProp(common_properties::_CIPComputed);
 
     boost::dynamic_bitset<> atoms(mol->getNumAtoms());
-    boost::dynamic_bitset<> bonds;
+    boost::dynamic_bitset<> bonds(mol->getNumBonds());
     atoms.set(7);
     CIPLabeler::assignCIPLabels(*mol, atoms, bonds);
 
@@ -601,17 +600,17 @@ TEST_CASE("assign specific atoms and bonds", "[accurateCIP]") {
     auto mol = "C[C@H](F)Cl"_smiles;
     REQUIRE(mol);
 
-    boost::dynamic_bitset<> noBonds;
+    boost::dynamic_bitset<> noBonds(mol->getNumBonds());
     boost::dynamic_bitset<> wrongAtoms(mol->getNumAtoms() + 1);
     wrongAtoms.set(1);
     CHECK_THROWS_AS(CIPLabeler::assignCIPLabels(*mol, wrongAtoms, noBonds),
-                    ValueErrorException);
+                    Invar::Invariant);
 
-    boost::dynamic_bitset<> noAtoms;
+    boost::dynamic_bitset<> noAtoms(mol->getNumAtoms());
     boost::dynamic_bitset<> wrongBonds(mol->getNumBonds() + 1);
     wrongBonds.set(0);
     CHECK_THROWS_AS(CIPLabeler::assignCIPLabels(*mol, noAtoms, wrongBonds),
-                    ValueErrorException);
+                    Invar::Invariant);
   }
 }
 
@@ -674,7 +673,7 @@ TEST_CASE("CIP label property lifecycle", "[accurateCIP]") {
     unselected->setProp(common_properties::_CIPCode, std::string("keep"));
 
     boost::dynamic_bitset<> atoms(mol->getNumAtoms());
-    boost::dynamic_bitset<> bonds;
+    boost::dynamic_bitset<> bonds(mol->getNumBonds());
     atoms.set(0);
     CIPLabeler::assignCIPLabels(*mol, atoms, bonds);
 

--- a/Code/GraphMol/CIPLabeler/catch_tests.cpp
+++ b/Code/GraphMol/CIPLabeler/catch_tests.cpp
@@ -26,6 +26,7 @@
 #include <RDGeneral/BoostStartInclude.h>
 #include <boost/algorithm/string.hpp>
 #include <RDGeneral/BoostEndInclude.h>
+#include <RDGeneral/Exceptions.h>
 
 #include <catch2/catch_all.hpp>
 
@@ -380,6 +381,32 @@ TEST_CASE("Rule2", "[accurateCIP]") {
 
     CHECK(rule.getSorter()->prioritize(origin, edges).isUnique());
   }
+
+  SECTION("Unknown isotope falls back to its mass number") {
+    auto mol = "[999C]O[14C]"_smiles;
+    CIPLabeler::CIPMol cipmol(*mol);
+    Digraph g(cipmol, cipmol.getAtom(1));
+    auto origin = g.getOriginalRoot();
+    auto edges = origin->getEdges();
+    REQUIRE(edges.size() == 2);
+
+    Edge *unknown = nullptr;
+    Edge *known = nullptr;
+    for (auto edge : edges) {
+      if (edge->getEnd()->getMassNum() == 999) {
+        unknown = edge;
+      } else if (edge->getEnd()->getMassNum() == 14) {
+        known = edge;
+      }
+    }
+    REQUIRE(unknown);
+    REQUIRE(known);
+    CHECK(unknown->getEnd()->getAtomicMass() == Catch::Approx(999.0));
+
+    Rule2 rule;
+    CHECK(rule.compare(unknown, known) > 0);
+    CHECK(rule.compare(known, unknown) < 0);
+  }
 }
 
 TEST_CASE("Tetrahedral assignment", "[accurateCIP]") {
@@ -474,6 +501,7 @@ TEST_CASE("assign specific atoms and bonds", "[accurateCIP]") {
     CHECK(atom1->getPropIfPresent(common_properties::_CIPCode, chirality));
     CHECK(chirality == "S");
     CHECK(!atom5->hasProp(common_properties::_CIPCode));
+    CHECK(!mol->hasProp(common_properties::_CIPComputed));
   }
   SECTION("Assign bonds") {
     auto mol = R"(C\C=C\C=C/C)"_smiles;
@@ -497,6 +525,160 @@ TEST_CASE("assign specific atoms and bonds", "[accurateCIP]") {
     CHECK(!bond1->hasProp(common_properties::_CIPCode));
     CHECK(bond3->getPropIfPresent(common_properties::_CIPCode, stereo));
     CHECK(stereo == "Z");
+    CHECK(!mol->hasProp(common_properties::_CIPComputed));
+  }
+  SECTION("Selected pseudoasymmetric center uses unselected dependencies") {
+    auto mol = "C\\C=C/[C@@H](\\C=C\\O)[C@H](C)[C@H](\\C=C/C)\\C=C\\O"_smiles;
+    REQUIRE(mol);
+
+    for (auto atom : mol->atoms()) {
+      atom->clearProp(common_properties::_CIPCode);
+      atom->clearProp(common_properties::_CIPNeighborOrder);
+    }
+    for (auto bond : mol->bonds()) {
+      bond->clearProp(common_properties::_CIPCode);
+      bond->clearProp(common_properties::_CIPNeighborOrder);
+    }
+    mol->clearProp(common_properties::_CIPComputed);
+
+    boost::dynamic_bitset<> atoms(mol->getNumAtoms());
+    boost::dynamic_bitset<> bonds;
+    atoms.set(7);
+    CIPLabeler::assignCIPLabels(*mol, atoms, bonds);
+
+    CHECK(!mol->getAtomWithIdx(3)->hasProp(common_properties::_CIPCode));
+    CHECK(mol->getAtomWithIdx(7)->getProp<std::string>(
+              common_properties::_CIPCode) == "r");
+    CHECK(!mol->getAtomWithIdx(9)->hasProp(common_properties::_CIPCode));
+    CHECK(!mol->hasProp(common_properties::_CIPComputed));
+  }
+  SECTION("Selection bitsets are validated") {
+    auto mol = "C[C@H](F)Cl"_smiles;
+    REQUIRE(mol);
+
+    boost::dynamic_bitset<> noBonds;
+    boost::dynamic_bitset<> wrongAtoms(mol->getNumAtoms() + 1);
+    wrongAtoms.set(1);
+    CHECK_THROWS_AS(CIPLabeler::assignCIPLabels(*mol, wrongAtoms, noBonds),
+                    ValueErrorException);
+
+    boost::dynamic_bitset<> noAtoms;
+    boost::dynamic_bitset<> wrongBonds(mol->getNumBonds() + 1);
+    wrongBonds.set(0);
+    CHECK_THROWS_AS(CIPLabeler::assignCIPLabels(*mol, noAtoms, wrongBonds),
+                    ValueErrorException);
+  }
+}
+
+TEST_CASE("CIP label property lifecycle", "[accurateCIP]") {
+  SECTION("Full assignment clears a center whose tag was removed") {
+    auto mol = "C[C@H](F)Cl"_smiles;
+    REQUIRE(mol);
+    auto atom = mol->getAtomWithIdx(1);
+
+    CIPLabeler::assignCIPLabels(*mol);
+    REQUIRE(atom->hasProp(common_properties::_CIPCode));
+    REQUIRE(atom->hasProp(common_properties::_CIPNeighborOrder));
+
+    atom->setChiralTag(Atom::CHI_UNSPECIFIED);
+    CIPLabeler::assignCIPLabels(*mol);
+    CHECK(!atom->hasProp(common_properties::_CIPCode));
+    CHECK(!atom->hasProp(common_properties::_CIPNeighborOrder));
+    CHECK(mol->hasProp(common_properties::_CIPComputed));
+  }
+
+  SECTION(
+      "Full assignment clears ranked neighbors when a center becomes tied") {
+    auto mol = "C[C@H](F)Cl"_smiles;
+    REQUIRE(mol);
+    auto atom = mol->getAtomWithIdx(1);
+
+    CIPLabeler::assignCIPLabels(*mol);
+    REQUIRE(atom->hasProp(common_properties::_CIPCode));
+    REQUIRE(atom->hasProp(common_properties::_CIPNeighborOrder));
+
+    mol->getAtomWithIdx(2)->setAtomicNum(17);
+    CIPLabeler::assignCIPLabels(*mol);
+    CHECK(!atom->hasProp(common_properties::_CIPCode));
+    CHECK(!atom->hasProp(common_properties::_CIPNeighborOrder));
+  }
+
+  SECTION("Full assignment clears a bond whose stereo flag was removed") {
+    auto mol = "F/C=C/Cl"_smiles;
+    REQUIRE(mol);
+    auto bond = mol->getBondWithIdx(1);
+
+    CIPLabeler::assignCIPLabels(*mol);
+    REQUIRE(bond->hasProp(common_properties::_CIPCode));
+    REQUIRE(bond->hasProp(common_properties::_CIPNeighborOrder));
+
+    bond->setStereo(Bond::STEREONONE);
+    CIPLabeler::assignCIPLabels(*mol);
+    CHECK(!bond->hasProp(common_properties::_CIPCode));
+    CHECK(!bond->hasProp(common_properties::_CIPNeighborOrder));
+  }
+
+  SECTION("Partial assignment clears only selected output state") {
+    auto mol = "C[C@H](F)Cl"_smiles;
+    REQUIRE(mol);
+    auto selected = mol->getAtomWithIdx(0);
+    auto unselected = mol->getAtomWithIdx(1);
+    selected->setProp(common_properties::_CIPCode, std::string("stale"));
+    selected->setProp(common_properties::_CIPNeighborOrder,
+                      std::vector<unsigned int>{1}, true);
+    unselected->setProp(common_properties::_CIPCode, std::string("keep"));
+
+    boost::dynamic_bitset<> atoms(mol->getNumAtoms());
+    boost::dynamic_bitset<> bonds;
+    atoms.set(0);
+    CIPLabeler::assignCIPLabels(*mol, atoms, bonds);
+
+    CHECK(!selected->hasProp(common_properties::_CIPCode));
+    CHECK(!selected->hasProp(common_properties::_CIPNeighborOrder));
+    CHECK(unselected->getProp<std::string>(common_properties::_CIPCode) ==
+          "keep");
+    CHECK(!mol->hasProp(common_properties::_CIPComputed));
+  }
+}
+
+TEST_CASE("Malformed stereo markers are ignored safely", "[accurateCIP]") {
+  SECTION("Tetrahedral atom with too few carriers") {
+    auto mol = "CF"_smiles;
+    REQUIRE(mol);
+    auto atom = mol->getAtomWithIdx(0);
+    atom->setChiralTag(Atom::CHI_TETRAHEDRAL_CW);
+    atom->setProp(common_properties::_CIPCode, std::string("stale"));
+    CHECK_NOTHROW(CIPLabeler::assignCIPLabels(*mol));
+    CHECK(!atom->hasProp(common_properties::_CIPCode));
+    CHECK(!atom->hasProp(common_properties::_CIPNeighborOrder));
+  }
+
+  SECTION("Cis/trans marker on a single bond") {
+    auto mol = "CCCC"_smiles;
+    REQUIRE(mol);
+    auto bond = mol->getBondBetweenAtoms(1, 2);
+    REQUIRE(bond);
+    REQUIRE(bond->getBondType() == Bond::SINGLE);
+
+    const auto beginCarrier = bond->getBeginAtomIdx() == 1 ? 0u : 3u;
+    const auto endCarrier = bond->getEndAtomIdx() == 2 ? 3u : 0u;
+    bond->setStereoAtoms(beginCarrier, endCarrier);
+    bond->setStereo(Bond::STEREOCIS);
+    bond->setProp(common_properties::_CIPCode, std::string("stale"));
+    CHECK_NOTHROW(CIPLabeler::assignCIPLabels(*mol));
+    CHECK(!bond->hasProp(common_properties::_CIPCode));
+    CHECK(!bond->hasProp(common_properties::_CIPNeighborOrder));
+  }
+
+  SECTION("Invalid atropisomer marker") {
+    auto mol = "CC"_smiles;
+    REQUIRE(mol);
+    auto bond = mol->getBondWithIdx(0);
+    bond->setStereo(Bond::STEREOATROPCW);
+    bond->setProp(common_properties::_CIPCode, std::string("stale"));
+    CHECK_NOTHROW(CIPLabeler::assignCIPLabels(*mol));
+    CHECK(!bond->hasProp(common_properties::_CIPCode));
+    CHECK(!bond->hasProp(common_properties::_CIPNeighborOrder));
   }
 }
 

--- a/Code/GraphMol/CIPLabeler/catch_tests.cpp
+++ b/Code/GraphMol/CIPLabeler/catch_tests.cpp
@@ -45,11 +45,25 @@
 #include "rules/Rule1a.h"
 #include "rules/Rule2.h"
 #include "rules/Rule6.h"
+#include "rules/Rules.h"
 
 #include "CIPMol.h"
 
 using namespace RDKit;
 using namespace RDKit::CIPLabeler;
+
+TEST_CASE("Rules eagerly initializes its composite sorter", "[accurateCIP]") {
+  const Rule1a standaloneRule;
+  REQUIRE(standaloneRule.getSorter());
+  CHECK(standaloneRule.getSorter()->getRules() ==
+        std::vector<const SequenceRule *>{&standaloneRule});
+
+  const Rules rules({new Rule1a});
+
+  REQUIRE(rules.getSorter());
+  CHECK(rules.getSorter()->getRules() ==
+        std::vector<const SequenceRule *>{&rules});
+}
 
 TEST_CASE("Descriptor lists", "[accurateCIP]") {
   auto descriptors = PairList();
@@ -202,8 +216,7 @@ TEST_CASE("Mancude fractional atomic numbers", "[accurateCIP]") {
     int bond_duplicates = 0;
     for (const auto edge : negative_node->getEdges()) {
       const auto end = edge->getEnd();
-      if (edge->isBeg(negative_node) &&
-          end->isSet(Node::BOND_DUPLICATE)) {
+      if (edge->isBeg(negative_node) && end->isSet(Node::BOND_DUPLICATE)) {
         ++bond_duplicates;
         CHECK(end->getAtomicNumFraction() == boost::rational<int>(4, 1));
       }

--- a/Code/GraphMol/CIPLabeler/catch_tests.cpp
+++ b/Code/GraphMol/CIPLabeler/catch_tests.cpp
@@ -96,6 +96,26 @@ TEST_CASE("Descriptor lists", "[accurateCIP]") {
   }
 }
 
+TEST_CASE("Iteration limit includes the preliminary pass",
+          "[bug][accurateCIP]") {
+  auto mol = "C[C@H](F)Cl"_smiles;
+  REQUIRE(mol);
+
+  CHECK_THROWS_AS(CIPLabeler::assignCIPLabels(*mol, 1),
+                  CIPLabeler::MaxIterationsExceeded);
+
+  // A bounded call must not leave the thread-local budget exhausted for
+  // standalone rule comparisons on the same thread.
+  auto comparisonMol = "COC"_smiles;
+  REQUIRE(comparisonMol);
+  CIPLabeler::CIPMol cipmol(*comparisonMol);
+  Digraph digraph(cipmol, cipmol.getAtom(1));
+  auto origin = digraph.getOriginalRoot();
+  auto edges = origin->getEdges();
+  Rule1a rule;
+  CHECK_NOTHROW(rule.getSorter()->prioritize(origin, edges));
+}
+
 void check_incoming_edge_count(Node *root) {
   auto queue = std::list<Node *>({root});
 
@@ -1458,7 +1478,9 @@ $$$$
   auto mol = v2::FileParsers::MolFromMolBlock(molBlock, params);
 
   REQUIRE(mol);
-  REQUIRE_THROWS_AS(CIPLabeler::assignCIPLabels(*mol, 1000),
+  // Leave enough of the global budget for the preliminary pass to visit the
+  // easy center before the difficult centers exhaust the remaining budget.
+  REQUIRE_THROWS_AS(CIPLabeler::assignCIPLabels(*mol, 100000),
                     CIPLabeler::MaxIterationsExceeded);
 
   auto at = mol->getAtomWithIdx(22);

--- a/Code/GraphMol/CIPLabeler/catch_tests.cpp
+++ b/Code/GraphMol/CIPLabeler/catch_tests.cpp
@@ -715,6 +715,23 @@ TEST_CASE("Malformed stereo markers are ignored safely", "[accurateCIP]") {
     CHECK(!bond->hasProp(common_properties::_CIPNeighborOrder));
   }
 
+  SECTION("Double bond with invalid stereo atom indexes") {
+    auto mol = "FC=CCl"_smiles;
+    REQUIRE(mol);
+    auto bond = mol->getBondWithIdx(1);
+    REQUIRE(bond->getBondType() == Bond::DOUBLE);
+    auto &stereoAtoms = bond->getStereoAtoms();
+    stereoAtoms.clear();
+    stereoAtoms.push_back(mol->getNumAtoms() + 1);
+    stereoAtoms.push_back(3);
+    bond->setStereo(Bond::STEREOCIS);
+    bond->setProp(common_properties::_CIPCode, std::string("stale"));
+
+    CHECK_NOTHROW(CIPLabeler::assignCIPLabels(*mol));
+    CHECK(!bond->hasProp(common_properties::_CIPCode));
+    CHECK(!bond->hasProp(common_properties::_CIPNeighborOrder));
+  }
+
   SECTION("Invalid atropisomer marker") {
     auto mol = "CC"_smiles;
     REQUIRE(mol);

--- a/Code/GraphMol/CIPLabeler/configs/AtropisomerBond.cpp
+++ b/Code/GraphMol/CIPLabeler/configs/AtropisomerBond.cpp
@@ -75,10 +75,6 @@ bool AtropisomerBond::hasPrimaryLabel() const {
   return dp_bond->hasProp(common_properties::_CIPCode);
 }
 
-void AtropisomerBond::resetPrimaryLabel() const {
-  dp_bond->clearProp(common_properties::_CIPCode);
-}
-
 Descriptor AtropisomerBond::label(const Rules &comp) {
   auto &digraph = getDigraph();
   auto root1 = digraph.getOriginalRoot();

--- a/Code/GraphMol/CIPLabeler/configs/AtropisomerBond.cpp
+++ b/Code/GraphMol/CIPLabeler/configs/AtropisomerBond.cpp
@@ -29,7 +29,8 @@ AtropisomerBond::AtropisomerBond(const CIPMol &mol, Bond *bond, Atom *startAtom,
 
   Atropisomers::AtropAtomAndBondVec atomAndBondVecs[2];
   if (!Atropisomers::getAtropisomerAtomsAndBonds(bond, atomAndBondVecs,
-                                                 bond->getOwningMol())) {
+                                                 bond->getOwningMol()) ||
+      atomAndBondVecs[0].second.empty() || atomAndBondVecs[1].second.empty()) {
     return;  // not an atropisomer
   }
   auto atom1 = mol.getAtom(atomAndBondVecs[0].second[0]->getOtherAtomIdx(
@@ -107,6 +108,10 @@ Descriptor AtropisomerBond::label(Node *root1, Digraph &digraph,
 
   removeDuplicatesAndHs(edges1);
   removeDuplicatesAndHs(edges2);
+
+  if (getCarriers().size() != 2 || edges1.empty() || edges2.empty()) {
+    return Descriptor::ns;
+  }
 
   auto carriers = std::vector<Atom *>(getCarriers());
   auto config = d_cfg;

--- a/Code/GraphMol/CIPLabeler/configs/AtropisomerBond.cpp
+++ b/Code/GraphMol/CIPLabeler/configs/AtropisomerBond.cpp
@@ -166,13 +166,13 @@ Descriptor AtropisomerBond::label(Node *root1, Digraph &digraph,
     }
   }
   if (config == Bond::STEREOATROPCCW) {
-    if (priority1.isPseudoAsymetric() || priority2.isPseudoAsymetric()) {
+    if (priority1.isPseudoAsymetric() != priority2.isPseudoAsymetric()) {
       return Descriptor::m;
     } else {
       return Descriptor::M;
     }
   } else if (config == Bond::STEREOATROPCW) {
-    if (priority1.isPseudoAsymetric() || priority2.isPseudoAsymetric()) {
+    if (priority1.isPseudoAsymetric() != priority2.isPseudoAsymetric()) {
       return Descriptor::p;
     } else {
       return Descriptor::P;

--- a/Code/GraphMol/CIPLabeler/configs/AtropisomerBond.h
+++ b/Code/GraphMol/CIPLabeler/configs/AtropisomerBond.h
@@ -26,8 +26,6 @@ class AtropisomerBond : public Configuration {
 
   bool hasPrimaryLabel() const override;
 
-  void resetPrimaryLabel() const override;
-
   Descriptor label(const Rules &comp) override;
 
   Descriptor label(Node *root1, Digraph &digraph, const Rules &comp) override;

--- a/Code/GraphMol/CIPLabeler/configs/Configuration.h
+++ b/Code/GraphMol/CIPLabeler/configs/Configuration.h
@@ -186,8 +186,6 @@ class Configuration {
 
   virtual bool hasPrimaryLabel() const = 0;
 
-  virtual void resetPrimaryLabel() const = 0;
-
  protected:
   Edge *findInternalEdge(const std::vector<Edge *> &edges, Atom *f1, Atom *f2);
 

--- a/Code/GraphMol/CIPLabeler/configs/Sp2Bond.cpp
+++ b/Code/GraphMol/CIPLabeler/configs/Sp2Bond.cpp
@@ -25,6 +25,9 @@ Sp2Bond::Sp2Bond(const CIPMol &mol, Bond *bond, Atom *startAtom, Atom *endAtom,
   CHECK_INVARIANT(d_cfg == Bond::STEREOTRANS || d_cfg == Bond::STEREOCIS,
                   "bad config")
 
+  if (bond->getBondType() != Bond::DOUBLE) {
+    return;
+  }
   auto stereo_atoms = Chirality::findStereoAtoms(bond);
   CHECK_INVARIANT(stereo_atoms.size() == 2, "incorrect number of stereo atoms")
 
@@ -98,6 +101,10 @@ Descriptor Sp2Bond::label(Node *root1, Digraph &digraph, const Rules &comp) {
   auto edges2 = root2->getEdges();
   removeInternalEdges(edges1, focus1, focus2);
   removeInternalEdges(edges2, focus1, focus2);
+
+  if (getCarriers().size() != 2 || edges1.empty() || edges2.empty()) {
+    return Descriptor::ns;
+  }
 
   auto carriers = std::vector<Atom *>(getCarriers());
   auto config = d_cfg;

--- a/Code/GraphMol/CIPLabeler/configs/Sp2Bond.cpp
+++ b/Code/GraphMol/CIPLabeler/configs/Sp2Bond.cpp
@@ -70,10 +70,6 @@ bool Sp2Bond::hasPrimaryLabel() const {
   return dp_bond->hasProp(common_properties::_CIPCode);
 }
 
-void Sp2Bond::resetPrimaryLabel() const {
-  dp_bond->clearProp(common_properties::_CIPCode);
-}
-
 Descriptor Sp2Bond::label(const Rules &comp) {
   auto &digraph = getDigraph();
   auto root1 = digraph.getOriginalRoot();

--- a/Code/GraphMol/CIPLabeler/configs/Sp2Bond.cpp
+++ b/Code/GraphMol/CIPLabeler/configs/Sp2Bond.cpp
@@ -31,6 +31,27 @@ Sp2Bond::Sp2Bond(const CIPMol &mol, Bond *bond, Atom *startAtom, Atom *endAtom,
   auto stereo_atoms = Chirality::findStereoAtoms(bond);
   CHECK_INVARIANT(stereo_atoms.size() == 2, "incorrect number of stereo atoms")
 
+  const auto isValidCarrier = [&mol](Atom *focus, Atom *otherFocus,
+                                     int carrierIdx) {
+    if (carrierIdx < 0 ||
+        static_cast<unsigned int>(carrierIdx) >= mol.getNumAtoms() ||
+        carrierIdx == static_cast<int>(focus->getIdx()) ||
+        carrierIdx == static_cast<int>(otherFocus->getIdx())) {
+      return false;
+    }
+    for (const auto neighbor : mol.getNeighbors(focus)) {
+      if (neighbor->getIdx() == static_cast<unsigned int>(carrierIdx)) {
+        return true;
+      }
+    }
+    return false;
+  };
+  if (stereo_atoms[0] == stereo_atoms[1] ||
+      !isValidCarrier(startAtom, endAtom, stereo_atoms[0]) ||
+      !isValidCarrier(endAtom, startAtom, stereo_atoms[1])) {
+    return;
+  }
+
   std::vector<Atom *> anchors{
       {mol.getAtom(stereo_atoms[0]), mol.getAtom(stereo_atoms[1])}};
 

--- a/Code/GraphMol/CIPLabeler/configs/Sp2Bond.h
+++ b/Code/GraphMol/CIPLabeler/configs/Sp2Bond.h
@@ -26,8 +26,6 @@ class Sp2Bond : public Configuration {
 
   bool hasPrimaryLabel() const override;
 
-  void resetPrimaryLabel() const override;
-
   Descriptor label(const Rules &comp) override;
 
   Descriptor label(Node *root1, Digraph &digraph, const Rules &comp) override;

--- a/Code/GraphMol/CIPLabeler/configs/Tetrahedral.cpp
+++ b/Code/GraphMol/CIPLabeler/configs/Tetrahedral.cpp
@@ -28,6 +28,9 @@ Tetrahedral::Tetrahedral(const CIPMol &mol, Atom *focus)
   for (auto &nbr : mol.getNeighbors(focus)) {
     carriers.push_back(nbr);
   }
+  if (carriers.size() < 2 || carriers.size() > 4) {
+    return;
+  }
   if (carriers.size() < 4) {
     // Implicit H -- use the central atom instead of a dummy H
     carriers.push_back(focus);
@@ -100,7 +103,7 @@ Descriptor Tetrahedral::label(Node *node, const Rules &comp) {
   d_ranked_anchors.clear();
 
   // something not right!?! bad creation
-  if (edges.size() < 3) {
+  if (getCarriers().size() != 4 || edges.size() < 3) {
     return Descriptor::ns;
   }
 
@@ -147,6 +150,9 @@ Descriptor Tetrahedral::label(Node *node, const Rules &comp) {
       continue;
     }
 
+    if (idx < 0 || static_cast<size_t>(idx) >= ordered.size()) {
+      throw std::runtime_error("Could not calculate parity! invalid atom index");
+    }
     auto atom = edge->getEnd()->getAtom();
     ordered[idx] = atom;
 

--- a/Code/GraphMol/CIPLabeler/configs/Tetrahedral.cpp
+++ b/Code/GraphMol/CIPLabeler/configs/Tetrahedral.cpp
@@ -77,10 +77,6 @@ bool Tetrahedral::hasPrimaryLabel() const {
   return getFocus()->hasProp(common_properties::_CIPCode);
 }
 
-void Tetrahedral::resetPrimaryLabel() const {
-  getFocus()->clearProp(common_properties::_CIPCode);
-}
-
 Descriptor Tetrahedral::label(const Rules &comp) {
   auto &digraph = getDigraph();
 

--- a/Code/GraphMol/CIPLabeler/configs/Tetrahedral.h
+++ b/Code/GraphMol/CIPLabeler/configs/Tetrahedral.h
@@ -25,8 +25,6 @@ class Tetrahedral : public Configuration {
 
   bool hasPrimaryLabel() const override;
 
-  void resetPrimaryLabel() const override;
-
   Descriptor label(const Rules &comp) override;
 
   Descriptor label(Node *node, Digraph &digraph, const Rules &comp) override;

--- a/Code/GraphMol/CIPLabeler/rules/Rules.h
+++ b/Code/GraphMol/CIPLabeler/rules/Rules.h
@@ -68,9 +68,7 @@ class Rules : public SequenceRule {
 
  private:
   void add(SequenceRule *rule) {
-    if (rule == nullptr) {
-      throw std::runtime_error("No sequence rule provided");
-    }
+    PRECONDITION(rule != nullptr, "null rule provided");
     d_rules.push_back(rule);
     rule->setSorter(new Sort(d_rules));
   }

--- a/Code/GraphMol/CIPLabeler/rules/Rules.h
+++ b/Code/GraphMol/CIPLabeler/rules/Rules.h
@@ -23,7 +23,7 @@ class Rules : public SequenceRule {
  public:
   Rules() = delete;
 
-  Rules(std::initializer_list<SequenceRule *> rules) {
+  Rules(std::initializer_list<SequenceRule *>&& rules) {
     for (auto &rule : rules) {
       add(rule);
     }
@@ -35,22 +35,7 @@ class Rules : public SequenceRule {
     }
   }
 
-  void add(SequenceRule *rule) {
-    if (rule == nullptr) {
-      throw std::runtime_error("No sequence rule provided");
-    }
-    d_rules.push_back(rule);
-    rule->setSorter(new Sort(d_rules));
-  }
-
   int getNumSubRules() const { return d_rules.size(); }
-
-  const Sort *getSorter() const override {
-    if (dp_sorter == nullptr) {
-      const_cast<Rules *>(this)->setSorter(new Sort(this));
-    }
-    return dp_sorter.get();
-  }
 
   int compare(const Edge *o1, const Edge *o2) const override {
     // Try using each rules. The rules will expand the search exhaustively
@@ -65,9 +50,8 @@ class Rules : public SequenceRule {
     return 0;
   }
 
-  int getComparision(const Edge *a, const Edge *b, bool deep) const override {
-    (void)deep;
-
+  int getComparision(const Edge *a, const Edge *b,
+                     bool /* unused */) const override {
     // Try using each rules. The rules will expand the search exhaustively
     // to all child substituents
     for (const auto &rule : d_rules) {
@@ -83,6 +67,14 @@ class Rules : public SequenceRule {
   }
 
  private:
+  void add(SequenceRule *rule) {
+    if (rule == nullptr) {
+      throw std::runtime_error("No sequence rule provided");
+    }
+    d_rules.push_back(rule);
+    rule->setSorter(new Sort(d_rules));
+  }
+
   std::vector<const SequenceRule *> d_rules;
 };
 

--- a/Code/GraphMol/CIPLabeler/rules/SequenceRule.cpp
+++ b/Code/GraphMol/CIPLabeler/rules/SequenceRule.cpp
@@ -17,7 +17,7 @@
 namespace RDKit {
 namespace CIPLabeler {
 
-SequenceRule::SequenceRule() = default;
+SequenceRule::SequenceRule() : dp_sorter{new Sort(this)} {}
 
 SequenceRule::~SequenceRule() = default;
 
@@ -42,12 +42,7 @@ int SequenceRule::getComparision(const Edge *a, const Edge *b,
   return deep ? recursiveCompare(a, b) : compare(a, b);
 }
 
-const Sort *SequenceRule::getSorter() const {
-  if (dp_sorter == nullptr) {
-    const_cast<SequenceRule *>(this)->setSorter(new Sort(this));
-  }
-  return dp_sorter.get();
-}
+const Sort *SequenceRule::getSorter() const { return dp_sorter.get(); }
 
 int SequenceRule::recursiveCompare(const Edge *a, const Edge *b) const {
   if (!CIPLabeler_detail::decrementRemainingCallCountAndCheck()) {


### PR DESCRIPTION
As I mentioned in https://github.com/rdkit/rdkit/pull/9561, I asked the AI to compare the RDKit's implementation of the CIP labeler against the original Java implementation in https://github.com/SiMolecule/centres and find differences in the implemented functionality.

Besides some fixes (the one in https://github.com/rdkit/rdkit/pull/9561 was the biggest one), it also suggested some other fixes for bugs and refactoring. I have reviewed them, discarded some and added some other of my own, and bundled all of them in this PR.

In summary, this:
- Adds the creation of the sorters into the rule set initialization (and gets rid of the ugly `const_cast` we were using.
- Refactors the way we apply the iteration limits onto the labeler.
- Fixes labeling only some atoms and/or bonds (not the whole mol). Before this fix, the labeling ignored other configs on which the selected atoms and bonds might depend on.
- We add a fall back onto isotope numbers in case we do not know an exact mass for the specified isotope.
- Fix one check in the atropisomer labeling that decides if the labels are "full" atropisomer labels or "pseudo".
- Changes some data types: Descriptors and atom masks were made `uint8_t`, and the Node visit arrays were made `uint32_t`, since it looked possible that we could overflow the `char` type we were using in case of complicated stuff.
- Hardens several parts of the code with additional checks and early exits.
- Adds testing

Besides the built in tests, I did benchmark this at some point (though I did some changes afterwards, so I should re-run the check) on the Coconut DB (https://coconut.naturalproducts.net/), checking labels before and after this patch. I only found 1 difference, which was due to the isotope number fallback (the mol had some weird isotopic numbers that were ignored before).