### PR TITLE
Add some deprecations

### DIFF
--- a/Projects/DbCLI/CreateDb.py
+++ b/Projects/DbCLI/CreateDb.py
@@ -28,6 +28,10 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 # Created by Greg Landrum, July 2007
+import warnings
+
+warnings.warn("the Projects.DbCLI.CreateDb module is deprecated", DeprecationWarning, stacklevel=2)
+
 _version = "0.13.0"
 
 _description = """

--- a/Projects/DbCLI/SearchDb.py
+++ b/Projects/DbCLI/SearchDb.py
@@ -29,6 +29,9 @@
 #
 #  Created by Greg Landrum, July 2007
 #
+import warnings
+
+warnings.warn("the Projects.DbCLI.SearchDb module is deprecated", DeprecationWarning, stacklevel=2)
 
 _version = "0.14.0"
 _description = """
@@ -60,8 +63,7 @@ import zlib
 
 from rdkit import Chem, DataStructs
 from rdkit.Chem.MolDb import FingerprintUtils
-from rdkit.Chem.MolDb.FingerprintUtils import (BuildSigFactory, DepickleFP,
-                                               LayeredOptions,
+from rdkit.Chem.MolDb.FingerprintUtils import (BuildSigFactory, DepickleFP, LayeredOptions,
                                                supportedSimilarityMethods)
 
 

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -61,6 +61,19 @@ GitHub)
   library during RDKit builds will be removed in a future release. Users who are
   building the RDKit themselves and who want to use Eigen will need to install
   Eigen themselves.
+- The DbCLI code (found in Projects/DbCLI) has been deprecated and will be removed in the next release.
+- The python package ML.MLUtils has been deprecated and will be removed in the
+  next release.
+- The python package Chem.MolDb has been deprecated and will be removed in the
+  next release.
+- The python package Chem.Fingerprints has been deprecated and will be removed
+  in the next release.
+- The python package Chem.fmcs has been deprecated and will be removed in the
+  next release. The C++ implementation in Chem.rdFMCS is more advanced and is
+  being maintained.
+  
+
+
 
 
 # Release_2026.03.1

--- a/rdkit/Chem/Fingerprints/__init__.py
+++ b/rdkit/Chem/Fingerprints/__init__.py
@@ -1,3 +1,6 @@
 #
 #  Copyright (C) 2003  Greg Landrum and Rational Discovery LLC
 #
+import warnings
+
+warnings.warn("the rdkit.Chem.Fingerprints module is deprecated", DeprecationWarning, stacklevel=2)

--- a/rdkit/Chem/MolDb/__init__.py
+++ b/rdkit/Chem/MolDb/__init__.py
@@ -1,0 +1,3 @@
+import warnings
+
+warnings.warn("the rdkit.Chem.MolDb module is deprecated", DeprecationWarning, stacklevel=2)

--- a/rdkit/Chem/fmcs/__init__.py
+++ b/rdkit/Chem/fmcs/__init__.py
@@ -6,6 +6,6 @@ import warnings
 
 import warnings
 
-warnings.warn("the rdkit.Chem.fmcs module is deprecated", DeprecationWarning, stacklevel=2)
+warnings.warn("the rdkit.Chem.fmcs module is deprecated, use rdkit.Chem.rdFMCS instead.", DeprecationWarning, stacklevel=2)
 
 from rdkit.Chem.fmcs.fmcs import *

--- a/rdkit/Chem/fmcs/__init__.py
+++ b/rdkit/Chem/fmcs/__init__.py
@@ -6,6 +6,6 @@ import warnings
 
 import warnings
 
-warnings.warn("the spam module is deprecated", DeprecationWarning, stacklevel=2)
+warnings.warn("the rdkit.Chem.fmcs module is deprecated", DeprecationWarning, stacklevel=2)
 
 from rdkit.Chem.fmcs.fmcs import *

--- a/rdkit/Chem/fmcs/__init__.py
+++ b/rdkit/Chem/fmcs/__init__.py
@@ -2,4 +2,10 @@
 This code should be used by importing rdkit.Chem.MCS
 
 """
+import warnings
+
+import warnings
+
+warnings.warn("the spam module is deprecated", DeprecationWarning, stacklevel=2)
+
 from rdkit.Chem.fmcs.fmcs import *

--- a/rdkit/ML/MLUtils/__init__.py
+++ b/rdkit/ML/MLUtils/__init__.py
@@ -1,0 +1,3 @@
+import warnings
+
+warnings.warn("the rdkit.ML.MLUtils module is deprecated", DeprecationWarning, stacklevel=2)


### PR DESCRIPTION
This deprecates some python modules that I hope are no longer being used. 
It adds warnings to the modules themselves and entries on the release notes:
```
- The DbCLI code (found in Projects/DbCLI) has been deprecated and will be removed in the next release.
- The python package ML.MLUtils has been deprecated and will be removed in the
  next release.
- The python package Chem.MolDb has been deprecated and will be removed in the
  next release.
- The python package Chem.Fingerprints has been deprecated and will be removed
  in the next release.
- The python package Chem.fmcs has been deprecated and will be removed in the
  next release. The C++ implementation in Chem.rdFMCS is more advanced and is
  being maintained.
```