### PR TITLE
Use available CPU count in testThreads

### DIFF
--- a/Code/GraphMol/Wrap/testThreads.py
+++ b/Code/GraphMol/Wrap/testThreads.py
@@ -1,4 +1,5 @@
 import multiprocessing
+import os
 import threading
 
 from rdkit import Chem
@@ -34,7 +35,15 @@ funcs = ["GetSubstructMatch", "GetSubstructMatches", "HasSubstructMatch"]
 for func in funcs:
   expected[func] = runner(func, core_mol)
 
-nthreads = int(multiprocessing.cpu_count() * 100 / 4)  # 100 threads per cpu
+if hasattr(os, "process_cpu_count"):
+  cpu_count = os.process_cpu_count()
+elif hasattr(os, "sched_getaffinity"):
+  cpu_count = len(os.sched_getaffinity(0))
+else:
+  cpu_count = multiprocessing.cpu_count()
+
+nthreads = int((cpu_count or 1) * 100 / 4)  # 100 threads per available cpu
+
 threads = []
 for i in range(0, nthreads):
   for func in funcs:


### PR DESCRIPTION

<!--
Thanks for contributing a pull request! 
-->
#### Reference Issue
#### What does this implement/fix? Explain your changes.
`testThreads.py` currently uses `multiprocessing.cpu_count()` to determine the number of threads to create. This reports the total number of CPUs on the system rather than the CPUs available to the current process.

On large HPC nodes this can result in the test creating tens of thousands of threads even when the job is allocated only a small subset of the node, eventually failing with:

`RuntimeError: can't start new thread`

Use `os.process_cpu_count()` when available, with `os.sched_getaffinity()` as a fallback on older Python versions, so the test scales with the CPUs available to the process.

#### Any other comments?

This can be worked around in EasyBuild by using sed to patch testThreads.py to use the process-available CPU count instead of multiprocessing.cpu_count(); see easybuilders/easybuild-easyconfigs#26847
